### PR TITLE
Allow shadowroot as canvaselement for play reuse

### DIFF
--- a/code/lib/types/src/modules/story.ts
+++ b/code/lib/types/src/modules/story.ts
@@ -21,7 +21,7 @@ import type {
 
 // Store Types
 export interface WebRenderer extends Renderer {
-  canvasElement: HTMLElement;
+  canvasElement: HTMLElement | ShadowRoot;
 }
 
 export type ModuleExport = any;


### PR DESCRIPTION
## What I did

Update typescript definition to allow shadowroot to be passed into play function's canvas element

If you are nesting web components inside of other components, you probably at one point want to reuse playbook play functions. This allows you to use a component's shadowroot as the root element for the next play function.

## How to test

Example

```
play: async ({canvasElement, ...rest}) => {
  await OtherStory.play({ ...rest, canvasElement: wc.shadowRoot });
}
```

- [ ] Is this testable with Jest or Chromatic screenshots?
No
- [ ] Does this need a new example in the kitchen sink apps?
No
- [ ] Does this need an update to the documentation?
Maybe?


If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
