### PR TITLE
Maintenance: fix chromatic version to 6.11.2 in local scripts

### DIFF
--- a/scripts/tasks/chromatic.ts
+++ b/scripts/tasks/chromatic.ts
@@ -13,7 +13,7 @@ export const chromatic: Task = {
     const token = process.env[tokenEnvVarName];
 
     await exec(
-      `npx chromatic \
+      `npx chromatic@6.11.2 \
           --exit-zero-on-changes \
           --storybook-build-dir=${builtSandboxDir} \
           --junit-report=${junitFilename} \


### PR DESCRIPTION
Issue: N/A

## What I did

Chromatic 6.11.4 is flaky, therefore we are just fixing it to 6.11.2 in the meantime

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
