### PR TITLE
Telemetry: Send start/build events even when there is no generator

### DIFF
--- a/code/lib/core-server/src/build-static.ts
+++ b/code/lib/core-server/src/build-static.ts
@@ -168,11 +168,7 @@ export async function buildStaticStandalone(
   if (!core?.disableTelemetry) {
     effects.push(
       initializedStoryIndexGenerator.then(async (generator) => {
-        if (!generator) {
-          return;
-        }
-
-        const storyIndex = await generator.getIndex();
+        const storyIndex = await generator?.getIndex();
         const payload = storyIndex
           ? {
               storyIndex: {

--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -80,11 +80,7 @@ export async function storybookDevServer(options: Options) {
 
   if (!core?.disableTelemetry) {
     initializedStoryIndexGenerator.then(async (generator) => {
-      if (!generator) {
-        return;
-      }
-
-      const storyIndex = await generator.getIndex();
+      const storyIndex = await generator?.getIndex();
       const payload = storyIndex
         ? {
             storyIndex: {


### PR DESCRIPTION
Issue: `'start'` / `'build'` events were not getting sent for the v6 store

## What I did

Ensure we do.

Note this code need some kind of tests to avoid future regressions. Let's discuss.