### PR TITLE
CSF-tools: Turn story comments into docs descriptions

### DIFF
--- a/code/addons/docs/template/stories/docspage/basic.stories.ts
+++ b/code/addons/docs/template/stories/docspage/basic.stories.ts
@@ -7,15 +7,24 @@ export default {
   parameters: { chromatic: { disable: true } },
 };
 
+/**
+ * A basic button
+ */
 export const Basic = {
   args: { label: 'Basic' },
 };
 
+/**
+ * Won't show up in DocsPage
+ */
 export const Disabled = {
   args: { label: 'Disabled in DocsPage' },
   parameters: { docs: { disable: true } },
 };
 
+/**
+ * Another button, just to show multiple stories
+ */
 export const Another = {
   args: { label: 'Another' },
 };

--- a/code/lib/csf-plugin/src/index.ts
+++ b/code/lib/csf-plugin/src/index.ts
@@ -1,21 +1,24 @@
 import { createUnplugin } from 'unplugin';
+import fs from 'fs';
 import { loadCsf, enrichCsf, formatCsf } from '@storybook/csf-tools';
 
 export interface CsfPluginOptions {
   source?: boolean;
+  description?: boolean;
 }
 
 const STORIES_REGEX = /\.(story|stories)\.[tj]sx?$/;
 
 const logger = console;
 
-export const unplugin = createUnplugin((options: CsfPluginOptions) => {
+export const unplugin = createUnplugin<CsfPluginOptions>((options) => {
   return {
     name: 'unplugin-csf',
-    transformInclude(id) {
+    loadInclude(id) {
       return STORIES_REGEX.test(id);
     },
-    transform(code) {
+    load(fname) {
+      const code = fs.readFileSync(fname, 'utf-8');
       try {
         const csf = loadCsf(code, { makeTitle: (userTitle) => userTitle || 'default' }).parse();
         enrichCsf(csf);

--- a/code/lib/csf-plugin/src/index.ts
+++ b/code/lib/csf-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import { createUnplugin } from 'unplugin';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { loadCsf, enrichCsf, formatCsf } from '@storybook/csf-tools';
 
 export interface CsfPluginOptions {
@@ -14,11 +14,12 @@ const logger = console;
 export const unplugin = createUnplugin<CsfPluginOptions>((options) => {
   return {
     name: 'unplugin-csf',
+    enforce: 'pre',
     loadInclude(id) {
       return STORIES_REGEX.test(id);
     },
-    load(fname) {
-      const code = fs.readFileSync(fname, 'utf-8');
+    async load(fname) {
+      const code = await fs.readFile(fname, 'utf-8');
       try {
         const csf = loadCsf(code, { makeTitle: (userTitle) => userTitle || 'default' }).parse();
         enrichCsf(csf);

--- a/code/lib/csf-plugin/src/index.ts
+++ b/code/lib/csf-plugin/src/index.ts
@@ -1,11 +1,9 @@
 import { createUnplugin } from 'unplugin';
 import fs from 'fs/promises';
 import { loadCsf, enrichCsf, formatCsf } from '@storybook/csf-tools';
+import type { EnrichCsfOptions } from '@storybook/csf-tools';
 
-export interface CsfPluginOptions {
-  source?: boolean;
-  description?: boolean;
-}
+export type CsfPluginOptions = EnrichCsfOptions;
 
 const STORIES_REGEX = /\.(story|stories)\.[tj]sx?$/;
 

--- a/code/lib/csf-tools/package.json
+++ b/code/lib/csf-tools/package.json
@@ -51,7 +51,6 @@
   "devDependencies": {
     "@babel/generator": "^7.12.11",
     "@babel/parser": "^7.12.11",
-    "@babel/template": "^7.12.11",
     "@babel/traverse": "^7.12.11",
     "@types/fs-extra": "^9.0.6",
     "js-yaml": "^3.14.1",

--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -156,6 +156,8 @@ export class CsfFile {
 
   _storyExports: Record<string, t.VariableDeclarator | t.FunctionDeclaration> = {};
 
+  _storyStatements: Record<string, t.ExportNamedDeclaration> = {};
+
   _storyAnnotations: Record<string, Record<string, t.Node>> = {};
 
   _templates: Record<string, t.Expression> = {};
@@ -283,6 +285,7 @@ export class CsfFile {
                   return;
                 }
                 self._storyExports[exportName] = decl;
+                self._storyStatements[exportName] = node;
                 let name = storyNameFromExport(exportName);
                 if (self._storyAnnotations[exportName]) {
                   logger.warn(

--- a/code/lib/csf-tools/src/enrichCsf.test.ts
+++ b/code/lib/csf-tools/src/enrichCsf.test.ts
@@ -34,10 +34,11 @@ describe('enrichCsf', () => {
         };
         export const Basic = () => <Button />;
         Basic.parameters = {
+          ...Basic.parameters,
           storySource: {
-            source: "() => <Button />"
-          },
-          ...Basic.parameters
+            source: "() => <Button />",
+            ...Basic.parameters?.storySource
+          }
         };
       `);
     });
@@ -61,10 +62,11 @@ describe('enrichCsf', () => {
           foo: 'bar'
         };
         Basic.parameters = {
+          ...Basic.parameters,
           storySource: {
-            source: "args => <Button {...args} />"
-          },
-          ...Basic.parameters
+            source: "args => <Button {...args} />",
+            ...Basic.parameters?.storySource
+          }
         };
       `);
     });
@@ -88,10 +90,11 @@ describe('enrichCsf', () => {
           }
         };
         Basic.parameters = {
+          ...Basic.parameters,
           storySource: {
-            source: "{\\n  parameters: {\\n    foo: 'bar'\\n  }\\n}"
-          },
-          ...Basic.parameters
+            source: "{\\n  parameters: {\\n    foo: 'bar'\\n  }\\n}",
+            ...Basic.parameters?.storySource
+          }
         };
       `);
     });
@@ -111,16 +114,18 @@ describe('enrichCsf', () => {
         export const A = {};
         export const B = {};
         A.parameters = {
+          ...A.parameters,
           storySource: {
-            source: "{}"
-          },
-          ...A.parameters
+            source: "{}",
+            ...A.parameters?.storySource
+          }
         };
         B.parameters = {
+          ...B.parameters,
           storySource: {
-            source: "{}"
-          },
-          ...B.parameters
+            source: "{}",
+            ...B.parameters?.storySource
+          }
         };
       `);
     });
@@ -143,10 +148,11 @@ describe('enrichCsf', () => {
         // The most basic button
         export const Basic = () => <Button />;
         Basic.parameters = {
+          ...Basic.parameters,
           storySource: {
-            source: "() => <Button />"
-          },
-          ...Basic.parameters
+            source: "() => <Button />",
+            ...Basic.parameters?.storySource
+          }
         };
       `);
     });
@@ -167,10 +173,11 @@ describe('enrichCsf', () => {
         /* The most basic button */
         export const Basic = () => <Button />;
         Basic.parameters = {
+          ...Basic.parameters,
           storySource: {
-            source: "() => <Button />"
-          },
-          ...Basic.parameters
+            source: "() => <Button />",
+            ...Basic.parameters?.storySource
+          }
         };
       `);
     });
@@ -191,15 +198,18 @@ describe('enrichCsf', () => {
         /** The most basic button */
         export const Basic = () => <Button />;
         Basic.parameters = {
+          ...Basic.parameters,
           storySource: {
-            source: "() => <Button />"
+            source: "() => <Button />",
+            ...Basic.parameters?.storySource
           },
           docs: {
+            ...Basic.parameters?.docs,
             description: {
-              story: "The most basic button"
+              story: "The most basic button",
+              ...Basic.parameters?.docs?.description
             }
-          },
-          ...Basic.parameters
+          }
         };
       `);
     });
@@ -228,15 +238,18 @@ describe('enrichCsf', () => {
          */
         export const Basic = () => <Button />;
         Basic.parameters = {
+          ...Basic.parameters,
           storySource: {
-            source: "() => <Button />"
+            source: "() => <Button />",
+            ...Basic.parameters?.storySource
           },
           docs: {
+            ...Basic.parameters?.docs,
             description: {
-              story: "The most basic button\\n\\nIn a block!"
+              story: "The most basic button\\n\\nIn a block!",
+              ...Basic.parameters?.docs?.description
             }
-          },
-          ...Basic.parameters
+          }
         };
       `);
     });
@@ -265,15 +278,18 @@ describe('enrichCsf', () => {
          */
         export const Basic = () => <Button />;
         Basic.parameters = {
+          ...Basic.parameters,
           storySource: {
-            source: "() => <Button />"
+            source: "() => <Button />",
+            ...Basic.parameters?.storySource
           },
           docs: {
+            ...Basic.parameters?.docs,
             description: {
-              story: "- A bullet list\\n  - A sub-bullet\\n- A second bullet"
+              story: "- A bullet list\\n  - A sub-bullet\\n- A second bullet",
+              ...Basic.parameters?.docs?.description
             }
-          },
-          ...Basic.parameters
+          }
         };
       `);
     });

--- a/code/lib/csf-tools/src/enrichCsf.test.ts
+++ b/code/lib/csf-tools/src/enrichCsf.test.ts
@@ -240,6 +240,43 @@ describe('enrichCsf', () => {
         };
       `);
     });
+
+    it('preserves indentation', () => {
+      expect(
+        enrich(dedent`
+          export default {
+           title: 'Button',
+          }
+          /**
+           * - A bullet list
+           *   - A sub-bullet
+           * - A second bullet
+           */
+          export const Basic = () => <Button />
+        `)
+      ).toMatchInlineSnapshot(`
+        export default {
+          title: 'Button'
+        };
+        /**
+         * - A bullet list
+         *   - A sub-bullet
+         * - A second bullet
+         */
+        export const Basic = () => <Button />;
+        Basic.parameters = {
+          storySource: {
+            source: "() => <Button />"
+          },
+          docs: {
+            description: {
+              story: "- A bullet list\\n  - A sub-bullet\\n- A second bullet"
+            }
+          },
+          ...Basic.parameters
+        };
+      `);
+    });
   });
 });
 

--- a/code/lib/csf-tools/src/enrichCsf.test.ts
+++ b/code/lib/csf-tools/src/enrichCsf.test.ts
@@ -125,6 +125,122 @@ describe('enrichCsf', () => {
       `);
     });
   });
+
+  describe('descriptions', () => {
+    it('skips inline comments', () => {
+      expect(
+        enrich(dedent`
+          export default {
+           title: 'Button',
+          }
+          // The most basic button
+          export const Basic = () => <Button />
+        `)
+      ).toMatchInlineSnapshot(`
+        export default {
+          title: 'Button'
+        };
+        // The most basic button
+        export const Basic = () => <Button />;
+        Basic.parameters = {
+          storySource: {
+            source: "() => <Button />"
+          },
+          ...Basic.parameters
+        };
+      `);
+    });
+
+    it('skips blocks without jsdoc', () => {
+      expect(
+        enrich(dedent`
+          export default {
+           title: 'Button',
+          }
+          /* The most basic button */
+          export const Basic = () => <Button />
+        `)
+      ).toMatchInlineSnapshot(`
+        export default {
+          title: 'Button'
+        };
+        /* The most basic button */
+        export const Basic = () => <Button />;
+        Basic.parameters = {
+          storySource: {
+            source: "() => <Button />"
+          },
+          ...Basic.parameters
+        };
+      `);
+    });
+
+    it('JSDoc single-line', () => {
+      expect(
+        enrich(dedent`
+          export default {
+           title: 'Button',
+          }
+          /** The most basic button */
+          export const Basic = () => <Button />
+        `)
+      ).toMatchInlineSnapshot(`
+        export default {
+          title: 'Button'
+        };
+        /** The most basic button */
+        export const Basic = () => <Button />;
+        Basic.parameters = {
+          storySource: {
+            source: "() => <Button />"
+          },
+          docs: {
+            description: {
+              story: "The most basic button"
+            }
+          },
+          ...Basic.parameters
+        };
+      `);
+    });
+
+    it('JSDoc multi-line', () => {
+      expect(
+        enrich(dedent`
+          export default {
+           title: 'Button',
+          }
+          /**
+           * The most basic button
+           * 
+           * In a block!
+           */
+          export const Basic = () => <Button />
+        `)
+      ).toMatchInlineSnapshot(`
+        export default {
+          title: 'Button'
+        };
+        /**
+         * The most basic button
+         * 
+         * In a block!
+         */
+        export const Basic = () => <Button />;
+        Basic.parameters = {
+          storySource: {
+            source: "() => <Button />"
+          },
+          docs: {
+            description: {
+              story: "The most basic button\\n\\nIn a block!"
+            }
+          },
+          ...Basic.parameters
+        };
+      `);
+    });
+  });
 });
 
 const source = (csfExport: string) => {

--- a/code/lib/csf-tools/src/enrichCsf.ts
+++ b/code/lib/csf-tools/src/enrichCsf.ts
@@ -2,20 +2,42 @@
 import * as t from '@babel/types';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as generate from '@babel/generator';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import * as template from '@babel/template';
 import type { CsfFile } from './CsfFile';
 
 export const enrichCsf = (csf: CsfFile) => {
   Object.keys(csf._storyExports).forEach((key) => {
     const storyExport = csf.getStoryExport(key);
     const source = extractSource(storyExport);
-    const addParameter = template.default(`
-       %%key%%.parameters = { storySource: { source: %%source%% }, ...%%key%%.parameters };
-    `)({
-      key: t.identifier(key),
-      source: t.stringLiteral(source),
-    }) as t.Statement;
+    const description = extractDescription(csf._storyStatements[key]);
+    const parameters = [];
+    // storySource: { source: %%source%% },
+    parameters.push(
+      t.objectProperty(
+        t.identifier('storySource'),
+        t.objectExpression([t.objectProperty(t.identifier('source'), t.stringLiteral(source))])
+      )
+    );
+    // docs: { description: { story: %%description%% } },
+    if (description) {
+      parameters.push(
+        t.objectProperty(
+          t.identifier('docs'),
+          t.objectExpression([
+            t.objectProperty(
+              t.identifier('description'),
+              t.objectExpression([
+                t.objectProperty(t.identifier('story'), t.stringLiteral(description)),
+              ])
+            ),
+          ])
+        )
+      );
+    }
+    const originalParameters = t.memberExpression(t.identifier(key), t.identifier('parameters'));
+    parameters.push(t.spreadElement(originalParameters));
+    const addParameter = t.expressionStatement(
+      t.assignmentExpression('=', originalParameters, t.objectExpression(parameters))
+    );
     csf._ast.program.body.push(addParameter);
   });
 };
@@ -24,4 +46,21 @@ export const extractSource = (node: t.Node) => {
   const src = t.isVariableDeclarator(node) ? node.init : node;
   const { code } = generate.default(src, {});
   return code;
+};
+
+export const extractDescription = (node?: t.Node) => {
+  if (node?.leadingComments) {
+    const comments = node.leadingComments
+      .map((comment) => {
+        if (comment.type === 'CommentLine' || !comment.value.startsWith('*')) return null;
+        return comment.value
+          .split('\n')
+          .map((line) => line.replace(/^(\s+)?(\*+)?(\s+)?/, ''))
+          .join('\n')
+          .trim();
+      })
+      .filter(Boolean);
+    return comments.join('\n');
+  }
+  return '';
 };

--- a/code/lib/csf-tools/src/enrichCsf.ts
+++ b/code/lib/csf-tools/src/enrichCsf.ts
@@ -49,18 +49,19 @@ export const extractSource = (node: t.Node) => {
 };
 
 export const extractDescription = (node?: t.Node) => {
-  if (node?.leadingComments) {
-    const comments = node.leadingComments
-      .map((comment) => {
-        if (comment.type === 'CommentLine' || !comment.value.startsWith('*')) return null;
-        return comment.value
+  if (!node?.leadingComments) return '';
+  const comments = node.leadingComments
+    .map((comment) => {
+      if (comment.type === 'CommentLine' || !comment.value.startsWith('*')) return null;
+      return (
+        comment.value
           .split('\n')
-          .map((line) => line.replace(/^(\s+)?(\*+)?(\s+)?/, ''))
+          // remove leading *'s and spaces from the beginning of each line
+          .map((line) => line.replace(/^(\s+)?(\*+)?(\s)?/, ''))
           .join('\n')
-          .trim();
-      })
-      .filter(Boolean);
-    return comments.join('\n');
-  }
-  return '';
+          .trim()
+      );
+    })
+    .filter(Boolean);
+  return comments.join('\n');
 };

--- a/code/lib/csf-tools/src/enrichCsf.ts
+++ b/code/lib/csf-tools/src/enrichCsf.ts
@@ -16,10 +16,10 @@ export const enrichCsf = (csf: CsfFile, options?: EnrichCsfOptions) => {
     const description =
       !options?.disableDescription && extractDescription(csf._storyStatements[key]);
     const parameters = [];
-    // storySource: { source: %%source%% },
     const originalParameters = t.memberExpression(t.identifier(key), t.identifier('parameters'));
     parameters.push(t.spreadElement(originalParameters));
 
+    // storySource: { source: %%source%% },
     if (source) {
       const optionalStorySource = t.optionalMemberExpression(
         originalParameters,

--- a/code/lib/csf-tools/src/enrichCsf.ts
+++ b/code/lib/csf-tools/src/enrichCsf.ts
@@ -11,30 +11,57 @@ export const enrichCsf = (csf: CsfFile) => {
     const description = extractDescription(csf._storyStatements[key]);
     const parameters = [];
     // storySource: { source: %%source%% },
+    const originalParameters = t.memberExpression(t.identifier(key), t.identifier('parameters'));
+    parameters.push(t.spreadElement(originalParameters));
+
+    const optionalStorySource = t.optionalMemberExpression(
+      originalParameters,
+      t.identifier('storySource'),
+      false,
+      true
+    );
+
     parameters.push(
       t.objectProperty(
         t.identifier('storySource'),
-        t.objectExpression([t.objectProperty(t.identifier('source'), t.stringLiteral(source))])
+        t.objectExpression([
+          t.objectProperty(t.identifier('source'), t.stringLiteral(source)),
+          t.spreadElement(optionalStorySource),
+        ])
       )
     );
     // docs: { description: { story: %%description%% } },
     if (description) {
+      const optionalDocs = t.optionalMemberExpression(
+        originalParameters,
+        t.identifier('docs'),
+        false,
+        true
+      );
+
+      const optionalDescription = t.optionalMemberExpression(
+        optionalDocs,
+        t.identifier('description'),
+        false,
+        true
+      );
+
       parameters.push(
         t.objectProperty(
           t.identifier('docs'),
           t.objectExpression([
+            t.spreadElement(optionalDocs),
             t.objectProperty(
               t.identifier('description'),
               t.objectExpression([
                 t.objectProperty(t.identifier('story'), t.stringLiteral(description)),
+                t.spreadElement(optionalDescription),
               ])
             ),
           ])
         )
       );
     }
-    const originalParameters = t.memberExpression(t.identifier(key), t.identifier('parameters'));
-    parameters.push(t.spreadElement(originalParameters));
     const addParameter = t.expressionStatement(
       t.assignmentExpression('=', originalParameters, t.objectExpression(parameters))
     );

--- a/code/lib/csf-tools/src/enrichCsf.ts
+++ b/code/lib/csf-tools/src/enrichCsf.ts
@@ -10,7 +10,7 @@ export interface EnrichCsfOptions {
 }
 
 export const enrichCsf = (csf: CsfFile, options?: EnrichCsfOptions) => {
-  const enablesSource = Object.keys(csf._storyExports).forEach((key) => {
+  Object.keys(csf._storyExports).forEach((key) => {
     const storyExport = csf.getStoryExport(key);
     const source = !options?.disableSource && extractSource(storyExport);
     const description =

--- a/code/ui/blocks/src/controls/Boolean.stories.tsx
+++ b/code/ui/blocks/src/controls/Boolean.stories.tsx
@@ -4,6 +4,7 @@ import { BooleanControl } from './Boolean';
 export default {
   title: 'Controls/Boolean',
   component: BooleanControl,
+  tags: ['docsPage'],
 };
 
 const Template = (initialValue?: boolean) => {
@@ -20,4 +21,7 @@ export const True = () => Template(true);
 
 export const False = () => Template(false);
 
+/**
+ * When no value is set on the control
+ */
 export const Undefined = () => Template(undefined);

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2119,7 +2119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.12.11, @babel/template@npm:^7.16.7, @babel/template@npm:^7.18.10, @babel/template@npm:^7.3.3, @babel/template@npm:^7.4.0, @babel/template@npm:^7.7.0, @babel/template@npm:^7.8.6":
+"@babel/template@npm:^7.16.7, @babel/template@npm:^7.18.10, @babel/template@npm:^7.3.3, @babel/template@npm:^7.4.0, @babel/template@npm:^7.7.0, @babel/template@npm:^7.8.6":
   version: 7.18.10
   resolution: "@babel/template@npm:7.18.10"
   dependencies:
@@ -6644,7 +6644,6 @@ __metadata:
   dependencies:
     "@babel/generator": ^7.12.11
     "@babel/parser": ^7.12.11
-    "@babel/template": ^7.12.11
     "@babel/traverse": ^7.12.11
     "@babel/types": ^7.12.11
     "@storybook/csf": next


### PR DESCRIPTION
Issue: #8527

Credit to @izhan for paving the way https://github.com/izhan/storybook-description-loader

## What I did

**Telescopes off https://github.com/storybookjs/storybook/pull/19680**

- [x] Parse out comments that start with `/**` and add them as `docs.description.story` parameters
- [x] Made it a loader so that it receives the original file with comments
- [x] Preserve user indentation
- [x] Added plugin options
- [x] Correctly merge generated parameters with user parameters
- [x] Made it async for performance

## How to test

- [ ] CI passes
- [ ] Test it out in `ui` storybook or CRA sandbox


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#8527: addon-docs: Descriptions per Story](https://issuehunt.io/repos/54173593/issues/8527)
---
</details>
<!-- /Issuehunt content-->