### PR TITLE
Fix: Point to correct .d.ts files from export maps

### DIFF
--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -40,7 +40,7 @@
     "./react": {
       "require": "./dist/react/index.js",
       "import": "./dist/react/index.mjs",
-      "types": "./dist/react.d.ts"
+      "types": "./dist/react/index.d.ts"
     },
     "./register": {
       "require": "./dist/manager.js",

--- a/code/addons/outline/package.json
+++ b/code/addons/outline/package.json
@@ -41,7 +41,7 @@
     "./preview": {
       "require": "./dist/preset/preview.js",
       "import": "./dist/preset/preview.mjs",
-      "types": "./dist/preview.d.ts"
+      "types": "./dist/preset/preview.d.ts"
     },
     "./register": {
       "require": "./dist/manager.js",


### PR DESCRIPTION
Issue: N/A

Related to https://github.com/storybookjs/storybook/pull/19723

## What I did

I found a few cases where the export map for types were pointing to the wrong files, so this updates them.

## How to test

Compile the code, check that these types point to the right spots.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
