### PR TITLE
Build: Bundle lib/telemetry with ts-up

### DIFF
--- a/code/lib/telemetry/package.json
+++ b/code/lib/telemetry/package.json
@@ -20,9 +20,17 @@
   },
   "license": "MIT",
   "sideEffects": false,
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",
     "README.md",
@@ -31,7 +39,7 @@
   ],
   "scripts": {
     "check": "../../../scripts/node_modules/.bin/tsc --noEmit",
-    "prep": "node ../../../scripts/prepare.js"
+    "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
     "@storybook/client-logger": "7.0.0-alpha.34",
@@ -49,6 +57,12 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bundler": {
+    "entries": [
+      "./src/index.ts"
+    ],
+    "platform": "node"
   },
   "gitHead": "fc90fc875462421c1faa35862ac4bc436de8e75f"
 }


### PR DESCRIPTION
Issue: 

Reference: https://github.com/storybookjs/storybook/issues/18732

This is my first contribution to this repo. 
If possible could you add the "hacktoberfest -accepted" label to this pr?

## What I did

update to /code/lib/telemetry/package.json in line with instructions [here](https://github.com/storybookjs/storybook/issues/18732)

After re-building the telemetry package, I verified that the three index files were present.

After updates to package.json here are the outputs of : 

```
yarn build 

✔ Select the packages to build › @storybook/telemetry
@storybook/telemetry:
skipping generating types for ./src/index.ts
@storybook/telemetry:
CLI Building entry: /storybook/code/lib/telemetry/src/index.ts
@storybook/telemetry:
CLI Using tsconfig: tsconfig.json
@storybook/telemetry:
CLI tsup v6.2.3
@storybook/telemetry:
CLI Target: node14
@storybook/telemetry:
CLI Building entry: /storybook/code/lib/telemetry/src/index.ts
@storybook/telemetry:
CLI Using tsconfig: tsconfig.json
@storybook/telemetry:
CLI tsup v6.2.3
@storybook/telemetry:
CLI Target: chrome100
@storybook/telemetry:
CLI Cleaning output folder
@storybook/telemetry:
CLI Cleaning output folder
@storybook/telemetry:
CJS Build start
@storybook/telemetry:
CJS You have emitDecoratorMetadata enabled but @swc/core was not installed, skipping swc plugin
@storybook/telemetry:
ESM Build start
@storybook/telemetry:
ESM You have emitDecoratorMetadata enabled but @swc/core was not installed, skipping swc plugin
@storybook/telemetry:
CJS dist/index.js 13.85 KB
@storybook/telemetry:
CJS ⚡️ Build success in 44ms
@storybook/telemetry:
ESM dist/index.mjs 11.66 KB
@storybook/telemetry:
ESM ⚡️ Build success in 36ms
```

```
yarn check 
@storybook/telemetry:
16:05:08 - Starting compilation in watch mode...

@storybook/telemetry:

16:05:12 - Found 0 errors. Watching for file changes.
```

```
/storybook/code   update-lib-telemetry  yarn test
Test Suites: 1 skipped, 169 passed, 169 of 170 total
Tests:       10 skipped, 2087 passed, 2097 total
Snapshots:   477 passed, 477 total
Time:        18.111 s
Ran all test suites.
```

```
/storybook/code   update-lib-telemetry  yarn test telemetry
 PASS  lib/telemetry/src/telemetry.test.ts
 PASS  lib/telemetry/src/storybook-metadata.test.ts
 PASS  lib/telemetry/src/get-monorepo-type.test.ts
 PASS  lib/telemetry/src/sanitize.test.ts

Test Suites: 4 passed, 4 total
Tests:       32 passed, 32 total
Snapshots:   2 passed, 2 total
Time:        1.979 s
Ran all test suites matching /telemetry/i.
```

I then verified that the telemetry is being generated in `/code/examples/react-ts`

```
STORYBOOK_DEBUG_TELEMETRY=true yarn storybook

@storybook/cli v7.0.0-alpha.34

info => Loading presets
info => Loading presets
info => Loading presets
info => Starting manager..
info Addon-docs: using MDX2
info => Using implicit CSS loaders
info => Using default Webpack5 setup
<i> [webpack-dev-middleware] wait until bundle finished
37% building 1/2 entries 81/118 dependencies 11/48 modules
[telemetry]
{
  "eventType": "start",
  "payload": {
    "storyIndex": {
      "storyCount": 28,
      "version": 4
    }
  },
  "metadata": {
    "generatedAt": 1664687535191,
    "builder": {
      "name": "webpack5"
    },
    "hasCustomBabel": false,
    "hasCustomWebpack": false,
    "hasStaticDirs": false,
    "hasStorybookEslint": false,
    "refCount": 0,
    "packageManager": {
      "type": "yarn",
      "version": "3.2.1"
    },
    "typescriptOptions": {
      "check": true,
      "checkOptions": {},
      "reactDocgenTypescriptOptions": {}
    },
    "features": {
      "postcss": false,
      "storyStoreV7": true,
      "buildStoriesJson": true,
      "babelModeV7": true,
      "warnOnLegacyHierarchySeparator": false,
      "previewMdx2": true,
      "breakingChangesV7": true
    },
    "storybookVersion": "7.0.0-alpha.34",
    "language": "typescript",
    "storybookPackages": {
      "@storybook/addons": {
        "version": "7.0.0-alpha.34"
      },
      "@storybook/cli": {
        "version": "7.0.0-alpha.34"
      },
      "@storybook/components": {
        "version": "7.0.0-alpha.34"
      },
      "@storybook/react": {
        "version": "7.0.0-alpha.34"
      },
      "@storybook/react-webpack5": {
        "version": "7.0.0-alpha.34"
      },
      "@storybook/theming": {
        "version": "7.0.0-alpha.34"
      },
      "storybook": {
        "version": "7.0.0-alpha.34"
      }
    },
    "framework": {
      "name": "react"
    },
    "addons": {
      "@storybook/addon-essentials": {
        "version": "7.0.0-alpha.34"
      },
      "@storybook/addon-storysource": {
        "version": "7.0.0-alpha.34"
      },
      "@storybook/addon-storyshots": {
        "version": "7.0.0-alpha.34"
      },
      "@storybook/addon-a11y": {
        "version": "7.0.0-alpha.34"
      }
    }
  }
}
```

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
