### PR TITLE
Fix type inference bug with decorators 

### DIFF
--- a/code/renderers/react/src/public-types.test.tsx
+++ b/code/renderers/react/src/public-types.test.tsx
@@ -1,7 +1,7 @@
 import { describe, test } from '@jest/globals';
 
 import { satisfies } from '@storybook/core-common';
-import type { StoryAnnotations } from '@storybook/types';
+import type { Args, StoryAnnotations, StrictArgs } from '@storybook/types';
 import { expectTypeOf } from 'expect-type';
 import type { KeyboardEventHandler, ReactNode } from 'react';
 import React from 'react';
@@ -11,7 +11,7 @@ import type { SetOptional } from 'type-fest';
 import type { Decorator, Meta, StoryObj } from './public-types';
 import type { ReactRenderer } from './types';
 
-type ReactStory<Args, RequiredArgs> = StoryAnnotations<ReactRenderer, Args, RequiredArgs>;
+type ReactStory<TArgs, TRequiredArgs> = StoryAnnotations<ReactRenderer, TArgs, TRequiredArgs>;
 
 type ButtonProps = { label: string; disabled: boolean };
 const Button: (props: ButtonProps) => JSX.Element = () => <></>;
@@ -172,10 +172,24 @@ describe('Story args can be inferred', () => {
       </>
     );
 
+    // decorator is not using args
+    const thirdDecorator: Decorator<Args> = (Story) => (
+      <>
+        <Story />
+      </>
+    );
+
+    // decorator is not using args
+    const fourthDecorator: Decorator<StrictArgs> = (Story) => (
+      <>
+        <Story />
+      </>
+    );
+
     const meta = satisfies<Meta<Props>>()({
       component: Button,
       args: { disabled: false },
-      decorators: [withDecorator, secondDecorator],
+      decorators: [withDecorator, secondDecorator, thirdDecorator, fourthDecorator],
     });
 
     const Basic: StoryObj<typeof meta> = {

--- a/code/renderers/react/src/public-types.ts
+++ b/code/renderers/react/src/public-types.ts
@@ -54,15 +54,22 @@ export type StoryObj<TMetaOrCmpOrArgs = Args> = TMetaOrCmpOrArgs extends {
     ? StoryAnnotations<
         ReactRenderer,
         TArgs,
-        SetOptional<TArgs, Extract<keyof TArgs, keyof (DefaultArgs & ActionArgs<TArgs>)>>
+        SetOptional<TArgs, keyof TArgs & keyof (DefaultArgs & ActionArgs<TArgs>)>
       >
     : never
   : TMetaOrCmpOrArgs extends ComponentType<any>
   ? StoryAnnotations<ReactRenderer, ComponentProps<TMetaOrCmpOrArgs>>
   : StoryAnnotations<ReactRenderer, TMetaOrCmpOrArgs>;
 
-type ActionArgs<RArgs> = {
-  [P in keyof RArgs as ((...args: any[]) => void) extends RArgs[P] ? P : never]: RArgs[P];
+type ActionArgs<TArgs> = {
+  // This can be read as: filter TArgs on functions where we can assign a void function to that function.
+  // The docs addon argsEnhancers can only safely provide a default value for void functions.
+  // Other kind of required functions should be provided by the user.
+  [P in keyof TArgs as TArgs[P] extends (...args: any[]) => any
+    ? ((...args: any[]) => void) extends TArgs[P]
+      ? P
+      : never
+    : never]: TArgs[P];
 };
 
 /**


### PR DESCRIPTION
## What I did

I stumbled on this, what I thought was an isssue with type-fest:
https://github.com/sindresorhus/type-fest/issues/509#issuecomment-1314006811

But fixed now in a better way by adding the constraint `& keyof TArgs` thanks to @papb 

Also improved the ActionArgs signature.
