### PR TITLE
Add missing addons/docs dependency for fs-extra

### DIFF
--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -71,6 +71,7 @@
     "@storybook/theming": "7.0.0-alpha.37",
     "babel-loader": "^8.2.5",
     "dequal": "^2.0.2",
+    "fs-extra": "^9.0.1",
     "global": "^4.4.0",
     "lodash": "^4.17.21",
     "remark-external-links": "^8.0.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6499,6 +6499,7 @@ __metadata:
     "@types/util-deprecate": ^1.0.0
     babel-loader: ^8.2.5
     dequal: ^2.0.2
+    fs-extra: ^9.0.1
     global: ^4.4.0
     lodash: ^4.17.21
     remark-external-links: ^8.0.0


### PR DESCRIPTION
Issue: [line 1](https://github.com/storybookjs/storybook/blob/next/code/addons/docs/src/preset.ts#L1) of addons/docs/src/preset.js is `import fs from 'fs-extra';`, but `fs-extra` is missing from addons/docs’ package.json.

## What I did

i added `"fs-extra": "^9.0.1",` to the package.json `dependencies` (the same version string that i found elsewhere, e.g. in [core-common](https://github.com/storybookjs/storybook/blob/acb3ed1f909d84c27a879ee29e1dc25149e7923a/code/lib/core-common/package.json#L62))

## How to test

i ran into this issue when trying to upgrade to storybook `v7.0.0-alpha.37` in a codebase using the vite builder and yarn v3.2.4.  the specific error is:

```
WARN   Failed to load preset: {"name":"/Users/me/my-repo/.yarn/__virtual__/@storybook-addon-docs-virtual-8d4a2f6481/0/cache/@storybook-addon-docs-npm-7.0.0-alpha.37-95b089e905-abc8952e75.zip/node_modules/@storybook/addon-docs/preset.js"} on level 3
ERR! Error: @storybook/addon-docs tried to access fs-extra, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
ERR!
ERR! Required package: fs-extra
ERR! Required by: @storybook/addon-docs@virtual:62e895eaa74935c5722a4de41d4984328b771f05bc9888b3fd8210e5282d0c5555d799ab7a4041d2fcfa758b27814e74dbaddade60b7b0a4795629e4e3c125c0#npm:7.0.0-alpha.37 (via /Users/me/my-repo/.yarn/__virtual__/@storybook-addon-docs-virtual-8d4a2f6481/0/cache/@storybook-addon-docs-npm-7.0.0-alpha.37-95b089e905-abc8952e75.zip/node_modules/@storybook/addon-docs/dist/cjs/)
```

i worked around it by adding the dependency via `packageExtensions ` in my `.yarnrc.yml`. this fix can be verified by checking to see that the error above no longer occurs when running `storybook` using the vite builder on yarn. but it’s also self-evidently correct, so there’s that.

note that i ran into the same kind of issue from `@storybook/common-core` requiring `@storybook/react-vite` even though it isn‘t in its deps, but i think that might be a dynamic require that comes from `.storybook/main.js`’s `framework.name`, so i’m not sure how that should be resolved. 