### PR TITLE
Codemods: Check if`React` is really imported when converting mdx to csf

### DIFF
--- a/code/lib/codemod/src/transforms/mdx-to-csf.js
+++ b/code/lib/codemod/src/transforms/mdx-to-csf.js
@@ -163,16 +163,15 @@ export default function transformer(file, api) {
 
   // Add back `import React from 'react';` which is implicit in MDX
   const react = root.find(j.ImportDeclaration).filter((decl) => {
-    var isReact = decl.node.source.value === 'react';
+    const isReact = decl.node.source.value === 'react';
     if (isReact) {
       // We need to check if the `React` is really imported, because sometimes we just need to import `useEffect` or `useState` etc.
-      var isReactImported = decl.node.specifiers.some(function (item) {
+      const isReactImported = decl.node.specifiers.some(function (item) {
         return item.local.name === 'React';
       });
       return isReactImported;
-    } else {
-      return false;
     }
+    return false;
   });
   if (react.size() === 0) {
     root

--- a/code/lib/codemod/src/transforms/mdx-to-csf.js
+++ b/code/lib/codemod/src/transforms/mdx-to-csf.js
@@ -162,7 +162,18 @@ export default function transformer(file, api) {
     .remove();
 
   // Add back `import React from 'react';` which is implicit in MDX
-  const react = root.find(j.ImportDeclaration).filter((decl) => decl.node.source.value === 'react');
+  const react = root.find(j.ImportDeclaration).filter((decl) => {
+    var isReact = decl.node.source.value === 'react';
+    if (isReact) {
+      // We need to check if the `React` is really imported, because sometimes we just need to import `useEffect` or `useState` etc.
+      var isReactImported = decl.node.specifiers.some(function (item) {
+        return item.local.name === 'React';
+      });
+      return isReactImported;
+    } else {
+      return false;
+    }
+  });
   if (react.size() === 0) {
     root
       .find(j.Statement)


### PR DESCRIPTION
Issue: N/A

## What I did

When converting MDX to CSF, we need to if the `React` obejct is really imported, because sometimes the developers just need to import `useState` or `useEffect` or other stuffs etc. 

For example, if we already have the `import { useEffect } from 'react` statement in the MDX file, then the generated CSF file won't have the `import React from 'react` statement inserted, you know, this kind of CSF file isn't able to be run.

## How to test

- [] Is this testable with Jest or Chromatic screenshots?
- [] Does this need a new example in the kitchen sink apps?
- [] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
