### PR TITLE
Core: Catch and do nothing to avoid triggering unhandled exception problems

### DIFF
--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -109,7 +109,9 @@ export async function storybookDevServer(options: Options) {
   // this is a preview route, the builder has to be started before we can serve it
   // this handler keeps request to that route pending until the builder is ready to serve it, preventing a 404
   router.get('/iframe.html', (req, res, next) => {
-    previewStarted.then(() => next());
+    // We need to catch here or node will treat any errors thrown by `previewStarted` as
+    // unhandled and exit (even though they are very much handled below)
+    previewStarted.catch(() => {}).then(() => next());
   });
 
   Promise.all([initializedStoryIndexGenerator, listening, usingStatics]).then(async () => {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/20161

## What I did

Put an extra empty `.catch()` in to avoid the issue.

## Explanation

Try running this code:

```js
async function errorFunction() {
  throw new Error('error')
}

async function go() {
  try {
    const r = errorFunction()
    //  r.then(() => { });
    await r;
  } catch (err) {
    console.log('caught error');
    await new Promise((r) => setTimeout(r, 10));
    console.log('done');
  }
}

go();
```

As written it will exit 0 and log:

```
caught error
done
```

If you comment the `.then()` block, it will exit 1 and log:

```
caught error
/Users/tom/GitHub/storybookjs/storybook/sandbox/nextjs-default-js/test.js:2
  throw new Error('error')
        ^

Error: error
    at errorFunction (/Users/tom/GitHub/storybookjs/storybook/sandbox/nextjs-default-js/test.js:2:9)
    at go (/Users/tom/GitHub/storybookjs/storybook/sandbox/nextjs-default-js/test.js:7:15)
    at Object.<anonymous> (/Users/tom/GitHub/storybookjs/storybook/sandbox/nextjs-default-js/test.js:17:1)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```

If you put a `.catch()` in *before* the `.then()` it will do the first behaviour.

I suppose node has a heuristic for whether exceptions are being handled that is wrong here. We could also (and maybe should) add a `process.on('unhandledException')` to deal with this.

## How to test

Run a sandbox (not with `--ci`) and put a incorrect import in a file.