### PR TITLE
Add args generic to CSFExports

### DIFF
--- a/code/lib/types/src/modules/composedStory.ts
+++ b/code/lib/types/src/modules/composedStory.ts
@@ -16,8 +16,8 @@ import type { ProjectAnnotations } from './story';
 
 // TODO -- I think the name "CSFExports" overlaps here a bit with the types in csfFile.ts
 // we might want to reconcile @yannbf
-export type Store_CSFExports<TRenderer extends Renderer = Renderer> = {
-  default: ComponentAnnotations<TRenderer, Args>;
+export type Store_CSFExports<TRenderer extends Renderer = Renderer, TArgs extends Args = Args> = {
+  default: ComponentAnnotations<TRenderer, TArgs>;
   __esModule?: boolean;
   __namedExportsOrder?: string[];
 };


### PR DESCRIPTION
Issue:

## What I did

The CSFExports type was using Args but not allowing them to come via generics. This PR adds that possibility. It's helpful in particular for packages like @storybook/testing-react

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
