### PR TITLE
Build: Remove unused angular_modern_inline_rendering

### DIFF
--- a/code/lib/cli/src/repro-generators/configs.ts
+++ b/code/lib/cli/src/repro-generators/configs.ts
@@ -148,17 +148,6 @@ export const angular13: Parameters = {
   version: '13.1.x',
 };
 
-export const angular_modern_inline_rendering: Parameters = {
-  ...baseAngular,
-  name: 'angular_modern_inline_rendering',
-  additionalDeps: ['jest@27', '@storybook/test-runner'],
-  mainOverrides: {
-    features: {
-      storyStoreV7: true,
-    },
-  },
-};
-
 export const angular: Parameters = baseAngular;
 // #endregion
 


### PR DESCRIPTION
Issue: N/A

## What I did

E2E extended tests are failing on `angular_modern_inline_rendering`, but it's a bogus repro now that the feature flag doesn't exist anymore.

## How to test

- [ ] CI passes