### PR TITLE
docs: Improve decorators React TS snippets

### DIFF
--- a/docs/snippets/react/button-story-component-decorator.ts.mdx
+++ b/docs/snippets/react/button-story-component-decorator.ts.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import type { ComponentMeta } from '@storybook/react';
+import type { ComponentMeta, StoryFn } from '@storybook/react';
 
 import { Button } from './Button';
 
@@ -15,7 +15,7 @@ export default {
   title: 'Button',
   component: Button,
   decorators: [
-    (Story) => (
+    (Story: StoryFn) => (
       <div style={{ margin: '3em' }}>
         <Story />
       </div>

--- a/docs/snippets/react/button-story-decorator.ts.mdx
+++ b/docs/snippets/react/button-story-decorator.ts.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+import type { ComponentStoryObj, ComponentMeta, StoryFn } from '@storybook/react';
 
 export default {
   /* 👇 The title prop is optional.
@@ -16,7 +16,7 @@ export default {
 
 export const Primary: ComponentStoryObj<typeof Button> = {
   decorators: [
-    (Story) => (
+    (Story: StoryFn) => (
       <div style={{ margin: '3em' }}>
         <Story />
       </div>

--- a/docs/snippets/react/your-component-with-decorator.ts.mdx
+++ b/docs/snippets/react/your-component-with-decorator.ts.mdx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { ComponentMeta } from '@storybook/react';
+import type { ComponentMeta, StoryFn } from '@storybook/react';
 
 import { YourComponent } from './YourComponent';
 
@@ -15,7 +15,7 @@ export default {
   title: 'YourComponent',
   component: YourComponent,
   decorators: [
-    (Story) => (
+    (Story: StoryFn) => (
       <div style={{ margin: '3em' }}>
         <Story />
       </div>

--- a/docs/writing-stories/decorators.md
+++ b/docs/writing-stories/decorators.md
@@ -89,6 +89,7 @@ To define a decorator for a single story, use the `decorators` key on a named ex
   paths={[
     'react/button-story-decorator.js.mdx',
     'react/button-story-decorator.story-function.js.mdx',
+    'react/button-story-decorator.ts.mdx',
     'react/button-story-decorator.mdx.mdx',
     'vue/button-story-decorator.js.mdx',
     'vue/button-story-decorator.mdx.mdx',


### PR DESCRIPTION
Issue:

## What I did

Updated the [decorators](https://storybook.js.org/docs/react/writing-stories/decorators) React TS spinnets to type the decorator's `Story` argument with the `StoryFn` type.

This should help anyone who has a strict TS config and copies the snippets avoid `Parameter 'Story' implicitly has an 'any' type` TS errors.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [x] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
