### PR TITLE
Disable keyboard shortcuts during (docs) play functions and add tests

### DIFF
--- a/code/e2e-tests/preview-web.spec.ts
+++ b/code/e2e-tests/preview-web.spec.ts
@@ -13,7 +13,6 @@ test.describe('preview-web', () => {
   test('should pass over shortcuts, but not from play functions, story', async ({ page }) => {
     const sbPage = new SbPage(page);
     await sbPage.navigateToStory('lib/store/shortcuts', 'keydown-during-play');
-    await new Promise((r) => setTimeout(r, 1000));
 
     await expect(sbPage.page.locator('.sidebar-container')).toBeVisible();
 
@@ -26,7 +25,6 @@ test.describe('preview-web', () => {
     await sbPage.navigateToStory('lib/store/shortcuts', 'docs');
 
     await expect(sbPage.page.locator('.sidebar-container')).toBeVisible();
-    await new Promise((r) => setTimeout(r, 1000));
 
     await sbPage.previewRoot().getByText('Submit').press('s');
     await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();

--- a/code/e2e-tests/preview-web.spec.ts
+++ b/code/e2e-tests/preview-web.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import process from 'process';
+import { SbPage } from './util';
+
+const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:8001';
+
+test.describe('preview-web', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(storybookUrl);
+    await new SbPage(page).waitUntilLoaded();
+  });
+
+  test('should pass over shortcuts, but not from play functions, story', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    await sbPage.navigateToStory('lib/store/shortcuts', 'keydown-during-play');
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await expect(sbPage.page.locator('.sidebar-container')).toBeVisible();
+
+    await sbPage.previewRoot().locator('button').press('s');
+    await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
+  });
+
+  test('should pass over shortcuts, but not from play functions, docs', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    await sbPage.navigateToStory('lib/store/shortcuts', 'docs');
+
+    await expect(sbPage.page.locator('.sidebar-container')).toBeVisible();
+    await new Promise((r) => setTimeout(r, 1000));
+
+    await sbPage.previewRoot().getByText('Submit').press('s');
+    await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
+  });
+});

--- a/code/e2e-tests/preview-web.spec.ts
+++ b/code/e2e-tests/preview-web.spec.ts
@@ -26,7 +26,7 @@ test.describe('preview-web', () => {
 
     await expect(sbPage.page.locator('.sidebar-container')).toBeVisible();
 
-    await sbPage.previewRoot().getByText('Submit').press('s');
+    await sbPage.previewRoot().getByRole('button').getByText('Submit').press('s');
     await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
   });
 });

--- a/code/lib/preview-web/src/PreviewWeb.test.ts
+++ b/code/lib/preview-web/src/PreviewWeb.test.ts
@@ -3302,6 +3302,52 @@ describe('PreviewWeb', () => {
         expect.objectContaining({})
       );
     });
+
+    it('does not emit PREVIEW_KEYDOWN during story play functions', async () => {
+      document.location.search = '?id=component-one--a';
+
+      const [gate, openGate] = createGate();
+      componentOneExports.a.play.mockImplementationOnce(async () => gate);
+      const preview = new PreviewWeb();
+      await preview.initialize({ importFn, getProjectAnnotations });
+      await waitForRenderPhase('playing');
+
+      await preview.onKeydown({
+        target: { tagName: 'div', getAttribute: jest.fn().mockReturnValue(null) },
+      } as any);
+
+      expect(mockChannel.emit).not.toHaveBeenCalledWith(
+        PREVIEW_KEYDOWN,
+        expect.objectContaining({})
+      );
+      openGate();
+    });
+
+    it('does not emit PREVIEW_KEYDOWN during docs play functions', async () => {
+      document.location.search = '?id=component-one--a';
+
+      const preview = await createAndRenderPreview();
+
+      mockChannel.emit.mockClear();
+      const [gate, openGate] = createGate();
+      componentOneExports.b.play.mockImplementationOnce(async () => gate);
+      preview.renderStoryToElement(
+        await preview.storyStore.loadStory({ storyId: 'component-one--b' }),
+        {} as any,
+        { runPlayFunction: true }
+      );
+      await waitForRenderPhase('playing');
+
+      await preview.onKeydown({
+        target: { tagName: 'div', getAttribute: jest.fn().mockReturnValue(null) },
+      } as any);
+
+      expect(mockChannel.emit).not.toHaveBeenCalledWith(
+        PREVIEW_KEYDOWN,
+        expect.objectContaining({})
+      );
+      openGate();
+    });
   });
 
   describe('extract', () => {

--- a/code/lib/preview-web/src/PreviewWeb.test.ts
+++ b/code/lib/preview-web/src/PreviewWeb.test.ts
@@ -3333,8 +3333,7 @@ describe('PreviewWeb', () => {
       componentOneExports.b.play.mockImplementationOnce(async () => gate);
       preview.renderStoryToElement(
         await preview.storyStore.loadStory({ storyId: 'component-one--b' }),
-        {} as any,
-        { runPlayFunction: true }
+        {} as any
       );
       await waitForRenderPhase('playing');
 

--- a/code/lib/preview-web/src/PreviewWeb.tsx
+++ b/code/lib/preview-web/src/PreviewWeb.tsx
@@ -200,6 +200,7 @@ export class PreviewWeb<TFramework extends AnyFramework> extends Preview<TFramew
   }
 
   onKeydown(event: KeyboardEvent) {
+    console.log('keydown');
     if (!this.storyRenders.find((r) => r.disableKeyListeners) && !focusInInput(event)) {
       // We have to pick off the keys of the event that we need on the other side
       const { altKey, ctrlKey, metaKey, shiftKey, key, code, keyCode } = event;

--- a/code/lib/preview-web/src/PreviewWeb.tsx
+++ b/code/lib/preview-web/src/PreviewWeb.tsx
@@ -200,7 +200,6 @@ export class PreviewWeb<TFramework extends AnyFramework> extends Preview<TFramew
   }
 
   onKeydown(event: KeyboardEvent) {
-    console.log('keydown');
     if (!this.storyRenders.find((r) => r.disableKeyListeners) && !focusInInput(event)) {
       // We have to pick off the keys of the event that we need on the other side
       const { altKey, ctrlKey, metaKey, shiftKey, key, code, keyCode } = event;

--- a/code/lib/preview-web/src/PreviewWeb.tsx
+++ b/code/lib/preview-web/src/PreviewWeb.tsx
@@ -200,7 +200,7 @@ export class PreviewWeb<TFramework extends AnyFramework> extends Preview<TFramew
   }
 
   onKeydown(event: KeyboardEvent) {
-    if (!this.currentRender?.disableKeyListeners && !focusInInput(event)) {
+    if (!this.storyRenders.find((r) => r.disableKeyListeners) && !focusInInput(event)) {
       // We have to pick off the keys of the event that we need on the other side
       const { altKey, ctrlKey, metaKey, shiftKey, key, code, keyCode } = event;
       this.channel.emit(PREVIEW_KEYDOWN, {

--- a/code/lib/store/template/stories/shortcuts.stories.ts
+++ b/code/lib/store/template/stories/shortcuts.stories.ts
@@ -1,0 +1,29 @@
+import globalThis from 'global';
+import { userEvent, within } from '@storybook/testing-library';
+import { PREVIEW_KEYDOWN } from '@storybook/core-events';
+import { jest, expect } from '@storybook/jest';
+
+export default {
+  component: globalThis.Components.Form,
+  tags: ['docsPage'],
+};
+
+export const KeydownDuringPlay = {
+  play: async ({ canvasElement }) => {
+    const channel = globalThis.__STORYBOOK_ADDONS_CHANNEL__;
+
+    const previewKeydown = jest.fn();
+    channel.on(PREVIEW_KEYDOWN, previewKeydown);
+    // eslint-disable-next-line storybook/await-interactions
+    const promise = userEvent.type(await within(canvasElement).findByTestId('value'), '000000', {
+      delay: 100,
+    });
+
+    const button = await within(canvasElement).findByRole('button');
+    button.focus();
+
+    await promise;
+
+    expect(previewKeydown).not.toBeCalled();
+  },
+};

--- a/code/lib/store/template/stories/shortcuts.stories.ts
+++ b/code/lib/store/template/stories/shortcuts.stories.ts
@@ -2,6 +2,7 @@ import globalThis from 'global';
 import { userEvent, within } from '@storybook/testing-library';
 import { PREVIEW_KEYDOWN } from '@storybook/core-events';
 import { jest, expect } from '@storybook/jest';
+import type { PlayFunctionContext } from '@storybook/csf';
 
 export default {
   component: globalThis.Components.Form,
@@ -9,20 +10,13 @@ export default {
 };
 
 export const KeydownDuringPlay = {
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement }: PlayFunctionContext) => {
     const channel = globalThis.__STORYBOOK_ADDONS_CHANNEL__;
 
     const previewKeydown = jest.fn();
     channel.on(PREVIEW_KEYDOWN, previewKeydown);
-    // eslint-disable-next-line storybook/await-interactions
-    const promise = userEvent.type(await within(canvasElement).findByTestId('value'), '000000', {
-      delay: 100,
-    });
-
-    const button = await within(canvasElement).findByRole('button');
-    button.focus();
-
-    await promise;
+    const button = await within(canvasElement).findByText('Submit');
+    await userEvent.type(button, 's');
 
     expect(previewKeydown).not.toBeCalled();
   },


### PR DESCRIPTION
Issue: If users autoplay in docs, we don't want to trigger keyboard shortcuts

## What I did

- Extend existing mechanism to also disable during docs play
- Add unit tests, stories and e2e tests

## How to test

See tests. Visit the shortcuts stories in docs mode.