### PR TITLE
Deal with a lot of different edge cases for git URLs

### DIFF
--- a/code/lib/telemetry/src/anonymous-id.test.ts
+++ b/code/lib/telemetry/src/anonymous-id.test.ts
@@ -1,0 +1,75 @@
+import { normalizeGitUrl } from './anonymous-id';
+
+describe('normalizeGitUrl', () => {
+  it('trims off https://', () => {
+    expect(normalizeGitUrl('https://github.com/storybookjs/storybook.git')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+
+  it('trims off http://', () => {
+    expect(normalizeGitUrl('http://github.com/storybookjs/storybook.git')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+
+  it('trims off git+https://', () => {
+    expect(normalizeGitUrl('git+https://github.com/storybookjs/storybook.git')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+
+  it('trims off https://username@', () => {
+    expect(normalizeGitUrl('https://username@github.com/storybookjs/storybook.git')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+
+  it('trims off http://username@', () => {
+    expect(normalizeGitUrl('http://username@github.com/storybookjs/storybook.git')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+
+  it('trims off https://username:password@', () => {
+    expect(
+      normalizeGitUrl('https://username:password@github.com/storybookjs/storybook.git')
+    ).toEqual('github.com/storybookjs/storybook.git');
+  });
+
+  it('trims off http://username:password@', () => {
+    expect(
+      normalizeGitUrl('http://username:password@github.com/storybookjs/storybook.git')
+    ).toEqual('github.com/storybookjs/storybook.git');
+  });
+
+  it('trims off git://', () => {
+    expect(normalizeGitUrl('git://github.com/storybookjs/storybook.git')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+
+  it('trims off git@', () => {
+    expect(normalizeGitUrl('git@github.com:storybookjs/storybook.git')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+
+  it('trims off git+ssh://git@', () => {
+    expect(normalizeGitUrl('git+ssh://git@github.com:storybookjs/storybook.git')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+
+  it('trims off ssh://git@', () => {
+    expect(normalizeGitUrl('ssh://git@github.com:storybookjs/storybook.git')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+
+  it('trims off #hash', () => {
+    expect(normalizeGitUrl('https://github.com/storybookjs/storybook.git#next')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+});

--- a/code/lib/telemetry/src/anonymous-id.ts
+++ b/code/lib/telemetry/src/anonymous-id.ts
@@ -1,7 +1,22 @@
 import path from 'path';
 import { execSync } from 'child_process';
 import { getProjectRoot } from '@storybook/core-common';
+
 import { oneWayHash } from './one-way-hash';
+
+const USERNAME_REGEXP = /^.*@(.*:?)/;
+export function normalizeGitUrl(rawUrl: string) {
+  // I don't *think* its possible to set a hash on a origin URL, but just in case
+  const urlWithoutHash = rawUrl.replace(/#.*$/, '');
+
+  // Strip anything ahead of an @
+  const urlWithoutUser = urlWithoutHash.replace(/^.*@/, '');
+
+  // Now strip off scheme
+  const urlWithoutScheme = urlWithoutUser.replace(/^.*\/\//, '');
+
+  return urlWithoutScheme.replace(':', '/');
+}
 
 let anonymousProjectId: string;
 export const getAnonymousProjectId = () => {
@@ -22,7 +37,7 @@ export const getAnonymousProjectId = () => {
 
     // we use a combination of remoteUrl and working directory
     // to separate multiple storybooks from the same project (e.g. monorepo)
-    unhashedProjectId = `${String(originBuffer).trim()}${projectRootPath}`;
+    unhashedProjectId = `${normalizeGitUrl(String(originBuffer))}${projectRootPath}`;
 
     anonymousProjectId = oneWayHash(unhashedProjectId);
   } catch (_) {

--- a/code/lib/telemetry/src/anonymous-id.ts
+++ b/code/lib/telemetry/src/anonymous-id.ts
@@ -4,7 +4,6 @@ import { getProjectRoot } from '@storybook/core-common';
 
 import { oneWayHash } from './one-way-hash';
 
-const USERNAME_REGEXP = /^.*@(.*:?)/;
 export function normalizeGitUrl(rawUrl: string) {
   // I don't *think* its possible to set a hash on a origin URL, but just in case
   const urlWithoutHash = rawUrl.replace(/#.*$/, '');


### PR DESCRIPTION
Issue: anonymousId wasn't stable due to differences in git URLs, primarily ssh vs https.

## What I did

Made a normalizer, deal with a lot of edge cases. There was a single package out there that did (some of) this: https://github.com/npm/normalize-git-url but it is super old and didn't really nail our use case anyway.

## How to test

- See unit tests.
- Try cloning a repo in a couple ways and see what anon ids you get.