### PR TITLE
Addon-controls: Exclude `{ table: { disable: true } }` controls while counting controls for panel title

### DIFF
--- a/code/addons/controls/src/manager.tsx
+++ b/code/addons/controls/src/manager.tsx
@@ -9,7 +9,9 @@ addons.register(ADDON_ID, (api: API) => {
   addons.addPanel(ADDON_ID, {
     title() {
       const rows = useArgTypes();
-      const controlsCount = Object.values(rows).filter((argType) => argType?.control).length;
+      const controlsCount = Object.values(rows).filter(
+        (argType) => argType?.control && !argType?.table?.disable
+      ).length;
       const suffix = controlsCount === 0 ? '' : ` (${controlsCount})`;
       return `Controls${suffix}`;
     },

--- a/code/addons/controls/template/stories/disable.stories.ts
+++ b/code/addons/controls/template/stories/disable.stories.ts
@@ -18,5 +18,7 @@ export const DisableTable = {
 
 export const DisableControl = {
   args: { a: 'a', b: 'b' },
-  b: { control: { disable: true } },
+  argTypes: {
+    b: { control: { disable: true } },
+  },
 };


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18780

## What I did

- Exclude controls with `{ table: { disable: true } }` config while counting controls for panel title.
- Correct `DisableControl` story config

## How to test

- Start a sandbox template (In screenshot `react-vite/default-ts` with `yarn task --task dev --template react-vite/default-ts`)
- Navigate to `http://localhost:6006/?path=/story/addons-controls-disable--disable-table`
- Verify that `addon-controls` tab title should be `Controls (1)` which is the expected behavior since `b` has `{ table: { disable: true } }`
- Navigate to `http://localhost:6006/?path=/story/addons-controls-disable--disable-control`
- Verify that there is no control for `b` prop but it is still visible in panel