### PR TITLE
Allow setting tags in storiesOf via parameters.

### DIFF
--- a/code/lib/client-api/src/ClientApi.ts
+++ b/code/lib/client-api/src/ClientApi.ts
@@ -360,7 +360,7 @@ Read more here: https://github.com/storybookjs/storybook/blob/master/MIGRATION.m
       return api;
     };
 
-    api.addParameters = ({ component, args, argTypes, ...parameters }: Parameters) => {
+    api.addParameters = ({ component, args, argTypes, tags, ...parameters }: Parameters) => {
       if (hasAdded)
         throw new Error(`You cannot add parameters after the first story for a kind.
 Read more here: https://github.com/storybookjs/storybook/blob/master/MIGRATION.md#can-no-longer-add-decoratorsparameters-after-stories`);
@@ -369,6 +369,7 @@ Read more here: https://github.com/storybookjs/storybook/blob/master/MIGRATION.m
       if (component) meta.component = component;
       if (args) meta.args = { ...meta.args, ...args };
       if (argTypes) meta.argTypes = { ...meta.argTypes, ...argTypes };
+      if (tags) meta.tags = tags;
       return api;
     };
 

--- a/code/lib/core-client/src/preview/start.test.ts
+++ b/code/lib/core-client/src/preview/start.test.ts
@@ -1121,7 +1121,7 @@ describe('start', () => {
         global.DOCS_OPTIONS = { enabled: true, docsPage: true, defaultName: 'Docs' };
       });
 
-      it('adds stories for each component', async () => {
+      it('adds stories for each component with docsPage tag', async () => {
         const renderToDOM = jest.fn();
 
         const { configure, clientApi } = start(renderToDOM);
@@ -1133,6 +1133,7 @@ describe('start', () => {
 
           clientApi
             .storiesOf('Component B', { id: 'file2' } as NodeModule)
+            .addParameters({ tags: ['docsPage'] })
             .add('Story Three', jest.fn());
 
           return [componentCExports];
@@ -1183,6 +1184,20 @@ describe('start', () => {
                 "title": "Component A",
                 "type": "story",
               },
+              "component-b--docs": Object {
+                "componentId": "component-b",
+                "id": "component-b--docs",
+                "importPath": "file2",
+                "name": "Docs",
+                "standalone": false,
+                "storiesImports": Array [],
+                "tags": Array [
+                  "docsPage",
+                  "docs",
+                ],
+                "title": "Component B",
+                "type": "docs",
+              },
               "component-b--story-three": Object {
                 "argTypes": Object {},
                 "args": Object {},
@@ -1198,6 +1213,7 @@ describe('start', () => {
                   "framework": "test",
                 },
                 "tags": Array [
+                  "docsPage",
                   "story",
                 ],
                 "title": "Component B",


### PR DESCRIPTION
Telescoping on https://github.com/storybookjs/storybook/pull/19627

Issue: Need to able to set tags in `storiesOf` for docpage opt-in

## What I did

Use the same mechanism we used for args+argTypes

## How to test

- [ ] See integration test