### PR TITLE
Add first MDX example for storybook/html

### DIFF
--- a/docs/snippets/html/checkbox-story.mdx.mdx
+++ b/docs/snippets/html/checkbox-story.mdx.mdx
@@ -1,0 +1,45 @@
+```md
+<!-- Checkbox.stories.mdx -->
+
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+
+export const Checkbox = (args) => `<label>
+  ${args?.label}
+  <input
+    type="checkbox"
+    ${args?.checked ? 'checked' : ''}
+    ${args?.appearance ? `class="${args.appearance}"` : ''}
+  />
+</label>`;
+
+<Meta title="MDX/Checkbox" component={Checkbox} />
+
+# Checkbox
+
+With `MDX`, we can define a story for `Checkbox` right in the middle of our
+Markdown documentation.
+
+<Canvas>
+  <Story 
+    name="Unchecked"
+    args={{ 
+      label: 'Unchecked',
+    }}
+    render={Checkbox} />
+  <Story 
+    name="Checked"
+    args={{ 
+      label: 'Unchecked', 
+      checked: true,
+    }}
+    render={Checkbox} />
+  <Story 
+    name="Secondary" 
+    args={{
+      label: 'Secondary', 
+      checked: true, 
+      appearance: 'secondary',
+    }}
+    render={Checkbox} />
+</Canvas>
+```


### PR DESCRIPTION
The https://storybook.js.org/docs/7.0/html/writing-docs/mdx page is missing all storybook/html snippets. I thought the `Story` needed a child string, but it actually needs a function that returns a string.

While I don't have time to add all the examples now, having at least the first one will help users a ton.

Issue:

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
