### PR TITLE
Only persist the (single) built sandbox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - sandbox
+            - sandbox/*/storybook-static
   test-runner-sandboxes:
     executor:
       class: medium+


### PR DESCRIPTION
Issue:

<img width="360" alt="image" src="https://user-images.githubusercontent.com/132554/194217136-91145092-64ab-425b-af92-12573983add1.png">

The reason was that each `build-sandboxes` job was persisting all the created sandboxes (and their node modules !!) rather than just the build storybook for one.