### PR TITLE
CLI: Replace addon-docs Meta with blocks and add blocks dep

### DIFF
--- a/code/frameworks/nextjs/template/cli/js/Introduction.mdx
+++ b/code/frameworks/nextjs/template/cli/js/Introduction.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs';
+import { Meta } from '@storybook/blocks';
 import Image from 'next/image';
 
 import Code from './assets/code-brackets.svg';

--- a/code/frameworks/nextjs/template/cli/ts-legacy/Introduction.stories.mdx
+++ b/code/frameworks/nextjs/template/cli/ts-legacy/Introduction.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs';
+import { Meta } from '@storybook/blocks';
 import Image from 'next/image';
 
 import Code from './assets/code-brackets.svg';

--- a/code/lib/cli/rendererAssets/common/Introduction.mdx
+++ b/code/lib/cli/rendererAssets/common/Introduction.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs';
+import { Meta } from '@storybook/blocks';
 import Code from './assets/code-brackets.svg';
 import Colors from './assets/colors.svg';
 import Comments from './assets/comments.svg';

--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -144,6 +144,7 @@ export async function baseGenerator(
   const addonPackages = [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
+    '@storybook/blocks',
     ...extraAddonPackages,
   ];
 
@@ -151,8 +152,6 @@ export async function baseGenerator(
     addons.push('@storybook/addon-interactions');
     addonPackages.push('@storybook/addon-interactions', '@storybook/testing-library');
   }
-
-  const yarn2ExtraPackages = packageManager.type === 'yarn2' ? ['@storybook/addon-docs'] : [];
 
   const files = await fse.readdir(process.cwd());
 
@@ -187,7 +186,6 @@ export async function baseGenerator(
     ...frameworkPackages,
     ...addonPackages,
     ...extraPackages,
-    ...yarn2ExtraPackages,
   ]
     .filter(Boolean)
     .filter(


### PR DESCRIPTION
Issue: N/A

## What I did

To support pnpm etc. in new projects
- [x] Add an extra dependency to `@storybook/blocks`
- [x] Replace the addon-docs Meta reference in `Introduction.mdx`

## How to test

- [ ] CI passes