### PR TITLE
Blocks: Setup and create example story for blocks with context

### DIFF
--- a/code/ui/.storybook/main.ts
+++ b/code/ui/.storybook/main.ts
@@ -36,6 +36,7 @@ const config: StorybookConfig = {
   viteFinal: (vite) => ({
     ...vite,
     plugins: [...(vite.plugins || []), csfPlugin({})],
+    optimizeDeps: { ...vite.optimizeDeps, force: true },
   }),
 };
 

--- a/code/ui/blocks/src/blocks/Story.stories.tsx
+++ b/code/ui/blocks/src/blocks/Story.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Story as StoryComponent } from './Story';
+import * as BooleanStories from '../controls/Boolean.stories';
+
+const meta: Meta<typeof StoryComponent> = {
+  component: StoryComponent,
+  parameters: {
+    relativeCsfPaths: ['../controls/Boolean.stories'],
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const BasicOf: Story = {
+  args: {
+    of: BooleanStories.Undefined,
+  },
+};


### PR DESCRIPTION
## What I did

Issue: NA

- Add loader/decorator to wrap stories in a docs context
- And a very simple story for the `<Story>` block

## How to test

View Storybook, or check Chromatic.