### PR TITLE
Vite: Support runStep in Vite builder SSv6

### DIFF
--- a/code/lib/builder-vite/src/codegen-iframe-script.ts
+++ b/code/lib/builder-vite/src/codegen-iframe-script.ts
@@ -39,6 +39,8 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
       addDecorator,
       addParameters,
       addLoader,
+      addArgs,
+      addArgTypes,
       addArgTypesEnhancer,
       addArgsEnhancer,
       setGlobalRender,
@@ -53,22 +55,10 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
         const value = config[key];
         switch (key) {
           case 'args': {
-            if (typeof clientApi.addArgs !== "undefined") {
-              return clientApi.addArgs(value);
-            } else {
-              return logger.warn(
-                "Could not add global args. Please open an issue in storybookjs/builder-vite."
-              );
-            }
+            return addArgs(value);
           }
           case 'argTypes': {
-            if (typeof clientApi.addArgTypes !== "undefined") {
-              return clientApi.addArgTypes(value);
-            } else {
-              return logger.warn(
-                "Could not add global argTypes. Please open an issue in storybookjs/builder-vite."
-              );
-            }
+            return addArgTypes(value);
           }
           case 'decorators': {
             return value.forEach((decorator) => addDecorator(decorator, false));

--- a/code/lib/builder-vite/src/codegen-iframe-script.ts
+++ b/code/lib/builder-vite/src/codegen-iframe-script.ts
@@ -41,6 +41,7 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
       addLoader,
       addArgs,
       addArgTypes,
+      addStepRunner,
       addArgTypesEnhancer,
       addArgsEnhancer,
       setGlobalRender,
@@ -88,6 +89,9 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
           case 'applyDecorators':
           case 'renderToDOM': {
             return null; // This key is not handled directly in v6 mode.
+          }
+          case 'runStep': {
+            return addStepRunner(value);
           }
           default: {
             // eslint-disable-next-line prefer-template


### PR DESCRIPTION
Issue: N/A

Ref: https://github.com/storybookjs/storybook/pull/18555#issuecomment-1253739956

## What I did

Support for `runStep` in story store v6 was added to the Webpack builder, but not Vite.  This adds it to vite as well, and cleans up some conditional calls which were necessary before.  Previously, we didn't have any guarantee which version of storybook the builder was being used with.  Now that it's in the monorepo, it'll be versioned together with the rest of storybook.

## How to test

CI, though I'm not sure there are any `step` functions being executed in tests, or else the Vite builder would have failed previously, I think...