### PR TITLE
CI: Schedule a daily job that runs all sandboxes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,12 @@
 version: 2.1
 
+parameters:
+  workflow:
+    description: Which workflow to run
+    type: enum
+    enum: ['tests', 'daily-tests']
+    default: 'tests'
+
 executors:
   sb_node_16_classic:
     parameters:
@@ -246,12 +253,12 @@ jobs:
           name: Test
           command: |
             cd scripts
-            yarn test --coverage --runInBand --ci
+            yarn test --coverage --ci
       - store_test_results:
           path: scripts/junit.xml
   unit-tests:
     executor:
-      class: medium+
+      class: xlarge
       name: sb_node_16_browsers
     steps:
       - git-shallow-clone/checkout_advanced:
@@ -262,7 +269,7 @@ jobs:
           name: Test
           command: |
             cd code
-            yarn test --coverage --runInBand --ci
+            yarn test --coverage --ci
       - store_test_results:
           path: code/junit.xml
       - persist_to_workspace:
@@ -302,10 +309,18 @@ jobs:
           path: test-results
   ## new workflow
   create-sandboxes:
+    parameters:
+      parallelism:
+        type: integer
+        default: 9
+      cadence:
+        type: enum
+        enum: [ "ci", "daily", "weekly" ]
+        default: "ci"
     executor:
       class: medium
       name: sb_node_16_browsers
-    parallelism: 9
+    parallelism: << parameters.parallelism >>
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -313,7 +328,7 @@ jobs:
           at: .
       - run:
           name: Creating Sandboxes
-          command: yarn task --task sandbox --template $(yarn get-template ci create) --no-link --start-from=never --junit
+          command: yarn task --task sandbox --template $(yarn get-template << parameters.cadence >> create) --no-link --start-from=never --junit
       - persist_to_workspace:
           root: .
           paths:
@@ -321,10 +336,18 @@ jobs:
       - store_test_results:
           path: test-results
   smoke-test-sandboxes:
+    parameters:
+      parallelism:
+        type: integer
+        default: 9
+      cadence:
+        type: enum
+        enum: [ "ci", "daily", "weekly" ]
+        default: "ci"
     executor:
       class: medium
       name: sb_node_16_browsers
-    parallelism: 9
+    parallelism: << parameters.parallelism >>
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -332,14 +355,22 @@ jobs:
           at: .
       - run:
           name: Smoke Testing Sandboxes
-          command: yarn task --task smoke-test --template $(yarn get-template ci smoke-test) --no-link --start-from=never --junit
+          command: yarn task --task smoke-test --template $(yarn get-template << parameters.cadence >> smoke-test) --no-link --start-from=never --junit
       - store_test_results:
           path: test-results
   build-sandboxes:
+    parameters:
+      parallelism:
+        type: integer
+        default: 9
+      cadence:
+        type: enum
+        enum: [ "ci", "daily", "weekly" ]
+        default: "ci"
     executor:
       class: medium+
       name: sb_node_16_browsers
-    parallelism: 9
+    parallelism: << parameters.parallelism >>
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -347,7 +378,7 @@ jobs:
           at: .
       - run:
           name: Building Sandboxes
-          command: yarn task --task build --template $(yarn get-template ci build) --no-link --start-from=never --junit
+          command: yarn task --task build --template $(yarn get-template << parameters.cadence >> build) --no-link --start-from=never --junit
       - store_test_results:
           path: test-results
       - persist_to_workspace:
@@ -355,10 +386,18 @@ jobs:
           paths:
             - sandbox/*/storybook-static
   test-runner-sandboxes:
+    parameters:
+      parallelism:
+        type: integer
+        default: 9
+      cadence:
+        type: enum
+        enum: [ "ci", "daily", "weekly" ]
+        default: "ci"
     executor:
       class: medium
       name: sb_playwright
-    parallelism: 9
+    parallelism: << parameters.parallelism >>
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -366,29 +405,44 @@ jobs:
           at: .
       - run:
           name: Running Test Runner
-          command: yarn task --task test-runner --template $(yarn get-template ci test-runner) --no-link --start-from=never --junit
+          command: yarn task --task test-runner --template $(yarn get-template << parameters.cadence >> test-runner) --no-link --start-from=never --junit
       - store_test_results:
           path: test-results
   chromatic-sandboxes:
+    parameters:
+      parallelism:
+        type: integer
+        default: 9
+      cadence:
+        type: enum
+        enum: ["ci", "daily", "weekly"]
+        default: "ci"
     executor:
       class: medium
       name: sb_node_16_browsers
-    parallelism: 9
+    parallelism: << parameters.parallelism >>
     steps:
-      - git-shallow-clone/checkout_advanced:
-          clone_options: '--depth 1 --verbose'
+      - checkout
       - attach_workspace:
           at: .
       - run:
           name: Running Chromatic
-          command: yarn task --task chromatic --template $(yarn get-template ci chromatic) --no-link --start-from=never --junit
+          command: yarn task --task chromatic --template $(yarn get-template << parameters.cadence >> chromatic) --no-link --start-from=never --junit
       - store_test_results:
           path: test-results
   e2e-sandboxes:
+    parameters:
+      parallelism:
+        type: integer
+        default: 9
+      cadence:
+        type: enum
+        enum: ["ci", "daily", "weekly"]
+        default: "ci"
     executor:
       class: medium
       name: sb_playwright
-    parallelism: 9
+    parallelism: << parameters.parallelism >>
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'
@@ -396,7 +450,7 @@ jobs:
           at: .
       - run:
           name: Running E2E Tests
-          command: yarn task --task e2e-tests --template $(yarn get-template ci e2e-tests) --no-link --start-from=never --junit
+          command: yarn task --task e2e-tests --template $(yarn get-template << parameters.cadence >> e2e-tests) --no-link --start-from=never --junit
       - store_test_results:
           path: test-results
       - store_artifacts: # this is where playwright puts more complex stuff
@@ -404,7 +458,45 @@ jobs:
           destination: playwright
 
 workflows:
+  daily-tests:
+    when:
+      equal: [ daily-tests, << pipeline.parameters.workflow >> ]
+    jobs:
+      - build
+      - publish:
+          requires:
+            - build
+      - create-sandboxes:
+          parallelism: 24
+          cadence: "daily"
+          requires:
+            - publish
+      # - smoke-test-sandboxes: # disabled for now
+      #     requires:
+      #       - create-sandboxes
+      - build-sandboxes:
+          parallelism: 24
+          cadence: "daily"
+          requires:
+            - create-sandboxes
+      - test-runner-sandboxes:
+          parallelism: 24
+          cadence: "daily"
+          requires:
+            - build-sandboxes
+      - chromatic-sandboxes:
+          parallelism: 24
+          cadence: "daily"
+          requires:
+            - build-sandboxes
+      - e2e-sandboxes:
+          parallelism: 24
+          cadence: "daily"
+          requires:
+            - build-sandboxes
   test:
+    when:
+      equal: [ tests, << pipeline.parameters.workflow >> ]
     jobs:
       - build
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
           destination: sb-bench.tar.gz
   react-vite-bench:
     executor:
-      class: medium
+      class: large
       name: sb_playwright
     working_directory: /tmp/storybook
     steps:


### PR DESCRIPTION
## What I did

Added a new workflow that will run all 24 sandboxes.
In Circle CI I added a trigger that will run this workflow every day at 1:00 UTC.

## How to test

- Play around in circle CI: https://app.circleci.com/pipelines/gh/storybookjs/storybook?branch=kasper%2Fdaily-job

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
