### PR TITLE
Remove .git folder when generating repros

### DIFF
--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -4,7 +4,7 @@ import { command } from 'execa';
 import type { Options as ExecaOptions } from 'execa';
 import pLimit from 'p-limit';
 import prettyTime from 'pretty-hrtime';
-import { copy, emptyDir, ensureDir, move, rename, writeFile } from 'fs-extra';
+import { copy, emptyDir, ensureDir, move, remove, rename, writeFile } from 'fs-extra';
 import { program } from 'commander';
 import { AbortController } from 'node-abort-controller';
 import { directory } from 'tempy';
@@ -153,6 +153,9 @@ const runGenerators = async (
 
         // Now move the created before dir into it's final location and add storybook
         await move(createBeforeDir, beforeDir);
+
+        // Make sure there are no git projects in the folder
+        await remove(join(beforeDir, '.git'));
 
         await addStorybook(baseDir, localRegistry, flags);
 


### PR DESCRIPTION
Issue: N/A

## What I did

When generating repros, .git folders should not be generated, else the umbrella repo gets confused.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
