### PR TITLE
Build: Re-enable test-runner for vue-cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ jobs:
     executor:
       class: medium
       name: sb_playwright
-    parallelism: 8
+    parallelism: 9
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: '--depth 1 --verbose'

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -259,8 +259,6 @@ const vueCliTemplates = {
     skipTasks: [
       // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
       'smoke-test',
-      // Re-enable once https://github.com/storybookjs/storybook/issues/19453 is fixed.
-      'test-runner',
     ],
     expected: {
       framework: '@storybook/vue3-webpack5',
@@ -276,8 +274,6 @@ const vueCliTemplates = {
     skipTasks: [
       // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
       'smoke-test',
-      // Re-enable once https://github.com/storybookjs/storybook/issues/19453 is fixed.
-      'test-runner',
     ],
     expected: {
       framework: '@storybook/vue-webpack5',


### PR DESCRIPTION
Issue: #19453 

## What I did

Restored the test-runner in `vue-cli` projects

Pretty sure pointing to `test-runner@next` in a previous PR fixed the `core-js` problem

Self-merging @tmeasday 

## How to test

- [ ] CI passes