### PR TITLE
Docs: Fix ordering of entries in `Stories` block

### DIFF
--- a/code/e2e-tests/addon-docs.spec.ts
+++ b/code/e2e-tests/addon-docs.spec.ts
@@ -52,4 +52,17 @@ test.describe('addon-docs', () => {
     const noAutoplayPre = root.locator('#story--addons-docs-docspage-autoplay--no-autoplay pre');
     await expect(noAutoplayPre).toHaveText('Play has not run');
   });
+
+  test('should order entries correctly', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    await sbPage.navigateToStory('addons/docs/docspage/basic', 'docs');
+
+    // The `<Primary>` block should render the "basic" story, and the `<Stories/>` block should
+    // render the "Another story"
+    const root = sbPage.previewRoot();
+    const stories = root.locator('.sbdocs-h3');
+
+    await expect(await stories.count()).toBe(1);
+    await expect(stories.first()).toHaveText('Another');
+  });
 });

--- a/code/e2e-tests/addon-docs.spec.ts
+++ b/code/e2e-tests/addon-docs.spec.ts
@@ -57,8 +57,8 @@ test.describe('addon-docs', () => {
     const sbPage = new SbPage(page);
     await sbPage.navigateToStory('addons/docs/docspage/basic', 'docs');
 
-    // The `<Primary>` block should render the "basic" story, and the `<Stories/>` block should
-    // render the "Another story"
+    // The `<Primary>` block should render the "Basic" story, and the `<Stories/>` block should
+    // render the "Another" story
     const root = sbPage.previewRoot();
     const stories = root.locator('.sbdocs-h3');
 

--- a/code/lib/preview-web/src/docs-context/DocsContext.ts
+++ b/code/lib/preview-web/src/docs-context/DocsContext.ts
@@ -49,14 +49,15 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
     Object.values(csfFile.stories).forEach((annotation) => {
       this.storyIdToCSFFile.set(annotation.id, csfFile);
       this.exportToStoryId.set(annotation.moduleExport, annotation.id);
+    });
 
-      if (addToComponentStories) {
-        this.nameToStoryId.set(annotation.name, annotation.id);
-        const story = this.storyById(annotation.id);
+    if (addToComponentStories) {
+      this.store.componentStoriesFromCSFFile({ csfFile }).forEach((story) => {
+        this.nameToStoryId.set(story.name, story.id);
         this.componentStoriesValue.push(story);
         if (!this.primaryStory) this.primaryStory = story;
-      }
-    });
+      });
+    }
   }
 
   setMeta(metaExports: Store_ModuleExports) {

--- a/scripts/tasks/serve.ts
+++ b/scripts/tasks/serve.ts
@@ -4,7 +4,9 @@ import detectFreePort from 'detect-port';
 import type { Task } from '../task';
 import { exec } from '../utils/exec';
 
-export const PORT = 8001;
+export const PORT = process.env.STORYBOOK_SERVE_PORT
+  ? parseInt(process.env.STORYBOOK_SERVE_PORT, 10)
+  : 8001;
 export const serve: Task = {
   description: 'Serve the build storybook for a sandbox',
   service: true,
@@ -22,7 +24,7 @@ export const serve: Task = {
       // If aborted, we want to make sure the rejection is handled.
       if (!err.killed) throw err;
     });
-    await exec('yarn wait-on http://localhost:8001', { cwd: codeDir }, { dryRun, debug });
+    await exec(`yarn wait-on http://localhost:${PORT}`, { cwd: codeDir }, { dryRun, debug });
 
     return controller;
   },


### PR DESCRIPTION
Issue: #19163

## What I did

Restored fix from https://github.com/storybookjs/storybook/pull/17669 that was lost in some refactoring -- make sure the `DocsContext` passes the CSF file through `componentStoriesFromCSFFile` to retain the correct order.


## How to test

- See e2e test - you can also view the page directly at http://localhost:6006/?path=/docs/addons-docs-docspage-basic--docs and make sure the order is right.