### PR TITLE
Cleanup: Make ESLint the default formatter in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "deepscan.enable": true,
+  "eslint.workingDirectories": ["./code", "./scripts"],
   "typescript.tsdk": "./code/node_modules/typescript/lib",
   "[javascript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,20 @@
 {
   "deepscan.enable": true,
-  "typescript.tsdk": "./code/node_modules/typescript/lib"
+  "typescript.tsdk": "./code/node_modules/typescript/lib",
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true
+  },
 }

--- a/code/.vscode/settings.json
+++ b/code/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "deepscan.enable": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "[javascript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",

--- a/code/.vscode/settings.json
+++ b/code/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "deepscan.enable": true,
+  "eslint.workingDirectories": [".", "../scripts"],
   "typescript.tsdk": "node_modules/typescript/lib",
   "[javascript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",

--- a/code/.vscode/settings.json
+++ b/code/.vscode/settings.json
@@ -1,3 +1,19 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true
+  }
 }


### PR DESCRIPTION
Issue: N/A

In my vscode global settings, I use prettier as my default format-on-save extension.  But, storybook runs prettier through ESLint, and has other rules like `@typescript-eslint/consistent-type-imports` (see https://github.com/storybookjs/storybook/pull/19656) which can auto-fix as well.

## What I did

I configured VSCode to use the ESLint extension to format javascript, typescript, and jsx files on save.

I also enabled deepscan when opening `/code` directly (to keep the vscode settings in-sync between root and code).

## How to test

Open either the storybook repo or the `/code` directory (where I often work out of), introduce a linting error that's auto-fixable, and press save, and formatting should happen.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
