### PR TITLE
Fix regression in the `#root` to `#storybook-root` change

### DIFF
--- a/code/ui/manager/src/components/preview/FramesRenderer.tsx
+++ b/code/ui/manager/src/components/preview/FramesRenderer.tsx
@@ -58,12 +58,12 @@ export const FramesRenderer: FC<FramesRendererProps> = ({
   const active = getActive(refId);
 
   const styles = useMemo<CSSObject>(() => {
-    // add #storybook-root to make the selector high enough in specificity
+    // add #root to make the selector high enough in specificity
     return {
-      '#storybook-root [data-is-storybook="false"]': {
+      '#root [data-is-storybook="false"]': {
         display: 'none',
       },
-      '#storybook-root [data-is-storybook="true"]': {
+      '#root [data-is-storybook="true"]': {
         display: 'block',
       },
     };


### PR DESCRIPTION
This fixes a regression in https://github.com/storybookjs/storybook/commit/36702ebe0ce54d97be435cdbf98d44322b7f961b#diff-d4f25936c153d9c0026feff4b56938aa365ac3556278f296a0c6809daef4dc30R62 

The CSS for hiding the inactive iframe was changed to `#storybook-root [data-is-storybook="false"]`, but the root id wasn't. So this CSS no longer applies, which causes composition to break: sometimes the active iframe is obscured by the inactive iframe. This PR fixes that.