### PR TITLE
No unused locals in tsconfig to disable deepscan

### DIFF
--- a/code/addons/actions/src/containers/ActionLogger/index.tsx
+++ b/code/addons/actions/src/containers/ActionLogger/index.tsx
@@ -26,6 +26,7 @@ const safeDeepEqual = (a: any, b: any): boolean => {
 };
 
 export default class ActionLogger extends Component<ActionLoggerProps, ActionLoggerState> {
+  // @ts-expect-error Unused, possibly remove, leaving, because it could be accessed even though it is private
   private mounted: boolean;
 
   constructor(props: ActionLoggerProps) {

--- a/code/addons/toolbars/src/components/ToolbarMenuList.tsx
+++ b/code/addons/toolbars/src/components/ToolbarMenuList.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 import React, { useCallback } from 'react';
 import { useGlobals } from '@storybook/manager-api';
 import { deprecate } from '@storybook/client-logger';
@@ -9,14 +9,6 @@ import { withKeyboardCycle } from '../hoc/withKeyboardCycle';
 import { getSelectedIcon, getSelectedTitle } from '../utils/get-selected';
 import type { ToolbarMenuProps } from '../types';
 import { ToolbarMenuListItem } from './ToolbarMenuListItem';
-
-type ItemProps = {
-  left?: ReactNode;
-  title?: ReactNode;
-  right?: ReactNode;
-  active?: boolean;
-  onClick?: () => void;
-};
 
 type ToolbarMenuListProps = ToolbarMenuProps & WithKeyboardCycleProps;
 

--- a/code/frameworks/angular/src/client/angular-beta/RendererFactory.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/RendererFactory.test.ts
@@ -306,10 +306,7 @@ describe('RendererFactory', () => {
           .appendChild(global.document.createElement('👾'));
 
         expect(global.document.getElementById('storybook-root').innerHTML).toContain('Canvas 🖼');
-        const render = await rendererFactory.getRendererInstance(
-          'my-story-in-docs',
-          rootDocstargetDOMNode
-        );
+        await rendererFactory.getRendererInstance('my-story-in-docs', rootDocstargetDOMNode);
         expect(global.document.getElementById('storybook-root').innerHTML).toBe('');
       });
     });

--- a/code/frameworks/angular/src/server/framework-preset-angular-cli.test.ts
+++ b/code/frameworks/angular/src/server/framework-preset-angular-cli.test.ts
@@ -34,11 +34,8 @@ describe('framework-preset-angular-cli', () => {
   });
 
   describe('without angular.json', () => {
-    let consoleErrorSpy: jest.SpyInstance;
-
     beforeEach(() => {
       initMockWorkspace('');
-      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
     });
     it('should return webpack base config and display log error', async () => {
       const webpackBaseConfig = newWebpackConfiguration();
@@ -421,10 +418,6 @@ describe('framework-preset-angular-cli', () => {
     it('should set webpack "module.rules"', async () => {
       const baseWebpackConfig = newWebpackConfiguration();
       const webpackFinalConfig = await webpackFinal(baseWebpackConfig, options);
-      const stylePaths = [
-        path.join(workspaceRoot, 'src', 'styles.css'),
-        path.join(workspaceRoot, 'src', 'styles.scss'),
-      ];
 
       const expectedRules: any = [
         {
@@ -507,10 +500,6 @@ describe('framework-preset-angular-cli', () => {
     it('should set webpack "module.rules"', async () => {
       const baseWebpackConfig = newWebpackConfiguration();
       const webpackFinalConfig = await webpackFinal(baseWebpackConfig, options);
-      const stylePaths = [
-        path.join(workspaceRoot, 'src', 'styles.css'),
-        path.join(workspaceRoot, 'src', 'styles.scss'),
-      ];
 
       const expectedRules: any = [
         {

--- a/code/frameworks/angular/tsconfig.build.json
+++ b/code/frameworks/angular/tsconfig.build.json
@@ -15,7 +15,8 @@
     "allowJs": true,
     "pretty": true,
     "noErrorTruncation": true,
-    "listEmittedFiles": false
+    "listEmittedFiles": false,
+    "noUnusedLocals": false
   },
   "include": ["src/**/*", "src/**/*.json"]
 }

--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -129,7 +129,6 @@ export async function baseGenerator(
   const {
     packages: frameworkPackages,
     type,
-    renderer: rendererInclude, // deepscan-disable-line UNUSED_DECL
     rendererId,
     framework: frameworkInclude,
     builder: builderInclude,

--- a/code/lib/docs-tools/src/argTypes/convert/__testfixtures__/typescript/optionals.tsx
+++ b/code/lib/docs-tools/src/argTypes/convert/__testfixtures__/typescript/optionals.tsx
@@ -17,5 +17,5 @@ export const Component: FC<Props> = ({
   ...rest
 }: Props) => {
   const props = { any, string, bool, number, ...rest };
-  return <>JSON.stringify(props)</>;
+  return <>{JSON.stringify(props)}</>;
 };

--- a/code/lib/manager-api/src/tests/stories.test.ts
+++ b/code/lib/manager-api/src/tests/stories.test.ts
@@ -876,7 +876,6 @@ describe('stories API', () => {
 
       const {
         api: { setIndex, jumpToStory },
-        state,
       } = initStories({ store, navigate, provider } as any);
       setIndex({ v: 4, entries: navigationEntries });
 

--- a/code/lib/preview-api/src/modules/core-client/start.test.ts
+++ b/code/lib/preview-api/src/modules/core-client/start.test.ts
@@ -386,7 +386,7 @@ describe('start', () => {
     it('re-emits SET_INDEX when a story is added', async () => {
       const renderToCanvas = jest.fn(({ storyFn }) => storyFn());
 
-      const { configure, clientApi, forceReRender } = start(renderToCanvas);
+      const { configure, clientApi } = start(renderToCanvas);
 
       let disposeCallback: () => void = () => {};
       const module = {

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -775,7 +775,7 @@ describe('PreviewWeb', () => {
 
     it('passes globals in context to renderToCanvas', async () => {
       document.location.search = '?id=component-one--a';
-      const preview = await createAndRenderPreview();
+      await createAndRenderPreview();
 
       mockChannel.emit.mockClear();
       projectAnnotations.renderToCanvas.mockClear();

--- a/code/lib/preview-api/src/modules/store/StoryStore.test.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.test.ts
@@ -208,7 +208,7 @@ describe('StoryStore', () => {
       store.setProjectAnnotations(projectAnnotations);
       store.initialize({ storyIndex, importFn, cache: false });
 
-      const story = await store.loadStory({ storyId: 'component-one--a' });
+      await store.loadStory({ storyId: 'component-one--a' });
       expect(processCSFFile).toHaveBeenCalledTimes(1);
       expect(prepareStory).toHaveBeenCalledTimes(1);
 

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -59,6 +59,7 @@ describe('Meta', () => {
         },
       }),
     };
+    expectTypeOf(meta).toMatchTypeOf<Meta<Button>>();
   });
 
   test('Events fallback to custom events when no component is specified', () => {
@@ -75,6 +76,7 @@ describe('Meta', () => {
         },
       }),
     };
+    expectTypeOf(meta).toMatchTypeOf<Meta<Button>>();
   });
 });
 

--- a/code/renderers/vue3/src/public-types.test.ts
+++ b/code/renderers/vue3/src/public-types.test.ts
@@ -60,6 +60,7 @@ describe('Meta', () => {
         });
       },
     };
+    expectTypeOf(meta).toMatchTypeOf<Meta<typeof Button>>();
   });
 });
 

--- a/code/renderers/web-components/src/docs/custom-elements.ts
+++ b/code/renderers/web-components/src/docs/custom-elements.ts
@@ -37,14 +37,6 @@ interface Module {
 interface Declaration {
   tagName: string;
 }
-interface Sections {
-  attributes?: any;
-  properties?: any;
-  events?: any;
-  slots?: any;
-  cssCustomProperties?: any;
-  cssShadowParts?: any;
-}
 
 function mapItem(item: TagItem, category: string): InputType {
   const type =

--- a/code/tsconfig.json
+++ b/code/tsconfig.json
@@ -14,7 +14,8 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "strictBindCallApply": true,
-    "lib": ["dom", "esnext"]
+    "lib": ["dom", "esnext"],
+    "noUnusedLocals": true
   },
   "exclude": ["dist", "**/dist", "node_modules", "**/node_modules", "**/setup-jest.ts"],
   "ts-node": {

--- a/code/ui/manager/src/runtime.ts
+++ b/code/ui/manager/src/runtime.ts
@@ -18,6 +18,7 @@ const { FEATURES, SERVER_CHANNEL_URL } = global;
 class ReactProvider extends Provider {
   private addons: AddonStore;
 
+  // @ts-expect-error Unused, possibly remove, leaving, because it could be accessed even though it is private
   private channel: Channel;
 
   private serverChannel?: Channel;

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -24,7 +24,7 @@
     "strict": false,
     "strictNullChecks": false,
     "forceConsistentCasingInFileNames": true,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
@@ -33,7 +33,7 @@
       "verdaccio": [
         "./typings.d.ts"
       ]
-    }
+    },
   },
   "exclude": [
     "dist",


### PR DESCRIPTION
Deep scan is not compatible with TS 4.9 yet. And the only issues it seems to find that are not covered yet by TS or ESLint are unused imports. TSC can catch those by enabling noUnusedLocals in tsconfig.