### PR TITLE
CSF: Fix `StoryObj<typeof Cmp>` to work the same as old ComponentStoryObj

### DIFF
--- a/code/renderers/react/src/public-types.test.tsx
+++ b/code/renderers/react/src/public-types.test.tsx
@@ -79,7 +79,7 @@ describe('Args can be provided in multiple ways', () => {
   });
 
   test('Component can be used as generic parameter for StoryObj', () => {
-    type Expected = ReactStory<ButtonProps, ButtonProps>;
+    type Expected = ReactStory<ButtonProps, Partial<ButtonProps>>;
     expectTypeOf<StoryObj<typeof Button>>().toEqualTypeOf<Expected>();
   });
 });

--- a/code/renderers/react/src/public-types.ts
+++ b/code/renderers/react/src/public-types.ts
@@ -53,11 +53,7 @@ export type StoryObj<TMetaOrCmpOrArgs = Args> = TMetaOrCmpOrArgs extends {
       >
     : never
   : TMetaOrCmpOrArgs extends ComponentType<any>
-  ? StoryAnnotations<
-      ReactFramework,
-      ComponentProps<TMetaOrCmpOrArgs>,
-      ComponentProps<TMetaOrCmpOrArgs>
-    >
+  ? StoryAnnotations<ReactFramework, ComponentProps<TMetaOrCmpOrArgs>>
   : StoryAnnotations<ReactFramework, TMetaOrCmpOrArgs>;
 
 type ActionArgs<RArgs> = {

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -141,7 +141,7 @@ describe('StoryObj', () => {
       SvelteStory<
         Button,
         { disabled: boolean; label: string },
-        { disabled: boolean; label: string }
+        { disabled?: boolean; label?: string }
       >
     >();
   });

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -49,11 +49,7 @@ export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
       >
     : never
   : MetaOrCmpOrArgs extends SvelteComponentTyped
-  ? StoryAnnotations<
-      SvelteFramework<MetaOrCmpOrArgs>,
-      ComponentProps<MetaOrCmpOrArgs>,
-      ComponentProps<MetaOrCmpOrArgs>
-    >
+  ? StoryAnnotations<SvelteFramework<MetaOrCmpOrArgs>, ComponentProps<MetaOrCmpOrArgs>>
   : StoryAnnotations<SvelteFramework, MetaOrCmpOrArgs>;
 
 export type DecoratorFn<TArgs = Args> = DecoratorFunction<SvelteFramework, TArgs>;


### PR DESCRIPTION
Make `StoryObj<typeof Cmp>` work the same as `ComponentStoryObj<typeof Cmp>` did. 
Otherwise, the deprecated ComponentStoryObj can not be fixed in a non-breaking way.

I found this issue when moving the templates to the renderer, so that we can run tsc against them 😅 

## How to test

- Running: `yarn task --task check --no-link`
