### PR TITLE
Don't set `argType.defaultValue` in angular/compodoc

### DIFF
--- a/code/frameworks/angular/src/client/docs/compodoc.ts
+++ b/code/frameworks/angular/src/client/docs/compodoc.ts
@@ -249,7 +249,6 @@ export const extractArgTypesFromData = (componentData: Class | Directive | Injec
       const argType = {
         name: item.name,
         description: item.rawdescription || item.description,
-        defaultValue,
         type,
         ...action,
         table: {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17004 https://github.com/storybookjs/storybook/issues/17001 https://github.com/storybookjs/storybook/issues/16959 https://github.com/storybookjs/storybook/issues/16865

Discussion on https://github.com/storybookjs/storybook/pull/19492

## What I did

- Back in https://github.com/storybookjs/storybook/pull/14900 (6.3) we stopped setting `argType.defaultValue` in React/Svelte/Vue(3), but for some reason not Angular (don't think it was intentional). This left the same kind of bugs in angular that we had fixed in the other renderers 🤦 

- In 7.0 as planned we are removing support for `argType.defaultValue` entirely.

- So let's drop default value in Angular too! See the original PR for justification.

## How to test

Visit this story: http://localhost:6006/?path=/story/stories-frameworks-angular-argtypes-doc-button--basic

Rather than showing (in the controls panel):

<img width="588" alt="image" src="https://user-images.githubusercontent.com/132554/203483005-fa566b0e-260a-45b7-a491-bf7d5a0a4449.png">

It will show:

<img width="368" alt="image" src="https://user-images.githubusercontent.com/132554/203483031-156f08b5-4dab-4d3e-8139-584cc6abf019.png">

However, if the component actually uses the default value (it doesn't but you can tweak it to do so), it is unaffected (that's the whole point).