### PR TITLE
Chore: (Docs - snippets) Testing react example

### DIFF
--- a/docs/snippets/react/storybook-testing-addon-optional-config.js.mdx
+++ b/docs/snippets/react/storybook-testing-addon-optional-config.js.mdx
@@ -6,5 +6,6 @@ import { setGlobalConfig } from '@storybook/testing-react';
 // Storybook's preview file location
 import * as globalStorybookConfig from './.storybook/preview';
 
+// Replace with setProjectAnnotations if you are using the new pre-release version the addon
 setGlobalConfig(globalStorybookConfig);
 ```


### PR DESCRIPTION
With this pull request, the snippet used in the import stories into tests with the `@storybook/testing-react` package is now fixed to include information about the deprecation.

Once the addon is fully released, the example will be updated.

