### PR TITLE
Maintenance: provide expected failure metadata in junit reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 *.DS_Store
 .cache
 junit.xml
+test-results
 /repros
 /sandbox
 .verdaccio-cache

--- a/code/playwright.config.ts
+++ b/code/playwright.config.ts
@@ -30,7 +30,17 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: process.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME
+    ? [
+        [
+          'junit',
+          {
+            embedAnnotationsAsProperties: true,
+            outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME,
+          },
+        ],
+      ]
+    : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/scripts/task.ts
+++ b/scripts/task.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import { AbortController } from 'node-abort-controller';
+import type { AbortController } from 'node-abort-controller';
 import { getJunitXml } from 'junit-xml';
 import { outputFile, existsSync, readFile } from 'fs-extra';
 import { join, resolve } from 'path';
@@ -7,7 +7,8 @@ import { prompt } from 'prompts';
 import boxen from 'boxen';
 import { dedent } from 'ts-dedent';
 
-import { createOptions, getCommand, getOptionsOrPrompt, OptionValues } from './utils/options';
+import type { OptionValues } from './utils/options';
+import { createOptions, getCommand, getOptionsOrPrompt } from './utils/options';
 import { install } from './tasks/install';
 import { compile } from './tasks/compile';
 import { check } from './tasks/check';
@@ -278,7 +279,10 @@ async function runTask(task: Task, details: TemplateDetails, optionValues: Passe
 
     return controller;
   } catch (err) {
-    if (junitFilename) await writeJunitXml(getTaskKey(task), details.key, startTime, err);
+    // If there's a non-test related error (junit report has not been reported already), we report the general failure in a junit report
+    if (junitFilename && !existsSync(junitFilename)) {
+      await writeJunitXml(getTaskKey(task), details.key, startTime, err);
+    }
 
     throw err;
   } finally {

--- a/scripts/tasks/e2e-tests.ts
+++ b/scripts/tasks/e2e-tests.ts
@@ -10,10 +10,8 @@ export const e2eTests: Task = {
     return false;
   },
   async run({ codeDir, junitFilename, template }, { dryRun, debug }) {
-    const reporter = process.env.CI ? 'junit' : 'html';
-
     await exec(
-      `yarn playwright test --reporter=${reporter}`,
+      `yarn playwright test`,
       {
         env: {
           STORYBOOK_URL: `http://localhost:${PORT}`,


### PR DESCRIPTION
Issue: N/A

## What I did

- Fixed a bug where junit.xml files were getting overwritten when they shouldn't
- The e2e tests will now attach metadata in case we use `test.fail` to Junit reports, for expected failures:

```xml
<!-- Example with an expected failure -->
<testsuite name="addon-interactions.spec.ts" timestamp="1667901141467" hostname="" tests="1" failures="0" skipped="0" time="6.584" errors="0">
  <testcase name="addon-interactions should have interactions" classname="[chromium] › addon-interactions.spec.ts › addon-interactions › should have interactions" time="6.584">
    <properties>
      <property name="fail" value="React Vite (JS) is failing, however it is expected">
      </property>
    </properties>
  </testcase>
</testsuite>

<!-- Example with no expected failure -->
<testsuite name="addon-viewport.spec.ts" timestamp="1667901141467" hostname="" tests="1" failures="0" skipped="0" time="1.724" errors="0">
  <testcase name="addon-viewport should have viewport button in the toolbar" classname="[chromium] › addon-viewport.spec.ts › addon-viewport › should have viewport button in the toolbar" time="1.724">
  </testcase>
</testsuite>
```

This way, if we have an e2e test that we know is failing, but we don't want the CI to be red all the time, however we want to know that failure so we can process it somewhere else, we can.

Here's an example of `test.fail` usage:

```ts
test('should have interactions', async ({ page }) => {
    test.fail(
      // eslint-disable-next-line jest/valid-title
      /^(Lit)/i.test(`${templateName}`),
      `${templateName} is failing, however it is expected`
    );
});

```


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
