### PR TITLE
refactor(cli): rename "latest" to "v13" app name in angular v13 repro template

### DIFF
--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -164,7 +164,7 @@ const angularCliTemplates = {
   'angular-cli/13-ts': {
     name: 'Angular CLI (Version 13)',
     script:
-      'npx -p @angular/cli@13 ng new angular-latest --directory . --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
+      'npx -p @angular/cli@13 ng new angular-v13 --directory . --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
     cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/angular',


### PR DESCRIPTION
## What I did#

Both, "latest" and. "v13" created an app that was called "latest".

```typescript
const angularCliTemplates = {
  'angular-cli/default-ts': {
    name: 'Angular CLI (latest)',
    script:
      'npx -p @angular/cli ng new angular-latest --directory . --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
   // ...
  },
  'angular-cli/13-ts': {
    name: 'Angular CLI (Version 13)',
    script:
      'npx -p @angular/cli@13 ng new angular-latest --directory . --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
    // ...
  },
};
```

I changed "latest" to "angular-v13"