### PR TITLE
Maintenance: improve error feedback when tasks fail in CI

### DIFF
--- a/scripts/task.ts
+++ b/scripts/task.ts
@@ -183,7 +183,7 @@ async function writeJunitXml(
   let errorData = {};
   if (err) {
     // we want to distinguish whether the error comes from the tests we are running or from arbitrary code
-    errorData = systemError ? { systemErr: [err.stack] } : { errors: [err] };
+    errorData = systemError ? { errors: [{ message: err.stack }] } : { errors: [err] };
   }
 
   const name = `${taskKey} - ${templateKey}`;

--- a/scripts/tasks/build.ts
+++ b/scripts/tasks/build.ts
@@ -9,6 +9,7 @@ export const build: Task = {
     return pathExists(builtSandboxDir);
   },
   async run({ sandboxDir }, { dryRun, debug }) {
+    throw new Error('Problems!');
     return exec(`yarn build-storybook --quiet`, { cwd: sandboxDir }, { dryRun, debug });
   },
 };

--- a/scripts/tasks/build.ts
+++ b/scripts/tasks/build.ts
@@ -9,7 +9,6 @@ export const build: Task = {
     return pathExists(builtSandboxDir);
   },
   async run({ sandboxDir }, { dryRun, debug }) {
-    throw new Error('Problems!');
     return exec(`yarn build-storybook --quiet`, { cwd: sandboxDir }, { dryRun, debug });
   },
 };


### PR DESCRIPTION
Issue: N/A

## What I did

Changed the output of JUnit.XML files when there is an arbitrary code error (not a failure coming from a test)

**From:**
```xml
<testsuites tests="1" errors="1" failures="0" skipped="0" name="e2e-tests - react-vite/default-js" time="0.001">
  <testsuite tests="1" errors="1" failures="0" skipped="0" name="e2e-tests - react-vite/default-js" time="0.001" timestamp="2022-11-09T08:48:00.915Z">
    <testcase name="e2e-tests - react-vite/default-js" classname="react-vite/default-js e2e-tests - react-vite/default-js" time="0.001" assertions="1">
      <error>iDoNotExist is not defined</error>
    </testcase>
  </testsuite>
</testsuites>
```

**To:**
```xml
<testsuites tests="1" errors="0" failures="0" skipped="0" name="e2e-tests - react-vite/default-js" time="0.001">
    <testsuite tests="1" errors="0" failures="0" skipped="0" name="e2e-tests - react-vite/default-js" time="0.001" timestamp="2022-11-09T08:17:43.019Z">
        <testcase name="e2e-tests - react-vite/default-js" classname="react-vite/default-js react-vite/default-js react-vite/default-js e2e-tests - react-vite/default-js" time="0.001" assertions="1">
            <error>
                ReferenceError: iDoNotExist is not defined
                    at Object.run (/Users/yannbraga/open-source/storybook/scripts/tasks/e2e-tests.ts:13:17)
                    at runTask (/Users/yannbraga/open-source/storybook/scripts/task.ts:277:35)
                    at run (/Users/yannbraga/open-source/storybook/scripts/task.ts:411:34)
                    at processTicksAndRejections (node:internal/process/task_queues:96:5)
            </error>
        </testcase>
    </testsuite>
</testsuites>
```

<img width="482" alt="image" src="https://user-images.githubusercontent.com/1671563/200802639-8a0500ef-2d7c-4efb-85c8-655ecf462702.png">


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
