### PR TITLE
Jest: switch from Parameters to StorybookInternalParameters

### DIFF
--- a/code/addons/jest/src/shared.test.ts
+++ b/code/addons/jest/src/shared.test.ts
@@ -27,6 +27,7 @@ describe('defineJestParameter', () => {
   });
 
   test('returns null if filename is a module ID that cannot be inferred from', () => {
+    // @ts-expect-error Storybook's fileName type is string, but according to this test it could be number in case it is a module id.
     expect(defineJestParameter({ fileName: 1234 })).toBeNull();
   });
 });

--- a/code/addons/jest/src/shared.ts
+++ b/code/addons/jest/src/shared.ts
@@ -1,4 +1,4 @@
-import type { Parameters } from '@storybook/types';
+import type { StorybookInternalParameters } from '@storybook/types';
 
 // addons, panels and events get unique names using a prefix
 export const PARAM_KEY = 'test';
@@ -7,7 +7,7 @@ export const PANEL_ID = `${ADDON_ID}/panel`;
 
 export const ADD_TESTS = `${ADDON_ID}/add_tests`;
 
-interface AddonParameters extends Parameters {
+interface AddonParameters extends StorybookInternalParameters {
   jest?: string | string[] | { disabled: true };
 }
 


### PR DESCRIPTION
Issue: N/A

## What I did

- There was a type change which moved `fileName` away from `Parameters`. This PR adjusts the type to the newly added `StorybookInternalParameters` type.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
