### PR TITLE
Next.js: use file path instead of image contents for next-image-loader-stub

### DIFF
--- a/code/frameworks/nextjs/src/next-image-loader-stub.ts
+++ b/code/frameworks/nextjs/src/next-image-loader-stub.ts
@@ -16,7 +16,7 @@ const nextImageLoaderStub: RawLoaderDefinition<LoaderOptions> = function (conten
 
   this.emitFile(outputPath, content);
 
-  const { width, height } = imageSizeOf(content);
+  const { width, height } = imageSizeOf(this.resourcePath);
 
   return `export default ${JSON.stringify({
     src: outputPath,
@@ -28,4 +28,4 @@ const nextImageLoaderStub: RawLoaderDefinition<LoaderOptions> = function (conten
 
 nextImageLoaderStub.raw = true;
 
-export = nextImageLoaderStub;
+export default nextImageLoaderStub;


### PR DESCRIPTION
Issue: #19857

## What I did

Fixed the default export syntax, which revealed another bug, and fixed that too.

## How to test

Check the unit-test CI job, you should no longer see an error at the end.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
