### PR TITLE
CSF-tools: Make ESM node compatible

### DIFF
--- a/code/lib/core-server/src/utils/summarizeIndex.ts
+++ b/code/lib/core-server/src/utils/summarizeIndex.ts
@@ -1,4 +1,4 @@
-import { Store_StoryIndex } from '@storybook/types';
+import type { Store_StoryIndex } from '@storybook/types';
 
 export function summarizeIndex(storyIndex: Store_StoryIndex) {
   let storyCount = 0;

--- a/code/lib/csf-tools/package.json
+++ b/code/lib/csf-tools/package.json
@@ -42,6 +42,7 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
+    "@babel/types": "^7.12.11",
     "@storybook/csf": "next",
     "@storybook/types": "7.0.0-alpha.45",
     "fs-extra": "^9.0.1",
@@ -51,7 +52,6 @@
     "@babel/generator": "^7.12.11",
     "@babel/parser": "^7.12.11",
     "@babel/traverse": "^7.12.11",
-    "@babel/types": "^7.12.11",
     "@types/fs-extra": "^9.0.6",
     "js-yaml": "^3.14.1",
     "typescript": "~4.6.3"

--- a/code/lib/csf-tools/package.json
+++ b/code/lib/csf-tools/package.json
@@ -42,16 +42,16 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@babel/generator": "^7.12.11",
-    "@babel/parser": "^7.12.11",
-    "@babel/traverse": "^7.12.11",
-    "@babel/types": "^7.12.11",
     "@storybook/csf": "next",
     "@storybook/types": "7.0.0-alpha.45",
     "fs-extra": "^9.0.1",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
+    "@babel/generator": "^7.12.11",
+    "@babel/parser": "^7.12.11",
+    "@babel/traverse": "^7.12.11",
+    "@babel/types": "^7.12.11",
     "@types/fs-extra": "^9.0.6",
     "js-yaml": "^3.14.1",
     "typescript": "~4.6.3"

--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -1,8 +1,11 @@
 /* eslint-disable no-underscore-dangle */
 import fs from 'fs-extra';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as t from '@babel/types';
-import generate from '@babel/generator';
-import traverse from '@babel/traverse';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as generate from '@babel/generator';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as traverse from '@babel/traverse';
 import { babelParse } from './babelParse';
 
 const logger = console;
@@ -104,7 +107,7 @@ export class ConfigFile {
   parse() {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
-    traverse(this._ast, {
+    traverse.default(this._ast, {
       ExportNamedDeclaration: {
         enter({ node, parent }) {
           if (t.isVariableDeclaration(node.declaration)) {
@@ -172,7 +175,7 @@ export class ConfigFile {
   getFieldValue(path: string[]) {
     const node = this.getFieldNode(path);
     if (node) {
-      const { code } = generate(node, {});
+      const { code } = generate.default(node, {});
       // eslint-disable-next-line no-eval
       const value = (0, eval)(`(() => (${code}))()`);
       return value;
@@ -222,9 +225,9 @@ export class ConfigFile {
     // we do this rather than t.valueToNode because apparently
     // babel only preserves quotes if they are parsed from the original code.
     if (quotes === 'single') {
-      const { code } = generate(t.valueToNode(value), { jsescOption: { quotes } });
+      const { code } = generate.default(t.valueToNode(value), { jsescOption: { quotes } });
       const program = babelParse(`const __x = ${code}`);
-      traverse(program, {
+      traverse.default(program, {
         VariableDeclaration: {
           enter({ node }) {
             if (
@@ -255,7 +258,7 @@ export const loadConfig = (code: string, fileName?: string) => {
 };
 
 export const formatConfig = (config: ConfigFile) => {
-  const { code } = generate(config._ast, {});
+  const { code } = generate.default(config._ast, {});
   return code;
 };
 

--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import fs from 'fs-extra';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import * as t from '@babel/types';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as generate from '@babel/generator';

--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import fs from 'fs-extra';
 import { dedent } from 'ts-dedent';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import * as t from '@babel/types';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as generate from '@babel/generator';

--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -1,9 +1,12 @@
 /* eslint-disable no-underscore-dangle */
 import fs from 'fs-extra';
 import { dedent } from 'ts-dedent';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as t from '@babel/types';
-import generate from '@babel/generator';
-import traverse from '@babel/traverse';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as generate from '@babel/generator';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as traverse from '@babel/traverse';
 import { toId, isExportStory, storyNameFromExport } from '@storybook/csf';
 import type { CSF_Meta, CSF_Story, Tag } from '@storybook/types';
 import { babelParse } from './babelParse';
@@ -192,7 +195,7 @@ export class CsfFile {
           // @ts-expect-error (Converted from ts-ignore)
           meta[p.key.name] = parseIncludeExclude(p.value);
         } else if (p.key.name === 'component') {
-          const { code } = generate(p.value, {});
+          const { code } = generate.default(p.value, {});
           meta.component = code;
         } else if (p.key.name === 'tags') {
           let node = p.value;
@@ -215,7 +218,7 @@ export class CsfFile {
   parse() {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
-    traverse(this._ast, {
+    traverse.default(this._ast, {
       ExportDefaultDeclaration: {
         enter({ node, parent }) {
           let metaNode: t.ObjectExpression;
@@ -472,7 +475,7 @@ export const loadCsf = (code: string, options: CsfOptions) => {
 };
 
 export const formatCsf = (csf: CsfFile) => {
-  const { code } = generate(csf._ast, {});
+  const { code } = generate.default(csf._ast, {});
   return code;
 };
 

--- a/code/lib/csf-tools/src/babelParse.ts
+++ b/code/lib/csf-tools/src/babelParse.ts
@@ -1,7 +1,8 @@
-import { parse } from '@babel/parser';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as parser from '@babel/parser';
 
 export const babelParse = (code: string) =>
-  parse(code, {
+  parser.parse(code, {
     sourceType: 'module',
     // FIXME: we should get this from the project config somehow?
     plugins: [

--- a/code/lib/csf-tools/src/getStorySortParameter.ts
+++ b/code/lib/csf-tools/src/getStorySortParameter.ts
@@ -1,6 +1,9 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as t from '@babel/types';
-import traverse from '@babel/traverse';
-import generate from '@babel/generator';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as traverse from '@babel/traverse';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as generate from '@babel/generator';
 import { dedent } from 'ts-dedent';
 import { babelParse } from './babelParse';
 
@@ -57,7 +60,7 @@ const unsupported = (unexpectedVar: string, isError: boolean) => {
 export const getStorySortParameter = (previewCode: string) => {
   let storySort: t.Expression;
   const ast = babelParse(previewCode);
-  traverse(ast, {
+  traverse.default(ast, {
     ExportNamedDeclaration: {
       enter({ node }) {
         if (t.isVariableDeclaration(node.declaration)) {
@@ -97,13 +100,13 @@ export const getStorySortParameter = (previewCode: string) => {
   if (!storySort) return undefined;
 
   if (t.isArrowFunctionExpression(storySort)) {
-    const { code: sortCode } = generate(storySort, {});
+    const { code: sortCode } = generate.default(storySort, {});
     // eslint-disable-next-line no-eval
     return (0, eval)(sortCode);
   }
 
   if (t.isFunctionExpression(storySort)) {
-    const { code: sortCode } = generate(storySort, {});
+    const { code: sortCode } = generate.default(storySort, {});
     const functionName = storySort.id.name;
     // Wrap the function within an arrow function, call it, and return
     const wrapper = `(a, b) => {

--- a/code/lib/csf-tools/src/getStorySortParameter.ts
+++ b/code/lib/csf-tools/src/getStorySortParameter.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as t from '@babel/types';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as traverse from '@babel/traverse';


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/19533

- bundle in babel 
- use `* as `-import
- configure tsup to build for node

I figured if we change the config & code a bit, and bundle babel in, maybe we can fix this issue easily?