### PR TITLE
Remove broken badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@
   <a href="https://circleci.com/gh/storybookjs/storybook">
     <img src="https://circleci.com/gh/storybookjs/storybook.svg?style=shield" alt="Build Status on CircleCI" />
   </a>
-  <a href="https://www.codefactor.io/repository/github/storybookjs/storybook">
-    <img src="https://www.codefactor.io/repository/github/storybookjs/storybook/badge" alt="CodeFactor" />
-  </a>
-  <a href="https://snyk.io/test/github/storybookjs/storybook">
-    <img src="https://snyk.io/test/github/storybookjs/storybook/badge.svg" alt="Known Vulnerabilities" />
-  </a>
   <a href="https://codecov.io/gh/storybookjs/storybook">
     <img src="https://codecov.io/gh/storybookjs/storybook/branch/main/graph/badge.svg" alt="codecov" />
   </a>


### PR DESCRIPTION
Issue:

<img width="510" alt="image" src="https://user-images.githubusercontent.com/263385/193697316-a06a05ee-c1bb-4fcf-8201-231ead172b3b.png">


## What I did
Removed the broken badges. The links no longer resolve.

## How to test
Look at the README to confirm that the badges are no longer there.

