### PR TITLE
chore: forward parameters in command execution

### DIFF
--- a/code/nx.json
+++ b/code/nx.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "npmScope": "storybook",
   "implicitDependencies": {
     "package.json": {
@@ -21,28 +22,15 @@
   "affected": {
     "defaultBase": "next"
   },
-  "targetDependencies": {
-    "build": [
-      {
-        "target": "build",
-        "projects": "dependencies"
-      }
-    ],
-    "package": [
-      {
-        "target": "package",
-        "projects": "dependencies"
-      }
-    ],
-    "prep": [
-      {
-        "target": "prep",
-        "projects": "dependencies"
-      }
-    ]
-  },
   "targetDefaults": {
+    "build": {
+      "dependsOn": [{ "projects": "dependencies", "target": "build" }]
+    },
+    "package": {
+      "dependsOn": [{ "projects": "dependencies", "target": "package" }]
+    },
     "prep": {
+      "dependsOn": [{ "projects": "dependencies", "target": "prep", "params": "forward" }],
       "outputs": ["{projectRoot}/dist"]
     }
   }


### PR DESCRIPTION
## What I did
* Changed `nx.json` schema to use `targetDefaults` instead of `targetDependencies`, so that we can take advantage of forwarding parameters.
* Added `"params": "forward"` to the `prep` task

Read: 
* [`dependsOn` documentation](https://nx.dev/reference/project-configuration#dependson)
* [Task dependencies](https://nx.dev/concepts/task-pipeline-configuration#define-task-dependencies-(aka-task-pipelines)): "_Note, older versions of Nx used targetDependencies instead of targetDefaults. Both still work, but targetDefaults is recommended._"
* [`targetDefaults` documentation](https://nx.dev/reference/nx-json#target-defaults)

## How to test

* Are parameters correctly passed down the commands?
* Is everything working as expected?