### PR TITLE
Update README logo for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 <p align="center">
   <a href="https://storybook.js.org/">
-    <img src="https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png" alt="Storybook" width="400" />
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/263385/199832481-bbbf5961-6a26-481d-8224-51258cce9b33.png">
+      <img src="https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png" alt="Storybook" width="400" />
+    </picture>
+    
   </a>
+  
 </p>
 
 <p align="center">Build bulletproof UI components faster</p>


### PR DESCRIPTION
Thanks for [the tip](https://twitter.com/_egoistlily/status/1588201619388190720) @egoist

## What I did

Swaps the README logo depending on whether dark mode is active or now

<img width="921" alt="image" src="https://user-images.githubusercontent.com/263385/199833493-a0691429-ccba-4e4e-be6b-c3acd6324f90.png">


## How to test

Go to the README file on this branch, look at the logo, then swap between dark and light modes. 

