### PR TITLE
Chore: (Docs) Interaction tests docs updates for CSF 3

### DIFF
--- a/docs/snippets/angular/login-form-with-play-function.ts.mdx
+++ b/docs/snippets/angular/login-form-with-play-function.ts.mdx
@@ -23,9 +23,12 @@ type Story = StoryObj<LoginForm>;
 
 export const EmptyForm: Story = {};
 
+/*
+ * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm: Story = {
   play: async ({ canvasElement }) => {
-    // Starts querying the component from its root element
     const canvas = within(canvasElement);
 
     // 👇 Simulate interactions with the component

--- a/docs/snippets/angular/my-component-play-function-alt-queries.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-alt-queries.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/angular';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.component';
 
@@ -19,10 +19,16 @@ const meta: Meta<MyComponent> = {
 export default meta;
 type Story = StoryObj<MyComponent>;
 
+/*
+ * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ExampleWithRole: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button', { name: / button label/i }));
+    await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/angular/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-composition.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/angular';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.component';
 
@@ -19,24 +19,34 @@ const meta: Meta<MyComponent> = {
 export default meta;
 type Story = StoryObj<MyComponent>;
 
+/*
+ * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FirstStory: Story = {
-  play: async () => {
-    userEvent.type(screen.getByTestId('an-element'), 'example-value');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    userEvent.type(canvas.getByTestId('an-element'), 'example-value');
   },
 };
 
 export const SecondStory: Story = {
-  play: async () => {
-    await userEvent.type(screen.getByTestId('other-element'), 'another value');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(canvas.getByTestId('other-element'), 'another value');
   },
 };
 
 export const CombinedStories: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Runs the FirstStory and Second story play function before running this story's play function
-    await FirstStory.play();
-    await SecondStory.play();
-    await userEvent.type(screen.getByTestId('another-element'), 'random value');
+    await FirstStory.play({ canvasElement });
+    await SecondStory.play({ canvasElement });
+    await userEvent.type(canvas.getByTestId('another-element'), 'random value');
   },
 };
 ```

--- a/docs/snippets/angular/my-component-play-function-query-findby.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-query-findby.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/angular';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.component';
 
@@ -19,12 +19,18 @@ const meta: Meta<MyComponent> = {
 export default meta;
 type Story = StoryObj<MyComponent>;
 
+/*
+ * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const AsyncExample: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Other steps
 
     // Waits for the component to be rendered before querying the element
-    await screen.findByRole('button', { name: / button label/i }));
+    await canvas.findByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/angular/my-component-play-function-waitfor.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-waitfor.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/angular';
 
-import { screen, userEvent, waitFor } from '@storybook/testing-library';
+import { userEvent, waitFor, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.component';
 
@@ -19,9 +19,15 @@ const meta: Meta<MyComponent> = {
 export default meta;
 type Story = StoryObj<MyComponent>;
 
+/*
+ * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ExampleAsyncStory: Story = {
-  play: async () => {
-    const Input = screen.getByLabelText('Username', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const Input = canvas.getByLabelText('Username', {
       selector: 'input',
     });
 
@@ -30,11 +36,11 @@ export const ExampleAsyncStory: Story = {
     });
 
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const Submit = screen.getByRole('button');
+    const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 
     await waitFor(async () => {
-      await userEvent.hover(screen.getByTestId('error'));
+      await userEvent.hover(canvas.getByTestId('error'));
     });
   },
 };

--- a/docs/snippets/angular/my-component-play-function-with-clickevent.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-with-clickevent.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/angular';
 
-import { fireEvent, screen, userEvent } from '@storybook/testing-library';
+import { fireEvent, userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.component';
 
@@ -19,17 +19,25 @@ const meta: Meta<MyComponent> = {
 export default meta;
 type Story = StoryObj<MyComponent>;
 
+/*
+ * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ClickExample: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(canvas.getByRole('button'));
   },
 };
 
 export const FireEventExample: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await fireEvent.click(screen.getByTestId('data-testid'));
+    await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };
 ```

--- a/docs/snippets/angular/my-component-play-function-with-delay.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-with-delay.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/angular';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.component';
 
@@ -19,16 +19,22 @@ const meta: Meta<MyComponent> = {
 export default meta;
 type Story = StoryObj<MyComponent>;
 
+/*
+ * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const DelayedStory: Story = {
-  play: async () => {
-    const exampleElement = screen.getByLabelText('example-element');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const exampleElement = canvas.getByLabelText('example-element');
 
     // The delay option set the ammount of milliseconds between characters being typed
     await userEvent.type(exampleElement, 'random string', {
       delay: 100,
     });
 
-    const AnotherExampleElement = screen.getByLabelText('another-example-element');
+    const AnotherExampleElement = canvas.getByLabelText('another-example-element');
     await userEvent.type(AnotherExampleElement, 'another random string', {
       delay: 100,
     });

--- a/docs/snippets/angular/my-component-play-function-with-selectevent.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-with-selectevent.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/angular';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent.component';
 
@@ -24,9 +24,15 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/*
+ * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ExampleChangeEvent: Story = {
-  play: async () => {
-    const select = screen.getByRole('listbox');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const select = canvas.getByRole('listbox');
 
     await userEvent.selectOptions(select, ['One Item']);
     await sleep(2000);

--- a/docs/snippets/angular/register-component-with-play-function.ts.mdx
+++ b/docs/snippets/angular/register-component-with-play-function.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/angular';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { RegistrationForm } from './RegistrationForm.component';
 
@@ -19,9 +19,15 @@ const meta: Meta<RegistrationForm> = {
 export default meta;
 type Story = StoryObj<RegistrationForm>;
 
+/*
+ * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm: Story = {
-  play: async () => {
-    const emailInput = screen.getByLabelText('email', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const emailInput = canvas.getByLabelText('email', {
       selector: 'input',
     });
 
@@ -29,7 +35,7 @@ export const FilledForm: Story = {
       delay: 100,
     });
 
-    const passwordInput = screen.getByLabelText('password', {
+    const passwordInput = canvas.getByLabelText('password', {
       selector: 'input',
     });
 
@@ -37,7 +43,7 @@ export const FilledForm: Story = {
       delay: 100,
     });
     // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const submitButton = screen.getByRole('button');
+    const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);
   },

--- a/docs/snippets/react/login-form-with-play-function.js.mdx
+++ b/docs/snippets/react/login-form-with-play-function.js.mdx
@@ -18,9 +18,12 @@ export default {
 
 export const EmptyForm = {};
 
+/*
+ * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm = {
   play: async ({ canvasElement }) => {
-    // Starts querying the component from its root element
     const canvas = within(canvasElement);
 
     // 👇 Simulate interactions with the component

--- a/docs/snippets/react/login-form-with-play-function.ts.mdx
+++ b/docs/snippets/react/login-form-with-play-function.ts.mdx
@@ -23,9 +23,12 @@ type Story = StoryObj<typeof LoginForm>;
 
 export const EmptyForm: Story = {};
 
+/*
+ * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm: Story = {
   play: async ({ canvasElement }) => {
-    // Starts querying the component from its root element
     const canvas = within(canvasElement);
 
     // 👇 Simulate interactions with the component

--- a/docs/snippets/react/my-component-play-function-alt-queries.js.mdx
+++ b/docs/snippets/react/my-component-play-function-alt-queries.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js|jsx
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -14,10 +14,15 @@ export default {
   component: MyComponent,
 };
 
+/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ExampleWithRole = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button', { name: / button label/i }));
+    await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/react/my-component-play-function-alt-queries.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-alt-queries.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -19,10 +19,15 @@ const meta: Meta<typeof MyComponent> = {
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
+/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ExampleWithRole: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button', { name: / button label/i }));
+    await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/react/my-component-play-function-composition.js.mdx
+++ b/docs/snippets/react/my-component-play-function-composition.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js|jsx
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -14,24 +14,34 @@ export default {
   component: MyComponent,
 };
 
+/*
+ * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FirstStory = {
-  play: async () => {
-    userEvent.type(screen.getByTestId('an-element'), 'example-value');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    userEvent.type(canvas.getByTestId('an-element'), 'example-value');
   },
 };
 
 export const SecondStory = {
-  play: async () => {
-    await userEvent.type(screen.getByTestId('other-element'), 'another value');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(canvas.getByTestId('other-element'), 'another value');
   },
 };
 
 export const CombinedStories = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Runs the FirstStory and Second story play function before running this story's play function
-    await FirstStory.play();
-    await SecondStory.play();
-    await userEvent.type(screen.getByTestId('another-element'), 'random value');
+    await FirstStory.play({ canvasElement });
+    await SecondStory.play({ canvasElement });
+    await userEvent.type(canvas.getByTestId('another-element'), 'random value');
   },
 };
 ```

--- a/docs/snippets/react/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-composition.ts.mdx
@@ -35,7 +35,7 @@ export const SecondStory: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.type(screen.getByTestId('other-element'), 'another value');
+    await userEvent.type(canvas.getByTestId('other-element'), 'another value');
   },
 };
 

--- a/docs/snippets/react/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-composition.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -19,24 +19,34 @@ const meta: Meta<typeof MyComponent> = {
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
+/*
+ * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FirstStory: Story = {
-  play: async () => {
-    userEvent.type(screen.getByTestId('an-element'), 'example-value');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    userEvent.type(canvas.getByTestId('an-element'), 'example-value');
   },
 };
 
 export const SecondStory: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     await userEvent.type(screen.getByTestId('other-element'), 'another value');
   },
 };
 
 export const CombinedStories: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Runs the FirstStory and Second story play function before running this story's play function
-    await FirstStory.play();
-    await SecondStory.play();
-    await userEvent.type(screen.getByTestId('another-element'), 'random value');
+    await FirstStory.play({ canvasElement });
+    await SecondStory.play({ canvasElement });
+    await userEvent.type(canvas.getByTestId('another-element'), 'random value');
   },
 };
 ```

--- a/docs/snippets/react/my-component-play-function-query-findby.js.mdx
+++ b/docs/snippets/react/my-component-play-function-query-findby.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js|jsx
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -14,12 +14,17 @@ export default {
   component: MyComponent,
 };
 
+/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const AsyncExample = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Other steps
 
     // Waits for the component to be rendered before querying the element
-    await screen.findByRole('button', { name: / button label/i }));
+    await canvas.findByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/react/my-component-play-function-query-findby.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-query-findby.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -19,12 +19,17 @@ const meta: Meta<typeof MyComponent> = {
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
+/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const AsyncExample: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Other steps
 
     // Waits for the component to be rendered before querying the element
-    await screen.findByRole('button', { name: / button label/i }));
+    await canvas.findByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/react/my-component-play-function-waitfor.js.mdx
+++ b/docs/snippets/react/my-component-play-function-waitfor.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js|jsx
 
-import { screen, userEvent, waitFor } from '@storybook/testing-library';
+import { userEvent, waitFor, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -14,9 +14,14 @@ export default {
   component: MyComponent,
 };
 
+/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ExampleAsyncStory = {
-  play: async () => {
-    const Input = screen.getByLabelText('Username', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const Input = canvas.getByLabelText('Username', {
       selector: 'input',
     });
 
@@ -25,11 +30,11 @@ export const ExampleAsyncStory = {
     });
 
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const Submit = screen.getByRole('button');
+    const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 
     await waitFor(async () => {
-      await userEvent.hover(screen.getByTestId('error'));
+      await userEvent.hover(canvas.getByTestId('error'));
     });
   },
 };

--- a/docs/snippets/react/my-component-play-function-waitfor.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-waitfor.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { screen, userEvent, waitFor } from '@storybook/testing-library';
+import { userEvent, waitFor, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -19,9 +19,14 @@ const meta: Meta<typeof MyComponent> = {
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
+/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ExampleAsyncStory: Story = {
-  play: async () => {
-    const Input = screen.getByLabelText('Username', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const Input = canvas.getByLabelText('Username', {
       selector: 'input',
     });
 
@@ -30,11 +35,11 @@ export const ExampleAsyncStory: Story = {
     });
 
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const Submit = screen.getByRole('button');
+    const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 
     await waitFor(async () => {
-      await userEvent.hover(screen.getByTestId('error'));
+      await userEvent.hover(canvas.getByTestId('error'));
     });
   },
 };

--- a/docs/snippets/react/my-component-play-function-with-clickevent.js.mdx
+++ b/docs/snippets/react/my-component-play-function-with-clickevent.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js|jsx
 
-import { fireEvent, screen, userEvent } from '@storybook/testing-library';
+import { fireEvent, userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -14,17 +14,24 @@ export default {
   component: MyComponent,
 };
 
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ClickExample = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(canvas.getByRole('button'));
   },
 };
 
 export const FireEventExample = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await fireEvent.click(screen.getByTestId('data-testid'));
+    await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };
 ```

--- a/docs/snippets/react/my-component-play-function-with-clickevent.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-clickevent.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { fireEvent, screen, userEvent } from '@storybook/testing-library';
+import { fireEvent, userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -19,17 +19,24 @@ const meta: Meta<typeof MyComponent> = {
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ClickExample: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(canvas.getByRole('button'));
   },
 };
 
 export const FireEventExample: Story = {
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await fireEvent.click(screen.getByTestId('data-testid'));
+    await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };
 ```

--- a/docs/snippets/react/my-component-play-function-with-delay.js.mdx
+++ b/docs/snippets/react/my-component-play-function-with-delay.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js|jsx
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -14,16 +14,21 @@ export default {
   component: MyComponent,
 };
 
+/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const DelayedStory = {
-  play: async () => {
-    const exampleElement = screen.getByLabelText('example-element');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const exampleElement = canvas.getByLabelText('example-element');
 
     // The delay option set the ammount of milliseconds between characters being typed
     await userEvent.type(exampleElement, 'random string', {
       delay: 100,
     });
 
-    const AnotherExampleElement = screen.getByLabelText('another-example-element');
+    const AnotherExampleElement = canvas.getByLabelText('another-example-element');
     await userEvent.type(AnotherExampleElement, 'another random string', {
       delay: 100,
     });

--- a/docs/snippets/react/my-component-play-function-with-delay.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-delay.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -19,16 +19,21 @@ const meta: Meta<typeof MyComponent> = {
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
+/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const DelayedStory: Story = {
-  play: async () => {
-    const exampleElement = screen.getByLabelText('example-element');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const exampleElement = canvas.getByLabelText('example-element');
 
     // The delay option set the ammount of milliseconds between characters being typed
     await userEvent.type(exampleElement, 'random string', {
       delay: 100,
     });
 
-    const AnotherExampleElement = screen.getByLabelText('another-example-element');
+    const AnotherExampleElement = canvas.getByLabelText('another-example-element');
     await userEvent.type(AnotherExampleElement, 'another random string', {
       delay: 100,
     });

--- a/docs/snippets/react/my-component-play-function-with-selectevent.js.mdx
+++ b/docs/snippets/react/my-component-play-function-with-selectevent.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js|jsx
 
-import { userEvent, screen } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -19,11 +19,14 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// Queries the element by it's role and fires the event
-
+/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ExampleChangeEvent = {
-  play: async () => {
-    const select = screen.getByRole('listbox');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const select = canvas.getByRole('listbox');
 
     await userEvent.selectOptions(select, ['One Item']);
     await sleep(2000);

--- a/docs/snippets/react/my-component-play-function-with-selectevent.ts.mdx
+++ b/docs/snippets/react/my-component-play-function-with-selectevent.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { userEvent, screen } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { MyComponent } from './MyComponent';
 
@@ -24,11 +24,14 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// Queries the element by it's role and fires the event
-
+/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const ExampleChangeEvent: Story = {
-  play: async () => {
-    const select = screen.getByRole('listbox');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const select = canvas.getByRole('listbox');
 
     await userEvent.selectOptions(select, ['One Item']);
     await sleep(2000);

--- a/docs/snippets/react/register-component-with-play-function.js.mdx
+++ b/docs/snippets/react/register-component-with-play-function.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // RegistrationForm.stories.js|jsx
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { RegistrationForm } from './RegistrationForm';
 
@@ -14,9 +14,15 @@ export default {
   component: RegistrationForm,
 };
 
+/*
+ * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm = {
-  play: async () => {
-    const emailInput = screen.getByLabelText('email', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const emailInput = canvas.getByLabelText('email', {
       selector: 'input',
     });
 
@@ -24,7 +30,7 @@ export const FilledForm = {
       delay: 100,
     });
 
-    const passwordInput = screen.getByLabelText('password', {
+    const passwordInput = canvas.getByLabelText('password', {
       selector: 'input',
     });
 
@@ -32,7 +38,7 @@ export const FilledForm = {
       delay: 100,
     });
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const submitButton = screen.getByRole('button');
+    const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);
   },

--- a/docs/snippets/react/register-component-with-play-function.ts.mdx
+++ b/docs/snippets/react/register-component-with-play-function.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { RegistrationForm } from './RegistrationForm';
 
@@ -19,9 +19,15 @@ const meta: Meta<typeof RegistrationForm> = {
 export default meta;
 type Story = StoryObj<typeof RegistrationForm>;
 
+/*
+ * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm: Story = {
-  play: async () => {
-    const emailInput = screen.getByLabelText('email', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const emailInput = canvas.getByLabelText('email', {
       selector: 'input',
     });
 
@@ -29,7 +35,7 @@ export const FilledForm: Story = {
       delay: 100,
     });
 
-    const passwordInput = screen.getByLabelText('password', {
+    const passwordInput = canvas.getByLabelText('password', {
       selector: 'input',
     });
 
@@ -37,7 +43,7 @@ export const FilledForm: Story = {
       delay: 100,
     });
     // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const submitButton = screen.getByRole('button');
+    const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);
   },

--- a/docs/snippets/svelte/login-form-with-play-function.js.mdx
+++ b/docs/snippets/svelte/login-form-with-play-function.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // LoginForm.stories.js
 
-import { within, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { expect } from '@storybook/jest';
 
@@ -28,13 +28,16 @@ export const EmptyForm = {
   }),
 };
 
+/*
+ * See https://storybook.js.org/docs/7.0/svelte/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm = {
   render: (args) => ({
     Component: LoginForm,
     props: args,
   }),
   play: async ({ canvasElement }) => {
-    // Starts querying the component from its root element
     const canvas = within(canvasElement);
 
     // 👇 Simulate interactions with the component

--- a/docs/snippets/svelte/my-component-play-function-alt-queries.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-alt-queries.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.svelte';
 
@@ -15,18 +15,19 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/svelte/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleWithRole = {
   render: (args) => ({
     Component: MyComponent,
     props: args,
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button', { name: / button label/i }));
+    await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/svelte/my-component-play-function-composition.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-composition.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.svelte';
 
@@ -15,18 +15,18 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/svelte/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
-
 export const FirstStory = {
   render: (args) => ({
     Component: MyComponent,
     props: args,
   }),
-  play: async () => {
-    userEvent.type(screen.getByTestId('an-element'), 'example-value');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    userEvent.type(canvas.getByTestId('an-element'), 'example-value');
   },
 };
 
@@ -35,7 +35,9 @@ export const SecondStory = {
     Component: MyComponent,
     props: args,
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     await userEvent.type(screen.getByTestId('other-element'), 'another value');
   },
 };
@@ -45,11 +47,13 @@ export const CombinedStories = {
     Component: MyComponent,
     props: args,
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Runs the FirstStory and Second story play function before running this story's play function
-    await FirstStory.play();
-    await SecondStory.play();
-    await userEvent.type(screen.getByTestId('another-element'), 'random value');
+    await FirstStory.play({ canvasElement });
+    await SecondStory.play({ canvasElement });
+    await userEvent.type(canvas.getByTestId('another-element'), 'random value');
   },
 };
 ```

--- a/docs/snippets/svelte/my-component-play-function-composition.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-composition.js.mdx
@@ -38,7 +38,7 @@ export const SecondStory = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.type(screen.getByTestId('other-element'), 'another value');
+    await userEvent.type(canvas.getByTestId('other-element'), 'another value');
   },
 };
 

--- a/docs/snippets/svelte/my-component-play-function-query-findby.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-query-findby.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.svelte';
 
@@ -15,20 +15,21 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/svelte/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const AsyncExample = {
   render: (args) => ({
     Component: MyComponent,
     props: args,
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Other steps
 
     // Waits for the component to be rendered before querying the element
-    await screen.findByRole('button', { name: / button label/i }));
+    await canvas.findByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/svelte/my-component-play-function-waitfor.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-waitfor.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { screen, userEvent, waitFor } from '@storybook/testing-library';
+import { userEvent, waitFor, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.svelte';
 
@@ -15,17 +15,18 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/svelte/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleAsyncStory = {
   render: (args) => ({
     component: MyComponent,
     props: args,
   }),
-  play: async () => {
-    const exampleElement = screen.getByLabelText('Username', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const exampleElement = canvas.getByLabelText('Username', {
       selector: 'input',
     });
 
@@ -35,11 +36,11 @@ export const ExampleAsyncStory = {
     });
 
     // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const Submit = screen.getByRole('button');
+    const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 
     await waitFor(async () => {
-      await userEvent.hover(screen.getByTestId('error'));
+      await userEvent.hover(canvas.getByTestId('error'));
     });
   },
 };

--- a/docs/snippets/svelte/my-component-play-function-with-clickevent.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-with-clickevent.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { fireEvent, screen, userEvent } from '@storybook/testing-library';
+import { fireEvent, userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.svelte';
 
@@ -15,19 +15,19 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/svelte/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
-
 export const ClickExample = {
   render: (args) => ({
     Component: MyComponent,
     props: args,
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(canvas.getByRole('button'));
   },
 };
 
@@ -36,9 +36,11 @@ export const FireEventExample = {
     Component: MyComponent,
     props: args,
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await fireEvent.click(screen.getByTestId('data-testid'));
+    await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };
 ```

--- a/docs/snippets/svelte/my-component-play-function-with-delay.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-with-delay.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.svelte';
 
@@ -15,24 +15,25 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/svelte/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const DelayedStory = {
   render: (args) => ({
     Component: MyComponent,
     props: args,
   }),
-  play: async () => {
-    const exampleElement = screen.getByLabelText('example-element');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const exampleElement = canvas.getByLabelText('example-element');
 
     // The delay option set the amount of milliseconds between characters being typed
     await userEvent.type(exampleElement, 'random string', {
       delay: 100,
     });
 
-    const AnotherExampleElement = screen.getByLabelText('another-example-element');
+    const AnotherExampleElement = canvas.getByLabelText('another-example-element');
     await userEvent.type(AnotherExampleElement, 'another random string', {
       delay: 100,
     });

--- a/docs/snippets/svelte/my-component-play-function-with-selectevent.js.mdx
+++ b/docs/snippets/svelte/my-component-play-function-with-selectevent.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { userEvent, screen } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.svelte';
 
@@ -20,17 +20,18 @@ function sleep(ms) {
 }
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/svelte/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleChangeEvent = {
   render: (args) => ({
     Component: MyComponent,
     props: args,
   }),
-  play: async () => {
-    const select = screen.getByRole('listbox');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const select = canvas.getByRole('listbox');
 
     await userEvent.selectOptions(select, ['One Item']);
     await sleep(2000);

--- a/docs/snippets/svelte/register-component-with-play-function.js.mdx
+++ b/docs/snippets/svelte/register-component-with-play-function.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // RegistrationForm.stories.js
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import RegistrationForm from './RegistrationForm.svelte';
 
@@ -15,18 +15,18 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/svelte/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
-
 export const FilledForm = {
   render: (args) => ({
     Component: RegistrationForm,
     props: args,
   }),
-  play: async () => {
-    const emailInput = screen.getByLabelText('email', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const emailInput = canvas.getByLabelText('email', {
       selector: 'input',
     });
 
@@ -34,7 +34,7 @@ export const FilledForm = {
       delay: 100,
     });
 
-    const passwordInput = screen.getByLabelText('password', {
+    const passwordInput = canvas.getByLabelText('password', {
       selector: 'input',
     });
 
@@ -42,7 +42,7 @@ export const FilledForm = {
       delay: 100,
     });
     // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const submitButton = screen.getByRole('button');
+    const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);
   },

--- a/docs/snippets/vue/login-form-with-play-function.2.js.mdx
+++ b/docs/snippets/vue/login-form-with-play-function.2.js.mdx
@@ -29,6 +29,10 @@ export const EmptyForm = {
   }),
 };
 
+/*
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm = {
   render: (args, { argTypes }) => ({
     components: { LoginForm },
@@ -36,7 +40,6 @@ export const FilledForm = {
     template: `<LoginForm v-bind="$props" v-on="$props" />`,
   }),
   play: async ({ canvasElement }) => {
-    // Starts querying the component from its root element
     const canvas = within(canvasElement);
 
     // 👇 Simulate interactions with the component

--- a/docs/snippets/vue/login-form-with-play-function.3.js.mdx
+++ b/docs/snippets/vue/login-form-with-play-function.3.js.mdx
@@ -31,6 +31,10 @@ export const EmptyForm = {
   }),
 };
 
+/*
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm = {
   render: (args) => ({
     components: { LoginForm },
@@ -40,7 +44,6 @@ export const FilledForm = {
     template: '<LoginForm @onSubmit="onSubmit" v-bind="args" />',
   }),
   play: async ({ canvasElement }) => {
-    // Starts querying the component from its root element
     const canvas = within(canvasElement);
 
     // 👇 Simulate interactions with the component

--- a/docs/snippets/vue/login-form-with-play-function.ts-2.ts.mdx
+++ b/docs/snippets/vue/login-form-with-play-function.ts-2.ts.mdx
@@ -34,6 +34,10 @@ export const EmptyForm: Story = {
   }),
 };
 
+/*
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm: Story = {
   render: (args, { argTypes }) => ({
     components: { LoginForm },
@@ -41,7 +45,6 @@ export const FilledForm: Story = {
     template: `<LoginForm v-bind="$props" v-on="$props" />`,
   }),
   play: async ({ canvasElement }) => {
-    // Starts querying the component from its root element
     const canvas = within(canvasElement);
 
     // 👇 Simulate interactions with the component

--- a/docs/snippets/vue/login-form-with-play-function.ts-3.ts.mdx
+++ b/docs/snippets/vue/login-form-with-play-function.ts-3.ts.mdx
@@ -36,6 +36,10 @@ export const EmptyForm: Story = {
   }),
 };
 
+/*
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
 export const FilledForm: Story = {
   render: (args) => ({
     components: { LoginForm },
@@ -45,7 +49,6 @@ export const FilledForm: Story = {
     template: '<LoginForm @onSubmit="onSubmit" v-bind="args" />',
   }),
   play: async ({ canvasElement }) => {
-    // Starts querying the component from its root element
     const canvas = within(canvasElement);
 
     // 👇 Simulate interactions with the component

--- a/docs/snippets/vue/my-component-play-function-alt-queries.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-alt-queries.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -15,18 +15,19 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleWithRole = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button', { name: / button label/i }));
+    await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/vue/my-component-play-function-alt-queries.ts.mdx
+++ b/docs/snippets/vue/my-component-play-function-alt-queries.ts.mdx
@@ -4,7 +4,7 @@
 // import type { Meta, StoryObj } from '@storybook/vue3'; for Vue 3
 import type { Meta, StoryObj } from '@storybook/vue';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -21,19 +21,19 @@ export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
-
 export const ExampleWithRole: Story = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button', { name: / button label/i }));
+    await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/vue/my-component-play-function-composition.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-composition.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 

--- a/docs/snippets/vue/my-component-play-function-composition.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-composition.js.mdx
@@ -15,17 +15,18 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const FirstStory = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
-    userEvent.type(screen.getByTestId('an-element'), 'example-value');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    userEvent.type(canvas.getByTestId('an-element'), 'example-value');
   },
 };
 
@@ -34,8 +35,10 @@ export const SecondStory = {
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
-    await userEvent.type(screen.getByTestId('other-element'), 'another value');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(canvas.getByTestId('other-element'), 'another value');
   },
 };
 
@@ -44,11 +47,13 @@ export const CombinedStories = {
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Runs the FirstStory and Second story play function before running this story's play function
-    await FirstStory.play();
-    await SecondStory.play();
-    await userEvent.type(screen.getByTestId('another-element'), 'random value');
+    await FirstStory.play({ canvasElement });
+    await SecondStory.play({ canvasElement });
+    await userEvent.type(canvas.getByTestId('another-element'), 'random value');
   },
 };
 ```

--- a/docs/snippets/vue/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/vue/my-component-play-function-composition.ts.mdx
@@ -4,7 +4,7 @@
 // import type { Meta, StoryObj } from '@storybook/vue3'; for Vue 3
 import type { Meta, StoryObj } from '@storybook/vue';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -21,17 +21,17 @@ export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
-
 export const FirstStory: Story = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     userEvent.type(screen.getByTestId('an-element'), 'example-value');
   },
 };
@@ -41,7 +41,9 @@ export const SecondStory: Story = {
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     await userEvent.type(screen.getByTestId('other-element'), 'another value');
   },
 };
@@ -51,11 +53,13 @@ export const CombinedStories: Story = {
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Runs the FirstStory and Second story play function before running this story's play function
-    await FirstStory.play();
-    await SecondStory.play();
-    await userEvent.type(screen.getByTestId('another-element'), 'random value');
+    await FirstStory.play({ canvasElement });
+    await SecondStory.play({ canvasElement });
+    await userEvent.type(canvas.getByTestId('another-element'), 'random value');
   },
 };
 ```

--- a/docs/snippets/vue/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/vue/my-component-play-function-composition.ts.mdx
@@ -32,7 +32,7 @@ export const FirstStory: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    userEvent.type(screen.getByTestId('an-element'), 'example-value');
+    userEvent.type(canvas.getByTestId('an-element'), 'example-value');
   },
 };
 
@@ -44,7 +44,7 @@ export const SecondStory: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.type(screen.getByTestId('other-element'), 'another value');
+    await userEvent.type(canvas.getByTestId('other-element'), 'another value');
   },
 };
 

--- a/docs/snippets/vue/my-component-play-function-query-findby.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-query-findby.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -15,20 +15,21 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const AsyncExample = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Other steps
 
     // Waits for the component to be rendered before querying the element
-    await screen.findByRole('button', { name: / button label/i }));
+    await canvas.findByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/vue/my-component-play-function-query-findby.ts.mdx
+++ b/docs/snippets/vue/my-component-play-function-query-findby.ts.mdx
@@ -4,7 +4,7 @@
 // import type { Meta, StoryObj } from '@storybook/vue3'; for Vue 3
 import type { Meta, StoryObj } from '@storybook/vue';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -21,21 +21,21 @@ export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
-
 export const AsyncExample: Story = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // Other steps
 
     // Waits for the component to be rendered before querying the element
-    await screen.findByRole('button', { name: / button label/i }));
+    await canvas.findByRole('button', { name: / button label/i }));
   },
 };
 ```

--- a/docs/snippets/vue/my-component-play-function-waitfor.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-waitfor.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { screen, userEvent, waitFor } from '@storybook/testing-library';
+import { userEvent, waitFor, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -15,17 +15,18 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleAsyncStory = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
-    const exampleElement = screen.getByLabelText('Username', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const exampleElement = canvas.getByLabelText('Username', {
       selector: 'input',
     });
 
@@ -34,11 +35,11 @@ export const ExampleAsyncStory = {
       delay: 100,
     });
     // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const Submit = screen.getByRole('button');
+    const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 
     await waitFor(async () => {
-      await userEvent.hover(screen.getByTestId('error'));
+      await userEvent.hover(canvas.getByTestId('error'));
     });
   },
 };

--- a/docs/snippets/vue/my-component-play-function-waitfor.ts.mdx
+++ b/docs/snippets/vue/my-component-play-function-waitfor.ts.mdx
@@ -4,7 +4,7 @@
 // import type { Meta, StoryObj } from '@storybook/vue3'; for Vue 3
 import type { Meta, StoryObj } from '@storybook/vue';
 
-import { screen, userEvent, waitFor } from '@storybook/testing-library';
+import { userEvent, waitFor, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -21,29 +21,29 @@ export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
-
 export const ExampleAsyncStory: Story = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
-    const Input = screen.getByLabelText('Username', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const Input = canvas.getByLabelText('Username', {
       selector: 'input',
     });
     await userEvent.type(Input, 'WrongInput', {
       delay: 100,
     });
     // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const Submit = screen.getByRole('button');
+    const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 
     await waitFor(async () => {
-      await userEvent.hover(screen.getByTestId('error'));
+      await userEvent.hover(canvas.getByTestId('error'));
     });
   },
 };

--- a/docs/snippets/vue/my-component-play-function-with-clickevent.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-with-clickevent.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { fireEvent, screen, userEvent } from '@storybook/testing-library';
+import { fireEvent, userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -15,18 +15,19 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const ClickExample = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent/>',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(canvas.getByRole('button'));
   },
 };
 
@@ -35,9 +36,11 @@ export const FireEventExample = {
     components: { MyComponent },
     template: '<MyComponent/>',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await fireEvent.click(screen.getByTestId('data-testid'));
+    await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };
 ```

--- a/docs/snippets/vue/my-component-play-function-with-clickevent.ts.mdx
+++ b/docs/snippets/vue/my-component-play-function-with-clickevent.ts.mdx
@@ -4,7 +4,7 @@
 // import type { Meta, StoryObj } from '@storybook/vue3'; for Vue 3
 import type { Meta, StoryObj } from '@storybook/vue';
 
-import { fireEvent, screen, userEvent } from '@storybook/testing-library';
+import { fireEvent, userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -21,19 +21,19 @@ export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
-
 export const ClickExample: Story = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent/>',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(canvas.getByRole('button'));
   },
 };
 
@@ -42,9 +42,11 @@ export const FireEventExample: Story = {
     components: { MyComponent },
     template: '<MyComponent/>',
   }),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    await fireEvent.click(screen.getByTestId('data-testid'));
+    await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };
 ```

--- a/docs/snippets/vue/my-component-play-function-with-delay.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-with-delay.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -15,24 +15,25 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const DelayedStory = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent />',
   }),
-  play: async () => {
-    const exampleElement = screen.getByLabelText('example-element');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const exampleElement = canvas.getByLabelText('example-element');
 
     // The delay option set the ammount of milliseconds between characters being typed
     await userEvent.type(exampleElement, 'random string', {
       delay: 100,
     });
 
-    const AnotherExampleElement = screen.getByLabelText('another-example-element');
+    const AnotherExampleElement = canvas.getByLabelText('another-example-element');
     await userEvent.type(AnotherExampleElement, 'another random string', {
       delay: 100,
     });

--- a/docs/snippets/vue/my-component-play-function-with-delay.ts.mdx
+++ b/docs/snippets/vue/my-component-play-function-with-delay.ts.mdx
@@ -4,7 +4,7 @@
 // import type { Meta, StoryObj } from '@storybook/vue3'; for Vue 3
 import type { Meta, StoryObj } from '@storybook/vue';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -21,24 +21,25 @@ export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const DelayedStory: Story = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent/>',
   }),
-  play: async () => {
-    const exampleElement = screen.getByLabelText('example-element');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const exampleElement = canvas.getByLabelText('example-element');
 
     // The delay option set the ammount of milliseconds between characters being typed
     await userEvent.type(exampleElement, 'random string', {
       delay: 100,
     });
 
-    const AnotherExampleElement = screen.getByLabelText('another-example-element');
+    const AnotherExampleElement = canvas.getByLabelText('another-example-element');
     await userEvent.type(AnotherExampleElement, 'another random string', {
       delay: 100,
     });

--- a/docs/snippets/vue/my-component-play-function-with-selectevent.js.mdx
+++ b/docs/snippets/vue/my-component-play-function-with-selectevent.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyComponent.stories.js
 
-import { userEvent, screen } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import MyComponent from './MyComponent.vue';
 
@@ -20,17 +20,18 @@ function sleep(ms) {
 }
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleChangeEvent = {
   render: () => ({
     components: { MyComponent },
     template: '<MyComponent/>',
   }),
-  play: async () => {
-    const select = screen.getByRole('listbox');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const select = canvas.getByRole('listbox');
 
     await userEvent.selectOptions(select, ['One Item']);
     await sleep(2000);

--- a/docs/snippets/vue/my-component-play-function-with-selectevent.ts.mdx
+++ b/docs/snippets/vue/my-component-play-function-with-selectevent.ts.mdx
@@ -4,7 +4,7 @@
 // import type { Meta, StoryObj } from '@storybook/vue3'; for Vue 3
 import type { Meta, StoryObj } from '@storybook/vue';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import WithSelectEvent from './WithSelectEvent.vue';
 
@@ -26,18 +26,18 @@ function sleep(ms: number) {
 }
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
-
 export const ExampleChangeEvent: Story = {
   render: () => ({
     components: { WithSelectEvent },
     template: '<WithSelectEvent/>',
   }),
-  play: async () => {
-    const select = screen.getByRole('listbox');
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const select = canvas.getByRole('listbox');
 
     await userEvent.selectOptions(select, ['One Item']);
     await sleep(2000);

--- a/docs/snippets/vue/register-component-with-play-function.js.mdx
+++ b/docs/snippets/vue/register-component-with-play-function.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // RegistrationForm.stories.js
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import RegistrationForm from './RegistrationForm.vue';
 
@@ -15,17 +15,18 @@ export default {
 };
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm = {
   render: () => ({
     components: { RegistrationForm },
     template: '<RegistrationForm />',
   }),
-  play: async () => {
-    const emailInput = screen.getByLabelText('email', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const emailInput = canvas.getByLabelText('email', {
       selector: 'input',
     });
 
@@ -33,7 +34,7 @@ export const FilledForm = {
       delay: 100,
     });
 
-    const passwordInput = screen.getByLabelText('password', {
+    const passwordInput = canvas.getByLabelText('password', {
       selector: 'input',
     });
 
@@ -42,7 +43,7 @@ export const FilledForm = {
     });
 
     // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const submitButton = screen.getByRole('button');
+    const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);
   },

--- a/docs/snippets/vue/register-component-with-play-function.ts.mdx
+++ b/docs/snippets/vue/register-component-with-play-function.ts.mdx
@@ -4,7 +4,7 @@
 // import type { Meta, StoryObj } from '@storybook/vue3'; for Vue 3
 import type { Meta, StoryObj } from '@storybook/vue';
 
-import { screen, userEvent } from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 
 import RegistrationForm from './RegistrationForm.vue';
 
@@ -21,17 +21,18 @@ export default meta;
 type Story = StoryObj<typeof RegistrationForm>;
 
 /*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
- * to learn how to use render functions.
+ * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
   render: () => ({
     components: { RegistrationForm },
     template: '<RegistrationForm />',
   }),
-  play: async () => {
-    const emailInput = screen.getByLabelText('email', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const emailInput = canvas.getByLabelText('email', {
       selector: 'input',
     });
 
@@ -39,7 +40,7 @@ export const FilledForm: Story = {
       delay: 100,
     });
 
-    const passwordInput = screen.getByLabelText('password', {
+    const passwordInput = canvas.getByLabelText('password', {
       selector: 'input',
     });
 
@@ -48,7 +49,7 @@ export const FilledForm: Story = {
     });
 
     // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
-    const submitButton = screen.getByRole('button');
+    const submitButton = canvas.getByRole('button');
     await userEvent.click(submitButton);
   },
 };


### PR DESCRIPTION
With this pull request, the snippets used in the documentation for CSF 3 will now feature `canvasElement` instead of `screen`. Follows ups on #19783

What was done:
- Converted the existing snippets used in the interaction's docs to feature the `canvasElement`