### PR TITLE
Svelte Docs: Add optional steps for using Native Format

### DIFF
--- a/docs/get-started/whats-a-story.md
+++ b/docs/get-started/whats-a-story.md
@@ -39,7 +39,7 @@ If all else fails, try asking for [help](https://storybook.js.org/support)
 
 <!-- prettier-ignore-end -->
 
-![Initial button story]ç
+![Initial button story](./example-button-noargs.png)
 
 View the rendered `Button` by clicking on it in the Storybook sidebar.
 

--- a/docs/get-started/whats-a-story.md
+++ b/docs/get-started/whats-a-story.md
@@ -10,6 +10,17 @@ Each example component has a set of stories that show the states it supports. Yo
 
 Let’s start with the `Button` component. A story is a function that describes how to render the component in question. Here’s how to render `Button` in the “primary” state and export a story called `Primary`.
 
+<details>
+<summary><h4 id="troubleshooting">Additional steps for using Native Format</h4></summary>
+
+- Install [addon-svelte-csf](https://github.com/storybookjs/addon-svelte-csf) as a dependency.
+- Update `.storybook/main.js` to include "@storybook/addon-svelte-csf" in the addons array.
+- Update `.storybook/main.js` to set `storyStoreV7` to false.
+
+If all else fails, try asking for [help](https://storybook.js.org/support)
+
+</details>
+
 <!-- prettier-ignore-start -->
 
 <CodeSnippets
@@ -28,7 +39,7 @@ Let’s start with the `Button` component. A story is a function that describes 
 
 <!-- prettier-ignore-end -->
 
-![Initial button story](./example-button-noargs.png)
+![Initial button story]ç
 
 View the rendered `Button` by clicking on it in the Storybook sidebar.
 


### PR DESCRIPTION
Issue:

It was confusing going through the guide as a new user from the Getting Started and following along to this page.

If you try to just use the tab labeled "NATIVE-FORMAT" without following the additional steps you'll have to do some investigating on what went wrong and what you need to install for it to function since it seems like core functionality at this point.

## What I did

Added some documentation so the next person isn't as confused hopefully.
