### PR TITLE
Re-enable TS 4.9 CLI templates

### DIFF
--- a/code/lib/cli/src/detect.test.ts
+++ b/code/lib/cli/src/detect.test.ts
@@ -296,22 +296,19 @@ describe('Detect', () => {
 
   it(`should return language typescript if the dependency is >TS4.9`, () => {
     expect(detectLanguage({ dependencies: { typescript: '4.9.1' } })).toBe(
-      // TODO: switch to TYPESCRIPT once csf-tools and eslint-plugin-storybook support `satisfies` operator
-      SupportedLanguage.TYPESCRIPT_LEGACY
+      SupportedLanguage.TYPESCRIPT
     );
   });
 
   it(`should return language typescript if the dependency is =TS4.9`, () => {
     expect(detectLanguage({ dependencies: { typescript: '4.9.0' } })).toBe(
-      // TODO: switch to TYPESCRIPT once csf-tools and eslint-plugin-storybook support `satisfies` operator
-      SupportedLanguage.TYPESCRIPT_LEGACY
+      SupportedLanguage.TYPESCRIPT
     );
   });
 
   it(`should return language typescript if the dependency is =TS4.9beta`, () => {
     expect(detectLanguage({ dependencies: { typescript: '^4.9.0-beta' } })).toBe(
-      // TODO: switch to TYPESCRIPT once csf-tools and eslint-plugin-storybook support `satisfies` operator
-      SupportedLanguage.TYPESCRIPT_LEGACY
+      SupportedLanguage.TYPESCRIPT
     );
   });
 

--- a/code/lib/cli/src/detect.ts
+++ b/code/lib/cli/src/detect.ts
@@ -170,10 +170,13 @@ export function detectLanguage(packageJson?: PackageJson) {
     (!hasDependency(packageJson, '@typescript-eslint/parser') ||
       hasDependency(packageJson, '@typescript-eslint/parser', (version) =>
         semver.gte(semver.coerce(version), '5.44.0')
+      )) &&
+    (!hasDependency(packageJson, 'eslint-plugin-storybook') ||
+      hasDependency(packageJson, 'eslint-plugin-storybook', (version) =>
+        semver.gte(semver.coerce(version), '0.6.8')
       ))
   ) {
-    // TODO: switch to TYPESCRIPT once csf-tools and eslint-plugin-storybook support `satisfies` operator
-    language = SupportedLanguage.TYPESCRIPT_LEGACY;
+    language = SupportedLanguage.TYPESCRIPT;
   } else if (hasDependency(packageJson, 'typescript')) {
     language = SupportedLanguage.TYPESCRIPT_LEGACY;
   }


### PR DESCRIPTION
Re enabling TS 4.9 CLI templates, now CSF-tools and the eslint plugin are updated.