### PR TITLE
Storyshots - Support .cjs and .mjs file extensions

### DIFF
--- a/code/addons/storyshots/storyshots-core/src/frameworks/configure.ts
+++ b/code/addons/storyshots/storyshots-core/src/frameworks/configure.ts
@@ -33,7 +33,7 @@ interface Output {
   requireContexts?: string[];
 }
 
-const supportedExtensions = ['ts', 'tsx', 'js', 'jsx'];
+const supportedExtensions = ['ts', 'tsx', 'js', 'jsx', 'cjs', 'mjs'];
 
 const resolveFile = (configDir: string, supportedFilenames: string[]) =>
   supportedFilenames


### PR DESCRIPTION
Issue:

In a native ESM project, the standard Storybook `main.js` file might need to be written as a CommonJS file, and therefore named with a .cjs extension.

## What I did

Added .cjs and .mjs to the list of supported extensions for configuration files in the Storyshots addon. These are valid extensions for Javascript source code files, and Jest has no issue requiring them.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
