### PR TITLE
Core: Open browser after manager is ready

### DIFF
--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -107,18 +107,18 @@ export async function storybookDevServer(options: Options) {
     logConfig('Preview webpack config', await previewBuilder.getConfig(options));
   }
 
-  Promise.all([initializedStoryIndexGenerator, listening, usingStatics]).then(async () => {
-    if (!options.ci && !options.smokeTest && options.open) {
-      openInBrowser(host ? networkAddress : address);
-    }
-  });
-
   const managerResult = await managerBuilder.start({
     startTime: process.hrtime(),
     options,
     router,
     server,
     channel: serverChannel,
+  });
+
+  Promise.all([initializedStoryIndexGenerator, listening, usingStatics]).then(async () => {
+    if (!options.ci && !options.smokeTest && options.open) {
+      openInBrowser(host ? networkAddress : address);
+    }
   });
 
   let previewResult;


### PR DESCRIPTION
fixes: https://github.com/storybookjs/storybook/issues/19968

## What I did

Wait for the manager to start before opening the manager