### PR TITLE
Tech: change `package.json` engines fields, set to minimal node16 and up

### DIFF
--- a/code/frameworks/angular/package.json
+++ b/code/frameworks/angular/package.json
@@ -116,7 +116,7 @@
     }
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/ember/package.json
+++ b/code/frameworks/ember/package.json
@@ -54,7 +54,7 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/html-webpack5/package.json
+++ b/code/frameworks/html-webpack5/package.json
@@ -66,7 +66,7 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -105,7 +105,7 @@
     }
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/preact-webpack5/package.json
+++ b/code/frameworks/preact-webpack5/package.json
@@ -67,7 +67,7 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/react-webpack5/package.json
+++ b/code/frameworks/react-webpack5/package.json
@@ -74,7 +74,7 @@
     }
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/server-webpack5/package.json
+++ b/code/frameworks/server-webpack5/package.json
@@ -64,7 +64,7 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/svelte-webpack5/package.json
+++ b/code/frameworks/svelte-webpack5/package.json
@@ -69,7 +69,7 @@
     "svelte-loader": "*"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/vue-vite/package.json
+++ b/code/frameworks/vue-vite/package.json
@@ -68,7 +68,7 @@
     "vue": "^2.7.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/vue-webpack5/package.json
+++ b/code/frameworks/vue-webpack5/package.json
@@ -73,7 +73,7 @@
     "vue-template-compiler": "^2.6.8"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/vue3-webpack5/package.json
+++ b/code/frameworks/vue3-webpack5/package.json
@@ -70,7 +70,7 @@
     "vue": "^3.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/frameworks/web-components-webpack5/package.json
+++ b/code/frameworks/web-components-webpack5/package.json
@@ -69,7 +69,7 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/package.json
+++ b/code/package.json
@@ -386,8 +386,7 @@
   },
   "packageManager": "yarn@3.3.0",
   "engines": {
-    "node": ">=10.13.0",
-    "yarn": ">=1.3.2"
+    "node": ">=16.0.0"
   },
   "collective": {
     "type": "opencollective",

--- a/code/presets/html-webpack/package.json
+++ b/code/presets/html-webpack/package.json
@@ -62,7 +62,7 @@
     "@babel/core": "*"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/presets/preact-webpack/package.json
+++ b/code/presets/preact-webpack/package.json
@@ -63,7 +63,7 @@
     "preact": "^8.0.0||^10.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/presets/react-webpack/package.json
+++ b/code/presets/react-webpack/package.json
@@ -105,7 +105,7 @@
     }
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/presets/server-webpack/package.json
+++ b/code/presets/server-webpack/package.json
@@ -71,7 +71,7 @@
     "yaml": "^1.10.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/presets/svelte-webpack/package.json
+++ b/code/presets/svelte-webpack/package.json
@@ -81,7 +81,7 @@
     "svelte-loader": "*"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/presets/vue-webpack/package.json
+++ b/code/presets/vue-webpack/package.json
@@ -84,7 +84,7 @@
     "vue-template-compiler": "^2.6.14"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/presets/vue3-webpack/package.json
+++ b/code/presets/vue3-webpack/package.json
@@ -81,7 +81,7 @@
     "vue": "^3.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/presets/web-components-webpack/package.json
+++ b/code/presets/web-components-webpack/package.json
@@ -68,7 +68,7 @@
     "lit-html": "^1.4.1 || ^2.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/renderers/html/package.json
+++ b/code/renderers/html/package.json
@@ -65,7 +65,7 @@
     "@babel/core": "*"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/renderers/preact/package.json
+++ b/code/renderers/preact/package.json
@@ -65,7 +65,7 @@
     "preact": "^8.0.0||^10.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -90,7 +90,7 @@
     }
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -61,7 +61,7 @@
     "typescript": "~4.9.3"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -75,7 +75,7 @@
     "svelte": "^3.1.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/renderers/vue/package.json
+++ b/code/renderers/vue/package.json
@@ -77,7 +77,7 @@
     }
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -70,7 +70,7 @@
     "vue": "^3.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/code/renderers/web-components/package.json
+++ b/code/renderers/web-components/package.json
@@ -71,7 +71,7 @@
     "lit-html": "^1.4.1 || ^2.0.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -185,7 +185,6 @@
   },
   "packageManager": "yarn@3.3.0",
   "engines": {
-    "node": ">=10.13.0",
-    "yarn": ">=1.3.2"
+    "node": ">=16.0.0"
   }
 }


### PR DESCRIPTION
Issue: our engines are stating we support node 10, this is not true, we support Node16 and up

## What I did

Changed all the engines versions in our package.json files