### PR TITLE
Maintenance: add angular 14 template and skip test runner on angular 15 for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,11 +689,11 @@ workflows:
           requires:
             - build
       - create-sandboxes:
-          parallelism: 14
+          parallelism: 15
           requires:
             - build
       - build-sandboxes:
-          parallelism: 14
+          parallelism: 15
           requires:
             - create-sandboxes
       - test-runner-sandboxes:
@@ -701,11 +701,11 @@ workflows:
           requires:
             - build-sandboxes
       - chromatic-sandboxes:
-          parallelism: 14
+          parallelism: 15
           requires:
             - build-sandboxes
       - e2e-sandboxes:
-          parallelism: 14
+          parallelism: 15
           requires:
             - build-sandboxes
   daily:
@@ -714,14 +714,14 @@ workflows:
     jobs:
       - build
       - create-sandboxes:
-          parallelism: 24
+          parallelism: 25
           requires:
             - build
       # - smoke-test-sandboxes: # disabled for now
       #     requires:
       #       - create-sandboxes
       - build-sandboxes:
-          parallelism: 24
+          parallelism: 25
           requires:
             - create-sandboxes
       - test-runner-sandboxes:
@@ -729,10 +729,10 @@ workflows:
           requires:
             - build-sandboxes
       - chromatic-sandboxes:
-          parallelism: 24
+          parallelism: 25
           requires:
             - build-sandboxes
       - e2e-sandboxes:
-          parallelism: 24
+          parallelism: 25
           requires:
             - build-sandboxes

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -141,6 +141,17 @@ export const allTemplates = {
     name: 'Angular CLI (latest)',
     script:
       'npx -p @angular/cli ng new angular-latest --directory . --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
+    skipTasks: ['test-runner'],
+    expected: {
+      framework: '@storybook/angular',
+      renderer: '@storybook/angular',
+      builder: '@storybook/builder-webpack5',
+    },
+  },
+  'angular-cli/14-ts': {
+    name: 'Angular CLI (Version 14)',
+    script:
+      'npx -p @angular/cli@14 ng new angular-v14 --directory . --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
     expected: {
       framework: '@storybook/angular',
       renderer: '@storybook/angular',
@@ -251,7 +262,8 @@ type TemplateKey = keyof typeof allTemplates;
 export const ci: TemplateKey[] = ['cra/default-ts', 'react-vite/default-ts'];
 export const pr: TemplateKey[] = [
   ...ci,
-  'angular-cli/default-ts',
+  // TODO: swap with 'angular-cli/default-ts' once angular 15 fully works with Storybook
+  'angular-cli/14-ts',
   'vue3-vite/default-ts',
   'vue-cli/vue2-default-js',
   'lit-vite/default-ts',
@@ -263,6 +275,7 @@ export const merged: TemplateKey[] = [
   ...pr,
   'react-webpack/18-ts',
   'react-webpack/17-ts',
+  'angular-cli/default-ts',
   'angular-cli/13-ts',
   'preact-webpack5/default-ts',
   'html-webpack/default',

--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -164,8 +164,10 @@ const runGenerators = async (
         // Remove node_modules to save space and avoid GH actions failing
         // They're not uploaded to the git repros repo anyway
         if (process.env.CLEANUP_REPRO_NODE_MODULES) {
+          console.log(`🗑️ Removing ${join(beforeDir, 'node_modules')}`);
           await remove(join(beforeDir, 'node_modules'));
-          await remove(join(baseDir, 'node_modules'));
+          console.log(`🗑️ Removing ${join(baseDir, AFTER_DIR_NAME, 'node_modules')}`);
+          await remove(join(baseDir, AFTER_DIR_NAME, 'node_modules'));
         }
 
         console.log(


### PR DESCRIPTION
Issue: N/A

## What I did

Angular 15 has been released and is now `latest`. As a result, the `test-runner` step is failing in the `next` branch.
This PR adds a new entry, so we test Angular 13, 14 and 15, but skips the test-runner step (for now) while we figure out what is going on.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
