### PR TITLE
Expose more CSF types in all renderers

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -871,13 +871,16 @@ In 6.x you could import the type `DecoratorFn`:
 
 ```ts
 import type { DecoratorFn } from '@storybook/react';
-// etc.
 ```
 
-This type is deprecated in 7.0, instead you can use the type `Decorator`:
+This type is deprecated in 7.0, instead you can use the type `Decorator`, which is now available for all renderers:
 
 ```ts
 import type { Decorator } from '@storybook/react';
+// or
+import type { Decorator } from '@storybook/vue';
+// or
+import type { Decorator } from '@storybook/svelte';
 // etc.
 ```
 
@@ -885,11 +888,12 @@ The type `Decorator` accepts a generic parameter `TArgs`. This can be used like 
 
 ```tsx
 import type { Decorator } from '@storybook/react';
+import { LocaleProvider } from './locale';
 
-const withTheme: Decorator<{ theme: 'light' | 'dark' }> = (Story, { args }) => (
-  <ThemeProvider theme={args.theme}>
+const withLocale: Decorator<{ locale: 'en' | 'es' }> = (Story, { args }) => (
+  <LocaleProvider lang={args.locale}>
     <Story />
-  </ThemeProvider>
+  </LocaleProvider>
 );
 ```
 
@@ -899,7 +903,7 @@ If you want to use `Decorator` in a backwards compatible way to `DecoratorFn`, y
 import type { Args, Decorator } from '@storybook/react';
 
 // Decorator<Args> behaves the same as DecoratorFn (without generic)
-const withTheme: Decorator<Args> = (Story, {args}) => // args has type { [name: string]: any }
+const withLocale: Decorator<Args> = (Story, { args }) => // args has type { [name: string]: any }
 ```
 
 ## From version 6.4.x to 6.5.0

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -898,7 +898,7 @@ If you want to use `Decorator` in a backwards compatible way to `DecoratorFn`, y
 ```tsx
 import type { Args, Decorator } from '@storybook/react';
 
-// same Decorator<Args> is the same as the old DecartorFn
+// Decorator<Args> behaves the same as DecoratorFn (without generic)
 const withTheme: Decorator<Args> = (Story, {args}) => // args has type { [name: string]: any }
 ```
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -43,8 +43,9 @@
   - [7.0 Deprecations](#70-deprecations)
     - [`Story` type deprecated](#story-type-deprecated)
     - [`ComponentStory`, `ComponentStoryObj`, `ComponentStoryFn` and `ComponentMeta` types are deprecated](#componentstory-componentstoryobj-componentstoryfn-and-componentmeta-types-are-deprecated)
-    - [Renamed `renderToDOM` to `renderToCanvas`](#renamed-rendertodom-to-rendertoroot)
+    - [Renamed `renderToDOM` to `renderToCanvas`](#renamed-rendertodom-to-rendertocanvas)
     - [Renamed `XFramework` to `XRenderer`](#renamed-xframework-to-xrenderer)
+    - [Renamed `DecoratorFn` to `Decorator`](#renamed-decoratorfn-to-decorator)
 - [From version 6.4.x to 6.5.0](#from-version-64x-to-650)
   - [Vue 3 upgrade](#vue-3-upgrade)
   - [React18 new root API](#react18-new-root-api)
@@ -862,6 +863,43 @@ import type { VueRenderer } from '@storybook/vue';
 import type { SvelteRenderer } from '@storybook/svelte';
 
 // etc.
+```
+
+#### Renamed `DecoratorFn` to `Decorator`
+
+In 6.x you could import the type `DecoratorFn`:
+
+```ts
+import type { DecoratorFn } from '@storybook/react';
+// etc.
+```
+
+This type is deprecated in 7.0, instead you can use the type `Decorator`:
+
+```ts
+import type { Decorator } from '@storybook/react';
+// etc.
+```
+
+The type `Decorator` accepts a generic parameter `TArgs`. This can be used like this:
+
+```tsx
+import type { Decorator } from '@storybook/react';
+
+const withTheme: Decorator<{ theme: 'light' | 'dark' }> = (Story, { args }) => (
+  <ThemeProvider theme={args.theme}>
+    <Story />
+  </ThemeProvider>
+);
+```
+
+If you want to use `Decorator` in a backwards compatible way to `DecoratorFn`, you can use:
+
+```tsx
+import type { Args, Decorator } from '@storybook/react';
+
+// same Decorator<Args> is the same as the old DecartorFn
+const withTheme: Decorator<Args> = (Story, {args}) => // args has type { [name: string]: any }
 ```
 
 ## From version 6.4.x to 6.5.0

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -79,7 +79,7 @@
     "@storybook/addons": "7.0.0-alpha.49",
     "@storybook/client-logger": "7.0.0-alpha.49",
     "@storybook/core-events": "7.0.0-alpha.49",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/router": "7.0.0-alpha.49",
     "@storybook/types": "7.0.0-alpha.49",
     "global": "^4.4.0",

--- a/code/addons/storyshots/storyshots-puppeteer/package.json
+++ b/code/addons/storyshots/storyshots-puppeteer/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@axe-core/puppeteer": "^4.2.0",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/node-logger": "7.0.0-alpha.49",
     "@storybook/types": "7.0.0-alpha.49",
     "@types/jest-image-snapshot": "^4.1.3",

--- a/code/frameworks/angular/src/client/public-types.ts
+++ b/code/frameworks/angular/src/client/public-types.ts
@@ -1,7 +1,18 @@
-import { AnnotatedStoryFn, Args, ComponentAnnotations, StoryAnnotations } from '@storybook/types';
+import {
+  AnnotatedStoryFn,
+  Args,
+  ComponentAnnotations,
+  DecoratorFunction,
+  LoaderFunction,
+  StoryAnnotations,
+  StoryContext as GenericStoryContext,
+  StrictArgs,
+} from '@storybook/types';
 import { AngularRenderer } from './types';
 
-export type { Args, ArgTypes } from '@storybook/types';
+export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
+export type { Parameters as AngularParameters } from './types';
+export type { AngularRenderer };
 
 /**
  * Metadata to configure the stories for a component.
@@ -34,3 +45,7 @@ export type StoryObj<TArgs = Args> = StoryAnnotations<AngularRenderer, TArgs>;
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
 export type Story<TArgs = Args> = StoryFn<TArgs>;
+
+export type Decorator<TArgs = StrictArgs> = DecoratorFunction<AngularRenderer, TArgs>;
+export type Loader<TArgs = StrictArgs> = LoaderFunction<AngularRenderer, TArgs>;
+export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<AngularRenderer, TArgs>;

--- a/code/lib/api/package.json
+++ b/code/lib/api/package.json
@@ -48,7 +48,7 @@
     "@storybook/channels": "7.0.0-alpha.49",
     "@storybook/client-logger": "7.0.0-alpha.49",
     "@storybook/core-events": "7.0.0-alpha.49",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/router": "7.0.0-alpha.49",
     "@storybook/theming": "7.0.0-alpha.49",
     "@storybook/types": "7.0.0-alpha.49",

--- a/code/lib/client-api/package.json
+++ b/code/lib/client-api/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@storybook/addons": "7.0.0-alpha.49",
     "@storybook/client-logger": "7.0.0-alpha.49",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/store": "7.0.0-alpha.49",
     "@storybook/types": "7.0.0-alpha.49",
     "@types/qs": "^6.9.5",

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@babel/types": "^7.12.11",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/csf-tools": "7.0.0-alpha.49",
     "@storybook/node-logger": "7.0.0-alpha.49",
     "@storybook/types": "7.0.0-alpha.49",

--- a/code/lib/core-client/package.json
+++ b/code/lib/core-client/package.json
@@ -42,7 +42,7 @@
     "@storybook/client-api": "7.0.0-alpha.49",
     "@storybook/client-logger": "7.0.0-alpha.49",
     "@storybook/core-events": "7.0.0-alpha.49",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/preview-web": "7.0.0-alpha.49",
     "@storybook/store": "7.0.0-alpha.49",
     "@storybook/types": "7.0.0-alpha.49",

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -39,7 +39,7 @@
     "@storybook/core-client": "7.0.0-alpha.49",
     "@storybook/core-common": "7.0.0-alpha.49",
     "@storybook/core-events": "7.0.0-alpha.49",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/csf-tools": "7.0.0-alpha.49",
     "@storybook/docs-mdx": "0.0.1-canary.12433cf.0",
     "@storybook/node-logger": "7.0.0-alpha.49",

--- a/code/lib/csf-tools/package.json
+++ b/code/lib/csf-tools/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/types": "^7.12.11",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/types": "7.0.0-alpha.49",
     "fs-extra": "^9.0.1",
     "ts-dedent": "^2.0.0"

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -43,7 +43,7 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/types": "7.0.0-alpha.49",
     "estraverse": "^5.2.0",
     "lodash": "^4.17.21",

--- a/code/lib/store/package.json
+++ b/code/lib/store/package.json
@@ -45,7 +45,7 @@
     "@storybook/addons": "7.0.0-alpha.49",
     "@storybook/client-logger": "7.0.0-alpha.49",
     "@storybook/core-events": "7.0.0-alpha.49",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/types": "7.0.0-alpha.49",
     "dequal": "^2.0.2",
     "global": "^4.4.0",

--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -47,7 +47,7 @@
     "file-system-cache": "^2.0.0"
   },
   "devDependencies": {
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@types/node": "^16.0.0",
     "synchronous-promise": "^2.0.15",
     "typescript": "~4.6.3"

--- a/code/lib/types/src/modules/csf.ts
+++ b/code/lib/types/src/modules/csf.ts
@@ -23,7 +23,7 @@ import type {
   LegacyStoryAnnotationsOrFn,
   LegacyStoryFn,
   LoaderFunction,
-  Parameters as ParametersBase,
+  Parameters,
   PartialStoryFn,
   PlayFunction,
   PlayFunctionContext,
@@ -51,6 +51,7 @@ import type {
   StoryIdentifier,
   StoryKind,
   StoryName,
+  StrictArgs,
   StrictArgTypes,
   StrictGlobalTypes,
   StrictInputType,
@@ -83,6 +84,7 @@ export type {
   LegacyStoryAnnotationsOrFn,
   LegacyStoryFn,
   LoaderFunction,
+  Parameters,
   PartialStoryFn,
   PlayFunction,
   PlayFunctionContext,
@@ -109,6 +111,7 @@ export type {
   StoryIdentifier,
   StoryKind,
   StoryName,
+  StrictArgs,
   StrictArgTypes,
   StrictGlobalTypes,
   StrictInputType,
@@ -135,13 +138,15 @@ export type ViewMode = ViewModeBase | 'story' | 'info' | 'settings' | string | u
 
 type Layout = 'centered' | 'fullscreen' | 'padded' | 'none';
 
-export interface Parameters extends ParametersBase {
-  fileName?: string;
+export interface StorybookParameters {
   options?: Addon_OptionsParameter;
   /** The layout property defines basic styles added to the preview body where the story is rendered. If you pass 'none', no styles are applied. */
   layout?: Layout;
-  docsOnly?: boolean;
-  [key: string]: any;
+}
+
+export interface StorybookInternalParameters extends StorybookParameters {
+  fileName?: string;
+  docsOnly?: true;
 }
 
 export type Path = string;

--- a/code/package.json
+++ b/code/package.json
@@ -184,7 +184,7 @@
     "@storybook/core-events": "workspace:*",
     "@storybook/core-server": "workspace:*",
     "@storybook/core-webpack": "workspace:*",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/csf-plugin": "workspace:*",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/docs-tools": "workspace:*",

--- a/code/renderers/html/src/public-types.ts
+++ b/code/renderers/html/src/public-types.ts
@@ -2,12 +2,16 @@ import type {
   AnnotatedStoryFn,
   Args,
   ComponentAnnotations,
+  DecoratorFunction,
+  LoaderFunction,
   StoryAnnotations,
+  StoryContext as GenericStoryContext,
+  StrictArgs,
 } from '@storybook/types';
-
 import type { HtmlRenderer } from './types';
 
-export type { Args, ArgTypes, Parameters } from '@storybook/types';
+export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
+export type { HtmlRenderer };
 
 /**
  * Metadata to configure the stories for a component.
@@ -40,3 +44,7 @@ export type StoryObj<TArgs = Args> = StoryAnnotations<HtmlRenderer, TArgs>;
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
 export type Story<TArgs = Args> = StoryFn<TArgs>;
+
+export type Decorator<TArgs = StrictArgs> = DecoratorFunction<HtmlRenderer, TArgs>;
+export type Loader<TArgs = StrictArgs> = LoaderFunction<HtmlRenderer, TArgs>;
+export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<HtmlRenderer, TArgs>;

--- a/code/renderers/preact/src/public-types.ts
+++ b/code/renderers/preact/src/public-types.ts
@@ -3,10 +3,15 @@ import type {
   Args,
   ComponentAnnotations,
   StoryAnnotations,
+  DecoratorFunction,
+  LoaderFunction,
+  StoryContext as GenericStoryContext,
+  StrictArgs,
 } from '@storybook/types';
 import type { PreactRenderer } from './types';
 
-export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/types';
+export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
+export type { PreactRenderer };
 
 /**
  * Metadata to configure the stories for a component.
@@ -39,3 +44,7 @@ export type StoryObj<TArgs = Args> = StoryAnnotations<PreactRenderer, TArgs>;
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
 export type Story<TArgs = Args> = StoryFn<TArgs>;
+
+export type Decorator<TArgs = StrictArgs> = DecoratorFunction<PreactRenderer, TArgs>;
+export type Loader<TArgs = StrictArgs> = LoaderFunction<PreactRenderer, TArgs>;
+export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<PreactRenderer, TArgs>;

--- a/code/renderers/react/src/public-api.tsx
+++ b/code/renderers/react/src/public-api.tsx
@@ -1,13 +1,8 @@
 /* eslint-disable prefer-destructuring */
-import type {
-  Addon_ClientStoryApi,
-  Addon_Loadable,
-  Args,
-  DecoratorFunction,
-} from '@storybook/types';
 import { start } from '@storybook/core-client';
+import type { Addon_ClientStoryApi, Addon_Loadable } from '@storybook/types';
 
-import { renderToCanvas, render } from './render';
+import { render, renderToCanvas } from './render';
 import type { ReactRenderer } from './types';
 
 interface ClientApi extends Addon_ClientStoryApi<ReactRenderer['storyResult']> {
@@ -28,5 +23,3 @@ export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
 export const configure: ClientApi['configure'] = (...args) => api.configure(FRAMEWORK, ...args);
 export const forceReRender: ClientApi['forceReRender'] = api.forceReRender;
 export const raw: ClientApi['raw'] = api.clientApi.raw;
-
-export type DecoratorFn<TArgs = Args> = DecoratorFunction<ReactRenderer, TArgs>;

--- a/code/renderers/react/src/public-types.test.tsx
+++ b/code/renderers/react/src/public-types.test.tsx
@@ -1,15 +1,14 @@
 import { describe, test } from '@jest/globals';
-import type { StoryAnnotations } from '@storybook/types';
 
 import { satisfies } from '@storybook/core-common';
+import type { StoryAnnotations } from '@storybook/types';
 import { expectTypeOf } from 'expect-type';
 import type { KeyboardEventHandler, ReactNode } from 'react';
 import React from 'react';
 
 import type { SetOptional } from 'type-fest';
 
-import type { DecoratorFn } from './public-api';
-import type { Meta, StoryObj } from './public-types';
+import type { Decorator, Meta, StoryObj } from './public-types';
 import type { ReactRenderer } from './types';
 
 type ReactStory<Args, RequiredArgs> = StoryAnnotations<ReactRenderer, Args, RequiredArgs>;
@@ -141,7 +140,7 @@ describe('Story args can be inferred', () => {
     expectTypeOf(Basic).toEqualTypeOf<Expected>();
   });
 
-  const withDecorator: DecoratorFn<{ decoratorArg: number }> = (Story, { args }) => (
+  const withDecorator: Decorator<{ decoratorArg: number }> = (Story, { args }) => (
     <>
       Decorator: {args.decoratorArg}
       <Story args={{ decoratorArg: 0 }} />
@@ -166,7 +165,7 @@ describe('Story args can be inferred', () => {
   test('Correct args are inferred when type is widened for multiple decorators', () => {
     type Props = ButtonProps & { decoratorArg: number; decoratorArg2: string };
 
-    const secondDecorator: DecoratorFn<{ decoratorArg2: string }> = (Story, { args }) => (
+    const secondDecorator: Decorator<{ decoratorArg2: string }> = (Story, { args }) => (
       <>
         Decorator: {args.decoratorArg2}
         <Story />

--- a/code/renderers/react/src/public-types.ts
+++ b/code/renderers/react/src/public-types.ts
@@ -4,15 +4,18 @@ import type {
   ArgsFromMeta,
   ArgsStoryFn,
   ComponentAnnotations,
+  DecoratorFunction,
+  LoaderFunction,
   StoryAnnotations,
+  StoryContext as GenericStoryContext,
+  StrictArgs,
 } from '@storybook/types';
-
 import type { ComponentProps, ComponentType, JSXElementConstructor } from 'react';
 import type { SetOptional, Simplify } from 'type-fest';
-
 import type { ReactRenderer } from './types';
 
-export { ReactRenderer };
+export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
+export type { ReactRenderer };
 
 type JSXElement = keyof JSX.IntrinsicElements | JSXElementConstructor<any>;
 
@@ -124,3 +127,11 @@ export type Story<TArgs = Args> = StoryFn<TArgs>;
  * ```
  */
 export type ComponentStory<T extends JSXElement> = ComponentStoryFn<T>;
+
+/**
+ * @deprecated Use Decorator instead.
+ */
+export type DecoratorFn<TArgs = Args> = DecoratorFunction<ReactRenderer, TArgs>;
+export type Decorator<TArgs = StrictArgs> = DecoratorFunction<ReactRenderer, TArgs>;
+export type Loader<TArgs = StrictArgs> = LoaderFunction<ReactRenderer, TArgs>;
+export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<ReactRenderer, TArgs>;

--- a/code/renderers/react/src/public-types.ts
+++ b/code/renderers/react/src/public-types.ts
@@ -131,7 +131,7 @@ export type ComponentStory<T extends JSXElement> = ComponentStoryFn<T>;
 /**
  * @deprecated Use Decorator instead.
  */
-export type DecoratorFn<TArgs = Args> = DecoratorFunction<ReactRenderer, TArgs>;
+export type DecoratorFn = DecoratorFunction<ReactRenderer>;
 export type Decorator<TArgs = StrictArgs> = DecoratorFunction<ReactRenderer, TArgs>;
 export type Loader<TArgs = StrictArgs> = LoaderFunction<ReactRenderer, TArgs>;
 export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<ReactRenderer, TArgs>;

--- a/code/renderers/server/src/public-types.ts
+++ b/code/renderers/server/src/public-types.ts
@@ -3,10 +3,14 @@ import type {
   Args,
   ComponentAnnotations,
   StoryAnnotations,
+  StoryContext as GenericStoryContext,
+  DecoratorFunction,
+  LoaderFunction,
+  StrictArgs,
 } from '@storybook/types';
 import type { ServerRenderer } from './types';
 
-export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/types';
+export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
 
 /**
  * Metadata to configure the stories for a component.
@@ -39,3 +43,8 @@ export type StoryObj<TArgs = Args> = StoryAnnotations<ServerRenderer, TArgs>;
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
 export type Story<TArgs = Args> = StoryFn<TArgs>;
+
+export type { ServerRenderer };
+export type Decorator<TArgs = StrictArgs> = DecoratorFunction<ServerRenderer, TArgs>;
+export type Loader<TArgs = StrictArgs> = LoaderFunction<ServerRenderer, TArgs>;
+export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<ServerRenderer, TArgs>;

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -4,10 +4,10 @@ import type { ComponentAnnotations, StoryAnnotations } from '@storybook/types';
 import { expectTypeOf } from 'expect-type';
 import type { ComponentProps, SvelteComponentTyped } from 'svelte';
 import Button from './__test__/Button.svelte';
-import Decorator from './__test__/Decorator.svelte';
+import Decorator1 from './__test__/Decorator.svelte';
 import Decorator2 from './__test__/Decorator2.svelte';
 
-import type { DecoratorFn, Meta, StoryObj } from './public-types';
+import type { Decorator, Meta, StoryObj } from './public-types';
 import type { SvelteRenderer } from './types';
 
 type SvelteStory<Component extends SvelteComponentTyped, Args, RequiredArgs> = StoryAnnotations<
@@ -172,11 +172,11 @@ describe('Story args can be inferred', () => {
     expectTypeOf(Basic).toEqualTypeOf<Expected>();
   });
 
-  const withDecorator: DecoratorFn<{ decoratorArg: string }> = (
+  const withDecorator: Decorator<{ decoratorArg: string }> = (
     storyFn,
     { args: { decoratorArg } }
   ) => ({
-    Component: Decorator,
+    Component: Decorator1,
     props: { decoratorArg },
   });
 
@@ -202,7 +202,7 @@ describe('Story args can be inferred', () => {
   test('Correct args are inferred when type is widened for multiple decorators', () => {
     type Props = ComponentProps<Button> & { decoratorArg: string; decoratorArg2: string };
 
-    const secondDecorator: DecoratorFn<{ decoratorArg2: string }> = (
+    const secondDecorator: Decorator<{ decoratorArg2: string }> = (
       storyFn,
       { args: { decoratorArg2 } }
     ) => ({

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -5,12 +5,17 @@ import type {
   ArgsStoryFn,
   ComponentAnnotations,
   DecoratorFunction,
+  LoaderFunction,
   StoryAnnotations,
+  StoryContext as GenericStoryContext,
+  StrictArgs,
 } from '@storybook/types';
 
 import type { ComponentProps, ComponentType, SvelteComponentTyped } from 'svelte';
 import type { SetOptional, Simplify } from 'type-fest';
 import type { SvelteRenderer } from './types';
+
+export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
 
 /**
  * Metadata to configure the stories for a component.
@@ -52,4 +57,7 @@ export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
   ? StoryAnnotations<SvelteRenderer<MetaOrCmpOrArgs>, ComponentProps<MetaOrCmpOrArgs>>
   : StoryAnnotations<SvelteRenderer, MetaOrCmpOrArgs>;
 
-export type DecoratorFn<TArgs = Args> = DecoratorFunction<SvelteRenderer, TArgs>;
+export type { SvelteRenderer };
+export type Decorator<TArgs = StrictArgs> = DecoratorFunction<SvelteRenderer, TArgs>;
+export type Loader<TArgs = StrictArgs> = LoaderFunction<SvelteRenderer, TArgs>;
+export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<SvelteRenderer, TArgs>;

--- a/code/renderers/vue/src/public-types.test.ts
+++ b/code/renderers/vue/src/public-types.test.ts
@@ -5,7 +5,7 @@ import type { SetOptional } from 'type-fest';
 import type { Component } from 'vue';
 import type { ExtendedVue } from 'vue/types/vue';
 import { Vue } from 'vue/types/vue';
-import type { DecoratorFn, Meta, StoryObj } from './public-types';
+import type { Decorator, Meta, StoryObj } from './public-types';
 import Button from './__tests__/Button.vue';
 import type { VueRenderer } from './types';
 
@@ -122,7 +122,7 @@ describe('Story args can be inferred', () => {
     expectTypeOf(Basic).toEqualTypeOf<Expected>();
   });
 
-  const withDecorator: DecoratorFn<{ decoratorArg: string }> = (
+  const withDecorator: Decorator<{ decoratorArg: string }> = (
     storyFn,
     { args: { decoratorArg } }
   ) =>
@@ -149,7 +149,7 @@ describe('Story args can be inferred', () => {
   test('Correct args are inferred when type is widened for multiple decorators', () => {
     type Props = ComponentProps<typeof Button> & { decoratorArg: string; decoratorArg2: string };
 
-    const secondDecorator: DecoratorFn<{ decoratorArg2: string }> = (
+    const secondDecorator: Decorator<{ decoratorArg2: string }> = (
       storyFn,
       { args: { decoratorArg2 } }
     ) => {

--- a/code/renderers/vue/src/public-types.ts
+++ b/code/renderers/vue/src/public-types.ts
@@ -5,14 +5,18 @@ import type {
   ArgsStoryFn,
   ComponentAnnotations,
   DecoratorFunction,
+  LoaderFunction,
   StoryAnnotations,
+  StoryContext as GenericStoryContext,
+  StrictArgs,
 } from '@storybook/types';
 import type { SetOptional, Simplify } from 'type-fest';
 import type { Component } from 'vue';
 import type { ExtendedVue } from 'vue/types/vue';
 import type { VueRenderer } from './types';
 
-export type { Args, ArgTypes, Parameters, StoryContext } from '@storybook/types';
+export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
+export type { VueRenderer };
 
 /**
  * Metadata to configure the stories for a component.
@@ -78,4 +82,6 @@ type ComponentPropsOrProps<TCmpOrArgs> = TCmpOrArgs extends Component<any>
  */
 export type Story<TArgs = Args> = StoryFn<TArgs>;
 
-export type DecoratorFn<TArgs = Args> = DecoratorFunction<VueRenderer, TArgs>;
+export type Decorator<TArgs = StrictArgs> = DecoratorFunction<VueRenderer, TArgs>;
+export type Loader<TArgs = StrictArgs> = LoaderFunction<VueRenderer, TArgs>;
+export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<VueRenderer, TArgs>;

--- a/code/renderers/vue3/src/public-types.test.ts
+++ b/code/renderers/vue3/src/public-types.test.ts
@@ -4,7 +4,7 @@ import { expectTypeOf } from 'expect-type';
 import type { SetOptional } from 'type-fest';
 import type { ComponentOptions, FunctionalComponent } from 'vue';
 import { h } from 'vue';
-import type { DecoratorFn, Meta, StoryObj } from './public-types';
+import type { Decorator, Meta, StoryObj } from './public-types';
 import type { VueRenderer } from './types';
 import Button from './__tests__/Button.vue';
 import DecoratorTsVue from './__tests__/Decorator.vue';
@@ -145,7 +145,7 @@ describe('Story args can be inferred', () => {
     expectTypeOf(Basic).toEqualTypeOf<Expected>();
   });
 
-  const withDecorator: DecoratorFn<{ decoratorArg: string }> = (
+  const withDecorator: Decorator<{ decoratorArg: string }> = (
     storyFn,
     { args: { decoratorArg } }
   ) => h(DecoratorTsVue, { decoratorArg }, h(storyFn()));
@@ -168,7 +168,7 @@ describe('Story args can be inferred', () => {
   test('Correct args are inferred when type is widened for multiple decorators', () => {
     type Props = ComponentProps<typeof Button> & { decoratorArg: string; decoratorArg2: string };
 
-    const secondDecorator: DecoratorFn<{ decoratorArg2: string }> = (
+    const secondDecorator: Decorator<{ decoratorArg2: string }> = (
       storyFn,
       { args: { decoratorArg2 } }
     ) => h(Decorator2TsVue, { decoratorArg2 }, h(storyFn()));

--- a/code/renderers/vue3/src/public-types.ts
+++ b/code/renderers/vue3/src/public-types.ts
@@ -5,12 +5,17 @@ import type {
   ArgsStoryFn,
   ComponentAnnotations,
   DecoratorFunction,
+  LoaderFunction,
   StoryAnnotations,
+  StoryContext as GenericStoryContext,
+  StrictArgs,
 } from '@storybook/types';
-
 import type { SetOptional, Simplify } from 'type-fest';
 import type { ComponentOptions, ConcreteComponent, FunctionalComponent } from 'vue';
 import type { VueRenderer } from './types';
+
+export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
+export type { VueRenderer };
 
 /**
  * Metadata to configure the stories for a component.
@@ -76,4 +81,6 @@ type ComponentPropsOrProps<TCmpOrArgs> = TCmpOrArgs extends ConcreteComponent<an
  */
 export type Story<TArgs = Args> = StoryFn<TArgs>;
 
-export type DecoratorFn<TArgs = Args> = DecoratorFunction<VueRenderer, TArgs>;
+export type Decorator<TArgs = StrictArgs> = DecoratorFunction<VueRenderer, TArgs>;
+export type Loader<TArgs = StrictArgs> = LoaderFunction<VueRenderer, TArgs>;
+export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<VueRenderer, TArgs>;

--- a/code/renderers/web-components/src/public-types.ts
+++ b/code/renderers/web-components/src/public-types.ts
@@ -2,9 +2,16 @@ import type {
   AnnotatedStoryFn,
   Args,
   ComponentAnnotations,
+  DecoratorFunction,
+  LoaderFunction,
   StoryAnnotations,
+  StoryContext as GenericStoryContext,
+  StrictArgs,
 } from '@storybook/types';
 import type { WebComponentsRenderer } from './types';
+
+export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
+export type { WebComponentsRenderer };
 
 /**
  * Metadata to configure the stories for a component.
@@ -37,3 +44,7 @@ export type StoryObj<TArgs = Args> = StoryAnnotations<WebComponentsRenderer, TAr
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
 export type Story<TArgs = Args> = StoryFn<TArgs>;
+
+export type Decorator<TArgs = StrictArgs> = DecoratorFunction<WebComponentsRenderer, TArgs>;
+export type Loader<TArgs = StrictArgs> = LoaderFunction<WebComponentsRenderer, TArgs>;
+export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<WebComponentsRenderer, TArgs>;

--- a/code/ui/blocks/package.json
+++ b/code/ui/blocks/package.json
@@ -47,7 +47,7 @@
     "@storybook/client-logger": "7.0.0-alpha.49",
     "@storybook/components": "7.0.0-alpha.49",
     "@storybook/core-events": "7.0.0-alpha.49",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/docs-tools": "7.0.0-alpha.49",
     "@storybook/preview-web": "7.0.0-alpha.49",
     "@storybook/store": "7.0.0-alpha.49",

--- a/code/ui/components/package.json
+++ b/code/ui/components/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@storybook/client-logger": "7.0.0-alpha.49",
-    "@storybook/csf": "0.0.2-next.5",
+    "@storybook/csf": "0.0.2-next.7",
     "@storybook/theming": "7.0.0-alpha.49",
     "@storybook/types": "7.0.0-alpha.49",
     "memoizerific": "^1.11.3",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5646,7 +5646,7 @@ __metadata:
     "@storybook/addons": 7.0.0-alpha.49
     "@storybook/client-logger": 7.0.0-alpha.49
     "@storybook/core-events": 7.0.0-alpha.49
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/router": 7.0.0-alpha.49
     "@storybook/types": 7.0.0-alpha.49
     global: ^4.4.0
@@ -5716,7 +5716,7 @@ __metadata:
   resolution: "@storybook/addon-storyshots-puppeteer@workspace:addons/storyshots/storyshots-puppeteer"
   dependencies:
     "@axe-core/puppeteer": ^4.2.0
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/node-logger": 7.0.0-alpha.49
     "@storybook/types": 7.0.0-alpha.49
     "@types/jest-image-snapshot": ^4.1.3
@@ -6041,7 +6041,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.49
     "@storybook/core-common": 7.0.0-alpha.49
     "@storybook/core-events": 7.0.0-alpha.49
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/router": 7.0.0-alpha.49
     "@storybook/theming": 7.0.0-alpha.49
     "@storybook/types": 7.0.0-alpha.49
@@ -6111,7 +6111,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0-alpha.49
     "@storybook/components": 7.0.0-alpha.49
     "@storybook/core-events": 7.0.0-alpha.49
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/docs-tools": 7.0.0-alpha.49
     "@storybook/preview-web": 7.0.0-alpha.49
     "@storybook/store": 7.0.0-alpha.49
@@ -6348,7 +6348,7 @@ __metadata:
     "@storybook/addons": 7.0.0-alpha.49
     "@storybook/client-logger": 7.0.0-alpha.49
     "@storybook/core-common": 7.0.0-alpha.49
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/store": 7.0.0-alpha.49
     "@storybook/types": 7.0.0-alpha.49
     "@types/qs": ^6.9.5
@@ -6389,7 +6389,7 @@ __metadata:
   resolution: "@storybook/codemod@workspace:lib/codemod"
   dependencies:
     "@babel/types": ^7.12.11
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/csf-tools": 7.0.0-alpha.49
     "@storybook/node-logger": 7.0.0-alpha.49
     "@storybook/types": 7.0.0-alpha.49
@@ -6412,7 +6412,7 @@ __metadata:
   dependencies:
     "@popperjs/core": ^2.6.0
     "@storybook/client-logger": 7.0.0-alpha.49
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/theming": 7.0.0-alpha.49
     "@storybook/types": 7.0.0-alpha.49
     "@types/overlayscrollbars": ^1.12.0
@@ -6447,7 +6447,7 @@ __metadata:
     "@storybook/client-api": 7.0.0-alpha.49
     "@storybook/client-logger": 7.0.0-alpha.49
     "@storybook/core-events": 7.0.0-alpha.49
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/preview-web": 7.0.0-alpha.49
     "@storybook/store": 7.0.0-alpha.49
     "@storybook/types": 7.0.0-alpha.49
@@ -6531,7 +6531,7 @@ __metadata:
     "@storybook/core-client": 7.0.0-alpha.49
     "@storybook/core-common": 7.0.0-alpha.49
     "@storybook/core-events": 7.0.0-alpha.49
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/csf-tools": 7.0.0-alpha.49
     "@storybook/docs-mdx": 0.0.1-canary.12433cf.0
     "@storybook/node-logger": 7.0.0-alpha.49
@@ -6619,7 +6619,7 @@ __metadata:
     "@babel/parser": ^7.12.11
     "@babel/traverse": ^7.12.11
     "@babel/types": ^7.12.11
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/types": 7.0.0-alpha.49
     "@types/fs-extra": ^9.0.6
     fs-extra: ^9.0.1
@@ -6638,14 +6638,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/csf@npm:0.0.2-next.5":
-  version: 0.0.2-next.5
-  resolution: "@storybook/csf@npm:0.0.2-next.5"
+"@storybook/csf@npm:0.0.2-next.7":
+  version: 0.0.2-next.7
+  resolution: "@storybook/csf@npm:0.0.2-next.7"
   dependencies:
     expect-type: ^0.14.2
     lodash: ^4.17.15
     type-fest: ^2.19.0
-  checksum: 5be51f30cf91895085ff2a2ab45af086f3a46233c2899b251c0ec04a14636dd58428af0f1ab9fb7a8995011e7fb2498ed6590e57b403d9f0cfefb2685403ca85
+  checksum: 3920626fdd6dc4875ba95ae46fa0776051f544a479029ee7d561b87602511010161750a42b0d5e1371ec336b47262e1098524c834805ca686d9bc2de5cae0e4e
   languageName: node
   linkType: hard
 
@@ -7401,7 +7401,7 @@ __metadata:
     "@storybook/core-events": "workspace:*"
     "@storybook/core-server": "workspace:*"
     "@storybook/core-webpack": "workspace:*"
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/csf-plugin": "workspace:*"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/docs-tools": "workspace:*"
@@ -7684,7 +7684,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@workspace:lib/source-loader"
   dependencies:
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/types": 7.0.0-alpha.49
     estraverse: ^5.2.0
     jest-specific-snapshot: ^4.0.0
@@ -7704,7 +7704,7 @@ __metadata:
     "@storybook/addons": 7.0.0-alpha.49
     "@storybook/client-logger": 7.0.0-alpha.49
     "@storybook/core-events": 7.0.0-alpha.49
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@storybook/types": 7.0.0-alpha.49
     dequal: ^2.0.2
     global: ^4.4.0
@@ -7869,7 +7869,7 @@ __metadata:
   resolution: "@storybook/types@workspace:lib/types"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/csf": 0.0.2-next.5
+    "@storybook/csf": 0.0.2-next.7
     "@types/babel__core": ^7.0.0
     "@types/express": ^4.7.0
     "@types/node": ^16.0.0


### PR DESCRIPTION
Issue:

## What I did

- Expose `Args`, `ArgTypes`, `Parameters` and `StrictArgs` in all renderers
- Expose `StoryContext` parametrized for the specific `Renderer`
- Expose `Decorator`, `Loader` which are also parametrized for the specific `Renderer`
- Deprecated `DecoratorFn` as I renamed it to `Decorator` for 7. This allows for making a breaking change to the DecoratorFn type. It now defaults to a more Strict version of `Args`. Making this strict was necessary so that `any` doesn't mess up type inference of `Meta` in the new strict `StoryObj`. 

Lastly, I changed the export of `@storybook/types` to be the bare `Parameters` again of `@storybook/csf` and made a new `StorybookParameters` and `StorybookInternalParameters` in `@storybook/types`.

The reason is that going forward we want users to have autocompletion for `Parameters`, that is specific to their setup. The easiest way for users to do this, is using module augmentation:


```ts
declare module '@storybook/react' {
  interface Parameters
    extends StorybookParameters,
      ChromaticParameters,
      DocsParameters,
      BackgroundParameters {}
}
```

This only works, if the export of `Parameters`, is actually a direct reference to the interface defined in `@storybook/csf`.

I think we should also offer users a way to achieve autocompletion for Parameters without module augmentation. Especially, in the case of libraries, such as addons, using module augmentation should be discouraged, as it can have unintended side effects. 

Next to module augmentation, we could also offer users to parametrize `Parameters` themself as well:

```ts
// storybook-types.ts (in user code)
import { StoryObj as StorybookStoryObj } from '@storybook/react';

interface Parameters
   extends StorybookParameters,
     ChromaticParameters,
     DocsParameters,
     BackgroundParameters {}

export type StoryObj<Args> = StorybookStoryObj<Args, Parameters>;
// then user can import this `StoryObj` instead of the one of storybook provides in the renderer
```

I didn't expose the `StorybookParameters`, as I want to first check the quality of it, and make sure that is complete.

Also I made an `InternalStorybookParameters` interface, as I had the feeling that we don't want to expose `fileName` and `docsOnly` to the user, as they should not be set by users I believe.

