### PR TITLE
Update storybook-preview-use-global-type.js.mdx

### DIFF
--- a/docs/snippets/common/storybook-preview-use-global-type.js.mdx
+++ b/docs/snippets/common/storybook-preview-use-global-type.js.mdx
@@ -14,7 +14,7 @@ const withThemeProvider=(Story,context)=>{
   const theme = getTheme(context.globals.theme);
   return (
     <ThemeProvider theme={theme}>
-      <Story {...context} />
+      <Story />
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
No need to spread `context` this is automatically done for you.

https://storybook.js.org/docs/react/writing-stories/decorators#decorator-inheritance

Issue: `{...context}` leftover from older way of setting up globals.

## What I did
Remove `{...context}` from **Create a decorator** Code Snippet example. 

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
