### PR TITLE
Improve framework version specific story handling

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -255,12 +255,18 @@ function addStoriesEntry(mainConfig: ConfigFile, path: string) {
   mainConfig.setFieldValue(['stories'], [...stories, entry]);
 }
 
+function addVariantToFolder(variant?: string, folder = 'stories') {
+  return variant ? `${folder}_${variant}` : folder;
+}
+
 // packageDir is eg 'renderers/react', 'addons/actions'
 async function linkPackageStories(
   packageDir: string,
-  { mainConfig, cwd, linkInDir }: { mainConfig: ConfigFile; cwd: string; linkInDir?: string }
+  { mainConfig, cwd, linkInDir }: { mainConfig: ConfigFile; cwd: string; linkInDir?: string },
+  frameworkVariant?: string
 ) {
-  const source = join(codeDir, packageDir, 'template', 'stories');
+  const storiesFolderName = frameworkVariant ? addVariantToFolder(frameworkVariant) : 'stories';
+  const source = join(codeDir, packageDir, 'template', storiesFolderName);
   // By default we link `stories` directories
   //   e.g '../../../code/lib/store/template/stories' to 'template-stories/lib/store'
   // if the directory <code>/lib/store/template/stories exists
@@ -268,8 +274,12 @@ async function linkPackageStories(
   // The files must be linked in the cwd, in order to ensure that any dependencies they
   // reference are resolved in the cwd. In particular 'react' resolved by MDX files.
   const target = linkInDir
-    ? resolve(linkInDir, packageDir)
+    ? resolve(
+        linkInDir,
+        frameworkVariant ? addVariantToFolder(frameworkVariant, packageDir) : packageDir
+      )
     : resolve(cwd, 'template-stories', packageDir);
+
   await ensureSymlink(source, target);
 
   if (!linkInDir) addStoriesEntry(mainConfig, packageDir);
@@ -280,11 +290,13 @@ async function linkPackageStories(
   await Promise.all(
     ['js', 'ts'].map(async (ext) => {
       const previewFile = `preview.${ext}`;
-      const previewPath = join(codeDir, packageDir, 'template', 'stories', previewFile);
+      const previewPath = join(codeDir, packageDir, 'template', storiesFolderName, previewFile);
       if (await pathExists(previewPath)) {
         let storiesDir = 'template-stories';
         if (linkInDir) {
-          storiesDir = (await pathExists(join(cwd, 'src/stories'))) ? 'src/stories' : 'stories';
+          storiesDir = (await pathExists(join(cwd, `src/${storiesFolderName}`)))
+            ? `src/${storiesFolderName}`
+            : storiesFolderName;
         }
         addPreviewAnnotations(mainConfig, [`./${join(storiesDir, packageDir, previewFile)}`]);
       }
@@ -315,7 +327,7 @@ function addExtraDependencies({
 }
 
 export const addStories: Task['run'] = async (
-  { sandboxDir, template },
+  { sandboxDir, template, key },
   { addon: extraAddons, dryRun, debug }
 ) => {
   const cwd = sandboxDir;
@@ -343,6 +355,7 @@ export const addStories: Task['run'] = async (
   });
 
   const frameworkPath = await workspacePath('frameworks', template.expected.framework);
+
   // Add stories for the framework if it has one. NOTE: these *do* need to be processed by the framework build system
   if (await pathExists(resolve(codeDir, frameworkPath, join('template', 'stories')))) {
     await linkPackageStories(frameworkPath, {
@@ -350,6 +363,21 @@ export const addStories: Task['run'] = async (
       cwd,
       linkInDir: resolve(cwd, storiesPath),
     });
+  }
+
+  const frameworkVariant = key.split('/')[1];
+  const storiesVariantFolder = addVariantToFolder(frameworkVariant);
+
+  if (await pathExists(resolve(codeDir, frameworkPath, join('template', storiesVariantFolder)))) {
+    await linkPackageStories(
+      frameworkPath,
+      {
+        mainConfig,
+        cwd,
+        linkInDir: resolve(cwd, storiesPath),
+      },
+      frameworkVariant
+    );
   }
 
   // Add stories for lib/store (and addons below). NOTE: these stories will be in the


### PR DESCRIPTION
## What I did

Sandboxes are now capable to load framework version specific stories.

Example:

1. The key of a sandbox in `code/lib/cli/src/repro-templates` is `nextjs/12-js`
2. Create a folder `code/frameworks/nextjs/template/stories_12-js`
3. During sandbox creation, the version 12 specific stories are symlinked to the target `sandbox/nextjs-default-js/stories/frameworks/nextjs_default-js`

It is possible now to create stories for specific versions of a framework

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
