### PR TITLE
Addons: Support SSR by not using global.window to store hooks context

### DIFF
--- a/code/lib/addons/src/hooks.test.js
+++ b/code/lib/addons/src/hooks.test.js
@@ -1,14 +1,12 @@
 import { useParameter, useStoryContext } from './hooks';
 
-const { window: globalWindow } = global;
-
 describe('addons/hooks', () => {
   beforeEach(() => {
-    globalWindow.STORYBOOK_HOOKS_CONTEXT = undefined;
+    global.STORYBOOK_HOOKS_CONTEXT = undefined;
   });
 
   afterEach(() => {
-    globalWindow.STORYBOOK_HOOKS_CONTEXT = undefined;
+    global.STORYBOOK_HOOKS_CONTEXT = undefined;
   });
 
   describe('useStoryContext', () => {
@@ -21,7 +19,7 @@ describe('addons/hooks', () => {
 
   describe('useParameter', () => {
     beforeEach(() => {
-      globalWindow.STORYBOOK_HOOKS_CONTEXT = {
+      global.STORYBOOK_HOOKS_CONTEXT = {
         currentContext: {
           parameters: {
             'undefined key': undefined,

--- a/code/lib/addons/src/hooks.ts
+++ b/code/lib/addons/src/hooks.ts
@@ -19,8 +19,6 @@ import {
 // eslint-disable-next-line import/no-cycle
 import { addons } from './index';
 
-const { window: globalWindow } = global;
-
 interface Hook {
   name: string;
   memoizedState?: any;
@@ -156,10 +154,10 @@ function hookify<TFramework extends AnyFramework>(fn: AbstractFunction) {
     }
     hooks.nextHookIndex = 0;
 
-    const prevContext = globalWindow.STORYBOOK_HOOKS_CONTEXT;
-    globalWindow.STORYBOOK_HOOKS_CONTEXT = hooks;
+    const prevContext = global.STORYBOOK_HOOKS_CONTEXT;
+    global.STORYBOOK_HOOKS_CONTEXT = hooks;
     const result = fn(...args);
-    globalWindow.STORYBOOK_HOOKS_CONTEXT = prevContext;
+    global.STORYBOOK_HOOKS_CONTEXT = prevContext;
 
     if (hooks.currentPhase === 'UPDATE' && hooks.getNextHook() != null) {
       throw new Error(
@@ -218,7 +216,7 @@ const invalidHooksError = () =>
   new Error('Storybook preview hooks can only be called inside decorators and story functions.');
 
 function getHooksContextOrNull<TFramework extends AnyFramework>(): HooksContext<TFramework> | null {
-  return globalWindow.STORYBOOK_HOOKS_CONTEXT || null;
+  return global.STORYBOOK_HOOKS_CONTEXT || null;
 }
 
 function getHooksContextOrThrow<TFramework extends AnyFramework>(): HooksContext<TFramework> {


### PR DESCRIPTION
In an effort to make it possible to serverside render storybook, this is one of many steps we'll have to take.