### PR TITLE
Add coverage video to docs

### DIFF
--- a/docs/writing-tests/test-coverage.md
+++ b/docs/writing-tests/test-coverage.md
@@ -2,6 +2,8 @@
 title: 'Test coverage'
 ---
 
+<YouTubeCallout id="wEa6W8uUGSA" title="These tests use NO CODE | component testing in Storybook" />
+
 Test coverage is the practice of measuring whether existing tests fully cover your code. That means surfacing areas which aren't currently being tested, such as: conditions, logic branches, functions and variables.
 
 Coverage tests examine the instrumented code against a set of industry-accepted best practices. They act as the last line of QA to improve the quality of your test suite.


### PR DESCRIPTION
## What I did

Add a YouTubeCallout for the [test coverage video](https://youtu.be/wEa6W8uUGSA) to the [relevant docs page](https://storybook.js.org/docs/7.0/react/writing-tests/test-coverage).

> **Note**: As this PR will likely serve as a reference for other, similar efforts, it's worth noting the use of the `patch` label. Because PRs target `next` by default, that label is used by our release script to patch the change back into `main` as well. For docs changes like this, the label should be used when the page being updated exists in both `next` (`7.0`, for this PR) and `main`, aka "latest" (`6.5`, for this PR).

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
