### PR TITLE
UI: Fix addon URL escaping in manager

### DIFF
--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -127,7 +127,7 @@ const starter: StarterFunction = async function* starterGeneratorFn({
   router.use(`/sb-addons`, express.static(addonsDir));
   router.use(`/sb-manager`, express.static(coreDirOrigin));
 
-  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation);
+  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation.outputFiles);
 
   yield;
 

--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -23,8 +23,7 @@ import { getData } from './utils/data';
 import { safeResolve } from './utils/safeResolve';
 import { readOrderedFiles } from './utils/files';
 
-// eslint-disable-next-line import/no-mutable-exports
-export let compilation: Compilation;
+let compilation: Compilation;
 let asyncIterator: ReturnType<StarterFunction> | ReturnType<BuilderFunction>;
 
 export const getConfig: ManagerBuilder['getConfig'] = async (options) => {
@@ -128,7 +127,7 @@ const starter: StarterFunction = async function* starterGeneratorFn({
   router.use(`/sb-addons`, express.static(addonsDir));
   router.use(`/sb-manager`, express.static(coreDirOrigin));
 
-  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir);
+  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation);
 
   yield;
 

--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -127,7 +127,7 @@ const starter: StarterFunction = async function* starterGeneratorFn({
   router.use(`/sb-addons`, express.static(addonsDir));
   router.use(`/sb-manager`, express.static(coreDirOrigin));
 
-  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation.outputFiles);
+  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation?.outputFiles);
 
   yield;
 
@@ -192,7 +192,7 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
   yield;
 
   const managerFiles = copy(coreDirOrigin, coreDirTarget);
-  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation.outputFiles);
+  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation?.outputFiles);
 
   yield;
 

--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -192,7 +192,7 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
   yield;
 
   const managerFiles = copy(coreDirOrigin, coreDirTarget);
-  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir);
+  const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation.outputFiles);
 
   yield;
 

--- a/code/lib/builder-manager/src/utils/files.test.ts
+++ b/code/lib/builder-manager/src/utils/files.test.ts
@@ -1,0 +1,19 @@
+import { sanatizePath } from './files';
+
+test('sanatizePath', () => {
+  const addonsDir = '/Users/username/Projects/projectname/storybook';
+  const text = 'demo text';
+  const file = {
+    path: '/Users/username/Projects/projectname/storybook/node_modules/@storybook/addon-x/dist/manager.mjs',
+    contents: Uint8Array.from(Array.from(text).map((letter) => letter.charCodeAt(0))),
+    text,
+  };
+  const { location, url } = sanatizePath(file, addonsDir);
+
+  expect(location).toMatchInlineSnapshot(
+    `"/Users/username/Projects/projectname/storybook/node-modules-storybook-addon-x-dist-manager.mjs"`
+  );
+  expect(url).toMatchInlineSnapshot(
+    `"./sb-addons/node-modules-storybook-addon-x-dist-manager.mjs"`
+  );
+});

--- a/code/lib/builder-manager/src/utils/files.test.ts
+++ b/code/lib/builder-manager/src/utils/files.test.ts
@@ -4,16 +4,16 @@ test('sanatizePath', () => {
   const addonsDir = '/Users/username/Projects/projectname/storybook';
   const text = 'demo text';
   const file = {
-    path: '/Users/username/Projects/projectname/storybook/node_modules/@storybook/addon-x/dist/manager.mjs',
+    path: '/Users/username/Projects/projectname/storybook/node_modules/@storybook/addon-x+y/dist/manager.mjs',
     contents: Uint8Array.from(Array.from(text).map((letter) => letter.charCodeAt(0))),
     text,
   };
   const { location, url } = sanatizePath(file, addonsDir);
 
   expect(location).toMatchInlineSnapshot(
-    `"/Users/username/Projects/projectname/storybook/node-modules-storybook-addon-x-dist-manager.mjs"`
+    `"/Users/username/Projects/projectname/storybook/node_modules/@storybook/addon-x+y/dist/manager.mjs"`
   );
   expect(url).toMatchInlineSnapshot(
-    `"./sb-addons/node-modules-storybook-addon-x-dist-manager.mjs"`
+    `"./sb-addons/node_modules/%40storybook/addon-x%2By/dist/manager.mjs"`
   );
 });

--- a/code/lib/builder-manager/src/utils/files.test.ts
+++ b/code/lib/builder-manager/src/utils/files.test.ts
@@ -1,6 +1,6 @@
-import { sanatizePath } from './files';
+import { sanitizePath } from './files';
 
-test('sanatizePath', () => {
+test('sanitizePath', () => {
   const addonsDir = '/Users/username/Projects/projectname/storybook';
   const text = 'demo text';
   const file = {
@@ -8,7 +8,7 @@ test('sanatizePath', () => {
     contents: Uint8Array.from(Array.from(text).map((letter) => letter.charCodeAt(0))),
     text,
   };
-  const { location, url } = sanatizePath(file, addonsDir);
+  const { location, url } = sanitizePath(file, addonsDir);
 
   expect(location).toMatchInlineSnapshot(
     `"/Users/username/Projects/projectname/storybook/node_modules/@storybook/addon-x+y/dist/manager.mjs"`

--- a/code/lib/builder-manager/src/utils/files.ts
+++ b/code/lib/builder-manager/src/utils/files.ts
@@ -3,7 +3,10 @@ import { writeFile, ensureFile } from 'fs-extra';
 import { join } from 'path';
 import { Compilation } from '../types';
 
-export async function readOrderedFiles(addonsDir: string, outputFiles: Compilation['outputFiles'] | undefined) {
+export async function readOrderedFiles(
+  addonsDir: string,
+  outputFiles: Compilation['outputFiles'] | undefined
+) {
   const files = await Promise.all(
     outputFiles?.map(async (file) => {
       // convert deeply nested paths to a single level, also remove special characters
@@ -20,11 +23,8 @@ export async function readOrderedFiles(addonsDir: string, outputFiles: Compilati
 }
 
 export function sanatizePath(file: OutputFile, addonsDir: string) {
-  const filePath = file.path
-    .replace(addonsDir, '')
-    .replace(/[^a-z0-9\-.]+/g, '-')
-    .replace(/^-/, '/');
+  const filePath = file.path.replace(addonsDir, '');
   const location = join(addonsDir, filePath);
-  const url = `./sb-addons${filePath}`;
+  const url = `./sb-addons${filePath.split('/').map(encodeURIComponent).join('/')}`;
   return { location, url };
 }

--- a/code/lib/builder-manager/src/utils/files.ts
+++ b/code/lib/builder-manager/src/utils/files.ts
@@ -3,7 +3,7 @@ import { writeFile, ensureFile } from 'fs-extra';
 import { join } from 'path';
 import { Compilation } from '../types';
 
-export async function readOrderedFiles(addonsDir: string, outputFiles: Compilation['outputFiles']) {
+export async function readOrderedFiles(addonsDir: string, outputFiles: Compilation['outputFiles'] | undefined) {
   const files = await Promise.all(
     outputFiles?.map(async (file) => {
       // convert deeply nested paths to a single level, also remove special characters

--- a/code/lib/builder-manager/src/utils/files.ts
+++ b/code/lib/builder-manager/src/utils/files.ts
@@ -1,11 +1,20 @@
 import { writeFile, ensureFile } from 'fs-extra';
+import { join } from 'path';
 import { compilation } from '../index';
 
 export async function readOrderedFiles(addonsDir: string) {
   const files = await Promise.all(
     compilation?.outputFiles?.map(async (file) => {
-      await ensureFile(file.path).then(() => writeFile(file.path, file.contents));
-      return file.path.replace(addonsDir, './sb-addons');
+      // convert deeply nested paths to a single level, also remove special characters
+      const filePath = file.path
+        .replace(addonsDir, '')
+        .replace(/[^a-z0-9\-.]+/g, '-')
+        .replace(/^-/, '/');
+      const location = join(addonsDir, filePath);
+      const url = `./sb-addons${filePath}`;
+
+      await ensureFile(location).then(() => writeFile(location, file.contents));
+      return url;
     }) || []
   );
 

--- a/code/lib/builder-manager/src/utils/files.ts
+++ b/code/lib/builder-manager/src/utils/files.ts
@@ -1,17 +1,13 @@
+import { OutputFile } from 'esbuild';
 import { writeFile, ensureFile } from 'fs-extra';
 import { join } from 'path';
-import { compilation } from '../index';
+import { Compilation } from '../types';
 
-export async function readOrderedFiles(addonsDir: string) {
+export async function readOrderedFiles(addonsDir: string, outputFiles: Compilation['outputFiles']) {
   const files = await Promise.all(
-    compilation?.outputFiles?.map(async (file) => {
+    outputFiles?.map(async (file) => {
       // convert deeply nested paths to a single level, also remove special characters
-      const filePath = file.path
-        .replace(addonsDir, '')
-        .replace(/[^a-z0-9\-.]+/g, '-')
-        .replace(/^-/, '/');
-      const location = join(addonsDir, filePath);
-      const url = `./sb-addons${filePath}`;
+      const { location, url } = sanatizePath(file, addonsDir);
 
       await ensureFile(location).then(() => writeFile(location, file.contents));
       return url;
@@ -21,4 +17,14 @@ export async function readOrderedFiles(addonsDir: string) {
   const jsFiles = files.filter((file) => file.endsWith('.mjs'));
   const cssFiles = files.filter((file) => file.endsWith('.css'));
   return { cssFiles, jsFiles };
+}
+
+export function sanatizePath(file: OutputFile, addonsDir: string) {
+  const filePath = file.path
+    .replace(addonsDir, '')
+    .replace(/[^a-z0-9\-.]+/g, '-')
+    .replace(/^-/, '/');
+  const location = join(addonsDir, filePath);
+  const url = `./sb-addons${filePath}`;
+  return { location, url };
 }

--- a/code/lib/builder-manager/src/utils/files.ts
+++ b/code/lib/builder-manager/src/utils/files.ts
@@ -10,7 +10,7 @@ export async function readOrderedFiles(
   const files = await Promise.all(
     outputFiles?.map(async (file) => {
       // convert deeply nested paths to a single level, also remove special characters
-      const { location, url } = sanatizePath(file, addonsDir);
+      const { location, url } = sanitizePath(file, addonsDir);
 
       await ensureFile(location).then(() => writeFile(location, file.contents));
       return url;
@@ -22,7 +22,7 @@ export async function readOrderedFiles(
   return { cssFiles, jsFiles };
 }
 
-export function sanatizePath(file: OutputFile, addonsDir: string) {
+export function sanitizePath(file: OutputFile, addonsDir: string) {
   const filePath = file.path.replace(addonsDir, '');
   const location = join(addonsDir, filePath);
   const url = `./sb-addons${filePath.split('/').map(encodeURIComponent).join('/')}`;


### PR DESCRIPTION
The URL injected into the manager for addons were not escaped properly causing them to 404 on some hosting platforms.

I added escaping for these URLs.