### PR TITLE
Build: Rollback forking off git-shallow-clone-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,123 +49,11 @@ executors:
     resource_class: <<parameters.class>>
 
 orbs:
-  git-shallow-clone: guitarrapc/git-shallow-clone@2.4.0
+  git-shallow-clone: guitarrapc/git-shallow-clone@2.4.1
   browser-tools: circleci/browser-tools@1.4.0
   discord: antonioned/discord@0.1.0
 
 commands:
-  # Forked off from https://github.com/guitarrapc/git-shallow-clone-orb
-  # See issue: https://github.com/guitarrapc/git-shallow-clone-orb/issues/34
-  checkout_advanced:
-    description: |
-      checkout by git shallow clone with git options. Support Alpine, Ubuntu, Debian and others.
-      eval is used in step, Fish shell is not supported.
-    parameters:
-      clone_options:
-        default: --depth 1
-        description: |
-          git clone options you want to add such as '--depth 1 --verbose' and '--depth 1 --shallow-since "5 days ago"'
-        type: string
-      fetch_options:
-        default: --depth 10
-        description: |
-          git fetch options you want to add such as '--depth 1 --verbose' and '--depth 1 --shallow-since "5 days ago"' you don't need set '--force' option as it already set by default. in case of tag, add '--no-tags' on this option and tag_fetch_options.
-        type: string
-      keyscan_bitbucket:
-        default: false
-        description: |
-          Pass `true` to dynamically get ssh-rsa from `bitbucket.org`.
-        type: boolean
-      keyscan_github:
-        default: false
-        description: |
-          Pass `true` to dynamically get ssh-rsa from `github.com`.
-        type: boolean
-      path:
-        default: .
-        description: |
-          Checkout directory (default: job’s working_directory)
-        type: string
-      tag_fetch_options:
-        default: --tags
-        description: |
-          This option apply when git operation is tag. Use 'fetch_options' instead if pr and other git operation. Additional git fetch options you want to add specifically for tags such as '--tags' or '--no-tags'. Default value is '--tags'
-        type: string
-    steps:
-      - run:
-          command: |
-            #!/bin/sh
-            set -ex
-            # Workaround old docker images with incorrect $HOME
-            # check https://github.com/docker/docker/issues/2968 for details
-            if [ "${HOME}" = "/" ]
-            then
-              export HOME=$(getent passwd $(id -un) | cut -d: -f6)
-            fi
-
-            # known_hosts
-            mkdir -p ~/.ssh
-            if [ -x "$(command -v ssh-keyscan)" ] && ([ "<< parameters.keyscan_github >>" == "true" ] || [ "<< parameters.keyscan_bitbucket >>" == "true" ])
-            then
-              if [ "<< parameters.keyscan_github >>" == "true" ]
-              then
-                ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-              fi
-              if [ "<< parameters.keyscan_bitbucket >>" == "true" ]
-              then
-                ssh-keyscan -H bitbucket.org >> ~/.ssh/known_hosts
-              fi
-            fi
-            if [ "<< parameters.keyscan_github >>" != "true" ]
-            then
-              echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
-            ' >> ~/.ssh/known_hosts
-            fi
-            if [ "<< parameters.keyscan_bitbucket >>" != "true" ]
-            then
-              echo 'bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
-            ' >> ~/.ssh/known_hosts
-            fi
-
-            (umask 077; touch ~/.ssh/id_rsa)
-            chmod 0600 ~/.ssh/id_rsa
-            (echo $CHECKOUT_KEY > ~/.ssh/id_rsa)
-
-            # use git+ssh instead of https
-            git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
-            git config --global gc.auto 0 || true
-
-            # checkout
-            git clone << parameters.clone_options >> $CIRCLE_REPOSITORY_URL "<< parameters.path >>"
-            cd "<< parameters.path >>"
-
-            # Fetch remote and check the commit ID of the checked out code
-            if [ -n "$CIRCLE_TAG" ]
-            then
-              # tag
-              git fetch << parameters.tag_fetch_options >> << parameters.fetch_options >> --force origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
-            elif [[ $(echo $CIRCLE_BRANCH | grep -e ^pull\/*) ]] # sh version of bash `elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]`
-            then
-              # pull request
-              git fetch << parameters.fetch_options >> --force origin "${CIRCLE_BRANCH}:remotes/origin/${CIRCLE_BRANCH}"
-            else
-              # others
-              git fetch << parameters.fetch_options >> --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
-            fi
-
-            # Check the commit ID of the checked out code
-            if [ -n "$CIRCLE_TAG" ]
-            then
-              git reset --hard "$CIRCLE_SHA1"
-              git checkout -q "$CIRCLE_TAG"
-            elif [ -n "$CIRCLE_BRANCH" ] && [ "$CIRCLE_BRANCH" != 'HEAD' ]
-            then
-              git reset --hard "$CIRCLE_SHA1"
-              git checkout -q -B "$CIRCLE_BRANCH"
-            fi
-
-            git reset --hard "$CIRCLE_SHA1"
-          name: Checkout code shallow
   cancel-workflow-on-failure:
     description: "Cancels the entire workflow in case the previous step has failed"
     steps:
@@ -198,7 +86,7 @@ jobs:
       class: small
       name: sb_node_16_classic
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - run:
           name: Prettier
@@ -211,7 +99,7 @@ jobs:
       class: large
       name: sb_node_16_classic
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - restore_cache:
           name: Restore Yarn cache
@@ -253,7 +141,7 @@ jobs:
       name: sb_playwright
     working_directory: /tmp/storybook
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -294,7 +182,7 @@ jobs:
       name: sb_playwright
     working_directory: /tmp/storybook
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -334,7 +222,7 @@ jobs:
       class: large
       name: sb_node_16_classic
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -350,7 +238,7 @@ jobs:
       class: xlarge
       name: sb_node_16_classic
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -364,7 +252,7 @@ jobs:
   script-unit-tests:
     executor: sb_node_16_browsers
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -382,7 +270,7 @@ jobs:
       class: xlarge
       name: sb_node_16_browsers
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -404,7 +292,7 @@ jobs:
       class: small
       name: sb_node_16_browsers
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -445,7 +333,7 @@ jobs:
       name: sb_node_16_browsers
     parallelism: << parameters.parallelism >>
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -470,7 +358,7 @@ jobs:
       name: sb_node_16_browsers
     parallelism: << parameters.parallelism >>
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -491,7 +379,7 @@ jobs:
       name: sb_node_16_browsers
     parallelism: << parameters.parallelism >>
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -525,7 +413,7 @@ jobs:
       name: sb_playwright
     parallelism: << parameters.parallelism >>
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
@@ -566,7 +454,7 @@ jobs:
       name: sb_playwright
     parallelism: << parameters.parallelism >>
     steps:
-      - checkout_advanced:
+      - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .


### PR DESCRIPTION
We can use the orb again with this issue fixed:

https://github.com/guitarrapc/git-shallow-clone-orb/issues/34