### PR TITLE
CSF tools: Add tags support

### DIFF
--- a/code/lib/csf-tools/src/CsfFile.test.ts
+++ b/code/lib/csf-tools/src/CsfFile.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="@types/jest" />;
+
 /* eslint-disable no-underscore-dangle */
 import { dedent } from 'ts-dedent';
 import yaml from 'js-yaml';
@@ -688,6 +690,106 @@ describe('CsfFile', () => {
       `;
       const csf = loadCsf(input, { makeTitle }).parse();
       expect(csf.imports).toMatchInlineSnapshot();
+    });
+  });
+
+  describe('tags', () => {
+    it('csf2', () => {
+      expect(
+        parse(
+          dedent`
+          export default { title: 'foo/bar', tags: ['X'] };
+          export const A = () => {};
+          A.tags = ['Y'];
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+          tags:
+            - X
+        stories:
+          - id: foo-bar--a
+            name: A
+            tags:
+              - 'Y'
+      `);
+    });
+
+    it('csf3', () => {
+      expect(
+        parse(
+          dedent`
+          export default { title: 'foo/bar', tags: ['X'] };
+          export const A = {
+            render: () => {},
+            tags: ['Y'],
+          };
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+          tags:
+            - X
+        stories:
+          - id: foo-bar--a
+            name: A
+            tags:
+              - 'Y'
+      `);
+    });
+
+    it('variables', () => {
+      expect(
+        parse(
+          dedent`
+          const x = ['X'];
+          const y = ['Y'];
+          export default { title: 'foo/bar', tags: x };
+          export const A = {
+            render: () => {},
+            tags: y,
+          };
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+          tags:
+            - X
+        stories:
+          - id: foo-bar--a
+            name: A
+            tags:
+              - 'Y'
+      `);
+    });
+
+    it('array error', () => {
+      expect(() =>
+        parse(
+          dedent`
+            export default { title: 'foo/bar', tags: 'X' };
+            export const A = {
+              render: () => {},
+            };
+          `
+        )
+      ).toThrow('CSF: Expected tags array');
+    });
+
+    it('array element handling', () => {
+      expect(() =>
+        parse(
+          dedent`
+            export default { title: 'foo/bar', tags: [10] };
+            export const A = {
+              render: () => {},
+            };
+          `
+        )
+      ).toThrow('CSF: Expected tag to be string literal');
     });
   });
 });

--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -6,7 +6,7 @@ import * as t from '@babel/types';
 import generate from '@babel/generator';
 import traverse from '@babel/traverse';
 import { toId, isExportStory, storyNameFromExport } from '@storybook/csf';
-import type { CSF_Meta, CSF_Story } from '@storybook/types';
+import type { CSF_Meta, CSF_Story, CSF_Tag } from '@storybook/types';
 import { babelParse } from './babelParse';
 
 const logger = console;
@@ -24,6 +24,17 @@ function parseIncludeExclude(prop: t.Node) {
   if (t.isRegExpLiteral(prop)) return new RegExp(prop.pattern, prop.flags);
 
   throw new Error(`Unknown include/exclude: ${prop}`);
+}
+
+function parseTags(prop: t.Node) {
+  if (!t.isArrayExpression(prop)) {
+    throw new Error('CSF: Expected tags array');
+  }
+
+  return prop.elements.map((e) => {
+    if (t.isStringLiteral(e)) return e.value;
+    throw new Error(`CSF: Expected tag to be string literal`);
+  }) as CSF_Tag[];
 }
 
 const findVarInitialization = (identifier: string, program: t.Program) => {
@@ -184,6 +195,12 @@ export class CsfFile {
         } else if (p.key.name === 'component') {
           const { code } = generate(p.value, {});
           meta.component = code;
+        } else if (p.key.name === 'tags') {
+          let node = p.value;
+          if (t.isIdentifier(node)) {
+            node = findVarInitialization(node.name, this._ast.program);
+          }
+          meta.tags = parseTags(node);
         } else if (p.key.name === 'id') {
           if (t.isStringLiteral(p.value)) {
             meta.id = p.value.value;
@@ -404,6 +421,13 @@ export class CsfFile {
           parameters.docsOnly = true;
         }
         acc[key] = { ...story, id, parameters };
+        const { tags } = self._storyAnnotations[key];
+        if (tags) {
+          const node = t.isIdentifier(tags)
+            ? findVarInitialization(tags.name, this._ast.program)
+            : tags;
+          acc[key].tags = parseTags(node);
+        }
       }
       return acc;
     }, {} as Record<string, CSF_Story>);

--- a/code/lib/types/src/modules/csf.ts
+++ b/code/lib/types/src/modules/csf.ts
@@ -114,18 +114,22 @@ export {
   StrictInputType,
 };
 
+export type CSF_Tag = string;
+
 export interface CSF_Meta {
   id?: string;
   title?: string;
   component?: string;
   includeStories?: string[] | RegExp;
   excludeStories?: string[] | RegExp;
+  tags?: CSF_Tag[];
 }
 
 export interface CSF_Story {
   id: string;
   name: string;
   parameters: Record<string, any>;
+  tags?: CSF_Tag[];
 }
 
 export type ViewMode = ViewModeFromCSF | 'story' | 'info' | 'settings' | string | undefined;


### PR DESCRIPTION
Issue: N/A

## What I did

Add parsing support for `tags` on the meta or story exports.

See test cases for examples

## How to test

- [ ] CI passes
