### PR TITLE
fix(react): update `react-element-to-jsx-string` to v15

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -74,7 +74,7 @@
     "html-tags": "^3.1.0",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
-    "react-element-to-jsx-string": "^14.3.4",
+    "react-element-to-jsx-string": "^15.0.0",
     "react-refresh": "^0.11.0",
     "read-pkg-up": "^7.0.1",
     "regenerator-runtime": "^0.13.7",


### PR DESCRIPTION
This will remove the following warnings

```sh
warning "@storybook/react > react-element-to-jsx-string@14.3.4" has incorrect peer dependency "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1".
warning "@storybook/react > react-element-to-jsx-string@14.3.4" has incorrect peer dependency "react-dom@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1".
```

---

https://github.com/algolia/react-element-to-jsx-string/blob/master/CHANGELOG.md#1500-2022-05-09