### PR TITLE
Vite: Keep using absolute path node_modules splitting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,7 +313,7 @@ jobs:
             cd bench/react-vite-default-ts
             rm -rf node_modules
             mkdir node_modules
-            npx -p @storybook/bench@next sb-bench 'yarn install' --no-start --label react-vite
+            npx -p @storybook/bench@next sb-bench 'yarn install' --label react-vite
       - run:
           name: prep artifacts
           when: always

--- a/code/lib/builder-vite/src/utils/process-preview-annotation.ts
+++ b/code/lib/builder-vite/src/utils/process-preview-annotation.ts
@@ -1,6 +1,7 @@
 import type { PreviewAnnotation } from '@storybook/types';
 import { resolve } from 'path';
 import slash from 'slash';
+import { transformAbsPath } from './transform-abs-path';
 
 /**
  * Preview annotations can take several forms, and vite needs them to be
@@ -28,6 +29,12 @@ export function processPreviewAnnotation(path: PreviewAnnotation | undefined) {
   // calling this function, but this makes typescript happy
   if (!path) {
     throw new Error('Could not determine path for previewAnnotation');
+  }
+
+  // For addon dependencies that use require.resolve(), we need to convert to a bare path
+  // so that vite will process it as a dependency (cjs -> esm, etc).
+  if (path.includes('node_modules')) {
+    return transformAbsPath(path);
   }
 
   return slash(path);

--- a/code/lib/builder-vite/src/utils/transform-abs-path.ts
+++ b/code/lib/builder-vite/src/utils/transform-abs-path.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+import { normalizePath } from 'vite';
+
+// We need to convert from an absolute path, to a traditional node module import path,
+// so that vite can correctly pre-bundle/optimize
+export function transformAbsPath(absPath: string) {
+  const splits = absPath.split(`node_modules${path.sep}`);
+  // Return everything after the final "node_modules/"
+  const module = normalizePath(splits[splits.length - 1]);
+  return module;
+}


### PR DESCRIPTION
Issue: https://github.com/lifeiscontent/storybook-addon-next-router/issues/69

Failing vite-bench jobs.

## What I did

In https://github.com/storybookjs/storybook/pull/19689, we removed a hack that splits addon paths by `node_modules` and tries to turn them into "bare" imports so that pnpm and vite can process them correctly.

Well, turns out that other addons out there are still using absolute paths, so we need to keep this hack around.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
