### PR TITLE
Add automigration to set docsPage = 'automatic' for existing Storybooks

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/docsPage-automatic.ts
+++ b/code/lib/cli/src/automigrate/fixes/docsPage-automatic.ts
@@ -1,0 +1,61 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import type { ConfigFile } from '@storybook/csf-tools';
+import { readConfig, writeConfig } from '@storybook/csf-tools';
+import { getStorybookInfo } from '@storybook/core-common';
+
+import type { Fix } from '../types';
+
+const logger = console;
+
+interface DocsPageAutomaticFrameworkRunOptions {
+  main: ConfigFile;
+}
+
+/**
+ * Set the docs.docsPage option to automatic if it isn't already set
+ */
+export const docsPageAutomatic: Fix<DocsPageAutomaticFrameworkRunOptions> = {
+  id: 'docsPageAutomatic',
+
+  async check({ packageManager }) {
+    const packageJson = packageManager.retrievePackageJson();
+
+    const { mainConfig } = getStorybookInfo(packageJson);
+
+    if (!mainConfig) {
+      logger.warn('Unable to find storybook main.js config, skipping');
+      return null;
+    }
+
+    const main = await readConfig(mainConfig);
+    const docs = main.getFieldValue(['docs']);
+
+    return docs?.docsPage === undefined ? { main } : null;
+  },
+
+  prompt() {
+    const docsPageAutomaticFormatted = chalk.cyan(`docs: { docsPage: 'automatic' }`);
+
+    return dedent`
+      We've detected that your main.js configuration file has not configured docsPage. In 6.x we
+      we defaulted to having a docsPage for every story, in 7.x you need to opt in per-component.
+      However, we can set the \`docs.docsPage\` to 'automatic' to approximate the old behaviour:
+
+      ${docsPageAutomaticFormatted}
+
+      More info: ${chalk.yellow(
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#docs-page'
+      )}
+    `;
+  },
+
+  async run({ result: { main }, dryRun }) {
+    logger.info(`✅ Setting 'docs.docsPage' to 'automatic' in main.js`);
+    if (!dryRun) {
+      main.setFieldValue(['docsPage', 'docs'], 'automatic');
+      await writeConfig(main);
+    }
+  },
+};

--- a/code/lib/cli/src/automigrate/fixes/index.ts
+++ b/code/lib/cli/src/automigrate/fixes/index.ts
@@ -12,6 +12,7 @@ import { sbScripts } from './sb-scripts';
 import { newFrameworks } from './new-frameworks';
 import { removedGlobalClientAPIs } from './remove-global-client-apis';
 import { mdx1to2 } from './mdx-1-to-2';
+import { docsPageAutomatic } from './docsPage-automatic';
 
 export * from '../types';
 
@@ -28,4 +29,5 @@ export const fixes: Fix[] = [
   newFrameworks,
   removedGlobalClientAPIs,
   mdx1to2,
+  docsPageAutomatic,
 ];


### PR DESCRIPTION
Telescoping on https://github.com/storybookjs/storybook/pull/19713

## What I did

Created automigration

## How to test

I ran locally.