### PR TITLE
State in docs that title/component/id must be statically defined

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -279,7 +279,10 @@ export default genDefault({
 })
 ```
 
-This is no longer possible in SB 7.0, as story titles are parsed at build time. Titles cannot depend on variables or functions, and cannot be dynamically computed even with local variables. All stories must have a static `title` property, or a static `component` property from which an automatic title will be derived.
+This is no longer possible in SB 7.0, as story titles are parsed at build time. In SB 6, titles were mostly produced manually. Now that [CSF3 auto-title](#csf3-auto-title-improvements) is available, optimisations were made that constrain how `id` and `title` can be defined manually.
+
+
+As a result, titles cannot depend on variables or functions, and cannot be dynamically computed (even with local variables). Stories must have a static `title` property, or a static `component` property used by the [CSF3 auto-title](#csf3-auto-title-improvements) feature to compute a title.
 
 Likewise, the `id` property must be statically defined. The URL defined for a story in the sidebar will be statically computed, so if you dynamically add an `id` through a function call like above, the story URL will not match the one in the sidebar and the story will be unreachable.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -902,6 +902,35 @@ module.exports = {
 };
 ```
 
+### Titles are statically computed
+
+Up until SB 7.0, it was possible to generate the default export of a CSF story by calling a function, or mixing in variables defined in other ES Modules. For instance:
+
+```js
+// Dynamically computed local title
+const categories = {
+  atoms: 'Atoms',
+  molecules: 'Molecules',
+  // etc.
+}
+
+export default {
+  title: `${categories.atoms}/MyComponent`
+}
+
+// Title returned by a function
+import { genDefault } from '../utils/storybook'
+
+export default genDefault({
+  category: 'Atoms',
+  title: 'MyComponent',
+})
+```
+
+This is no longer possible in SB 7.0, as story titles are parsed at build time. Titles cannot depend on variables or functions, and cannot be dynamically computed even with local variables. All stories must have a static `title` property, or a static `component` property from which an automatic title will be derived.
+
+Likewise, the `id` property must be statically defined. The URL defined for a story in the sidebar will be statically computed, so if you dynamically add an `id` through a function call like above, the story URL will not match the one in the sidebar and the story will be unreachable.
+
 ### CSF3 auto-title improvements
 
 SB 6.4 introduced experimental "auto-title", in which a story's location in the sidebar (aka `title`) can be automatically inferred from its location on disk. For example, the file `atoms/Button.stories.js` might result in the title `Atoms/Button`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,7 +3,7 @@
 - [From version 6.5.x to 7.0.0](#from-version-65x-to-700)
   - [Alpha release notes](#alpha-release-notes)
   - [7.0 breaking changes](#70-breaking-changes)
-    - [removed auto injection of @storybook/addon-actions decorator](#removed-auto-injection-of-storybookaddon-actions-decorator)
+    - [Titles are statically computed](#titles-are-statically-computed)
     - [register.js removed](#registerjs-removed)
     - [Change of root html IDs](#change-of-root-html-ids)
     - [No more default export from `@storybook/addons`](#no-more-default-export-from-storybookaddons)
@@ -50,7 +50,6 @@
   - [Vite builder renamed](#vite-builder-renamed)
   - [Docs framework refactor for React](#docs-framework-refactor-for-react)
   - [Opt-in MDX2 support](#opt-in-mdx2-support)
-  - [Titles are statically computed](#titles-are-statically-computed)
   - [CSF3 auto-title improvements](#csf3-auto-title-improvements)
     - [Auto-title filename case](#auto-title-filename-case)
     - [Auto-title redundant filename](#auto-title-redundant-filename)
@@ -254,6 +253,44 @@ Storybook 7.0 is in early alpha. During the alpha, we are making a large number 
 In the meantime, these migration notes are the best available documentation on things you should know upgrading to 7.0.
 
 ### 7.0 breaking changes
+
+#### Titles are statically computed
+
+Up until SB 7.0, it was possible to generate the default export of a CSF story by calling a function, or mixing in variables defined in other ES Modules. For instance:
+
+```js
+// Dynamically computed local title
+const categories = {
+  atoms: 'Atoms',
+  molecules: 'Molecules',
+  // etc.
+}
+
+export default {
+  title: `${categories.atoms}/MyComponent`
+}
+
+// Title returned by a function
+import { genDefault } from '../utils/storybook'
+
+export default genDefault({
+  category: 'Atoms',
+  title: 'MyComponent',
+})
+```
+
+This is no longer possible in SB 7.0, as story titles are parsed at build time. Titles cannot depend on variables or functions, and cannot be dynamically computed even with local variables. All stories must have a static `title` property, or a static `component` property from which an automatic title will be derived.
+
+Likewise, the `id` property must be statically defined. The URL defined for a story in the sidebar will be statically computed, so if you dynamically add an `id` through a function call like above, the story URL will not match the one in the sidebar and the story will be unreachable.
+
+To opt-out of the old behavior you can set the `storyStoreV7` feature flag to `false` in `main.js`. However, a variety of performance optimizations depend on the new behavior, and the old behavior is deprecated and will be removed from Storybook in 8.0.
+
+```js
+module.exports = {
+  features: {
+    storyStoreV7: false,
+  }
+}
 
 #### removed auto injection of @storybook/addon-actions decorator
 
@@ -902,35 +939,6 @@ module.exports = {
   },
 };
 ```
-
-### Titles are statically computed
-
-Up until SB 7.0, it was possible to generate the default export of a CSF story by calling a function, or mixing in variables defined in other ES Modules. For instance:
-
-```js
-// Dynamically computed local title
-const categories = {
-  atoms: 'Atoms',
-  molecules: 'Molecules',
-  // etc.
-}
-
-export default {
-  title: `${categories.atoms}/MyComponent`
-}
-
-// Title returned by a function
-import { genDefault } from '../utils/storybook'
-
-export default genDefault({
-  category: 'Atoms',
-  title: 'MyComponent',
-})
-```
-
-This is no longer possible in SB 7.0, as story titles are parsed at build time. Titles cannot depend on variables or functions, and cannot be dynamically computed even with local variables. All stories must have a static `title` property, or a static `component` property from which an automatic title will be derived.
-
-Likewise, the `id` property must be statically defined. The URL defined for a story in the sidebar will be statically computed, so if you dynamically add an `id` through a function call like above, the story URL will not match the one in the sidebar and the story will be unreachable.
 
 ### CSF3 auto-title improvements
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -50,6 +50,7 @@
   - [Vite builder renamed](#vite-builder-renamed)
   - [Docs framework refactor for React](#docs-framework-refactor-for-react)
   - [Opt-in MDX2 support](#opt-in-mdx2-support)
+  - [Titles are statically computed](#titles-are-statically-computed)
   - [CSF3 auto-title improvements](#csf3-auto-title-improvements)
     - [Auto-title filename case](#auto-title-filename-case)
     - [Auto-title redundant filename](#auto-title-redundant-filename)

--- a/docs/writing-stories/introduction.md
+++ b/docs/writing-stories/introduction.md
@@ -44,6 +44,12 @@ The _default_ export metadata controls how Storybook lists your stories and prov
 
 <!-- prettier-ignore-end -->
 
+<div class="aside">
+
+Starting with Storybook version 7.0, story titles are analysed statically as part of the build process. The _default_ export must contain a `title` property that can be read statically, or a `component` property from which an automatic title can be computed. If you use the `id` property to customise your story URL, it must also be statically readable.
+
+</div>
+
 ### Defining stories
 
 Use the _named_ exports of a CSF file to define your component’s stories. We recommend you use UpperCamelCase for your story exports. Here’s how to render `Button` in the “primary” state and export a story called `Primary`.


### PR DESCRIPTION
Issue: if one uses a function to generate their stories' default export, the story file is skipped in SB 7, as there is no way to statically generate a title for it.

## What I did

I added a note in the documentation that helps SB 7 users make sense of this new behaviour. Having it indexed somewhere in the doc may help users find a self-service explanation through search engines when they run into the same issue as I did.

Besides that, an explicit migration note would help current users discover this new limitation without requiring live community support.

## How to test

- [ ] ~Is this testable with Jest or Chromatic screenshots?~
- [ ] ~Does this need a new example in the kitchen sink apps?~
- [ ] ~Does this need an update to the documentation?~
