### PR TITLE
Fix: addon panel content is invisible for any addon listed after the interactions panel

### DIFF
--- a/code/ui/components/src/addon-panel/addon-panel.tsx
+++ b/code/ui/components/src/addon-panel/addon-panel.tsx
@@ -25,10 +25,7 @@ export interface AddonPanelProps {
 
 export const AddonPanel = ({ active, children }: AddonPanelProps) => {
   return (
-    // the transform is to prevent a bug where the content would be invisible
     // the hidden attribute is an valid html element that's both accessible and works to visually hide content
-    <div hidden={!active} style={{ transform: 'translateX(0px)' }}>
-      {useUpdate(active, children)}
-    </div>
+    <div hidden={!active}>{useUpdate(active, children)}</div>
   );
 };


### PR DESCRIPTION
## Issue
Addon-panel content is invisible if the addon is listed after the Interactions panel. The addon content is in the DOM but hidden due to a style error. See: https://github.com/storybookjs/storybook/issues/17818

## What I did
I removed the `addon-panel` transform style. This code was originally added as a hack to "prevent a bug where the content would be invisible." The original PR is here: https://github.com/storybookjs/storybook/pull/6759

I couldn't find any documentation about said bug, and the fix is over 3 years old. @ndelangen do you recall how to recreate that bug? Is it still an issue in modern browsers or with vite-builder? In my testing this transform fix has now become the cause. Removing the style override is the simplest way to resolve the issue.

## How to test

- [N] Is this testable with Jest or Chromatic screenshots?
- [N] Does this need a new example in the kitchen sink apps?
- [N] Does this need an update to the documentation?

To test, simply add any custom addon to Storybook and list is after the Interactions panel. See: https://github.com/storybookjs/storybook/issues/17818

Addon doesn't work:

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/1676931/200412341-9caed384-abca-489d-957d-c430dd02f17d.png">

Addon works when changing the order:

<img width="1133" alt="image" src="https://user-images.githubusercontent.com/1676931/200414760-63584b58-77f7-4f00-b31d-2a0333816a2d.png">


Addon works when disabling transform:

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/1676931/200412518-156f0397-f28e-450d-b069-08656cf4155f.png">

## Alternatives

If we need to keep the translate hack, then we should consider adding `height: 100%` to the AddonPanel div style to ensure addons using relative heights will render. This would also be a sufficient fix.

Height fix:
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/1676931/200413258-3cf8f1ad-fae2-4b90-b221-a42fdc6d6f2f.png">


<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
