### PR TITLE
Svelte: Fix regression causing all stories to error

### DIFF
--- a/code/renderers/svelte/src/render.ts
+++ b/code/renderers/svelte/src/render.ts
@@ -2,7 +2,8 @@ import global from 'global';
 
 import type { Store_RenderContext, ArgsStoryFn } from '@storybook/types';
 import { SvelteComponentTyped } from 'svelte';
-import PreviewRender from '../templates/PreviewRender.svelte';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import PreviewRender from '@storybook/svelte/templates/PreviewRender.svelte';
 
 import { SvelteFramework } from './types';
 


### PR DESCRIPTION
Issue: #19634 

## What I did

Reverted a change made in https://github.com/storybookjs/storybook/pull/19512/files#diff-8e2b2768c655a2de34733307ce49b791b83cbee8126497632f03be49f00c7bfb.

I'm not 100% certain why this change broke svelte.  The closest I could come was a mention in https://stackoverflow.com/questions/64847693/uncaught-error-target-is-a-required-option-svelte about different copies of svelte being used to render the components.  Maybe @benmccann would know more.  But at least this change fixes it.

## How to test

yarn task --task sandbox --template svelte-vite/default-js
cd sandbox/svelte-vite-default-js/
yarn storybook
Open any story, it should render without error
