### PR TITLE
Vite: Prepare for Vite 4

### DIFF
--- a/code/frameworks/html-vite/package.json
+++ b/code/frameworks/html-vite/package.json
@@ -60,13 +60,11 @@
     "@storybook/html": "7.0.0-alpha.58",
     "@storybook/node-logger": "7.0.0-alpha.58",
     "@storybook/preview-web": "7.0.0-alpha.58",
-    "magic-string": "^0.26.1",
-    "vite": "3"
+    "magic-string": "^0.26.1"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
-    "typescript": "~4.9.3",
-    "vite": "^3.1.0"
+    "typescript": "~4.9.3"
   },
   "engines": {
     "node": "^14.18 || >=16"

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -59,12 +59,12 @@
     "ast-types": "^0.14.2",
     "magic-string": "^0.26.1",
     "react-docgen": "^6.0.0-alpha.3",
-    "vite": "^3.1.3"
+    "vite": "^3.0.0||^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
     "typescript": "~4.9.3",
-    "vite": "^3.1.3"
+    "vite": "^4.0.0-beta.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/code/frameworks/svelte-vite/package.json
+++ b/code/frameworks/svelte-vite/package.json
@@ -59,12 +59,12 @@
     "magic-string": "^0.26.1",
     "svelte": "^3.0.0",
     "sveltedoc-parser": "^4.2.1",
-    "vite": "^3.1.3"
+    "vite": "^3.0.0||^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
     "typescript": "~4.9.3",
-    "vite": "^3.1.3"
+    "vite": "^4.0.0-beta.2"
   },
   "peerDependencies": {
     "@storybook/addon-svelte-csf": "^2.0.0"

--- a/code/frameworks/sveltekit/package.json
+++ b/code/frameworks/sveltekit/package.json
@@ -56,8 +56,7 @@
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
-    "typescript": "^4.9.3",
-    "vite": "^3.1.3"
+    "typescript": "^4.9.3"
   },
   "peerDependencies": {
     "@storybook/addon-svelte-csf": "^2.0.0"

--- a/code/frameworks/vue-vite/package.json
+++ b/code/frameworks/vue-vite/package.json
@@ -55,11 +55,12 @@
     "@storybook/core-server": "7.0.0-alpha.58",
     "@storybook/vue": "7.0.0-alpha.58",
     "magic-string": "^0.26.1",
-    "vite": "^3.1.3",
+    "vite": "^3.0.0||^4.0.0",
     "vue-docgen-api": "^4.40.0"
   },
   "devDependencies": {
     "typescript": "~4.9.3",
+    "vite": "^4.0.0-beta.2",
     "vue": "^2.7.10"
   },
   "peerDependencies": {

--- a/code/frameworks/vue3-vite/package.json
+++ b/code/frameworks/vue3-vite/package.json
@@ -56,13 +56,13 @@
     "@storybook/vue3": "7.0.0-alpha.58",
     "@vitejs/plugin-vue": "^3.0.0",
     "magic-string": "^0.26.1",
-    "vite": "^3.1.3",
+    "vite": "^3.0.0||^4.0.0",
     "vue-docgen-api": "^4.40.0"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
     "typescript": "~4.9.3",
-    "vite": "^3.1.3"
+    "vite": "^4.0.0-beta.2"
   },
   "engines": {
     "node": "^14.18 || >=16"

--- a/code/frameworks/web-components-vite/package.json
+++ b/code/frameworks/web-components-vite/package.json
@@ -55,13 +55,11 @@
     "@storybook/core-server": "7.0.0-alpha.58",
     "@storybook/node-logger": "7.0.0-alpha.58",
     "@storybook/web-components": "7.0.0-alpha.58",
-    "magic-string": "^0.26.1",
-    "vite": "3"
+    "magic-string": "^0.26.1"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
-    "typescript": "~4.9.3",
-    "vite": "^3.1.0"
+    "typescript": "~4.9.3"
   },
   "engines": {
     "node": "^14.18 || >=16"

--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -60,13 +60,13 @@
     "magic-string": "^0.26.1",
     "rollup-plugin-external-globals": "^0.7.1",
     "slash": "^3.0.0",
-    "vite": "^3.1.3"
+    "vite": "^3.0.0||^4.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/node": "^16.0.0",
     "typescript": "~4.9.3",
-    "vite": "^3.1.3"
+    "vite": "^4.0.0-beta.2"
   },
   "peerDependencies": {
     "@preact/preset-vite": "*",

--- a/code/package.json
+++ b/code/package.json
@@ -338,7 +338,7 @@
     "tsup": "^6.2.2",
     "typescript": "~4.9.3",
     "util": "^0.12.4",
-    "vite": "^3.1.7",
+    "vite": "^4.0.0-beta.2",
     "vite-plugin-turbosnap": "^1.0.1",
     "wait-on": "^5.2.1",
     "web-component-analyzer": "^1.1.6",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5895,7 +5895,7 @@ __metadata:
     rollup-plugin-external-globals: ^0.7.1
     slash: ^3.0.0
     typescript: ~4.9.3
-    vite: ^3.1.3
+    vite: ^4.0.0-beta.2
   peerDependencies:
     "@preact/preset-vite": "*"
     vite-plugin-glimmerx: "*"
@@ -7017,7 +7017,7 @@ __metadata:
     magic-string: ^0.26.1
     react-docgen: ^6.0.0-alpha.3
     typescript: ~4.9.3
-    vite: ^3.1.3
+    vite: ^4.0.0-beta.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -7312,7 +7312,7 @@ __metadata:
     util: ^0.12.4
     verdaccio: ^4.10.0
     verdaccio-auth-memory: ^9.7.2
-    vite: ^3.1.7
+    vite: ^4.0.0-beta.2
     vite-plugin-turbosnap: ^1.0.1
     wait-on: ^5.2.1
     web-component-analyzer: ^1.1.6
@@ -7467,7 +7467,7 @@ __metadata:
     svelte: ^3.0.0
     sveltedoc-parser: ^4.2.1
     typescript: ~4.9.3
-    vite: ^3.1.3
+    vite: ^4.0.0-beta.2
   peerDependencies:
     "@storybook/addon-svelte-csf": ^2.0.0
   peerDependenciesMeta:
@@ -7632,7 +7632,7 @@ __metadata:
     "@storybook/vue": 7.0.0-alpha.58
     magic-string: ^0.26.1
     typescript: ~4.9.3
-    vite: ^3.1.3
+    vite: ^4.0.0-beta.2
     vue: ^2.7.10
     vue-docgen-api: ^4.40.0
   peerDependencies:
@@ -7676,7 +7676,7 @@ __metadata:
     "@vitejs/plugin-vue": ^3.0.0
     magic-string: ^0.26.1
     typescript: ~4.9.3
-    vite: ^3.1.3
+    vite: ^4.0.0-beta.2
     vue-docgen-api: ^4.40.0
   languageName: unknown
   linkType: soft
@@ -26647,7 +26647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.1.10, postcss@npm:^8.2.14, postcss@npm:^8.2.15, postcss@npm:^8.3.7, postcss@npm:^8.4.14, postcss@npm:^8.4.18":
+"postcss@npm:^8.1.10, postcss@npm:^8.2.14, postcss@npm:^8.2.15, postcss@npm:^8.3.7, postcss@npm:^8.4.14, postcss@npm:^8.4.18, postcss@npm:^8.4.19":
   version: 8.4.19
   resolution: "postcss@npm:8.4.19"
   dependencies:
@@ -29181,20 +29181,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.79.1":
-  version: 2.79.1
-  resolution: "rollup@npm:2.79.1"
-  dependencies:
-    fsevents: ~2.3.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: 421418687f5dcd7324f4387f203c6bfc7118b7ace789e30f5da022471c43e037a76f5fd93837052754eeeae798a4fb266ac05ccee1e594406d912a59af98dde9
-  languageName: node
-  linkType: hard
-
 "rollup@npm:^3.2.5":
   version: 3.5.0
   resolution: "rollup@npm:3.5.0"
@@ -29206,6 +29192,20 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 15ac1b50c436c90d690f606dc0004eb80ff172ae38469a45494dd13e45723ebe9ec56f6122c0e834f2e51b092706b89e02ab5dc59dc42ff1f289bec558b68ab0
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "rollup@npm:3.6.0"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: cb0ac6ba2e02ec544ca4658a184255b843ea3b7d4d62266706052f93e036bb1ab9e200ccfb8716855497cf52462551774b5fd54412bd02fcd6e8d7159533f54b
   languageName: node
   linkType: hard
 
@@ -33201,15 +33201,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^3.1.3, vite@npm:^3.1.7":
-  version: 3.2.4
-  resolution: "vite@npm:3.2.4"
+"vite@npm:^4.0.0-beta.2":
+  version: 4.0.0-beta.2
+  resolution: "vite@npm:4.0.0-beta.2"
   dependencies:
-    esbuild: ^0.15.9
+    esbuild: ^0.15.18
     fsevents: ~2.3.2
-    postcss: ^8.4.18
+    postcss: ^8.4.19
     resolve: ^1.22.1
-    rollup: ^2.79.1
+    rollup: ^3.6.0
   peerDependencies:
     "@types/node": ">= 14"
     less: "*"
@@ -33235,7 +33235,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: c3b6a1643e6436e4628db1fe183a3eb7db970bf8cf20104540079b9e97b6f5ce1ea33c498373f130ddee7259a96cc3f9ce96d5e43a8b23f7484e35ac8634bcc7
+  checksum: 8b23b39b9d4475fdb73d8a849ea3ebac79dd3d8853904bb8a7aee70704da3e2443915a43504668526ff90a6e67dd1b5abf508c6a2a7ffa3baef675ddc77a1fa0
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6432,7 +6432,6 @@ __metadata:
     "@types/node": ^16.0.0
     magic-string: ^0.26.1
     typescript: ~4.9.3
-    vite: ^3.1.0
   languageName: unknown
   linkType: soft
 
@@ -7529,7 +7528,6 @@ __metadata:
     "@storybook/svelte-vite": 7.0.0-alpha.58
     "@types/node": ^16.0.0
     typescript: ^4.9.3
-    vite: ^3.1.3
   peerDependencies:
     "@storybook/addon-svelte-csf": ^2.0.0
   peerDependenciesMeta:
@@ -7772,7 +7770,6 @@ __metadata:
     "@types/node": ^16.0.0
     magic-string: ^0.26.1
     typescript: ~4.9.3
-    vite: ^3.1.0
   languageName: unknown
   linkType: soft
 
@@ -33204,7 +33201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^3.1.0, vite@npm:^3.1.3, vite@npm:^3.1.7":
+"vite@npm:^3.1.3, vite@npm:^3.1.7":
   version: 3.2.4
   resolution: "vite@npm:3.2.4"
   dependencies:


### PR DESCRIPTION
Issue:

Vite is about to release version 4 in a few days, but our packages depend strictly on version 3.

## What I did

- I removed vite from some of the frameworks which do not directly import from Vite.
- I updated the `dependency` range to encompass version 3 and 4.
- I updated our `devDependency` to the latest version 4 beta.

## How to test

Ideally, we would also update our sandboxes to use `yarn create vite@beta` or something like that.  But `create-vite` has not yet been updated to use the beta.  I'm discussing with the vite team if that can be done prior to the final release.

So, I think this isn't a great test that vite 4 will work correctly, until we can update those sandboxes, but we need to make this change anyway to avoid problems once vite 4 is released.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
