### PR TITLE
Vue: Add babel loader 9.0.0 to vue-webpack5 peer dependencies

### DIFF
--- a/code/frameworks/vue-webpack5/package.json
+++ b/code/frameworks/vue-webpack5/package.json
@@ -66,7 +66,7 @@
   },
   "peerDependencies": {
     "@babel/core": "*",
-    "babel-loader": "^7.0.0 || ^8.0.0",
+    "babel-loader": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "css-loader": "*",
     "vue": "^2.6.8",
     "vue-loader": "^15.7.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7955,7 +7955,7 @@ __metadata:
     vue-template-compiler: ^2.6.14
   peerDependencies:
     "@babel/core": "*"
-    babel-loader: ^7.0.0 || ^8.0.0
+    babel-loader: ^7.0.0 || ^8.0.0 || ^9.0.0
     css-loader: "*"
     vue: ^2.6.8
     vue-loader: ^15.7.0


### PR DESCRIPTION
Issue: In our project, we would like to update babel loader to 9.0.0 and above. Currently, the vue-webpack-5 package from storybook is blocking this update.

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @storybook/vue@6.5.13
npm ERR! Found: babel-loader@9.0.0
npm ERR! node_modules/babel-loader
npm ERR!   dev babel-loader@"^9.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer babel-loader@"^7.0.0 || ^8.0.0" from @storybook/vue@6.5.13
npm ERR! node_modules/@storybook/vue
npm ERR!   dev @storybook/vue@"^6.5.13" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: babel-loader@8.2.5
npm ERR! node_modules/babel-loader
npm ERR!   peer babel-loader@"^7.0.0 || ^8.0.0" from @storybook/vue@6.5.13
npm ERR!   node_modules/@storybook/vue
npm ERR!     dev @storybook/vue@"^6.5.13" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/runner/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-10-31T12_25_40_569Z-debug-0.log
```

Are there any concerns or other processes to get this live? I'm happy to contribute :)

https://github.com/babel/babel-loader/releases/tag/v9.0.0

## What I did
Added babel loader 9.0.0 to peer dependencies of the vue-webpack-5 package

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
