### PR TITLE
Fix the “Learn how to add interactions to your story” link

### DIFF
--- a/addons/interactions/src/Panel.tsx
+++ b/addons/interactions/src/Panel.tsx
@@ -101,7 +101,7 @@ export const AddonPanelPure: React.FC<InteractionsPanelProps> = React.memo(
         <Placeholder>
           No interactions found
           <Link
-            href="https://github.com/storybookjs/storybook/blob/next/addons/interactions/README.md"
+            href="https://storybook.js.org/docs/react/writing-stories/play-function"
             target="_blank"
             withArrow
           >


### PR DESCRIPTION
Issue: #20058 

This fix specifically targets `main`, since the URL used on `next` [is correct](https://github.com/storybookjs/storybook/blob/2d4150c6307b5b463b2c1a8c6375971a0f0e4e5d/code/addons/interactions/src/components/InteractionsPanel.tsx#L151).
