### PR TITLE
Add option `--story-filter` in cli to filter stories when starting storybook

### DIFF
--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -233,6 +233,7 @@ program
   )
   .option('--force-build-preview', 'Build the preview iframe even if you are using --preview-url')
   .option('--docs', 'Build a documentation-only site using addon-docs')
+  .option('--story-filter <regexp>', 'Regexp to filter story file paths specified on main.js')
   .action((options) => {
     logger.setLevel(program.loglevel);
     consoleLogger.log(chalk.bold(`${pkg.name} v${pkg.version}`) + chalk.reset('\n'));
@@ -270,6 +271,7 @@ program
   .option('--force-build-preview', 'Build the preview iframe even if you are using --preview-url')
   .option('--docs', 'Build a documentation-only site using addon-docs')
   .option('--no-manager-cache', 'Do not cache the manager UI')
+  .option('--story-filter <regexp>', 'Regexp to filter story file paths specified on main.js')
   .action((options) => {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production';
     logger.setLevel(program.loglevel);

--- a/code/lib/core-common/src/types.ts
+++ b/code/lib/core-common/src/types.ts
@@ -154,6 +154,7 @@ export interface CLIOptions {
   debugWebpack?: boolean;
   webpackStatsJson?: string | boolean;
   outputDir?: string;
+  storyFilter?: string;
 }
 
 export interface BuilderOptions {

--- a/code/lib/core-server/src/build-static.ts
+++ b/code/lib/core-server/src/build-static.ts
@@ -150,6 +150,7 @@ export async function buildStaticStandalone(
       docs: docsOptions,
       storiesV2Compatibility: !features?.breakingChangesV7 && !features?.storyStoreV7,
       storyStoreV7: !!features?.storyStoreV7,
+      storyFilter: options.storyFilter,
     });
 
     initializedStoryIndexGenerator = generator.initialize().then(() => generator);

--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -59,6 +59,7 @@ export async function storybookDevServer(options: Options) {
         workingDir,
         storiesV2Compatibility: !features?.breakingChangesV7 && !features?.storyStoreV7,
         storyStoreV7: features?.storyStoreV7,
+        storyFilter: options.storyFilter,
       });
 
       initializedStoryIndexGenerator = generator.initialize().then(() => generator);

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -79,6 +79,7 @@ export class StoryIndexGenerator {
       storyStoreV7: boolean;
       storyIndexers: StoryIndexer[];
       docs: DocsOptions;
+      storyFilter: string;
     }
   ) {
     this.specifierToCache = new Map();
@@ -94,7 +95,12 @@ export class StoryIndexGenerator {
           path.join(this.options.workingDir, specifier.directory, specifier.files)
         );
         const files = await glob(fullGlob);
-        files.sort().forEach((absolutePath: Path) => {
+        const filteredFiles = this.options.storyFilter
+          ? files.filter((absolutePath) =>
+              new RegExp(this.options.storyFilter, 'g').test(absolutePath)
+            )
+          : files;
+        filteredFiles.sort().forEach((absolutePath: Path) => {
           const ext = path.extname(absolutePath);
           if (ext === '.storyshot') {
             const relativePath = path.relative(this.options.workingDir, absolutePath);

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -79,7 +79,7 @@ export class StoryIndexGenerator {
       storyStoreV7: boolean;
       storyIndexers: StoryIndexer[];
       docs: DocsOptions;
-      storyFilter: string;
+      storyFilter?: string;
     }
   ) {
     this.specifierToCache = new Map();

--- a/code/ui/manager/src/components/sidebar/RefBlocks.tsx
+++ b/code/ui/manager/src/components/sidebar/RefBlocks.tsx
@@ -209,6 +209,10 @@ export const EmptyBlock: FC<any> = ({ isMain }) => (
                   The glob specified in <code>main.js</code> isn't correct.
                 </li>
                 <li>No stories are defined in your story files.</li>
+                <li>
+                  The regexp specified when running storybook <code>--story-filter</code> is
+                  filtering all your files.
+                </li>
               </ul>{' '}
             </>
           ) : (

--- a/docs/api/cli-options.md
+++ b/docs/api/cli-options.md
@@ -40,6 +40,7 @@ Usage: start-storybook [options]
 | `--docs`                        | Starts Storybook in documentation mode. Learn more about it in [here](../writing-docs/build-documentation.md#preview-storybooks-documentation)<br/>`start-storybook --docs` |
 | `--no-manager-cache`            | Disables Storybook's manager caching mechanism. See note below<br/>`start-storybook --no-manager-cache`                                                                     |
 | `--disable-telemetry`           | Disables Storybook's telemetry. Learn more about it [here](../configure/telemetry.md)<br/>`start-storybook --disable-telemetry`                                             |
+| `--story-filter`                | Regexp to filter stories based on their path. `start-storybook --story-filter button.stories`                                                                               |
 
 <div class="aside">
 💡 The flag <code>--no-manager-cache</code> disables the internal caching of Storybook and can severely impact your Storybook loading time, so only use it when you need to refresh Storybook's UI, such as when editing themes.
@@ -71,6 +72,7 @@ Usage: build-storybook [options]
 | `--webpack-stats-json`          | Write Webpack Stats JSON to disk<br/>`build-storybook --webpack-stats-json /my-storybook/webpack-stats`                                                                     |
 | `--docs`                        | Builds Storybook in documentation mode. Learn more about it in [here](../writing-docs/build-documentation.md#publish-storybooks-documentation)<br/>`build-storybook --docs` |
 | `--disable-telemetry`           | Disables Storybook's telemetry. Learn more about it [here](../configure/telemetry.md).<br/>`build-storybook --disable-telemetry`                                            |
+| `--story-filter`                | Regexp to filter stories based on their path. `build-storybook --story-filter button.stories`                                                                               |
 
 <div class="aside">
 💡  If you're using npm instead of yarn to publish Storybook, the commands work slightly different. For example, <code>npm run build-storybook -- -o ./path/to/build</code>.


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/5065

## What I did

Added the option `--story-filter` to CLI. Now when running `storybook dev` and `storybook build` you can specify a regexp to filter the stories that are going to be built. Eg.: `storybook dev --story-filter Button.stories`.

---

During the implementation I was in doubt if it would be better to implement:

1. An option to filter, as suggested by the issue https://github.com/storybookjs/storybook/issues/5065
2. An option to pass the glob of stories, which would override the stories specified in `main.js` as one comment suggested https://github.com/storybookjs/storybook/issues/5065#issuecomment-807295362.

I've ended up following the first option as it was more in line with the suggestion of the original issue.

Another point which I wasn't able to test, is if this will have a performance improvement on repos with many stories. If I understood correctly it should improve, as we are filtering the file paths before actually loading the content.

---

## How to test

In the example sandbox run the command passing the `--story-filter` argument (eg.: `storybook dev --story-filter Button`). It should only show the stories that match `Button`.

![chrome_tbeFJBqvpS](https://user-images.githubusercontent.com/9583920/196560039-540d9e60-95cb-4fe3-9cfe-96b0ab43a851.png)

I am not 100% sure on how to approach doing an automated test for this, any help would be apprecianted!

- [ ] Is this testable with Jest or Chromatic screenshots?
	- I don't think so.
- [ ] Does this need a new example in the kitchen sink apps?
	- I don't think so
- [x] Does this need an update to the documentation?
    - Yes. I've included in the `docs/api/cli-options.md` file.


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
