### PR TITLE
Alias decorateStory as applyDecorators for angular integration

### DIFF
--- a/code/frameworks/angular/src/client/config.ts
+++ b/code/frameworks/angular/src/client/config.ts
@@ -1,6 +1,6 @@
 import './globals';
 
 export { render, renderToDOM } from './render';
-export { decorateStory } from './decorateStory';
+export { decorateStory as applyDecorators } from './decorateStory';
 
 export const parameters = { framework: 'angular' as const };


### PR DESCRIPTION
Change Angular integration to export decorateStory as applyDecorators

Issue: #17330

## What I did

Changed the decorateStory export to applyDecorators in the angular client config.ts

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
