### PR TITLE
fix playwright version again

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -152,7 +152,7 @@
     "@nrwl/cli": "14.6.1",
     "@nrwl/nx-cloud": "14.6.0",
     "@nrwl/workspace": "14.6.1",
-    "@playwright/test": "^1.24.2",
+    "@playwright/test": "1.26.0",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6538,15 +6538,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.24.2":
-  version: 1.25.2
-  resolution: "@playwright/test@npm:1.25.2"
+"@playwright/test@npm:1.26.0":
+  version: 1.26.0
+  resolution: "@playwright/test@npm:1.26.0"
   dependencies:
     "@types/node": "*"
-    playwright-core: 1.25.2
+    playwright-core: 1.26.0
   bin:
     playwright: cli.js
-  checksum: 3f94187d3943c2ac10a120b5ba7858526806d1f31afee4b65ec93d2e870d54ace662fd473538a644a9eb5ce61071e4dc12f7b737847d253e1f2a45deed1ad143
+  checksum: 6927284c13a8ab50405412d6fb9fea0dbee9be45573b51355111c26e7258f6742266f51963a87caba30237bbcebb720647b5dcad2b67cb60a64c1b3d8b1a5c54
   languageName: node
   linkType: hard
 
@@ -9005,7 +9005,7 @@ __metadata:
     "@nrwl/cli": 14.6.1
     "@nrwl/nx-cloud": 14.6.0
     "@nrwl/workspace": 14.6.1
-    "@playwright/test": ^1.24.2
+    "@playwright/test": 1.26.0
     "@rollup/plugin-babel": ^5.3.1
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-json": ^4.1.0
@@ -34792,15 +34792,6 @@ __metadata:
   version: 0.4.1
   resolution: "pkginfo@npm:0.4.1"
   checksum: 487ace8df0dc7d5669cc2cb61af5c418cc4082bd246dc7fa4008b52d693dca4adc3563e427794c532ac70c9c287e6bb5fe5393465a0927765e6d85a12ddd6539
-  languageName: node
-  linkType: hard
-
-"playwright-core@npm:1.25.2":
-  version: 1.25.2
-  resolution: "playwright-core@npm:1.25.2"
-  bin:
-    playwright: cli.js
-  checksum: 9c5fb23220a824e755d9bca4055ba85fe08538722f0837b9012505a76f387103eee4e30e4cebe0d704904b5e7a5d9d33cfc3f67181d6fd1a8488cb5ffbeb469b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This should fix this:
https://app.circleci.com/pipelines/github/storybookjs/storybook/29335/workflows/1b9da84a-81f7-46e9-9303-f9fbf6e29974/jobs/414802

Seems when I upgraded playwright, I missed this second dependency which should be exactly in sync.