### PR TITLE
fix the svelte button component not accepting the onClick handler

### DIFF
--- a/code/examples/svelte-kitchen-sink/src/stories/views/ActionLinkView.svelte
+++ b/code/examples/svelte-kitchen-sink/src/stories/views/ActionLinkView.svelte
@@ -1,3 +1,13 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher();
+
+  export let onClick = (event) => {
+    dispatch('click', event);
+  };
+</script>
+
 <div class="main">
   <h1>Link Action</h1>
   <button on:click={onClick} class="link">
@@ -6,15 +16,4 @@
 </div>
 
 <style>
-
 </style>
-
-<script>
-  import { createEventDispatcher } from 'svelte';
-
-  const dispatch = createEventDispatcher();
-
-  function onClick(event) {
-    dispatch('click', event);
-  }
-</script>

--- a/code/lib/cli/rendererAssets/svelte/Button.svelte
+++ b/code/lib/cli/rendererAssets/svelte/Button.svelte
@@ -28,15 +28,16 @@
   /**
    * Optional click handler
    */
-  function onClick(event) {
+  export let onClick = (event) => {
     dispatch('click', event);
-  }
+  };
 </script>
 
 <button
   type="button"
   class={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
   {style}
-  on:click={onClick}>
+  on:click={onClick}
+>
   {label}
 </button>

--- a/code/renderers/svelte/template/components/Button.svelte
+++ b/code/renderers/svelte/template/components/Button.svelte
@@ -28,9 +28,9 @@
   /**
    * Optional click handler
    */
-  function onClick(event) {
+  export let onClick = (event) => {
     dispatch('click', event);
-  }
+  };
 </script>
 
 <button

--- a/docs/snippets/svelte/button-implementation.js.mdx
+++ b/docs/snippets/svelte/button-implementation.js.mdx
@@ -28,9 +28,9 @@
   /**
    * Optional click handler
    */
-  function onClick(event) {
+  export let onClick = (event) => {
     dispatch('click', event);
-  }
+  };
 </script>
 
 <button type="button" {style} on:click="{onClick}">{label}</button>


### PR DESCRIPTION
## What I did

I fixed this CI issue:
https://app.circleci.com/pipelines/github/storybookjs/storybook/29329/workflows/b5939c19-2e6f-4588-a0fc-e6569cbdff75/jobs/414724

The svelte button implementation didn't allow for a onClick prop, I fixed this, and fixed it at a few other places too, because that seemed like the right thing to do..