### PR TITLE
CLI: remove `npx` usage from storybook scripts

### DIFF
--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -308,12 +308,12 @@ export abstract class JsPackageManager {
   }) {
     const sbPort = options?.port ?? 6006;
     const storybookCmd = options?.staticFolder
-      ? `npx storybook dev -p ${sbPort} -s ${options.staticFolder}`
-      : `npx storybook dev -p ${sbPort}`;
+      ? `storybook dev -p ${sbPort} -s ${options.staticFolder}`
+      : `storybook dev -p ${sbPort}`;
 
     const buildStorybookCmd = options?.staticFolder
-      ? `npx storybook build -s ${options.staticFolder}`
-      : `npx storybook build`;
+      ? `storybook build -s ${options.staticFolder}`
+      : `storybook build`;
 
     const preCommand = options?.preCommand ? this.getRunCommand(options.preCommand) : undefined;
     this.addScripts({


### PR DESCRIPTION
Issue: https://github.com/yarnpkg/berry/actions/runs/3191237001/jobs/5207299422

https://github.com/storybookjs/storybook/pull/17898 updated the scripts added to the project to use `npx`.

## What I did

Removed `npx` from the scripts added to the project `package.json` during
```sh
yarn dlx -p @storybook/cli@next sb init --yes
```

## How to test

The e2e tests should have covered this but seems it was removed in https://github.com/storybookjs/storybook/pull/19303.
