### PR TITLE
docs: update link to create a vue app

### DIFF
--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -27,7 +27,7 @@ Storybook needs to be installed into a project that is already set up with a fra
 
 - 📦 [Create an Angular Workspace](https://angular.io/cli/new)
 - 📦 [Create React App](https://reactjs.org/docs/create-a-new-react-app.html)
-- 📦 [Vue CLI](https://cli.vuejs.org/)
+- 📦 [Create a Vue App](https://vuejs.org/guide/quick-start.html)
 - 📦 [Ember CLI](https://guides.emberjs.com/release/getting-started/quick-start/)
 - Or any other tooling available.
 


### PR DESCRIPTION
Vue CLI is in Maintenance Mode! https://cli.vuejs.org/

Issue:

## What I did

I updated the link to create a vue app. `vue-cli` is deprecated

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?
