### PR TITLE
Upgrade loader-utils to 2.0.4 in storysource and source-loader

### DIFF
--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -50,7 +50,7 @@
     "@storybook/theming": "6.5.13",
     "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
-    "loader-utils": "^2.0.3",
+    "loader-utils": "^2.0.4",
     "prop-types": "^15.7.2",
     "react-syntax-highlighter": "^15.4.5",
     "regenerator-runtime": "^0.13.7"

--- a/addons/storysource/package.json
+++ b/addons/storysource/package.json
@@ -50,7 +50,7 @@
     "@storybook/theming": "6.5.13",
     "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
-    "loader-utils": "^2.0.0",
+    "loader-utils": "^2.0.3",
     "prop-types": "^15.7.2",
     "react-syntax-highlighter": "^15.4.5",
     "regenerator-runtime": "^0.13.7"

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -47,7 +47,7 @@
     "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
     "global": "^4.4.0",
-    "loader-utils": "^2.0.0",
+    "loader-utils": "^2.0.3",
     "lodash": "^4.17.21",
     "prettier": ">=2.2.1 <=2.3.0",
     "regenerator-runtime": "^0.13.7"

--- a/lib/source-loader/package.json
+++ b/lib/source-loader/package.json
@@ -47,7 +47,7 @@
     "core-js": "^3.8.2",
     "estraverse": "^5.2.0",
     "global": "^4.4.0",
-    "loader-utils": "^2.0.3",
+    "loader-utils": "^2.0.4",
     "lodash": "^4.17.21",
     "prettier": ">=2.2.1 <=2.3.0",
     "regenerator-runtime": "^0.13.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6413,18 +6413,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-a11y@6.5.13-alpha.1, @storybook/addon-a11y@workspace:*, @storybook/addon-a11y@workspace:addons/a11y":
+"@storybook/addon-a11y@6.5.13, @storybook/addon-a11y@workspace:*, @storybook/addon-a11y@workspace:addons/a11y":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-a11y@workspace:addons/a11y"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/channels": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/channels": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/theming": 6.5.13
     "@testing-library/react": ^11.2.2
     "@types/webpack-env": ^1.16.0
     axe-core: ^4.2.0
@@ -6446,17 +6446,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-actions@6.5.13-alpha.1, @storybook/addon-actions@workspace:*, @storybook/addon-actions@workspace:addons/actions":
+"@storybook/addon-actions@6.5.13, @storybook/addon-actions@workspace:*, @storybook/addon-actions@workspace:addons/actions":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-actions@workspace:addons/actions"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/theming": 6.5.13
     "@types/lodash": ^4.14.167
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -6482,17 +6482,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-backgrounds@6.5.13-alpha.1, @storybook/addon-backgrounds@workspace:*, @storybook/addon-backgrounds@workspace:addons/backgrounds":
+"@storybook/addon-backgrounds@6.5.13, @storybook/addon-backgrounds@workspace:*, @storybook/addon-backgrounds@workspace:addons/backgrounds":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-backgrounds@workspace:addons/backgrounds"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/theming": 6.5.13
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -6511,19 +6511,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-controls@6.5.13-alpha.1, @storybook/addon-controls@workspace:*, @storybook/addon-controls@workspace:addons/controls":
+"@storybook/addon-controls@6.5.13, @storybook/addon-controls@workspace:*, @storybook/addon-controls@workspace:addons/controls":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-controls@workspace:addons/controls"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-common": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/node-logger": 6.5.13
+    "@storybook/store": 6.5.13
+    "@storybook/theming": 6.5.13
     core-js: ^3.8.2
     lodash: ^4.17.21
     ts-dedent: ^2.0.0
@@ -6538,7 +6538,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-docs@6.5.13-alpha.1, @storybook/addon-docs@workspace:*, @storybook/addon-docs@workspace:addons/docs":
+"@storybook/addon-docs@6.5.13, @storybook/addon-docs@workspace:*, @storybook/addon-docs@workspace:addons/docs":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-docs@workspace:addons/docs"
   dependencies:
@@ -6547,21 +6547,21 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@jest/transform": ^26.6.2
     "@mdx-js/react": ^1.6.22
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/docs-tools": 6.5.13-alpha.1
+    "@storybook/docs-tools": 6.5.13
     "@storybook/mdx1-csf": ^0.0.1
     "@storybook/mdx2-csf": ^0.0.3
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/postinstall": 6.5.13-alpha.1
-    "@storybook/preview-web": 6.5.13-alpha.1
-    "@storybook/source-loader": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/node-logger": 6.5.13
+    "@storybook/postinstall": 6.5.13
+    "@storybook/preview-web": 6.5.13
+    "@storybook/source-loader": 6.5.13
+    "@storybook/store": 6.5.13
+    "@storybook/theming": 6.5.13
     "@types/util-deprecate": ^1.0.0
     babel-loader: ^8.0.0
     core-js: ^3.8.2
@@ -6587,24 +6587,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-essentials@6.5.13-alpha.1, @storybook/addon-essentials@workspace:*, @storybook/addon-essentials@workspace:addons/essentials":
+"@storybook/addon-essentials@6.5.13, @storybook/addon-essentials@workspace:*, @storybook/addon-essentials@workspace:addons/essentials":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-essentials@workspace:addons/essentials"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-backgrounds": 6.5.13-alpha.1
-    "@storybook/addon-controls": 6.5.13-alpha.1
-    "@storybook/addon-docs": 6.5.13-alpha.1
-    "@storybook/addon-measure": 6.5.13-alpha.1
-    "@storybook/addon-outline": 6.5.13-alpha.1
-    "@storybook/addon-toolbars": 6.5.13-alpha.1
-    "@storybook/addon-viewport": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/vue": 6.5.13-alpha.1
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-backgrounds": 6.5.13
+    "@storybook/addon-controls": 6.5.13
+    "@storybook/addon-docs": 6.5.13
+    "@storybook/addon-measure": 6.5.13
+    "@storybook/addon-outline": 6.5.13
+    "@storybook/addon-toolbars": 6.5.13
+    "@storybook/addon-viewport": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/node-logger": 6.5.13
+    "@storybook/vue": 6.5.13
     "@types/jest": ^26.0.16
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -6667,22 +6667,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-interactions@6.5.13-alpha.1, @storybook/addon-interactions@workspace:*, @storybook/addon-interactions@workspace:addons/interactions":
+"@storybook/addon-interactions@6.5.13, @storybook/addon-interactions@workspace:*, @storybook/addon-interactions@workspace:addons/interactions":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-interactions@workspace:addons/interactions"
   dependencies:
     "@devtools-ds/object-inspector": ^1.1.2
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/instrumenter": 6.5.13-alpha.1
+    "@storybook/instrumenter": 6.5.13
     "@storybook/jest": ^0.0.5
     "@storybook/testing-library": ^0.0.7
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/theming": 6.5.13
     core-js: ^3.8.2
     formik: ^2.2.9
     global: ^4.4.0
@@ -6700,16 +6700,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-jest@6.5.13-alpha.1, @storybook/addon-jest@workspace:*, @storybook/addon-jest@workspace:addons/jest":
+"@storybook/addon-jest@6.5.13, @storybook/addon-jest@workspace:*, @storybook/addon-jest@workspace:addons/jest":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-jest@workspace:addons/jest"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-events": 6.5.13
+    "@storybook/theming": 6.5.13
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -6727,15 +6727,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-links@6.5.13-alpha.1, @storybook/addon-links@workspace:*, @storybook/addon-links@workspace:addons/links":
+"@storybook/addon-links@6.5.13, @storybook/addon-links@workspace:*, @storybook/addon-links@workspace:addons/links":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-links@workspace:addons/links"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/router": 6.5.13-alpha.1
+    "@storybook/router": 6.5.13
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -6755,15 +6755,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-measure@6.5.13-alpha.1, @storybook/addon-measure@workspace:*, @storybook/addon-measure@workspace:addons/measure":
+"@storybook/addon-measure@6.5.13, @storybook/addon-measure@workspace:*, @storybook/addon-measure@workspace:addons/measure":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-measure@workspace:addons/measure"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -6779,15 +6779,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-outline@6.5.13-alpha.1, @storybook/addon-outline@workspace:*, @storybook/addon-outline@workspace:addons/outline":
+"@storybook/addon-outline@6.5.13, @storybook/addon-outline@workspace:*, @storybook/addon-outline@workspace:addons/outline":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-outline@workspace:addons/outline"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -6818,20 +6818,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-storyshots-puppeteer@6.5.13-alpha.1, @storybook/addon-storyshots-puppeteer@workspace:*, @storybook/addon-storyshots-puppeteer@workspace:addons/storyshots/storyshots-puppeteer":
+"@storybook/addon-storyshots-puppeteer@6.5.13, @storybook/addon-storyshots-puppeteer@workspace:*, @storybook/addon-storyshots-puppeteer@workspace:addons/storyshots/storyshots-puppeteer":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-storyshots-puppeteer@workspace:addons/storyshots/storyshots-puppeteer"
   dependencies:
     "@axe-core/puppeteer": ^4.2.0
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/node-logger": 6.5.13-alpha.1
+    "@storybook/node-logger": 6.5.13
     "@types/jest-image-snapshot": ^4.1.3
     "@types/puppeteer": ^5.4.0
     core-js: ^3.8.2
     jest-image-snapshot: ^4.3.0
     regenerator-runtime: ^0.13.7
   peerDependencies:
-    "@storybook/addon-storyshots": 6.5.13-alpha.1
+    "@storybook/addon-storyshots": 6.5.13
     puppeteer: ^2.0.0 || ^3.0.0
   peerDependenciesMeta:
     puppeteer:
@@ -6839,7 +6839,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-storyshots@6.5.13-alpha.1, @storybook/addon-storyshots@workspace:*, @storybook/addon-storyshots@workspace:addons/storyshots/storyshots-core":
+"@storybook/addon-storyshots@6.5.13, @storybook/addon-storyshots@workspace:*, @storybook/addon-storyshots@workspace:addons/storyshots/storyshots-core":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-storyshots@workspace:addons/storyshots/storyshots-core"
   dependencies:
@@ -6847,18 +6847,18 @@ __metadata:
     "@angular/platform-browser-dynamic": ^11.2.0
     "@emotion/jest": ^11.8.0
     "@jest/transform": ^26.6.2
-    "@storybook/addon-docs": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/angular": 6.5.13-alpha.1
+    "@storybook/addon-docs": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/angular": 6.5.13
     "@storybook/babel-plugin-require-context-hook": 1.0.1
-    "@storybook/client-api": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-client": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/client-api": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-client": 6.5.13
+    "@storybook/core-common": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/react": 6.5.13-alpha.1
-    "@storybook/vue": 6.5.13-alpha.1
-    "@storybook/vue3": 6.5.13-alpha.1
+    "@storybook/react": 6.5.13
+    "@storybook/vue": 6.5.13
+    "@storybook/vue3": 6.5.13
     "@types/glob": ^7.1.3
     "@types/jest": ^26.0.16
     "@types/jest-specific-snapshot": ^0.5.3
@@ -6930,22 +6930,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-storysource@6.5.13-alpha.1, @storybook/addon-storysource@workspace:*, @storybook/addon-storysource@workspace:addons/storysource":
+"@storybook/addon-storysource@6.5.13, @storybook/addon-storysource@workspace:*, @storybook/addon-storysource@workspace:addons/storysource":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-storysource@workspace:addons/storysource"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/router": 6.5.13-alpha.1
-    "@storybook/source-loader": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/router": 6.5.13
+    "@storybook/source-loader": 6.5.13
+    "@storybook/theming": 6.5.13
     "@types/react": ^16.14.23
     "@types/react-syntax-highlighter": ^11.0.5
     core-js: ^3.8.2
     estraverse: ^5.2.0
-    loader-utils: ^2.0.0
+    loader-utils: ^2.0.4
     prop-types: ^15.7.2
     react-syntax-highlighter: ^15.4.5
     regenerator-runtime: ^0.13.7
@@ -6960,15 +6960,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-toolbars@6.5.13-alpha.1, @storybook/addon-toolbars@workspace:*, @storybook/addon-toolbars@workspace:addons/toolbars":
+"@storybook/addon-toolbars@6.5.13, @storybook/addon-toolbars@workspace:*, @storybook/addon-toolbars@workspace:addons/toolbars":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-toolbars@workspace:addons/toolbars"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/theming": 6.5.13
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
   peerDependencies:
@@ -6982,16 +6982,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-viewport@6.5.13-alpha.1, @storybook/addon-viewport@workspace:*, @storybook/addon-viewport@workspace:addons/viewport":
+"@storybook/addon-viewport@6.5.13, @storybook/addon-viewport@workspace:*, @storybook/addon-viewport@workspace:addons/viewport":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-viewport@workspace:addons/viewport"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-events": 6.5.13
+    "@storybook/theming": 6.5.13
     core-js: ^3.8.2
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -7008,17 +7008,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addons@6.5.13-alpha.1, @storybook/addons@workspace:*, @storybook/addons@workspace:lib/addons":
+"@storybook/addons@6.5.13, @storybook/addons@workspace:*, @storybook/addons@workspace:lib/addons":
   version: 0.0.0-use.local
   resolution: "@storybook/addons@workspace:lib/addons"
   dependencies:
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/channels": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/api": 6.5.13
+    "@storybook/channels": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/router": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/router": 6.5.13
+    "@storybook/theming": 6.5.13
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -7051,29 +7051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addons@npm:6.5.12":
-  version: 6.5.12
-  resolution: "@storybook/addons@npm:6.5.12"
-  dependencies:
-    "@storybook/api": 6.5.12
-    "@storybook/channels": 6.5.12
-    "@storybook/client-logger": 6.5.12
-    "@storybook/core-events": 6.5.12
-    "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/router": 6.5.12
-    "@storybook/theming": 6.5.12
-    "@types/webpack-env": ^1.16.0
-    core-js: ^3.8.2
-    global: ^4.4.0
-    regenerator-runtime: ^0.13.7
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 253df9fef74f0fe6de084b40e68e24f9c5d71e0ecd8e3b14a8aaae9bf695ee84b659be4a3b26180ac5fe64ef3aa95d84b50fbde2e2ad52a79fcb2bb3d612066b
-  languageName: node
-  linkType: hard
-
-"@storybook/angular@6.5.13-alpha.1, @storybook/angular@workspace:*, @storybook/angular@workspace:app/angular":
+"@storybook/angular@6.5.13, @storybook/angular@workspace:*, @storybook/angular@workspace:app/angular":
   version: 0.0.0-use.local
   resolution: "@storybook/angular@workspace:app/angular"
   dependencies:
@@ -7089,17 +7067,17 @@ __metadata:
     "@angular/platform-browser": ^11.2.14
     "@angular/platform-browser-dynamic": ^11.2.14
     "@nrwl/workspace": ^11.6.3
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/docs-tools": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
+    "@storybook/docs-tools": 6.5.13
+    "@storybook/node-logger": 6.5.13
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/store": 6.5.13
     "@types/autoprefixer": ^9.7.2
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/react": ^16.14.23
@@ -7161,17 +7139,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/api@6.5.13-alpha.1, @storybook/api@workspace:*, @storybook/api@workspace:lib/api":
+"@storybook/api@6.5.13, @storybook/api@workspace:*, @storybook/api@workspace:lib/api":
   version: 0.0.0-use.local
   resolution: "@storybook/api@workspace:lib/api"
   dependencies:
-    "@storybook/channels": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/channels": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/router": 6.5.13-alpha.1
+    "@storybook/router": 6.5.13
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/theming": 6.5.13
     "@types/lodash": ^4.14.167
     "@types/qs": ^6
     "@types/semver": ^7.3.4
@@ -7222,34 +7200,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/api@npm:6.5.12":
-  version: 6.5.12
-  resolution: "@storybook/api@npm:6.5.12"
-  dependencies:
-    "@storybook/channels": 6.5.12
-    "@storybook/client-logger": 6.5.12
-    "@storybook/core-events": 6.5.12
-    "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/router": 6.5.12
-    "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.5.12
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-    regenerator-runtime: ^0.13.7
-    store2: ^2.12.0
-    telejson: ^6.0.8
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 40cbba08fa132f9ae54e5475667e44a9dd0e64f4e8b1fe46427a452bec9377bd2d60a877d21deccc95f8416aff0322b2b5128ceef5b90380a07f0a1687aab430
-  languageName: node
-  linkType: hard
-
 "@storybook/babel-plugin-require-context-hook@npm:1.0.1":
   version: 1.0.1
   resolution: "@storybook/babel-plugin-require-context-hook@npm:1.0.1"
@@ -7257,27 +7207,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack4@6.5.13-alpha.1, @storybook/builder-webpack4@workspace:lib/builder-webpack4":
+"@storybook/builder-webpack4@6.5.13, @storybook/builder-webpack4@workspace:lib/builder-webpack4":
   version: 0.0.0-use.local
   resolution: "@storybook/builder-webpack4@workspace:lib/builder-webpack4"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/channel-postmessage": 6.5.13-alpha.1
-    "@storybook/channels": 6.5.13-alpha.1
-    "@storybook/client-api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/preview-web": 6.5.13-alpha.1
-    "@storybook/router": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/channel-postmessage": 6.5.13
+    "@storybook/channels": 6.5.13
+    "@storybook/client-api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/core-events": 6.5.13
+    "@storybook/node-logger": 6.5.13
+    "@storybook/preview-web": 6.5.13
+    "@storybook/router": 6.5.13
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
-    "@storybook/ui": 6.5.13-alpha.1
+    "@storybook/store": 6.5.13
+    "@storybook/theming": 6.5.13
+    "@storybook/ui": 6.5.13
     "@types/case-sensitive-paths-webpack-plugin": ^2.1.4
     "@types/node": ^14.0.10 || ^16.0.0
     "@types/terser-webpack-plugin": ^4.2.0
@@ -7322,26 +7272,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/builder-webpack5@6.5.13-alpha.1, @storybook/builder-webpack5@workspace:lib/builder-webpack5":
+"@storybook/builder-webpack5@6.5.13, @storybook/builder-webpack5@workspace:lib/builder-webpack5":
   version: 0.0.0-use.local
   resolution: "@storybook/builder-webpack5@workspace:lib/builder-webpack5"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/channel-postmessage": 6.5.13-alpha.1
-    "@storybook/channels": 6.5.13-alpha.1
-    "@storybook/client-api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/preview-web": 6.5.13-alpha.1
-    "@storybook/router": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/channel-postmessage": 6.5.13
+    "@storybook/channels": 6.5.13
+    "@storybook/client-api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/core-events": 6.5.13
+    "@storybook/node-logger": 6.5.13
+    "@storybook/preview-web": 6.5.13
+    "@storybook/router": 6.5.13
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/store": 6.5.13
+    "@storybook/theming": 6.5.13
     "@types/case-sensitive-paths-webpack-plugin": ^2.1.4
     "@types/node": ^14.0.10 || ^16.0.0
     "@types/terser-webpack-plugin": ^5.0.2
@@ -7378,13 +7328,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/channel-postmessage@6.5.13-alpha.1, @storybook/channel-postmessage@workspace:*, @storybook/channel-postmessage@workspace:lib/channel-postmessage":
+"@storybook/channel-postmessage@6.5.13, @storybook/channel-postmessage@workspace:*, @storybook/channel-postmessage@workspace:lib/channel-postmessage":
   version: 0.0.0-use.local
   resolution: "@storybook/channel-postmessage@workspace:lib/channel-postmessage"
   dependencies:
-    "@storybook/channels": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/channels": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core-events": 6.5.13
     core-js: ^3.8.2
     global: ^4.4.0
     qs: ^6.10.0
@@ -7392,19 +7342,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/channel-websocket@6.5.13-alpha.1, @storybook/channel-websocket@workspace:*, @storybook/channel-websocket@workspace:lib/channel-websocket":
+"@storybook/channel-websocket@6.5.13, @storybook/channel-websocket@workspace:*, @storybook/channel-websocket@workspace:lib/channel-websocket":
   version: 0.0.0-use.local
   resolution: "@storybook/channel-websocket@workspace:lib/channel-websocket"
   dependencies:
-    "@storybook/channels": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
+    "@storybook/channels": 6.5.13
+    "@storybook/client-logger": 6.5.13
     core-js: ^3.8.2
     global: ^4.4.0
     telejson: ^6.0.8
   languageName: unknown
   linkType: soft
 
-"@storybook/channels@6.5.13-alpha.1, @storybook/channels@workspace:*, @storybook/channels@workspace:lib/channels":
+"@storybook/channels@6.5.13, @storybook/channels@workspace:*, @storybook/channels@workspace:lib/channels":
   version: 0.0.0-use.local
   resolution: "@storybook/channels@workspace:lib/channels"
   dependencies:
@@ -7425,30 +7375,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:6.5.12":
-  version: 6.5.12
-  resolution: "@storybook/channels@npm:6.5.12"
-  dependencies:
-    core-js: ^3.8.2
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  checksum: 8a7d2d79faab8445ae2e8fbc2207ec5cdafe152d4ecd66e4ed91ee5021688094be2b394d267d05d69c7778a186bc62fb6eb6a8541731c8039d8df66d68dac97b
-  languageName: node
-  linkType: hard
-
-"@storybook/cli@6.5.13-alpha.1, @storybook/cli@workspace:*, @storybook/cli@workspace:lib/cli":
+"@storybook/cli@6.5.13, @storybook/cli@workspace:*, @storybook/cli@workspace:lib/cli":
   version: 0.0.0-use.local
   resolution: "@storybook/cli@workspace:lib/cli"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/preset-env": ^7.12.11
-    "@storybook/client-api": 6.5.13-alpha.1
-    "@storybook/codemod": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/csf-tools": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
+    "@storybook/client-api": 6.5.13
+    "@storybook/codemod": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/csf-tools": 6.5.13
+    "@storybook/node-logger": 6.5.13
     "@storybook/semver": ^7.3.2
-    "@storybook/telemetry": 6.5.13-alpha.1
+    "@storybook/telemetry": 6.5.13
     "@types/cross-spawn": ^6.0.2
     "@types/prompts": ^2.0.9
     "@types/puppeteer-core": ^2.1.0
@@ -7482,17 +7421,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/client-api@6.5.13-alpha.1, @storybook/client-api@workspace:*, @storybook/client-api@workspace:lib/client-api":
+"@storybook/client-api@6.5.13, @storybook/client-api@workspace:*, @storybook/client-api@workspace:lib/client-api":
   version: 0.0.0-use.local
   resolution: "@storybook/client-api@workspace:lib/client-api"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/channel-postmessage": 6.5.13-alpha.1
-    "@storybook/channels": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/channel-postmessage": 6.5.13
+    "@storybook/channels": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/store": 6.5.13
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -7512,7 +7451,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/client-logger@6.5.13-alpha.1, @storybook/client-logger@workspace:*, @storybook/client-logger@workspace:lib/client-logger":
+"@storybook/client-logger@6.5.13, @storybook/client-logger@^6.4.0 || >=6.5.0-0, @storybook/client-logger@workspace:*, @storybook/client-logger@workspace:lib/client-logger":
   version: 0.0.0-use.local
   resolution: "@storybook/client-logger@workspace:lib/client-logger"
   dependencies:
@@ -7531,25 +7470,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@npm:6.5.12, @storybook/client-logger@npm:^6.4.0 || >=6.5.0-0":
-  version: 6.5.12
-  resolution: "@storybook/client-logger@npm:6.5.12"
-  dependencies:
-    core-js: ^3.8.2
-    global: ^4.4.0
-  checksum: 959b3cce73c2434eee1b39c4f5ed82d0df4fb725475004a24760f02a8c22acee6b55214d5b0756c4df27a466f2b095dbfc52f7cc0a3b1f8c64e8ed50dabe7a7c
-  languageName: node
-  linkType: hard
-
-"@storybook/codemod@6.5.13-alpha.1, @storybook/codemod@workspace:*, @storybook/codemod@workspace:lib/codemod":
+"@storybook/codemod@6.5.13, @storybook/codemod@workspace:*, @storybook/codemod@workspace:lib/codemod":
   version: 0.0.0-use.local
   resolution: "@storybook/codemod@workspace:lib/codemod"
   dependencies:
     "@babel/types": ^7.12.11
     "@mdx-js/mdx": ^1.6.22
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/csf-tools": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
+    "@storybook/csf-tools": 6.5.13
+    "@storybook/node-logger": 6.5.13
     core-js: ^3.8.2
     cross-spawn: ^7.0.3
     globby: ^11.0.2
@@ -7563,14 +7492,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/components@6.5.13-alpha.1, @storybook/components@workspace:*, @storybook/components@workspace:lib/components":
+"@storybook/components@6.5.13, @storybook/components@workspace:*, @storybook/components@workspace:lib/components":
   version: 0.0.0-use.local
   resolution: "@storybook/components@workspace:lib/components"
   dependencies:
     "@popperjs/core": ^2.6.0
-    "@storybook/client-logger": 6.5.13-alpha.1
+    "@storybook/client-logger": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/theming": 6.5.13
     "@types/color-convert": ^2.0.0
     "@types/overlayscrollbars": ^1.12.0
     "@types/react-syntax-highlighter": 11.0.5
@@ -7602,20 +7531,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-client@6.5.13-alpha.1, @storybook/core-client@workspace:lib/core-client":
+"@storybook/core-client@6.5.13, @storybook/core-client@workspace:lib/core-client":
   version: 0.0.0-use.local
   resolution: "@storybook/core-client@workspace:lib/core-client"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/channel-postmessage": 6.5.13-alpha.1
-    "@storybook/channel-websocket": 6.5.13-alpha.1
-    "@storybook/client-api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/channel-postmessage": 6.5.13
+    "@storybook/channel-websocket": 6.5.13
+    "@storybook/client-api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/preview-web": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
-    "@storybook/ui": 6.5.13-alpha.1
+    "@storybook/preview-web": 6.5.13
+    "@storybook/store": 6.5.13
+    "@storybook/ui": 6.5.13
     airbnb-js-shims: ^2.2.1
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
@@ -7636,7 +7565,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-common@6.5.13-alpha.1, @storybook/core-common@workspace:lib/core-common":
+"@storybook/core-common@6.5.13, @storybook/core-common@workspace:lib/core-common":
   version: 0.0.0-use.local
   resolution: "@storybook/core-common@workspace:lib/core-common"
   dependencies:
@@ -7662,7 +7591,7 @@ __metadata:
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
     "@babel/register": ^7.12.1
-    "@storybook/node-logger": 6.5.13-alpha.1
+    "@storybook/node-logger": 6.5.13
     "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0
     "@storybook/semver": ^7.3.2
     "@types/compression": ^1.7.0
@@ -7705,7 +7634,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-events@6.5.13-alpha.1, @storybook/core-events@workspace:*, @storybook/core-events@workspace:lib/core-events":
+"@storybook/core-events@6.5.13, @storybook/core-events@workspace:*, @storybook/core-events@workspace:lib/core-events":
   version: 0.0.0-use.local
   resolution: "@storybook/core-events@workspace:lib/core-events"
   dependencies:
@@ -7722,32 +7651,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/core-events@npm:6.5.12":
-  version: 6.5.12
-  resolution: "@storybook/core-events@npm:6.5.12"
-  dependencies:
-    core-js: ^3.8.2
-  checksum: 846aa0381b103dbd79be2a10f6d64449f19749e10b5cb49a92958af388f04b77d3b8a90bbf605a48752f93dda1308eeead117879f2641be8c70312fc8cfc7274
-  languageName: node
-  linkType: hard
-
-"@storybook/core-server@6.5.13-alpha.1, @storybook/core-server@workspace:lib/core-server":
+"@storybook/core-server@6.5.13, @storybook/core-server@workspace:lib/core-server":
   version: 0.0.0-use.local
   resolution: "@storybook/core-server@workspace:lib/core-server"
   dependencies:
     "@discoveryjs/json-ext": ^0.5.3
-    "@storybook/builder-webpack4": 6.5.13-alpha.1
-    "@storybook/builder-webpack5": 6.5.13-alpha.1
-    "@storybook/core-client": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/builder-webpack4": 6.5.13
+    "@storybook/builder-webpack5": 6.5.13
+    "@storybook/core-client": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/csf-tools": 6.5.13-alpha.1
-    "@storybook/manager-webpack4": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
+    "@storybook/csf-tools": 6.5.13
+    "@storybook/manager-webpack4": 6.5.13
+    "@storybook/node-logger": 6.5.13
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.5.13-alpha.1
-    "@storybook/telemetry": 6.5.13-alpha.1
+    "@storybook/store": 6.5.13
+    "@storybook/telemetry": 6.5.13
     "@types/compression": ^1.7.0
     "@types/ip": ^1.1.0
     "@types/node": ^14.0.10 || ^16.0.0
@@ -7799,12 +7719,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core@6.5.13-alpha.1, @storybook/core@workspace:*, @storybook/core@workspace:lib/core":
+"@storybook/core@6.5.13, @storybook/core@workspace:*, @storybook/core@workspace:lib/core":
   version: 0.0.0-use.local
   resolution: "@storybook/core@workspace:lib/core"
   dependencies:
-    "@storybook/core-client": 6.5.13-alpha.1
-    "@storybook/core-server": 6.5.13-alpha.1
+    "@storybook/core-client": 6.5.13
+    "@storybook/core-server": 6.5.13
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -7819,7 +7739,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/csf-tools@6.5.13-alpha.1, @storybook/csf-tools@workspace:*, @storybook/csf-tools@workspace:lib/csf-tools":
+"@storybook/csf-tools@6.5.13, @storybook/csf-tools@workspace:*, @storybook/csf-tools@workspace:lib/csf-tools":
   version: 0.0.0-use.local
   resolution: "@storybook/csf-tools@workspace:lib/csf-tools"
   dependencies:
@@ -7898,13 +7818,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/docs-tools@6.5.13-alpha.1, @storybook/docs-tools@workspace:*, @storybook/docs-tools@workspace:lib/docs-tools":
+"@storybook/docs-tools@6.5.13, @storybook/docs-tools@workspace:*, @storybook/docs-tools@workspace:lib/docs-tools":
   version: 0.0.0-use.local
   resolution: "@storybook/docs-tools@workspace:lib/docs-tools"
   dependencies:
     "@babel/core": ^7.12.10
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/store": 6.5.13
     core-js: ^3.8.2
     doctrine: ^3.0.0
     jest-specific-snapshot: ^4.0.0
@@ -7926,14 +7846,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/ember@6.5.13-alpha.1, @storybook/ember@workspace:*, @storybook/ember@workspace:app/ember":
+"@storybook/ember@6.5.13, @storybook/ember@workspace:*, @storybook/ember@workspace:app/ember":
   version: 0.0.0-use.local
   resolution: "@storybook/ember@workspace:app/ember"
   dependencies:
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/docs-tools": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/core": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/docs-tools": 6.5.13
+    "@storybook/store": 6.5.13
     core-js: ^3.8.2
     global: ^4.4.0
     react: 16.14.0
@@ -7966,10 +7886,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/example-react-ts-webpack4@workspace:examples/react-ts-webpack4"
   dependencies:
-    "@storybook/addon-controls": 6.5.13-alpha.1
-    "@storybook/addon-essentials": 6.5.13-alpha.1
-    "@storybook/builder-webpack4": 6.5.13-alpha.1
-    "@storybook/react": 6.5.13-alpha.1
+    "@storybook/addon-controls": 6.5.13
+    "@storybook/addon-essentials": 6.5.13
+    "@storybook/builder-webpack4": 6.5.13
+    "@storybook/react": 6.5.13
     "@types/react": ^16.14.23
     "@types/react-dom": ^16.9.14
     prop-types: 15.7.2
@@ -7987,14 +7907,14 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addon-essentials": 6.5.13-alpha.1
-    "@storybook/addon-storyshots": 6.5.13-alpha.1
-    "@storybook/addon-storysource": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/cli": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/react": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/addon-essentials": 6.5.13
+    "@storybook/addon-storyshots": 6.5.13
+    "@storybook/addon-storysource": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/cli": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/react": 6.5.13
+    "@storybook/theming": 6.5.13
     "@testing-library/dom": ^7.31.2
     "@testing-library/react": 12.1.2
     "@testing-library/user-event": ^13.1.9
@@ -8028,13 +7948,13 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addon-essentials": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
+    "@storybook/addon-essentials": 6.5.13
+    "@storybook/components": 6.5.13
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/preview-web": 6.5.13-alpha.1
-    "@storybook/react": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/preview-web": 6.5.13
+    "@storybook/react": 6.5.13
+    "@storybook/store": 6.5.13
+    "@storybook/theming": 6.5.13
     "@testing-library/dom": ^7.31.2
     "@testing-library/user-event": ^13.1.9
     "@types/babel__preset-env": ^7
@@ -8051,17 +7971,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/html@6.5.13-alpha.1, @storybook/html@workspace:*, @storybook/html@workspace:app/html":
+"@storybook/html@6.5.13, @storybook/html@workspace:*, @storybook/html@workspace:app/html":
   version: 0.0.0-use.local
   resolution: "@storybook/html@workspace:app/html"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-common": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/docs-tools": 6.5.13-alpha.1
-    "@storybook/preview-web": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/docs-tools": 6.5.13
+    "@storybook/preview-web": 6.5.13
+    "@storybook/store": 6.5.13
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -8082,13 +8002,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/instrumenter@6.5.13-alpha.1, @storybook/instrumenter@workspace:*, @storybook/instrumenter@workspace:lib/instrumenter":
+"@storybook/instrumenter@6.5.13, @storybook/instrumenter@^6.4.0 || >=6.5.0-0, @storybook/instrumenter@workspace:*, @storybook/instrumenter@workspace:lib/instrumenter":
   version: 0.0.0-use.local
   resolution: "@storybook/instrumenter@workspace:lib/instrumenter"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core-events": 6.5.13
     core-js: ^3.8.2
     global: ^4.4.0
   languageName: unknown
@@ -8103,19 +8023,6 @@ __metadata:
     "@storybook/core-events": 6.4.0-rc.5
     global: ^4.4.0
   checksum: 91bbb54a730d011d51768482de2d3e664b7fc2f4964a89bcaa31269085e27e70f81bfd48f70872690a81b5ebb41fbb6377305ae68c2bd570e2af7aaf01ddaf45
-  languageName: node
-  linkType: hard
-
-"@storybook/instrumenter@npm:^6.4.0 || >=6.5.0-0":
-  version: 6.5.12
-  resolution: "@storybook/instrumenter@npm:6.5.12"
-  dependencies:
-    "@storybook/addons": 6.5.12
-    "@storybook/client-logger": 6.5.12
-    "@storybook/core-events": 6.5.12
-    core-js: ^3.8.2
-    global: ^4.4.0
-  checksum: 165f5b1a7fd865fea7ca272f5cc2dc4a7596204b73da9a5aaae38aabf25e88855627d4e1abfaf4f597f6998b8da2fffb4aa0cd5966206a621f26241846f95c70
   languageName: node
   linkType: hard
 
@@ -8158,19 +8065,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/manager-webpack4@6.5.13-alpha.1, @storybook/manager-webpack4@workspace:lib/manager-webpack4":
+"@storybook/manager-webpack4@6.5.13, @storybook/manager-webpack4@workspace:lib/manager-webpack4":
   version: 0.0.0-use.local
   resolution: "@storybook/manager-webpack4@workspace:lib/manager-webpack4"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/core-client": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
-    "@storybook/ui": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/core-client": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/node-logger": 6.5.13
+    "@storybook/theming": 6.5.13
+    "@storybook/ui": 6.5.13
     "@types/case-sensitive-paths-webpack-plugin": ^2.1.4
     "@types/node": ^14.0.10 || ^16.0.0
     "@types/terser-webpack-plugin": ^4.2.0
@@ -8217,12 +8124,12 @@ __metadata:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/core-client": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
-    "@storybook/ui": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/core-client": 6.5.13
+    "@storybook/core-common": 6.5.13
+    "@storybook/node-logger": 6.5.13
+    "@storybook/theming": 6.5.13
+    "@storybook/ui": 6.5.13
     "@types/case-sensitive-paths-webpack-plugin": ^2.1.4
     "@types/node": ^14.0.10 || ^16.0.0
     "@types/terser-webpack-plugin": ^5.0.2
@@ -8294,7 +8201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/node-logger@6.5.13-alpha.1, @storybook/node-logger@workspace:*, @storybook/node-logger@workspace:lib/node-logger":
+"@storybook/node-logger@*, @storybook/node-logger@6.5.13, @storybook/node-logger@^6.1.14, @storybook/node-logger@workspace:*, @storybook/node-logger@workspace:lib/node-logger":
   version: 0.0.0-use.local
   resolution: "@storybook/node-logger@workspace:lib/node-logger"
   dependencies:
@@ -8307,20 +8214,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/node-logger@npm:*, @storybook/node-logger@npm:^6.1.14":
-  version: 6.5.12
-  resolution: "@storybook/node-logger@npm:6.5.12"
-  dependencies:
-    "@types/npmlog": ^4.1.2
-    chalk: ^4.1.0
-    core-js: ^3.8.2
-    npmlog: ^5.0.1
-    pretty-hrtime: ^1.0.3
-  checksum: 23666dd8765a2df4abfd9d308b1e58d7c540fc27df006aeb41aeb2c65dac5c827cb9876697e9d1f309e86ae6afcdedddde93d07fa2a7a6784b065d287c4f5c46
-  languageName: node
-  linkType: hard
-
-"@storybook/postinstall@6.5.13-alpha.1, @storybook/postinstall@workspace:*, @storybook/postinstall@workspace:lib/postinstall":
+"@storybook/postinstall@6.5.13, @storybook/postinstall@workspace:*, @storybook/postinstall@workspace:lib/postinstall":
   version: 0.0.0-use.local
   resolution: "@storybook/postinstall@workspace:lib/postinstall"
   dependencies:
@@ -8331,16 +8225,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/preact@6.5.13-alpha.1, @storybook/preact@workspace:*, @storybook/preact@workspace:app/preact":
+"@storybook/preact@6.5.13, @storybook/preact@workspace:*, @storybook/preact@workspace:app/preact":
   version: 0.0.0-use.local
   resolution: "@storybook/preact@workspace:app/preact"
   dependencies:
     "@babel/plugin-transform-react-jsx": ^7.12.12
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-common": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/store": 6.5.13
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -8393,16 +8287,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/preview-web@6.5.13-alpha.1, @storybook/preview-web@workspace:*, @storybook/preview-web@workspace:lib/preview-web":
+"@storybook/preview-web@6.5.13, @storybook/preview-web@workspace:*, @storybook/preview-web@workspace:lib/preview-web":
   version: 0.0.0-use.local
   resolution: "@storybook/preview-web@workspace:lib/preview-web"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/channel-postmessage": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/channel-postmessage": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/store": 6.5.13
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
     global: ^4.4.0
@@ -8437,23 +8331,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react@6.5.13-alpha.1, @storybook/react@workspace:*, @storybook/react@workspace:app/react":
+"@storybook/react@6.5.13, @storybook/react@workspace:*, @storybook/react@workspace:app/react":
   version: 0.0.0-use.local
   resolution: "@storybook/react@workspace:app/react"
   dependencies:
     "@babel/preset-flow": ^7.12.1
     "@babel/preset-react": ^7.12.10
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.3
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-common": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/docs-tools": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
+    "@storybook/docs-tools": 6.5.13
+    "@storybook/node-logger": 6.5.13
     "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/store": 6.5.13
     "@types/estree": ^0.0.51
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/util-deprecate": ^1.0.0
@@ -8752,11 +8646,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/router@6.5.13-alpha.1, @storybook/router@workspace:*, @storybook/router@workspace:lib/router":
+"@storybook/router@6.5.13, @storybook/router@workspace:*, @storybook/router@workspace:lib/router":
   version: 0.0.0-use.local
   resolution: "@storybook/router@workspace:lib/router"
   dependencies:
-    "@storybook/client-logger": 6.5.13-alpha.1
+    "@storybook/client-logger": 6.5.13
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
@@ -8797,22 +8691,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/router@npm:6.5.12":
-  version: 6.5.12
-  resolution: "@storybook/router@npm:6.5.12"
-  dependencies:
-    "@storybook/client-logger": 6.5.12
-    core-js: ^3.8.2
-    memoizerific: ^1.11.3
-    qs: ^6.10.0
-    regenerator-runtime: ^0.13.7
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: e51ea851d97e04ae296bc7393752beecaff2c4d794527c934b0c2688d8417ac57001928b8d357c47d4ca0021d488a0b43b6cc596a140c81efb3c86601ba22a26
-  languageName: node
-  linkType: hard
-
 "@storybook/semver@npm:^7.3.2":
   version: 7.3.2
   resolution: "@storybook/semver@npm:7.3.2"
@@ -8825,19 +8703,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/server@6.5.13-alpha.1, @storybook/server@workspace:*, @storybook/server@workspace:app/server":
+"@storybook/server@6.5.13, @storybook/server@workspace:*, @storybook/server@workspace:app/server":
   version: 0.0.0-use.local
   resolution: "@storybook/server@workspace:app/server"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/client-api": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/client-api": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-common": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/preview-web": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/node-logger": 6.5.13
+    "@storybook/preview-web": 6.5.13
+    "@storybook/store": 6.5.13
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -8858,17 +8736,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/source-loader@6.5.13-alpha.1, @storybook/source-loader@workspace:*, @storybook/source-loader@workspace:lib/source-loader":
+"@storybook/source-loader@6.5.13, @storybook/source-loader@workspace:*, @storybook/source-loader@workspace:lib/source-loader":
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@workspace:lib/source-loader"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/client-logger": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
     core-js: ^3.8.2
     estraverse: ^5.2.0
     global: ^4.4.0
-    loader-utils: ^2.0.0
+    loader-utils: ^2.0.4
     lodash: ^4.17.21
     prettier: ">=2.2.1 <=2.3.0"
     regenerator-runtime: ^0.13.7
@@ -8878,13 +8756,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/store@6.5.13-alpha.1, @storybook/store@workspace:*, @storybook/store@workspace:lib/store":
+"@storybook/store@6.5.13, @storybook/store@workspace:*, @storybook/store@workspace:lib/store":
   version: 0.0.0-use.local
   resolution: "@storybook/store@workspace:lib/store"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -8903,18 +8781,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/svelte@6.5.13-alpha.1, @storybook/svelte@workspace:*, @storybook/svelte@workspace:app/svelte":
+"@storybook/svelte@6.5.13, @storybook/svelte@workspace:*, @storybook/svelte@workspace:app/svelte":
   version: 0.0.0-use.local
   resolution: "@storybook/svelte@workspace:app/svelte"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-common": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/docs-tools": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/docs-tools": 6.5.13
+    "@storybook/node-logger": 6.5.13
+    "@storybook/store": 6.5.13
     "@types/loader-utils": ^2.0.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -8943,12 +8821,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/telemetry@6.5.13-alpha.1, @storybook/telemetry@workspace:*, @storybook/telemetry@workspace:lib/telemetry":
+"@storybook/telemetry@6.5.13, @storybook/telemetry@workspace:*, @storybook/telemetry@workspace:lib/telemetry":
   version: 0.0.0-use.local
   resolution: "@storybook/telemetry@workspace:lib/telemetry"
   dependencies:
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core-common": 6.5.13
     chalk: ^4.1.0
     core-js: ^3.8.2
     detect-package-manager: ^2.0.1
@@ -8988,7 +8866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/theming@6.5.13-alpha.1, @storybook/theming@workspace:*, @storybook/theming@workspace:lib/theming":
+"@storybook/theming@6.5.13, @storybook/theming@workspace:*, @storybook/theming@workspace:lib/theming":
   version: 0.0.0-use.local
   resolution: "@storybook/theming@workspace:lib/theming"
   dependencies:
@@ -8996,7 +8874,7 @@ __metadata:
     "@emotion/is-prop-valid": ^1.1.2
     "@emotion/react": ^11.8.1
     "@emotion/styled": ^11.8.1
-    "@storybook/client-logger": 6.5.13-alpha.1
+    "@storybook/client-logger": 6.5.13
     "@types/node": ^14.14.20 || ^16.0.0
     core-js: ^3.8.2
     deep-object-diff: ^1.1.0
@@ -9035,35 +8913,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:6.5.12":
-  version: 6.5.12
-  resolution: "@storybook/theming@npm:6.5.12"
-  dependencies:
-    "@storybook/client-logger": 6.5.12
-    core-js: ^3.8.2
-    memoizerific: ^1.11.3
-    regenerator-runtime: ^0.13.7
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: ef649ca76f57cfa2524ecfd864ca175a370e1abfd89c5b8a7205b280bfeb95f23e071e8662e61b670dac1630dffb01616acdec66cfa5109d30e1b64ccb84d0ae
-  languageName: node
-  linkType: hard
-
-"@storybook/ui@6.5.13-alpha.1, @storybook/ui@workspace:*, @storybook/ui@workspace:lib/ui":
+"@storybook/ui@6.5.13, @storybook/ui@workspace:*, @storybook/ui@workspace:lib/ui":
   version: 0.0.0-use.local
   resolution: "@storybook/ui@workspace:lib/ui"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/api": 6.5.13-alpha.1
-    "@storybook/channels": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
-    "@storybook/router": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/api": 6.5.13
+    "@storybook/channels": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-events": 6.5.13
+    "@storybook/router": 6.5.13
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/theming": 6.5.13
     "@testing-library/react": ^11.2.2
     copy-to-clipboard: ^3.3.1
     core-js: ^3.8.2
@@ -9092,16 +8955,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/vue3@6.5.13-alpha.1, @storybook/vue3@workspace:app/vue3":
+"@storybook/vue3@6.5.13, @storybook/vue3@workspace:app/vue3":
   version: 0.0.0-use.local
   resolution: "@storybook/vue3@workspace:app/vue3"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-common": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/docs-tools": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/docs-tools": 6.5.13
+    "@storybook/store": 6.5.13
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/webpack-env": ^1.16.0
     "@vue/compiler-sfc": 3.0.0
@@ -9130,17 +8993,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/vue@6.5.13-alpha.1, @storybook/vue@workspace:*, @storybook/vue@workspace:app/vue":
+"@storybook/vue@6.5.13, @storybook/vue@workspace:*, @storybook/vue@workspace:app/vue":
   version: 0.0.0-use.local
   resolution: "@storybook/vue@workspace:app/vue"
   dependencies:
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-common": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/docs-tools": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/docs-tools": 6.5.13
+    "@storybook/store": 6.5.13
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -9178,15 +9041,15 @@ __metadata:
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
     "@babel/plugin-syntax-import-meta": ^7.10.4
     "@babel/preset-env": ^7.12.11
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/client-api": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-common": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/client-api": 6.5.13
+    "@storybook/client-logger": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-common": 6.5.13
     "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/docs-tools": 6.5.13-alpha.1
-    "@storybook/preview-web": 6.5.13-alpha.1
-    "@storybook/store": 6.5.13-alpha.1
+    "@storybook/docs-tools": 6.5.13
+    "@storybook/preview-web": 6.5.13
+    "@storybook/store": 6.5.13
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/webpack-env": ^1.16.0
     babel-plugin-bundled-import-meta: ^0.3.1
@@ -13070,21 +12933,21 @@ __metadata:
     "@angular/platform-browser-dynamic": ^11.2.14
     "@compodoc/compodoc": ^1.1.18
     "@ngrx/store": ^10.1.2
-    "@storybook/addon-a11y": 6.5.13-alpha.1
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-backgrounds": 6.5.13-alpha.1
-    "@storybook/addon-controls": 6.5.13-alpha.1
-    "@storybook/addon-docs": 6.5.13-alpha.1
-    "@storybook/addon-interactions": 6.5.13-alpha.1
-    "@storybook/addon-jest": 6.5.13-alpha.1
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/addon-storyshots": 6.5.13-alpha.1
-    "@storybook/addon-storysource": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/angular": 6.5.13-alpha.1
+    "@storybook/addon-a11y": 6.5.13
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-backgrounds": 6.5.13
+    "@storybook/addon-controls": 6.5.13
+    "@storybook/addon-docs": 6.5.13
+    "@storybook/addon-interactions": 6.5.13
+    "@storybook/addon-jest": 6.5.13
+    "@storybook/addon-links": 6.5.13
+    "@storybook/addon-storyshots": 6.5.13
+    "@storybook/addon-storysource": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/angular": 6.5.13
     "@storybook/babel-plugin-require-context-hook": 1.0.1
     "@storybook/jest": ^0.0.5
-    "@storybook/source-loader": 6.5.13-alpha.1
+    "@storybook/source-loader": 6.5.13
     "@storybook/testing-library": ^0.0.7
     "@types/core-js": ^2.5.4
     "@types/jest": ^26.0.16
@@ -18147,20 +18010,20 @@ __metadata:
   resolution: "cra-kitchen-sink@workspace:examples/cra-kitchen-sink"
   dependencies:
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.3
-    "@storybook/addon-a11y": 6.5.13-alpha.1
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-backgrounds": 6.5.13-alpha.1
-    "@storybook/addon-docs": 6.5.13-alpha.1
+    "@storybook/addon-a11y": 6.5.13
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-backgrounds": 6.5.13
+    "@storybook/addon-docs": 6.5.13
     "@storybook/addon-ie11": 0.0.7--canary.5e87b64.0
-    "@storybook/addon-jest": 6.5.13-alpha.1
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/addon-storyshots": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/builder-webpack4": 6.5.13-alpha.1
-    "@storybook/client-logger": 6.5.13-alpha.1
+    "@storybook/addon-jest": 6.5.13
+    "@storybook/addon-links": 6.5.13
+    "@storybook/addon-storyshots": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/builder-webpack4": 6.5.13
+    "@storybook/client-logger": 6.5.13
     "@storybook/preset-create-react-app": ^3.1.6
-    "@storybook/react": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/react": 6.5.13
+    "@storybook/theming": 6.5.13
     global: ^4.4.0
     prop-types: ^15.7.2
     react: 16.14.0
@@ -18175,14 +18038,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "cra-react15@workspace:examples/cra-react15"
   dependencies:
-    "@storybook/addon-actions": 6.5.13-alpha.1
+    "@storybook/addon-actions": 6.5.13
     "@storybook/addon-ie11": 0.0.7--canary.5e87b64.0
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/builder-webpack4": 6.5.13-alpha.1
+    "@storybook/addon-links": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/builder-webpack4": 6.5.13
     "@storybook/preset-create-react-app": ^3.1.6
-    "@storybook/react": 6.5.13-alpha.1
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/react": 6.5.13
+    "@storybook/theming": 6.5.13
     babel-core: 6
     babel-loader: ^8.0.0
     babel-runtime: 6
@@ -18199,15 +18062,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "cra-ts-essentials@workspace:examples/cra-ts-essentials"
   dependencies:
-    "@storybook/addon-essentials": 6.5.13-alpha.1
+    "@storybook/addon-essentials": 6.5.13
     "@storybook/addon-ie11": 0.0.7--canary.5e87b64.0
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/builder-webpack4": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
+    "@storybook/addons": 6.5.13
+    "@storybook/builder-webpack4": 6.5.13
+    "@storybook/components": 6.5.13
     "@storybook/preset-create-react-app": ^3.1.6
-    "@storybook/react": 6.5.13-alpha.1
+    "@storybook/react": 6.5.13
     "@storybook/testing-library": ^0.0.9
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/theming": 6.5.13
     "@types/jest": ^26.0.16
     "@types/node": ^14.14.20 || ^16.0.0
     "@types/react": ^16.14.23
@@ -18226,15 +18089,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "cra-ts-kitchen-sink@workspace:examples/cra-ts-kitchen-sink"
   dependencies:
-    "@storybook/addon-a11y": 6.5.13-alpha.1
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-docs": 6.5.13-alpha.1
+    "@storybook/addon-a11y": 6.5.13
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-docs": 6.5.13
     "@storybook/addon-ie11": 0.0.7--canary.5e87b64.0
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/builder-webpack4": 6.5.13-alpha.1
+    "@storybook/addon-links": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/builder-webpack4": 6.5.13
     "@storybook/preset-create-react-app": ^3.1.6
-    "@storybook/react": 6.5.13-alpha.1
+    "@storybook/react": 6.5.13
     "@types/enzyme": ^3.10.8
     "@types/jest": 25.2.3
     "@types/node": ^14.14.20 || ^16.0.0
@@ -20647,18 +20510,18 @@ __metadata:
   dependencies:
     "@babel/core": ^7.12.10
     "@ember/optional-features": ^2.0.0
-    "@storybook/addon-a11y": 6.5.13-alpha.1
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-backgrounds": 6.5.13-alpha.1
-    "@storybook/addon-controls": 6.5.13-alpha.1
-    "@storybook/addon-docs": 6.5.13-alpha.1
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/addon-storysource": 6.5.13-alpha.1
-    "@storybook/addon-viewport": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/ember": 6.5.13-alpha.1
+    "@storybook/addon-a11y": 6.5.13
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-backgrounds": 6.5.13
+    "@storybook/addon-controls": 6.5.13
+    "@storybook/addon-docs": 6.5.13
+    "@storybook/addon-links": 6.5.13
+    "@storybook/addon-storysource": 6.5.13
+    "@storybook/addon-viewport": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/ember": 6.5.13
     "@storybook/ember-cli-storybook": ^0.2.1
-    "@storybook/source-loader": 6.5.13-alpha.1
+    "@storybook/source-loader": 6.5.13
     babel-loader: ^8.0.0
     broccoli-asset-rev: ^3.0.0
     cross-env: ^7.0.3
@@ -25356,23 +25219,23 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "html-kitchen-sink@workspace:examples/html-kitchen-sink"
   dependencies:
-    "@storybook/addon-a11y": 6.5.13-alpha.1
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-backgrounds": 6.5.13-alpha.1
-    "@storybook/addon-controls": 6.5.13-alpha.1
-    "@storybook/addon-docs": 6.5.13-alpha.1
-    "@storybook/addon-jest": 6.5.13-alpha.1
-    "@storybook/addon-links": 6.5.13-alpha.1
+    "@storybook/addon-a11y": 6.5.13
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-backgrounds": 6.5.13
+    "@storybook/addon-controls": 6.5.13
+    "@storybook/addon-docs": 6.5.13
+    "@storybook/addon-jest": 6.5.13
+    "@storybook/addon-links": 6.5.13
     "@storybook/addon-postcss": ^2.0.0
-    "@storybook/addon-storyshots": 6.5.13-alpha.1
-    "@storybook/addon-storysource": 6.5.13-alpha.1
-    "@storybook/addon-viewport": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/client-api": 6.5.13-alpha.1
-    "@storybook/core": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
-    "@storybook/html": 6.5.13-alpha.1
-    "@storybook/source-loader": 6.5.13-alpha.1
+    "@storybook/addon-storyshots": 6.5.13
+    "@storybook/addon-storysource": 6.5.13
+    "@storybook/addon-viewport": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/client-api": 6.5.13
+    "@storybook/core": 6.5.13
+    "@storybook/core-events": 6.5.13
+    "@storybook/html": 6.5.13
+    "@storybook/source-loader": 6.5.13
     autoprefixer: ^10.0.1
     eventemitter3: ^4.0.7
     format-json: ^1.0.3
@@ -30427,6 +30290,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loader-utils@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "loader-utils@npm:2.0.4"
+  dependencies:
+    big.js: ^5.2.2
+    emojis-list: ^3.0.0
+    json5: ^2.1.2
+  checksum: d5654a77f9d339ec2a03d88221a5a695f337bf71eb8dea031b3223420bb818964ba8ed0069145c19b095f6c8b8fd386e602a3fc7ca987042bd8bb1dcc90d7100
+  languageName: node
+  linkType: hard
+
 "loader.js@npm:^4.7.0":
   version: 4.7.0
   resolution: "loader.js@npm:4.7.0"
@@ -34046,31 +33920,31 @@ __metadata:
   dependencies:
     "@emotion/jest": ^11.8.0
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.3
-    "@storybook/addon-a11y": 6.5.13-alpha.1
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-backgrounds": 6.5.13-alpha.1
-    "@storybook/addon-controls": 6.5.13-alpha.1
-    "@storybook/addon-docs": 6.5.13-alpha.1
-    "@storybook/addon-interactions": 6.5.13-alpha.1
-    "@storybook/addon-jest": 6.5.13-alpha.1
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/addon-storyshots": 6.5.13-alpha.1
-    "@storybook/addon-storyshots-puppeteer": 6.5.13-alpha.1
-    "@storybook/addon-storysource": 6.5.13-alpha.1
-    "@storybook/addon-toolbars": 6.5.13-alpha.1
-    "@storybook/addon-viewport": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/cli": 6.5.13-alpha.1
-    "@storybook/components": 6.5.13-alpha.1
-    "@storybook/core-events": 6.5.13-alpha.1
+    "@storybook/addon-a11y": 6.5.13
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-backgrounds": 6.5.13
+    "@storybook/addon-controls": 6.5.13
+    "@storybook/addon-docs": 6.5.13
+    "@storybook/addon-interactions": 6.5.13
+    "@storybook/addon-jest": 6.5.13
+    "@storybook/addon-links": 6.5.13
+    "@storybook/addon-storyshots": 6.5.13
+    "@storybook/addon-storyshots-puppeteer": 6.5.13
+    "@storybook/addon-storysource": 6.5.13
+    "@storybook/addon-toolbars": 6.5.13
+    "@storybook/addon-viewport": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/cli": 6.5.13
+    "@storybook/components": 6.5.13
+    "@storybook/core-events": 6.5.13
     "@storybook/design-system": ^5.4.7
     "@storybook/jest": ^0.0.5
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/react": 6.5.13-alpha.1
-    "@storybook/router": 6.5.13-alpha.1
-    "@storybook/source-loader": 6.5.13-alpha.1
+    "@storybook/node-logger": 6.5.13
+    "@storybook/react": 6.5.13
+    "@storybook/router": 6.5.13
+    "@storybook/source-loader": 6.5.13
     "@storybook/testing-library": ^0.0.7
-    "@storybook/theming": 6.5.13-alpha.1
+    "@storybook/theming": 6.5.13
     "@testing-library/dom": ^7.31.2
     "@testing-library/user-event": ^13.1.9
     chromatic: ^6.0.2
@@ -36845,16 +36719,16 @@ __metadata:
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-runtime": ^7.12.10
-    "@storybook/addon-a11y": 6.5.13-alpha.1
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-backgrounds": 6.5.13-alpha.1
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/addon-storyshots": 6.5.13-alpha.1
-    "@storybook/addon-storysource": 6.5.13-alpha.1
-    "@storybook/addon-viewport": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
-    "@storybook/preact": 6.5.13-alpha.1
-    "@storybook/source-loader": 6.5.13-alpha.1
+    "@storybook/addon-a11y": 6.5.13
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-backgrounds": 6.5.13
+    "@storybook/addon-links": 6.5.13
+    "@storybook/addon-storyshots": 6.5.13
+    "@storybook/addon-storysource": 6.5.13
+    "@storybook/addon-viewport": 6.5.13
+    "@storybook/addons": 6.5.13
+    "@storybook/preact": 6.5.13
+    "@storybook/source-loader": 6.5.13
     "@types/prop-types": ^15.7.3
     "@types/react": ^17
     "@types/react-dom": ^17
@@ -40861,7 +40735,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "sb@workspace:lib/cli-sb"
   dependencies:
-    "@storybook/cli": 6.5.13-alpha.1
+    "@storybook/cli": 6.5.13
   bin:
     sb: ./index.js
   languageName: unknown
@@ -41185,13 +41059,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "server-kitchen-sink@workspace:examples/server-kitchen-sink"
   dependencies:
-    "@storybook/addon-a11y": 6.5.13-alpha.1
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-backgrounds": 6.5.13-alpha.1
-    "@storybook/addon-controls": 6.5.13-alpha.1
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/node-logger": 6.5.13-alpha.1
-    "@storybook/server": 6.5.13-alpha.1
+    "@storybook/addon-a11y": 6.5.13
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-backgrounds": 6.5.13
+    "@storybook/addon-controls": 6.5.13
+    "@storybook/addon-links": 6.5.13
+    "@storybook/node-logger": 6.5.13
+    "@storybook/server": 6.5.13
     concurrently: ^5.3.0
     cors: ^2.8.5
     express: ~4.17.1
@@ -42149,9 +42023,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "standalone-preview@workspace:examples/standalone-preview"
   dependencies:
-    "@storybook/addon-docs": 6.5.13-alpha.1
-    "@storybook/cli": 6.5.13-alpha.1
-    "@storybook/react": 6.5.13-alpha.1
+    "@storybook/addon-docs": 6.5.13
+    "@storybook/cli": 6.5.13
+    "@storybook/react": 6.5.13
     cross-env: ^7.0.3
     parcel: 2.0.1
     react: 16.14.0
@@ -42248,7 +42122,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "storybook@workspace:lib/cli-storybook"
   dependencies:
-    "@storybook/cli": 6.5.13-alpha.1
+    "@storybook/cli": 6.5.13
   bin:
     sb: ./index.js
     storybook: ./index.js
@@ -42968,20 +42842,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "svelte-example@workspace:examples/svelte-kitchen-sink"
   dependencies:
-    "@storybook/addon-a11y": 6.5.13-alpha.1
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-backgrounds": 6.5.13-alpha.1
-    "@storybook/addon-controls": 6.5.13-alpha.1
-    "@storybook/addon-docs": 6.5.13-alpha.1
-    "@storybook/addon-interactions": 6.5.13-alpha.1
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/addon-storyshots": 6.5.13-alpha.1
-    "@storybook/addon-storysource": 6.5.13-alpha.1
-    "@storybook/addon-viewport": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
+    "@storybook/addon-a11y": 6.5.13
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-backgrounds": 6.5.13
+    "@storybook/addon-controls": 6.5.13
+    "@storybook/addon-docs": 6.5.13
+    "@storybook/addon-interactions": 6.5.13
+    "@storybook/addon-links": 6.5.13
+    "@storybook/addon-storyshots": 6.5.13
+    "@storybook/addon-storysource": 6.5.13
+    "@storybook/addon-viewport": 6.5.13
+    "@storybook/addons": 6.5.13
     "@storybook/jest": ^0.0.5
-    "@storybook/source-loader": 6.5.13-alpha.1
-    "@storybook/svelte": 6.5.13-alpha.1
+    "@storybook/source-loader": 6.5.13
+    "@storybook/svelte": 6.5.13
     "@storybook/testing-library": ^0.0.7
     global: ^4.4.0
     svelte-jester: 1.3.0
@@ -45903,14 +45777,14 @@ __metadata:
   resolution: "vue-3-cli-example@workspace:examples/vue-3-cli"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-essentials": 6.5.13-alpha.1
-    "@storybook/addon-interactions": 6.5.13-alpha.1
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/addon-storyshots": 6.5.13-alpha.1
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-essentials": 6.5.13
+    "@storybook/addon-interactions": 6.5.13
+    "@storybook/addon-links": 6.5.13
+    "@storybook/addon-storyshots": 6.5.13
     "@storybook/jest": ^0.0.5
     "@storybook/testing-library": ^0.0.7
-    "@storybook/vue3": 6.5.13-alpha.1
+    "@storybook/vue3": 6.5.13
     "@vue/cli-plugin-babel": ~4.5.0
     "@vue/cli-plugin-typescript": ~4.5.0
     "@vue/cli-service": ~4.5.0
@@ -45937,11 +45811,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vue-cli-example@workspace:examples/vue-cli"
   dependencies:
-    "@storybook/addon-controls": 6.5.13-alpha.1
-    "@storybook/addon-essentials": 6.5.13-alpha.1
+    "@storybook/addon-controls": 6.5.13
+    "@storybook/addon-essentials": 6.5.13
     "@storybook/preset-scss": ^1.0.3
-    "@storybook/source-loader": 6.5.13-alpha.1
-    "@storybook/vue": 6.5.13-alpha.1
+    "@storybook/source-loader": 6.5.13
+    "@storybook/vue": 6.5.13
     "@vue/cli-plugin-babel": ~4.3.1
     "@vue/cli-plugin-typescript": ~4.3.1
     "@vue/cli-service": ~4.3.1
@@ -45993,21 +45867,21 @@ __metadata:
   resolution: "vue-example@workspace:examples/vue-kitchen-sink"
   dependencies:
     "@babel/core": ^7.12.10
-    "@storybook/addon-a11y": 6.5.13-alpha.1
-    "@storybook/addon-actions": 6.5.13-alpha.1
-    "@storybook/addon-backgrounds": 6.5.13-alpha.1
-    "@storybook/addon-controls": 6.5.13-alpha.1
-    "@storybook/addon-docs": 6.5.13-alpha.1
-    "@storybook/addon-interactions": 6.5.13-alpha.1
-    "@storybook/addon-links": 6.5.13-alpha.1
-    "@storybook/addon-storyshots": 6.5.13-alpha.1
-    "@storybook/addon-storysource": 6.5.13-alpha.1
-    "@storybook/addon-viewport": 6.5.13-alpha.1
-    "@storybook/addons": 6.5.13-alpha.1
+    "@storybook/addon-a11y": 6.5.13
+    "@storybook/addon-actions": 6.5.13
+    "@storybook/addon-backgrounds": 6.5.13
+    "@storybook/addon-controls": 6.5.13
+    "@storybook/addon-docs": 6.5.13
+    "@storybook/addon-interactions": 6.5.13
+    "@storybook/addon-links": 6.5.13
+    "@storybook/addon-storyshots": 6.5.13
+    "@storybook/addon-storysource": 6.5.13
+    "@storybook/addon-viewport": 6.5.13
+    "@storybook/addons": 6.5.13
     "@storybook/jest": ^0.0.5
-    "@storybook/source-loader": 6.5.13-alpha.1
+    "@storybook/source-loader": 6.5.13
     "@storybook/testing-library": ^0.0.7
-    "@storybook/vue": 6.5.13-alpha.1
+    "@storybook/vue": 6.5.13
     "@vue/babel-preset-jsx": ^1.2.4
     babel-loader: ^8.0.0
     cross-env: ^7.0.3


### PR DESCRIPTION
… to resolve a critical security issue found by npm audit
I just upgraded the versions of the loader utils in source-loader and storysource to resolve the security finding from the npm audit

Issue: critical security vulnerability in the loader-utils

## What I did
Upgraded the loader-utils to 2.0.4 in storysource and source-loader

## How to test

loader-utils  2.0.0 - 2.0.3 || 3.0.0 - 3.2.0
Severity: critical
Prototype pollution in webpack loader-utils - https://github.com/advisories/GHSA-76p3-8jx3-jpfq
loader-utils is vulnerable to Regular Expression Denial of Service (ReDoS) via url variable - https://github.com/advisories/GHSA-3rfm-jhwj-7488
loader-utils is vulnerable to Regular Expression Denial of Service (ReDoS) via url variable - https://github.com/advisories/GHSA-3rfm-jhwj-7488
loader-utils is vulnerable to Regular Expression Denial of Service (ReDoS)  - https://github.com/advisories/GHSA-hhq3-ff78-jv3g
loader-utils is vulnerable to Regular Expression Denial of Service (ReDoS)  - https://github.com/advisories/GHSA-hhq3-ff78-jv3g
fix available via `npm audit fix`
node_modules/@storybook/addon-storysource/node_modules/loader-utils
node_modules/@storybook/angular/node_modules/loader-utils
node_modules/@storybook/builder-webpack5/node_modules/loader-utils
node_modules/@storybook/manager-webpack5/node_modules/loader-utils
node_modules/adjust-sourcemap-loader/node_modules/loader-utils
node_modules/babel-loader/node_modules/loader-utils
node_modules/loader-utils
node_modules/resolve-url-loader/node_modules/loader-utils
node_modules/style-loader/node_modules/loader-utils
node_modules/ts-loader/node_modules/loader-utils



If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->

To @maintainers, I would like this to be patched for 6.5.13 versions.
Although this issue might have been fixed for 7-next, since there is no stable version 7, I need to have 6.5.14 as a stable version.
