### PR TITLE
Add YouTube callouts to relevant docs pages

### DIFF
--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -2,6 +2,8 @@
 title: 'Controls'
 ---
 
+<YouTubeCallout id="vAh0KdRcXpI" title="How to connect props with Storybook controls" />
+
 Storybook Controls gives you a graphical UI to interact with a component's arguments dynamically without needing to code. It creates an addon panel next to your component examples ("stories"), so you can edit them live.
 
 <video autoPlay muted playsInline loop>

--- a/docs/essentials/measure-and-outline.md
+++ b/docs/essentials/measure-and-outline.md
@@ -2,6 +2,8 @@
 title: 'Measure & outline'
 ---
 
+<YouTubeCallout id="-S7GtH0hdc4" title="Debug CSS without DevTools — Storybook" />
+
 Storybook's [Measure](https://storybook.js.org/addons/@storybook/addon-measure/) and [Outline](https://storybook.js.org/addons/@storybook/addon-outline) addons give you the necessary tooling to inspect and visually debug CSS layout and alignment issues within your stories. It makes it easy to catch UI bugs early in development.
 
 ## Measure addon

--- a/docs/essentials/toolbars-and-globals.md
+++ b/docs/essentials/toolbars-and-globals.md
@@ -2,6 +2,8 @@
 title: 'Toolbars & globals'
 ---
 
+<YouTubeCallout id="DuJ_gmSncLM" title="Create custom toolbar items using global types" />
+
 Storybook ships with toolbar addons to control the [viewport](./viewport.md) and [background](./backgrounds.md) the story renders in. You can also create your own toolbar items which control special “globals” which you can then read to create [decorators](../writing-stories/decorators.md) to control story rendering.
 
 ## Globals

--- a/docs/essentials/viewport.md
+++ b/docs/essentials/viewport.md
@@ -2,6 +2,8 @@
 title: 'Viewport'
 ---
 
+<YouTubeCallout id="uydF1ltw7-g" title="Stop resizing your browser — Storybook viewport" />
+
 The Viewport toolbar item allows you to adjust the dimensions of the iframe your story is rendered in. It makes it easy to develop responsive UIs.
 
 <video autoPlay muted playsInline loop>

--- a/docs/writing-stories/play-function.md
+++ b/docs/writing-stories/play-function.md
@@ -2,6 +2,8 @@
 title: 'Play function'
 ---
 
+<YouTubeCallout id="dcuzwCHI940" title="Component testing in Storybook with play functions" />
+
 `Play` functions are small snippets of code executed after the story renders. Enabling you to interact with your components and test scenarios that otherwise required user intervention.
 
 ## Setup the interactions addon


### PR DESCRIPTION
## What I did

This is the `main` version of #20014. The only difference is that this one does not include the update to the CSF doc, as that video is about CSF 3 and these docs still use CSF 2.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
