### PR TITLE
Maintenance: fix execa usage in build and check scripts

### DIFF
--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -115,7 +115,8 @@ async function run() {
   selection?.filter(Boolean).forEach(async (v) => {
     const commmand = (await readJSON(resolve(v.location, 'package.json'))).scripts.prep;
     const cwd = resolve(__dirname, '..', 'code', v.location);
-    const sub = await import('execa').execaCommand(
+    const { execaCommand } = await import('execa');
+    const sub = execaCommand(
       `${commmand}${watchMode ? ' --watch' : ''}${prodMode ? ' --optimized' : ''}`,
       {
         cwd,

--- a/scripts/check-package.js
+++ b/scripts/check-package.js
@@ -98,7 +98,8 @@ async function run() {
   selection?.filter(Boolean).forEach(async (v) => {
     const commmand = (await readJSON(resolve(v.location, 'package.json'))).scripts.check;
     const cwd = resolve(__dirname, '..', 'code', v.location);
-    const sub = await import('execa').execaCommand(`${commmand}${watchMode ? ' --watch' : ''}`, {
+    const { execaCommand } = await import('execa');
+    const sub = execaCommand(`${commmand}${watchMode ? ' --watch' : ''}`, {
       cwd,
       buffer: false,
       shell: true,


### PR DESCRIPTION
Issue: N/A

## What I did

Fixed a little bug from #19759

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
