### PR TITLE
fix svelte e2e test: generate preview file with js extension always

### DIFF
--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -205,7 +205,7 @@ export async function baseGenerator(
       : {}),
   });
 
-  await configurePreview(renderer, options.commonJs);
+  await configurePreview(renderer);
 
   if (addComponents) {
     await copyComponents(renderer, language);

--- a/code/lib/cli/src/generators/configure.ts
+++ b/code/lib/cli/src/generators/configure.ts
@@ -64,9 +64,9 @@ const frameworkToPreviewParts: Partial<Record<SupportedRenderers, any>> = {
   },
 };
 
-export async function configurePreview(framework: SupportedRenderers, commonJs: boolean) {
+export async function configurePreview(framework: SupportedRenderers) {
   const { prefix = '', extraParameters = '' } = frameworkToPreviewParts[framework] || {};
-  const previewPath = `./.storybook/preview.${commonJs ? 'cjs' : 'js'}`;
+  const previewPath = `./.storybook/preview.js`;
 
   // If the framework template included a preview then we have nothing to do
   if (await fse.pathExists(previewPath)) {


### PR DESCRIPTION
This should fix this problem in CI:
https://app.circleci.com/pipelines/github/storybookjs/storybook/29348/workflows/e643b119-e6e4-43aa-a6d2-2da254593755/jobs/415013/parallel-runs/13?filterBy=FAILED