### PR TITLE
Maintenance: Use typescript legacy templates until our ecosystem fully supports ts 4.9

### DIFF
--- a/code/lib/cli/src/detect.test.ts
+++ b/code/lib/cli/src/detect.test.ts
@@ -296,19 +296,22 @@ describe('Detect', () => {
 
   it(`should return language typescript if the dependency is >TS4.9`, () => {
     expect(detectLanguage({ dependencies: { typescript: '4.9.1' } })).toBe(
-      SupportedLanguage.TYPESCRIPT
+      // TODO: switch to TYPESCRIPT once csf-tools and eslint-plugin-storybook support `satisfies` operator
+      SupportedLanguage.TYPESCRIPT_LEGACY
     );
   });
 
   it(`should return language typescript if the dependency is =TS4.9`, () => {
     expect(detectLanguage({ dependencies: { typescript: '4.9.0' } })).toBe(
-      SupportedLanguage.TYPESCRIPT
+      // TODO: switch to TYPESCRIPT once csf-tools and eslint-plugin-storybook support `satisfies` operator
+      SupportedLanguage.TYPESCRIPT_LEGACY
     );
   });
 
   it(`should return language typescript if the dependency is =TS4.9beta`, () => {
     expect(detectLanguage({ dependencies: { typescript: '^4.9.0-beta' } })).toBe(
-      SupportedLanguage.TYPESCRIPT
+      // TODO: switch to TYPESCRIPT once csf-tools and eslint-plugin-storybook support `satisfies` operator
+      SupportedLanguage.TYPESCRIPT_LEGACY
     );
   });
 

--- a/code/lib/cli/src/detect.ts
+++ b/code/lib/cli/src/detect.ts
@@ -172,7 +172,8 @@ export function detectLanguage(packageJson?: PackageJson) {
         semver.gte(semver.coerce(version), '5.44.0')
       ))
   ) {
-    language = SupportedLanguage.TYPESCRIPT;
+    // TODO: switch to TYPESCRIPT once csf-tools and eslint-plugin-storybook support `satisfies` operator
+    language = SupportedLanguage.TYPESCRIPT_LEGACY;
   } else if (hasDependency(packageJson, 'typescript')) {
     language = SupportedLanguage.TYPESCRIPT_LEGACY;
   }


### PR DESCRIPTION

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
