### PR TITLE
Maintenance: Cancel workflow in CI on steps failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,8 @@ commands:
           name: Cancel current workflow
           when: on_fail
           command: |
-            echo "Canceling workflow as previous step resulted in failure. To test locally, please run yarn ci-tests"
+            echo "Canceling workflow as previous step resulted in failure."
+            echo "To execute all checks locally, please run yarn ci-tests"
             curl -X POST --header "Content-Type: application/json" "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${WORKFLOW_CANCELER}"
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,6 +456,29 @@ jobs:
       - store_artifacts: # this is where playwright puts more complex stuff
           path: code/playwright-results/
           destination: playwright
+  cancel-workflow-on-failure:
+    executor: default
+    steps:
+      - run:
+          command: |
+            while true; do
+              json=$(curl -s -H 'Accept: application/json' -X GET https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/job?circle-token=${CIRCLE_TOKEN})
+              any_required_step_failed=$(echo $json | jq '.items | map(select(.name == "check" or .name == "lint" or .name == "publish" or .name == "script-unit-tests" or .name == "unit-tests")) | any(.status == "failed")')
+              any_required_step_pending=$(echo $json | jq '.items | map(select(.name == "check" or .name == "lint" or .name == "publish" or .name == "script-unit-tests" or .name == "unit-tests")) | any(.status == "running")')
+              all_jobs_done=$(echo $json | jq '.items | map(select(.status == "running")) | length > 0')
+
+              if [ "$any_required_step_pending" == "true" ]; then
+                echo "Waiting for other required jobs to finish..."
+              elif [ "$any_required_step_failed" == "true" ]; then
+                echo "One of the required steps failed, canceling workflow..."
+                curl -s -H 'Accept: application/json' -X POST https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${CIRCLE_TOKEN}
+                exit 0
+              elif [ "$all_jobs_done" == "true" ]; then
+                echo "All jobs are done!"
+                exit 0
+              fi
+              sleep 30 # run this check every 30 seconds
+            done
 
 workflows:
   daily-tests:
@@ -499,6 +522,9 @@ workflows:
       equal: [ tests, << pipeline.parameters.workflow >> ]
     jobs:
       - build
+      - cancel-workflow-on-failure:
+          requires:
+            - build
       - lint:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,15 @@ commands:
               echo "🏁 The PR isn't labelled with '<< parameters.label >>' so this job will end at the current step."
               circleci-agent step halt
             fi
-
+  cancel-workflow-on-failure:
+    description: 'Cancels the entire workflow in case the previous step has failed'
+    steps:
+      - run:
+          name: Cancel current workflow
+          when: on_fail
+          command: |
+            echo "Canceling workflow as previous step resulted in failure. To test locally, please run yarn ci-tests"
+            curl -X POST --header "Content-Type: application/json" "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${WORKFLOW_CANCELER}"
 jobs:
   build:
     executor:
@@ -228,6 +236,7 @@ jobs:
           command: |
             cd code
             yarn lint
+      - cancel-workflow-on-failure
   check:
     executor:
       class: xlarge
@@ -242,6 +251,7 @@ jobs:
           command: |
             yarn task --task check --start-from=auto --no-link --debug
             git diff --exit-code
+      - cancel-workflow-on-failure
   script-unit-tests:
     executor: sb_node_16_browsers
     steps:
@@ -256,6 +266,7 @@ jobs:
             yarn test --coverage --ci
       - store_test_results:
           path: scripts/junit.xml
+      - cancel-workflow-on-failure
   unit-tests:
     executor:
       class: xlarge
@@ -276,6 +287,7 @@ jobs:
           root: .
           paths:
             - code/coverage
+      - cancel-workflow-on-failure
   coverage:
     executor:
       class: small
@@ -456,32 +468,6 @@ jobs:
       - store_artifacts: # this is where playwright puts more complex stuff
           path: code/playwright-results/
           destination: playwright
-  cancel-workflow-on-failure:
-    executor:
-      class: small
-      name: sb_node_16_classic
-    steps:
-      - run:
-          name: 'cancel-workflow-on-failure'
-          command: |
-            while true; do
-              json=$(curl -s -H 'Accept: application/json' -X GET https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/job?circle-token=${CIRCLE_TOKEN})
-              any_required_step_failed=$(echo $json | jq '.items | map(select(.name == "check" or .name == "lint" or .name == "publish" or .name == "script-unit-tests" or .name == "unit-tests")) | any(.status == "failed")')
-              any_required_step_pending=$(echo $json | jq '.items | map(select(.name == "check" or .name == "lint" or .name == "publish" or .name == "script-unit-tests" or .name == "unit-tests")) | any(.status == "running")')
-              all_jobs_done=$(echo $json | jq '.items | map(select(.status == "running")) | length > 0')
-
-              if [ "$any_required_step_pending" == "true" ]; then
-                echo "Waiting for other required jobs to finish..."
-              elif [ "$any_required_step_failed" == "true" ]; then
-                echo "One of the required steps failed, canceling workflow..."
-                curl -s -H 'Accept: application/json' -X POST https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${WORKFLOW_CANCELER}
-                exit 0
-              elif [ "$all_jobs_done" == "true" ]; then
-                echo "All jobs are done!"
-                exit 0
-              fi
-              sleep 30 # run this check every 30 seconds
-            done
 
 workflows:
   daily-tests:
@@ -525,9 +511,6 @@ workflows:
       equal: [ tests, << pipeline.parameters.workflow >> ]
     jobs:
       - build
-      - cancel-workflow-on-failure:
-          requires:
-            - build
       - lint:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,7 +473,7 @@ jobs:
                 echo "Waiting for other required jobs to finish..."
               elif [ "$any_required_step_failed" == "true" ]; then
                 echo "One of the required steps failed, canceling workflow..."
-                curl -s -H 'Accept: application/json' -X POST https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${CIRCLE_TOKEN}
+                curl -s -H 'Accept: application/json' -X POST https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${WORKFLOW_CANCELER}
                 exit 0
               elif [ "$all_jobs_done" == "true" ]; then
                 echo "All jobs are done!"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,11 @@ jobs:
           command: |
             yarn task --task compile --start-from=auto --no-link --debug
             git diff --exit-code
+      - run:
+          name: Publish to Verdaccio
+          command: |
+            cd code
+            yarn local-registry --publish
       - save_cache:
           name: Save Yarn cache
           key: build-yarn-2-cache-v4--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
@@ -124,23 +129,6 @@ jobs:
             - code/ui
             - code/renderers
             - code/presets
-  publish:
-    executor:
-      class: small
-      name: sb_node_16_classic
-    steps:
-      - git-shallow-clone/checkout_advanced:
-          clone_options: '--depth 1 --verbose'
-      - attach_workspace:
-          at: .
-      - run:
-          name: running local registry
-          command: |
-            cd code
-            yarn local-registry --publish
-      - persist_to_workspace:
-          root: .
-          paths:
             - .verdaccio-cache
   cra-bench:
     executor:
@@ -475,14 +463,11 @@ workflows:
       equal: [ daily-tests, << pipeline.parameters.workflow >> ]
     jobs:
       - build
-      - publish:
-          requires:
-            - build
       - create-sandboxes:
           parallelism: 24
           cadence: "daily"
           requires:
-            - publish
+            - build
       # - smoke-test-sandboxes: # disabled for now
       #     requires:
       #       - create-sandboxes
@@ -529,19 +514,16 @@ workflows:
       - coverage:
           requires:
             - unit-tests
-      - publish:
-          requires:
-            - build
       - cra-bench:
           requires:
-            - publish
+            - build
       - react-vite-bench:
           requires:
-            - publish
+            - build
       ## new workflow
       - create-sandboxes:
           requires:
-            - publish
+            - build
       # - smoke-test-sandboxes: # disabled for now
       #     requires:
       #       - create-sandboxes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,9 @@ jobs:
           path: code/playwright-results/
           destination: playwright
   cancel-workflow-on-failure:
-    executor: default
+    executor:
+      class: small
+      name: sb_node_16_classic
     steps:
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,6 +462,7 @@ jobs:
       name: sb_node_16_classic
     steps:
       - run:
+          name: 'cancel-workflow-on-failure'
           command: |
             while true; do
               json=$(curl -s -H 'Accept: application/json' -X GET https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/job?circle-token=${CIRCLE_TOKEN})

--- a/code/lib/node-logger/src/index.test.ts
+++ b/code/lib/node-logger/src/index.test.ts
@@ -8,9 +8,6 @@ jest.mock('npmlog', () => ({
 }));
 
 describe('node-logger', () => {
-  it('should fail', () => {
-    expect(true).toBe(false);
-  })
   it('should have an info method', () => {
     const message = 'information';
     logger.info(message);

--- a/code/lib/node-logger/src/index.test.ts
+++ b/code/lib/node-logger/src/index.test.ts
@@ -8,6 +8,9 @@ jest.mock('npmlog', () => ({
 }));
 
 describe('node-logger', () => {
+  it('should fail', () => {
+    expect(true).toBe(false);
+  })
   it('should have an info method', () => {
     const message = 'information';
     logger.info(message);


### PR DESCRIPTION
Issue: N/A

## What I did

This PR does a couple of things:

1. Merges the `publish` and `build` steps into one. There's no reason to have them run separately, and this saves time (about 20 seconds).

2. Adds a new command which is attached to the critical jobs:
`[ check, lint, unit-tests, script-unit-tests ]`

And if any of them failed, it will cancel the entire workflow. This way we don't spend unnecessary time running a bunch of sandbox/e2e tests in case the basic checks are failing, and they should be quickly fixed.

Here's an example when I forced a unit test failure:
<img width="1465" alt="image" src="https://user-images.githubusercontent.com/1671563/199943721-eb515bc2-e8bf-425d-83f2-8d3f6ecd351c.png">

Therefore, the entire run took less than 5 minutes instead of 20 minutes (including a bunch of unnecessary sandbox scripts that got executed)

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
