### PR TITLE
CLI: Improve sb-scripts automigration logic

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/sb-scripts.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-scripts.test.ts
@@ -50,11 +50,12 @@ describe('getStorybookScripts', () => {
       })
     ).toEqual({
       custom: {
-        'sb:start': 'start-storybook',
         'sb:mocked': 'MOCKS=true start-storybook',
+      },
+      official: {
+        'sb:start': 'start-storybook',
         'sb:build': 'build-storybook',
       },
-      official: {},
     });
   });
 });
@@ -115,7 +116,7 @@ describe('sb scripts fix', () => {
           'sb:build': 'build-storybook -o buid/storybook',
           'sb:build-mocked': 'MOCKS=true sb:build',
           'test-storybook:ci':
-            'concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "yarn build-storybook --quiet && npx http-server storybook-static --port 6006 --silent" "wait-on tcp:6006 && yarn test-storybook"',
+            'concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "yarn sb:build --quiet && npx http-server storybook-static --port 6006 --silent" "wait-on tcp:6006 && yarn test-storybook"',
         },
       };
 
@@ -127,13 +128,11 @@ describe('sb scripts fix', () => {
         ).resolves.toEqual(
           expect.objectContaining({
             storybookScripts: {
-              custom: {
-                'sb:start': 'start-storybook -p 6006',
-                'sb:build': 'build-storybook -o buid/storybook',
-                'test-storybook:ci':
-                  'concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "yarn build-storybook --quiet && npx http-server storybook-static --port 6006 --silent" "wait-on tcp:6006 && yarn test-storybook"',
+              custom: {},
+              official: {
+                'sb:build': 'storybook build -o buid/storybook',
+                'sb:start': 'storybook dev -p 6006',
               },
-              official: {},
             },
             storybookVersion: '^7.0.0-alpha.0',
           })
@@ -153,7 +152,7 @@ describe('sb scripts fix', () => {
             'storybook:build': 'build-storybook -o buid/storybook',
             'storybook:build-mocked': 'MOCKS=true yarn storybook:build',
             'test-storybook:ci':
-              'concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "yarn build-storybook --quiet && npx http-server storybook-static --port 6006 --silent" "wait-on tcp:6006 && yarn test-storybook"',
+              'concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "yarn storybook:build-mocked --quiet && npx http-server storybook-static --port 6006 --silent" "wait-on tcp:6006 && yarn test-storybook"',
           },
         };
         it('should update scripts to new format', async () => {
@@ -164,12 +163,9 @@ describe('sb scripts fix', () => {
           ).resolves.toEqual(
             expect.objectContaining({
               storybookScripts: {
-                custom: {
-                  'storybook:build': 'build-storybook -o buid/storybook',
-                  'test-storybook:ci':
-                    'concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "yarn build-storybook --quiet && npx http-server storybook-static --port 6006 --silent" "wait-on tcp:6006 && yarn test-storybook"',
-                },
+                custom: {},
                 official: {
+                  'storybook:build': 'storybook build -o buid/storybook',
                   storybook: 'storybook dev -p 6006',
                 },
               },
@@ -204,8 +200,8 @@ describe('sb scripts fix', () => {
             storybook: '^7.0.0-alpha.0',
           },
           scripts: {
-            storybook: 'npx sb dev -p 6006',
-            'build-storybook': 'npx sb build -o build/storybook',
+            storybook: 'storybook dev -p 6006',
+            'build-storybook': 'storybook build -o build/storybook',
           },
         };
         it('should no-op', async () => {

--- a/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
@@ -114,27 +114,23 @@ export const sbScripts: Fix<SbScriptsRunOptions> = {
       return acc;
     }, []);
 
-    const explanationMessage = [
-      `Starting in Storybook 7, the ${chalk.yellow('start-storybook')} and ${chalk.yellow(
-        'build-storybook'
-      )} binaries have changed to ${chalk.magenta('storybook dev')} and ${chalk.magenta(
-        'storybook build'
-      )} respectively.`,
-      `In order to work with ${sbFormatted}, Storybook's ${chalk.magenta(
-        'storybook'
-      )} binary has to be installed and your storybook scripts have to be adjusted to use the binary. We can install the storybook binary and adjust your scripts for you:\n`,
-      newScriptsMessage.join('\n\n'),
-    ].join('\n');
+    return dedent`
+      We've detected you are using ${sbFormatted} with scripts from previous versions of Storybook.
+      Starting in Storybook 7, the ${chalk.yellow('start-storybook')} and ${chalk.yellow(
+      'build-storybook'
+    )} binaries have changed to ${chalk.magenta('storybook dev')} and ${chalk.magenta(
+      'storybook build'
+    )} respectively.
+      In order to work with ${sbFormatted}, Storybook's ${chalk.magenta(
+      'storybook'
+    )} binary has to be installed and your storybook scripts have to be adjusted to use the binary. We can install the storybook binary and adjust your scripts for you:
 
-    return [
-      `We've detected you are using ${sbFormatted} with scripts from previous versions of Storybook.`,
-      explanationMessage,
-      `In case this migration did not cover all of your scripts, or you'd like more info: ${chalk.yellow(
+      ${newScriptsMessage.join('\n\n')}
+
+      In case this migration did not cover all of your scripts, or you'd like more info: ${chalk.yellow(
         'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#start-storybook--build-storybook-binaries-removed'
-      )}`,
-    ]
-      .filter(Boolean)
-      .join('\n\n');
+      )}
+      `;
   },
 
   async run({ result: { storybookScripts, packageJson }, packageManager, dryRun }) {

--- a/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
@@ -24,7 +24,12 @@ export const getStorybookScripts = (scripts: Record<string, string>) => {
   };
 
   Object.keys(scripts).forEach((key) => {
-    if (key === 'storybook' || key === 'build-storybook') {
+    if (
+      key === 'storybook' ||
+      key === 'build-storybook' ||
+      scripts[key].startsWith('start-storybook') ||
+      scripts[key].startsWith('build-storybook')
+    ) {
       storybookScripts.official[key] = scripts[key];
     } else if (scripts[key].match(/start-storybook/) || scripts[key].match(/build-storybook/)) {
       storybookScripts.custom[key] = scripts[key];

--- a/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
@@ -7,36 +7,54 @@ import { getStorybookVersionSpecifier } from '../../helpers';
 import type { PackageJsonWithDepsAndDevDeps } from '../../js-package-manager';
 
 interface SbScriptsRunOptions {
-  storybookScripts: {
-    custom: Record<string, string>;
-    official: Record<string, string>;
-  };
+  storybookScripts: Record<string, { before: string; after: string }>;
   storybookVersion: string;
   packageJson: PackageJsonWithDepsAndDevDeps;
 }
 
 const logger = console;
 
-export const getStorybookScripts = (scripts: Record<string, string>) => {
-  const storybookScripts: SbScriptsRunOptions['storybookScripts'] = {
-    custom: {},
-    official: {},
-  };
+/**
+ * Slightly big function because JS regex doesn't have proper full-word boundary.
+ * This goes through all the words in each script, and only return the scripts
+ * that do contain the actual sb binary, and not something like "npm run start-storybook"
+ * which could actually be a custom script even though the name matches the legacy binary name
+ */
+export const getStorybookScripts = (allScripts: Record<string, string>) => {
+  return Object.keys(allScripts).reduce((acc, key) => {
+    let isStorybookScript = false;
+    const allWordsFromScript = allScripts[key].split(' ');
+    const newScript = allWordsFromScript
+      .map((currentWord, index) => {
+        const previousWord = allWordsFromScript[index - 1];
 
-  Object.keys(scripts).forEach((key) => {
-    if (
-      key === 'storybook' ||
-      key === 'build-storybook' ||
-      scripts[key].startsWith('start-storybook') ||
-      scripts[key].startsWith('build-storybook')
-    ) {
-      storybookScripts.official[key] = scripts[key];
-    } else if (scripts[key].match(/start-storybook/) || scripts[key].match(/build-storybook/)) {
-      storybookScripts.custom[key] = scripts[key];
+        // full word check, rather than regex which could be faulty
+        const isSbBinary = currentWord === 'build-storybook' || currentWord === 'start-storybook';
+
+        // in case people have scripts like `yarn start-storybook`
+        const isPrependedByPkgManager =
+          previousWord && ['npx', 'run', 'yarn', 'pnpx'].some((cmd) => previousWord.includes(cmd));
+
+        if (isSbBinary && !isPrependedByPkgManager) {
+          isStorybookScript = true;
+          return currentWord
+            .replace('start-storybook', 'storybook dev')
+            .replace('build-storybook', 'storybook build');
+        }
+
+        return currentWord;
+      })
+      .join(' ');
+
+    if (isStorybookScript) {
+      acc[key] = {
+        before: allScripts[key],
+        after: newScript,
+      };
     }
-  });
 
-  return storybookScripts;
+    return acc;
+  }, {} as Record<string, { before: string; after: string }>);
 };
 
 /**
@@ -71,26 +89,30 @@ export const sbScripts: Fix<SbScriptsRunOptions> = {
 
     const storybookScripts = getStorybookScripts(scripts);
 
-    if (
-      Object.keys(storybookScripts.official).length === 0 &&
-      Object.keys(storybookScripts.custom).length === 0
-    ) {
+    if (Object.keys(storybookScripts).length === 0) {
       return null;
     }
-
-    Object.keys(storybookScripts.official).forEach((key) => {
-      storybookScripts.official[key] = storybookScripts.official[key]
-        .replace('start-storybook', 'storybook dev')
-        .replace('build-storybook', 'storybook build');
-    });
 
     return semver.gte(storybookCoerced, '7.0.0')
       ? { packageJson, storybookScripts, storybookVersion }
       : null;
   },
 
-  prompt({ storybookVersion }) {
+  prompt({ storybookVersion, storybookScripts }) {
     const sbFormatted = chalk.cyan(`Storybook ${storybookVersion}`);
+
+    const newScriptsMessage = Object.keys(storybookScripts).reduce((acc, scriptKey) => {
+      acc.push(
+        [
+          chalk.bold(scriptKey),
+          'from:',
+          chalk.cyan(storybookScripts[scriptKey].before),
+          'to:',
+          chalk.cyan(storybookScripts[scriptKey].after),
+        ].join('\n')
+      );
+      return acc;
+    }, []);
 
     const explanationMessage = [
       `Starting in Storybook 7, the ${chalk.yellow('start-storybook')} and ${chalk.yellow(
@@ -100,13 +122,14 @@ export const sbScripts: Fix<SbScriptsRunOptions> = {
       )} respectively.`,
       `In order to work with ${sbFormatted}, Storybook's ${chalk.magenta(
         'storybook'
-      )} binary has to be installed and your storybook scripts have to be adjusted to use the binary. We can install the storybook binary and attempt to adjust your scripts for you.`,
+      )} binary has to be installed and your storybook scripts have to be adjusted to use the binary. We can install the storybook binary and adjust your scripts for you:\n`,
+      newScriptsMessage.join('\n\n'),
     ].join('\n');
 
     return [
       `We've detected you are using ${sbFormatted} with scripts from previous versions of Storybook.`,
       explanationMessage,
-      `More info: ${chalk.yellow(
+      `In case this migration did not cover all of your scripts, or you'd like more info: ${chalk.yellow(
         'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#start-storybook--build-storybook-binaries-removed'
       )}`,
     ]
@@ -128,30 +151,15 @@ export const sbScripts: Fix<SbScriptsRunOptions> = {
 
     logger.info(`Updating scripts in package.json`);
     logger.log();
-    if (!dryRun && Object.keys(storybookScripts.official).length > 0) {
-      const message = [
-        `Migrating your scripts to:`,
-        chalk.yellow(JSON.stringify(storybookScripts.official, null, 2)),
-      ].join('\n');
+    if (!dryRun) {
+      const newScripts = Object.keys(storybookScripts).reduce((acc, scriptKey) => {
+        acc[scriptKey] = storybookScripts[scriptKey].after;
+        return acc;
+      }, {} as Record<string, string>);
 
-      logger.log(message);
       logger.log();
 
-      packageManager.addScripts(storybookScripts.official);
-    }
-
-    if (!dryRun && Object.keys(storybookScripts.custom).length > 0) {
-      const message = [
-        `We detected custom scripts that we can't automigrate:`,
-        chalk.yellow(JSON.stringify(storybookScripts.custom, null, 2)),
-        '\n',
-        `Please manually migrate the ones applicable and use the documentation below for reference: ${chalk.yellow(
-          'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#start-storybook--build-storybook-binaries-removed'
-        )}`,
-      ].join('\n');
-
-      logger.log(message);
-      logger.log();
+      packageManager.addScripts(newScripts);
     }
   },
 };


### PR DESCRIPTION
Issue: #19728 

## What I did

The `sb-scripts` automigration was only migrating scripts based on the key, not on its content. Now it checks for contents, therefore it covers more, if not all use cases.

The prompt also provides better feedback, with before/after versions of the scripts:

<img width="678" alt="image" src="https://user-images.githubusercontent.com/1671563/205125203-e97c09f4-70ab-4525-8ad3-6a22e6d1393c.png">


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
