### PR TITLE
CLI: Don't run MDX2 automigration on node_modules

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/mdx-1-to-2.ts
+++ b/code/lib/cli/src/automigrate/fixes/mdx-1-to-2.ts
@@ -29,7 +29,7 @@ export const mdx1to2: Fix<Mdx1to2Options> = {
   id: 'mdx1to2',
 
   async check() {
-    const storiesMdxFiles = await globby('**/*.(story|stories).mdx');
+    const storiesMdxFiles = await globby('./!(node_modules)**/*.(story|stories).mdx');
     return storiesMdxFiles.length ? { storiesMdxFiles } : undefined;
   },
 


### PR DESCRIPTION
Issue: N/A

## What I did

Only run MDX2 automigration on user files

self-merging @yannbf 

## How to test

```
yarn create next-app next-app
cd next-app
/path/to/cli/bin/index.js init
```