### PR TITLE
Chore: (Docs) Extends a11y docs and test runner to feature helpers

### DIFF
--- a/docs/snippets/common/storybook-test-runner-a11y-configure.js.mdx
+++ b/docs/snippets/common/storybook-test-runner-a11y-configure.js.mdx
@@ -1,0 +1,33 @@
+```js
+// .storybook/test-runner.js
+
+const { injectAxe, checkA11y, configureAxe } = require('axe-playwright');
+
+const { getStoryContext } = require('@storybook/test-runner');
+
+/*
+ * See https://storybook.js.org/docs/7.0/react/writing-tests/test-runner#test-hook-api-experimental
+ * to learn more about the test-runner hooks API.
+ */
+module.exports = {
+  async preRender(page) {
+    await injectAxe(page);
+  },
+  async postRender(page, context) {
+    // Get the entire context of a story, including parameters, args, argTypes, etc.
+    const storyContext = await getStoryContext(page, context);
+
+    // Apply story-level a11y rules
+    await configureAxe(page, {
+      rules: storyContext.parameters?.a11y?.config?.rules,
+    });
+
+    await checkA11y(page, '#storybook-root', {
+      detailedReport: true,
+      detailedReportOptions: {
+        html: true,
+      },
+    });
+  },
+};
+```

--- a/docs/snippets/common/storybook-test-runner-a11y-configure.ts.mdx
+++ b/docs/snippets/common/storybook-test-runner-a11y-configure.ts.mdx
@@ -1,0 +1,37 @@
+```ts
+// .storybook/test-runner.ts
+
+import { injectAxe, checkA11y, configureAxe } from 'axe-playwright';
+
+import { getStoryContext } =  from '@storybook/test-runner';
+
+import type { TestRunnerConfig } from '@storybook/test-runner';
+
+/*
+ * See https://storybook.js.org/docs/7.0/react/writing-tests/test-runner#test-hook-api-experimental
+ * to learn more about the test-runner hooks API.
+ */
+const a11yConfig: TestRunnerConfig = {
+  async preRender(page) {
+    await injectAxe(page);
+  },
+  async postRender(page, context) {
+    // Get the entire context of a story, including parameters, args, argTypes, etc.
+    const storyContext = await getStoryContext(page, context);
+
+    // Apply story-level a11y rules
+    await configureAxe(page, {
+      rules: storyContext.parameters?.a11y?.config?.rules,
+    });
+
+    await checkA11y(page, '#storybook-root', {
+      detailedReport: true,
+      detailedReportOptions: {
+        html: true,
+      },
+    });
+  },
+};
+
+module.exports = a11yConfig;
+```

--- a/docs/snippets/common/storybook-test-runner-a11y-disable.js.mdx
+++ b/docs/snippets/common/storybook-test-runner-a11y-disable.js.mdx
@@ -1,0 +1,32 @@
+```js
+// .storybook/test-runner.js
+
+const { injectAxe, checkA11y } = require('axe-playwright');
+
+const { getStoryContext } = require('@storybook/test-runner');
+
+/*
+ * See https://storybook.js.org/docs/7.0/react/writing-tests/test-runner#test-hook-api-experimental
+ * to learn more about the test-runner hooks API.
+ */
+module.exports = {
+  async preRender(page) {
+    await injectAxe(page);
+  },
+  async postRender(page, context) {
+    // Get the entire context of a story, including parameters, args, argTypes, etc.
+    const storyContext = await getStoryContext(page, context);
+
+    // Do not run a11y tests on disabled stories.
+    if (storyContext.parameters?.a11y?.disable) {
+      return;
+    }
+    await checkA11y(page, '#storybook-root', {
+      detailedReport: true,
+      detailedReportOptions: {
+        html: true,
+      },
+    });
+  },
+};
+```

--- a/docs/snippets/common/storybook-test-runner-a11y-disable.ts.mdx
+++ b/docs/snippets/common/storybook-test-runner-a11y-disable.ts.mdx
@@ -1,0 +1,36 @@
+```ts
+// .storybook/test-runner.ts
+
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+import { getStoryContext } =  from '@storybook/test-runner';
+
+import type { TestRunnerConfig } from '@storybook/test-runner';
+
+/*
+ * See https://storybook.js.org/docs/7.0/react/writing-tests/test-runner#test-hook-api-experimental
+ * to learn more about the test-runner hooks API.
+ */
+const a11yConfig: TestRunnerConfig = {
+  async preRender(page) {
+    await injectAxe(page);
+  },
+  async postRender(page, context) {
+    // Get the entire context of a story, including parameters, args, argTypes, etc.
+    const storyContext = await getStoryContext(page, context);
+
+    // Do not run a11y tests on disabled stories.
+    if (storyContext.parameters?.a11y?.disable) {
+      return;
+    }
+    await checkA11y(page, '#storybook-root', {
+      detailedReport: true,
+      detailedReportOptions: {
+        html: true,
+      },
+    });
+  },
+};
+
+module.exports = a11yConfig;
+```

--- a/docs/snippets/common/storybook-test-runner-helper-function.js.mdx
+++ b/docs/snippets/common/storybook-test-runner-helper-function.js.mdx
@@ -1,0 +1,29 @@
+```js
+// .storybook/test-runner.js
+
+const { getStoryContext } = require('@storybook/test-runner');
+
+module.exports = {
+  // Hook that is executed before the test runner starts running tests
+  setup() {
+    // Add your configuration here.
+  },
+  /* Hook to execute before a story is rendered.
+   * The page argument is the Playwright's page object for the story.
+   * The context argument is a Storybook object containing the story's id, title, and name.
+   */
+  async preRender(page, context) {
+    // Add your configuration here.
+  },
+  /* Hook to execute after a story is rendered.
+   * The page argument is the Playwright's page object for the story
+   * The context argument is a Storybook object containing the story's id, title, and name.
+   */
+  async postRender(page, context) {
+    // Get the entire context of a story, including parameters, args, argTypes, etc.
+    const storyContext = await getStoryContext(page, context);
+
+    // Add your configuration here.
+  },
+};
+```

--- a/docs/snippets/common/storybook-test-runner-helper-function.ts.mdx
+++ b/docs/snippets/common/storybook-test-runner-helper-function.ts.mdx
@@ -1,0 +1,33 @@
+```ts
+// .storybook/test-runner.ts
+
+import type { TestRunnerConfig } from '@storybook/test-runner';
+
+import { getStoryContext } from '@storybook/test-runner';
+
+const config: TestRunnerConfig = {
+  // Hook that is executed before the test runner starts running tests
+  setup() {
+    // Add your configuration here.
+  },
+  /* Hook to execute before a story is rendered.
+   * The page argument is the Playwright's page object for the story.
+   * The context argument is a Storybook object containing the story's id, title, and name.
+   */
+  async preRender(page, context) {
+    // Add your configuration here.
+  },
+  /* Hook to execute after a story is rendered.
+   * The page argument is the Playwright's page object for the story
+   * The context argument is a Storybook object containing the story's id, title, and name.
+   */
+  async postRender(page, context) {
+    // Get the entire context of a story, including parameters, args, argTypes, etc.
+    const storyContext = await getStoryContext(page, context);
+
+    // Add your configuration here.
+  },
+};
+
+module.exports = config;
+```

--- a/docs/writing-tests/accessibility-testing.md
+++ b/docs/writing-tests/accessibility-testing.md
@@ -190,6 +190,36 @@ It starts checking for issues by traversing the DOM tree starting from the story
 
 ![Accessibility testing with the test runner](./test-runner-a11y-optimized.png)
 
+### A11y config with the test runner
+
+The test runner provides [helper methods](./test-runner.md#helpers), allowing access to the story's information. You can use them to extend the test runner's configuration and provide additional options you may have for a specific story. For example:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-test-runner-a11y-configure.js.mdx',
+    'common/storybook-test-runner-a11y-configure.ts.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+### Disable a11y tests with the test runner
+
+Additionally, if you have already [disabled accessibility](#how-to-disable-a11y-tests) tests for any particular story, you can also configure the test runner to avoid testing it as well. For example:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-test-runner-a11y-disable.js.mdx',
+    'common/storybook-test-runner-a11y-disable.ts.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
 ---
 
 #### What’s the difference between browser-based and linter-based accessibility tests?

--- a/docs/writing-tests/test-runner.md
+++ b/docs/writing-tests/test-runner.md
@@ -223,6 +223,21 @@ When the test-runner executes, your existing tests will go through the following
 - The story is rendered, and any existing `play` functions are executed.
 - The `postRender` function is executed.
 
+### Helpers
+
+The test-runner exports a few helpers that can be used to make your tests more readable and maintainable by accessing Storybook's internals (e.g., `args`, `parameters`). Listed below are the available helpers and an overview of how to use them.
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-test-runner-helper-function.js.mdx',
+    'common/storybook-test-runner-helper-function.ts.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
 ### Stories.json mode
 
 The test-runner transforms your story files into tests when testing a local Storybook. For a remote Storybook, it uses the Storybook's [stories.json](../configure/overview.md#feature-flags) file (a static index of all the stories) to run the tests.


### PR DESCRIPTION
This pull request extends the accessibility and the test runner documentation to feature the existing helper function that already exist and how to configure them.

Closes #19896
What was done:
- Updated the test-runner and a11y docs
- Created the required snippets