### PR TITLE
Add a new `version-update` check telemetry event

### DIFF
--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -16,6 +16,7 @@ import {
 } from '@storybook/core-common';
 import prompts from 'prompts';
 import global from 'global';
+import { telemetry } from '@storybook/telemetry';
 
 import { join, resolve } from 'path';
 import { logger } from '@storybook/node-logger';
@@ -85,7 +86,17 @@ export async function buildDevStandalone(options: CLIOptions & LoadOptions & Bui
     ...options,
   });
 
-  const { renderer, builder } = await presets.apply<CoreConfig>('core', undefined);
+  const { renderer, builder, disableTelemetry } = await presets.apply<CoreConfig>(
+    'core',
+    undefined
+  );
+
+  if (!options.disableTelemetry && !disableTelemetry) {
+    if (versionCheck.success && !versionCheck.cached) {
+      telemetry('version-update');
+    }
+  }
+
   const builderName = typeof builder === 'string' ? builder : builder?.name;
   const [previewBuilder, managerBuilder] = await Promise.all([
     getPreviewBuilder(builderName, options.configDir),

--- a/code/lib/core-server/src/utils/update-check.ts
+++ b/code/lib/core-server/src/utils/update-check.ts
@@ -5,7 +5,6 @@ import semver from 'semver';
 import { dedent } from 'ts-dedent';
 import { cache } from '@storybook/core-common';
 import type { VersionCheck } from '@storybook/types';
-import { telemetry } from '@storybook/telemetry';
 
 const { STORYBOOK_VERSION_BASE = 'https://storybook.js.org', CI } = process.env;
 
@@ -17,8 +16,6 @@ export const updateCheck = async (version: string): Promise<VersionCheck> => {
 
     // if last check was more then 24h ago
     if (time - 86400000 > fromCache.time && !CI) {
-      telemetry('version-update');
-
       const fromFetch: any = await Promise.race([
         fetch(`${STORYBOOK_VERSION_BASE}/versions.json?current=${version}`),
         // if fetch is too slow, we won't wait for it

--- a/code/lib/core-server/src/utils/update-check.ts
+++ b/code/lib/core-server/src/utils/update-check.ts
@@ -5,6 +5,7 @@ import semver from 'semver';
 import { dedent } from 'ts-dedent';
 import { cache } from '@storybook/core-common';
 import type { VersionCheck } from '@storybook/types';
+import { telemetry } from '@storybook/telemetry';
 
 const { STORYBOOK_VERSION_BASE = 'https://storybook.js.org', CI } = process.env;
 
@@ -16,6 +17,8 @@ export const updateCheck = async (version: string): Promise<VersionCheck> => {
 
     // if last check was more then 24h ago
     if (time - 86400000 > fromCache.time && !CI) {
+      telemetry('version-update');
+
       const fromFetch: any = await Promise.race([
         fetch(`${STORYBOOK_VERSION_BASE}/versions.json?current=${version}`),
         // if fetch is too slow, we won't wait for it

--- a/code/lib/telemetry/src/types.ts
+++ b/code/lib/telemetry/src/types.ts
@@ -3,7 +3,15 @@ import type { PM } from 'detect-package-manager';
 
 import type { MonorepoType } from './get-monorepo-type';
 
-export type EventType = 'boot' | 'dev' | 'build' | 'upgrade' | 'init' | 'error' | 'error-metadata';
+export type EventType =
+  | 'boot'
+  | 'dev'
+  | 'build'
+  | 'upgrade'
+  | 'init'
+  | 'error'
+  | 'error-metadata'
+  | 'version-update';
 
 export interface Dependency {
   version: string | undefined;


### PR DESCRIPTION
Issue: N/A

## What I did

Fire a telemetry event whenever `version-update` successfully runs. This makes it possible for us to tell if the version update logic is working correctly.

## How to test

```bash
rm -rf node_modules/.cache/storybook

STORYBOOK_TELEMETRY_DEBUG=1 yst
# check for 'version-update' event

STORYBOOK_TELEMETRY_DEBUG=1 yst
# check for no 'version-update' event
```

If we had a smoke test we could also check that it gets emitted there; this will come later.