### PR TITLE
Add YouTube callouts to relevant docs pages

### DIFF
--- a/docs/api/csf.md
+++ b/docs/api/csf.md
@@ -2,6 +2,8 @@
 title: 'Component Story Format (CSF)'
 ---
 
+<YouTubeCallout id="uH9_dfc-6Kc" title="Test components the EASY way | Component Story Format 3" />
+
 Component Story Format (CSF) is the recommended way to [write stories](../writing-stories/introduction.md). It's an [open standard](https://github.com/ComponentDriven/csf) based on ES6 modules that is portable beyond Storybook.
 
 <div class="aside">

--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -2,6 +2,8 @@
 title: 'Controls'
 ---
 
+<YouTubeCallout id="vAh0KdRcXpI" title="How to connect props with Storybook controls" />
+
 Storybook Controls gives you a graphical UI to interact with a component's arguments dynamically without needing to code. It creates an addon panel next to your component examples ("stories"), so you can edit them live.
 
 <video autoPlay muted playsInline loop>

--- a/docs/essentials/measure-and-outline.md
+++ b/docs/essentials/measure-and-outline.md
@@ -2,6 +2,8 @@
 title: 'Measure & outline'
 ---
 
+<YouTubeCallout id="-S7GtH0hdc4" title="Debug CSS without DevTools — Storybook" />
+
 Storybook's [Measure](https://storybook.js.org/addons/@storybook/addon-measure/) and [Outline](https://storybook.js.org/addons/@storybook/addon-outline) addons give you the necessary tooling to inspect and visually debug CSS layout and alignment issues within your stories. It makes it easy to catch UI bugs early in development.
 
 ## Measure addon

--- a/docs/essentials/toolbars-and-globals.md
+++ b/docs/essentials/toolbars-and-globals.md
@@ -2,6 +2,8 @@
 title: 'Toolbars & globals'
 ---
 
+<YouTubeCallout id="DuJ_gmSncLM" title="Create custom toolbar items using global types" />
+
 Storybook ships with toolbar addons to control the [viewport](./viewport.md) and [background](./backgrounds.md) the story renders in. You can also create your own toolbar items which control special “globals” which you can then read to create [decorators](../writing-stories/decorators.md) to control story rendering.
 
 ## Globals

--- a/docs/essentials/viewport.md
+++ b/docs/essentials/viewport.md
@@ -2,6 +2,8 @@
 title: 'Viewport'
 ---
 
+<YouTubeCallout id="uydF1ltw7-g" title="Stop resizing your browser — Storybook viewport" />
+
 The Viewport toolbar item allows you to adjust the dimensions of the iframe your story is rendered in. It makes it easy to develop responsive UIs.
 
 <video autoPlay muted playsInline loop>

--- a/docs/writing-stories/play-function.md
+++ b/docs/writing-stories/play-function.md
@@ -2,6 +2,8 @@
 title: 'Play function'
 ---
 
+<YouTubeCallout id="dcuzwCHI940" title="Component testing in Storybook with play functions" />
+
 `Play` functions are small snippets of code executed after the story renders. Enabling you to interact with your components and test scenarios that otherwise required user intervention.
 
 ## Setup the interactions addon


### PR DESCRIPTION
## What I did

Now that the [YouTubeCallout component is available in MDX documents](https://github.com/storybookjs/frontpage/pull/429), this adds it to the relevant docs pages.

Because the YouTube video `id` is opaque, here's a table of the updates:

| Page | Video |
|------|-------|
| [Write stories / Play function](https://storybook.js.org/docs/7.0/react/writing-stories/play-function) | [Component testing in Storybook with play functions](https://youtu.be/dcuzwCHI940) |
| [Essential addons / Controls](https://storybook.js.org/docs/7.0/react/essentials/controls) | [How to connect props with Storybook controls](https://youtu.be/vAh0KdRcXpI) |
| [Essential addons / Viewport](https://storybook.js.org/docs/7.0/react/essentials/viewport) | [Stop resizing your browser — Storybook viewport](https://youtu.be/uydF1ltw7-g) |
| [Essential addons / Toolbars & globals](https://storybook.js.org/docs/7.0/react/essentials/toolbars-and-globals) | [Create custom toolbar items using global types](https://youtu.be/DuJ_gmSncLM) |
| [Essential addons / Measure & outline](https://storybook.js.org/docs/7.0/react/essentials/measure-and-outline) | [Debug CSS without DevTools — Storybook](https://youtu.be/-S7GtH0hdc4) |
| [API / Stories / Component Story Format (CSF)](https://storybook.js.org/docs/7.0/react/api/csf) | [Test components the EASY way \| Component Story Format 3](https://youtu.be/uH9_dfc-6Kc) |

And here's what it looks like in-context:

**Closed**
![Screenshot of YouTubeCallout component on the page, in the closed state](https://user-images.githubusercontent.com/486540/204590207-3e70be17-495b-4004-a490-4cfffb5ed326.png)

**Open**
![Screenshot of YouTubeCallout component on the page, in the open state](https://user-images.githubusercontent.com/486540/204590173-3ba59149-3d9f-4acd-8a48-e1eec938a072.png)

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
