### PR TITLE
Build: Increase max node memory for jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,6 +405,8 @@ jobs:
     executor:
       class: medium+
       name: sb_node_16_browsers
+    environment:
+        NODE_OPTIONS: --max_old_space_size=6144
     steps:
       # switched this to the CircleCI helper to get the full git history for TurboSnap
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
     docker:
       - image: cimg/node:16.17.1
         environment:
-          NODE_OPTIONS: --max_old_space_size=3076
+          NODE_OPTIONS: --max_old_space_size=6144
     resource_class: <<parameters.class>>
   sb_node_16_browsers:
     parameters:
@@ -32,7 +32,7 @@ executors:
     docker:
       - image: cimg/node:16.17.1-browsers
         environment:
-          NODE_OPTIONS: --max_old_space_size=3076
+          NODE_OPTIONS: --max_old_space_size=6144
     resource_class: <<parameters.class>>
   sb_playwright:
     parameters:
@@ -45,7 +45,7 @@ executors:
     docker:
       - image: mcr.microsoft.com/playwright:v1.27.0-focal
         environment:
-          NODE_OPTIONS: --max_old_space_size=3076
+          NODE_OPTIONS: --max_old_space_size=6144
     resource_class: <<parameters.class>>
 
 orbs:


### PR DESCRIPTION
Issue:

## What I did

Increased the memory available to node in circle CI, trying to get the chromatic build to pass in CI.

## How to test

CI 

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
