### PR TITLE
Build-storybook: Only copy .mjs files for manager build

### DIFF
--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'path';
+import { dirname, join, parse } from 'path';
 import fs from 'fs-extra';
 import express from 'express';
 
@@ -192,7 +192,15 @@ const builder: BuilderFunction = async function* builderGeneratorFn({ startTime,
 
   yield;
 
-  const managerFiles = fs.copy(coreDirOrigin, coreDirTarget);
+  const managerFiles = fs.copy(coreDirOrigin, coreDirTarget, {
+    filter: (src) => {
+      const { ext } = parse(src);
+      if (ext) {
+        return ext === '.mjs';
+      }
+      return true;
+    },
+  });
   const { cssFiles, jsFiles } = await readOrderedFiles(addonsDir, compilation?.outputFiles);
 
   yield;


### PR DESCRIPTION
reduces the size of a deployed storybook by about 12MB!

The manager is build using ESM only, the JS files generated are only for the builder to read which globals to inject into addons.
Only the .mjs files need to be copied.