### PR TITLE
Build: improve inDevelopment mode for yarn task

### DIFF
--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -25,14 +25,15 @@ import { parseList, getEnvConfig } from './utils';
 const pkg = readUpSync({ cwd: __dirname }).packageJson;
 const consoleLogger = console;
 
-program.option(
-  '--disable-telemetry',
-  'disable sending telemetry data',
-  // default value is false, but if the user sets STORYBOOK_DISABLE_TELEMETRY, it can be true
-  process.env.STORYBOOK_DISABLE_TELEMETRY && process.env.STORYBOOK_DISABLE_TELEMETRY !== 'false'
-);
-
-program.option('--enable-crash-reports', 'enable sending crash reports to telemetry data');
+program
+  .option(
+    '--disable-telemetry',
+    'disable sending telemetry data',
+    // default value is false, but if the user sets STORYBOOK_DISABLE_TELEMETRY, it can be true
+    process.env.STORYBOOK_DISABLE_TELEMETRY && process.env.STORYBOOK_DISABLE_TELEMETRY !== 'false'
+  )
+  .option('--debug', 'Get more logs in debug mode', false)
+  .option('--enable-crash-reports', 'enable sending crash reports to telemetry data');
 
 program
   .command('init')

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -14,7 +14,7 @@ export type Template = {
   script: string;
   /**
    * Used to assert various things about the generated template.
-   * If the template is generated with a different expected framework, it will fail.
+   * If the template is generated with a different expected framework, it will fail, detecting a possible regression.
    */
   expected: {
     framework: string;

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -68,7 +68,7 @@ export const allTemplates: Record<string, Template> = {
   },
   'nextjs/default-js': {
     name: 'Next.js (JavaScript)',
-    script: 'yarn create next-app {{beforeDir}}',
+    script: 'yarn create next-app {{beforeDir}} --javascript --eslint',
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',
@@ -77,7 +77,7 @@ export const allTemplates: Record<string, Template> = {
   },
   'nextjs/default-ts': {
     name: 'Next.js (TypeScript)',
-    script: 'yarn create next-app {{beforeDir}} --typescript',
+    script: 'yarn create next-app {{beforeDir}} --typescript --eslint',
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -84,6 +84,16 @@ export const allTemplates: Record<string, Template> = {
       builder: '@storybook/builder-webpack5',
     },
   },
+  'new-framework/default-js': {
+    name: 'Just testing',
+    inDevelopment: true,
+    script: 'yarn create next-app {{beforeDir}} --javascript --eslint',
+    expected: {
+      framework: '@storybook/nextjs',
+      renderer: '@storybook/react',
+      builder: '@storybook/builder-webpack5',
+    },
+  },
   'react-vite/default-js': {
     name: 'React Vite (JS)',
     script: 'yarn create vite . --template react',

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -1,4 +1,39 @@
-export const allTemplates = {
+export type SkippableTask = 'smoke-test' | 'test-runner' | 'chromatic' | 'e2e-tests';
+export type TemplateKey = keyof typeof allTemplates;
+export type Cadence = keyof typeof templatesByCadence;
+export type Template = {
+  /**
+   * Readable name for the template, which will be used for feedback and the status page
+   */
+  name: string;
+  /**
+   * Script used to generate the base project of a template.
+   * The Storybook CLI will then initialize Storybook on top of that template.
+   * This is used to generate projects which are pushed to https://github.com/storybookjs/repro-templates-temp
+   */
+  script: string;
+  /**
+   * Used to assert various things about the generated template.
+   * If the template is generated with a different expected framework, it will fail.
+   */
+  expected: {
+    framework: string;
+    renderer: string;
+    builder: string;
+  };
+  /**
+   * Some sandboxes might not work properly in specific tasks temporarily, but we might
+   * still want to run the other tasks. Set the ones to skip in this property.
+   */
+  skipTasks?: SkippableTask[];
+  /**
+   * Set this only while developing a newly created framework, to avoid using it in CI.
+   * NOTE: Make sure to always add a TODO comment to remove this flag in a subsequent PR.
+   */
+  inDevelopment?: boolean;
+};
+
+export const allTemplates: Record<string, Template> = {
   'cra/default-js': {
     name: 'Create React App (Javascript)',
     script: 'npx create-react-app .',
@@ -265,8 +300,6 @@ export const allTemplates = {
     },
   },
 };
-
-type TemplateKey = keyof typeof allTemplates;
 
 export const ci: TemplateKey[] = ['cra/default-ts', 'react-vite/default-ts'];
 export const pr: TemplateKey[] = [

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -84,16 +84,6 @@ export const allTemplates: Record<string, Template> = {
       builder: '@storybook/builder-webpack5',
     },
   },
-  'new-framework/default-js': {
-    name: 'Just testing',
-    inDevelopment: true,
-    script: 'yarn create next-app {{beforeDir}} --javascript --eslint',
-    expected: {
-      framework: '@storybook/nextjs',
-      renderer: '@storybook/react',
-      builder: '@storybook/builder-webpack5',
-    },
-  },
   'react-vite/default-js': {
     name: 'React Vite (JS)',
     script: 'yarn create vite . --template react',

--- a/docs/contribute/code.md
+++ b/docs/contribute/code.md
@@ -216,23 +216,25 @@ The **`key`** `cra/default-js` consists of two parts:
 - The prefix is the tool that was used to generate the repro app
 - The suffix is options that modify the default install, e.g. a specific version or options
 
-The **`script`** field is what generates the application environment. The `.` argument is “the current working directory” which is auto-generated based on the key (e.g. `repros/cra/default-js/before-storybook`).
+The **`script`** field is what generates the application environment. The `.` argument is “the current working directory” which is auto-generated based on the key (e.g. `repros/cra/default-js/before-storybook`). The `{{beforeDir}}` key can also be used, which will be replaced by the path of that directory.
 
 The rest of the fields are self-explanatory:
 
-- **`name`**: Human readable name/description
-- **`cadence`:** How often this runs in CI (for now these are the same for every template)
-- **`expected`**: What framework/renderer/builder we expect `sb init` to generate
+The **`skipTasks`** field exists because some sandboxes might not work properly in specific tasks temporarily, but we might still want to run the other tasks. For instance, a bug was introduced outside of our control, which fails only in the `test-runner` task.
+
+The **`name`** field should contain a human readable name/description of the template.
+
+The **`expected`** field reflects what framework/renderer/builder we expect `sb init` to generate. This is useful for assertions while generating sandboxes. If the template is generated with a different expected framework, for instance, it will fail, serving as a way to detect regressions.
 
 ### Running a sandbox
 
-If your template has a `inDevelopment` flag, it will be generated (locally) as part of the sandbox process. You can create the sandbox with:
+If your template has a `inDevelopment` flag, it will be generated (locally) as part of the sandbox process. You can create the sandbox with the following command, where `<template-key>` is replaced by the id of the selected template e.g. `cra/default-js`:
 
 ```bash
-yarn task --task dev --template cra/default-js --no-link --start-from=install
+yarn task --task dev --template <template-key> --start-from=install
 ```
 
-Make sure you pass the `--no-link` flag as it is required for the local template generation to work.
+Templates with `inDevelopment` will automatically run with `--no-link` flag as it is required for the local template generation to work.
 
 Once the PR is merged, the template will be generated on a nightly cadence and you can remove the `inDevelopment` flag and the sandbox will pull the code from our templates repository.
 

--- a/scripts/get-template.ts
+++ b/scripts/get-template.ts
@@ -1,16 +1,17 @@
 import { readdir } from 'fs/promises';
 import { pathExists } from 'fs-extra';
 import { resolve } from 'path';
-import { allTemplates, templatesByCadence } from '../code/lib/cli/src/repro-templates';
+import {
+  allTemplates,
+  templatesByCadence,
+  type Cadence,
+  type Template as TTemplate,
+  type SkippableTask,
+} from '../code/lib/cli/src/repro-templates';
 
 const sandboxDir = process.env.SANDBOX_ROOT || resolve(__dirname, '../sandbox');
 
-export type Cadence = keyof typeof templatesByCadence;
-export type Template = {
-  cadence?: readonly Cadence[];
-  skipTasks?: string[];
-  // there are other fields but we don't use them here
-};
+type Template = Pick<TTemplate, 'inDevelopment' | 'skipTasks'>;
 export type TemplateKey = keyof typeof allTemplates;
 export type Templates = Record<TemplateKey, Template>;
 
@@ -44,9 +45,13 @@ export async function getTemplate(
     potentialTemplateKeys = cadenceTemplates.map(([k]) => k) as TemplateKey[];
   }
 
-  potentialTemplateKeys = potentialTemplateKeys.filter(
-    (t) => !(allTemplates[t] as Template).skipTasks?.includes(scriptName)
-  );
+  potentialTemplateKeys = potentialTemplateKeys.filter((t) => {
+    const currentTemplate = allTemplates[t] as Template;
+    return (
+      currentTemplate.inDevelopment !== true &&
+      !currentTemplate.skipTasks?.includes(scriptName as SkippableTask)
+    );
+  });
 
   if (potentialTemplateKeys.length !== total) {
     throw new Error(`Circle parallelism set incorrectly.

--- a/scripts/task.ts
+++ b/scripts/task.ts
@@ -23,7 +23,11 @@ import { testRunner } from './tasks/test-runner';
 import { chromatic } from './tasks/chromatic';
 import { e2eTests } from './tasks/e2e-tests';
 
-import { allTemplates as TEMPLATES } from '../code/lib/cli/src/repro-templates';
+import {
+  allTemplates as TEMPLATES,
+  type TemplateKey,
+  type Template,
+} from '../code/lib/cli/src/repro-templates';
 
 const sandboxDir = process.env.SANDBOX_ROOT || resolve(__dirname, '../sandbox');
 const codeDir = resolve(__dirname, '../code');
@@ -31,8 +35,6 @@ const junitDir = resolve(__dirname, '../test-results');
 
 export const extraAddons = ['a11y', 'storysource'];
 
-export type TemplateKey = keyof typeof TEMPLATES;
-export type Template = typeof TEMPLATES[TemplateKey];
 export type Path = string;
 export type TemplateDetails = {
   key: TemplateKey;

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -53,7 +53,7 @@ export const create: Task['run'] = async (
   } else {
     await executeCLIStep(steps.repro, {
       argument: key,
-      optionValues: { output: sandboxDir, branch: 'next' },
+      optionValues: { output: sandboxDir, branch: 'next', debug },
       cwd: parentDir,
       dryRun,
       debug,

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -20,7 +20,7 @@ export const sandbox: Task = {
   async run(details, options) {
     if (options.link && details.template.inDevelopment) {
       logger.log(
-        `The ${options.template} has inDevelopment property enabled, thefore the sandbox for that template cannot be linked. Enabling --no-link mode..`
+        `The ${options.template} has inDevelopment property enabled, therefore the sandbox for that template cannot be linked. Enabling --no-link mode..`
       );
       // eslint-disable-next-line no-param-reassign
       options.link = false;

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -18,12 +18,12 @@ export const sandbox: Task = {
     return pathExists(sandboxDir);
   },
   async run(details, options) {
-    if (!options.link && details.template.inDevelopment) {
+    if (options.link && details.template.inDevelopment) {
       logger.log(
         `The ${options.template} has inDevelopment property enabled, thefore the sandbox for that template cannot be linked. Enabling --no-link mode..`
       );
       // eslint-disable-next-line no-param-reassign
-      options.link = true;
+      options.link = false;
     }
     if (await this.ready(details)) {
       logger.info('🗑  Removing old sandbox dir');

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -8,8 +8,6 @@ export const sandbox: Task = {
   description: 'Create the sandbox from a template',
   dependsOn: ({ template }, { link }) => {
     if ('inDevelopment' in template && template.inDevelopment) {
-      if (link) throw new Error('Cannot link an in development template');
-
       return ['run-registry', 'generate'];
     }
 
@@ -20,6 +18,13 @@ export const sandbox: Task = {
     return pathExists(sandboxDir);
   },
   async run(details, options) {
+    if (!options.link && details.template.inDevelopment) {
+      logger.log(
+        `The ${options.template} has inDevelopment property enabled, thefore the sandbox for that template cannot be linked. Enabling --no-link mode..`
+      );
+      // eslint-disable-next-line no-param-reassign
+      options.link = true;
+    }
     if (await this.ready(details)) {
       logger.info('🗑  Removing old sandbox dir');
       await remove(details.sandboxDir);

--- a/scripts/utils/cli-step.ts
+++ b/scripts/utils/cli-step.ts
@@ -23,6 +23,7 @@ export const steps = {
       output: { type: 'string' },
       // TODO allow default values for strings
       branch: { type: 'string', values: ['next'] },
+      debug: { type: 'boolean' },
     }),
   },
   add: {


### PR DESCRIPTION
Issue: N/A

## What I did

This PR improves the `yarn task --task sandbox` command:

1. ignores repro templates with `inDevelopment` in CI.
1. support a debug flag, that adds more logging in some places

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
