### PR TITLE
CI: Use a new cadence (ci, pr, merged, daily) and trigger CircleCI from github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,14 +498,10 @@ workflows:
       - react-vite-bench:
           requires:
             - build
-      ## new workflow
       - create-sandboxes:
           parallelism: 9
           requires:
             - build
-      # - smoke-test-sandboxes: # disabled for now
-      #     requires:
-      #       - create-sandboxes
       - build-sandboxes:
           parallelism: 9
           requires:
@@ -551,14 +547,10 @@ workflows:
       - react-vite-bench:
           requires:
             - build
-      ## new workflow
       - create-sandboxes:
           parallelism: 14
           requires:
             - build
-      # - smoke-test-sandboxes: # disabled for now
-      #     requires:
-      #       - create-sandboxes
       - build-sandboxes:
           parallelism: 14
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,37 +49,122 @@ executors:
     resource_class: <<parameters.class>>
 
 orbs:
-  git-shallow-clone: guitarrapc/git-shallow-clone@2.0.3
+  git-shallow-clone: guitarrapc/git-shallow-clone@2.4.0
   browser-tools: circleci/browser-tools@1.4.0
 
 commands:
-  ensure-pr-is-labeled-with:
-    description: 'A command looking for the labels set on the PR associated to this workflow and checking it contains the label given as parameter'
+  # Forked off from https://github.com/guitarrapc/git-shallow-clone-orb
+  # See issue: https://github.com/guitarrapc/git-shallow-clone-orb/issues/34
+  checkout_advanced:
+    description: |
+      checkout by git shallow clone with git options. Support Alpine, Ubuntu, Debian and others.
+      eval is used in step, Fish shell is not supported.
     parameters:
-      label:
+      clone_options:
+        default: --depth 1
+        description: |
+          git clone options you want to add such as '--depth 1 --verbose' and '--depth 1 --shallow-since "5 days ago"'
+        type: string
+      fetch_options:
+        default: --depth 10
+        description: |
+          git fetch options you want to add such as '--depth 1 --verbose' and '--depth 1 --shallow-since "5 days ago"' you don't need set '--force' option as it already set by default. in case of tag, add '--no-tags' on this option and tag_fetch_options.
+        type: string
+      keyscan_bitbucket:
+        default: false
+        description: |
+          Pass `true` to dynamically get ssh-rsa from `bitbucket.org`.
+        type: boolean
+      keyscan_github:
+        default: false
+        description: |
+          Pass `true` to dynamically get ssh-rsa from `github.com`.
+        type: boolean
+      path:
+        default: .
+        description: |
+          Checkout directory (default: job’s working_directory)
+        type: string
+      tag_fetch_options:
+        default: --tags
+        description: |
+          This option apply when git operation is tag. Use 'fetch_options' instead if pr and other git operation. Additional git fetch options you want to add specifically for tags such as '--tags' or '--no-tags'. Default value is '--tags'
         type: string
     steps:
       - run:
-          name: Check if PR is labeled with "<< parameters.label >>"
           command: |
-            apt-get -y install jq
-
-            PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed "s/.*\/pull\///")
-            echo "PR_NUMBER: $PR_NUMBER"
-
-            API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
-            PR_REQUEST_URL="$API_GITHUB/pulls/$PR_NUMBER"
-            PR_RESPONSE=$(curl -H "Authorization: token $GITHUB_TOKEN_STORYBOOK_BOT_READ_REPO" "$PR_REQUEST_URL")
-
-
-            if [ $(echo $PR_RESPONSE | jq '.labels | map(select(.name == "<< parameters.label >>")) | length') -ge 1 ] ||
-               ( [ $(echo $PR_RESPONSE | jq '.labels | length') -ge 1 ] && [ "<< parameters.label >>" == "*" ])
+            #!/bin/sh
+            set -ex
+            # Workaround old docker images with incorrect $HOME
+            # check https://github.com/docker/docker/issues/2968 for details
+            if [ "${HOME}" = "/" ]
             then
-              echo "🚀 The PR is labelled with '<< parameters.label >>', job will continue!"
-            else
-              echo "🏁 The PR isn't labelled with '<< parameters.label >>' so this job will end at the current step."
-              circleci-agent step halt
+              export HOME=$(getent passwd $(id -un) | cut -d: -f6)
             fi
+            
+            # known_hosts
+            mkdir -p ~/.ssh
+            if [ -x "$(command -v ssh-keyscan)" ] && ([ "<< parameters.keyscan_github >>" == "true" ] || [ "<< parameters.keyscan_bitbucket >>" == "true" ])
+            then
+              if [ "<< parameters.keyscan_github >>" == "true" ]
+              then
+                ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+              fi
+              if [ "<< parameters.keyscan_bitbucket >>" == "true" ]
+              then
+                ssh-keyscan -H bitbucket.org >> ~/.ssh/known_hosts
+              fi
+            fi
+            if [ "<< parameters.keyscan_github >>" != "true" ]
+            then
+              echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+            ' >> ~/.ssh/known_hosts
+            fi
+            if [ "<< parameters.keyscan_bitbucket >>" != "true" ]
+            then
+              echo 'bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
+            ' >> ~/.ssh/known_hosts
+            fi
+            
+            (umask 077; touch ~/.ssh/id_rsa)
+            chmod 0600 ~/.ssh/id_rsa
+            (echo $CHECKOUT_KEY > ~/.ssh/id_rsa)
+            
+            # use git+ssh instead of https
+            git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
+            git config --global gc.auto 0 || true
+            
+            # checkout
+            git clone << parameters.clone_options >> $CIRCLE_REPOSITORY_URL "<< parameters.path >>"
+            cd "<< parameters.path >>"
+            
+            # Fetch remote and check the commit ID of the checked out code
+            if [ -n "$CIRCLE_TAG" ]
+            then
+              # tag
+              git fetch << parameters.tag_fetch_options >> << parameters.fetch_options >> --force origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
+            elif [[ $(echo $CIRCLE_BRANCH | grep -e ^pull\/*) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]`
+            then
+              # pull request
+              git fetch << parameters.fetch_options >> --force origin "${CIRCLE_BRANCH}:remotes/origin/${CIRCLE_BRANCH}"
+            else
+              # others
+              git fetch << parameters.fetch_options >> --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+            fi
+            
+            # Check the commit ID of the checked out code
+            if [ -n "$CIRCLE_TAG" ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q "$CIRCLE_TAG"
+            elif [ -n "$CIRCLE_BRANCH" ] && [ "$CIRCLE_BRANCH" != 'HEAD' ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q -B "$CIRCLE_BRANCH"
+            fi
+            
+            git reset --hard "$CIRCLE_SHA1"
+          name: Checkout code shallow
   cancel-workflow-on-failure:
     description: 'Cancels the entire workflow in case the previous step has failed'
     steps:
@@ -96,7 +181,7 @@ jobs:
       class: large
       name: sb_node_16_classic
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - restore_cache:
           name: Restore Yarn cache
@@ -137,7 +222,7 @@ jobs:
       name: sb_playwright
     working_directory: /tmp/storybook
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -177,7 +262,7 @@ jobs:
       name: sb_playwright
     working_directory: /tmp/storybook
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -216,7 +301,7 @@ jobs:
       class: medium
       name: sb_node_16_classic
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -231,7 +316,7 @@ jobs:
       class: xlarge
       name: sb_node_16_classic
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -244,7 +329,7 @@ jobs:
   script-unit-tests:
     executor: sb_node_16_browsers
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -261,7 +346,7 @@ jobs:
       class: xlarge
       name: sb_node_16_browsers
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -282,7 +367,7 @@ jobs:
       class: small
       name: sb_node_16_browsers
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -296,7 +381,7 @@ jobs:
       class: medium
       name: sb_node_16_browsers
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -319,7 +404,7 @@ jobs:
       name: sb_node_16_browsers
     parallelism: << parameters.parallelism >>
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -342,7 +427,7 @@ jobs:
       name: sb_node_16_browsers
     parallelism: << parameters.parallelism >>
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -361,7 +446,7 @@ jobs:
       name: sb_node_16_browsers
     parallelism: << parameters.parallelism >>
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -384,7 +469,7 @@ jobs:
       name: sb_playwright
     parallelism: << parameters.parallelism >>
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -421,7 +506,7 @@ jobs:
       name: sb_playwright
     parallelism: << parameters.parallelism >>
     steps:
-      - git-shallow-clone/checkout_advanced:
+      - checkout_advanced:
           clone_options: '--depth 1 --verbose'
       - attach_workspace:
           at: .
@@ -435,7 +520,7 @@ jobs:
           destination: playwright
 
 workflows:
-  test:
+  ci:
     when:
       and:
         - equal: [ api, << pipeline.trigger_source >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ parameters:
   workflow:
     description: Which workflow to run
     type: enum
-    enum: ['tests', 'daily-tests']
-    default: 'tests'
+    enum: ['ci', 'pr', 'merged', 'daily']
+    default: 'ci'
 
 executors:
   sb_node_16_classic:
@@ -313,11 +313,7 @@ jobs:
     parameters:
       parallelism:
         type: integer
-        default: 9
-      cadence:
-        type: enum
-        enum: [ "ci", "daily", "weekly" ]
-        default: "ci"
+        default: 2
     executor:
       class: medium
       name: sb_node_16_browsers
@@ -329,7 +325,7 @@ jobs:
           at: .
       - run:
           name: Creating Sandboxes
-          command: yarn task --task sandbox --template $(yarn get-template << parameters.cadence >> create) --no-link --start-from=never --junit
+          command: yarn task --task sandbox --template $(yarn get-template << pipeline.parameters.workflow >> create) --no-link --start-from=never --junit
       - persist_to_workspace:
           root: .
           paths:
@@ -340,11 +336,7 @@ jobs:
     parameters:
       parallelism:
         type: integer
-        default: 9
-      cadence:
-        type: enum
-        enum: [ "ci", "daily", "weekly" ]
-        default: "ci"
+        default: 2
     executor:
       class: medium
       name: sb_node_16_browsers
@@ -356,18 +348,14 @@ jobs:
           at: .
       - run:
           name: Smoke Testing Sandboxes
-          command: yarn task --task smoke-test --template $(yarn get-template << parameters.cadence >> smoke-test) --no-link --start-from=never --junit
+          command: yarn task --task smoke-test --template $(yarn get-template << pipeline.parameters.workflow >> smoke-test) --no-link --start-from=never --junit
       - store_test_results:
           path: test-results
   build-sandboxes:
     parameters:
       parallelism:
         type: integer
-        default: 9
-      cadence:
-        type: enum
-        enum: [ "ci", "daily", "weekly" ]
-        default: "ci"
+        default: 2
     executor:
       class: medium+
       name: sb_node_16_browsers
@@ -379,7 +367,7 @@ jobs:
           at: .
       - run:
           name: Building Sandboxes
-          command: yarn task --task build --template $(yarn get-template << parameters.cadence >> build) --no-link --start-from=never --junit
+          command: yarn task --task build --template $(yarn get-template << pipeline.parameters.workflow >> build) --no-link --start-from=never --junit
       - store_test_results:
           path: test-results
       - persist_to_workspace:
@@ -390,11 +378,7 @@ jobs:
     parameters:
       parallelism:
         type: integer
-        default: 9
-      cadence:
-        type: enum
-        enum: [ "ci", "daily", "weekly" ]
-        default: "ci"
+        default: 2
     executor:
       class: medium
       name: sb_playwright
@@ -406,18 +390,14 @@ jobs:
           at: .
       - run:
           name: Running Test Runner
-          command: yarn task --task test-runner --template $(yarn get-template << parameters.cadence >> test-runner) --no-link --start-from=never --junit
+          command: yarn task --task test-runner --template $(yarn get-template << pipeline.parameters.workflow >> test-runner) --no-link --start-from=never --junit
       - store_test_results:
           path: test-results
   chromatic-sandboxes:
     parameters:
       parallelism:
         type: integer
-        default: 9
-      cadence:
-        type: enum
-        enum: ["ci", "daily", "weekly"]
-        default: "ci"
+        default: 2
     executor:
       class: medium
       name: sb_node_16_browsers
@@ -428,18 +408,14 @@ jobs:
           at: .
       - run:
           name: Running Chromatic
-          command: yarn task --task chromatic --template $(yarn get-template << parameters.cadence >> chromatic) --no-link --start-from=never --junit
+          command: yarn task --task chromatic --template $(yarn get-template << pipeline.parameters.workflow >> chromatic) --no-link --start-from=never --junit
       - store_test_results:
           path: test-results
   e2e-sandboxes:
     parameters:
       parallelism:
         type: integer
-        default: 9
-      cadence:
-        type: enum
-        enum: ["ci", "daily", "weekly"]
-        default: "ci"
+        default: 2
     executor:
       class: medium
       name: sb_playwright
@@ -451,7 +427,7 @@ jobs:
           at: .
       - run:
           name: Running E2E Tests
-          command: yarn task --task e2e-tests --template $(yarn get-template << parameters.cadence >> e2e-tests) --no-link --start-from=never --junit
+          command: yarn task --task e2e-tests --template $(yarn get-template << pipeline.parameters.workflow >> e2e-tests) --no-link --start-from=never --junit
       - store_test_results:
           path: test-results
       - store_artifacts: # this is where playwright puts more complex stuff
@@ -459,42 +435,43 @@ jobs:
           destination: playwright
 
 workflows:
-  daily-tests:
+  test:
     when:
-      equal: [ daily-tests, << pipeline.parameters.workflow >> ]
+      and:
+        - equal: [ api, << pipeline.trigger_source >> ]
+        - equal:  [ ci, << pipeline.parameters.workflow >> ]
     jobs:
       - build
-      - create-sandboxes:
-          parallelism: 24
-          cadence: "daily"
+      - lint:
           requires:
             - build
-      # - smoke-test-sandboxes: # disabled for now
-      #     requires:
-      #       - create-sandboxes
+      - check:
+          requires:
+            - build
+      - unit-tests:
+          requires:
+            - build
+      - script-unit-tests:
+          requires:
+            - build
+      - create-sandboxes:
+          requires:
+            - build
       - build-sandboxes:
-          parallelism: 24
-          cadence: "daily"
           requires:
             - create-sandboxes
       - test-runner-sandboxes:
-          parallelism: 24
-          cadence: "daily"
           requires:
             - build-sandboxes
       - chromatic-sandboxes:
-          parallelism: 24
-          cadence: "daily"
           requires:
             - build-sandboxes
       - e2e-sandboxes:
-          parallelism: 24
-          cadence: "daily"
           requires:
             - build-sandboxes
-  test:
+  pr:
     when:
-      equal: [ tests, << pipeline.parameters.workflow >> ]
+      equal: [ pr, << pipeline.parameters.workflow >> ]
     jobs:
       - build
       - lint:
@@ -523,20 +500,106 @@ workflows:
             - build
       ## new workflow
       - create-sandboxes:
+          parallelism: 9
           requires:
             - build
       # - smoke-test-sandboxes: # disabled for now
       #     requires:
       #       - create-sandboxes
       - build-sandboxes:
+          parallelism: 9
           requires:
             - create-sandboxes
       - test-runner-sandboxes:
+          parallelism: 9
           requires:
             - build-sandboxes
       - chromatic-sandboxes:
+          parallelism: 9
           requires:
             - build-sandboxes
       - e2e-sandboxes:
+          parallelism: 9
+          requires:
+            - build-sandboxes
+  merged:
+    when:
+      equal: [ merged, << pipeline.parameters.workflow >> ]
+    jobs:
+      - build
+      - lint:
+          requires:
+            - build
+      - check:
+          requires:
+            - build
+      - unit-tests:
+          requires:
+            - build
+      - script-unit-tests:
+          requires:
+            - build
+      - chromatic-internal-storybooks:
+          requires:
+            - build
+      - coverage:
+          requires:
+            - unit-tests
+      - cra-bench:
+          requires:
+            - build
+      - react-vite-bench:
+          requires:
+            - build
+      ## new workflow
+      - create-sandboxes:
+          parallelism: 14
+          requires:
+            - build
+      # - smoke-test-sandboxes: # disabled for now
+      #     requires:
+      #       - create-sandboxes
+      - build-sandboxes:
+          parallelism: 14
+          requires:
+            - create-sandboxes
+      - test-runner-sandboxes:
+          parallelism: 14
+          requires:
+            - build-sandboxes
+      - chromatic-sandboxes:
+          parallelism: 14
+          requires:
+            - build-sandboxes
+      - e2e-sandboxes:
+          parallelism: 14
+          requires:
+            - build-sandboxes
+  daily:
+    when:
+      equal: [ daily, << pipeline.parameters.workflow >> ]
+    jobs:
+      - build
+      - create-sandboxes:
+          parallelism: 24
+          requires:
+            - build
+      # - smoke-test-sandboxes: # disabled for now
+      #     requires:
+      #       - create-sandboxes
+      - build-sandboxes:
+          parallelism: 24
+          requires:
+            - create-sandboxes
+      - test-runner-sandboxes:
+          parallelism: 24
+          requires:
+            - build-sandboxes
+      - chromatic-sandboxes:
+          parallelism: 24
+          requires:
+            - build-sandboxes
+      - e2e-sandboxes:
+          parallelism: 24
           requires:
             - build-sandboxes

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -1,21 +1,101 @@
 name: Trigger CircleCI workflow
 
 on:
-  pull_request:
-    types: [labeled]
+  # Use pull_request_target, as we don't need to check out the actual code of the fork in this script.
+  # And this is the only way to trigger the Circle CI API on forks as well.
+  pull_request_target:
+    types: [opened, synchronize, labeled, unlabeled, reopened, converted_to_draft, ready_for_review]
+  push:
+    branches:
+      - next
 
 jobs:
-  trigger:
-    if: github.event.label.name == 'run e2e extended test suite' && github.event.pull_request.head.repo.fork == false
-    name: Run workflow with all e2e tests
+  get-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Make request to CircleCI
+      - id: get-branch
+        run: |
+          if  [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+            export BRANCH=pull/${{ github.event.pull_request.number }}/head
+            elif [ "${{ github.event_name }}" = "push" ]; then
+            export BRANCH=${{ github.ref_name }}
+            else
+            export BRANCH=${{ github.event.pull_request.head.ref }}
+          fi
+          echo "$BRANCH"
+          echo "branch=$BRANCH" >> $GITHUB_ENV
+    outputs:
+      branch: ${{ env.branch }}
+
+  trigger-ci-tests:
+    runs-on: ubuntu-latest
+    needs: get-branch
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == true && !contains(github.event.pull_request.labels.*.name, 'ci:pr') && !contains(github.event.pull_request.labels.*.name, 'ci:merged') && !contains(github.event.pull_request.labels.*.name, 'ci:daily')
+    steps:
+      - name: Trigger draft PR tests
         run: >
-          curl --request POST
-          --url https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline
-          --header 'Circle-Token: '"$CIRCLE_CI_TOKEN"' '
-          --header 'content-type: application/json'
-          --data '{"branch":"${{ github.event.pull_request.head.ref }}"}'
+          curl -X POST --location "https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline" \
+            -H "Content-Type: application/json" \
+            -H "Circle-Token: $CIRCLE_CI_TOKEN" \
+            -d '{
+                  "branch": "${{ needs.get-branch.outputs.branch }}",
+                  "parameters": {
+                    "workflow": "ci"
+                  }
+                }'
+        env:
+          CIRCLE_CI_TOKEN: ${{ secrets.CIRCLE_CI_TOKEN }}
+  trigger-pr-tests:
+    runs-on: ubuntu-latest
+    needs: get-branch
+    if: github.event_name == 'pull_request_target' && ((github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ci:pr')) && !contains(github.event.pull_request.labels.*.name, 'ci:merged') && !contains(github.event.pull_request.labels.*.name, 'ci:daily'))
+    steps:
+      - name: Trigger PR tests
+        run: >
+          curl -X POST --location "https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline" \
+            -H "Content-Type: application/json" \
+            -H "Circle-Token: $CIRCLE_CI_TOKEN" \
+            -d '{
+                  "branch": "${{ needs.get-branch.outputs.branch }}",
+                  "parameters": {
+                    "workflow": "pr"
+                  }
+                }'
+        env:
+          CIRCLE_CI_TOKEN: ${{ secrets.CIRCLE_CI_TOKEN }}
+  trigger-merged-tests:
+    runs-on: ubuntu-latest
+    needs: get-branch
+    if: github.event_name == 'push' || (contains(github.event.pull_request.labels.*.name, 'ci:merged') && !contains(github.event.pull_request.labels.*.name, 'ci:daily'))
+    steps:
+      - name: Trigger merged tests
+        run: >
+          curl -X POST --location "https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline" \
+            -H "Content-Type: application/json" \
+            -H "Circle-Token: $CIRCLE_CI_TOKEN" \
+            -d '{
+                  "branch": "${{ needs.get-branch.outputs.branch }}",
+                  "parameters": {
+                    "workflow": "merged"
+                  }
+                }'
+        env:
+          CIRCLE_CI_TOKEN: ${{ secrets.CIRCLE_CI_TOKEN }}
+  trigger-daily-tests:
+    runs-on: ubuntu-latest
+    needs: get-branch
+    if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:daily')
+    steps:
+      - name: Trigger the daily tests
+        run: >
+          curl -X POST --location "https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline" \
+            -H "Content-Type: application/json" \
+            -H "Circle-Token: $CIRCLE_CI_TOKEN" \
+            -d '{
+                  "branch": "${{ needs.get-branch.outputs.branch }}",
+                  "parameters": {
+                    "workflow": "daily"
+                  }
+                }'
         env:
           CIRCLE_CI_TOKEN: ${{ secrets.CIRCLE_CI_TOKEN }}

--- a/code/lib/cli/src/repro-next.ts
+++ b/code/lib/cli/src/repro-next.ts
@@ -6,7 +6,7 @@ import { dedent } from 'ts-dedent';
 import degit from 'degit';
 
 import { existsSync } from 'fs-extra';
-import TEMPLATES from './repro-templates';
+import { allTemplates as TEMPLATES } from './repro-templates';
 
 const logger = console;
 

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -1,8 +1,7 @@
-const craTemplates = {
+export const allTemplates = {
   'cra/default-js': {
     name: 'Create React App (Javascript)',
     script: 'npx create-react-app .',
-    cadence: ['daily', 'weekly'],
     expected: {
       // TODO: change this to @storybook/cra once that package is created
       framework: '@storybook/react-webpack5',
@@ -13,7 +12,6 @@ const craTemplates = {
   'cra/default-ts': {
     name: 'Create React App (Typescript)',
     script: 'npx create-react-app . --template typescript',
-    cadence: ['ci', 'daily', 'weekly'],
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
     expected: {
@@ -23,13 +21,9 @@ const craTemplates = {
       builder: '@storybook/builder-webpack5',
     },
   },
-};
-
-const nextjsTemplates = {
   'nextjs/default-js': {
     name: 'Next.js (JavaScript)',
     script: 'npx create-next-app {{beforeDir}}',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',
@@ -39,20 +33,15 @@ const nextjsTemplates = {
   'nextjs/default-ts': {
     name: 'Next.js (TypeScript)',
     script: 'npx create-next-app {{beforeDir}} --typescript',
-    cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',
       builder: '@storybook/builder-webpack5',
     },
   },
-};
-
-const reactViteTemplates = {
   'react-vite/default-js': {
     name: 'React Vite (JS)',
     script: 'yarn create vite . --template react',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/react-vite',
       renderer: '@storybook/react',
@@ -62,20 +51,15 @@ const reactViteTemplates = {
   'react-vite/default-ts': {
     name: 'React Vite (TS)',
     script: 'yarn create vite . --template react-ts',
-    cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/react-vite',
       renderer: '@storybook/react',
       builder: '@storybook/builder-vite',
     },
   },
-};
-
-const reactWebpackTemplates = {
   'react-webpack/18-ts': {
     name: 'React Webpack5 (TS)',
     script: 'yarn create webpack5-react .',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/react-webpack5',
       renderer: '@storybook/react',
@@ -85,20 +69,15 @@ const reactWebpackTemplates = {
   'react-webpack/17-ts': {
     name: 'React Webpack5 (TS)',
     script: 'yarn create webpack5-react . --version-react="17" --version-react-dom="17"',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/react-webpack5',
       renderer: '@storybook/react',
       builder: '@storybook/builder-webpack5',
     },
   },
-};
-
-const vue3ViteTemplates = {
   'vue3-vite/default-js': {
     name: 'Vue3 Vite (JS)',
     script: 'yarn create vite . --template vue',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/vue3-vite',
       renderer: '@storybook/vue3',
@@ -108,16 +87,12 @@ const vue3ViteTemplates = {
   'vue3-vite/default-ts': {
     name: 'Vue3 Vite (TS)',
     script: 'yarn create vite . --template vue-ts',
-    cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/vue3-vite',
       renderer: '@storybook/vue3',
       builder: '@storybook/builder-vite',
     },
   },
-};
-
-const vue2ViteTemplates = {
   'vue2-vite/2.7-js': {
     name: 'Vue2 Vite (vue 2.7 JS)',
     // TODO: convert this to an `npm create` script, use that instead.
@@ -125,7 +100,6 @@ const vue2ViteTemplates = {
     // preferring community bootstrap scripts / generators instead.
     script:
       'yarn create vite . --template vanilla && yarn add --dev @vitejs/plugin-vue2 vue-template-compiler vue@2 && echo "import vue2 from \'@vitejs/plugin-vue2\';\n\nexport default {\n\tplugins: [vue2()]\n};" > vite.config.js',
-    cadence: ['daily', 'weekly'],
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
     expected: {
@@ -134,26 +108,18 @@ const vue2ViteTemplates = {
       builder: '@storybook/builder-vite',
     },
   },
-};
-
-const htmlWebpackTemplates = {
   'html-webpack/default': {
     name: 'HTML Webpack5',
     script: 'yarn create webpack5-html .',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/html-webpack5',
       renderer: '@storybook/html',
       builder: '@storybook/builder-webpack5',
     },
   },
-};
-
-const svelteViteTemplates = {
   'svelte-vite/default-js': {
     name: 'Svelte Vite (JS)',
     script: 'yarn create vite . --template svelte',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/svelte-vite',
       renderer: '@storybook/svelte',
@@ -163,7 +129,6 @@ const svelteViteTemplates = {
   'svelte-vite/default-ts': {
     name: 'Svelte Vite (TS)',
     script: 'yarn create vite . --template svelte-ts',
-    cadence: ['ci', 'daily', 'weekly'],
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
     expected: {
@@ -172,14 +137,10 @@ const svelteViteTemplates = {
       builder: '@storybook/builder-vite',
     },
   },
-};
-
-const angularCliTemplates = {
   'angular-cli/default-ts': {
     name: 'Angular CLI (latest)',
     script:
       'npx -p @angular/cli ng new angular-latest --directory . --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
-    cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/angular',
       renderer: '@storybook/angular',
@@ -190,21 +151,16 @@ const angularCliTemplates = {
     name: 'Angular CLI (Version 13)',
     script:
       'npx -p @angular/cli@13 ng new angular-v13 --directory . --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/angular',
       renderer: '@storybook/angular',
       builder: '@storybook/builder-webpack5',
     },
   },
-};
-
-const svelteKitTemplates = {
   'svelte-kit/skeleton-js': {
     name: 'Svelte Kit (JS)',
     script:
       'yarn create svelte-with-args --name=svelte-kit/skeleton-js --directory=. --template=skeleton --types=null --no-prettier --no-eslint --no-playwright',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/svelte-vite',
       renderer: '@storybook/svelte',
@@ -215,20 +171,15 @@ const svelteKitTemplates = {
     name: 'Svelte Kit (TS)',
     script:
       'yarn create svelte-with-args --name=svelte-kit/skeleton-ts --directory=. --template=skeleton --types=typescript --no-prettier --no-eslint --no-playwright',
-    cadence: ['ci', 'daily', 'weekly'],
     expected: {
       framework: '@storybook/svelte-vite',
       renderer: '@storybook/svelte',
       builder: '@storybook/builder-vite',
     },
   },
-};
-
-const litViteTemplates = {
   'lit-vite/default-js': {
     name: 'Lit Vite (JS)',
     script: 'yarn create vite . --template lit',
-    cadence: ['daily', 'weekly'] as any,
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
     expected: {
@@ -240,7 +191,6 @@ const litViteTemplates = {
   'lit-vite/default-ts': {
     name: 'Lit Vite (TS)',
     script: 'yarn create vite . --template lit-ts',
-    cadence: ['ci', 'daily', 'weekly'] as any,
     // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test'],
     expected: {
@@ -249,13 +199,9 @@ const litViteTemplates = {
       builder: '@storybook/builder-vite',
     },
   },
-};
-
-const vueCliTemplates = {
   'vue-cli/default-js': {
     name: 'Vue-CLI (Default JS)',
     script: 'npx -p @vue/cli vue create . --default --packageManager=yarn --force --merge',
-    cadence: ['daily', 'weekly'],
     skipTasks: [
       // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
       'smoke-test',
@@ -270,7 +216,6 @@ const vueCliTemplates = {
     name: 'Vue-CLI (Vue2 JS)',
     script:
       'npx -p @vue/cli vue create . --default --packageManager=yarn --force --merge --preset="Default (Vue 2)"',
-    cadence: ['ci', 'daily', 'weekly'],
     skipTasks: [
       // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
       'smoke-test',
@@ -281,13 +226,9 @@ const vueCliTemplates = {
       builder: '@storybook/builder-webpack5',
     },
   },
-};
-
-const preactWebpackTemplates = {
   'preact-webpack5/default-js': {
     name: 'Preact CLI (Default JS)',
     script: 'npx preact-cli create default {{beforeDir}} --name preact-app --yarn --no-install',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/preact-webpack5',
       renderer: '@storybook/preact',
@@ -297,7 +238,6 @@ const preactWebpackTemplates = {
   'preact-webpack5/default-ts': {
     name: 'Preact CLI (Default TS)',
     script: 'npx preact-cli create typescript {{beforeDir}} --name preact-app --yarn --no-install',
-    cadence: ['daily', 'weekly'],
     expected: {
       framework: '@storybook/preact-webpack5',
       renderer: '@storybook/preact',
@@ -306,20 +246,39 @@ const preactWebpackTemplates = {
   },
 };
 
-const reproTemplates = {
-  ...craTemplates,
-  ...reactViteTemplates,
-  ...reactWebpackTemplates,
-  ...vue2ViteTemplates,
-  ...vue3ViteTemplates,
-  ...svelteViteTemplates,
-  ...svelteKitTemplates,
-  ...angularCliTemplates,
-  ...litViteTemplates,
-  ...vueCliTemplates,
-  ...htmlWebpackTemplates,
-  ...preactWebpackTemplates,
-  ...nextjsTemplates,
-};
+type TemplateKey = keyof typeof allTemplates;
 
-export default reproTemplates;
+export const ci: TemplateKey[] = ['cra/default-ts', 'react-vite/default-ts'];
+export const pr: TemplateKey[] = [
+  ...ci,
+  'angular-cli/default-ts',
+  'vue3-vite/default-ts',
+  'vue-cli/vue2-default-js',
+  'lit-vite/default-ts',
+  'svelte-vite/default-ts',
+  'svelte-kit/skeleton-ts',
+  'nextjs/default-ts',
+];
+export const merged: TemplateKey[] = [
+  ...pr,
+  'react-webpack/18-ts',
+  'react-webpack/17-ts',
+  'angular-cli/13-ts',
+  'preact-webpack5/default-ts',
+  'html-webpack/default',
+];
+export const daily: TemplateKey[] = [
+  ...merged,
+  'cra/default-js',
+  'react-vite/default-js',
+  'vue3-vite/default-js',
+  'vue2-vite/2.7-js',
+  'vue-cli/default-js',
+  'lit-vite/default-js',
+  'svelte-kit/skeleton-js',
+  'svelte-vite/default-js',
+  'nextjs/default-js',
+  'preact-webpack5/default-js',
+];
+
+export const templatesByCadence = { ci, pr, merged, daily };

--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -9,7 +9,7 @@ import { program } from 'commander';
 import type { AbortController } from 'node-abort-controller';
 import { directory } from 'tempy';
 
-import reproTemplates from '../../code/lib/cli/src/repro-templates';
+import { allTemplates as reproTemplates } from '../../code/lib/cli/src/repro-templates';
 import storybookVersions from '../../code/lib/cli/src/versions';
 import { JsPackageManagerFactory } from '../../code/lib/cli/src/js-package-manager/JsPackageManagerFactory';
 

--- a/scripts/next-repro-generators/utils/template.ts
+++ b/scripts/next-repro-generators/utils/template.ts
@@ -2,7 +2,7 @@ import { render } from 'ejs';
 import { readFile } from 'fs-extra';
 import { format } from 'prettier';
 import { GeneratorConfig } from './types';
-import reproTemplates from '../../../code/lib/cli/src/repro-templates';
+import { allTemplates as reproTemplates } from '../../../code/lib/cli/src/repro-templates';
 
 export async function renderTemplate(templatePath: string, templateData: Record<string, any>) {
   const template = await readFile(templatePath, 'utf8');

--- a/scripts/next-repro-generators/utils/types.ts
+++ b/scripts/next-repro-generators/utils/types.ts
@@ -1,7 +1,6 @@
 export type GeneratorConfig = {
   name: string;
   script: string;
-  cadence: ('ci' | 'daily' | 'weekly')[];
   expected: {
     framework: string;
     renderer: string;

--- a/scripts/task.ts
+++ b/scripts/task.ts
@@ -22,7 +22,7 @@ import { testRunner } from './tasks/test-runner';
 import { chromatic } from './tasks/chromatic';
 import { e2eTests } from './tasks/e2e-tests';
 
-import TEMPLATES from '../code/lib/cli/src/repro-templates';
+import { allTemplates as TEMPLATES } from '../code/lib/cli/src/repro-templates';
 
 const sandboxDir = resolve(__dirname, '../sandbox');
 const codeDir = resolve(__dirname, '../code');


### PR DESCRIPTION
## What I did

- Made a new cadence: ci, pr, merged, daily
- Trigger those cadences from github actions
- Labels can be used to override the default behavior

## How to test

- Try adding labels to this PR, and see it being triggered
- Move the PR to draft, and back to ready for review
- Trigger workflows from the circle ci API or web UI by passing workflow is `ci`, `pr`, `merged` or `daily`
