### PR TITLE
Don't pass the full path to repro generators

### DIFF
--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -248,7 +248,7 @@ const vueCliTemplates = {
   'vue-cli/vue2-default-js': {
     name: 'Vue-CLI (Vue2 JS)',
     script:
-      'npx -p @vue/cli vue create . --default --packageManager=yarn --force --merge --preset=Default\\ (Vue\\ 2)',
+      'npx -p @vue/cli vue create . --default --packageManager=yarn --force --merge --preset="Default (Vue 2)"',
     cadence: ['ci', 'daily', 'weekly'],
     skipTasks: [
       // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -1,7 +1,7 @@
 const craTemplates = {
   'cra/default-js': {
     name: 'Create React App (Javascript)',
-    script: 'npx create-react-app {{beforeDir}}',
+    script: 'npx create-react-app .',
     cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/cra',
@@ -11,7 +11,7 @@ const craTemplates = {
   },
   'cra/default-ts': {
     name: 'Create React App (Typescript)',
-    script: 'npx create-react-app {{beforeDir}} --template typescript',
+    script: 'npx create-react-app . --template typescript',
     cadence: ['ci', 'daily', 'weekly'],
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
@@ -26,7 +26,7 @@ const craTemplates = {
 const reactViteTemplates = {
   'react-vite/default-js': {
     name: 'React Vite (JS)',
-    script: 'yarn create vite {{beforeDir}} --template react',
+    script: 'yarn create vite . --template react',
     cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/react-vite',
@@ -36,7 +36,7 @@ const reactViteTemplates = {
   },
   'react-vite/default-ts': {
     name: 'React Vite (TS)',
-    script: 'yarn create vite {{beforeDir}} --template react-ts',
+    script: 'yarn create vite . --template react-ts',
     cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/react-vite',
@@ -49,7 +49,7 @@ const reactViteTemplates = {
 const reactWebpackTemplates = {
   'react-webpack/18-ts': {
     name: 'React Webpack5 (TS)',
-    script: 'yarn create webpack5-react {{beforeDir}}',
+    script: 'yarn create webpack5-react .',
     cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/react-webpack5',
@@ -59,8 +59,7 @@ const reactWebpackTemplates = {
   },
   'react-webpack/17-ts': {
     name: 'React Webpack5 (TS)',
-    script:
-      'yarn create webpack5-react {{beforeDir}} --version-react="17" --version-react-dom="17"',
+    script: 'yarn create webpack5-react . --version-react="17" --version-react-dom="17"',
     cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/react-webpack5',
@@ -73,7 +72,7 @@ const reactWebpackTemplates = {
 const vue3ViteTemplates = {
   'vue3-vite/default-js': {
     name: 'Vue3 Vite (JS)',
-    script: 'yarn create vite {{beforeDir}} --template vue',
+    script: 'yarn create vite . --template vue',
     cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/vue3-vite',
@@ -83,7 +82,7 @@ const vue3ViteTemplates = {
   },
   'vue3-vite/default-ts': {
     name: 'Vue3 Vite (TS)',
-    script: 'yarn create vite {{beforeDir}} --template vue-ts',
+    script: 'yarn create vite . --template vue-ts',
     cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/vue3-vite',
@@ -100,7 +99,7 @@ const vue2ViteTemplates = {
     // We don't really want to maintain weird custom scripts like this,
     // preferring community bootstrap scripts / generators instead.
     script:
-      'yarn create vite {{beforeDir}} --template vanilla && yarn add --dev @vitejs/plugin-vue2 vue-template-compiler vue@2 && echo "import vue2 from \'@vitejs/plugin-vue2\';\n\nexport default {\n\tplugins: [vue2()]\n};" > vite.config.js',
+      'yarn create vite . --template vanilla && yarn add --dev @vitejs/plugin-vue2 vue-template-compiler vue@2 && echo "import vue2 from \'@vitejs/plugin-vue2\';\n\nexport default {\n\tplugins: [vue2()]\n};" > vite.config.js',
     cadence: ['ci', 'daily', 'weekly'],
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
@@ -115,7 +114,7 @@ const vue2ViteTemplates = {
 const htmlWebpackTemplates = {
   'html-webpack/default': {
     name: 'HTML Webpack5',
-    script: 'yarn create webpack5-html {{beforeDir}}',
+    script: 'yarn create webpack5-html .',
     cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/html-webpack5',
@@ -128,7 +127,7 @@ const htmlWebpackTemplates = {
 const svelteViteTemplates = {
   'svelte-vite/default-js': {
     name: 'Svelte Vite (JS)',
-    script: 'yarn create vite {{beforeDir}} --template svelte',
+    script: 'yarn create vite . --template svelte',
     cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/svelte-vite',
@@ -138,7 +137,7 @@ const svelteViteTemplates = {
   },
   'svelte-vite/default-ts': {
     name: 'Svelte Vite (TS)',
-    script: 'yarn create vite {{beforeDir}} --template svelte-ts',
+    script: 'yarn create vite . --template svelte-ts',
     cadence: ['ci', 'daily', 'weekly'],
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
@@ -205,7 +204,7 @@ const angularCliTemplates = {
 const litViteTemplates = {
   'lit-vite/default-js': {
     name: 'Lit Vite (JS)',
-    script: 'yarn create vite {{beforeDir}} --template lit',
+    script: 'yarn create vite . --template lit',
     cadence: ['ci', 'daily', 'weekly'] as any,
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
@@ -217,7 +216,7 @@ const litViteTemplates = {
   },
   'lit-vite/default-ts': {
     name: 'Lit Vite (TS)',
-    script: 'yarn create vite {{beforeDir}} --template lit-ts',
+    script: 'yarn create vite . --template lit-ts',
     cadence: ['ci', 'daily', 'weekly'] as any,
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
@@ -232,8 +231,7 @@ const litViteTemplates = {
 const vueCliTemplates = {
   'vue-cli/default-js': {
     name: 'Vue-CLI (Default JS)',
-    script:
-      'npx -p @vue/cli vue create {{beforeDir}} --default --packageManager=yarn --force --merge',
+    script: 'npx -p @vue/cli vue create . --default --packageManager=yarn --force --merge',
     cadence: ['ci', 'daily', 'weekly'],
     skipTasks: [
       // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
@@ -250,7 +248,7 @@ const vueCliTemplates = {
   'vue-cli/vue2-default-js': {
     name: 'Vue-CLI (Vue2 JS)',
     script:
-      'npx -p @vue/cli vue create {{beforeDir}} --default --packageManager=yarn --force --merge --preset=Default\\ (Vue\\ 2)',
+      'npx -p @vue/cli vue create . --default --packageManager=yarn --force --merge --preset=Default\\ (Vue\\ 2)',
     cadence: ['ci', 'daily', 'weekly'],
     skipTasks: [
       // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.

--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -24,6 +24,7 @@ import { runRegistry } from '../tasks/run-registry';
 const OUTPUT_DIRECTORY = join(__dirname, '..', '..', 'repros');
 const BEFORE_DIR_NAME = 'before-storybook';
 const AFTER_DIR_NAME = 'after-storybook';
+const SCRIPT_TIMEOUT = 5 * 60 * 1000;
 
 const sbInit = async (cwd: string, flags?: string[]) => {
   const sbCliBinaryPath = join(__dirname, `../../code/lib/cli/bin/index.js`);
@@ -142,10 +143,10 @@ const runGenerators = async (
         // handle different modes of operation.
         if (script.includes('{{beforeDir}}')) {
           const scriptWithBeforeDir = script.replace('{{beforeDir}}', BEFORE_DIR_NAME);
-          await runCommand(scriptWithBeforeDir, { cwd: createBaseDir });
+          await runCommand(scriptWithBeforeDir, { cwd: createBaseDir, timeout: SCRIPT_TIMEOUT });
         } else {
           await ensureDir(createBeforeDir);
-          await runCommand(script, { cwd: createBeforeDir });
+          await runCommand(script, { cwd: createBeforeDir, timeout: SCRIPT_TIMEOUT });
         }
 
         await localizeYarnConfigFiles(createBaseDir, createBeforeDir);

--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -136,7 +136,7 @@ const runGenerators = async (
         await setupYarn({ cwd: createBaseDir });
 
         const createBeforeDir = join(createBaseDir, BEFORE_DIR_NAME);
-        const scriptWithBeforeDir = script.replace('{{beforeDir}}', createBeforeDir);
+        const scriptWithBeforeDir = script.replace('{{beforeDir}}', BEFORE_DIR_NAME);
         await runCommand(scriptWithBeforeDir, { cwd: createBaseDir });
 
         await localizeYarnConfigFiles(createBaseDir, createBeforeDir);


### PR DESCRIPTION
Issue: Repro generation was hanging as `yarn create vite` prompts if you pass an absolute path

## What I did

Just path the relative path and run from inside the temp dir

## How to test

I'll kick off a repro generation