### PR TITLE
fix the CI by adding a resolution for the broken release of enhanced resolve, and also overriding the dep version of types/node on sandboxes so that they may be linked

### DIFF
--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -19,7 +19,7 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
 
   const packageJsonPath = path.join(cwd, 'package.json');
   const packageJson = await readJSON(packageJsonPath);
-  packageJson.resolutions = storybookVersions;
+  packageJson.resolutions = { ...storybookVersions, 'enhanced-resolve': '~5.10.0' };
   await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
 };
 


### PR DESCRIPTION
Issue: the CI is currently failing, this should resolve that until https://github.com/webpack/enhanced-resolve/issues/362 is fixed upstream

## What I did

I added a yarn resolution to the script that generates the sandboxes.
This forces the use of a version of `enhanced-resolve` that we know works.

I added a install of `@types/node` version 16, that overrides the version of the generator, the ensure we can link the sanbox to storybook code via portals.