### PR TITLE
Remove peer deps from core-common

### DIFF
--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -77,10 +77,6 @@
     "type-fest": "^2.19.0",
     "typescript": "~4.9.3"
   },
-  "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-  },
   "peerDependenciesMeta": {
     "typescript": {
       "optional": true

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6188,9 +6188,6 @@ __metadata:
     ts-dedent: ^2.0.0
     type-fest: ^2.19.0
     typescript: ~4.9.3
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   peerDependenciesMeta:
     typescript:
       optional: true


### PR DESCRIPTION
## What I did

Removed peer deps from core-common

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
