### PR TITLE
web-components -> Changed slot behavior and fixed order of fields

### DIFF
--- a/app/web-components/package.json
+++ b/app/web-components/package.json
@@ -63,6 +63,7 @@
     "@types/webpack-env": "^1.16.0",
     "babel-plugin-bundled-import-meta": "^0.3.1",
     "core-js": "^3.8.2",
+    "custom-elements-manifest": "^2.0.0",
     "global": "^4.4.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/app/web-components/src/client/docs/custom-elements.ts
+++ b/app/web-components/src/client/docs/custom-elements.ts
@@ -71,8 +71,19 @@ function mapData(data: TagItem[], category: string) {
 }
 
 function mapItem(item: TagItem, category: string): ArgType {
-  const type =
-    category === 'properties' ? { name: item.type?.text || item.type } : { name: 'void' };
+  let type;
+  switch (category) {
+    case 'attributes':
+    case 'properties':
+      type = { name: item.type?.text || item.type };
+      break;
+    case 'slots':
+      type = { name: 'string' };
+      break;
+    default:
+      type = { name: 'void' };
+      break;
+  }
 
   return {
     name: item.name,
@@ -138,9 +149,9 @@ export const extractArgTypesFromElements = (tagName: string, customElements: Cus
   const metaData = getMetaData(tagName, customElements);
   return (
     metaData && {
-      ...mapData(metaData.attributes, 'attributes'),
       ...mapData(metaData.members, 'properties'),
       ...mapData(metaData.properties, 'properties'),
+      ...mapData(metaData.attributes, 'attributes'),
       ...mapData(metaData.events, 'events'),
       ...mapData(metaData.slots, 'slots'),
       ...mapData(metaData.cssProperties, 'css custom properties'),

--- a/examples/web-components-kitchen-sink/custom-elements.json
+++ b/examples/web-components-kitchen-sink/custom-elements.json
@@ -1,5 +1,6 @@
 {
-  "schemaVersion": "1.0.0",
+  "$schema": "./node_modules/custom-elements-manifest/schema.json",
+  "schemaVersion": "2.0.0",
   "readme": "",
   "modules": [
     {
@@ -131,6 +132,12 @@
             "name": "LitElement",
             "package": "lit"
           },
+          "slots": [
+            {
+              "name": "prefix",
+              "description": "Label prefix"
+            }
+          ],
           "tagName": "sb-button",
           "summary": "This is a simple Storybook Button",
           "customElement": true

--- a/examples/web-components-kitchen-sink/src/components/sb-button.stories.ts
+++ b/examples/web-components-kitchen-sink/src/components/sb-button.stories.ts
@@ -4,6 +4,10 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { SbButton } from './sb-button';
 
+interface SbButtonSlots extends SbButton {
+  prefix: string;
+}
+
 export default {
   title: 'Example/Button',
   // Need to set the tag to make addon-docs works properly with CustomElementsManifest
@@ -18,32 +22,33 @@ export default {
   },
 } as Meta;
 
-const Template: Story<SbButton> = ({ primary, backgroundColor, size, label }) =>
+const Template: Story<SbButtonSlots> = ({ primary, backgroundColor, size, label, prefix }) =>
   html`<sb-button
     ?primary="${primary}"
     size="${ifDefined(size)}"
     label="${ifDefined(label)}"
     background-color="${ifDefined(backgroundColor)}"
-  ></sb-button>`;
+    ><span slot="prefix">${prefix}</span></sb-button
+  >`;
 
-export const Primary: Story<SbButton> = Template.bind({});
+export const Primary: Story<SbButtonSlots> = Template.bind({});
 Primary.args = {
   primary: true,
   label: 'Button',
 };
 
-export const Secondary: Story<SbButton> = Template.bind({});
+export const Secondary: Story<SbButtonSlots> = Template.bind({});
 Secondary.args = {
   label: 'Button',
 };
 
-export const Large: Story<SbButton> = Template.bind({});
+export const Large: Story<SbButtonSlots> = Template.bind({});
 Large.args = {
   size: 'large',
   label: 'Button',
 };
 
-export const Small: Story<SbButton> = Template.bind({});
+export const Small: Story<SbButtonSlots> = Template.bind({});
 Small.args = {
   size: 'small',
   label: 'Button',

--- a/examples/web-components-kitchen-sink/src/components/sb-button.ts
+++ b/examples/web-components-kitchen-sink/src/components/sb-button.ts
@@ -94,7 +94,7 @@ export class SbButton extends LitElement {
         style=${style}
         @click="${this.onClick}"
       >
-        ${this.label}
+        <slot name="prefix"></slot> ${this.label}
       </button>
     `;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9054,6 +9054,7 @@ __metadata:
     "@types/webpack-env": ^1.16.0
     babel-plugin-bundled-import-meta: ^0.3.1
     core-js: ^3.8.2
+    custom-elements-manifest: ^2.0.0
     global: ^4.4.0
     lit-html: 2.0.2
     react: 16.14.0
@@ -18834,6 +18835,13 @@ __metadata:
   dependencies:
     array-find-index: ^1.0.1
   checksum: 32d197689ec32f035910202c1abb0dc6424dce01d7b51779c685119b380d98535c110ffff67a262fc7e367612a7dfd30d3d3055f9a6634b5a9dd1302de7ef11c
+  languageName: node
+  linkType: hard
+
+"custom-elements-manifest@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "custom-elements-manifest@npm:2.0.0"
+  checksum: 0499cc63e87813fbd895ad4d23657b371842ce2b632d83c1f5ab272784be4f9f78be693fe9a73370ae7fdb0bf5830cf6ee03ef8c3f27ae8922c8a156da71bebb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes:
- https://github.com/storybookjs/storybook/issues/19167
- https://github.com/storybookjs/storybook/issues/18858

## What I did
- Installed the newest version of the custom element manifest to get typings and schema validation
- Changed mapping of manifest fields to automatically set content type of slot to "string"
  - Attributes and properties have the same behavior on this mapping now
- Changed order of property mapping
- Added interface that contains the properties for slots
- Updated default story of button component to use slot

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
