### PR TITLE
Vite: Fix preview annotation paths on Windows

### DIFF
--- a/code/lib/builder-vite/src/utils/process-preview-annotation.ts
+++ b/code/lib/builder-vite/src/utils/process-preview-annotation.ts
@@ -1,5 +1,6 @@
 import type { PreviewAnnotation } from '@storybook/types';
 import { resolve } from 'path';
+import slash from 'slash';
 
 /**
  * Preview annotations can take several forms, and vite needs them to be
@@ -21,7 +22,7 @@ export function processPreviewAnnotation(path: PreviewAnnotation | undefined) {
   }
   // resolve relative paths into absolute paths, but don't resolve "bare" imports
   if (path?.startsWith('./') || path?.startsWith('../')) {
-    return resolve(path);
+    return slash(resolve(path));
   }
   // This should not occur, since we use `.filter(Boolean)` prior to
   // calling this function, but this makes typescript happy
@@ -29,5 +30,5 @@ export function processPreviewAnnotation(path: PreviewAnnotation | undefined) {
     throw new Error('Could not determine path for previewAnnotation');
   }
 
-  return path;
+  return slash(path);
 }


### PR DESCRIPTION
issue: https://github.com/storybookjs/storybook/issues/19824

Not sure if it's related to https://discord.com/channels/486522875931656193/1040648399973781535

But I ran into this when trying to run the vite sandbox