### PR TITLE
React: Expose ReactFramework type

### DIFF
--- a/code/renderers/react/src/public-types.ts
+++ b/code/renderers/react/src/public-types.ts
@@ -12,6 +12,8 @@ import type { SetOptional, Simplify } from 'type-fest';
 
 import type { ReactFramework } from './types';
 
+export { ReactFramework };
+
 type JSXElement = keyof JSX.IntrinsicElements | JSXElementConstructor<any>;
 
 /**


### PR DESCRIPTION
Issue: N/A

## What I did

Re-exported the type `ReactFramework` from `@storybook/react`, to support uses like `@storybook/testing-react` in https://github.com/storybookjs/testing-react/pull/120.  I think it wasn't intentionally made private.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
