### PR TITLE
CLI: support .json in eslint-plugin migration

### DIFF
--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -55,6 +55,7 @@
     "commander": "^6.2.1",
     "cross-spawn": "^7.0.3",
     "degit": "^2.8.4",
+    "detect-indent": "^7.0.1",
     "envinfo": "^7.7.3",
     "execa": "^5.0.0",
     "express": "^4.17.1",

--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -55,7 +55,7 @@
     "commander": "^6.2.1",
     "cross-spawn": "^7.0.3",
     "degit": "^2.8.4",
-    "detect-indent": "^7.0.1",
+    "detect-indent": "^6.1.0",
     "envinfo": "^7.7.3",
     "execa": "^5.0.0",
     "express": "^4.17.1",

--- a/code/lib/cli/src/automigrate/fixes/eslint-plugin.ts
+++ b/code/lib/cli/src/automigrate/fixes/eslint-plugin.ts
@@ -82,7 +82,7 @@ export const eslintPlugin: Fix<EslintPluginRunOptions> = {
 
     if (!dryRun && unsupportedExtension) {
       logger.info(dedent`
-          ⚠️ The plugin was successfuly installed but failed to configure.
+          ⚠️ The plugin was successfully installed but failed to configure.
           
           Found an eslint config file with an unsupported automigration format: .eslintrc.${unsupportedExtension}.
           The supported formats for this automigration are: ${SUPPORTED_ESLINT_EXTENSIONS.join(

--- a/code/lib/cli/src/automigrate/fixes/eslint-plugin.ts
+++ b/code/lib/cli/src/automigrate/fixes/eslint-plugin.ts
@@ -84,8 +84,10 @@ export const eslintPlugin: Fix<EslintPluginRunOptions> = {
       logger.info(dedent`
           ⚠️ The plugin was successfuly installed but failed to configure.
           
-          Found an .eslintrc config file with an unsupported automigration format: ${unsupportedExtension}.
-          Supported formats for automigration are: ${SUPPORTED_ESLINT_EXTENSIONS.join(', ')}.
+          Found an eslint config file with an unsupported automigration format: .eslintrc.${unsupportedExtension}.
+          The supported formats for this automigration are: ${SUPPORTED_ESLINT_EXTENSIONS.join(
+            ', '
+          )}.
 
           Please refer to https://github.com/storybookjs/eslint-plugin-storybook#usage to finish setting up the plugin manually.
       `);

--- a/code/lib/cli/src/automigrate/fixes/eslint-plugin.ts
+++ b/code/lib/cli/src/automigrate/fixes/eslint-plugin.ts
@@ -91,6 +91,7 @@ export const eslintPlugin: Fix<EslintPluginRunOptions> = {
 
           Please refer to https://github.com/storybookjs/eslint-plugin-storybook#usage to finish setting up the plugin manually.
       `);
+      return;
     }
 
     logger.info(`✅ Adding Storybook plugin to ${eslintFile}`);

--- a/code/lib/cli/src/automigrate/helpers/getEslintInfo.ts
+++ b/code/lib/cli/src/automigrate/helpers/getEslintInfo.ts
@@ -1,7 +1,7 @@
 import fse from 'fs-extra';
 
-export const SUPPORTED_ESLINT_EXTENSIONS = ['js', 'cjs'];
-const UNSUPPORTED_ESLINT_EXTENSIONS = ['yaml', 'yml', 'json'];
+export const SUPPORTED_ESLINT_EXTENSIONS = ['js', 'cjs', 'json'];
+const UNSUPPORTED_ESLINT_EXTENSIONS = ['yaml', 'yml'];
 
 export const findEslintFile = () => {
   const filePrefix = '.eslintrc';

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7318,6 +7318,7 @@ __metadata:
     commander: ^6.2.1
     cross-spawn: ^7.0.3
     degit: ^2.8.4
+    detect-indent: ^7.0.1
     envinfo: ^7.7.3
     execa: ^5.0.0
     express: ^4.17.1
@@ -16759,6 +16760,13 @@ __metadata:
   version: 6.1.0
   resolution: "detect-indent@npm:6.1.0"
   checksum: dd83cdeda9af219cf77f5e9a0dc31d828c045337386cfb55ce04fad94ba872ee7957336834154f7647b89b899c3c7acc977c57a79b7c776b506240993f97acc7
+  languageName: node
+  linkType: hard
+
+"detect-indent@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "detect-indent@npm:7.0.1"
+  checksum: 47b6e3e3dda603c386e73b129f3e84844ae59bc2615f5072becf3cc02eab400bed5a4e6379c49d0b18cf630e80c2b07e87e0038b777addbc6ef793ad77dd05bc
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7318,7 +7318,7 @@ __metadata:
     commander: ^6.2.1
     cross-spawn: ^7.0.3
     degit: ^2.8.4
-    detect-indent: ^7.0.1
+    detect-indent: ^6.1.0
     envinfo: ^7.7.3
     execa: ^5.0.0
     express: ^4.17.1
@@ -16756,17 +16756,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-indent@npm:^6.0.0":
+"detect-indent@npm:^6.0.0, detect-indent@npm:^6.1.0":
   version: 6.1.0
   resolution: "detect-indent@npm:6.1.0"
   checksum: dd83cdeda9af219cf77f5e9a0dc31d828c045337386cfb55ce04fad94ba872ee7957336834154f7647b89b899c3c7acc977c57a79b7c776b506240993f97acc7
-  languageName: node
-  linkType: hard
-
-"detect-indent@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "detect-indent@npm:7.0.1"
-  checksum: 47b6e3e3dda603c386e73b129f3e84844ae59bc2615f5072becf3cc02eab400bed5a4e6379c49d0b18cf630e80c2b07e87e0038b777addbc6ef793ad77dd05bc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: N/A

## What I did

This PR adds support for updating `.eslintrc.json` files when installing eslint-plugin-storybook

## How to test

1. Bootstrap the project
```
yarn tast --task compile
```

2. In a Nextjs project, run `sb init` where `sb` points to the local binary of the cli package
3. See the update happen correctly:
<img width="903" alt="image" src="https://user-images.githubusercontent.com/1671563/196176117-8b9b7347-d755-452d-ba42-b5b8e4f00f6f.png">


- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
