### PR TITLE
fix(addon-actions): update `react-inspector` to v6

### DIFF
--- a/addons/actions/package.json
+++ b/addons/actions/package.json
@@ -54,7 +54,7 @@
     "lodash": "^4.17.21",
     "polished": "^4.2.2",
     "prop-types": "^15.7.2",
-    "react-inspector": "^5.1.0",
+    "react-inspector": "^6.0.1",
     "regenerator-runtime": "^0.13.7",
     "telejson": "^6.0.8",
     "ts-dedent": "^2.0.0",


### PR DESCRIPTION
This will remove the following warning

```sh
warning "@storybook/addon-actions > react-inspector@5.1.1" has incorrect peer dependency "react@^16.8.4 || ^17.0.0".
```

---

https://github.com/storybookjs/react-inspector/blob/master/HISTORY.md#600-04072022