### PR TITLE
Maintenance: Drop `inDevelopment` from `cra/default-js`

### DIFF
--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -2,7 +2,6 @@ export const allTemplates = {
   'cra/default-js': {
     name: 'Create React App (Javascript)',
     script: 'npx create-react-app .',
-    inDevelopment: true,
     expected: {
       // TODO: change this to @storybook/cra once that package is created
       framework: '@storybook/react-webpack5',


### PR DESCRIPTION
Issue: Accidentally checked this in, see https://discord.com/channels/486522875931656193/1040570734499610704/1044543147843276851