### PR TITLE
Fix Vite builder source loader plugin

### DIFF
--- a/code/lib/builder-vite/src/plugins/source-loader-plugin.ts
+++ b/code/lib/builder-vite/src/plugins/source-loader-plugin.ts
@@ -11,6 +11,7 @@ const mockClassLoader = (id: string) => ({
   // eslint-disable-next-line no-console
   emitWarning: (message: string) => console.warn(message),
   resourcePath: id,
+  getOptions: () => ({}),
 });
 
 // HACK: Until we can support only node 15+ and use string.prototype.replaceAll
@@ -25,6 +26,7 @@ export function sourceLoaderPlugin(config: ExtendedOptions): Plugin | Plugin[] {
       enforce: 'pre',
       async transform(src: string, id: string) {
         if (id.match(storyPattern)) {
+          // @ts-expect-error - source loader doesn't have types
           const code: string = await sourceLoaderTransform.call(mockClassLoader(id), src);
           const s = new MagicString(src);
           // Entirely replace with new code
@@ -52,6 +54,7 @@ export function sourceLoaderPlugin(config: ExtendedOptions): Plugin | Plugin[] {
       },
       async transform(src: string, id: string) {
         if (id.match(storyPattern)) {
+          // @ts-expect-error - source loader doesn't have types
           let code: string = await sourceLoaderTransform.call(mockClassLoader(id), src);
           // eslint-disable-next-line @typescript-eslint/naming-convention
           const [_, sourceString] = code.match(storySourcePattern) ?? [null, null];

--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -15,6 +15,7 @@ import {
   injectExportOrderPlugin,
   mdxPlugin,
   stripStoryHMRBoundary,
+  sourceLoaderPlugin,
 } from './plugins';
 import type { ExtendedOptions } from './types';
 
@@ -79,7 +80,7 @@ export async function pluginConfig(options: ExtendedOptions) {
 
   const plugins = [
     codeGeneratorPlugin(options),
-    // sourceLoaderPlugin(options),
+    sourceLoaderPlugin(options),
     mdxPlugin(),
     injectExportOrderPlugin,
     stripStoryHMRBoundary(),

--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -80,7 +80,7 @@ export async function pluginConfig(options: ExtendedOptions) {
 
   const plugins = [
     codeGeneratorPlugin(options),
-    sourceLoaderPlugin(options),
+    await sourceLoaderPlugin(options),
     mdxPlugin(),
     injectExportOrderPlugin,
     stripStoryHMRBoundary(),


### PR DESCRIPTION
Issue: #19554

## What I did

Added getOptions to the mocked class loader.

sourceloader doesn't have any types so I added expect error.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
