### PR TITLE
disable smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,9 +458,9 @@ workflows:
       - create-sandboxes:
           requires:
             - publish
-      - smoke-test-sandboxes:
-          requires:
-            - create-sandboxes
+      # - smoke-test-sandboxes: # disabled for now
+      #     requires:
+      #       - create-sandboxes
       - build-sandboxes:
           requires:
             - create-sandboxes


### PR DESCRIPTION
disable the smoke-test-sandboxes for now.
because they are inconsistent, don't add a tremendous amount of confidence either.

CI is blocked too much with these inconsistent failures.
https://app.circleci.com/pipelines/github/storybookjs/storybook/30265/workflows/647fd6a6-d9fb-40d5-9325-709db6da2191/jobs/425672