### PR TITLE
Chore: (Docs) Histogram stories migration to CSF 3

### DIFF
--- a/docs/snippets/angular/histogram-story.mdx.mdx
+++ b/docs/snippets/angular/histogram-story.mdx.mdx
@@ -7,7 +7,11 @@ import { HistogramComponent } from './histogram.component';
 
 <Meta title="Histogram" component={HistogramComponent} />
 
-export const Template = (args) => ({ props: args });
+<!--
+ 👇 Render functions are a framework specific feature to allow you control on how the component renders.
+  See https://storybook.js.org/docs/7.0/angular/api/csf
+  to learn how to use render functions.
+-->
 
 <Canvas>
   <Story
@@ -17,8 +21,9 @@ export const Template = (args) => ({ props: args });
       showHistogramLabels: true,
       histogramAccentColor: '#1EA7FD',
       label: 'Latency distribution',
-    }} >
-    {Template.bind({})}
-  </Story>
+    }}
+    render={(args) => ({
+      props: args,
+    })} />
 </Canvas>
 ```

--- a/docs/snippets/angular/histogram-story.ts.mdx
+++ b/docs/snippets/angular/histogram-story.ts.mdx
@@ -1,28 +1,25 @@
 ```ts
 // Histogram.stories.ts
 
-import { Meta, Story } from '@storybook/angular';
+import type { Meta, Story } from '@storybook/angular';
 
 import { HistogramComponent } from './histogram.component';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
   component: HistogramComponent,
 } as Meta;
 
-const Template: Story = (args) => ({
-  props: args,
-});
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
+export const Default: Story = {
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
+  },
 };
 ```

--- a/docs/snippets/html/histogram-story.js.mdx
+++ b/docs/snippets/html/histogram-story.js.mdx
@@ -4,20 +4,25 @@
 import { createHistogram } from './Histogram';
 
 export default {
-  /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/html/configure/overview#configure-story-loading
+    /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/7.0/html/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
 };
 
-const Template = (args) => createHistogram(args);
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/html/api/csf
+ * to learn how to use render functions.
+ */
+export const Default = {
+  render: (args) => createHistogram(args),
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
+  },
 };
 ```

--- a/docs/snippets/html/histogram-story.ts.mdx
+++ b/docs/snippets/html/histogram-story.ts.mdx
@@ -1,25 +1,30 @@
 ```ts
 // Histogram.stories.ts
 
-import { Meta, StoryFn } from '@storybook/html';
+import type { Meta, Story } from '@storybook/html';
 
 import { Histogram, HistogramProps } from './Histogram';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/html/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/html/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
-} as Meta;
+} as Meta<HistogramProps>;
 
-const Template: StoryFn<HistogramProps> = (args) => createHistogram(args);
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/html/api/csf
+ * to learn how to use render functions.
+ */
+export const Default: Story = {
+  render: (args) => createHistogram(args),
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
+  },
 };
 ```

--- a/docs/snippets/preact/histogram-story.js.mdx
+++ b/docs/snippets/preact/histogram-story.js.mdx
@@ -8,20 +8,25 @@ import { Histogram } from './Histogram';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/preact/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/preact/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
   component: Histogram,
 };
 
-const Template = (args) => <Histogram {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/preact/api/csf
+ * to learn how to use render functions.
+ */
+export const Default = {
+  render: (args) => <Histogram {...args} />,
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
+  },
 };
 ```

--- a/docs/snippets/preact/histogram-story.mdx.mdx
+++ b/docs/snippets/preact/histogram-story.mdx.mdx
@@ -7,18 +7,21 @@ import { Histogram } from './Histogram';
 
 <Meta title="Histogram" component={Histogram} />
 
-export const Template = (args) => <Histogram {...args} />;
+<!--
+ 👇 Render functions are a framework specific feature to allow you control on how the component renders.
+  See https://storybook.js.org/docs/7.0/preact/api/csf
+  to learn how to use render functions.
+-->
 
 <Canvas>
-  <Story
+  <Story 
     name="Default"
     args={{
       dataType: 'latency',
       showHistogramLabels: true,
       histogramAccentColor: '#1EA7FD',
       label: 'Latency distribution',
-    }} >
-    {Template.bind({})}
-  </Story>
+    }}
+    render={(args) => <Histogram {...args} /> />
 </Canvas>
 ```

--- a/docs/snippets/react/histogram-story.js.mdx
+++ b/docs/snippets/react/histogram-story.js.mdx
@@ -1,26 +1,23 @@
 ```js
 // Histogram.stories.js|jsx
 
-import React from 'react';
-
 import { Histogram } from './Histogram';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
   component: Histogram,
 };
 
-const Template = (args) => <Histogram {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
+export const Default = {
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
+  },
 };
 ```

--- a/docs/snippets/react/histogram-story.mdx.mdx
+++ b/docs/snippets/react/histogram-story.mdx.mdx
@@ -7,7 +7,11 @@ import { Histogram } from './Histogram';
 
 <Meta title="Histogram" component={Histogram} />
 
-export const Template = (args) => <Histogram {...args} />;
+<!--
+ 👇 Render functions are a framework specific feature to allow you control on how the component renders.
+  See https://storybook.js.org/docs/7.0/react/api/csf
+  to learn how to use render functions.
+-->
 
 <Canvas>
   <Story
@@ -17,8 +21,7 @@ export const Template = (args) => <Histogram {...args} />;
       showHistogramLabels: true,
       histogramAccentColor: '#1EA7FD',
       label: 'Latency distribution',
-    }} >
-    {Template.bind({})}
-  </Story>
+    }}
+    render={(args) => <Histogram {...args} />} />
 </Canvas>
 ```

--- a/docs/snippets/react/histogram-story.ts.mdx
+++ b/docs/snippets/react/histogram-story.ts.mdx
@@ -3,26 +3,25 @@
 
 import React from 'react';
 
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 
 import { Histogram } from './Histogram';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
   component: Histogram,
 } as ComponentMeta<typeof Histogram>;
 
-const Template: ComponentStory<typeof Histogram> = (args) => <Histogram {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
+export const Default: ComponentStoryObj<typeof Histogram> = {
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
+  },
 };
 ```

--- a/docs/snippets/svelte/histogram-story.js.mdx
+++ b/docs/snippets/svelte/histogram-story.js.mdx
@@ -5,23 +5,28 @@ import Histogram from './Histogram.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
   component: Histogram,
 };
 
-const Template = (args) => ({
-  Component: Histogram,
-  props: args,
-});
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * to learn how to use render functions.
+ */
+export const Default = {
+  render: (args) => ({
+    Component: Histogram,
+    props: args,
+  }),
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
+  },
 };
 ```

--- a/docs/snippets/svelte/histogram-story.mdx.mdx
+++ b/docs/snippets/svelte/histogram-story.mdx.mdx
@@ -7,10 +7,11 @@ import Histogram from './Histogram.svelte';
 
 <Meta title="Histogram" component={Histogram} />
 
-export const Template = (args) => ({
-  Component: Histogram,
-  props: args,
-});
+<!--
+ 👇 Render functions are a framework specific feature to allow you control on how the component renders.
+  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  to learn how to use render functions.
+-->
 
 <Canvas>
   <Story
@@ -20,8 +21,10 @@ export const Template = (args) => ({
       showHistogramLabels: true,
       histogramAccentColor: '#1EA7FD',
       label: 'Latency distribution',
-    }} >
-    {Template.bind({})}
-  </Story>
+    }}
+    render={(args) => ({
+      Component: Histogram,
+      props: args,
+    })} />
 </Canvas>
 ```

--- a/docs/snippets/vue/histogram-story.2.js.mdx
+++ b/docs/snippets/vue/histogram-story.2.js.mdx
@@ -5,24 +5,29 @@ import Histogram from './Histogram.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
   component: Histogram,
 };
 
-const Template = (args, { argTypes }) => ({
-  components: { Histogram },
-  props: Object.keys(argTypes),
-  template: '<Histogram v-bind="$props" v-on="$props" />',
-});
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * to learn how to use render functions.
+ */
+export const Default = {
+  render: (args, { argTypes }) => ({
+    components: { Histogram },
+    props: Object.keys(argTypes),
+    template: '<Histogram v-bind="$props" v-on="$props" />',
+  }),
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
+  },
 };
 ```

--- a/docs/snippets/vue/histogram-story.3.js.mdx
+++ b/docs/snippets/vue/histogram-story.3.js.mdx
@@ -5,26 +5,31 @@ import Histogram from './Histogram.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
   component: Histogram,
 };
 
-const Template = (args) => ({
-  components: { Histogram },
-  setup() {
-    return { args };
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * to learn how to use render functions.
+ */
+export const Default = {
+  render: (args) => ({
+    components: { Histogram },
+    setup() {
+      return { args };
+    },
+    template: '<Histogram v-bind="args" />',
+  }),
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
   },
-  template: '<Histogram v-bind="args" />',
-});
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
 };
 ```

--- a/docs/snippets/vue/histogram-story.mdx-2.mdx
+++ b/docs/snippets/vue/histogram-story.mdx-2.mdx
@@ -7,11 +7,11 @@ import Histogram from './Histogram.vue';
 
 <Meta title="Histogram" component={Histogram} />
 
-export const Template = (args, { argTypes }) => ({
-  components: { Histogram },
-  props: Object.keys(argTypes),
-  template: `<Histogram v-bind="$props" v-on="$props" />`,
-});
+<!--
+ 👇 Render functions are a framework specific feature to allow you control on how the component renders.
+  See https://storybook.js.org/docs/7.0/vue/api/csf
+  to learn how to use render functions.
+-->
 
 <Canvas>
   <Story
@@ -21,8 +21,11 @@ export const Template = (args, { argTypes }) => ({
       showHistogramLabels: true,
       histogramAccentColor: '#1EA7FD',
       label: 'Latency distribution',
-    }} >
-    {Template.bind({})}
-  </Story>
+    }}
+    render={(args, { argTypes }) => ({
+      components: { Histogram },
+      props: Object.keys(argTypes),
+      template: `<Histogram v-bind="$props" v-on="$props" />`,
+    })} />
 </Canvas>
 ```

--- a/docs/snippets/vue/histogram-story.mdx-3.mdx
+++ b/docs/snippets/vue/histogram-story.mdx-3.mdx
@@ -7,13 +7,11 @@ import Histogram from './Histogram.vue';
 
 <Meta title="Histogram" component={Histogram} />
 
-export const Template = (args) => ({
-  components: { Histogram },
-  setup() {
-    return { args };
-  },
-  template: '<Histogram v-bind="args" />',
-});
+<!--
+ 👇 Render functions are a framework specific feature to allow you control on how the component renders.
+  See https://storybook.js.org/docs/7.0/vue/api/csf
+  to learn how to use render functions.
+-->
 
 <Canvas>
   <Story
@@ -23,8 +21,13 @@ export const Template = (args) => ({
       showHistogramLabels: true,
       histogramAccentColor: '#1EA7FD',
       label: 'Latency distribution',
-    }} >
-    {Template.bind({})}
-  </Story>
+    }}
+    render={(args) => ({
+      components: { Histogram },
+      setup() {
+        return { args };
+      },
+      template: '<Histogram v-bind="args" />',
+    })} />
 </Canvas>
 ```

--- a/docs/snippets/vue/histogram-story.ts-2.ts.mdx
+++ b/docs/snippets/vue/histogram-story.ts-2.ts.mdx
@@ -1,30 +1,35 @@
 ```ts
 // Histogram.stories.ts
 
-import { Meta, StoryFn } from '@storybook/vue';
+import type { Meta, Story } from '@storybook/vue';
 
 import Histogram from './Histogram.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
   component: Histogram,
 } as Meta<typeof Histogram>;
 
-const Template: StoryFn<typeof Histogram> = (args, { argTypes }) => ({
-  components: { Button },
-  props: Object.keys(argTypes),
-  template: '<Histogram v-bind="$props" v-on="$props" />',
-});
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * to learn how to use render functions.
+ */
+export const Default: Story = {
+  render: (args, { argTypes }) => ({
+    components: { Button },
+    props: Object.keys(argTypes),
+    template: '<Histogram v-bind="$props" v-on="$props" />',
+  }),
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
+  },
 };
 ```

--- a/docs/snippets/vue/histogram-story.ts-3.ts.mdx
+++ b/docs/snippets/vue/histogram-story.ts-3.ts.mdx
@@ -1,33 +1,37 @@
 ```ts
 // Histogram.stories.ts
 
-import { Meta, StoryFn } from '@storybook/vue3';
+import type { Meta, Story } from '@storybook/vue3';
 
 import Histogram from './Histogram.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
   component: Histogram,
 } as Meta<typeof Histogram>;
 
-//👇 We create a “template” of how args map to rendering
-const Template: StoryFn<typeof Histogram> = (args) => ({
-  components: { Histogram },
-  setup() {
-    return { args };
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * to learn how to use render functions.
+ */
+export const Default: Story = {
+  render: (args) => ({
+    components: { Histogram },
+    setup() {
+      return { args };
+    },
+    template: '<Histogram v-bind="args" />',
+  }),
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
   },
-  template: '<Histogram v-bind="args" />',
-});
-
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
 };
 ```

--- a/docs/snippets/web-components/histogram-story.js.mdx
+++ b/docs/snippets/web-components/histogram-story.js.mdx
@@ -7,26 +7,32 @@ import './histogram-component';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/web-components/configure/overview
+   * See https://storybook.js.org/docs/7.0/web-components/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
 };
 
-const Template = ({ dataType, showHistogramLabels, histogramAccentColor, label }) => html`
-  <histogram-component
-    .dataType=${dataType}
-    .showHistogramLabels=${showHistogramLabels}
-    .histogramAccentColor=${histogramAccentColor}
-    .label=${label}
-  ></histogram-component>
-`;
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * to learn how to use render functions.
+ */
 
-export const Default = Template.bind({});
-Default.args = {
-  dataType: 'latency',
-  showHistogramLabels: true,
-  histogramAccentColor: '#1EA7FD',
-  label: 'Latency distribution',
+export const Default = {
+  render: ({ dataType, showHistogramLabels, histogramAccentColor, label }) => html`
+    <histogram-component
+      .dataType=${dataType}
+      .showHistogramLabels=${showHistogramLabels}
+      .histogramAccentColor=${histogramAccentColor}
+      .label=${label}
+    ></histogram-component>
+  `,
+  args: {
+    dataType: 'latency',
+    showHistogramLabels: true,
+    histogramAccentColor: '#1EA7FD',
+    label: 'Latency distribution',
+  },
 };
 ```


### PR DESCRIPTION
With this pull request the recently introduced examples for the Why page in the Storybook docs are updated to CSF3.

What was done:
- Updated the existing snippets to CSF3