### PR TITLE
Core: added .entries property to error thrown when duplicate stories are present

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -36,8 +36,15 @@ type StoriesCacheEntry = {
 };
 type CacheEntry = false | StoriesCacheEntry | DocsCacheEntry;
 type SpecifierStoriesCache = Record<Path, CacheEntry>;
-interface DuplicateEntriesError extends Error {
+
+export class DuplicateEntriesError extends Error {
   entries: IndexEntry[];
+
+  constructor(message: string, entries: IndexEntry[]) {
+    super();
+    this.message = message;
+    this.entries = entries;
+  }
 }
 
 const makeAbsolute = (otherImport: Path, normalizedPath: Path, workingDir: Path) =>
@@ -355,13 +362,11 @@ export class StoryIndexGenerator {
     const changeDocsName = 'Use `<Meta of={} name="Other Name">` to distinguish them.';
 
     // This shouldn't be possible, but double check and use for typing
-    if (worseEntry.type === 'story') {
-      const duplicatedStoryError = new Error(
-        `Duplicate stories with id: ${firstEntry.id}`
-      ) as unknown as DuplicateEntriesError;
-      duplicatedStoryError.entries = [firstEntry, secondEntry];
-      throw duplicatedStoryError;
-    }
+    if (worseEntry.type === 'story')
+      throw new DuplicateEntriesError(`Duplicate stories with id: ${firstEntry.id}`, [
+        firstEntry,
+        secondEntry,
+      ]);
 
     if (betterEntry.type === 'story') {
       const worseDescriptor = worseEntry.standalone


### PR DESCRIPTION
Issue:

## What I did
As per https://github.com/storybookjs/storybook/issues/19094 I extended the `Error` thrown at `StoryIndexGenerator.ts > chooseDuplicate` method to include the full information from the entries being compared

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.


## Extra info

I tried running the process as per https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md and `yarn start` is failing
```
Failed tasks:
   
   - @storybook/theming:prep

   See Nx Cloud run details at https://nx.app/runs/uGNl2rIURN

    at makeError (file:///([path/to/my/local/fork/escaped]/storybook/scripts/node_modules/execa/lib/error.js:59:11)
    at handlePromise (file:///([path/to/my/local/fork/escaped]/storybook/scripts/node_modules/execa/index.js:119:26)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async exec ([path/to/my/local/fork]/storybook/scripts/utils/exec.ts:58:7)
    at async runTask ([path/to/my/local/fork]/storybook/scripts/task.ts:286:24)
    at async run ([path/to/my/local/fork]/storybook/scripts/task.ts:420:28) {
  shortMessage: 'Command failed with exit code 1: nx run-many --target="prep" --all --parallel --exclude=@storybook/addon-storyshots,@storybook/addon-storyshots-puppeteer -- --reset',
  command: 'nx run-many --target="prep" --all --parallel --exclude=@storybook/addon-storyshots,@storybook/addon-storyshots-puppeteer -- --reset',
  escapedCommand: 'nx run-many "--target=\\"prep\\"" --all --parallel "--exclude=@storybook/addon-storyshots,@storybook/addon-storyshots-puppeteer" -- --reset',
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
```

also, since this failed, I could not run `yarn test` either

This PR is pretty straightforward couple liners anyway, so maybe we don't need those steps?