### PR TITLE
Preact: Make preact use inline stories (without iframe) by default in docs

### DIFF
--- a/code/renderers/preact/src/config.ts
+++ b/code/renderers/preact/src/config.ts
@@ -1,3 +1,5 @@
+import { parameters as docsParams } from './docs/config';
+
 export { renderToDOM, render } from './render';
 
-export const parameters = { framework: 'preact' as const };
+export const parameters = { framework: 'preact' as const, ...docsParams };

--- a/code/renderers/preact/src/docs/config.ts
+++ b/code/renderers/preact/src/docs/config.ts
@@ -1,0 +1,5 @@
+export const parameters = {
+  docs: {
+    inlineStories: true,
+  },
+};


### PR DESCRIPTION
## What I did

Preact is missing config files for docs in the renderer. I have added the first bit in this PR, which will make sure that stories in docs will be inlined by default and not using iframes. This is what other renderers use by default as well.


## How to test

Go to the published chromatic storybook, and see that it is not using iframes anymore in docs.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
