### PR TITLE
TypeScript: Revert a few @ts-expect-errors

### DIFF
--- a/code/lib/api/src/modules/versions.ts
+++ b/code/lib/api/src/modules/versions.ts
@@ -1,5 +1,5 @@
 import global from 'global';
-// @ts-expect-error no typedefs
+// @ts-ignore (FIXME should be expect-error no typedefs but fails build --prep)
 import semver from '@storybook/semver';
 import memoize from 'memoizerific';
 

--- a/code/lib/builder-webpack5/src/index.ts
+++ b/code/lib/builder-webpack5/src/index.ts
@@ -72,7 +72,7 @@ export const bail: WebpackBuilder['bail'] = async () => {
   }
   // we wait for the compiler to finish it's work, so it's command-line output doesn't interfere
   return new Promise((res, rej) => {
-    // @ts-expect-error (Converted from ts-ignore)
+    // @ts-ignore (FIXME: should be expect-error but fails build --prep)
     if (process && compilation) {
       try {
         compilation.close(() => res());
@@ -219,7 +219,7 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
 
       logger.trace({ message: '=> Preview built', time: process.hrtime(startTime) });
       if (stats && stats.hasWarnings()) {
-        // @ts-expect-error (Converted from ts-ignore)
+        // @ts-ignore (FIXME should be @ts-expect-error but fails build --prep)
         stats
           .toJson({ warnings: true } as StatsOptions)
           .warnings.forEach((e) => logger.warn(e.message));

--- a/code/lib/core-common/src/utils/envs.ts
+++ b/code/lib/core-common/src/utils/envs.ts
@@ -1,4 +1,4 @@
-// @ts-expect-error does not have defs, but universal-dotenv is in TS now
+// @ts-ignore (FIXME should be "@ts-expect-error does not have defs, but universal-dotenv is in TS now" but fails build --prep)
 import { getEnvironment } from 'lazy-universal-dotenv';
 import { nodePathsToArray } from './paths';
 

--- a/code/lib/core-common/src/utils/normalize-stories.ts
+++ b/code/lib/core-common/src/utils/normalize-stories.ts
@@ -15,7 +15,7 @@ const DEFAULT_FILES = '**/*.@(mdx|stories.mdx|stories.tsx|stories.ts|stories.jsx
 // TODO: remove - LEGACY support for bad glob patterns we had in SB 5 - remove in SB7
 const fixBadGlob = deprecate(
   (match: RegExpMatchArray) => {
-    // @ts-expect-error this will get removed later anyway
+    // @ts-ignore (FIXME should be "@ts-expect-error this will get removed later anyway" but fails build --prep)
     return match.input.replace(match[1], `@${match[1]}`);
   },
   dedent`

--- a/code/lib/preview-web/src/render/StoryRender.ts
+++ b/code/lib/preview-web/src/render/StoryRender.ts
@@ -40,7 +40,7 @@ function createController(): AbortController {
   return {
     signal: { aborted: false },
     abort() {
-      // @ts-expect-error (Converted from ts-ignore)
+      // @ts-ignore (should be @ts-expect-error but fails build --prep)
       this.signal.aborted = true;
     },
   } as AbortController;


### PR DESCRIPTION
Issue: N/A

## What I did

Reverts a few lines from https://github.com/storybookjs/storybook/pull/19122

The analysis done by `yarn bootstrap --core` and `yarn bootstrap --prep` is subtly different, meaning that a few "expect-errors" are not actually errors in `bootstrap --prep`. As I understand it, `yarn bootstrap --core` stops analysis at package boundaries, whereas `bootstrap --prep` actually analyzes across packages (kind of like inlining one package in another), so the results are slightly different.

This PR is a workaround to get things moving, since the nightly repro template generation job is currently failing based on these errors. The real fix is to dive into the specific errors and fix them.

Self-merging @IanVS @ndelangen 

## How to test

Before & after this change:

```
yarn build --prep
```