### PR TITLE
React Native: Patch preview-web and refs to support RN

### DIFF
--- a/lib/api/src/modules/refs.ts
+++ b/lib/api/src/modules/refs.ts
@@ -75,7 +75,7 @@ const findFilename = /(\/((?:[^\/]+?)\.[^\/]+?)|\/)$/;
 
 export const getSourceType = (source: string, refId: string) => {
   const { origin: localOrigin, pathname: localPathname } = location;
-  const { origin: sourceOrigin, pathname: sourcePathname } = new URL(source);
+  const { origin: sourceOrigin, pathname: sourcePathname } = new URL(source || location.origin);
 
   const localFull = `${localOrigin + localPathname}`.replace(findFilename, '');
   const sourceFull = `${sourceOrigin + sourcePathname}`.replace(findFilename, '');

--- a/lib/preview-web/src/PreviewWeb.tsx
+++ b/lib/preview-web/src/PreviewWeb.tsx
@@ -58,11 +58,11 @@ export class PreviewWeb<TFramework extends AnyFramework> extends Preview<TFramew
 
   currentRender: Render<TFramework>;
 
-  constructor() {
+  constructor(urlStore: UrlStore = new UrlStore(), webview: WebView = new WebView()) {
     super();
 
-    this.view = new WebView();
-    this.urlStore = new UrlStore();
+    this.view = webview;
+    this.urlStore = urlStore;
 
     // Add deprecated APIs for back-compat
     // @ts-ignore


### PR DESCRIPTION
Issue: 

## What I did

These are some changes discussed previously with @tmeasday @ndelangen and @shilman.

Just hoping I can help move things forward by making this PR.

I applied some small changes in order to enable the v6 of react native storybook. These are:

- making preview and url store optional parameters on the preview web constructor which fixes a crash on react native
- in refs passing a default value when source is not defined in order to bypass a crash in react-native-server

These changes along side this pr on telejson are the main blockers for v6 on react native.

https://github.com/storybookjs/telejson/pull/84

Heres the related react-native-server PR
https://github.com/storybookjs/react-native/pull/393

I'm not sure if there are further implications of these changes and I'm very happy to adjust these changes if they don't make sense.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->