### PR TITLE
Chore: Enable Scorecard Github Action and Badge

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,72 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecards supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '31 16 * * 5'
+  push:
+    branches: [ "next" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) Read-only PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecards on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@807578363a7869ca324a79039e6db9c843e0e100 # v2.1.27
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
   <a href="https://twitter.com/intent/follow?screen_name=storybookjs">
     <img src="https://badgen.net/twitter/follow/storybookjs?icon=twitter&label=%40storybookjs" alt="Official Twitter Handle" />
   </a>
+  <a href="https://api.securityscorecards.dev/projects/github.com/joycebrum/storybook-scorecard">
+    <img src="https://api.securityscorecards.dev/projects/github.com/joycebrum/storybook-scorecard/badge)" alt="OpenSSF Scorecard"/>
+  </a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
   <a href="https://twitter.com/intent/follow?screen_name=storybookjs">
     <img src="https://badgen.net/twitter/follow/storybookjs?icon=twitter&label=%40storybookjs" alt="Official Twitter Handle" />
   </a>
-  <a href="https://api.securityscorecards.dev/projects/github.com/joycebrum/storybook-scorecard">
-    <img src="https://api.securityscorecards.dev/projects/github.com/joycebrum/storybook-scorecard/badge)" alt="OpenSSF Scorecard"/>
+  <a href="https://api.securityscorecards.dev/projects/github.com/storybookjs/storybook">
+    <img src="https://api.securityscorecards.dev/projects/github.com/storybookjs/storybook/badge" alt="OpenSSF Scorecard"/>
   </a>
 </p>
 


### PR DESCRIPTION
Issue: Closes #19743 

## What I did

- I've configured the Scorecard Github Action
- I've added the Scorecard Badge to the README file

## How to test

- Take a look at the result of the action https://github.com/joycebrum/storybook-scorecard/actions/runs/3388884943
- See the Badge https://github.com/joycebrum/storybook-scorecard#readme

OBS: The badge when added to the forked repo does not show the real project score, being always a little lower. 

- [x] Is this testable with Jest or Chromatic screenshots? No
- [x] Does this need a new example in the kitchen sink apps? No
- [x] Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
