### PR TITLE
CSF-tools: Support main.js default exports

### DIFF
--- a/code/lib/csf-tools/src/ConfigFile.test.ts
+++ b/code/lib/csf-tools/src/ConfigFile.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="@types/jest" />;
+
 import { dedent } from 'ts-dedent';
 import { formatConfig, loadConfig } from './ConfigFile';
 
@@ -83,6 +85,7 @@ describe('ConfigFile', () => {
         ).toEqual('webpack5');
       });
     });
+
     describe('module exports', () => {
       it('missing export', () => {
         expect(
@@ -137,6 +140,66 @@ describe('ConfigFile', () => {
                 stories: [{ directory: '../src', titlePrefix: 'Demo' }],
               }
               module.exports = config;
+            `
+          )
+        ).toEqual([{ directory: '../src', titlePrefix: 'Demo' }]);
+      });
+    });
+
+    describe('default export', () => {
+      it('missing export', () => {
+        expect(
+          getField(
+            ['core', 'builder'],
+            dedent`
+            export default { foo: { builder: 'webpack5' } }
+            `
+          )
+        ).toBeUndefined();
+      });
+      it('found scalar', () => {
+        expect(
+          getField(
+            ['core', 'builder'],
+            dedent`
+            export default { core: { builder: 'webpack5' } }
+            `
+          )
+        ).toEqual('webpack5');
+      });
+      it('variable ref export', () => {
+        expect(
+          getField(
+            ['core', 'builder'],
+            dedent`
+            const core = { builder: 'webpack5' };
+            export default { core };
+            `
+          )
+        ).toEqual('webpack5');
+      });
+      it('variable rename', () => {
+        expect(
+          getField(
+            ['core', 'builder'],
+            dedent`
+            const coreVar = { builder: 'webpack5' };
+            export default { core: coreVar };
+            `
+          )
+        ).toEqual('webpack5');
+      });
+      it('variable exports', () => {
+        expect(
+          getField(
+            ['stories'],
+            dedent`
+              import type { StorybookConfig } from '@storybook/react-webpack5';
+
+              const config: StorybookConfig = {
+                stories: [{ directory: '../src', titlePrefix: 'Demo' }],
+              }
+              export default config;
             `
           )
         ).toEqual([{ directory: '../src', titlePrefix: 'Demo' }]);
@@ -228,6 +291,7 @@ describe('ConfigFile', () => {
         `);
       });
     });
+
     describe('module exports', () => {
       it('missing export', () => {
         expect(
@@ -283,6 +347,63 @@ describe('ConfigFile', () => {
         `);
       });
     });
+
+    describe('default export', () => {
+      it('missing export', () => {
+        expect(
+          setField(
+            ['core', 'builder'],
+            'webpack5',
+            dedent`
+              export default { addons: [] };
+            `
+          )
+        ).toMatchInlineSnapshot(`
+          export default {
+            addons: [],
+            core: {
+              builder: "webpack5"
+            }
+          };
+        `);
+      });
+      it('missing field', () => {
+        expect(
+          setField(
+            ['core', 'builder'],
+            'webpack5',
+            dedent`
+              export default { core: { foo: 'bar' }};
+            `
+          )
+        ).toMatchInlineSnapshot(`
+          export default {
+            core: {
+              foo: 'bar',
+              builder: 'webpack5'
+            }
+          };
+        `);
+      });
+      it('found scalar', () => {
+        expect(
+          setField(
+            ['core', 'builder'],
+            'webpack5',
+            dedent`
+              export default { core: { builder: 'webpack4' } };
+            `
+          )
+        ).toMatchInlineSnapshot(`
+          export default {
+            core: {
+              builder: 'webpack5'
+            }
+          };
+        `);
+      });
+    });
+
     describe('quotes', () => {
       it('no quotes', () => {
         expect(setField(['foo', 'bar'], 'baz', '')).toMatchInlineSnapshot(`


### PR DESCRIPTION
Issue: N/A

## What I did

Starting in SB7 it's possible to use a default export in `.storybook/main.js` (and potentially also in `preview.js`)

This PR adds default export support to `@storybook/csf-tools`, the library for statically analyzing these files.

## How to test

- [ ] CI passes