### PR TITLE
Build: Upgrade jest-specific-snapshot

### DIFF
--- a/code/addons/storyshots/storyshots-core/package.json
+++ b/code/addons/storyshots/storyshots-core/package.json
@@ -49,7 +49,7 @@
     "core-js": "^3.8.2",
     "glob": "^7.1.6",
     "global": "^4.4.0",
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "preact-render-to-string": "^5.1.19",
     "pretty-format": "^28.0.0",
     "react-test-renderer": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/code/frameworks/angular/package.json
+++ b/code/frameworks/angular/package.json
@@ -82,7 +82,7 @@
     "cross-spawn": "^7.0.3",
     "jest": "^29.3.1",
     "jest-preset-angular": "^12.0.0",
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "rimraf": "^3.0.2",
     "tmp": "^0.2.1",
     "typescript": "^4.9.3",

--- a/code/frameworks/react-webpack5/package.json
+++ b/code/frameworks/react-webpack5/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^16.0.0"
   },
   "devDependencies": {
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "typescript": "^4.9.3"
   },
   "peerDependencies": {

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "jest": "^29.3.1",
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "typescript": "^4.9.3"
   },
   "publishConfig": {

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -82,7 +82,7 @@
     "@types/serve-favicon": "^2.5.2",
     "@types/ws": "^8",
     "jest-os-detection": "^1.3.1",
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "typescript": "^4.9.3",
     "webpack": "5"
   },

--- a/code/lib/docs-tools/package.json
+++ b/code/lib/docs-tools/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "require-from-string": "^2.0.2",
     "typescript": "^4.9.3"
   },

--- a/code/lib/postinstall/package.json
+++ b/code/lib/postinstall/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "jest": "^29.3.1",
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "jscodeshift": "^0.13.1",
     "typescript": "^4.9.3"
   },

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -50,7 +50,7 @@
     "prettier": "^2.7.1"
   },
   "devDependencies": {
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "typescript": "^4.9.3"
   },
   "peerDependencies": {

--- a/code/presets/react-webpack/package.json
+++ b/code/presets/react-webpack/package.json
@@ -93,7 +93,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.11.5",
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "require-from-string": "^2.0.2",

--- a/code/presets/server-webpack/package.json
+++ b/code/presets/server-webpack/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "fs-extra": "^9.0.1",
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "typescript": "^4.9.3",
     "yaml": "^1.10.0"
   },

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -76,7 +76,7 @@
     "@babel/core": "^7.20.2",
     "@types/util-deprecate": "^1.0.0",
     "expect-type": "^0.14.2",
-    "jest-specific-snapshot": "^6.0.0",
+    "jest-specific-snapshot": "^7.0.0",
     "require-from-string": "^2.0.2",
     "typescript": "^4.9.3"
   },

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5504,7 +5504,7 @@ __metadata:
     glob: ^7.1.6
     global: ^4.4.0
     jest-preset-angular: ^8.3.2
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     jest-vue-preprocessor: ^1.7.1
     preact-render-to-string: ^5.1.19
     pretty-format: ^28.0.0
@@ -5730,7 +5730,7 @@ __metadata:
     global: ^4.4.0
     jest: ^29.3.1
     jest-preset-angular: ^12.0.0
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     react: ^16.14.0
     react-dom: ^16.14.0
     read-pkg-up: ^7.0.1
@@ -6107,7 +6107,7 @@ __metadata:
     cross-spawn: ^7.0.3
     globby: ^11.0.2
     jest: ^29.3.1
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     jscodeshift: ^0.13.1
     lodash: ^4.17.21
     prettier: ^2.7.1
@@ -6251,7 +6251,7 @@ __metadata:
     globby: ^11.0.2
     ip: ^2.0.0
     jest-os-detection: ^1.3.1
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     lodash: ^4.17.21
     node-fetch: ^2.6.7
     open: ^8.4.0
@@ -6366,7 +6366,7 @@ __metadata:
     "@storybook/preview-api": 7.0.0-alpha.54
     "@storybook/types": 7.0.0-alpha.54
     doctrine: ^3.0.0
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     lodash: ^4.17.21
     require-from-string: ^2.0.2
     typescript: ^4.9.3
@@ -6689,7 +6689,7 @@ __metadata:
   resolution: "@storybook/postinstall@workspace:lib/postinstall"
   dependencies:
     jest: ^29.3.1
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     jscodeshift: ^0.13.1
     typescript: ^4.9.3
   languageName: unknown
@@ -6788,7 +6788,7 @@ __metadata:
     typescript: ^4.9.3
   peerDependencies:
     "@babel/core": ^7.11.5
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     require-from-string: ^2.0.2
@@ -6811,7 +6811,7 @@ __metadata:
     "@types/node": ^16.0.0
     fs-extra: ^9.0.1
     global: ^4.4.0
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     react: 16.14.0
     react-dom: 16.14.0
     safe-identifier: ^0.4.1
@@ -7016,7 +7016,7 @@ __metadata:
     "@storybook/preset-react-webpack": 7.0.0-alpha.54
     "@storybook/react": 7.0.0-alpha.54
     "@types/node": ^16.0.0
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     typescript: ^4.9.3
   peerDependencies:
     "@babel/core": ^7.11.5
@@ -7050,7 +7050,7 @@ __metadata:
     expect-type: ^0.14.2
     global: ^4.4.0
     html-tags: ^3.1.0
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     lodash: ^4.17.21
     prop-types: ^15.7.2
     react-element-to-jsx-string: ^15.0.0
@@ -7417,7 +7417,7 @@ __metadata:
     "@storybook/csf": next
     "@storybook/types": 7.0.0-alpha.54
     estraverse: ^5.2.0
-    jest-specific-snapshot: ^6.0.0
+    jest-specific-snapshot: ^7.0.0
     lodash: ^4.17.21
     prettier: ^2.7.1
     typescript: ^4.9.3
@@ -21224,7 +21224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-snapshot@npm:^28.0.0, jest-snapshot@npm:^28.1.3":
+"jest-snapshot@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-snapshot@npm:28.1.3"
   dependencies:
@@ -21255,7 +21255,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-snapshot@npm:^29.3.1":
+"jest-snapshot@npm:^29.0.0, jest-snapshot@npm:^29.3.1":
   version: 29.3.1
   resolution: "jest-snapshot@npm:29.3.1"
   dependencies:
@@ -21287,14 +21287,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-specific-snapshot@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "jest-specific-snapshot@npm:6.0.0"
+"jest-specific-snapshot@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "jest-specific-snapshot@npm:7.0.0"
   dependencies:
-    jest-snapshot: ^28.0.0
+    jest-snapshot: ^29.0.0
   peerDependencies:
-    jest: ">= 28.0.0"
-  checksum: ee3d04e352a07fcd17619370338b7beeb8e09ed39fb700ca7b481e0531097770cfab5fb00303a4bd81077ed5c88307cecb001ea0f7a0a59f3281c736796ad6b2
+    jest: ">= 29.0.0"
+  checksum: a5ff13f7088ecf2644fc44e70681da1d5669db64bb34aa922576462f617c184b4f528fb58b227e3634520d776a42f992df3a5a291f00073944d7e260209479f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: N/A

## What I did

This bumps jest-specific-snapshot to the latest version which includes jest 29 as a dependency, instead of jest 28.  https://github.com/igor-dv/jest-specific-snapshot/releases/tag/v7.0.0

## How to test

- Unit tests
