### PR TITLE
Frameworks: Don't re-export renderer types from frameworks

### DIFF
--- a/code/frameworks/html-webpack5/src/index.ts
+++ b/code/frameworks/html-webpack5/src/index.ts
@@ -1,2 +1,1 @@
-export * from '@storybook/html';
 export * from './types';

--- a/code/frameworks/preact-webpack5/src/index.ts
+++ b/code/frameworks/preact-webpack5/src/index.ts
@@ -1,2 +1,1 @@
-export * from '@storybook/preact';
 export * from './types';

--- a/code/frameworks/react-vite/src/index.ts
+++ b/code/frameworks/react-vite/src/index.ts
@@ -5,5 +5,4 @@ export { addons } from '@storybook/addons';
 export { composeConfigs, PreviewWeb } from '@storybook/preview-web';
 export { ClientApi } from '@storybook/client-api';
 
-export * from '@storybook/react';
 export type { StorybookConfig } from '@storybook/builder-vite';

--- a/code/frameworks/react-webpack5/src/index.ts
+++ b/code/frameworks/react-webpack5/src/index.ts
@@ -1,2 +1,1 @@
-export * from '@storybook/react';
 export * from './types';

--- a/code/frameworks/server-webpack5/src/index.ts
+++ b/code/frameworks/server-webpack5/src/index.ts
@@ -1,2 +1,1 @@
-export * from '@storybook/server';
 export * from './types';

--- a/code/frameworks/svelte-vite/src/index.ts
+++ b/code/frameworks/svelte-vite/src/index.ts
@@ -5,5 +5,4 @@ export { addons } from '@storybook/addons';
 export { composeConfigs, PreviewWeb } from '@storybook/preview-web';
 export { ClientApi } from '@storybook/client-api';
 
-export * from '@storybook/svelte';
 export type { StorybookConfig } from '@storybook/builder-vite';

--- a/code/frameworks/svelte-webpack5/src/index.ts
+++ b/code/frameworks/svelte-webpack5/src/index.ts
@@ -1,2 +1,1 @@
-export * from '@storybook/svelte';
 export * from './types';

--- a/code/frameworks/vue-vite/src/index.ts
+++ b/code/frameworks/vue-vite/src/index.ts
@@ -5,5 +5,4 @@ export { addons } from '@storybook/addons';
 export { composeConfigs, PreviewWeb } from '@storybook/preview-web';
 export { ClientApi } from '@storybook/client-api';
 
-export * from '@storybook/vue';
 export type { StorybookConfig } from '@storybook/builder-vite';

--- a/code/frameworks/vue-webpack5/src/index.ts
+++ b/code/frameworks/vue-webpack5/src/index.ts
@@ -1,2 +1,1 @@
-export * from '@storybook/vue';
 export * from './types';

--- a/code/frameworks/vue3-vite/src/index.ts
+++ b/code/frameworks/vue3-vite/src/index.ts
@@ -5,5 +5,4 @@ export { addons } from '@storybook/addons';
 export { composeConfigs, PreviewWeb } from '@storybook/preview-web';
 export { ClientApi } from '@storybook/client-api';
 
-export * from '@storybook/vue3';
 export type { StorybookConfig } from '@storybook/builder-vite';

--- a/code/frameworks/vue3-webpack5/src/index.ts
+++ b/code/frameworks/vue3-webpack5/src/index.ts
@@ -1,2 +1,1 @@
-export * from '@storybook/vue3';
 export * from './types';

--- a/code/frameworks/web-components-vite/src/index.ts
+++ b/code/frameworks/web-components-vite/src/index.ts
@@ -5,5 +5,4 @@ export { addons } from '@storybook/addons';
 export { composeConfigs, PreviewWeb } from '@storybook/preview-web';
 export { ClientApi } from '@storybook/client-api';
 
-export * from '@storybook/web-components';
 export type { StorybookConfig } from '@storybook/builder-vite';

--- a/code/frameworks/web-components-webpack5/src/index.ts
+++ b/code/frameworks/web-components-webpack5/src/index.ts
@@ -1,2 +1,1 @@
-export * from '@storybook/web-components';
 export * from './types';


### PR DESCRIPTION
Issue: N/A

## What I did

We were re-exporting types from renderers in their respective frameworks. But users should import directly from the renderers themselves.

Self-merging @ndelangen 

## How to test

- [ ] CI passes