### PR TITLE
Chore: (Docs) Changes the script to run the docs site

### DIFF
--- a/docs/contribute/new-snippets.md
+++ b/docs/contribute/new-snippets.md
@@ -108,7 +108,7 @@ yarn link-monorepo-docs  ./path-to-your-local-storybook
 And run the Storybook website with the following command:
 
 ```shell
-yarn start:skip-addons
+yarn start:docs-only
 ```
 
 <div class="aside">


### PR DESCRIPTION
Following some changes in the Storybook website repository, how we're instructing our community to run the website to preview the docs required a small change.

With this pull request it addresses the issue.
