### PR TITLE
React: Sound arg types for CSF3

### DIFF
--- a/code/addons/a11y/package.json
+++ b/code/addons/a11y/package.json
@@ -69,7 +69,7 @@
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/components": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/theming": "7.0.0-alpha.35",
     "axe-core": "^4.2.0",
     "global": "^4.4.0",

--- a/code/addons/actions/package.json
+++ b/code/addons/actions/package.json
@@ -63,7 +63,7 @@
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/components": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/theming": "7.0.0-alpha.35",
     "dequal": "^2.0.2",
     "global": "^4.4.0",

--- a/code/addons/backgrounds/package.json
+++ b/code/addons/backgrounds/package.json
@@ -67,7 +67,7 @@
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/components": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/theming": "7.0.0-alpha.35",
     "global": "^4.4.0",
     "memoizerific": "^1.11.3",

--- a/code/addons/controls/package.json
+++ b/code/addons/controls/package.json
@@ -63,7 +63,7 @@
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/components": "7.0.0-alpha.35",
     "@storybook/core-common": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/node-logger": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",
     "@storybook/theming": "7.0.0-alpha.35",

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -59,7 +59,7 @@
     "@storybook/components": "7.0.0-alpha.35",
     "@storybook/core-common": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/csf-tools": "7.0.0-alpha.35",
     "@storybook/docs-tools": "7.0.0-alpha.35",
     "@storybook/mdx1-csf": "0.0.5-canary.13.9ce928a.0",

--- a/code/addons/interactions/package.json
+++ b/code/addons/interactions/package.json
@@ -65,7 +65,7 @@
     "@storybook/components": "7.0.0-alpha.35",
     "@storybook/core-common": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/instrumenter": "7.0.0-alpha.35",
     "@storybook/theming": "7.0.0-alpha.35",
     "global": "^4.4.0",

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -66,7 +66,7 @@
     "@storybook/addons": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/router": "7.0.0-alpha.35",
     "global": "^4.4.0",
     "prop-types": "^15.7.2",

--- a/code/addons/measure/package.json
+++ b/code/addons/measure/package.json
@@ -66,7 +66,7 @@
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/components": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "global": "^4.4.0"
   },
   "devDependencies": {

--- a/code/addons/outline/package.json
+++ b/code/addons/outline/package.json
@@ -69,7 +69,7 @@
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/components": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "global": "^4.4.0",
     "ts-dedent": "^2.0.0"
   },

--- a/code/addons/storyshots/storyshots-core/package.json
+++ b/code/addons/storyshots/storyshots-core/package.json
@@ -44,7 +44,7 @@
     "@storybook/core-client": "7.0.0-alpha.35",
     "@storybook/core-common": "7.0.0-alpha.35",
     "@storybook/core-webpack": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.16",
     "@types/jest-specific-snapshot": "^0.5.3",

--- a/code/addons/storyshots/storyshots-puppeteer/package.json
+++ b/code/addons/storyshots/storyshots-puppeteer/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@axe-core/puppeteer": "^4.2.0",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/node-logger": "7.0.0-alpha.35",
     "@types/jest-image-snapshot": "^4.1.3",
     "jest-image-snapshot": "^4.3.0"

--- a/code/examples/external-docs/package.json
+++ b/code/examples/external-docs/package.json
@@ -15,7 +15,7 @@
     "@storybook/addon-essentials": "7.0.0-alpha.35",
     "@storybook/blocks": "7.0.0-alpha.35",
     "@storybook/components": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/preview-web": "7.0.0-alpha.35",
     "@storybook/react": "7.0.0-alpha.35",
     "@storybook/react-webpack5": "7.0.0-alpha.35",

--- a/code/frameworks/angular/package.json
+++ b/code/frameworks/angular/package.json
@@ -42,7 +42,7 @@
     "@storybook/core-common": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
     "@storybook/core-server": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/docs-tools": "7.0.0-alpha.35",
     "@storybook/node-logger": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",

--- a/code/lib/addons/package.json
+++ b/code/lib/addons/package.json
@@ -46,7 +46,7 @@
     "@storybook/channels": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/router": "7.0.0-alpha.35",
     "@storybook/theming": "7.0.0-alpha.35",
     "global": "^4.4.0"

--- a/code/lib/api/package.json
+++ b/code/lib/api/package.json
@@ -48,7 +48,7 @@
     "@storybook/channels": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/router": "7.0.0-alpha.35",
     "@storybook/theming": "7.0.0-alpha.35",
     "dequal": "^2.0.2",

--- a/code/lib/blocks/package.json
+++ b/code/lib/blocks/package.json
@@ -46,7 +46,7 @@
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/components": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/docs-tools": "7.0.0-alpha.35",
     "@storybook/preview-web": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",

--- a/code/lib/client-api/package.json
+++ b/code/lib/client-api/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/store": "7.0.0-alpha.35",
     "@types/qs": "^6.9.5",
     "@types/webpack-env": "^1.16.4",

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/types": "^7.12.11",
     "@mdx-js/mdx": "^1.6.22",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/csf-tools": "7.0.0-alpha.35",
     "@storybook/node-logger": "7.0.0-alpha.35",
     "cross-spawn": "^7.0.3",

--- a/code/lib/components/package.json
+++ b/code/lib/components/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@storybook/client-logger": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/theming": "7.0.0-alpha.35",
     "memoizerific": "^1.11.3",
     "util-deprecate": "^1.0.2"

--- a/code/lib/core-client/package.json
+++ b/code/lib/core-client/package.json
@@ -41,7 +41,7 @@
     "@storybook/client-api": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/preview-web": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",
     "@storybook/ui": "7.0.0-alpha.35",

--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.12.10",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/node-logger": "7.0.0-alpha.35",
     "@types/babel__core": "^7.0.0",
     "@types/express": "^4.7.0",

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -39,7 +39,7 @@
     "@storybook/core-client": "7.0.0-alpha.35",
     "@storybook/core-common": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/csf-tools": "7.0.0-alpha.35",
     "@storybook/docs-mdx": "0.0.1-canary.12433cf.0",
     "@storybook/node-logger": "7.0.0-alpha.35",

--- a/code/lib/csf-tools/package.json
+++ b/code/lib/csf-tools/package.json
@@ -46,7 +46,7 @@
     "@babel/parser": "^7.12.11",
     "@babel/traverse": "^7.12.11",
     "@babel/types": "^7.12.11",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "fs-extra": "^9.0.1",
     "ts-dedent": "^2.0.0"
   },

--- a/code/lib/docs-tools/package.json
+++ b/code/lib/docs-tools/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.12.10",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/store": "7.0.0-alpha.35",
     "doctrine": "^3.0.0",
     "lodash": "^4.17.21"

--- a/code/lib/preview-web/package.json
+++ b/code/lib/preview-web/package.json
@@ -38,7 +38,7 @@
     "@storybook/channels": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/store": "7.0.0-alpha.35",
     "ansi-to-html": "^0.6.11",
     "global": "^4.4.0",

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -43,7 +43,7 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "estraverse": "^5.2.0",
     "lodash": "^4.17.21",
     "prettier": ">=2.2.1 <=2.3.0"

--- a/code/lib/store/package.json
+++ b/code/lib/store/package.json
@@ -45,7 +45,7 @@
     "@storybook/addons": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "dequal": "^2.0.2",
     "global": "^4.4.0",
     "lodash": "^4.17.21",

--- a/code/lib/ui/package.json
+++ b/code/lib/ui/package.json
@@ -61,7 +61,7 @@
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/components": "7.0.0-alpha.35",
     "@storybook/core-events": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/router": "7.0.0-alpha.35",
     "@storybook/theming": "7.0.0-alpha.35",
     "@testing-library/react": "^11.2.2",

--- a/code/renderers/html/package.json
+++ b/code/renderers/html/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.35",
     "@storybook/core-client": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/docs-tools": "7.0.0-alpha.35",
     "@storybook/preview-web": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",

--- a/code/renderers/preact/package.json
+++ b/code/renderers/preact/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.35",
     "@storybook/core-client": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/store": "7.0.0-alpha.35",
     "global": "^4.4.0",
     "react": "16.14.0",

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -54,7 +54,7 @@
     "@storybook/addons": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/core-client": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/docs-tools": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",
     "@types/estree": "^0.0.51",
@@ -69,11 +69,14 @@
     "prop-types": "^15.7.2",
     "react-element-to-jsx-string": "^15.0.0",
     "ts-dedent": "^2.0.0",
+    "type-fest": "^2.19.0",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.11.5",
+    "@jest/globals": "^26.6.2",
     "@types/util-deprecate": "^1.0.0",
+    "expect-type": "^0.14.2",
     "jest-specific-snapshot": "^4.0.0",
     "require-from-string": "^2.0.2",
     "typescript": "~4.6.3"

--- a/code/renderers/react/src/__test__/CSF3.test.tsx
+++ b/code/renderers/react/src/__test__/CSF3.test.tsx
@@ -1,0 +1,181 @@
+import React, { KeyboardEventHandler, ReactNode } from 'react';
+import { expectTypeOf } from 'expect-type';
+import { describe, test } from '@jest/globals';
+import { StoryAnnotations } from '@storybook/csf';
+import { SetOptional } from 'type-fest';
+
+import { Meta, StoryObj } from '../public-types';
+import { DecoratorFn } from '../public-api';
+import { satisfies } from './utils';
+import { ReactFramework } from '../types';
+
+type ReactStory<Args, RequiredArgs> = StoryAnnotations<ReactFramework, Args, RequiredArgs>;
+
+type ButtonProps = { label: string; disabled: boolean };
+const Button: (props: ButtonProps) => JSX.Element = () => <></>;
+
+describe('Args can be provided in multiple ways', () => {
+  test('✅ All required args may be provided in meta', () => {
+    const meta = satisfies<Meta<typeof Button>>()({
+      component: Button,
+      args: { label: 'good', disabled: false },
+    });
+
+    type Story = StoryObj<typeof meta>;
+    const Basic: Story = {};
+
+    expectTypeOf(Basic).toEqualTypeOf<
+      ReactStory<ButtonProps, SetOptional<ButtonProps, 'label' | 'disabled'>>
+    >();
+  });
+
+  test('✅ Required args may be provided partial in meta and the story', () => {
+    const meta = satisfies<Meta<typeof Button>>()({
+      component: Button,
+      args: { label: 'good' },
+    });
+    const Basic: StoryObj<typeof meta> = {
+      args: { disabled: false },
+    };
+
+    type Expected = ReactStory<ButtonProps, SetOptional<ButtonProps, 'label'>>;
+    expectTypeOf(Basic).toEqualTypeOf<Expected>();
+  });
+
+  test('❌ The combined shape of meta args and story args must match the required args.', () => {
+    {
+      const meta = satisfies<Meta<typeof Button>>()({ component: Button });
+      const Basic: StoryObj<typeof meta> = {
+        // @ts-expect-error disabled not provided ❌
+        args: { label: 'good' },
+      };
+
+      type Expected = ReactStory<ButtonProps, ButtonProps>;
+      expectTypeOf(Basic).toEqualTypeOf<Expected>();
+    }
+    {
+      const meta = satisfies<Meta<typeof Button>>()({
+        component: Button,
+        args: { label: 'good' },
+      });
+      // @ts-expect-error disabled not provided ❌
+      const Basic: StoryObj<typeof meta> = {};
+
+      type Expected = ReactStory<ButtonProps, SetOptional<ButtonProps, 'label'>>;
+      expectTypeOf(Basic).toEqualTypeOf<Expected>();
+    }
+    {
+      const meta = satisfies<Meta<ButtonProps>>()({ component: Button });
+      const Basic: StoryObj<typeof meta> = {
+        // @ts-expect-error disabled not provided ❌
+        args: { label: 'good' },
+      };
+
+      type Expected = ReactStory<ButtonProps, ButtonProps>;
+      expectTypeOf(Basic).toEqualTypeOf<Expected>();
+    }
+  });
+});
+
+test('✅ All void functions are optional', () => {
+  interface CmpProps {
+    label: string;
+    disabled: boolean;
+    onClick(): void;
+    onKeyDown: KeyboardEventHandler;
+    onLoading: (s: string) => JSX.Element;
+    submitAction(): void;
+  }
+
+  const Cmp: (props: CmpProps) => JSX.Element = () => <></>;
+
+  const meta = satisfies<Meta<CmpProps>>()({
+    component: Cmp,
+    args: { label: 'good' },
+  });
+
+  const Basic: StoryObj<typeof meta> = {
+    args: { disabled: false, onLoading: () => <div>Loading...</div> },
+  };
+
+  type Expected = ReactStory<
+    CmpProps,
+    SetOptional<CmpProps, 'label' | 'onClick' | 'onKeyDown' | 'submitAction'>
+  >;
+  expectTypeOf(Basic).toEqualTypeOf<Expected>();
+});
+
+type ThemeData = 'light' | 'dark';
+declare const Theme: (props: { theme: ThemeData; children?: ReactNode }) => JSX.Element;
+
+describe('Story args can be inferred', () => {
+  test('Correct args are inferred when type is widened for render function', () => {
+    type Props = ButtonProps & { theme: ThemeData };
+
+    const meta = satisfies<Meta<Props>>()({
+      component: Button,
+      args: { disabled: false },
+      render: (args, { component }) => {
+        // component is not null as it is provided in meta
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const Component = component!;
+        return (
+          <Theme theme={args.theme}>
+            <Component {...args} />
+          </Theme>
+        );
+      },
+    });
+
+    const Basic: StoryObj<typeof meta> = { args: { theme: 'light', label: 'good' } };
+
+    type Expected = ReactStory<Props, SetOptional<Props, 'disabled'>>;
+    expectTypeOf(Basic).toEqualTypeOf<Expected>();
+  });
+
+  const withDecorator: DecoratorFn<{ decoratorArg: number }> = (Story, { args }) => (
+    <>
+      Decorator: {args.decoratorArg}
+      <Story args={{ decoratorArg: 0 }} />
+    </>
+  );
+
+  test('Correct args are inferred when type is widened for decorators', () => {
+    type Props = ButtonProps & { decoratorArg: number };
+
+    const meta = satisfies<Meta<Props>>()({
+      component: Button,
+      args: { disabled: false },
+      decorators: [withDecorator],
+    });
+
+    const Basic: StoryObj<typeof meta> = { args: { decoratorArg: 0, label: 'good' } };
+
+    type Expected = ReactStory<Props, SetOptional<Props, 'disabled'>>;
+    expectTypeOf(Basic).toEqualTypeOf<Expected>();
+  });
+
+  test('Correct args are inferred when type is widened for multiple decorators', () => {
+    type Props = ButtonProps & { decoratorArg: number; decoratorArg2: string };
+
+    const secondDecorator: DecoratorFn<{ decoratorArg2: string }> = (Story, { args }) => (
+      <>
+        Decorator: {args.decoratorArg2}
+        <Story />
+      </>
+    );
+
+    const meta = satisfies<Meta<Props>>()({
+      component: Button,
+      args: { disabled: false },
+      decorators: [withDecorator, secondDecorator],
+    });
+
+    const Basic: StoryObj<typeof meta> = {
+      args: { decoratorArg: 0, decoratorArg2: '', label: 'good' },
+    };
+
+    type Expected = ReactStory<Props, SetOptional<Props, 'disabled'>>;
+    expectTypeOf(Basic).toEqualTypeOf<Expected>();
+  });
+});

--- a/code/renderers/react/src/__test__/utils.ts
+++ b/code/renderers/react/src/__test__/utils.ts
@@ -1,0 +1,6 @@
+/**
+ * Mimicking the satisfies operator until we can upgrade to TS4.9
+ */
+export function satisfies<A>() {
+  return <T extends A>(x: T) => x;
+}

--- a/code/renderers/react/src/public-api.test.ts
+++ b/code/renderers/react/src/public-api.test.ts
@@ -1,4 +1,5 @@
-/* eslint-disable global-require */
+import * as api from '.';
+
 describe('preview', () => {
   afterEach(() => {
     jest.resetModules();
@@ -7,13 +8,11 @@ describe('preview', () => {
   const isFunction = (value: unknown) => typeof value === 'function';
 
   it('should return the client api in a browser environment', () => {
-    const api = require('.');
     expect(Object.keys(api).length).toBeGreaterThan(0);
     expect(Object.values(api).every(isFunction)).toEqual(true);
   });
 
   it('should return the client api in a node.js environment', () => {
-    const api = require('.');
     expect(Object.keys(api).length).toBeGreaterThan(0);
     expect(Object.values(api).every(isFunction)).toEqual(true);
   });

--- a/code/renderers/react/src/public-api.tsx
+++ b/code/renderers/react/src/public-api.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable prefer-destructuring */
 import { start } from '@storybook/core-client';
 import type { ClientStoryApi, Loadable } from '@storybook/addons';
+import type { Args, DecoratorFunction } from '@storybook/csf';
 
 import { renderToDOM, render } from './render';
 import type { IStorybookSection, ReactFramework } from './types';
@@ -26,7 +27,7 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 export const configure: ClientApi['configure'] = (...args) => api.configure(FRAMEWORK, ...args);
 export const addDecorator: ClientApi['addDecorator'] = api.clientApi
   .addDecorator as ClientApi['addDecorator'];
-export type DecoratorFn = Parameters<typeof addDecorator>[0];
+export type DecoratorFn<TArgs = Args> = DecoratorFunction<ReactFramework, TArgs>;
 export const addParameters: ClientApi['addParameters'] = api.clientApi
   .addParameters as ClientApi['addParameters'];
 export const clearDecorators: ClientApi['clearDecorators'] = api.clientApi.clearDecorators;

--- a/code/renderers/react/src/public-types.ts
+++ b/code/renderers/react/src/public-types.ts
@@ -1,6 +1,16 @@
-import { AnnotatedStoryFn, Args, ComponentAnnotations, StoryAnnotations } from '@storybook/csf';
-import { ComponentProps, JSXElementConstructor } from 'react';
+import type {
+  AnnotatedStoryFn,
+  Args,
+  ArgsStoryFn,
+  ComponentAnnotations,
+  LoaderFunction,
+  StoryAnnotations,
+} from '@storybook/csf';
+import { SetOptional, Simplify, UnionToIntersection } from 'type-fest';
+import { ComponentProps, ComponentType, JSXElementConstructor } from 'react';
+
 import { ReactFramework } from './types';
+import { DecoratorFn } from './public-api';
 
 type JSXElement = keyof JSX.IntrinsicElements | JSXElementConstructor<any>;
 
@@ -9,7 +19,9 @@ type JSXElement = keyof JSX.IntrinsicElements | JSXElementConstructor<any>;
  *
  * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
  */
-export type Meta<TArgs = Args> = ComponentAnnotations<ReactFramework, TArgs>;
+export type Meta<CmpOrArgs = Args> = CmpOrArgs extends ComponentType<infer CmpArgs>
+  ? ComponentAnnotations<ReactFramework, CmpArgs>
+  : ComponentAnnotations<ReactFramework, CmpOrArgs>;
 
 /**
  * Story function that represents a CSFv2 component example.
@@ -23,9 +35,37 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<ReactFramework, TArgs>;
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryObj<TArgs = Args> = StoryAnnotations<ReactFramework, TArgs>;
+
+export type StoryObj<MetaOrArgs = Args> = MetaOrArgs extends {
+  render?: ArgsStoryFn<ReactFramework, infer RArgs>;
+  component?: ComponentType<infer CmpArgs>;
+  loaders?: (infer Loaders)[];
+  args?: infer DefaultArgs;
+  decorators?: (infer Decorators)[];
+}
+  ? Simplify<CmpArgs & RArgs & DecoratorsArgs<Decorators> & LoaderArgs<Loaders>> extends infer TArgs
+    ? StoryAnnotations<
+        ReactFramework,
+        TArgs,
+        SetOptional<TArgs, Extract<keyof TArgs, keyof (DefaultArgs & ActionArgs<TArgs>)>>
+      >
+    : never
+  : StoryAnnotations<ReactFramework, MetaOrArgs>;
+
+type DecoratorsArgs<Decorators> = UnionToIntersection<
+  Decorators extends DecoratorFn<infer Args> ? Args : unknown
+>;
+
+type LoaderArgs<Loaders> = UnionToIntersection<
+  Loaders extends LoaderFunction<ReactFramework, infer Args> ? Args : unknown
+>;
+
+type ActionArgs<Args> = {
+  [P in keyof Args as ((...args: any[]) => void) extends Args[P] ? P : never]: Args[P];
+};
 
 /**
+ * @deprecated Use `Meta` instead.
  * For the common case where a component's stories are simple components that receives args as props:
  *
  * ```tsx
@@ -44,6 +84,8 @@ export type ComponentMeta<T extends JSXElement> = Meta<ComponentProps<T>>;
 export type ComponentStoryFn<T extends JSXElement> = StoryFn<ComponentProps<T>>;
 
 /**
+ * @deprecated Use `StoryObj` instead.
+ *
  * For the common case where a (CSFv3) story is a simple component that receives args as props:
  *
  * ```tsx
@@ -56,14 +98,18 @@ export type ComponentStoryObj<T extends JSXElement> = StoryObj<ComponentProps<T>
 
 /**
 
-/**
+ /**
+ * @deprecated Use `StoryObj` instead.
+ *
  * Story function that represents a CSFv3 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryObj<TArgs>;
+export type Story<TArgs = Args> = StoryFn<TArgs>;
 
 /**
+ * @deprecated Use StoryObj instead.
+ *
  * For the common case where a (CSFv3) story is a simple component that receives args as props:
  *
  * ```tsx
@@ -71,4 +117,5 @@ export type Story<TArgs = Args> = StoryObj<TArgs>;
  *   args: { buttonArg1: 'val' },
  * }
  * ```
- */ export type ComponentStory<T extends JSXElement> = ComponentStoryObj<T>;
+ */
+export type ComponentStory<T extends JSXElement> = ComponentStoryObj<T>;

--- a/code/renderers/react/src/types.ts
+++ b/code/renderers/react/src/types.ts
@@ -1,12 +1,13 @@
 import type { ComponentType, ReactElement } from 'react';
+import type { AnyFramework } from '@storybook/csf';
 
 export type { RenderContext } from '@storybook/store';
 export type { StoryContext } from '@storybook/csf';
 
-export type ReactFramework = {
-  component: ComponentType<any>;
+export interface ReactFramework extends AnyFramework {
+  component: ComponentType<this['T']>;
   storyResult: StoryFnReactReturnType;
-};
+}
 
 export interface ShowErrorArgs {
   title: string;

--- a/code/renderers/react/tsconfig.json
+++ b/code/renderers/react/tsconfig.json
@@ -5,5 +5,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.*", "src/**/__testfixtures__/**"]
+  "exclude": ["src/docs/**/*.test.*", "src/**/__testfixtures__/**"]
 }

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.35",
     "@storybook/core-client": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/preview-web": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",
     "global": "^4.4.0",

--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -57,7 +57,7 @@
     "@storybook/addons": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/core-client": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/docs-tools": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",
     "global": "^4.4.0",

--- a/code/renderers/vue/package.json
+++ b/code/renderers/vue/package.json
@@ -53,7 +53,7 @@
     "@storybook/addons": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/core-client": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/docs-tools": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",
     "global": "^4.4.0",

--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.35",
     "@storybook/core-client": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/docs-tools": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",
     "global": "^4.4.0",

--- a/code/renderers/web-components/package.json
+++ b/code/renderers/web-components/package.json
@@ -56,7 +56,7 @@
     "@storybook/api": "7.0.0-alpha.35",
     "@storybook/client-logger": "7.0.0-alpha.35",
     "@storybook/core-client": "7.0.0-alpha.35",
-    "@storybook/csf": "0.0.2--canary.0899bb7.0",
+    "@storybook/csf": "0.0.2--canary.49.258942b.0",
     "@storybook/docs-tools": "7.0.0-alpha.35",
     "@storybook/preview-web": "7.0.0-alpha.35",
     "@storybook/store": "7.0.0-alpha.35",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6409,7 +6409,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/components": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/theming": 7.0.0-alpha.35
     "@testing-library/react": ^11.2.2
     axe-core: ^4.2.0
@@ -6439,7 +6439,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/components": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/theming": 7.0.0-alpha.35
     "@types/lodash": ^4.14.167
     dequal: ^2.0.2
@@ -6473,7 +6473,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/components": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/theming": 7.0.0-alpha.35
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -6501,7 +6501,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/components": 7.0.0-alpha.35
     "@storybook/core-common": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/node-logger": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
     "@storybook/theming": 7.0.0-alpha.35
@@ -6533,7 +6533,7 @@ __metadata:
     "@storybook/components": 7.0.0-alpha.35
     "@storybook/core-common": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/csf-tools": 7.0.0-alpha.35
     "@storybook/docs-tools": 7.0.0-alpha.35
     "@storybook/mdx1-csf": 0.0.5-canary.13.9ce928a.0
@@ -6643,7 +6643,7 @@ __metadata:
     "@storybook/components": 7.0.0-alpha.35
     "@storybook/core-common": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/instrumenter": 7.0.0-alpha.35
     "@storybook/jest": ^0.0.10
     "@storybook/testing-library": 0.0.14-next.0
@@ -6698,7 +6698,7 @@ __metadata:
     "@storybook/addons": 7.0.0-alpha.35
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/router": 7.0.0-alpha.35
     global: ^4.4.0
     prop-types: ^15.7.2
@@ -6724,7 +6724,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/components": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     global: ^4.4.0
     typescript: ~4.6.3
   peerDependencies:
@@ -6747,7 +6747,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/components": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     global: ^4.4.0
     ts-dedent: ^2.0.0
     typescript: ~4.6.3
@@ -6767,7 +6767,7 @@ __metadata:
   resolution: "@storybook/addon-storyshots-puppeteer@workspace:addons/storyshots/storyshots-puppeteer"
   dependencies:
     "@axe-core/puppeteer": ^4.2.0
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/node-logger": 7.0.0-alpha.35
     "@types/jest-image-snapshot": ^4.1.3
     "@types/puppeteer": ^5.4.0
@@ -6798,7 +6798,7 @@ __metadata:
     "@storybook/core-client": 7.0.0-alpha.35
     "@storybook/core-common": 7.0.0-alpha.35
     "@storybook/core-webpack": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/react": 7.0.0-alpha.35
     "@storybook/vue": 7.0.0-alpha.35
     "@storybook/vue3": 7.0.0-alpha.35
@@ -6970,7 +6970,7 @@ __metadata:
     "@storybook/channels": 7.0.0-alpha.35
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/router": 7.0.0-alpha.35
     "@storybook/theming": 7.0.0-alpha.35
     global: ^4.4.0
@@ -7027,7 +7027,7 @@ __metadata:
     "@storybook/core-common": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
     "@storybook/core-server": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/docs-tools": 7.0.0-alpha.35
     "@storybook/node-logger": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
@@ -7099,7 +7099,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-common": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/router": 7.0.0-alpha.35
     "@storybook/theming": 7.0.0-alpha.35
     "@types/lodash": ^4.14.167
@@ -7168,7 +7168,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/components": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/docs-tools": 7.0.0-alpha.35
     "@storybook/preview-web": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
@@ -7404,7 +7404,7 @@ __metadata:
     "@storybook/addons": 7.0.0-alpha.35
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-common": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/store": 7.0.0-alpha.35
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.4
@@ -7445,7 +7445,7 @@ __metadata:
   dependencies:
     "@babel/types": ^7.12.11
     "@mdx-js/mdx": ^1.6.22
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/csf-tools": 7.0.0-alpha.35
     "@storybook/node-logger": 7.0.0-alpha.35
     cross-spawn: ^7.0.3
@@ -7466,7 +7466,7 @@ __metadata:
   dependencies:
     "@popperjs/core": ^2.6.0
     "@storybook/client-logger": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/theming": 7.0.0-alpha.35
     "@types/overlayscrollbars": ^1.12.0
     "@types/react-syntax-highlighter": 11.0.5
@@ -7499,7 +7499,7 @@ __metadata:
     "@storybook/client-api": 7.0.0-alpha.35
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/preview-web": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
     "@storybook/ui": 7.0.0-alpha.35
@@ -7518,7 +7518,7 @@ __metadata:
   resolution: "@storybook/core-common@workspace:lib/core-common"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/node-logger": 7.0.0-alpha.35
     "@types/babel__core": ^7.0.0
     "@types/express": ^4.7.0
@@ -7584,7 +7584,7 @@ __metadata:
     "@storybook/core-client": 7.0.0-alpha.35
     "@storybook/core-common": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/csf-tools": 7.0.0-alpha.35
     "@storybook/docs-mdx": 0.0.1-canary.12433cf.0
     "@storybook/node-logger": 7.0.0-alpha.35
@@ -7660,7 +7660,7 @@ __metadata:
     "@babel/parser": ^7.12.11
     "@babel/traverse": ^7.12.11
     "@babel/types": ^7.12.11
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@types/fs-extra": ^9.0.6
     fs-extra: ^9.0.1
     js-yaml: ^3.14.1
@@ -7669,21 +7669,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/csf@npm:0.0.2--canary.0899bb7.0":
-  version: 0.0.2--canary.0899bb7.0
-  resolution: "@storybook/csf@npm:0.0.2--canary.0899bb7.0"
-  dependencies:
-    lodash: ^4.17.15
-  checksum: 5cd7b51980a62be01bbfa54a010a7691690198bba6a9f5bd05b46688e4bdffb2cc1bbb5d90cf578c635a79bd1d616d5901c774fb0976fe9d6bc946749fc51861
-  languageName: node
-  linkType: hard
-
 "@storybook/csf@npm:0.0.2--canary.4566f4d.1":
   version: 0.0.2--canary.4566f4d.1
   resolution: "@storybook/csf@npm:0.0.2--canary.4566f4d.1"
   dependencies:
     lodash: ^4.17.15
   checksum: dc0fe9940a47fbba9762275083816953da07a188f0315a631c307716b16a7073586a4d229df6b177dfb4b01604667e2bb24c13d6bfcb137d2f4d306874a590f4
+  languageName: node
+  linkType: hard
+
+"@storybook/csf@npm:0.0.2--canary.49.258942b.0":
+  version: 0.0.2--canary.49.258942b.0
+  resolution: "@storybook/csf@npm:0.0.2--canary.49.258942b.0"
+  dependencies:
+    lodash: ^4.17.15
+  checksum: f765e427fa086ea00a313a107672a092a607e8086cd0d126fb8a3f6cf305af16db8cba8a0a9b81594fa378ade7d6842ab682d951c45c4b3ee74406b83e989404
   languageName: node
   linkType: hard
 
@@ -7736,7 +7736,7 @@ __metadata:
   resolution: "@storybook/docs-tools@workspace:lib/docs-tools"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/store": 7.0.0-alpha.35
     doctrine: ^3.0.0
     jest-specific-snapshot: ^4.0.0
@@ -7837,7 +7837,7 @@ __metadata:
     "@storybook/addon-essentials": 7.0.0-alpha.35
     "@storybook/blocks": 7.0.0-alpha.35
     "@storybook/components": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/preview-web": 7.0.0-alpha.35
     "@storybook/react": 7.0.0-alpha.35
     "@storybook/react-webpack5": 7.0.0-alpha.35
@@ -7887,7 +7887,7 @@ __metadata:
   dependencies:
     "@storybook/addons": 7.0.0-alpha.35
     "@storybook/core-client": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/docs-tools": 7.0.0-alpha.35
     "@storybook/preview-web": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
@@ -8068,7 +8068,7 @@ __metadata:
   dependencies:
     "@storybook/addons": 7.0.0-alpha.35
     "@storybook/core-client": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/store": 7.0.0-alpha.35
     global: ^4.4.0
     preact: ^10.5.13
@@ -8272,7 +8272,7 @@ __metadata:
     "@storybook/channels": 7.0.0-alpha.35
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/store": 7.0.0-alpha.35
     ansi-to-html: ^0.6.11
     global: ^4.4.0
@@ -8358,10 +8358,11 @@ __metadata:
   resolution: "@storybook/react@workspace:renderers/react"
   dependencies:
     "@babel/core": ^7.11.5
+    "@jest/globals": ^26.6.2
     "@storybook/addons": 7.0.0-alpha.35
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-client": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/docs-tools": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
     "@types/estree": ^0.0.51
@@ -8371,6 +8372,7 @@ __metadata:
     acorn-jsx: ^5.3.1
     acorn-walk: ^7.2.0
     escodegen: ^2.0.0
+    expect-type: ^0.14.2
     global: ^4.4.0
     html-tags: ^3.1.0
     jest-specific-snapshot: ^4.0.0
@@ -8379,6 +8381,7 @@ __metadata:
     react-element-to-jsx-string: ^15.0.0
     require-from-string: ^2.0.2
     ts-dedent: ^2.0.0
+    type-fest: ^2.19.0
     typescript: ~4.6.3
     util-deprecate: ^1.0.2
   peerDependencies:
@@ -8717,7 +8720,7 @@ __metadata:
   dependencies:
     "@storybook/addons": 7.0.0-alpha.35
     "@storybook/core-client": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/preview-web": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
     global: ^4.4.0
@@ -8732,7 +8735,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@workspace:lib/source-loader"
   dependencies:
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     estraverse: ^5.2.0
     jest-specific-snapshot: ^4.0.0
     lodash: ^4.17.21
@@ -8751,7 +8754,7 @@ __metadata:
     "@storybook/addons": 7.0.0-alpha.35
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     dequal: ^2.0.2
     global: ^4.4.0
     lodash: ^4.17.21
@@ -8822,7 +8825,7 @@ __metadata:
     "@storybook/addons": 7.0.0-alpha.35
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-client": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/docs-tools": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
     global: ^4.4.0
@@ -8920,7 +8923,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/components": 7.0.0-alpha.35
     "@storybook/core-events": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/router": 7.0.0-alpha.35
     "@storybook/theming": 7.0.0-alpha.35
     "@testing-library/react": ^11.2.2
@@ -9048,7 +9051,7 @@ __metadata:
     "@digitak/esrun": ^3.2.2
     "@storybook/addons": 7.0.0-alpha.35
     "@storybook/core-client": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/docs-tools": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
     global: ^4.4.0
@@ -9071,7 +9074,7 @@ __metadata:
     "@storybook/addons": 7.0.0-alpha.35
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-client": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/docs-tools": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
     global: ^4.4.0
@@ -9136,7 +9139,7 @@ __metadata:
     "@storybook/api": 7.0.0-alpha.35
     "@storybook/client-logger": 7.0.0-alpha.35
     "@storybook/core-client": 7.0.0-alpha.35
-    "@storybook/csf": 0.0.2--canary.0899bb7.0
+    "@storybook/csf": 0.0.2--canary.49.258942b.0
     "@storybook/docs-tools": 7.0.0-alpha.35
     "@storybook/preview-web": 7.0.0-alpha.35
     "@storybook/store": 7.0.0-alpha.35
@@ -19901,6 +19904,13 @@ __metadata:
   dependencies:
     homedir-polyfill: ^1.0.1
   checksum: 205a60497422746d1c3acbc1d65bd609b945066f239a2b785e69a7a651ac4cbeb4e08555b1ea0023abbe855e6fcb5bbf27d0b371367fdccd303d4fb2b4d66845
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^0.14.2":
+  version: 0.14.2
+  resolution: "expect-type@npm:0.14.2"
+  checksum: 862d5cb25a07b1dc26032ceeab2975f047e641175db2d3bbb34cee73ed8c04ca5e93457cc59ddf5006ddd7a694eb0e0bf2537512caa41e533a2044ed9d13a775
   languageName: node
   linkType: hard
 
@@ -40211,7 +40221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^2.17.0":
+"type-fest@npm:^2.17.0, type-fest@npm:^2.19.0":
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb

--- a/scripts/.eslintrc.js
+++ b/scripts/.eslintrc.js
@@ -8,6 +8,12 @@ module.exports = {
       { additionalTestBlockFunctions: ['it.skipWindows', 'it.onWindows'] },
     ],
     'no-use-before-define': 'off',
+    'jest/expect-expect': [
+      'warn',
+      {
+        assertFunctionNames: ['expect', 'expectTypeOf'],
+      },
+    ],
   },
   overrides: [
     {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/13747


Depends on this CSF pull request:
https://github.com/ComponentDriven/csf/pull/49

## What I did

### Typesafe args
Changed StoryObj and Meta so that we have increased typesafety for when the user provides args partially in meta.

Considering a Component like this:

```ts
interface ButtonProps {
  label: string;
  disabled: boolean;
}

declare const Button: (props: ButtonProps) => JSX.Element;
```

It is valid to provide args like this:

```ts

// ✅ valid
const meta = {
  component: Button,
  args: { disabled: false },
} satisfies Meta<typeof Button>;

export default meta;

type Story = StoryObj<typeof meta>;

export const Basic = {
  args: { label: 'good' }
} satisfies Story;
```

While it is invalid too forget an arg, in either meta or the story:

```ts
// ❌ invalid
const meta = {
  component: Button,
} satisfies Meta<typeof Button>;

export const Basic = {
  args: { label: 'good' }
} satisfies Story;

// ❌ invalid
const meta = {
  component: Button,
  args: { label: 'good' }
} satisfies Meta<typeof Button>;

export const Basic = {} satisfies Story;
```

Changed Meta to make sure both a Component, as the Props of the component can be used:

```ts
const meta = {
  component: Button,
} satisfies Meta<typeof Button>;

export default meta;

export const meta = {
  component: Button,
} satisfies Meta<ButtonProps>;

export default meta;
```

### Typesafe decorators/loaders

Decorators now accept a new generic arg argument to be specified:

```ts
const withDecorator: DecoratorFn<{ decoratorArg: number }> = (Story, { args }) => (
  <>
    Decorator: {args.decoratorArg}
    <Story args={{ decoratorArg: 0 }} />
  </>
);
```

And the type of meta/story will check if this arg is part of the generic type:

```ts
type Props = ButtonProps & { decoratorArg: number };

const meta = {
  component: Button,
  args: { disabled: false },
  decorators: [withDecorator],
} satisfies Meta<Props>;

type Story = StoryObj<typeof meta>;
const Basic: Story = { args: { decoratorArg: 0, label: 'good' } };
```

## How to test

You can test it by playing with test-d file. 

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->


