### PR TITLE
Telemetry: Measure docs usage

### DIFF
--- a/code/lib/core-server/src/build-static.ts
+++ b/code/lib/core-server/src/build-static.ts
@@ -32,6 +32,7 @@ import { getBuilders } from './utils/get-builders';
 import { extractStoriesJson, convertToIndexV3 } from './utils/stories-json';
 import { extractStorybookMetadata } from './utils/metadata';
 import { StoryIndexGenerator } from './utils/StoryIndexGenerator';
+import { summarizeIndex } from './utils/summarizeIndex';
 
 export async function buildStaticStandalone(
   options: CLIOptions & LoadOptions & BuilderOptions & { outputDir: string }
@@ -174,10 +175,7 @@ export async function buildStaticStandalone(
         const storyIndex = await generator?.getIndex();
         const payload = storyIndex
           ? {
-              storyIndex: {
-                storyCount: Object.keys(storyIndex.entries).length,
-                version: storyIndex.v,
-              },
+              storyIndex: summarizeIndex(storyIndex),
             }
           : undefined;
         await telemetry('build', payload, { configDir: options.configDir });

--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -17,6 +17,7 @@ import { getServerChannel } from './utils/get-server-channel';
 import { openInBrowser } from './utils/open-in-browser';
 import { getBuilders } from './utils/get-builders';
 import { StoryIndexGenerator } from './utils/StoryIndexGenerator';
+import { summarizeIndex } from './utils/summarizeIndex';
 
 // @ts-expect-error (Converted from ts-ignore)
 export const router: Router = new Router();
@@ -66,12 +67,13 @@ export async function storybookDevServer(options: Options) {
   if (!core?.disableTelemetry) {
     initializedStoryIndexGenerator.then(async (generator) => {
       const storyIndex = await generator?.getIndex();
+      const entries = Object.values(storyIndex.entries);
+      if (storyIndex) {
+        console.dir(entries.filter((e) => e.type === 'docs')); // .map((e) => ({ id: e.id, type: e.type })));
+      }
       const payload = storyIndex
         ? {
-            storyIndex: {
-              storyCount: Object.keys(storyIndex.entries).length,
-              version: storyIndex.v,
-            },
+            storyIndex: summarizeIndex(storyIndex),
           }
         : undefined;
       telemetry('dev', payload, { configDir: options.configDir });

--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -67,10 +67,6 @@ export async function storybookDevServer(options: Options) {
   if (!core?.disableTelemetry) {
     initializedStoryIndexGenerator.then(async (generator) => {
       const storyIndex = await generator?.getIndex();
-      const entries = Object.values(storyIndex.entries);
-      if (storyIndex) {
-        console.dir(entries.filter((e) => e.type === 'docs')); // .map((e) => ({ id: e.id, type: e.type })));
-      }
       const payload = storyIndex
         ? {
             storyIndex: summarizeIndex(storyIndex),

--- a/code/lib/core-server/src/utils/summarizeIndex.ts
+++ b/code/lib/core-server/src/utils/summarizeIndex.ts
@@ -1,0 +1,28 @@
+import { Store_StoryIndex } from '@storybook/types';
+
+export function summarizeIndex(storyIndex: Store_StoryIndex) {
+  let storyCount = 0;
+  let docsPageCount = 0;
+  let storiesMdxCount = 0;
+  let mdxCount = 0;
+  Object.values(storyIndex.entries).forEach((entry) => {
+    if (entry.type === 'story') {
+      storyCount += 1;
+    } else if (entry.type === 'docs') {
+      if (entry.standalone) {
+        mdxCount += 1;
+      } else if (entry.importPath.endsWith('.mdx')) {
+        storiesMdxCount += 1;
+      } else {
+        docsPageCount += 1;
+      }
+    }
+  });
+  return {
+    storyCount,
+    docsPageCount,
+    storiesMdxCount,
+    mdxCount,
+    version: storyIndex.v,
+  };
+}

--- a/code/lib/telemetry/src/index.ts
+++ b/code/lib/telemetry/src/index.ts
@@ -14,7 +14,11 @@ export const telemetry = async (
   payload: Payload = {},
   options: Partial<Options> = {}
 ) => {
-  await notify();
+  // Don't notify on boot since it can lead to double notification in `sb init`.
+  // The notification will happen when the actual command runs.
+  if (eventType !== 'boot') {
+    await notify();
+  }
   const telemetryData: TelemetryData = {
     eventType,
     payload,


### PR DESCRIPTION
Issue: N/A

## What I did

- [x] Fix `storyCount` for v7 (we were overcounting)
- [x] Track different types of docs entries (`docsPage`, `storiesMdx`, `mdx`)
- [x] Fix boot notification

## How to test

We'll be adding proper testing for this soon. For now, manually:

- [ ] `STORYBOOK_TELEMETRY_DEBUG=true` and enable telemetry