### PR TITLE
Ensure v6 store works even with no explicit renderer

### DIFF
--- a/code/lib/core-common/src/utils/get-renderer-name.ts
+++ b/code/lib/core-common/src/utils/get-renderer-name.ts
@@ -8,7 +8,6 @@ export async function getRendererName(options: Options) {
   const { renderer } = await options.presets.apply('core', {}, options);
 
   if (!renderer) {
-    console.log('getting framework name');
     // At the moment some frameworks (Angular/Ember) do not define a renderer, but themselves
     // serve the purpose (in particular exporting the symbols needed by entrypoints)
     return getFrameworkName(options);

--- a/code/lib/core-common/src/utils/get-renderer-name.ts
+++ b/code/lib/core-common/src/utils/get-renderer-name.ts
@@ -1,5 +1,5 @@
-import { dedent } from 'ts-dedent';
 import type { Options } from '@storybook/types';
+import { getFrameworkName } from './get-framework-name';
 
 /**
  * Render is set as a string on core. It must be set by the framework
@@ -8,11 +8,10 @@ export async function getRendererName(options: Options) {
   const { renderer } = await options.presets.apply('core', {}, options);
 
   if (!renderer) {
-    throw new Error(dedent`
-      You must specify a framework in '.storybook/main.js' config.
-
-      https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#framework-field-mandatory
-    `);
+    console.log('getting framework name');
+    // At the moment some frameworks (Angular/Ember) do not define a renderer, but themselves
+    // serve the purpose (in particular exporting the symbols needed by entrypoints)
+    return getFrameworkName(options);
   }
 
   return renderer;


### PR DESCRIPTION
Issue: Angular CLI (and likely Ember) didn't work in v6 mode.

## What I did

As discussed, `getRendererName` falls back to `getFrameworkName` for now. Once we actually split those renderers we should probably revert this PR.

## How to test

```
yarn task --task sandbox --no-link --template angular-cli/default-ts --start-from install
cd sandbox/angular-cli-default-ts
# update to v6 store
yarn storybook
```