### PR TITLE
future tag to next

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -381,7 +381,7 @@ To convert this project to 7.0:
     "build-storybook": "storybook build <some flags>"
   },
   "devDependencies": {
-    "storybook": "future"
+    "storybook": "next"
   }
 }
 ```


### PR DESCRIPTION
Issue:

## What I did

The `next` tag is currently used for the latest `alpha` as pointed by @IanVS , and changed it in the migration document

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [X] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
