### PR TITLE
Docs: Deprecate Story and ComponentX types

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,9 +2,8 @@
 
 - [From version 6.5.x to 7.0.0](#from-version-65x-to-700)
   - [Alpha release notes](#alpha-release-notes)
-  - [Breaking changes](#breaking-changes)
+  - [7.0 breaking changes](#70-breaking-changes)
     - [register.js removed](#registerjs-removed)
-    - [`Story` type change to `StoryFn`, and the new `Story` type now refers to `StoryObj`](#story-type-change-to-storyfn-and-the-new-story-type-now-refers-to-storyobj)
     - [Change of root html IDs](#change-of-root-html-ids)
     - [No more default export from `@storybook/addons`](#no-more-default-export-from-storybookaddons)
     - [Modern browser support](#modern-browser-support)
@@ -38,11 +37,12 @@
     - [External Docs](#external-docs)
     - [MDX2 upgrade](#mdx2-upgrade)
     - [Dropped addon-docs manual configuration](#dropped-addon-docs-manual-configuration)
+  - [7.0 Deprecations](#70-deprecations)
+    - [`Story` type deprecated](#story-type-deprecated)
 - [From version 6.4.x to 6.5.0](#from-version-64x-to-650)
   - [Vue 3 upgrade](#vue-3-upgrade)
   - [React18 new root API](#react18-new-root-api)
   - [Renamed isToolshown to showToolbar](#renamed-istoolshown-to-showtoolbar)
-  - [Deprecated register.js](#deprecated-registerjs)
   - [Dropped support for addon-actions addDecorators](#dropped-support-for-addon-actions-adddecorators)
   - [Vite builder renamed](#vite-builder-renamed)
   - [Docs framework refactor for React](#docs-framework-refactor-for-react)
@@ -51,6 +51,8 @@
     - [Auto-title filename case](#auto-title-filename-case)
     - [Auto-title redundant filename](#auto-title-redundant-filename)
     - [Auto-title always prefixes](#auto-title-always-prefixes)
+  - [6.5 Deprecations](#65-deprecations)
+    - [Deprecated register.js](#deprecated-registerjs)
 - [From version 6.3.x to 6.4.0](#from-version-63x-to-640)
   - [Automigrate](#automigrate)
   - [CRA5 upgrade](#cra5-upgrade)
@@ -247,7 +249,7 @@ Storybook 7.0 is in early alpha. During the alpha, we are making a large number 
 
 In the meantime, these migration notes are the best available documentation on things you should know upgrading to 7.0.
 
-### Breaking changes
+### 7.0 breaking changes
 
 #### register.js removed
 
@@ -256,46 +258,6 @@ In SB 6.x and earlier, addons exported a `register.js` entry point by convention
 In 7.0, most of Storybook's addons now export a `manager.js` entry point, which is automatically registered in Storybook's manager when the addon is listed in `.storybook/main.js`'s `addons` field.
 
 If your `.manager.js` config references `register.js` of any of the following addons, you can remove it: `a11y`, `actions`, `backgrounds`, `controls`, `interactions`, `jest`, `links`, `measure`, `outline`, `toolbars`, `viewport`.
-
-#### `Story` type change to `StoryFn`, and the new `Story` type now refers to `StoryObj`
-
-In 6.x you were able to do this:
-
-```js
-import type { Story } from '@storybook/react';
-
-export const MyStory: Story = () => <div />;
-```
-
-But this will produce an error in 7.0 because `Story` is now a type that refers to the `StoryObj` type.
-You must now use the new `StoryFn` type:
-
-```js
-import type { StoryFn } from '@storybook/react';
-
-export const MyStory: StoryFn = () => <div />;
-```
-
-This change was done to improve the experience of writing CSF3 stories, which is the recommended way of writing stories in 7.0:
-
-```js
-import type { Story } from '@storybook/react';
-import { Button, ButtonProps } from './Button';
-
-export default {
-  component: Button,
-};
-
-export const Primary: Story<ButtonProps> = {
-  variant: 'primary',
-};
-```
-
-If you want to be explicit, you can also import `StoryObj` instead of `Story`, they are the same type.
-
-For Storybook for react users: We also changed `ComponentStory` to refer to `ComponentStoryObj` instead of `ComponentStoryFn`, so if you were using `ComponentStory` you should now import/use `ComponentStoryFn` instead.
-
-You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
 
 #### Change of root html IDs
 
@@ -730,7 +692,9 @@ import * as previewAnnotations from '../.storybook/preview';
 
 export default function App({ Component, pageProps }) {
   return (
-    <ExternalDocs projectAnnotationsList={[reactAnnotations, previewAnnotations]}>
+    <ExternalDocs
+      projectAnnotationsList={[reactAnnotations, previewAnnotations]}
+    >
       <Component {...pageProps} />
     </ExternalDocs>
   );
@@ -750,6 +714,31 @@ As part of the upgrade we deleted the codemod `mdx-to-csf` and will be replacing
 #### Dropped addon-docs manual configuration
 
 Storybook Docs 5.x shipped with instructions for how to manually configure webpack and storybook without the use of Storybook's "presets" feature. Over time, these docs went out of sync. Now in Storybook 7 we have removed support for manual configuration entirely.
+
+### 7.0 Deprecations
+
+#### `Story` type deprecated
+
+In 6.x you were able to do this:
+
+```js
+import type { Story } from '@storybook/react';
+
+export const MyStory: Story = () => <div />;
+```
+
+But this will produce a deprecation warning in 7.0 because `Story` has been deprecated.
+To fix the deprecation wanring, use the `StoryFn` type:
+
+```js
+import type { StoryFn } from '@storybook/react';
+
+export const MyStory: StoryFn = () => <div />;
+```
+
+This change is part of our move to CSF3, which uses objects instead of functions to represent stories.
+
+You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
 
 ## From version 6.4.x to 6.5.0
 
@@ -782,22 +771,6 @@ import { addons } from '@storybook/addons';
 addons.setConfig({
   showToolbar: false,
 });
-```
-
-### Deprecated register.js
-
-In ancient versions of Storybook, addons were registered by referring to `addon-name/register.js`. This is going away in SB7.0. Instead you should just add `addon-name` to the `addons` array in `.storybook/main.js`.
-
-Before:
-
-```js
-module.exports = { addons: ['my-addon/register.js'] };
-```
-
-After:
-
-```js
-module.exports = { addons: ['my-addon'] };
 ```
 
 ### Dropped support for addon-actions addDecorators
@@ -868,7 +841,8 @@ import startCase from 'lodash/startCase';
 
 addons.setConfig({
   sidebar: {
-    renderLabel: ({ name, type }) => (type === 'story' ? name : startCase(name)),
+    renderLabel: ({ name, type }) =>
+      type === 'story' ? name : startCase(name),
   },
 });
 ```
@@ -916,6 +890,24 @@ In 6.5, the final titles would be:
 - `Title.stories.js` => `Custom/Bar`
 
 <!-- markdown-link-check-disable -->
+
+### 6.5 Deprecations
+
+#### Deprecated register.js
+
+In ancient versions of Storybook, addons were registered by referring to `addon-name/register.js`. This is going away in SB7.0. Instead you should just add `addon-name` to the `addons` array in `.storybook/main.js`.
+
+Before:
+
+```js
+module.exports = { addons: ['my-addon/register.js'] };
+```
+
+After:
+
+```js
+module.exports = { addons: ['my-addon'] };
+```
 
 ## From version 6.3.x to 6.4.0
 
@@ -1295,7 +1287,11 @@ After:
 ```js
 // .storybook/main.js
 module.exports = {
-  staticDirs: ['../public', '../static', { from: '../foo/assets', to: '/assets' }],
+  staticDirs: [
+    '../public',
+    '../static',
+    { from: '../foo/assets', to: '/assets' },
+  ],
 };
 ```
 
@@ -1843,13 +1839,17 @@ This breaking change only affects you if your stories actually use the context, 
 Consider the following story that uses the context:
 
 ```js
-export const Dummy = ({ parameters }) => <div>{JSON.stringify(parameters)}</div>;
+export const Dummy = ({ parameters }) => (
+  <div>{JSON.stringify(parameters)}</div>
+);
 ```
 
 Here's an updated story for 6.0 that ignores the args object:
 
 ```js
-export const Dummy = (_args, { parameters }) => <div>{JSON.stringify(parameters)}</div>;
+export const Dummy = (_args, { parameters }) => (
+  <div>{JSON.stringify(parameters)}</div>
+);
 ```
 
 Alternatively, if you want to opt out of the new behavior, you can add the following to your `.storybook/preview.js` config:
@@ -2639,7 +2639,9 @@ For example, here's how to sort by story ID using `storySort`:
 addParameters({
   options: {
     storySort: (a, b) =>
-      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
+      a[1].kind === b[1].kind
+        ? 0
+        : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
   },
 });
 ```
@@ -2685,7 +2687,9 @@ Storybook 5.1 relies on `core-js@^3.0.0` and therefore causes a conflict with An
 {
   "compilerOptions": {
     "paths": {
-      "core-js/es7/reflect": ["node_modules/core-js/proposals/reflect-metadata"],
+      "core-js/es7/reflect": [
+        "node_modules/core-js/proposals/reflect-metadata"
+      ],
       "core-js/es6/*": ["node_modules/core-js/es"]
     }
   }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -739,7 +739,7 @@ You can read more about the CSF3 format here: https://storybook.js.org/blog/comp
 
 #### `ComponentStory`, `ComponentStoryObj`, `ComponentStoryFn` and `ComponentMeta` types are deprecated
 
-We have changed the type of StoryObj and StoryFn in 7.0 so that both the component as the props of the component will be accepted as the generic parameter.
+The type of StoryObj and StoryFn have been changed in 7.0 so that both the "component" as "the props of the component" will be accepted as the generic parameter.
 
 ```ts
 import type { Story } from '@storybook/react';

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -719,7 +719,7 @@ Storybook Docs 5.x shipped with instructions for how to manually configure webpa
 
 In 6.x you were able to do this:
 
-```js
+```ts
 import type { Story } from '@storybook/react';
 
 export const MyStory: Story = () => <div />;

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -692,9 +692,7 @@ import * as previewAnnotations from '../.storybook/preview';
 
 export default function App({ Component, pageProps }) {
   return (
-    <ExternalDocs
-      projectAnnotationsList={[reactAnnotations, previewAnnotations]}
-    >
+    <ExternalDocs projectAnnotationsList={[reactAnnotations, previewAnnotations]}>
       <Component {...pageProps} />
     </ExternalDocs>
   );
@@ -728,17 +726,41 @@ export const MyStory: Story = () => <div />;
 ```
 
 But this will produce a deprecation warning in 7.0 because `Story` has been deprecated.
-To fix the deprecation wanring, use the `StoryFn` type:
+To fix the deprecation warning, use the `StoryFn` type:
 
-```js
+```ts
 import type { StoryFn } from '@storybook/react';
 
 export const MyStory: StoryFn = () => <div />;
 ```
 
 This change is part of our move to CSF3, which uses objects instead of functions to represent stories.
-
 You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
+
+#### `ComponentStory`, `ComponentStoryObj`, `ComponentStoryFn` and `ComponentMeta` types are deprecated
+
+We have changed the type of StoryObj and StoryFn in 7.0 so that both the component as the props of the component will be accepted as the generic parameter.
+
+```ts
+import type { Story } from '@storybook/react';
+import { Button, ButtonProps } from './Button';
+
+// This works in 7.0, making the ComponentX types redundant.
+const meta: Meta<typeof Button> = { component: Button };
+
+export const CSF3Story: StoryObj<typeof Button> = { args: { label: 'Label' } };
+
+export const CSF2Story: StoryFn<typeof Button> = (args) => <Button {...args} />;
+CSF2Story.args = { label: 'Label' };
+
+// Passing props directly still works as well.
+const meta: Meta<ButtonProps> = { component: Button };
+
+export const CSF3Story: StoryObj<ButtonProps> = { args: { label: 'Label' } };
+
+export const CSF2Story: StoryFn<ButtonProps> = (args) => <Button {...args} />;
+CSF2Story.args = { label: 'Label' };
+```
 
 ## From version 6.4.x to 6.5.0
 
@@ -841,8 +863,7 @@ import startCase from 'lodash/startCase';
 
 addons.setConfig({
   sidebar: {
-    renderLabel: ({ name, type }) =>
-      type === 'story' ? name : startCase(name),
+    renderLabel: ({ name, type }) => (type === 'story' ? name : startCase(name)),
   },
 });
 ```
@@ -1287,11 +1308,7 @@ After:
 ```js
 // .storybook/main.js
 module.exports = {
-  staticDirs: [
-    '../public',
-    '../static',
-    { from: '../foo/assets', to: '/assets' },
-  ],
+  staticDirs: ['../public', '../static', { from: '../foo/assets', to: '/assets' }],
 };
 ```
 
@@ -1839,17 +1856,13 @@ This breaking change only affects you if your stories actually use the context, 
 Consider the following story that uses the context:
 
 ```js
-export const Dummy = ({ parameters }) => (
-  <div>{JSON.stringify(parameters)}</div>
-);
+export const Dummy = ({ parameters }) => <div>{JSON.stringify(parameters)}</div>;
 ```
 
 Here's an updated story for 6.0 that ignores the args object:
 
 ```js
-export const Dummy = (_args, { parameters }) => (
-  <div>{JSON.stringify(parameters)}</div>
-);
+export const Dummy = (_args, { parameters }) => <div>{JSON.stringify(parameters)}</div>;
 ```
 
 Alternatively, if you want to opt out of the new behavior, you can add the following to your `.storybook/preview.js` config:
@@ -2639,9 +2652,7 @@ For example, here's how to sort by story ID using `storySort`:
 addParameters({
   options: {
     storySort: (a, b) =>
-      a[1].kind === b[1].kind
-        ? 0
-        : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
+      a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
   },
 });
 ```
@@ -2687,9 +2698,7 @@ Storybook 5.1 relies on `core-js@^3.0.0` and therefore causes a conflict with An
 {
   "compilerOptions": {
     "paths": {
-      "core-js/es7/reflect": [
-        "node_modules/core-js/proposals/reflect-metadata"
-      ],
+      "core-js/es7/reflect": ["node_modules/core-js/proposals/reflect-metadata"],
       "core-js/es6/*": ["node_modules/core-js/es"]
     }
   }

--- a/code/frameworks/angular/src/client/public-types.ts
+++ b/code/frameworks/angular/src/client/public-types.ts
@@ -30,8 +30,11 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<AngularFramework, TArgs>;
 export type StoryObj<TArgs = Args> = StoryAnnotations<AngularFramework, TArgs>;
 
 /**
- * Story function that represents a CSFv3 component example.
+ * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
+ *
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryObj<TArgs>;
+export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/code/frameworks/angular/src/client/public-types.ts
+++ b/code/frameworks/angular/src/client/public-types.ts
@@ -30,7 +30,8 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<AngularFramework, TArgs>;
 export type StoryObj<TArgs = Args> = StoryAnnotations<AngularFramework, TArgs>;
 
 /**
- * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * @deprecated Use `StoryFn` instead.
+ * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
  * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
  *
  * Story function that represents a CSFv2 component example.

--- a/code/renderers/html/src/public-types.ts
+++ b/code/renderers/html/src/public-types.ts
@@ -30,7 +30,8 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<HtmlFramework, TArgs>;
 export type StoryObj<TArgs = Args> = StoryAnnotations<HtmlFramework, TArgs>;
 
 /**
- * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * @deprecated Use `StoryFn` instead.
+ * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
  * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
  *
  * Story function that represents a CSFv2 component example.

--- a/code/renderers/html/src/public-types.ts
+++ b/code/renderers/html/src/public-types.ts
@@ -30,8 +30,11 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<HtmlFramework, TArgs>;
 export type StoryObj<TArgs = Args> = StoryAnnotations<HtmlFramework, TArgs>;
 
 /**
- * Story function that represents a CSFv3 component example.
+ * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
+ *
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryObj<TArgs>;
+export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/code/renderers/preact/src/public-types.ts
+++ b/code/renderers/preact/src/public-types.ts
@@ -30,8 +30,11 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<PreactFramework, TArgs>;
 export type StoryObj<TArgs = Args> = StoryAnnotations<PreactFramework, TArgs>;
 
 /**
- * Story function that represents a CSFv3 component example.
+ * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
+ *
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryObj<TArgs>;
+export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/code/renderers/preact/src/public-types.ts
+++ b/code/renderers/preact/src/public-types.ts
@@ -30,7 +30,8 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<PreactFramework, TArgs>;
 export type StoryObj<TArgs = Args> = StoryAnnotations<PreactFramework, TArgs>;
 
 /**
- * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * @deprecated Use `StoryFn` instead.
+ * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
  * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
  *
  * Story function that represents a CSFv2 component example.

--- a/code/renderers/react/src/public-types.ts
+++ b/code/renderers/react/src/public-types.ts
@@ -19,31 +19,32 @@ type JSXElement = keyof JSX.IntrinsicElements | JSXElementConstructor<any>;
  *
  * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
  */
-export type Meta<CmpOrArgs = Args> = CmpOrArgs extends ComponentType<infer CmpArgs>
-  ? ComponentAnnotations<ReactFramework, CmpArgs>
-  : ComponentAnnotations<ReactFramework, CmpOrArgs>;
+export type Meta<TCmpOrArgs = Args> = TCmpOrArgs extends ComponentType<any>
+  ? ComponentAnnotations<ReactFramework, ComponentProps<TCmpOrArgs>>
+  : ComponentAnnotations<ReactFramework, TCmpOrArgs>;
 
 /**
  * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryFn<TArgs = Args> = AnnotatedStoryFn<ReactFramework, TArgs>;
+export type StoryFn<TCmpOrArgs = Args> = TCmpOrArgs extends ComponentType<any>
+  ? AnnotatedStoryFn<ReactFramework, ComponentProps<TCmpOrArgs>>
+  : AnnotatedStoryFn<ReactFramework, TCmpOrArgs>;
 
 /**
  * Story function that represents a CSFv3 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-
-export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
+export type StoryObj<TMetaOrCmpOrArgs = Args> = TMetaOrCmpOrArgs extends {
   render?: ArgsStoryFn<ReactFramework, any>;
   component?: infer Component;
   args?: infer DefaultArgs;
 }
   ? Simplify<
       (Component extends ComponentType<any> ? ComponentProps<Component> : unknown) &
-        ArgsFromMeta<ReactFramework, MetaOrCmpOrArgs>
+        ArgsFromMeta<ReactFramework, TMetaOrCmpOrArgs>
     > extends infer TArgs
     ? StoryAnnotations<
         ReactFramework,
@@ -51,20 +52,21 @@ export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
         SetOptional<TArgs, Extract<keyof TArgs, keyof (DefaultArgs & ActionArgs<TArgs>)>>
       >
     : never
-  : MetaOrCmpOrArgs extends ComponentType<any>
+  : TMetaOrCmpOrArgs extends ComponentType<any>
   ? StoryAnnotations<
       ReactFramework,
-      ComponentProps<MetaOrCmpOrArgs>,
-      ComponentProps<MetaOrCmpOrArgs>
+      ComponentProps<TMetaOrCmpOrArgs>,
+      ComponentProps<TMetaOrCmpOrArgs>
     >
-  : StoryAnnotations<ReactFramework, MetaOrCmpOrArgs>;
+  : StoryAnnotations<ReactFramework, TMetaOrCmpOrArgs>;
 
 type ActionArgs<Args> = {
   [P in keyof Args as ((...args: any[]) => void) extends Args[P] ? P : never]: Args[P];
 };
 
 /**
- * @deprecated Use `Meta` instead.
+ * @deprecated Use `Meta` instead, e.g. ComponentMeta<typeof Button> -> Meta<typeof Button>.
+ *
  * For the common case where a component's stories are simple components that receives args as props:
  *
  * ```tsx
@@ -74,6 +76,10 @@ type ActionArgs<Args> = {
 export type ComponentMeta<T extends JSXElement> = Meta<ComponentProps<T>>;
 
 /**
+ * @deprecated Use `StoryFn` instead, e.g. ComponentStoryFn<typeof Button> -> StoryFn<typeof Button>.
+ * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
+ *
  * For the common case where a (CSFv2) story is a simple component that receives args as props:
  *
  * ```tsx
@@ -83,7 +89,7 @@ export type ComponentMeta<T extends JSXElement> = Meta<ComponentProps<T>>;
 export type ComponentStoryFn<T extends JSXElement> = StoryFn<ComponentProps<T>>;
 
 /**
- * @deprecated Use `StoryObj` instead.
+ * @deprecated Use `StoryObj` instead, e.g. ComponentStoryObj<typeof Button> -> StoryObj<typeof Button>.
  *
  * For the common case where a (CSFv3) story is a simple component that receives args as props:
  *
@@ -96,18 +102,19 @@ export type ComponentStoryFn<T extends JSXElement> = StoryFn<ComponentProps<T>>;
 export type ComponentStoryObj<T extends JSXElement> = StoryObj<ComponentProps<T>>;
 
 /**
-
- /**
- * @deprecated Use `StoryObj` instead.
+ * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
  *
- * Story function that represents a CSFv3 component example.
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
 export type Story<TArgs = Args> = StoryFn<TArgs>;
 
 /**
- * @deprecated Use StoryObj instead.
+ * @deprecated Use `StoryFn` instead, e.g. ComponentStory<typeof Button> -> StoryFn<typeof Button>.
+ * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories
+ * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/.
  *
  * For the common case where a (CSFv3) story is a simple component that receives args as props:
  *
@@ -117,4 +124,4 @@ export type Story<TArgs = Args> = StoryFn<TArgs>;
  * }
  * ```
  */
-export type ComponentStory<T extends JSXElement> = ComponentStoryObj<T>;
+export type ComponentStory<T extends JSXElement> = ComponentStoryFn<T>;

--- a/code/renderers/react/src/public-types.ts
+++ b/code/renderers/react/src/public-types.ts
@@ -102,7 +102,8 @@ export type ComponentStoryFn<T extends JSXElement> = StoryFn<ComponentProps<T>>;
 export type ComponentStoryObj<T extends JSXElement> = StoryObj<ComponentProps<T>>;
 
 /**
- * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * @deprecated Use `StoryFn` instead.
+ * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
  * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
  *
  * Story function that represents a CSFv2 component example.

--- a/code/renderers/react/template/stories/decorators.stories.tsx
+++ b/code/renderers/react/template/stories/decorators.stories.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import type { ComponentStory, ComponentMeta } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 
 const Component: FC = () => <p>Story</p>;
 
@@ -13,9 +13,9 @@ export default {
       </>
     ),
   ],
-} as ComponentMeta<typeof Component>;
+} as Meta<typeof Component>;
 
-export const All: ComponentStory<typeof Component> = {
+export const All: StoryObj<typeof Component> = {
   decorators: [
     (Story) => (
       <>

--- a/code/renderers/server/src/public-types.ts
+++ b/code/renderers/server/src/public-types.ts
@@ -30,8 +30,11 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<ServerFramework, TArgs>;
 export type StoryObj<TArgs = Args> = StoryAnnotations<ServerFramework, TArgs>;
 
 /**
- * Story function that represents a CSFv3 component example.
+ * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
+ *
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryObj<TArgs>;
+export type Story<TArgs = Args> = StoryFn<TArgs>;

--- a/code/renderers/server/src/public-types.ts
+++ b/code/renderers/server/src/public-types.ts
@@ -30,7 +30,8 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<ServerFramework, TArgs>;
 export type StoryObj<TArgs = Args> = StoryAnnotations<ServerFramework, TArgs>;
 
 /**
- * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * @deprecated Use `StoryFn` instead.
+ * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
  * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
  *
  * Story function that represents a CSFv2 component example.

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -25,7 +25,9 @@ export type Meta<CmpOrArgs = Args> = CmpOrArgs extends SvelteComponentTyped<infe
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryFn<TArgs = Args> = AnnotatedStoryFn<SvelteFramework, TArgs>;
+export type StoryFn<TCmpOrArgs = Args> = TCmpOrArgs extends SvelteComponentTyped<infer Props>
+  ? AnnotatedStoryFn<SvelteFramework, Props>
+  : AnnotatedStoryFn<SvelteFramework, TCmpOrArgs>;
 
 /**
  * Story function that represents a CSFv3 component example.

--- a/code/renderers/vue/src/public-types.ts
+++ b/code/renderers/vue/src/public-types.ts
@@ -63,7 +63,9 @@ type ComponentProps<C> = C extends ExtendedVue<any, any, any, any, infer P>
   : unknown;
 
 /**
- * @deprecated Use `StoryFn` instead.
+ * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
+ *
  * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)

--- a/code/renderers/vue/src/public-types.ts
+++ b/code/renderers/vue/src/public-types.ts
@@ -19,19 +19,20 @@ export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/types'
  *
  * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
  */
-export type Meta<TCmpOrArgs = Args> = TCmpOrArgs extends Component<any>
-  ? ComponentAnnotations<
-      VueFramework,
-      unknown extends ComponentProps<TCmpOrArgs> ? TCmpOrArgs : ComponentProps<TCmpOrArgs>
-    >
-  : ComponentAnnotations<VueFramework, TCmpOrArgs>;
+export type Meta<TCmpOrArgs = Args> = ComponentAnnotations<
+  VueFramework,
+  ComponentPropsOrProps<TCmpOrArgs>
+>;
 
 /**
  * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryFn<TArgs = Args> = AnnotatedStoryFn<VueFramework, TArgs>;
+export type StoryFn<TCmpOrArgs = Args> = AnnotatedStoryFn<
+  VueFramework,
+  ComponentPropsOrProps<TCmpOrArgs>
+>;
 
 /**
  * Story function that represents a CSFv3 component example.
@@ -43,8 +44,8 @@ export type StoryObj<TMetaOrCmpOrArgs = Args> = TMetaOrCmpOrArgs extends {
   component?: infer C;
   args?: infer DefaultArgs;
 }
-  ? TMetaOrCmpOrArgs extends Component<any>
-    ? StoryAnnotations<VueFramework, ComponentProps<TMetaOrCmpOrArgs>>
+  ? TMetaOrCmpOrArgs extends Component<any> // needed because StoryObj<typeof Button> falls into this branch, see test
+    ? StoryAnnotations<VueFramework, ComponentPropsOrProps<TMetaOrCmpOrArgs>>
     : Simplify<ComponentProps<C> & ArgsFromMeta<VueFramework, TMetaOrCmpOrArgs>> extends infer TArgs
     ? StoryAnnotations<
         VueFramework,
@@ -52,15 +53,19 @@ export type StoryObj<TMetaOrCmpOrArgs = Args> = TMetaOrCmpOrArgs extends {
         SetOptional<TArgs, Extract<keyof TArgs, keyof DefaultArgs>>
       >
     : never
-  : TMetaOrCmpOrArgs extends Component<any>
-  ? StoryAnnotations<VueFramework, ComponentProps<TMetaOrCmpOrArgs>>
-  : StoryAnnotations<VueFramework, TMetaOrCmpOrArgs>;
+  : StoryAnnotations<VueFramework, ComponentPropsOrProps<TMetaOrCmpOrArgs>>;
 
 type ComponentProps<C> = C extends ExtendedVue<any, any, any, any, infer P>
   ? P
   : C extends Component<any, any, any, infer P>
   ? P
   : unknown;
+
+type ComponentPropsOrProps<TCmpOrArgs> = TCmpOrArgs extends Component<any>
+  ? unknown extends ComponentProps<TCmpOrArgs>
+    ? TCmpOrArgs
+    : ComponentProps<TCmpOrArgs>
+  : TCmpOrArgs;
 
 /**
  * @deprecated Use `StoryFn` instead.

--- a/code/renderers/vue/src/public-types.ts
+++ b/code/renderers/vue/src/public-types.ts
@@ -19,12 +19,12 @@ export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/types'
  *
  * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
  */
-export type Meta<CmpOrArgs = Args> = CmpOrArgs extends Component<any>
+export type Meta<TCmpOrArgs = Args> = TCmpOrArgs extends Component<any>
   ? ComponentAnnotations<
       VueFramework,
-      unknown extends ComponentProps<CmpOrArgs> ? CmpOrArgs : ComponentProps<CmpOrArgs>
+      unknown extends ComponentProps<TCmpOrArgs> ? TCmpOrArgs : ComponentProps<TCmpOrArgs>
     >
-  : ComponentAnnotations<VueFramework, CmpOrArgs>;
+  : ComponentAnnotations<VueFramework, TCmpOrArgs>;
 
 /**
  * Story function that represents a CSFv2 component example.
@@ -38,23 +38,23 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<VueFramework, TArgs>;
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
+export type StoryObj<TMetaOrCmpOrArgs = Args> = TMetaOrCmpOrArgs extends {
   render?: ArgsStoryFn<VueFramework, any>;
   component?: infer C;
   args?: infer DefaultArgs;
 }
-  ? MetaOrCmpOrArgs extends Component<any>
-    ? StoryAnnotations<VueFramework, ComponentProps<MetaOrCmpOrArgs>>
-    : Simplify<ComponentProps<C> & ArgsFromMeta<VueFramework, MetaOrCmpOrArgs>> extends infer TArgs
+  ? TMetaOrCmpOrArgs extends Component<any>
+    ? StoryAnnotations<VueFramework, ComponentProps<TMetaOrCmpOrArgs>>
+    : Simplify<ComponentProps<C> & ArgsFromMeta<VueFramework, TMetaOrCmpOrArgs>> extends infer TArgs
     ? StoryAnnotations<
         VueFramework,
         TArgs,
         SetOptional<TArgs, Extract<keyof TArgs, keyof DefaultArgs>>
       >
     : never
-  : MetaOrCmpOrArgs extends Component<any>
-  ? StoryAnnotations<VueFramework, ComponentProps<MetaOrCmpOrArgs>>
-  : StoryAnnotations<VueFramework, MetaOrCmpOrArgs>;
+  : TMetaOrCmpOrArgs extends Component<any>
+  ? StoryAnnotations<VueFramework, ComponentProps<TMetaOrCmpOrArgs>>
+  : StoryAnnotations<VueFramework, TMetaOrCmpOrArgs>;
 
 type ComponentProps<C> = C extends ExtendedVue<any, any, any, any, infer P>
   ? P
@@ -63,7 +63,8 @@ type ComponentProps<C> = C extends ExtendedVue<any, any, any, any, infer P>
   : unknown;
 
 /**
- * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * @deprecated Use `StoryFn` instead.
+ * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
  * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
  *
  * Story function that represents a CSFv2 component example.

--- a/code/renderers/vue3/src/public-types.test.ts
+++ b/code/renderers/vue3/src/public-types.test.ts
@@ -3,11 +3,11 @@ import { ComponentAnnotations, StoryAnnotations } from '@storybook/csf';
 import { expectTypeOf } from 'expect-type';
 import { SetOptional } from 'type-fest';
 import { ComponentOptions, FunctionalComponent, h } from 'vue';
-import Button from './__tests__/Button.vue';
-import Decorator2TsVue from './__tests__/Decorator2.vue';
-import DecoratorTsVue from './__tests__/Decorator.vue';
 import { DecoratorFn, Meta, StoryObj } from './public-types';
 import { VueFramework } from './types';
+import Button from './__tests__/Button.vue';
+import DecoratorTsVue from './__tests__/Decorator.vue';
+import Decorator2TsVue from './__tests__/Decorator2.vue';
 
 describe('Meta', () => {
   test('Generic parameter of Meta can be a component', () => {

--- a/code/renderers/vue3/src/public-types.ts
+++ b/code/renderers/vue3/src/public-types.ts
@@ -17,9 +17,9 @@ import type { VueFramework } from './types';
  *
  * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
  */
-export type Meta<CmpOrArgs = Args> = CmpOrArgs extends ComponentOptions<infer Props>
-  ? ComponentAnnotations<VueFramework, unknown extends Props ? CmpOrArgs : Props>
-  : ComponentAnnotations<VueFramework, CmpOrArgs>;
+export type Meta<TCmpOrArgs = Args> = TCmpOrArgs extends ComponentOptions<infer Props>
+  ? ComponentAnnotations<VueFramework, unknown extends Props ? TCmpOrArgs : Props>
+  : ComponentAnnotations<VueFramework, TCmpOrArgs>;
 
 /**
  * Story function that represents a CSFv2 component example.
@@ -33,13 +33,13 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<VueFramework, TArgs>;
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
+export type StoryObj<TMetaOrCmpOrArgs = Args> = TMetaOrCmpOrArgs extends {
   render?: ArgsStoryFn<VueFramework, any>;
   component?: infer Component;
   args?: infer DefaultArgs;
 }
   ? Simplify<
-      ComponentProps<Component> & ArgsFromMeta<VueFramework, MetaOrCmpOrArgs>
+      ComponentProps<Component> & ArgsFromMeta<VueFramework, TMetaOrCmpOrArgs>
     > extends infer TArgs
     ? StoryAnnotations<
         VueFramework,
@@ -47,17 +47,18 @@ export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
         SetOptional<TArgs, Extract<keyof TArgs, keyof DefaultArgs>>
       >
     : never
-  : MetaOrCmpOrArgs extends ConcreteComponent<any>
-  ? StoryAnnotations<VueFramework, ComponentProps<MetaOrCmpOrArgs>>
-  : StoryAnnotations<VueFramework, MetaOrCmpOrArgs>;
+  : TMetaOrCmpOrArgs extends ConcreteComponent<any>
+  ? StoryAnnotations<VueFramework, ComponentProps<TMetaOrCmpOrArgs>>
+  : StoryAnnotations<VueFramework, TMetaOrCmpOrArgs>;
 
-type ComponentProps<Component> = Component extends ComponentOptions<infer P>
+type ComponentProps<C> = C extends ComponentOptions<infer P>
   ? P
-  : Component extends FunctionalComponent<infer P>
+  : C extends FunctionalComponent<infer P>
   ? P
   : unknown;
 /**
- * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * @deprecated Use `StoryFn` instead.
+ * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
  * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
  *
  * Story function that represents a CSFv2 component example.

--- a/code/renderers/vue3/src/public-types.ts
+++ b/code/renderers/vue3/src/public-types.ts
@@ -17,16 +17,20 @@ import type { VueFramework } from './types';
  *
  * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
  */
-export type Meta<TCmpOrArgs = Args> = TCmpOrArgs extends ComponentOptions<infer Props>
-  ? ComponentAnnotations<VueFramework, unknown extends Props ? TCmpOrArgs : Props>
-  : ComponentAnnotations<VueFramework, TCmpOrArgs>;
+export type Meta<TCmpOrArgs = Args> = ComponentAnnotations<
+  VueFramework,
+  ComponentPropsOrProps<TCmpOrArgs>
+>;
 
 /**
  * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryFn<TArgs = Args> = AnnotatedStoryFn<VueFramework, TArgs>;
+export type StoryFn<TCmpOrArgs = Args> = AnnotatedStoryFn<
+  VueFramework,
+  ComponentPropsOrProps<TCmpOrArgs>
+>;
 
 /**
  * Story function that represents a CSFv3 component example.
@@ -47,15 +51,20 @@ export type StoryObj<TMetaOrCmpOrArgs = Args> = TMetaOrCmpOrArgs extends {
         SetOptional<TArgs, Extract<keyof TArgs, keyof DefaultArgs>>
       >
     : never
-  : TMetaOrCmpOrArgs extends ConcreteComponent<any>
-  ? StoryAnnotations<VueFramework, ComponentProps<TMetaOrCmpOrArgs>>
-  : StoryAnnotations<VueFramework, TMetaOrCmpOrArgs>;
+  : StoryAnnotations<VueFramework, ComponentPropsOrProps<TMetaOrCmpOrArgs>>;
 
 type ComponentProps<C> = C extends ComponentOptions<infer P>
   ? P
   : C extends FunctionalComponent<infer P>
   ? P
   : unknown;
+
+type ComponentPropsOrProps<TCmpOrArgs> = TCmpOrArgs extends ConcreteComponent<any>
+  ? unknown extends ComponentProps<TCmpOrArgs>
+    ? TCmpOrArgs
+    : ComponentProps<TCmpOrArgs>
+  : TCmpOrArgs;
+
 /**
  * @deprecated Use `StoryFn` instead.
  * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.

--- a/code/renderers/vue3/src/public-types.ts
+++ b/code/renderers/vue3/src/public-types.ts
@@ -57,11 +57,13 @@ type ComponentProps<Component> = Component extends ComponentOptions<infer P>
   ? P
   : unknown;
 /**
- * @deprecated Use `StoryObj` instead.
- * Story function that represents a CSFv3 component example.
+ * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
+ *
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryObj<TArgs>;
+export type Story<TArgs = Args> = StoryFn<TArgs>;
 
 export type DecoratorFn<TArgs = Args> = DecoratorFunction<VueFramework, TArgs>;

--- a/code/renderers/web-components/src/public-types.ts
+++ b/code/renderers/web-components/src/public-types.ts
@@ -28,7 +28,8 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<WebComponentsFramework, TAr
 export type StoryObj<TArgs = Args> = StoryAnnotations<WebComponentsFramework, TArgs>;
 
 /**
- * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * @deprecated Use `StoryFn` instead.
+ * Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
  * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
  *
  * Story function that represents a CSFv2 component example.

--- a/code/renderers/web-components/src/public-types.ts
+++ b/code/renderers/web-components/src/public-types.ts
@@ -28,8 +28,11 @@ export type StoryFn<TArgs = Args> = AnnotatedStoryFn<WebComponentsFramework, TAr
 export type StoryObj<TArgs = Args> = StoryAnnotations<WebComponentsFramework, TArgs>;
 
 /**
- * Story function that represents a CSFv3 component example.
+ * @deprecated Use `StoryFn` instead. Use `StoryObj` if you want to migrate to CSF3, which uses objects instead of functions to represent stories.
+ * You can read more about the CSF3 format here: https://storybook.js.org/blog/component-story-format-3-0/
+ *
+ * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type Story<TArgs = Args> = StoryObj<TArgs>;
+export type Story<TArgs = Args> = StoryFn<TArgs>;


### PR DESCRIPTION
What I did:

* Added deprecations notes for Story and ComponentX types
* Story is using StoryFn again, so that it is a non-breaking change.
* Story is deprecated (users should use StoryFn or preferably StoryObj)
* Deprecated the ComponentX types of react, as it is redundant now
* Adopted the prefix T for all generic types @tmeasday 

(this is written by Kasper, editing @shilman PR out of convenience 😅 ) 
