### PR TITLE
CI: Fix fix handle-release-branches workflow

### DIFF
--- a/.github/workflows/handle-release-branches.yml
+++ b/.github/workflows/handle-release-branches.yml
@@ -40,7 +40,7 @@ jobs:
       - id: next-version
         uses: notiz-dev/github-action-json-property@release
         with:
-          path: ${{ github.workspace }}/next/package.json
+          path: ${{ github.workspace }}/next/code/package.json
           prop_path: version
 
       - run: |


### PR DESCRIPTION
## What I did

- This workflow started failing 3 months ago with the move to the code directory, addressing this change

## How to test

- I tested this by faking being next branch, which at least fixes the error. Need to merge to see the full effect on the next branch.


