### PR TITLE
Build: Add vue-cli/vue2 repro template

### DIFF
--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -105,20 +105,18 @@ const vueCliTemplates = {
       builder: '@storybook/builder-webpack5',
     },
   },
-  //
-  // FIXME: https://github.com/storybookjs/storybook/issues/19204
-  //
-  // 'vue-cli/vue2-default-js': {
-  //   name: 'Vue-CLI (Vue2 JS)',
-  //   script:
-  //     'npx -p @vue/cli vue create . --default --packageManager=yarn --force --merge --preset=Default\\ (Vue\\ 2)',
-  //   cadence: ['ci', 'daily', 'weekly'],
-  //   expected: {
-  //     framework: '@storybook/vue-webpack5',
-  //     renderer: '@storybook/vue',
-  //     builder: '@storybook/builder-webpack5',
-  //   },
-  // },
+  'vue-cli/vue2-default-js': {
+    name: 'Vue-CLI (Vue2 JS)',
+    script:
+      'npx -p @vue/cli vue create . --default --packageManager=yarn --force --merge --preset=Default\\ (Vue\\ 2)',
+    // FIXME: https://github.com/storybookjs/storybook/issues/19204
+    cadence: [] as any,
+    expected: {
+      framework: '@storybook/vue-webpack5',
+      renderer: '@storybook/vue',
+      builder: '@storybook/builder-webpack5',
+    },
+  },
 };
 
 export default {


### PR DESCRIPTION
Issue: N/A

## What I did

Set up the repro template for vue-cli/vue2. Don't run it in CI yet due to https://github.com/storybookjs/storybook/issues/19204

The benefit of defining the repro template first is that it will get cached in the nightly build which helps with development & debugging the actual fix.

Self-merging @tmeasday 

## How to test

- [ ] CI passes