### PR TITLE
Fix: typescript.checkOptions not a valid interface

### DIFF
--- a/code/lib/builder-webpack5/src/types.ts
+++ b/code/lib/builder-webpack5/src/types.ts
@@ -16,7 +16,7 @@ export interface TypescriptOptions extends TypeScriptOptionsBase {
   /**
    * Configures `fork-ts-checker-webpack-plugin`
    */
-  checkOptions?: ForkTsCheckerWebpackPlugin['options'];
+  checkOptions?: ConstructorParameters<typeof ForkTsCheckerWebpackPlugin>[0];
 }
 
 export interface StorybookConfigWebpack extends Pick<StorybookConfig, 'webpack' | 'webpackFinal'> {

--- a/code/lib/cli/src/link.ts
+++ b/code/lib/cli/src/link.ts
@@ -63,7 +63,7 @@ export const link = async ({ target, local, start }: LinkOptions) => {
     `Magic stuff related to @storybook/preset-create-react-app, we need to fix peerDependencies`
   );
 
-  if (!reproPackageJson.devDependencies.vite) {
+  if (!reproPackageJson.devDependencies?.vite) {
     await exec(`yarn add -D webpack-hot-middleware`, { cwd: reproDir });
   }
 

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -341,7 +341,7 @@ export interface StorybookConfig {
   /**
    * References external Storybooks
    */
-  refs?: CoreCommon_StorybookRefs | ((config: any, options: Options) => CoreCommon_StorybookRefs);
+  refs?: PresetValue<CoreCommon_StorybookRefs>;
 
   /**
    * Modify or return babel config.
@@ -364,17 +364,17 @@ export interface StorybookConfig {
    *
    * @deprecated use `previewAnnotations` or `/preview.js` file instead
    */
-  config?: (entries: Entry[], options: Options) => Entry[];
+  config?: PresetValue<Entry[]>;
 
   /**
    * Add additional scripts to run in the preview a la `.storybook/preview.js`
    */
-  previewAnnotations?: (entries: Entry[], options: Options) => Entry[];
+  previewAnnotations?: PresetValue<Entry[]>;
 
   /**
    * Process CSF files for the story index.
    */
-  storyIndexers?: (indexers: StoryIndexer[], options: Options) => StoryIndexer[];
+  storyIndexers?: PresetValue<StoryIndexer[]>;
 
   /**
    * Docs related features in index generation
@@ -386,10 +386,12 @@ export interface StorybookConfig {
    * The previewHead and previewBody functions accept a string,
    * which is the existing head/body, and return a modified string.
    */
-  previewHead?: (head: string, options: Options) => string;
+  previewHead?: PresetValue<string>;
 
-  previewBody?: (body: string, options: Options) => string;
+  previewBody?: PresetValue<string>;
 }
+
+export type PresetValue<T> = T | ((config: T, options: Options) => T | Promise<T>);
 
 export type PresetProperty<K, TStorybookConfig = StorybookConfig> =
   | TStorybookConfig[K extends keyof TStorybookConfig ? K : never]

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -143,7 +143,7 @@ function addEsbuildLoaderToStories(mainConfig: ConfigFile) {
   (config) => ({
     ...config,
     module: {
-      ...config.modules,
+      ...config.module,
       rules: [
         // Ensure esbuild-loader applies to all files in ./template-stories
         {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/19731

## What I did

I fixed and cleaned up a few typings in core-common

I found a way to gain access to the correct interface from `ForkTsCheckerWebpackPlugin`
that should address the reported bug, I think