### PR TITLE
fix: Referencing AssertionResult from @jest/test-result

### DIFF
--- a/code/addons/jest/package.json
+++ b/code/addons/jest/package.json
@@ -65,6 +65,7 @@
     "@storybook/components": "7.0.0-alpha.33",
     "@storybook/core-events": "7.0.0-alpha.33",
     "@storybook/theming": "7.0.0-alpha.33",
+    "@jest/test-result": "^29.0.3",
     "global": "^4.4.0",
     "react-sizeme": "^3.0.1",
     "upath": "^1.2.0"

--- a/code/addons/jest/src/hoc/provideJestResult.tsx
+++ b/code/addons/jest/src/hoc/provideJestResult.tsx
@@ -1,15 +1,8 @@
 import React, { Component as ReactComponent, ComponentType } from 'react';
 import { STORY_CHANGED } from '@storybook/core-events';
 import { API } from '@storybook/api';
+import { AssertionResult } from '@jest/test-result';
 import { ADD_TESTS } from '../shared';
-
-// TODO: import type from @types/jest
-interface AssertionResult {
-  status: string;
-  fullName: string;
-  title: string;
-  failureMessages: string[];
-}
 
 export interface Test {
   name: string;

--- a/code/package.json
+++ b/code/package.json
@@ -148,6 +148,7 @@
     "@compodoc/compodoc": "^1.1.18",
     "@emotion/babel-plugin": "^11.10.2",
     "@emotion/jest": "^11.10.0",
+    "@jest/test-result": "^29.0.3",
     "@linear/sdk": "^1.21.0",
     "@nicolo-ribaudo/chokidar-2": "^2.1.8",
     "@nrwl/cli": "14.6.1",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -3300,6 +3300,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/console@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/console@npm:29.0.3"
+  dependencies:
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    jest-message-util: ^29.0.3
+    jest-util: ^29.0.3
+    slash: ^3.0.0
+  checksum: 0b72ecedf90a21bca876b68bce1d296a15eaa09ff483d564741984ed04542388c43c2e734221d9ccbb81c223fda349f767bc665c8c49de6067f107575a2d1041
+  languageName: node
+  linkType: hard
+
 "@jest/core@npm:^26.6.3":
   version: 26.6.3
   resolution: "@jest/core@npm:26.6.3"
@@ -3772,6 +3786,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/test-result@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/test-result@npm:29.0.3"
+  dependencies:
+    "@jest/console": ^29.0.3
+    "@jest/types": ^29.0.3
+    "@types/istanbul-lib-coverage": ^2.0.0
+    collect-v8-coverage: ^1.0.0
+  checksum: 72a81912bf12ea75ef73046c30ecc6cf329364997f5e8f7ca1a88fcd062db00fabade9e60551c320ebebea4ae5615aebe905f9c230a77eb1d6e096cb619b6ade
+  languageName: node
+  linkType: hard
+
 "@jest/test-sequencer@npm:^26.6.3":
   version: 26.6.3
   resolution: "@jest/test-sequencer@npm:26.6.3"
@@ -3976,6 +4002,20 @@ __metadata:
     "@types/yargs": ^17.0.8
     chalk: ^4.0.0
   checksum: f817dc8447f3b2273a60ed7bfcbe1ba2386383e5c88198ac9f6214b2b7a0f27bdf5696aba95f2d473555a6510b343aa28180f59a2d06baed1740cb8d6a94bfc1
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "@jest/types@npm:29.0.3"
+  dependencies:
+    "@jest/schemas": ^29.0.0
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^17.0.8
+    chalk: ^4.0.0
+  checksum: 3dfcf19631d6143382f3bd367f0120c2c271a37535e5f6de2532e5c2e83198bd8403a75901920f84e14cb886976c76892eb99c915d494c7e627649e72ba95107
   languageName: node
   linkType: hard
 
@@ -9010,6 +9050,7 @@ __metadata:
     "@cypress/webpack-preprocessor": ^5.9.1
     "@emotion/babel-plugin": ^11.10.2
     "@emotion/jest": ^11.10.0
+    "@jest/test-result": ^29.0.3
     "@linear/sdk": ^1.21.0
     "@nicolo-ribaudo/chokidar-2": ^2.1.8
     "@nrwl/cli": 14.6.1
@@ -27714,6 +27755,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-message-util@npm:29.0.3"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@jest/types": ^29.0.3
+    "@types/stack-utils": ^2.0.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    micromatch: ^4.0.4
+    pretty-format: ^29.0.3
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 49d521a31de3dbc795ccfcd689cf45401eeadf58198649a018db05928beb5f4ca99f4d3a772e8843de8f4788937c2338cd19b80ddcd0b08089c1c6df718cf1a3
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^24.0.0, jest-mock@npm:^24.9.0":
   version: 24.9.0
   resolution: "jest-mock@npm:24.9.0"
@@ -28348,6 +28406,20 @@ __metadata:
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   checksum: eb76e9e9cb60c2e2d68bc198a83fba8fd366464b35040f71ec4214816a5f83be71bb459f6842152992f8688136a8f4cfb1a9e0ffdc846842106dc0ec54f85d70
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "jest-util@npm:29.0.3"
+  dependencies:
+    "@jest/types": ^29.0.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    graceful-fs: ^4.2.9
+    picomatch: ^2.2.3
+  checksum: cbcfb2a327354450498505f0d09c58077c168ec1baa3bdf09eb51e1e34b2653d7a9ff0cda2ee92041d5367f56445afe305874fe607eb83c32538e62b631a8581
   languageName: node
   linkType: hard
 
@@ -36265,6 +36337,17 @@ __metadata:
     ansi-styles: ^5.0.0
     react-is: ^18.0.0
   checksum: 35e942285ab11cc873256817d7a542e0776d05c8eea869a6ed40c94d36dd0e28cbbc269788dc19d8e6eb12d717d74f7b423b57be86306385839786780f2e0a51
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "pretty-format@npm:29.0.3"
+  dependencies:
+    "@jest/schemas": ^29.0.0
+    ansi-styles: ^5.0.0
+    react-is: ^18.0.0
+  checksum: f9614758d58838ab24d53b546ccdf0db525652ecfd97d6b5e5345f6a773eb3a99bf57a59981ece4116e49e4de6c8afec142b960a0638288c2559082598873690
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue:

## What I did
AssertionResult types are now referenced from the library instead of being written manually.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
