### PR TITLE
Webpack5: Fix lazy compilation/fscache builderOptions when base config is disabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_14_browsers
-    parallelism: 13
+    parallelism: 12
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -336,7 +336,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_14_browsers
-    parallelism: 13
+    parallelism: 12
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -352,7 +352,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_14_browsers
-    parallelism: 13
+    parallelism: 12
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -372,7 +372,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_14_browsers
-    parallelism: 13
+    parallelism: 12
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -388,7 +388,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_14_browsers
-    parallelism: 13
+    parallelism: 12
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -404,7 +404,7 @@ jobs:
     executor:
       class: medium+
       name: sb_playwright
-    parallelism: 13
+    parallelism: 12
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'

--- a/code/lib/builder-webpack5/src/preview/base-webpack.config.ts
+++ b/code/lib/builder-webpack5/src/preview/base-webpack.config.ts
@@ -1,7 +1,6 @@
 import { logger } from '@storybook/node-logger';
-import type { Options, CoreConfig } from '@storybook/core-common';
+import type { Options } from '@storybook/core-common';
 import type { Configuration } from 'webpack';
-import type { BuilderOptions } from '../types';
 
 export async function createDefaultWebpackConfig(
   storybookBaseConfig: Configuration,
@@ -45,15 +44,6 @@ export async function createDefaultWebpackConfig(
 
   const isProd = storybookBaseConfig.mode !== 'development';
 
-  const coreOptions = await options.presets.apply<CoreConfig>('core');
-  const builderOptions: BuilderOptions =
-    typeof coreOptions.builder === 'string'
-      ? {}
-      : coreOptions.builder?.options || ({} as BuilderOptions);
-  const cacheConfig = builderOptions.fsCache ? { cache: { type: 'filesystem' as const } } : {};
-  const lazyCompilationConfig =
-    builderOptions.lazyCompilation && !isProd ? { lazyCompilation: { entries: false } } : {};
-
   return {
     ...storybookBaseConfig,
     module: {
@@ -94,7 +84,5 @@ export async function createDefaultWebpackConfig(
         ...storybookBaseConfig.resolve?.fallback,
       },
     },
-    ...cacheConfig,
-    experiments: { ...storybookBaseConfig.experiments, ...lazyCompilationConfig },
   };
 }

--- a/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -78,7 +78,9 @@ export default async (
   const template = await presets.apply<string>('previewMainTemplate');
   const coreOptions = await presets.apply<CoreConfig>('core');
   const builderOptions: BuilderOptions =
-    typeof coreOptions.builder === 'string' ? {} : coreOptions.builder?.options || {};
+    typeof coreOptions.builder === 'string'
+      ? {}
+      : coreOptions.builder?.options || ({} as BuilderOptions);
   const docsOptions = await presets.apply<DocsOptions>('docs');
 
   const previewAnnotations = [
@@ -159,6 +161,14 @@ export default async (
 
   const shouldCheckTs = typescriptOptions.check && !typescriptOptions.skipBabel;
   const tsCheckOptions = typescriptOptions.checkOptions || {};
+
+  const cacheConfig = builderOptions.fsCache ? { cache: { type: 'filesystem' as const } } : {};
+  const lazyCompilationConfig =
+    builderOptions.lazyCompilation && !isProd
+      ? {
+          lazyCompilation: { entries: false },
+        }
+      : {};
 
   return {
     name: 'preview',
@@ -289,5 +299,7 @@ export default async (
     performance: {
       hints: isProd ? 'warning' : false,
     },
+    ...cacheConfig,
+    experiments: { ...lazyCompilationConfig },
   };
 };


### PR DESCRIPTION
replaces: https://github.com/storybookjs/storybook/pull/19376

@shilman you were right, this is an issue on 7.0 as well.