### PR TITLE
Fix broken link in docs-page

### DIFF
--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -200,6 +200,6 @@ Here’s an example of how to render Vue stories inline. The following docs conf
 
 <!-- prettier-ignore-end -->
 
-With this function, anyone using the docs addon for [@storybook/vue](https://github.com/storybookjs/storybook/tree/master/frameworks/vue-webpack5) can make their stories render inline, either globally with the inlineStories docs parameter, or on a per-story-basis using the inline prop on the `<Story>` doc block.
+With this function, anyone using the docs addon for [@storybook/vue](https://github.com/storybookjs/storybook/blob/next/code/frameworks/vue-webpack5/README.md) can make their stories render inline, either globally with the inlineStories docs parameter, or on a per-story-basis using the inline prop on the `<Story>` doc block.
 
 If you come up with an elegant and flexible implementation for the `prepareForInline` function for your framework, let us know. We'd love to make it the default configuration to make inline stories more accessible for a larger variety of frameworks!


### PR DESCRIPTION
## What I did

A link is dead in the docs-page

I updated the link from https://github.com/storybookjs/storybook/tree/master/frameworks/vue-webpack5 to
https://github.com/storybookjs/storybook/blob/next/code/frameworks/vue-webpack5/README.md

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
