### PR TITLE
CLI: Fix upgrade --prerelease to upgrade to the next tag

### DIFF
--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -173,7 +173,10 @@ export const doUpgrade = async ({
 
   let target = 'latest';
   if (prerelease) {
-    target = 'greatest';
+    // '@next' is storybook's convention for the latest prerelease tag.
+    // This used to be 'greatest', but that was not reliable and could pick canaries, etc.
+    // and random releases of other packages with storybook in their name.
+    target = '@next';
   } else if (tag) {
     target = `@${tag}`;
   }


### PR DESCRIPTION
Issue: N/A

## What I did

What the PR says

## How to test

On the `frontpage` repo, where `sb` is aliased to your local build of the CLI:

```
sb upgrade --prerelease
```