### PR TITLE
React: fix typo in react snippet component comment

### DIFF
--- a/docs/snippets/react/your-component.js.mdx
+++ b/docs/snippets/react/your-component.js.mdx
@@ -6,7 +6,7 @@ import { YourComponent } from './YourComponent';
 //👇 This default export determines where your story goes in the story list
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/eact/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',


### PR DESCRIPTION
Issue:
Typo in react story snippet comment. This does not affect any production code

## What I did
Fix the typo

## How to test
- [x] Click on the link from your IDE