### PR TITLE
NextJS: Fix import url on windows

### DIFF
--- a/code/frameworks/nextjs/src/config/webpack.ts
+++ b/code/frameworks/nextjs/src/config/webpack.ts
@@ -5,6 +5,7 @@ import { pathExists } from 'fs-extra';
 import type { NextConfig } from 'next';
 import dedent from 'ts-dedent';
 import { DefinePlugin } from 'webpack';
+import { pathToFileURL } from 'node:url';
 import { addScopedAlias } from '../utils';
 
 export const configureConfig = async ({
@@ -60,7 +61,7 @@ const resolveNextConfig = async ({
     );
   }
 
-  const nextConfigExport = await import(nextConfigFile);
+  const nextConfigExport = await import(pathToFileURL(nextConfigFile).href);
 
   const nextConfig =
     typeof nextConfigExport === 'function'


### PR DESCRIPTION
Issue: `@storybook/nextjs` package failed on windows with following error:
```output
ERR! Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

## What I did
Use the `file://` scheme using `pathToFileURL()` when dynamic import.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
