### PR TITLE
change export-generating script to use exec util over shelljs

### DIFF
--- a/code/ui/manager/package.json
+++ b/code/ui/manager/package.json
@@ -83,7 +83,6 @@
     "react-sizeme": "^3.0.1",
     "resolve-from": "^5.0.0",
     "semver": "^7.3.7",
-    "shelljs": "^0.8.5",
     "store2": "^2.12.0",
     "ts-dedent": "^2.0.0",
     "typescript": "^4.9.3"

--- a/code/ui/manager/scripts/generate-exports-file.ts
+++ b/code/ui/manager/scripts/generate-exports-file.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 import fs from 'fs-extra';
 import path from 'path';
-import shelljs from 'shelljs';
 import { dedent } from 'ts-dedent';
+import { exec } from '../../../../scripts/utils/exec';
 
 const removeDefault = (input: string) => input !== 'default';
 
@@ -28,7 +28,7 @@ const run = async () => {
   );
 
   console.log('Linting...');
-  shelljs.exec(`yarn lint:js:cmd --fix ${location}`, {
+  await exec(`yarn lint:js:cmd --fix ${location}`, {
     cwd: path.join(__dirname, '..', '..', '..'),
   });
   console.log('Done!');

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6598,7 +6598,6 @@ __metadata:
     react-sizeme: ^3.0.1
     resolve-from: ^5.0.0
     semver: ^7.3.7
-    shelljs: ^0.8.5
     store2: ^2.12.0
     ts-dedent: ^2.0.0
     typescript: ^4.9.3


### PR DESCRIPTION
Issue:
I’m getting some build to fail over git diffs on generated code.
Code that should be generated during a pre command ran when a package is bundled.
Somehow the command isn’t awaited on? Or something else is failing, but not being detected.
Re-running the CI job works, but there’s some sort of race condition for sure.

## What I did

I changed the code so it uses our exec util from scripts.
I probably should move this localized script into the scripts directory?

I did not change the one in lib/preview, because it's about to get deleted:
https://github.com/storybookjs/storybook/pull/19978