### PR TITLE
fix grammer mistake on introduction page

### DIFF
--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -83,7 +83,7 @@ Use the _named_ exports of a CSF file to define your component’s stories. We r
 <!-- prettier-ignore-end -->
 
 <div class="aside">
-💡 The recommendation mentioned above also applies to other frameworks other than React.
+💡 The recommendation mentioned above also applies to other frameworks, not only React.
 </div>
 
 ### Rename stories

--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -83,7 +83,7 @@ Use the _named_ exports of a CSF file to define your component’s stories. We r
 <!-- prettier-ignore-end -->
 
 <div class="aside">
-💡 The recommendation mentioned above also applies to other frameworks not only React.
+💡 The recommendation mentioned above also applies to other frameworks other than React.
 </div>
 
 ### Rename stories


### PR DESCRIPTION
Issue: Grammer mistake on [docs/writing-stories/introduction.md](https://github.com/storybookjs/storybook/compare/next...Nightvision53:storybook:patch-1#diff-929f7c1ec107ef9fcf6dda864bbae4360b57722d11da19d674103f0467a50cea)

## What I did
Changed line 86 on introduction.md

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
