### PR TITLE
Maintenance: Delete node_modules in repro generation

### DIFF
--- a/.github/workflows/generate-repros-next.yml
+++ b/.github/workflows/generate-repros-next.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
+      CLEANUP_REPRO_NODE_MODULES: true
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -6,7 +6,7 @@ import pLimit from 'p-limit';
 import prettyTime from 'pretty-hrtime';
 import { copy, emptyDir, ensureDir, move, remove, rename, writeFile } from 'fs-extra';
 import { program } from 'commander';
-import { AbortController } from 'node-abort-controller';
+import type { AbortController } from 'node-abort-controller';
 import { directory } from 'tempy';
 
 import reproTemplates from '../../code/lib/cli/src/repro-templates';
@@ -16,9 +16,9 @@ import { JsPackageManagerFactory } from '../../code/lib/cli/src/js-package-manag
 import { maxConcurrentTasks } from '../utils/maxConcurrentTasks';
 
 import { localizeYarnConfigFiles, setupYarn } from './utils/yarn';
-import { GeneratorConfig } from './utils/types';
+import type { GeneratorConfig } from './utils/types';
 import { getStackblitzUrl, renderTemplate } from './utils/template';
-import { JsPackageManager } from '../../code/lib/cli/src/js-package-manager';
+import type { JsPackageManager } from '../../code/lib/cli/src/js-package-manager';
 import { runRegistry } from '../tasks/run-registry';
 
 const OUTPUT_DIRECTORY = join(__dirname, '..', '..', 'repros');
@@ -160,6 +160,13 @@ const runGenerators = async (
         await addStorybook(baseDir, localRegistry, flags);
 
         await addDocumentation(baseDir, { name, dirName });
+
+        // Remove node_modules to save space and avoid GH actions failing
+        // They're not uploaded to the git repros repo anyway
+        if (process.env.CI) {
+          await remove(join(beforeDir, 'node_modules'));
+          await remove(join(baseDir, 'node_modules'));
+        }
 
         console.log(
           `✅ Created ${dirName} in ./${relative(

--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -163,7 +163,7 @@ const runGenerators = async (
 
         // Remove node_modules to save space and avoid GH actions failing
         // They're not uploaded to the git repros repo anyway
-        if (process.env.CI) {
+        if (process.env.CLEANUP_REPRO_NODE_MODULES) {
           await remove(join(beforeDir, 'node_modules'));
           await remove(join(baseDir, 'node_modules'));
         }


### PR DESCRIPTION
Issue: N/A

## What I did

GH repros action was broken due to space limits. This PR fixes that by removing node_modules when running `yarn generate-repros` in CI.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
