### PR TITLE
Fix prepare script on Windows machines

### DIFF
--- a/scripts/prepare/bundle.ts
+++ b/scripts/prepare/bundle.ts
@@ -41,7 +41,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
         const pathName = join(process.cwd(), dir.replace('./src', 'dist'), `${entryName}.d.ts`);
         const srcName = join(process.cwd(), file);
   
-        const rel = relative(dirname(pathName), dirname(srcName));
+        const rel = relative(dirname(pathName), dirname(srcName)).split(path.sep).join(path.posix.sep);
   
         await fs.ensureFile(pathName);
         await fs.writeFile(


### PR DESCRIPTION
Issue: On windows machines the prepare script produces index.d.ts files with Windows path separators, instead of POSIX ones.

## What I did

On Windows machines POSIX paths are generated for index.d.ts files.

## How to test

- Run `yarn task` on a windows machine and select "Compile the source code of the monorepo (compile)"
- All dependencies should be installed. All 82 prep tasks should run successfully