### PR TITLE
Maintenance: fix execa import in get-report-message

### DIFF
--- a/scripts/get-report-message.ts
+++ b/scripts/get-report-message.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
-import { command } from 'execa';
 import { readJson } from 'fs-extra';
 import { join } from 'path';
+import { execaCommand } from './utils/exec';
 
 type Branch = 'main' | 'next' | 'alpha' | 'next-release' | 'latest-release';
 type Workflow = 'merged' | 'daily';
@@ -26,7 +26,7 @@ const getFooter = async (branch: Branch, workflow: Workflow, job: string) => {
       : // show last 24h merges for daily workflow
         `git log --merges --since="24 hours ago" --pretty=format:"\`%h\` %<(12)%ar %s [%an]"`;
 
-  const result = await command(mergeCommits, { shell: true });
+  const result = await execaCommand(mergeCommits, { shell: true });
   const formattedResult = result.stdout
     // discord needs escaped line breaks
     .replace(/\n/g, '\\n')


### PR DESCRIPTION
Issue: N/A

## What I did

The change in execa version broke the mechanism that generates report messages:

<img width="318" alt="image" src="https://user-images.githubusercontent.com/1671563/203103210-b10876fe-384c-4eb7-8d83-6ef5cc65a1c9.png">

This PR fixes that

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
