### PR TITLE
 feat(angular): disable ngcc when not needed

### DIFF
--- a/code/examples/angular-cli/.storybook/main.ts
+++ b/code/examples/angular-cli/.storybook/main.ts
@@ -34,6 +34,7 @@ const mainConfig: import('@storybook/angular').StorybookConfig = {
     name: '@storybook/angular',
     options: {
       enableIvy: true,
+      enableNgcc: true,
     },
   },
 };

--- a/code/frameworks/angular/src/server/framework-preset-angular-ivy.ts
+++ b/code/frameworks/angular/src/server/framework-preset-angular-ivy.ts
@@ -58,7 +58,7 @@ export const webpack = async (webpackConfig: Configuration, options: PresetOptio
     return webpackConfig;
   }
 
-  if(angularOptions.disableNgcc !== false) {
+  if(angularOptions.enableNgcc === false) {
     runNgcc();
   }
 

--- a/code/frameworks/angular/src/server/framework-preset-angular-ivy.ts
+++ b/code/frameworks/angular/src/server/framework-preset-angular-ivy.ts
@@ -58,7 +58,7 @@ export const webpack = async (webpackConfig: Configuration, options: PresetOptio
     return webpackConfig;
   }
 
-  if(angularOptions.enableNgcc === false) {
+  if(angularOptions.enableNgcc !== false) {
     runNgcc();
   }
 

--- a/code/frameworks/angular/src/server/framework-preset-angular-ivy.ts
+++ b/code/frameworks/angular/src/server/framework-preset-angular-ivy.ts
@@ -58,7 +58,9 @@ export const webpack = async (webpackConfig: Configuration, options: PresetOptio
     return webpackConfig;
   }
 
-  runNgcc();
+  if(angularOptions.disableNgcc !== false) {
+    runNgcc();
+  }
 
   return {
     ...webpackConfig,

--- a/code/frameworks/angular/src/types.ts
+++ b/code/frameworks/angular/src/types.ts
@@ -46,4 +46,5 @@ export type StorybookConfig = Omit<
 
 export interface AngularOptions {
   enableIvy: boolean;
+  disableNgcc: boolean;
 }

--- a/code/frameworks/angular/src/types.ts
+++ b/code/frameworks/angular/src/types.ts
@@ -46,5 +46,5 @@ export type StorybookConfig = Omit<
 
 export interface AngularOptions {
   enableIvy: boolean;
-  disableNgcc: boolean;
+  enableNgcc: boolean;
 }

--- a/code/frameworks/angular/src/types.ts
+++ b/code/frameworks/angular/src/types.ts
@@ -45,6 +45,6 @@ export type StorybookConfig = Omit<
   StorybookConfigFramework;
 
 export interface AngularOptions {
-  enableIvy: boolean;
-  enableNgcc: boolean;
+  enableIvy?: boolean;
+  enableNgcc?: boolean;
 }

--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.test.ts
@@ -196,6 +196,7 @@ describe('new-frameworks fix', () => {
               },
               angularOptions: {
                 enableIvy: true,
+                enableNgcc: true,
               },
             },
           })
@@ -206,6 +207,7 @@ describe('new-frameworks fix', () => {
             dependenciesToRemove: ['@storybook/builder-webpack5', '@storybook/manager-webpack5'],
             frameworkOptions: {
               enableIvy: true,
+              enableNgcc: true,
             },
             builderInfo: {
               name: 'webpack5',

--- a/code/lib/telemetry/src/storybook-metadata.test.ts
+++ b/code/lib/telemetry/src/storybook-metadata.test.ts
@@ -123,11 +123,12 @@ describe('await computeStorybookMetadata', () => {
         ...mainJsMock,
         angularOptions: {
           enableIvy: true,
+          enableNgcc: true,
         },
       },
     });
 
-    expect(angularResult.framework).toEqual({ name: 'angular', options: { enableIvy: true } });
+    expect(angularResult.framework).toEqual({ name: 'angular', options: { enableIvy: true, enableNgcc: true } });
   });
 
   test('should separate storybook packages and addons', async () => {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,6 +24,26 @@ module.exports = {
   },
 };
 ```
+### How can I opt-out of Angular ngcc?
+
+In case you postinstall ngcc, you can disable it:
+
+```javascript
+module.exports = {
+  stories: [
+    /* ... */
+  ],
+  addons: [
+    /* ... */
+  ],
+  framework: {
+    name: '@storybook/angular',
+    options: {
+      enableNgcc: false,
+    },
+  },
+};
+```
 
 Please report any issues related to Ivy in our [GitHub Issue Tracker](https://github.com/storybookjs/storybook/labels/app%3A%20angular) as the support for View Engine will be dropped in a future release of Angular.
 


### PR DESCRIPTION
Issue:

## What I did

If you run postInstall ngcc, you don't have to run it every time you start a storybook instance.
If you have a monorepo project with a lot of storybook settings and tests, this can cause lockouts and a message like this: `“Another process, with id 5197, is currently running ngcc.”` 
We're adding an optional parameter to the angular configuration to disable ngcc. Ngcc is enabled by default

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [x] Does this need a new example in the kitchen sink apps?
- [X] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
