### PR TITLE
Next.js: only set next/future/image mocks from version 12.2

### DIFF
--- a/code/frameworks/nextjs/src/images/next-image-stub.tsx
+++ b/code/frameworks/nextjs/src/images/next-image-stub.tsx
@@ -54,7 +54,7 @@ if (semver.satisfies(process.env.__NEXT_VERSION!, '^13.0.0')) {
   });
 }
 
-if (semver.satisfies(process.env.__NEXT_VERSION!, '^12.0.0')) {
+if (semver.satisfies(process.env.__NEXT_VERSION!, '^12.2.0')) {
   const NextFutureImage = require('next/future/image') as typeof _NextImage;
   const OriginalNextFutureImage = NextFutureImage.default;
 

--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -59,7 +59,7 @@ export const allTemplates: Record<string, Template> = {
   'nextjs/12-js': {
     name: 'Next.js v12 (JavaScript)',
     script:
-      'yarn create next-app {{beforeDir}} -e https://github.com/vercel/next.js/tree/next-12-3-2/examples/hello-world && cd {{beforeDir}} && npm pkg set "dependencies.next"="^12" && yarn && git add . && git commit --amend --no-edit && cd ..',
+      'yarn create next-app {{beforeDir}} -e https://github.com/vercel/next.js/tree/next-12-3-2/examples/hello-world && cd {{beforeDir}} && npm pkg set "dependencies.next"="^12.2.0" && yarn && git add . && git commit --amend --no-edit && cd ..',
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',


### PR DESCRIPTION
Issue: N/A

## What I did

The version check was wrong, given that Next.js only introduced `next/future/image` from version 12.2

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
