### PR TITLE
CLI: Remove render functions and infer argTypes for svelte CLI templates

### DIFF
--- a/code/renderers/svelte/template/cli/js/Button.stories.js
+++ b/code/renderers/svelte/template/cli/js/Button.stories.js
@@ -5,22 +5,8 @@ export default {
   title: 'Example/Button',
   component: Button,
   tags: ['docsPage'],
-  render: (args) => ({
-    Component: Button,
-    props: args,
-    on: {
-      click: args.onClick,
-    },
-  }),
   argTypes: {
     backgroundColor: { control: 'color' },
-    label: { control: 'text' },
-    onClick: { action: 'onClick' },
-    primary: { control: 'boolean' },
-    size: {
-      control: { type: 'select' },
-      options: ['small', 'medium', 'large'],
-    },
   },
 };
 

--- a/code/renderers/svelte/template/cli/js/Button.svelte
+++ b/code/renderers/svelte/template/cli/js/Button.svelte
@@ -1,6 +1,6 @@
 <script>
   import './button.css';
-  import { createEventDispatcher } from 'svelte';
+
   /**
    * Is this the principal call to action on the page?
    */
@@ -17,27 +17,18 @@
   /**
    * Button contents
    */
-  export let label = '';
+  export let label;
 
   $: mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
 
   $: style = backgroundColor ? `background-color: ${backgroundColor}` : '';
-
-  const dispatch = createEventDispatcher();
-
-  /**
-   * Optional click handler
-   */
-  export let onClick = (event) => {
-    dispatch('click', event);
-  };
 </script>
 
 <button
   type="button"
   class={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
   {style}
-  on:click={onClick}
+  on:click
 >
   {label}
 </button>

--- a/code/renderers/svelte/template/cli/js/Header.stories.js
+++ b/code/renderers/svelte/template/cli/js/Header.stories.js
@@ -5,23 +5,9 @@ export default {
   component: Header,
   // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/7.0/svelte/writing-docs/docs-page
   tags: ['docsPage'],
-  render: (args) => ({
-    Component: Header,
-    props: args,
-    on: {
-      login: args.onLogin,
-      logout: args.onLogout,
-      createAccount: args.onCreateAccount,
-    },
-  }),
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/7.0/svelte/configure/story-layout
     layout: 'fullscreen',
-  },
-  argTypes: {
-    onLogin: { action: 'onLogin' },
-    onLogout: { action: 'onLogout' },
-    onCreateAccount: { action: 'onCreateAccount' },
   },
 };
 

--- a/code/renderers/svelte/template/cli/js/Header.svelte
+++ b/code/renderers/svelte/template/cli/js/Header.svelte
@@ -26,10 +26,12 @@
         <g fill="none" fill-rule="evenodd">
           <path
             d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
-            fill="#FFF" />
+            fill="#FFF"
+          />
           <path
             d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
-            fill="#555AB9" />
+            fill="#555AB9"
+          />
           <path d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z" fill="#91BAF8" />
         </g>
       </svg>
@@ -41,8 +43,7 @@
           Welcome, <b>{user.name}</b>!
         </span>
         <Button size="small" on:click={onLogout} label="Log out" />
-      {/if}
-      {#if !user}
+      {:else}
         <Button size="small" on:click={onLogin} label="Log in" />
         <Button primary size="small" on:click={onCreateAccount} label="Sign up" />
       {/if}

--- a/code/renderers/svelte/template/cli/js/Page.stories.js
+++ b/code/renderers/svelte/template/cli/js/Page.stories.js
@@ -1,0 +1,25 @@
+import { within, userEvent } from '@storybook/testing-library';
+
+import Page from './Page.svelte';
+
+export default {
+  title: 'Example/Page',
+  component: Page,
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/7.0/svelte/configure/story-layout
+    layout: 'fullscreen',
+  },
+};
+
+export const LoggedOut = {};
+
+// More on interaction testing: https://storybook.js.org/docs/7.0/svelte/writing-tests/interaction-testing
+export const LoggedIn = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const loginButton = await canvas.getByRole('button', {
+      name: /Log in/i,
+    });
+    await userEvent.click(loginButton);
+  },
+};

--- a/code/renderers/svelte/template/cli/js/Page.svelte
+++ b/code/renderers/svelte/template/cli/js/Page.svelte
@@ -1,0 +1,70 @@
+<script>
+  import './page.css';
+  import Header from './Header.svelte';
+
+  let user = null;
+</script>
+
+<article>
+  <Header
+    {user}
+    on:login={() => (user = { name: 'Jane Doe' })}
+    on:logout={() => (user = null)}
+    on:createAccount={() => (user = { name: 'Jane Doe' })}
+  />
+
+  <section>
+    <h2>Pages in Storybook</h2>
+    <p>
+      We recommend building UIs with a
+      <a
+        href="https://blog.hichroma.com/component-driven-development-ce1109d56c8e"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <strong>component-driven</strong>
+      </a>
+      process starting with atomic components and ending with pages.
+    </p>
+    <p>
+      Render pages with mock data. This makes it easy to build and review page states without
+      needing to navigate to them in your app. Here are some handy patterns for managing page data
+      in Storybook:
+    </p>
+    <ul>
+      <li>
+        Use a higher-level connected component. Storybook helps you compose such data from the
+        "args" of child component stories
+      </li>
+      <li>
+        Assemble data in the page component from your services. You can mock these services out
+        using Storybook.
+      </li>
+    </ul>
+    <p>
+      Get a guided tutorial on component-driven development at
+      <a href="https://storybook.js.org/tutorials/" target="_blank" rel="noopener noreferrer">
+        Storybook tutorials
+      </a>
+      . Read more in the
+      <a href="https://storybook.js.org/docs" target="_blank" rel="noopener noreferrer">docs</a>
+      .
+    </p>
+    <div class="tip-wrapper">
+      <span class="tip">Tip</span>
+      Adjust the width of the canvas with the
+      <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+        <g fill="none" fill-rule="evenodd">
+          <path
+            d="M1.5 5.2h4.8c.3 0 .5.2.5.4v5.1c-.1.2-.3.3-.4.3H1.4a.5.5 0
+            01-.5-.4V5.7c0-.3.2-.5.5-.5zm0-2.1h6.9c.3 0 .5.2.5.4v7a.5.5 0 01-1 0V4H1.5a.5.5 0
+            010-1zm0-2.1h9c.3 0 .5.2.5.4v9.1a.5.5 0 01-1 0V2H1.5a.5.5 0 010-1zm4.3 5.2H2V10h3.8V6.2z"
+            id="a"
+            fill="#999"
+          />
+        </g>
+      </svg>
+      Viewports addon in the toolbar
+    </div>
+  </section>
+</article>

--- a/code/renderers/svelte/template/cli/ts/Button.stories.ts
+++ b/code/renderers/svelte/template/cli/ts/Button.stories.ts
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+
+import Button from './Button.svelte';
+
+// More on how to set up stories at: https://storybook.js.org/docs/7.0/svelte/writing-stories/introduction
+const meta: Meta<Button> = {
+  title: 'Example/Button',
+  component: Button,
+  tags: ['docsPage'],
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<Button>;
+
+// More on writing stories with args: https://storybook.js.org/docs/7.0/svelte/writing-stories/args
+export const Primary: Story = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    label: 'Button',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'large',
+    label: 'Button',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'small',
+    label: 'Button',
+  },
+};

--- a/code/renderers/svelte/template/cli/ts/Button.svelte
+++ b/code/renderers/svelte/template/cli/ts/Button.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import './button.css';
+
+  /**
+   * Is this the principal call to action on the page?
+   */
+  export let primary = false;
+
+  /**
+   * What background color to use
+   */
+  export let backgroundColor: string | undefined = undefined;
+  /**
+   * How large should the button be?
+   */
+  export let size: 'small' | 'medium' | 'large' = 'medium';
+  /**
+   * Button contents
+   */
+  export let label: string;
+
+  $: mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+
+  $: style = backgroundColor ? `background-color: ${backgroundColor}` : '';
+</script>
+
+<button
+  type="button"
+  class={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+  {style}
+  on:click
+>
+  {label}
+</button>

--- a/code/renderers/svelte/template/cli/ts/Header.stories.ts
+++ b/code/renderers/svelte/template/cli/ts/Header.stories.ts
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import Header from './Header.svelte';
+
+const meta: Meta<Header> = {
+  title: 'Example/Header',
+  component: Header,
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  tags: ['docsPage'],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/7.0/svelte/configure/story-layout
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<Header>;
+
+export const LoggedIn: Story = {
+  args: {
+    user: {
+      name: 'Jane Doe',
+    },
+  },
+};
+
+export const LoggedOut: Story = {};

--- a/code/renderers/svelte/template/cli/ts/Header.svelte
+++ b/code/renderers/svelte/template/cli/ts/Header.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import './header.css';
+  import Button from './Button.svelte';
+
+  import { createEventDispatcher } from 'svelte';
+
+  export let user: { name: string } | null = null;
+
+  const dispatch = createEventDispatcher();
+
+  function onLogin(event: MouseEvent) {
+    dispatch('login', event);
+  }
+  function onLogout(event: MouseEvent) {
+    dispatch('logout', event);
+  }
+  function onCreateAccount(event: MouseEvent) {
+    dispatch('createAccount', event);
+  }
+</script>
+
+<header>
+  <div class="wrapper">
+    <div>
+      <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+        <g fill="none" fill-rule="evenodd">
+          <path
+            d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
+            fill="#FFF"
+          />
+          <path
+            d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
+            fill="#555AB9"
+          />
+          <path d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z" fill="#91BAF8" />
+        </g>
+      </svg>
+      <h1>Acme</h1>
+    </div>
+    <div>
+      {#if user}
+        <span class="welcome">
+          Welcome, <b>{user.name}</b>!
+        </span>
+        <Button size="small" on:click={onLogout} label="Log out" />
+      {:else}
+        <Button size="small" on:click={onLogin} label="Log in" />
+        <Button primary size="small" on:click={onCreateAccount} label="Sign up" />
+      {/if}
+    </div>
+  </div>
+</header>

--- a/code/renderers/svelte/template/cli/ts/Page.stories.ts
+++ b/code/renderers/svelte/template/cli/ts/Page.stories.ts
@@ -1,7 +1,9 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
 import { within, userEvent } from '@storybook/testing-library';
+
 import Page from './Page.svelte';
 
-export default {
+const meta: Meta<Page> = {
   title: 'Example/Page',
   component: Page,
   parameters: {
@@ -9,14 +11,14 @@ export default {
     layout: 'fullscreen',
   },
 };
-export const LoggedOut = {};
+
+export default meta;
+type Story = StoryObj<Page>;
+
+export const LoggedOut: Story = {};
 
 // More on interaction testing: https://storybook.js.org/docs/7.0/svelte/writing-tests/interaction-testing
-export const LoggedIn = {
-  render: (args) => ({
-    Component: Page,
-    props: args,
-  }),
+export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const loginButton = await canvas.getByRole('button', {

--- a/code/renderers/svelte/template/cli/ts/Page.svelte
+++ b/code/renderers/svelte/template/cli/ts/Page.svelte
@@ -1,12 +1,17 @@
-<script>
+<script lang="ts">
   import './page.css';
   import Header from './Header.svelte';
 
-  let user = null;
+  let user: { name: string } | null = null;
 </script>
 
 <article>
-  <Header {user} on:login={() => user = { name: 'Jane Doe' }} on:logout={() => user = null} on:createAccount={() => user = { name: 'Jane Doe' }} />
+  <Header
+    {user}
+    on:login={() => (user = { name: 'Jane Doe' })}
+    on:logout={() => (user = null)}
+    on:createAccount={() => (user = { name: 'Jane Doe' })}
+  />
 
   <section>
     <h2>Pages in Storybook</h2>
@@ -15,7 +20,8 @@
       <a
         href="https://blog.hichroma.com/component-driven-development-ce1109d56c8e"
         target="_blank"
-        rel="noopener noreferrer">
+        rel="noopener noreferrer"
+      >
         <strong>component-driven</strong>
       </a>
       process starting with atomic components and ending with pages.
@@ -54,7 +60,8 @@
             01-.5-.4V5.7c0-.3.2-.5.5-.5zm0-2.1h6.9c.3 0 .5.2.5.4v7a.5.5 0 01-1 0V4H1.5a.5.5 0
             010-1zm0-2.1h9c.3 0 .5.2.5.4v9.1a.5.5 0 01-1 0V2H1.5a.5.5 0 010-1zm4.3 5.2H2V10h3.8V6.2z"
             id="a"
-            fill="#999" />
+            fill="#999"
+          />
         </g>
       </svg>
       Viewports addon in the toolbar


### PR DESCRIPTION
## What I did

Updated the CLI templates for svelte

- Removed the render functions CLI templates, as they are inferred now
- Infer argTypes, only manual override an argType when it is different than would be inferred
- Added TS templates

I also tried to align more with svelte conventions: 

- Forward click event with on:click 
- Don't use props for events like you would do in react

I am also adding CLI templates for TS 4.9 with satisfies for svelte, but I wanted to split this work off from the TS 4.9 PR, so that it can be reviewed seperately.