### PR TITLE
Chore: (Addon Interactions) Updates link to the correct location

### DIFF
--- a/addons/interactions/src/Panel.tsx
+++ b/addons/interactions/src/Panel.tsx
@@ -101,7 +101,7 @@ export const AddonPanelPure: React.FC<InteractionsPanelProps> = React.memo(
         <Placeholder>
           No interactions found
           <Link
-            href="https://github.com/storybookjs/storybook/blob/next/addons/interactions/README.md"
+            href="https://storybook.js.org/docs/react/writing-stories/play-function"
             target="_blank"
             withArrow
           >


### PR DESCRIPTION
With this small pull request, the link used in the interactions panel is updated to the correct place as with the recent changes in the monorepo the link would return a 404 instead. This is only happening on the stable version.

Addresses and closes #18957 and subsequent issues (#19171, #19527)


What was done:
- Updated the link in the `Interactions` panel to point at the right place.


@shilman when you're able check it out and let me know of any feedback you may have. Appreciate you taking a look at this.

