### PR TITLE
CLI/React native: Fix addons template to import register instead of manager

### DIFF
--- a/code/lib/cli/templates/react-native/template-csf/storybook/addons.js
+++ b/code/lib/cli/templates/react-native/template-csf/storybook/addons.js
@@ -1,3 +1,3 @@
-import '@storybook/addon-actions/manager';
-import '@storybook/addon-links/manager';
-import '@storybook/addon-knobs/manager';
+import '@storybook/addon-actions/register';
+import '@storybook/addon-links/register';
+import '@storybook/addon-knobs/register';


### PR DESCRIPTION
React native's stable version uses 5.3 where register is still the correct import

Issue:

## What I did

Updated the react native template for 5.3 to use register instead of manager since in that version its the correct import.

## How to test

generate a new react naitve project and the server should work with the included addons
