### PR TITLE
Fix new-frameworks automigration failing to read frameworkOptions field.

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
@@ -70,7 +70,20 @@ export const getBuilder = (builder: string | { name: string }) => {
 };
 
 export const getFrameworkOptions = (framework: string, main: ConfigFile) => {
-  const frameworkOptions = main.getFieldValue([`${framework}Options`]);
+  let frameworkOptions = {};
+  try {
+    frameworkOptions = main.getFieldValue([`${framework}Options`]);
+  } catch (e) {
+    logger.warn(dedent`
+      Unable to get the ${framework}Options field.
+      
+      Please review the changes made to your main.js config and make any necessary changes.
+      The ${framework}Options should be moved to the framework.options field.
+
+      The following error occurred when we tried to get the ${framework}Options field:
+    `);
+    console.log(e);
+  }
   return frameworkOptions || {};
 };
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/20080

## What I did

wrap with a try-catch as suggested by shilman