### PR TITLE
CLI: Add upgrade telemetry details

### DIFF
--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -9,12 +9,22 @@ import { fixes } from './fixes';
 
 const logger = console;
 
+type FixId = string;
+
 interface FixOptions {
-  fixId?: string;
+  fixId?: FixId;
   yes?: boolean;
   dryRun?: boolean;
   useNpm?: boolean;
   force?: PackageManagerName;
+}
+
+enum FixStatus {
+  CHECK_FAILED = 'check_failed',
+  UNNECESSARY = 'unnecessary',
+  SKIPPED = 'skipped',
+  SUCCEEDED = 'succeeded',
+  FAILED = 'failed',
 }
 
 export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOptions = {}) => {
@@ -22,16 +32,21 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
   const filtered = fixId ? fixes.filter((f) => f.id === fixId) : fixes;
 
   logger.info('🔎 checking possible migrations..');
+  const fixResults = {} as Record<FixId, FixStatus>;
 
   for (let i = 0; i < filtered.length; i += 1) {
     const f = fixes[i] as Fix;
     let result;
+    let fixStatus;
     try {
       result = await f.check({ packageManager });
     } catch (e) {
+      fixStatus = FixStatus.CHECK_FAILED;
       logger.info(`failed to check fix: ${f.id}`);
     }
-    if (result) {
+    if (!result) {
+      fixStatus = FixStatus.UNNECESSARY;
+    } else {
       logger.info(`🔎 found a '${chalk.cyan(f.id)}' migration:`);
       logger.info();
       const message = f.prompt(result);
@@ -58,12 +73,15 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
         try {
           await f.run({ result, packageManager, dryRun });
           logger.info(`✅ ran ${chalk.cyan(f.id)} migration`);
+          fixStatus = FixStatus.SUCCEEDED;
         } catch (error) {
+          fixStatus = FixStatus.FAILED;
           logger.info(`❌ error when running ${chalk.cyan(f.id)} migration:`);
           logger.info(error);
           logger.info();
         }
       } else {
+        fixStatus = FixStatus.SKIPPED;
         logger.info(`Skipping the ${chalk.cyan(f.id)} migration.`);
         logger.info();
         logger.info(
@@ -71,9 +89,13 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
         );
       }
     }
+
+    fixResults[f.id] = fixStatus;
   }
 
   logger.info();
   logger.info('✅ migration check successfully ran');
   logger.info();
+  
+  return fixResults;
 };

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -96,6 +96,6 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
   logger.info();
   logger.info('✅ migration check successfully ran');
   logger.info();
-  
+
   return fixResults;
 };

--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -189,12 +189,12 @@ program
   .option('-n --dry-run', 'Only check for fixes, do not actually run them')
   .option('--package-manager <npm|pnpm|yarn1|yarn2>', 'Force package manager')
   .option('-N --use-npm', 'Use npm as package manager (deprecated)')
-  .action((fixId, options) =>
-    automigrate({ fixId, ...options }).catch((e) => {
+  .action(async (fixId, options) => {
+    await automigrate({ fixId, ...options }).catch((e) => {
       logger.error(e);
       process.exit(1);
-    })
-  );
+    });
+  });
 
 program
   .command('dev')

--- a/code/lib/telemetry/src/index.ts
+++ b/code/lib/telemetry/src/index.ts
@@ -9,6 +9,8 @@ export * from './storybook-metadata';
 
 export * from './types';
 
+export { getStorybookCoreVersion } from './package-json';
+
 export const telemetry = async (
   eventType: EventType,
   payload: Payload = {},

--- a/code/lib/telemetry/src/package-json.ts
+++ b/code/lib/telemetry/src/package-json.ts
@@ -1,3 +1,4 @@
+import { readJson } from 'fs-extra';
 import path from 'path';
 
 import type { Dependency } from './types';
@@ -20,7 +21,17 @@ export const getActualPackageVersion = async (packageName: string) => {
 };
 
 export const getActualPackageJson = async (packageName: string) => {
-  // eslint-disable-next-line import/no-dynamic-require,global-require
-  const packageJson = require(path.join(packageName, 'package.json'));
+  const resolvedPackageJson = require.resolve(path.join(packageName, 'package.json'), {
+    paths: [process.cwd()],
+  });
+  const packageJson = await readJson(resolvedPackageJson);
   return packageJson;
+};
+
+// Note that this probably doesn't work in PNPM mode
+export const getStorybookCoreVersion = async () => {
+  const coreVersions = await Promise.all(
+    ['@storybook/core-common', '@storybook/core-server'].map(getActualPackageVersion)
+  );
+  return coreVersions.find((v) => v.version)?.version;
 };


### PR DESCRIPTION
Issue: N/A

## What I did

Add extra metadata to the `upgrade` event:
- Before version
- After version
- All of the automigrations that ran & their statuses

## How to test

In the project of your choice, where `sb` is the locally-built version:

```
STORYBOOK_TELEMETRY_DEBUG=true sb upgrade --prerelease
```
