### PR TITLE
Don't generate docs page entries for CSF files with no stories

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="@types/jest" />;
+
 import path from 'path';
 import fs from 'fs-extra';
 import { normalizeStoriesEntry } from '@storybook/core-common';
@@ -458,6 +460,24 @@ describe('StoryIndexGenerator', () => {
                 "type": "story",
               },
             },
+            "v": 4,
+          }
+        `);
+      });
+
+      // https://github.com/storybookjs/storybook/issues/19142
+      it('does not generate a docs page entry if there are no stories in the CSF file', async () => {
+        const csfSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
+          './errors/NoStories.stories.ts',
+          options
+        );
+
+        const generator = new StoryIndexGenerator([csfSpecifier], docsPageOptions);
+        await generator.initialize();
+
+        expect(await generator.getIndex()).toMatchInlineSnapshot(`
+          Object {
+            "entries": Object {},
             "v": 4,
           }
         `);

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -217,7 +217,7 @@ export class StoryIndexGenerator {
         }
       });
 
-      if (this.options.docs.enabled) {
+      if (this.options.docs.enabled && csf.stories.length) {
         // We always add a template for *.stories.mdx, but only if docs page is enabled for
         // regular CSF files
         if (storyIndexer.addDocsTemplate || this.options.docs.docsPage) {

--- a/code/lib/core-server/src/utils/__mockdata__/errors/NoStories.stories.ts
+++ b/code/lib/core-server/src/utils/__mockdata__/errors/NoStories.stories.ts
@@ -1,0 +1,5 @@
+/* eslint-disable storybook/story-exports */
+const component = {};
+export default {
+  component,
+};


### PR DESCRIPTION
Issue: #19142

## What I did

Made sure that empty CSF files don't generate docs page entries.

## How to test

See tests. Or delete all stories from a sandbox CSF file.