### PR TITLE
UI Storybook: Disable sourcemaps when building in CI

### DIFF
--- a/code/ui/.storybook/main.ts
+++ b/code/ui/.storybook/main.ts
@@ -67,6 +67,11 @@ const config: StorybookConfig = {
       configType === 'PRODUCTION' ? pluginTurbosnap({ rootDir: viteConfig.root || '' }) : [],
     ],
     optimizeDeps: { ...viteConfig.optimizeDeps, force: true },
+    build: {
+      ...viteConfig.build,
+      // disable sourcemaps in CI to not run out of memory
+      sourcemap: process.env.CI !== 'true',
+    },
   }),
 };
 


### PR DESCRIPTION
Disable sourcemaps when building the UI and Blocks Storybooks in CI, in an attempt to fix the issue with running out of memory.

Example of a failed pipeline: https://app.circleci.com/pipelines/github/storybookjs/storybook/32439/workflows/fc163113-af9a-4919-9699-84407170251e/jobs/442029