### PR TITLE
Pull renderer+builder from framework's package.json + a known list

### DIFF
--- a/code/lib/telemetry/src/get-framework-info.ts
+++ b/code/lib/telemetry/src/get-framework-info.ts
@@ -1,4 +1,5 @@
 import type { PackageJson, StorybookConfig } from '@storybook/types';
+import { getActualPackageJson } from './package-json';
 
 const knownRenderers = [
   'html',
@@ -36,8 +37,7 @@ export async function getFrameworkInfo(mainConfig: StorybookConfig) {
 
   const framework = typeof frameworkInput === 'string' ? { name: frameworkInput } : frameworkInput;
 
-  // eslint-disable-next-line import/no-dynamic-require, global-require
-  const frameworkPackageJson = require(`${framework.name}/package.json`);
+  const frameworkPackageJson = await getActualPackageJson(framework.name);
 
   const builder = findMatchingPackage(frameworkPackageJson, knownBuilders);
   const renderer = findMatchingPackage(frameworkPackageJson, knownRenderers);

--- a/code/lib/telemetry/src/get-framework-info.ts
+++ b/code/lib/telemetry/src/get-framework-info.ts
@@ -1,0 +1,50 @@
+import type { PackageJson, StorybookConfig } from '@storybook/types';
+
+const knownRenderers = [
+  'html',
+  'react',
+  'svelte',
+  'vue3',
+  'preact',
+  'server',
+  'vue',
+  'web-components',
+  'angular',
+  'ember',
+];
+
+const knownBuilders = ['builder-webpack5', 'builder-vite'];
+
+function findMatchingPackage(packageJson: PackageJson, suffixes: string[]) {
+  const { name = '', version, dependencies, devDependencies, peerDependencies } = packageJson;
+
+  const allDependencies = {
+    // We include the framework itself because it may be a renderer too (e.g. angular)
+    [name]: version,
+    ...dependencies,
+    ...devDependencies,
+    ...peerDependencies,
+  };
+
+  return suffixes.map((suffix) => `@storybook/${suffix}`).find((pkg) => allDependencies[pkg]);
+}
+
+export async function getFrameworkInfo(mainConfig: StorybookConfig) {
+  const { framework: frameworkInput } = mainConfig;
+
+  if (!frameworkInput) return {};
+
+  const framework = typeof frameworkInput === 'string' ? { name: frameworkInput } : frameworkInput;
+
+  // eslint-disable-next-line import/no-dynamic-require, global-require
+  const frameworkPackageJson = require(`${framework.name}/package.json`);
+
+  const builder = findMatchingPackage(frameworkPackageJson, knownBuilders);
+  const renderer = findMatchingPackage(frameworkPackageJson, knownRenderers);
+
+  return {
+    framework,
+    builder,
+    renderer,
+  };
+}

--- a/code/lib/telemetry/src/package-json.ts
+++ b/code/lib/telemetry/src/package-json.ts
@@ -9,8 +9,7 @@ export const getActualPackageVersions = async (packages: Record<string, Partial<
 
 export const getActualPackageVersion = async (packageName: string) => {
   try {
-    // eslint-disable-next-line import/no-dynamic-require,global-require
-    const packageJson = require(path.join(packageName, 'package.json'));
+    const packageJson = await getActualPackageJson(packageName);
     return {
       name: packageName,
       version: packageJson.version,
@@ -18,4 +17,10 @@ export const getActualPackageVersion = async (packageName: string) => {
   } catch (err) {
     return { name: packageName, version: null };
   }
+};
+
+export const getActualPackageJson = async (packageName: string) => {
+  // eslint-disable-next-line import/no-dynamic-require,global-require
+  const packageJson = require(path.join(packageName, 'package.json'));
+  return packageJson;
 };

--- a/code/lib/telemetry/src/storybook-metadata.test.ts
+++ b/code/lib/telemetry/src/storybook-metadata.test.ts
@@ -12,7 +12,7 @@ const mainJsMock: StorybookConfig = {
   stories: [],
 };
 
-jest.mock('./package-versions', () => {
+jest.mock('./package-json', () => {
   const getActualPackageVersion = jest.fn((name) =>
     Promise.resolve({
       name,
@@ -24,9 +24,17 @@ jest.mock('./package-versions', () => {
     Promise.all(Object.keys(packages).map(getActualPackageVersion))
   );
 
+  const getActualPackageJson = jest.fn((name) => ({
+    dependencies: {
+      '@storybook/react': 'x.x.x',
+      '@storybook/builder-vite': 'x.x.x',
+    },
+  }));
+
   return {
     getActualPackageVersions,
     getActualPackageVersion,
+    getActualPackageJson,
   };
 });
 
@@ -96,40 +104,39 @@ describe('sanitizeAddonName', () => {
 describe('await computeStorybookMetadata', () => {
   test('should return frameworkOptions from mainjs', async () => {
     const reactResult = await computeStorybookMetadata({
-      packageJson: {
-        ...packageJsonMock,
-        devDependencies: {
-          '@storybook/react': 'x.x.x',
-        },
-      },
+      packageJson: packageJsonMock,
       mainConfig: {
         ...mainJsMock,
-        reactOptions: {
-          fastRefresh: false,
+        framework: {
+          name: '@storybook/react-vite',
+          options: {
+            fastRefresh: false,
+          },
         },
       },
     });
 
-    expect(reactResult.framework).toEqual({ name: 'react', options: { fastRefresh: false } });
+    expect(reactResult.framework).toEqual({
+      name: '@storybook/react-vite',
+      options: { fastRefresh: false },
+    });
 
     const angularResult = await computeStorybookMetadata({
-      packageJson: {
-        ...packageJsonMock,
-        devDependencies: {
-          '@storybook/angular': 'x.x.x',
-        },
-      },
+      packageJson: packageJsonMock,
       mainConfig: {
         ...mainJsMock,
-        angularOptions: {
-          enableIvy: true,
-          enableNgcc: true,
+        framework: {
+          name: '@storybook/angular',
+          options: {
+            enableIvy: true,
+            enableNgcc: true,
+          },
         },
       },
     });
 
     expect(angularResult.framework).toEqual({
-      name: 'angular',
+      name: '@storybook/angular',
       options: { enableIvy: true, enableNgcc: true },
     });
   });
@@ -196,40 +203,19 @@ describe('await computeStorybookMetadata', () => {
     expect(result.features).toEqual(features);
   });
 
-  test('should handle different types of builders', async () => {
-    const simpleBuilder = 'webpack4';
-    const complexBuilder = {
-      name: 'webpack5',
-      options: {
-        lazyCompilation: true,
-      },
-    };
+  test('should infer builder and renderer from framework package.json', async () => {
     expect(
-      (
-        await computeStorybookMetadata({
-          packageJson: packageJsonMock,
-          mainConfig: {
-            ...mainJsMock,
-            core: {
-              builder: complexBuilder,
-            },
-          },
-        })
-      ).builder
-    ).toEqual(complexBuilder);
-    expect(
-      (
-        await computeStorybookMetadata({
-          packageJson: packageJsonMock,
-          mainConfig: {
-            ...mainJsMock,
-            core: {
-              builder: simpleBuilder,
-            },
-          },
-        })
-      ).builder
-    ).toEqual({ name: simpleBuilder });
+      await computeStorybookMetadata({
+        packageJson: packageJsonMock,
+        mainConfig: {
+          ...mainJsMock,
+          framework: '@storybook/react-vite',
+        },
+      })
+    ).toMatchObject({
+      renderer: '@storybook/react',
+      builder: '@storybook/builder-vite',
+    });
   });
 
   test('should return the number of refs', async () => {

--- a/code/lib/telemetry/src/storybook-metadata.test.ts
+++ b/code/lib/telemetry/src/storybook-metadata.test.ts
@@ -213,6 +213,7 @@ describe('await computeStorybookMetadata', () => {
         },
       })
     ).toMatchObject({
+      framework: { name: '@storybook/react-vite' },
       renderer: '@storybook/react',
       builder: '@storybook/builder-vite',
     });

--- a/code/lib/telemetry/src/storybook-metadata.ts
+++ b/code/lib/telemetry/src/storybook-metadata.ts
@@ -9,7 +9,7 @@ import {
 import type { StorybookConfig, PackageJson } from '@storybook/types';
 
 import type { StorybookMetadata, Dependency, StorybookAddon } from './types';
-import { getActualPackageVersion, getActualPackageVersions } from './package-versions';
+import { getActualPackageVersion, getActualPackageVersions } from './package-json';
 import { getMonorepoType } from './get-monorepo-type';
 import { cleanPaths } from './sanitize';
 import { getFrameworkInfo } from './get-framework-info';

--- a/code/lib/telemetry/src/storybook-metadata.ts
+++ b/code/lib/telemetry/src/storybook-metadata.ts
@@ -12,6 +12,7 @@ import type { StorybookMetadata, Dependency, StorybookAddon } from './types';
 import { getActualPackageVersion, getActualPackageVersions } from './package-versions';
 import { getMonorepoType } from './get-monorepo-type';
 import { cleanPaths } from './sanitize';
+import { getFrameworkInfo } from './get-framework-info';
 
 export const metaFrameworks = {
   next: 'Next',
@@ -22,31 +23,6 @@ export const metaFrameworks = {
   '@vue/cli-service': 'vue-cli',
   '@sveltejs/kit': 'svelte-kit',
 } as Record<string, string>;
-
-// @TODO: This should be removed in 7.0 as the framework.options field in main.js will replace this
-const getFrameworkOptions = (mainConfig: any) => {
-  const possibleOptions = [
-    'angular',
-    'ember',
-    'html',
-    'preact',
-    'react',
-    'server',
-    'svelte',
-    'vue',
-    'vue3',
-    'webComponents',
-  ].map((opt) => `${opt}Options`);
-
-  // eslint-disable-next-line no-restricted-syntax
-  for (const opt of possibleOptions) {
-    if (opt in mainConfig) {
-      return mainConfig[opt] as any;
-    }
-  }
-
-  return undefined;
-};
 
 export const sanitizeAddonName = (name: string) => {
   return cleanPaths(name)
@@ -68,7 +44,6 @@ export const computeStorybookMetadata = async ({
 }): Promise<StorybookMetadata> => {
   const metadata: Partial<StorybookMetadata> = {
     generatedAt: new Date().getTime(),
-    builder: { name: 'webpack5' },
     hasCustomBabel: false,
     hasCustomWebpack: false,
     hasStaticDirs: false,
@@ -118,14 +93,7 @@ export const computeStorybookMetadata = async ({
     metadata.typescriptOptions = mainConfig.typescript;
   }
 
-  if (mainConfig.core?.builder) {
-    const { builder } = mainConfig.core;
-
-    metadata.builder = {
-      name: typeof builder === 'string' ? builder : builder.name,
-      options: typeof builder === 'string' ? undefined : builder?.options ?? undefined,
-    };
-  }
+  const frameworkInfo = await getFrameworkInfo(mainConfig);
 
   if (mainConfig.refs) {
     metadata.refCount = Object.keys(mainConfig.refs).length;
@@ -181,22 +149,16 @@ export const computeStorybookMetadata = async ({
 
   const hasStorybookEslint = !!allDependencies['eslint-plugin-storybook'];
 
-  // FIXME: resolve framework/renderer split in 7.0
-  //        OR should be getting this from mainConfig instead?
   const storybookInfo = getStorybookInfo(packageJson);
-
   const storybookVersion =
     storybookPackages[storybookInfo.frameworkPackage]?.version || storybookInfo.version;
 
   return {
     ...metadata,
+    ...frameworkInfo,
     storybookVersion,
     language,
     storybookPackages,
-    framework: {
-      name: storybookInfo.framework,
-      options: getFrameworkOptions(mainConfig),
-    },
     addons,
     hasStorybookEslint,
   };

--- a/code/lib/telemetry/src/types.ts
+++ b/code/lib/telemetry/src/types.ts
@@ -17,14 +17,12 @@ export type StorybookMetadata = {
   storybookVersion: string;
   generatedAt?: number;
   language: 'typescript' | 'javascript';
-  framework: {
+  framework?: {
     name: string;
     options?: any;
   };
-  builder?: {
-    name: string;
-    options?: Record<string, any>;
-  };
+  builder?: string;
+  renderer?: string;
   monorepo?: MonorepoType;
   packageManager?: {
     type: PM;


### PR DESCRIPTION
Issue: Framework concept was out of date here.

## What I did

- Pull framework from `main:framework`.
- Then search that package's `package.json` for known dependencies to work out renderer + builder.

This was an approach we thought was a good compromise between reliability and correctness.

## How to test

See tests

```
STORYBOOK_TELEMETRY_DEBUG=1 yarn storybook
```