### PR TITLE
fix(addon-docs): update `@mdx-js/react` to v2

### DIFF
--- a/addons/docs/package.json
+++ b/addons/docs/package.json
@@ -58,7 +58,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.12",
     "@babel/preset-env": "^7.12.11",
     "@jest/transform": "^26.6.2",
-    "@mdx-js/react": "^1.6.22",
+    "@mdx-js/react": "^2.1.5",
     "@storybook/addons": "6.5.13",
     "@storybook/api": "6.5.13",
     "@storybook/components": "6.5.13",


### PR DESCRIPTION
This will remove the following warning

```sh
warning "@storybook/addon-docs > @mdx-js/react@1.6.22" has incorrect peer dependency "react@^16.13.1 || ^17.0.0".
```

---

https://github.com/mdx-js/mdx/releases/tag/2.0.0