### PR TITLE
CLI: Scope styles in sample components from the CLI templates

### DIFF
--- a/code/lib/cli/rendererAssets/angular/header.component.ts
+++ b/code/lib/cli/rendererAssets/angular/header.component.ts
@@ -4,7 +4,7 @@ import { User } from './User';
 @Component({
   selector: 'storybook-header',
   template: `<header>
-    <div class="wrapper">
+    <div class="storybook-header wrapper">
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">

--- a/code/lib/cli/rendererAssets/angular/page.component.ts
+++ b/code/lib/cli/rendererAssets/angular/page.component.ts
@@ -10,7 +10,7 @@ import { User } from './User';
       (onLogin)="doLogin()"
       (onCreateAccount)="doCreateAccount()"
     ></storybook-header>
-    <section>
+    <section class="storybook-page">
       <h2>Pages in Storybook</h2>
       <p>
         We recommend building UIs with a

--- a/code/lib/cli/rendererAssets/common/header.css
+++ b/code/lib/cli/rendererAssets/common/header.css
@@ -1,4 +1,4 @@
-.wrapper {
+.storybook-header.wrapper {
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   padding: 15px 20px;
@@ -7,12 +7,12 @@
   justify-content: space-between;
 }
 
-svg {
+.storybook-header svg {
   display: inline-block;
   vertical-align: top;
 }
 
-h1 {
+.storybook-header h1 {
   font-weight: 900;
   font-size: 20px;
   line-height: 1;
@@ -21,11 +21,11 @@ h1 {
   vertical-align: top;
 }
 
-button + button {
+.storybook-header button + button {
   margin-left: 10px;
 }
 
-.welcome {
+.storybook-header .welcome {
   color: #333;
   font-size: 14px;
   margin-right: 10px;

--- a/code/lib/cli/rendererAssets/common/page.css
+++ b/code/lib/cli/rendererAssets/common/page.css
@@ -1,4 +1,4 @@
-section {
+.storybook-page {
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 24px;
@@ -8,7 +8,7 @@ section {
   color: #333;
 }
 
-section h2 {
+.storybook-page h2 {
   font-weight: 900;
   font-size: 32px;
   line-height: 1;
@@ -17,25 +17,25 @@ section h2 {
   vertical-align: top;
 }
 
-section p {
+.storybook-page p {
   margin: 1em 0;
 }
 
-section a {
+.storybook-page a {
   text-decoration: none;
   color: #1ea7fd;
 }
 
-section ul {
+.storybook-page ul {
   padding-left: 30px;
   margin: 1em 0;
 }
 
-section li {
+.storybook-page li {
   margin-bottom: 8px;
 }
 
-section .tip {
+.storybook-page .tip {
   display: inline-block;
   border-radius: 1em;
   font-size: 11px;
@@ -48,14 +48,14 @@ section .tip {
   vertical-align: top;
 }
 
-section .tip-wrapper {
+.storybook-page .tip-wrapper {
   font-size: 13px;
   line-height: 20px;
   margin-top: 40px;
   margin-bottom: 40px;
 }
 
-section .tip-wrapper svg {
+.storybook-page .tip-wrapper svg {
   display: inline-block;
   height: 12px;
   width: 12px;
@@ -64,6 +64,6 @@ section .tip-wrapper svg {
   margin-top: 3px;
 }
 
-section .tip-wrapper svg path {
+.storybook-page .tip-wrapper svg path {
   fill: #1ea7fd;
 }

--- a/code/lib/cli/rendererAssets/html/js/Header.js
+++ b/code/lib/cli/rendererAssets/html/js/Header.js
@@ -5,7 +5,7 @@ export const createHeader = ({ user, onLogout, onLogin, onCreateAccount }) => {
   const header = document.createElement('header');
 
   const wrapper = document.createElement('div');
-  wrapper.className = 'wrapper';
+  wrapper.className = 'storybook-header wrapper';
 
   const logo = `<div>
     <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">

--- a/code/lib/cli/rendererAssets/html/js/Page.js
+++ b/code/lib/cli/rendererAssets/html/js/Page.js
@@ -34,7 +34,7 @@ export const createPage = () => {
   article.appendChild(header);
 
   const section = `
-  <section>
+  <section class="storybook-page">
     <h2>Pages in Storybook</h2>
     <p>
       We recommend building UIs with a

--- a/code/lib/cli/rendererAssets/html/ts/Header.ts
+++ b/code/lib/cli/rendererAssets/html/ts/Header.ts
@@ -12,7 +12,7 @@ export const createHeader = ({ user, onLogout, onLogin, onCreateAccount }: Heade
   const header = document.createElement('header');
 
   const wrapper = document.createElement('div');
-  wrapper.className = 'wrapper';
+  wrapper.className = 'storybook-header wrapper';
 
   const logo = `<div>
     <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">

--- a/code/lib/cli/rendererAssets/html/ts/Page.ts
+++ b/code/lib/cli/rendererAssets/html/ts/Page.ts
@@ -38,7 +38,7 @@ export const createPage = () => {
   article.appendChild(header);
 
   const section = `
-  <section>
+  <section class="storybook-page">
     <h2>Pages in Storybook</h2>
     <p>
       We recommend building UIs with a

--- a/code/lib/cli/rendererAssets/mithril/Header.js
+++ b/code/lib/cli/rendererAssets/mithril/Header.js
@@ -8,7 +8,7 @@ import './header.css';
 export const Header = {
   view: ({ attrs }) => (
     <header>
-      <div class="wrapper">
+      <div class="storybook-header wrapper">
         <div>
           <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
             <g fill="none" fillRule="evenodd">

--- a/code/lib/cli/rendererAssets/mithril/Page.js
+++ b/code/lib/cli/rendererAssets/mithril/Page.js
@@ -16,7 +16,7 @@ export const Page = {
           onCreateAccount: attrs.onCreateAccount,
         })}
       </div>
-      <section>
+      <section class="storybook-page">
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}

--- a/code/lib/cli/rendererAssets/preact/Header.jsx
+++ b/code/lib/cli/rendererAssets/preact/Header.jsx
@@ -7,7 +7,7 @@ import './header.css';
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => (
   <header>
-    <div className="wrapper">
+    <div className="storybook-header wrapper">
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">

--- a/code/lib/cli/rendererAssets/preact/Page.jsx
+++ b/code/lib/cli/rendererAssets/preact/Page.jsx
@@ -17,7 +17,7 @@ export const Page = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section>
+      <section class="storybook-page">
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}

--- a/code/lib/cli/rendererAssets/preact/Page.jsx
+++ b/code/lib/cli/rendererAssets/preact/Page.jsx
@@ -17,7 +17,7 @@ export const Page = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section class="storybook-page">
+      <section className="storybook-page">
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}

--- a/code/lib/cli/rendererAssets/rax/Header.js
+++ b/code/lib/cli/rendererAssets/rax/Header.js
@@ -5,7 +5,7 @@ import './header.css';
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => (
   <header>
-    <div className="wrapper">
+    <div className="storybook-header wrapper">
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">

--- a/code/lib/cli/rendererAssets/rax/Page.js
+++ b/code/lib/cli/rendererAssets/rax/Page.js
@@ -7,7 +7,7 @@ export const Page = ({ user, onLogin, onLogout, onCreateAccount }) => (
   <article>
     <Header user={user} onLogin={onLogin} onLogout={onLogout} onCreateAccount={onCreateAccount} />
 
-    <section>
+    <section class="storybook-page">
       <h2>Pages in Storybook</h2>
       <p>
         We recommend building UIs with a{' '}

--- a/code/lib/cli/rendererAssets/rax/Page.js
+++ b/code/lib/cli/rendererAssets/rax/Page.js
@@ -7,7 +7,7 @@ export const Page = ({ user, onLogin, onLogout, onCreateAccount }) => (
   <article>
     <Header user={user} onLogin={onLogin} onLogout={onLogout} onCreateAccount={onCreateAccount} />
 
-    <section class="storybook-page">
+    <section className="storybook-page">
       <h2>Pages in Storybook</h2>
       <p>
         We recommend building UIs with a{' '}

--- a/code/lib/cli/rendererAssets/react/js/Header.jsx
+++ b/code/lib/cli/rendererAssets/react/js/Header.jsx
@@ -6,7 +6,7 @@ import './header.css';
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => (
   <header>
-    <div className="wrapper">
+    <div className="storybook-header wrapper">
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">

--- a/code/lib/cli/rendererAssets/react/js/Page.jsx
+++ b/code/lib/cli/rendererAssets/react/js/Page.jsx
@@ -15,7 +15,7 @@ export const Page = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section>
+      <section class="storybook-page">
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}

--- a/code/lib/cli/rendererAssets/react/js/Page.jsx
+++ b/code/lib/cli/rendererAssets/react/js/Page.jsx
@@ -15,7 +15,7 @@ export const Page = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section class="storybook-page">
+      <section className="storybook-page">
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}

--- a/code/lib/cli/rendererAssets/react/ts/Header.tsx
+++ b/code/lib/cli/rendererAssets/react/ts/Header.tsx
@@ -16,7 +16,7 @@ interface HeaderProps {
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => (
   <header>
-    <div className="wrapper">
+    <div className="storybook-header wrapper">
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">

--- a/code/lib/cli/rendererAssets/react/ts/Page.tsx
+++ b/code/lib/cli/rendererAssets/react/ts/Page.tsx
@@ -19,7 +19,7 @@ export const Page: React.VFC = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section class="storybook-page">
+      <section className="storybook-page">
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}

--- a/code/lib/cli/rendererAssets/react/ts/Page.tsx
+++ b/code/lib/cli/rendererAssets/react/ts/Page.tsx
@@ -19,7 +19,7 @@ export const Page: React.VFC = () => {
         onCreateAccount={() => setUser({ name: 'Jane Doe' })}
       />
 
-      <section>
+      <section class="storybook-page">
         <h2>Pages in Storybook</h2>
         <p>
           We recommend building UIs with a{' '}

--- a/code/lib/cli/rendererAssets/svelte/Header.svelte
+++ b/code/lib/cli/rendererAssets/svelte/Header.svelte
@@ -20,7 +20,7 @@
 </script>
 
 <header>
-  <div class="wrapper">
+  <div class="storybook-header wrapper">
     <div>
       <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
         <g fill="none" fill-rule="evenodd">

--- a/code/lib/cli/rendererAssets/svelte/Page.svelte
+++ b/code/lib/cli/rendererAssets/svelte/Page.svelte
@@ -8,7 +8,7 @@
 <article>
   <Header {user} on:login={() => user = { name: 'Jane Doe' }} on:logout={() => user = null} on:createAccount={() => user = { name: 'Jane Doe' }} />
 
-  <section>
+  <section class="storybook-page">
     <h2>Pages in Storybook</h2>
     <p>
       We recommend building UIs with a

--- a/code/lib/cli/rendererAssets/vue/Header.vue
+++ b/code/lib/cli/rendererAssets/vue/Header.vue
@@ -1,6 +1,6 @@
 <template>
   <header>
-    <div class="wrapper">
+    <div class="storybook-header wrapper">
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fill-rule="evenodd">

--- a/code/lib/cli/rendererAssets/vue/Page.vue
+++ b/code/lib/cli/rendererAssets/vue/Page.vue
@@ -7,7 +7,7 @@
       @onCreateAccount="onCreateAccount"
     />
 
-    <section>
+    <section class="storybook-page">
       <h2>Pages in Storybook</h2>
       <p>
         We recommend building UIs with a

--- a/code/lib/cli/rendererAssets/vue3/Header.vue
+++ b/code/lib/cli/rendererAssets/vue3/Header.vue
@@ -1,6 +1,6 @@
 <template>
   <header>
-    <div class="wrapper">
+    <div class="storybook-header wrapper">
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fill-rule="evenodd">

--- a/code/lib/cli/rendererAssets/vue3/Page.vue
+++ b/code/lib/cli/rendererAssets/vue3/Page.vue
@@ -7,7 +7,7 @@
       @createAccount="onCreateAccount"
     />
 
-    <section>
+    <section class="storybook-page">
       <h2>Pages in Storybook</h2>
       <p>
         We recommend building UIs with a

--- a/code/lib/cli/rendererAssets/web-components/js/Header.js
+++ b/code/lib/cli/rendererAssets/web-components/js/Header.js
@@ -5,7 +5,7 @@ import './header.css';
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => html`
   <header>
-    <div class="wrapper">
+    <div class="storybook-header wrapper">
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">

--- a/code/lib/cli/rendererAssets/web-components/js/Page.js
+++ b/code/lib/cli/rendererAssets/web-components/js/Page.js
@@ -11,7 +11,7 @@ export const Page = ({ user, onLogin, onLogout, onCreateAccount }) => html`
       onCreateAccount,
     })}
 
-    <section>
+    <section class="storybook-page">
       <h2>Pages in Storybook</h2>
       <p>
         We recommend building UIs with a

--- a/code/lib/cli/rendererAssets/web-components/ts/Header.ts
+++ b/code/lib/cli/rendererAssets/web-components/ts/Header.ts
@@ -12,7 +12,7 @@ export interface HeaderProps {
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => html`
   <header>
-    <div class="wrapper">
+    <div class="storybook-header wrapper">
       <div>
         <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
           <g fill="none" fillRule="evenodd">

--- a/code/lib/cli/rendererAssets/web-components/ts/Page.ts
+++ b/code/lib/cli/rendererAssets/web-components/ts/Page.ts
@@ -18,7 +18,7 @@ export const Page = ({ user, onLogin, onLogout, onCreateAccount }: PageProps) =>
       onCreateAccount,
     })}
 
-    <section>
+    <section class="storybook-page">
       <h2>Pages in Storybook</h2>
       <p>
         We recommend building UIs with a


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/19409 #12423

## What I did
Added storybook specific classes to Page and Header components to prevent its CSS being applied to other elements.

This solution was discussed here before: https://github.com/storybookjs/storybook/pull/19410#issuecomment-1273626505