### PR TITLE
Fix path to checkActionsLoaded

### DIFF
--- a/code/addons/interactions/package.json
+++ b/code/addons/interactions/package.json
@@ -99,8 +99,10 @@
     "entries": [
       "./src/index.ts",
       "./src/manager.tsx",
-      "./src/preset/preview.ts"
-    ]
+      "./src/preset/preview.ts",
+      "./src/preset/checkActionsLoaded.ts"
+    ],
+    "platform": "node"
   },
   "gitHead": "fc90fc875462421c1faa35862ac4bc436de8e75f",
   "storybook": {

--- a/code/addons/interactions/preset.js
+++ b/code/addons/interactions/preset.js
@@ -1,4 +1,4 @@
-const { checkActionsLoaded } = require('./dist/cjs/preset/checkActionsLoaded');
+const { checkActionsLoaded } = require('./dist/preset/checkActionsLoaded');
 
 function previewAnnotations(entry = [], options) {
   checkActionsLoaded(options.configDir);


### PR DESCRIPTION
Issue:

I got an error in a different PR:

https://app.circleci.com/pipelines/github/storybookjs/storybook/29618/workflows/0931a8cf-b0da-4cbd-8a03-9bad0fdf9174/jobs/418314?invite=true#step-105-471

## What I did

I noticed that in the transition to tsup for addon-interactions, a few things seemed to be missed.  This PR updates the link from `preset.js` to the correct build location, and also adds the target (`checkActionsLoaded`) to the list of entry points.

The part I'm not sure about is adding `platform: node`, since different parts of the addon runs both in node and in the browser.  But, `checkActionsLoaded` uses the `path` node builtin, so it needed the flag to build correctly.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
