### PR TITLE
Build: Reduce CI usage by 60%

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_16_browsers
-    parallelism: 10
+    parallelism: 9
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -324,7 +324,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_16_browsers
-    parallelism: 10
+    parallelism: 9
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -339,7 +339,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_16_browsers
-    parallelism: 10
+    parallelism: 9
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -358,7 +358,7 @@ jobs:
     executor:
       class: medium+
       name: sb_playwright
-    parallelism: 9
+    parallelism: 8
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -373,7 +373,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_16_browsers
-    parallelism: 10
+    parallelism: 9
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -388,7 +388,7 @@ jobs:
     executor:
       class: medium+
       name: sb_playwright
-    parallelism: 10
+    parallelism: 9
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_16_browsers
-    parallelism: 24
+    parallelism: 10
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -324,7 +324,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_16_browsers
-    parallelism: 24
+    parallelism: 10
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -339,7 +339,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_16_browsers
-    parallelism: 24
+    parallelism: 10
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -358,7 +358,7 @@ jobs:
     executor:
       class: medium+
       name: sb_playwright
-    parallelism: 22
+    parallelism: 9
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -373,7 +373,7 @@ jobs:
     executor:
       class: medium+
       name: sb_node_16_browsers
-    parallelism: 24
+    parallelism: 10
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -388,7 +388,7 @@ jobs:
     executor:
       class: medium+
       name: sb_playwright
-    parallelism: 24
+    parallelism: 10
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -2,7 +2,7 @@ const craTemplates = {
   'cra/default-js': {
     name: 'Create React App (Javascript)',
     script: 'npx create-react-app .',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       // TODO: change this to @storybook/cra once that package is created
       framework: '@storybook/react-webpack5',
@@ -29,7 +29,7 @@ const nextjsTemplates = {
   'nextjs/default-js': {
     name: 'Next.js (JavaScript)',
     script: 'npx create-next-app {{beforeDir}}',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',
@@ -52,7 +52,7 @@ const reactViteTemplates = {
   'react-vite/default-js': {
     name: 'React Vite (JS)',
     script: 'yarn create vite . --template react',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/react-vite',
       renderer: '@storybook/react',
@@ -75,7 +75,7 @@ const reactWebpackTemplates = {
   'react-webpack/18-ts': {
     name: 'React Webpack5 (TS)',
     script: 'yarn create webpack5-react .',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/react-webpack5',
       renderer: '@storybook/react',
@@ -85,7 +85,7 @@ const reactWebpackTemplates = {
   'react-webpack/17-ts': {
     name: 'React Webpack5 (TS)',
     script: 'yarn create webpack5-react . --version-react="17" --version-react-dom="17"',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/react-webpack5',
       renderer: '@storybook/react',
@@ -98,7 +98,7 @@ const vue3ViteTemplates = {
   'vue3-vite/default-js': {
     name: 'Vue3 Vite (JS)',
     script: 'yarn create vite . --template vue',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/vue3-vite',
       renderer: '@storybook/vue3',
@@ -125,7 +125,7 @@ const vue2ViteTemplates = {
     // preferring community bootstrap scripts / generators instead.
     script:
       'yarn create vite . --template vanilla && yarn add --dev @vitejs/plugin-vue2 vue-template-compiler vue@2 && echo "import vue2 from \'@vitejs/plugin-vue2\';\n\nexport default {\n\tplugins: [vue2()]\n};" > vite.config.js',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
     expected: {
@@ -140,7 +140,7 @@ const htmlWebpackTemplates = {
   'html-webpack/default': {
     name: 'HTML Webpack5',
     script: 'yarn create webpack5-html .',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/html-webpack5',
       renderer: '@storybook/html',
@@ -153,7 +153,7 @@ const svelteViteTemplates = {
   'svelte-vite/default-js': {
     name: 'Svelte Vite (JS)',
     script: 'yarn create vite . --template svelte',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/svelte-vite',
       renderer: '@storybook/svelte',
@@ -190,7 +190,7 @@ const angularCliTemplates = {
     name: 'Angular CLI (Version 13)',
     script:
       'npx -p @angular/cli@13 ng new angular-v13 --directory . --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/angular',
       renderer: '@storybook/angular',
@@ -204,7 +204,7 @@ const svelteKitTemplates = {
     name: 'Svelte Kit (JS)',
     script:
       'yarn create svelte-with-args --name=svelte-kit/skeleton-js --directory=. --template=skeleton --types=null --no-prettier --no-eslint --no-playwright',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/svelte-vite',
       renderer: '@storybook/svelte',
@@ -228,7 +228,7 @@ const litViteTemplates = {
   'lit-vite/default-js': {
     name: 'Lit Vite (JS)',
     script: 'yarn create vite . --template lit',
-    cadence: ['ci', 'daily', 'weekly'] as any,
+    cadence: ['daily', 'weekly'] as any,
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
     expected: {
@@ -255,7 +255,7 @@ const vueCliTemplates = {
   'vue-cli/default-js': {
     name: 'Vue-CLI (Default JS)',
     script: 'npx -p @vue/cli vue create . --default --packageManager=yarn --force --merge',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     skipTasks: [
       // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
       'smoke-test',
@@ -291,7 +291,7 @@ const preactWebpackTemplates = {
   'preact-webpack5/default-js': {
     name: 'Preact CLI (Default JS)',
     script: 'npx preact-cli create default {{beforeDir}} --name preact-app --yarn --no-install',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/preact-webpack5',
       renderer: '@storybook/preact',
@@ -301,7 +301,7 @@ const preactWebpackTemplates = {
   'preact-webpack5/default-ts': {
     name: 'Preact CLI (Default TS)',
     script: 'npx preact-cli create typescript {{beforeDir}} --name preact-app --yarn --no-install',
-    cadence: ['ci', 'daily', 'weekly'],
+    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/preact-webpack5',
       renderer: '@storybook/preact',


### PR DESCRIPTION
Issue: N/A

## What I did

CI costs have gone beyond comfortable levels. I reduced the CI jobs to one of each major framework/version for both webpack & vite.

This should significantly reduce the cost, but we'll probably need to get it down further. We'll also have to figure out a good process for daily/weekly builds.

Self-merging @tmeasday @ndelangen @yannbf @kasperpeulen 

## How to test

- [ ] CI passes