### PR TITLE
e2e: change onClick to click to support svelte examples

### DIFF
--- a/code/e2e-tests/addon-actions.spec.ts
+++ b/code/e2e-tests/addon-actions.spec.ts
@@ -20,7 +20,7 @@ test.describe('addon-actions', () => {
 
     await sbPage.viewAddonPanel('Actions');
     const logItem = await page.locator('#storybook-panel-root #panel-tab-content', {
-      hasText: 'onClick',
+      hasText: 'click',
     });
     await expect(logItem).toBeVisible();
   });


### PR DESCRIPTION
Issue:

## What I did

In Svelte, the actions panel shows `click` instead of `onClick`. The check now works for both scenarios

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
