### PR TITLE
undo - client-api should export from store

### DIFF
--- a/code/lib/client-api/src/index.ts
+++ b/code/lib/client-api/src/index.ts
@@ -11,4 +11,6 @@ export {
   setGlobalRender,
 } from './ClientApi';
 
+export * from '@storybook/store';
+
 export * from './queryparams';

--- a/code/lib/store/src/hooks.ts
+++ b/code/lib/store/src/hooks.ts
@@ -1,6 +1,37 @@
 import { SHARED_STATE_CHANGED, SHARED_STATE_SET } from '@storybook/core-events';
 
-import { addons, useMemo, useState, useEffect, useChannel } from '@storybook/addons';
+import {
+  addons,
+  HooksContext,
+  applyHooks,
+  useMemo,
+  useCallback,
+  useRef,
+  useState,
+  useReducer,
+  useEffect,
+  useChannel,
+  useStoryContext,
+  useParameter,
+  useArgs,
+  useGlobals,
+} from '@storybook/addons';
+
+export {
+  HooksContext,
+  applyHooks,
+  useMemo,
+  useCallback,
+  useRef,
+  useState,
+  useReducer,
+  useEffect,
+  useChannel,
+  useStoryContext,
+  useParameter,
+  useArgs,
+  useGlobals,
+};
 
 export function useSharedState<S>(sharedId: string, defaultState?: S): [S, (s: S) => void] {
   const channel = addons.getChannel();


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/pull/19580/files#r1010414204

I removed a few re-exports which users have reported as now being missing.
This adds those back.