### PR TITLE
Build addons/storysource with tsup

### DIFF
--- a/code/addons/storysource/manager.js
+++ b/code/addons/storysource/manager.js
@@ -1,1 +1,0 @@
-import './dist/manager';

--- a/code/addons/storysource/manager.js
+++ b/code/addons/storysource/manager.js
@@ -1,0 +1,1 @@
+import './dist/manager';

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -91,7 +91,7 @@
       "./src/manager.tsx"
     ]
   },
-  "gitHead": "02c013c33186479017098d532a18ff8654b91f1f",
+  "gitHead": "fc90fc875462421c1faa35862ac4bc436de8e75f",
   "storybook": {
     "displayName": "Storysource",
     "icon": "https://user-images.githubusercontent.com/263385/101991675-48cdf300-3c7c-11eb-9400-58de5ac6daa7.png",

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -27,7 +27,7 @@
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
-    "./manager": {
+    "./register": {
       "require": "./dist/manager.js",
       "import": "./dist/manager.mjs",
       "types": "./dist/manager.d.ts"

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/addon-storysource",
-  "version": "7.0.0-alpha.31",
+  "version": "7.0.0-alpha.34",
   "description": "View a story’s source code to see how it works and paste into your app",
   "keywords": [
     "addon",
@@ -53,13 +53,13 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/addons": "7.0.0-alpha.17",
-    "@storybook/api": "7.0.0-alpha.17",
-    "@storybook/client-logger": "7.0.0-alpha.17",
-    "@storybook/components": "7.0.0-alpha.17",
-    "@storybook/router": "7.0.0-alpha.17",
-    "@storybook/source-loader": "7.0.0-alpha.17",
-    "@storybook/theming": "7.0.0-alpha.17",
+    "@storybook/addons": "7.0.0-alpha.34",
+    "@storybook/api": "7.0.0-alpha.34",
+    "@storybook/client-logger": "7.0.0-alpha.34",
+    "@storybook/components": "7.0.0-alpha.34",
+    "@storybook/router": "7.0.0-alpha.34",
+    "@storybook/source-loader": "7.0.0-alpha.34",
+    "@storybook/theming": "7.0.0-alpha.34",
     "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
     "prop-types": "^15.7.2",

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -89,8 +89,7 @@
     "entries": [
       "./src/index.ts",
       "./src/manager.tsx"
-    ],
-    "platform": "browser"
+    ]
   },
   "gitHead": "02c013c33186479017098d532a18ff8654b91f1f",
   "storybook": {

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/addon-storysource",
-  "version": "7.0.0-alpha.34",
+  "version": "7.0.0-alpha.31",
   "description": "View a story’s source code to see how it works and paste into your app",
   "keywords": [
     "addon",
@@ -27,7 +27,12 @@
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
-    "./register": {
+    "./manager": {
+      "require": "./dist/manager.js",
+      "import": "./dist/manager.mjs",
+      "types": "./dist/manager.d.ts"
+    },
+    "./register.js": {
       "require": "./dist/manager.js",
       "import": "./dist/manager.mjs",
       "types": "./dist/manager.d.ts"
@@ -48,13 +53,14 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/addons": "7.0.0-alpha.34",
-    "@storybook/api": "7.0.0-alpha.34",
-    "@storybook/client-logger": "7.0.0-alpha.34",
-    "@storybook/components": "7.0.0-alpha.34",
-    "@storybook/router": "7.0.0-alpha.34",
-    "@storybook/source-loader": "7.0.0-alpha.34",
-    "@storybook/theming": "7.0.0-alpha.34",
+    "@storybook/addons": "7.0.0-alpha.17",
+    "@storybook/api": "7.0.0-alpha.17",
+    "@storybook/client-logger": "7.0.0-alpha.17",
+    "@storybook/components": "7.0.0-alpha.17",
+    "@storybook/router": "7.0.0-alpha.17",
+    "@storybook/source-loader": "7.0.0-alpha.17",
+    "@storybook/theming": "7.0.0-alpha.17",
+    "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
     "prop-types": "^15.7.2",
     "react-syntax-highlighter": "^15.5.0"
@@ -83,9 +89,10 @@
     "entries": [
       "./src/index.ts",
       "./src/manager.tsx"
-    ]
+    ],
+    "platform": "browser"
   },
-  "gitHead": "fc90fc875462421c1faa35862ac4bc436de8e75f",
+  "gitHead": "02c013c33186479017098d532a18ff8654b91f1f",
   "storybook": {
     "displayName": "Storysource",
     "icon": "https://user-images.githubusercontent.com/263385/101991675-48cdf300-3c7c-11eb-9400-58de5ac6daa7.png",

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -21,9 +21,32 @@
     "url": "https://opencollective.com/storybook"
   },
   "license": "MIT",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./manager": {
+      "require": "./dist/manager.js",
+      "import": "./dist/manager.mjs",
+      "types": "./dist/manager.d.ts"
+    },
+    "./events": {
+      "require": "./dist/events.js",
+      "import": "./dist/events.mjs",
+      "types": "./dist/events.d.ts"
+    },
+    "./StoryPanel": {
+      "require": "./dist/StoryPanel.js",
+      "import": "./dist/StoryPanel.mjs",
+      "types": "./dist/StoryPanel.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",
     "README.md",
@@ -32,7 +55,7 @@
   ],
   "scripts": {
     "check": "../../../scripts/node_modules/.bin/tsc --noEmit",
-    "prep": "node ../../../scripts/prepare.js"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.34",
@@ -65,6 +88,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bundler": {
+    "entries": [
+      "./src/events.ts",
+      "./src/index.ts",
+      "./src/manager.tsx",
+      "./src/StoryPanel.tsx"
+    ]
   },
   "gitHead": "fc90fc875462421c1faa35862ac4bc436de8e75f",
   "storybook": {

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -60,6 +60,7 @@
     "@storybook/router": "7.0.0-alpha.34",
     "@storybook/source-loader": "7.0.0-alpha.34",
     "@storybook/theming": "7.0.0-alpha.34",
+    "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
     "prop-types": "^15.7.2",
     "react-syntax-highlighter": "^15.5.0"

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -60,7 +60,6 @@
     "@storybook/router": "7.0.0-alpha.34",
     "@storybook/source-loader": "7.0.0-alpha.34",
     "@storybook/theming": "7.0.0-alpha.34",
-    "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
     "prop-types": "^15.7.2",
     "react-syntax-highlighter": "^15.5.0"

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -32,16 +32,6 @@
       "import": "./dist/manager.mjs",
       "types": "./dist/manager.d.ts"
     },
-    "./events": {
-      "require": "./dist/events.js",
-      "import": "./dist/events.mjs",
-      "types": "./dist/events.d.ts"
-    },
-    "./StoryPanel": {
-      "require": "./dist/StoryPanel.js",
-      "import": "./dist/StoryPanel.mjs",
-      "types": "./dist/StoryPanel.d.ts"
-    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",
@@ -91,10 +81,8 @@
   },
   "bundler": {
     "entries": [
-      "./src/events.ts",
       "./src/index.ts",
-      "./src/manager.tsx",
-      "./src/StoryPanel.tsx"
+      "./src/manager.tsx"
     ]
   },
   "gitHead": "fc90fc875462421c1faa35862ac4bc436de8e75f",

--- a/code/addons/storysource/preset.js
+++ b/code/addons/storysource/preset.js
@@ -25,7 +25,7 @@ function webpack(webpackConfig = {}, options = {}) {
 }
 
 function managerEntries(entry = []) {
-  return [...entry, require.resolve('./dist/esm/manager')];
+  return [...entry, require.resolve('./dist/manager')];
 }
 
 module.exports = { webpack, managerEntries };

--- a/code/addons/storysource/register.js
+++ b/code/addons/storysource/register.js
@@ -1,1 +1,1 @@
-import './dist/esm/manager';
+import './dist/manager';

--- a/code/addons/storysource/register.js
+++ b/code/addons/storysource/register.js
@@ -1,1 +1,6 @@
-import './dist/manager';
+import { once } from '@storybook/client-logger';
+import './manager';
+
+once.warn(
+  'register.js is deprecated see https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-registerjs'
+);

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7267,6 +7267,7 @@ __metadata:
     "@storybook/theming": 7.0.0-alpha.34
     "@types/react": ^16.14.23
     "@types/react-syntax-highlighter": 11.0.5
+    core-js: ^3.8.2
     estraverse: ^5.2.0
     prop-types: ^15.7.2
     react-syntax-highlighter: ^15.5.0

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7267,7 +7267,6 @@ __metadata:
     "@storybook/theming": 7.0.0-alpha.34
     "@types/react": ^16.14.23
     "@types/react-syntax-highlighter": 11.0.5
-    core-js: ^3.8.2
     estraverse: ^5.2.0
     prop-types: ^15.7.2
     react-syntax-highlighter: ^15.5.0


### PR DESCRIPTION
Issue: [#18732](https://github.com/storybookjs/storybook/issues/18732)

## What I did
Migrated `addon-storysource` to use the ts-up bundler.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
