### PR TITLE
Use import.meta.webpackHot instead of module.hot for check

### DIFF
--- a/code/lib/builder-webpack5/templates/virtualModuleModernEntry.js.handlebars
+++ b/code/lib/builder-webpack5/templates/virtualModuleModernEntry.js.handlebars
@@ -32,7 +32,7 @@ window.__STORYBOOK_CLIENT_API__ = new ClientApi({ storyStore: preview.storyStore
 
 preview.initialize({ importFn, getProjectAnnotations });
 
-if (module.hot) {
+if (import.meta.webpackHot) {
   import.meta.webpackHot.accept('./{{storiesFilename}}', () => {
     // importFn has changed so we need to patch the new one in
     preview.onStoriesChanged({ importFn });


### PR DESCRIPTION
Issue: "Uncaught TypeError: importMeta.webpackHot is undefined"

## What I did

Updated the template to check if importMeta.webpackHot exists before trying to use it.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

I don't seem to see any tests that test this sort of thing i'd need to update. And I'm not sure why i'd have module.hot instead of import.meta.webpackHot, as I thought that was a webpack 5 change. But it made sense to me to check if what you are using exists.
<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
