### PR TITLE
Addon-docs: Remove mdx-compiler-plugin

### DIFF
--- a/code/addons/docs/mdx-compiler-plugin.js
+++ b/code/addons/docs/mdx-compiler-plugin.js
@@ -1,1 +1,0 @@
-module.exports = require('@storybook/mdx1-csf').createCompiler;


### PR DESCRIPTION
Issue: #19677

## What I did

Remove the `addon-docs`  `mdx-compiler-plugin` entry point. This would only be used if the user was manually configuring MDX, which [has been dropped in 7.0](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#dropped-addon-docs-manual-configuration).

## How to test

- [ ] CI passes