### PR TITLE
Controls: Arrow keys don't work on number controls

### DIFF
--- a/code/ui/manager/src/components/sidebar/useHighlighted.ts
+++ b/code/ui/manager/src/components/sidebar/useHighlighted.ts
@@ -85,7 +85,6 @@ export const useHighlighted = ({
       const isArrowUp = matchesKeyCode('ArrowUp', event);
       const isArrowDown = matchesKeyCode('ArrowDown', event);
       if (!(isArrowUp || isArrowDown)) return;
-      event.preventDefault();
 
       const requestId = globalWindow.requestAnimationFrame(() => {
         globalWindow.cancelAnimationFrame(lastRequestId);


### PR DESCRIPTION
https://github.com/storybookjs/storybook/issues/16701

## What I did

We are catching keydown events of `ArrowUp` `ArrowDown` in `useHighlighted` for switching highlight story on sidebar but with `event.preventDefault()` it breaks browser native behaviors of `ArrowUp` `ArrowDown` for input number control. 

In this PR, we see that we can remove `event.preventDefault()` to fix the issue and doesn't break current behaviors.

## How to test

- Start a sandbox
- Visit `http://localhost: 6006/?path=/story/addons-controls-basics--undefined`
- Focus on a number control and verify `up` `down` arrow keys work as expected (increase/decrease value)
- Demo: https://www.loom.com/share/bc24380090064938b8d47546d5af52ac
