### PR TITLE
Vite: Do not add Webpack loaders when using Vite builder

### DIFF
--- a/code/lib/cli/src/generators/SVELTE/index.ts
+++ b/code/lib/cli/src/generators/SVELTE/index.ts
@@ -1,6 +1,7 @@
 import fse from 'fs-extra';
 import { logger } from '@storybook/node-logger';
 
+import { CoreBuilder } from '../../project_types';
 import { baseGenerator } from '../baseGenerator';
 import { Generator } from '../types';
 
@@ -31,8 +32,10 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
     }
   }
 
+  const extraPackages = options.builder === CoreBuilder.Webpack5 ? ['svelte', 'svelte-loader'] : [];
+
   await baseGenerator(packageManager, npmOptions, options, 'svelte', {
-    extraPackages: ['svelte', 'svelte-loader'],
+    extraPackages,
     extensions: ['js', 'jsx', 'ts', 'tsx', 'svelte'],
     extraMain,
     commonJs: true,

--- a/code/lib/cli/src/generators/VUE/index.ts
+++ b/code/lib/cli/src/generators/VUE/index.ts
@@ -1,9 +1,11 @@
+import { CoreBuilder } from '../../project_types';
 import { baseGenerator } from '../baseGenerator';
 import { Generator } from '../types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
+  const extraPackages = options.builder === CoreBuilder.Webpack5 ? ['vue-loader@^15.7.0'] : [];
   await baseGenerator(packageManager, npmOptions, options, 'vue', {
-    extraPackages: ['vue-loader@^15.7.0'],
+    extraPackages,
   });
 };
 

--- a/code/lib/cli/src/generators/VUE3/index.ts
+++ b/code/lib/cli/src/generators/VUE3/index.ts
@@ -1,9 +1,14 @@
+import { CoreBuilder } from '../../project_types';
 import { baseGenerator } from '../baseGenerator';
 import { Generator } from '../types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
+  const extraPackages =
+    options.builder === CoreBuilder.Webpack5
+      ? ['vue-loader@^17.0.0', '@vue/compiler-sfc@^3.2.0']
+      : [];
   await baseGenerator(packageManager, npmOptions, options, 'vue3', {
-    extraPackages: ['vue-loader@^17.0.0', '@vue/compiler-sfc@^3.2.0'],
+    extraPackages,
   });
 };
 


### PR DESCRIPTION
Issue: N/A

## What I did

I noticed that the `sb init` command was adding a vue-loader and svelte-loader even when I'm using a vite-based framework.  To prevent this, while keeping the original behavior for webpack projects, I updated the generators to only add the extra packages when webpack is being used.  

## How to test

Build the branch (necessary?), then run `yarn generate-repros-next --local-registry`.  Check the `/repros/svelte-vite/default-js` directory and verify that `svelte-loader` is not in `package.json`. Similarly for the vue3 repro.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
