### PR TITLE
Telemetry: Add precedingUpgrade data to dev/build events

### DIFF
--- a/code/lib/core-server/src/build-static.ts
+++ b/code/lib/core-server/src/build-static.ts
@@ -5,7 +5,7 @@ import { dedent } from 'ts-dedent';
 import global from 'global';
 
 import { logger } from '@storybook/node-logger';
-import { telemetry } from '@storybook/telemetry';
+import { telemetry, getPrecedingUpgrade } from '@storybook/telemetry';
 import type {
   BuilderOptions,
   CLIOptions,
@@ -173,11 +173,14 @@ export async function buildStaticStandalone(
     effects.push(
       initializedStoryIndexGenerator.then(async (generator) => {
         const storyIndex = await generator?.getIndex();
-        const payload = storyIndex
-          ? {
-              storyIndex: summarizeIndex(storyIndex),
-            }
-          : undefined;
+        const payload = {
+          precedingUpgrade: await getPrecedingUpgrade('build'),
+        };
+        if (storyIndex) {
+          Object.assign(payload, {
+            storyIndex: summarizeIndex(storyIndex),
+          });
+        }
         await telemetry('build', payload, { configDir: options.configDir });
       })
     );

--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -11,7 +11,7 @@ import type {
 
 import { normalizeStories, logConfig } from '@storybook/core-common';
 
-import { telemetry } from '@storybook/telemetry';
+import { telemetry, getPrecedingUpgrade } from '@storybook/telemetry';
 import { getMiddleware } from './utils/middleware';
 import { getServerAddresses } from './utils/server-address';
 import { getServer } from './utils/server-init';
@@ -156,12 +156,16 @@ async function doTelemetry(
     initializedStoryIndexGenerator.then(async (generator) => {
       const storyIndex = await generator?.getIndex();
       const { versionCheck, versionUpdates } = options;
-      const payload = storyIndex
-        ? {
-            versionStatus: versionUpdates ? versionStatus(versionCheck) : 'disabled',
-            storyIndex: summarizeIndex(storyIndex),
-          }
-        : undefined;
+      const payload = {
+        precedingUpgrade: await getPrecedingUpgrade('dev'),
+      };
+      if (storyIndex) {
+        Object.assign(payload, {
+          versionStatus: versionUpdates ? versionStatus(versionCheck) : 'disabled',
+          storyIndex: summarizeIndex(storyIndex),
+        });
+      }
+
       telemetry('dev', payload, { configDir: options.configDir });
     });
   }

--- a/code/lib/telemetry/src/event-cache.test.ts
+++ b/code/lib/telemetry/src/event-cache.test.ts
@@ -1,0 +1,128 @@
+import { getPrecedingUpgrade } from './event-cache';
+
+expect.addSnapshotSerializer({
+  print: (val: any) => JSON.stringify(val, null, 2),
+  test: (val) => typeof val !== 'string',
+});
+
+describe('event-cache', () => {
+  const init = { body: { eventType: 'init', eventId: 1 }, timestamp: 1 };
+  const upgrade = { body: { eventType: 'upgrade', eventId: 2 }, timestamp: 2 };
+  const dev = { body: { eventType: 'dev', eventId: 3 }, timestamp: 3 };
+  const secondUpgrade = { body: { eventType: 'upgrade', eventId: 4 }, timestamp: 4 };
+
+  describe('data handling', () => {
+    it('errors', async () => {
+      const preceding = await getPrecedingUpgrade('dev', {
+        init: { timestamp: 1, body: { ...init.body, error: {} } },
+      });
+      expect(preceding).toMatchInlineSnapshot(`
+        {
+          "timestamp": 1,
+          "eventType": "init",
+          "eventId": 1
+        }
+      `);
+    });
+
+    it('session IDs', async () => {
+      const preceding = await getPrecedingUpgrade('dev', {
+        init: { timestamp: 1, body: { ...init.body, sessionId: 100 } },
+      });
+      expect(preceding).toMatchInlineSnapshot(`
+        {
+          "timestamp": 1,
+          "eventType": "init",
+          "eventId": 1,
+          "sessionId": 100
+        }
+      `);
+    });
+
+    it('extra fields', async () => {
+      const preceding = await getPrecedingUpgrade('dev', {
+        init: { timestamp: 1, body: { ...init.body, foobar: 'baz' } },
+      });
+      expect(preceding).toMatchInlineSnapshot(`
+        {
+          "timestamp": 1,
+          "eventType": "init",
+          "eventId": 1
+        }
+      `);
+    });
+  });
+
+  describe('no intervening dev events', () => {
+    it('no upgrade events', async () => {
+      const preceding = await getPrecedingUpgrade('dev', {});
+      expect(preceding).toBeUndefined();
+    });
+
+    it('init', async () => {
+      const preceding = await getPrecedingUpgrade('dev', { init });
+      expect(preceding).toMatchInlineSnapshot(`
+        {
+          "timestamp": 1,
+          "eventType": "init",
+          "eventId": 1
+        }
+      `);
+    });
+
+    it('upgrade', async () => {
+      const preceding = await getPrecedingUpgrade('dev', { upgrade });
+      expect(preceding).toMatchInlineSnapshot(`
+        {
+          "timestamp": 2,
+          "eventType": "upgrade",
+          "eventId": 2
+        }
+      `);
+    });
+
+    it('both init and upgrade', async () => {
+      const preceding = await getPrecedingUpgrade('dev', { init, upgrade });
+      expect(preceding).toMatchInlineSnapshot(`
+        {
+          "timestamp": 2,
+          "eventType": "upgrade",
+          "eventId": 2
+        }
+      `);
+    });
+  });
+
+  describe('intervening dev events', () => {
+    it('no upgrade events', async () => {
+      const preceding = await getPrecedingUpgrade('dev', { dev });
+      expect(preceding).toBeUndefined();
+    });
+
+    it('init', async () => {
+      const preceding = await getPrecedingUpgrade('dev', { init, dev });
+      expect(preceding).toBeUndefined();
+    });
+
+    it('upgrade', async () => {
+      const preceding = await getPrecedingUpgrade('dev', { upgrade, dev });
+      expect(preceding).toBeUndefined();
+    });
+
+    it('both init and upgrade', async () => {
+      const preceding = await getPrecedingUpgrade('dev', { init, upgrade, dev });
+      expect(preceding).toBeUndefined();
+    });
+
+    it('both init and upgrade with intervening dev', async () => {
+      const preceding = await getPrecedingUpgrade('dev', { init, dev, upgrade: secondUpgrade });
+      expect(preceding).toMatchInlineSnapshot(`
+        {
+          "timestamp": 4,
+          "eventType": "upgrade",
+          "eventId": 4
+        }
+      `);
+    });
+  });
+});

--- a/code/lib/telemetry/src/event-cache.ts
+++ b/code/lib/telemetry/src/event-cache.ts
@@ -1,0 +1,40 @@
+import { cache } from '@storybook/core-common';
+import type { EventType } from './types';
+
+export const set = async (eventType: EventType, body: any) => {
+  const lastEvents = (await cache.get('lastEvents')) || {};
+  lastEvents[eventType] = { body, timestamp: Date.now() };
+  await cache.set('lastEvents', lastEvents);
+};
+
+export const get = async (eventType: EventType) => {
+  const lastEvents = await cache.get('lastEvents');
+  return lastEvents?.[eventType];
+};
+
+const upgradeFields = (event: any) => {
+  const { body, timestamp } = event;
+  return {
+    timestamp,
+    eventType: body?.eventType,
+    eventId: body?.eventId,
+    sessionId: body?.sessionId,
+  };
+};
+
+export const getPrecedingUpgrade = async (eventType: EventType, events: any = undefined) => {
+  const lastEvents = events || (await cache.get('lastEvents'));
+  console.log({ lastEvents });
+  const init = lastEvents?.init;
+  let precedingEvent = init;
+  const upgrade = lastEvents?.upgrade;
+  if (upgrade && (!precedingEvent || upgrade.timestamp > precedingEvent?.timestamp)) {
+    precedingEvent = upgrade;
+  }
+  const precedingThis = lastEvents?.[eventType];
+  if (!precedingThis?.timestamp) return precedingEvent && upgradeFields(precedingEvent);
+  if (!precedingEvent?.timestamp) return undefined;
+  return precedingEvent?.timestamp > precedingThis.timestamp
+    ? upgradeFields(precedingEvent)
+    : undefined;
+};

--- a/code/lib/telemetry/src/event-cache.ts
+++ b/code/lib/telemetry/src/event-cache.ts
@@ -24,17 +24,16 @@ const upgradeFields = (event: any) => {
 
 export const getPrecedingUpgrade = async (eventType: EventType, events: any = undefined) => {
   const lastEvents = events || (await cache.get('lastEvents'));
-  console.log({ lastEvents });
   const init = lastEvents?.init;
-  let precedingEvent = init;
+  let precedingUpgrade = init;
   const upgrade = lastEvents?.upgrade;
-  if (upgrade && (!precedingEvent || upgrade.timestamp > precedingEvent?.timestamp)) {
-    precedingEvent = upgrade;
+  if (upgrade && (!precedingUpgrade || upgrade.timestamp > precedingUpgrade?.timestamp)) {
+    precedingUpgrade = upgrade;
   }
-  const precedingThis = lastEvents?.[eventType];
-  if (!precedingThis?.timestamp) return precedingEvent && upgradeFields(precedingEvent);
-  if (!precedingEvent?.timestamp) return undefined;
-  return precedingEvent?.timestamp > precedingThis.timestamp
-    ? upgradeFields(precedingEvent)
+  if (!precedingUpgrade) return undefined;
+
+  const lastEventOfType = lastEvents?.[eventType];
+  return !lastEventOfType?.timestamp || precedingUpgrade.timestamp > lastEventOfType.timestamp
+    ? upgradeFields(precedingUpgrade)
     : undefined;
 };

--- a/code/lib/telemetry/src/index.ts
+++ b/code/lib/telemetry/src/index.ts
@@ -11,6 +11,8 @@ export * from './types';
 
 export { getStorybookCoreVersion } from './package-json';
 
+export { getPrecedingUpgrade } from './event-cache';
+
 export const telemetry = async (
   eventType: EventType,
   payload: Payload = {},


### PR DESCRIPTION
Issue: N/A

## What I did

If it's the first dev/build run after an upgrade, record a reference to that upgrade.

This will allow us to track failures more easily and improve our upgrade heuristics

## How to test

In a test project, where `sb` is aliased to your local version:

```sh
STORYBOOK_TELEMETRY_DEBUG=true sb upgrade --prerelease
STORYBOOK_TELEMETRY_DEBUG=true sb dev    
STORYBOOK_TELEMETRY_DEBUG=true sb dev
```

The first `dev` event should contain extra data like

```
    "precedingUpgrade": {
      "timestamp": 1670159585083,
      "eventType": "upgrade",
      "eventId": "Y54r_tWjm9BFrYKGRHQt8",
      "sessionId": "U9A7qs-aiuDQt6tO4z_rv"
    },
```

The second should have none