### PR TITLE
Update logic around `next/future/image`

### DIFF
--- a/code/frameworks/nextjs/src/nextImport/webpack.ts
+++ b/code/frameworks/nextjs/src/nextImport/webpack.ts
@@ -21,7 +21,7 @@ export function configureNextImport(baseConfig: WebpackConfig) {
     );
   }
 
-  if (isNext12 && isNextVersionSmallerThan12dot2) {
+  if (!isNext12 || isNextVersionSmallerThan12dot2) {
     baseConfig.plugins.push(
       new IgnorePlugin({
         resourceRegExp: /next\/future\/image$/,

--- a/code/frameworks/nextjs/src/nextImport/webpack.ts
+++ b/code/frameworks/nextjs/src/nextImport/webpack.ts
@@ -8,6 +8,7 @@ export function configureNextImport(baseConfig: WebpackConfig) {
 
   const isNext12 = semver.satisfies(nextJSVersion, '~12');
   const isNext13 = semver.satisfies(nextJSVersion, '~13');
+  const isNextVersionSmallerThan12dot2 = semver.lt(nextJSVersion, '12.2.0');
   const isNextVersionSmallerThan13 = semver.lt(nextJSVersion, '13.0.0');
 
   baseConfig.plugins = baseConfig.plugins ?? [];
@@ -20,7 +21,7 @@ export function configureNextImport(baseConfig: WebpackConfig) {
     );
   }
 
-  if (!isNext12) {
+  if (isNext12 && isNextVersionSmallerThan12dot2) {
     baseConfig.plugins.push(
       new IgnorePlugin({
         resourceRegExp: /next\/future\/image$/,
@@ -36,7 +37,7 @@ export function configureNextImport(baseConfig: WebpackConfig) {
     );
   }
 
-  if (semver.lt(nextJSVersion, '12.2.0')) {
+  if (isNextVersionSmallerThan12dot2) {
     baseConfig.plugins.push(
       new IgnorePlugin({
         resourceRegExp: /next\/dist\/shared\/lib\/app-router-context$/,


### PR DESCRIPTION
## What I did

Currently, the logic to ignore imports of `next/future/image` (introduced in `12.2` and removed in `13`) does not apply correctly when using a version of next between `12` (inclusive) and `12.2` (exclusive), e.g. `12.1.5`.

This PR updates the logic.

Related PR: https://github.com/storybookjs/storybook/pull/20098

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
