### PR TITLE
Chore: (Docs) Adjusts the installation issues docs for the new framework matrix

### DIFF
--- a/docs/get-started/installation-problems/angular.mdx
+++ b/docs/get-started/installation-problems/angular.mdx
@@ -42,4 +42,4 @@
 | `"styles"`                   | Provide the location of the [application's styles](../configure/styling-and-css.md#importing-css-files) to be used with Storybook. <br/> `"styles": ["src/styles.css", "src/styles.scss"]` <br/> |
 | `"stylePreprocessorOptions"` | Provides further customization for style preprocessors resolved to the workspace root. <br/> `"stylePreprocessorOptions": { "includePaths": ["src/styles"] }`                                    |
 
-- For other installation issues, check the [Angular README](../../app/angular/README.md) for additional instructions.
+- For other installation issues, check the [Angular README](https://github.com/storybookjs/storybook/tree/next/code/frameworks/angular) for additional instructions.

--- a/docs/get-started/installation-problems/ember.mdx
+++ b/docs/get-started/installation-problems/ember.mdx
@@ -20,4 +20,4 @@ Update the [`@storybook/ember-cli-storybook`](https://www.npmjs.com/package/@sto
   npx storybook init --package-manager=npm
   ```
 
-- For other installation issues, check the [Ember README](../../app/ember/README.md) for additional instructions.
+- For other installation issues, check the [Ember README](https://github.com/storybookjs/storybook/tree/next/code/frameworks/ember) for additional instructions.

--- a/docs/get-started/installation-problems/html.mdx
+++ b/docs/get-started/installation-problems/html.mdx
@@ -4,4 +4,6 @@
   npx storybook init --type html
   ```
 
-- For other installation issues, check the [Html README](../../app/html/README.md) for additional instructions.
+- For other installation issues, check the React README files for additional instructions:
+  - [HTML with Webpack]( https://github.com/storybookjs/storybook/tree/next/code/frameworks/html-webpack5)
+  - [HTML with Vite](https://github.com/storybookjs/storybook/tree/next/code/frameworks/html-vite)

--- a/docs/get-started/installation-problems/preact.mdx
+++ b/docs/get-started/installation-problems/preact.mdx
@@ -10,4 +10,4 @@
   npx storybook init --package-manager=npm
   ```
 
-- For other installation issues, check the [Preact README](../../app/preact/README.md) for additional instructions.
+- For other installation issues, check the [Preact README](https://github.com/storybookjs/storybook/tree/next/code/frameworks/preact-webpack5) for additional instructions.

--- a/docs/get-started/installation-problems/react.mdx
+++ b/docs/get-started/installation-problems/react.mdx
@@ -16,6 +16,8 @@
   npx storybook@next automigrate
   ```
 
-  Check the [Migration Guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#cra5-upgrade) for more information on how to set up Webpack 5.
+Check the [Migration Guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#cra5-upgrade) for more information on how to set up Webpack 5.
 
-- For other installation issues, check the [React README](../../app/react/README.md) for additional instructions.
+- For other installation issues, check the React README files for additional instructions:
+  - [React with Webpack](https://github.com/storybookjs/storybook/tree/next/code/frameworks/react-webpack5)
+  - [React with Vite](https://github.com/storybookjs/storybook/tree/next/code/frameworks/react-vite)

--- a/docs/get-started/installation-problems/svelte.mdx
+++ b/docs/get-started/installation-problems/svelte.mdx
@@ -10,5 +10,16 @@
   npx storybook init --package-manager=npm
   ```
 
+### Svelte Native
+
+To enable support for Svelte Native story format you'll need to make the following changes your Storybook configuration:
+- Add the [`@storybook/addon-svelte-csf`](https://storybook.js.org/addons/@storybook/addon-svelte-csf/) addon as development dependency.
+- Enable the addon in your Storybook configuration file (e.g., `.storybook/main.js`).
+- Disable on demand story loading configuration property (e.g., `storyStoreV7`) in your Storybook configuration file.
 - For issues with Svelte Native Story Format, check the [Svelte Story Format addon repository](https://github.com/storybookjs/addon-svelte-csf) for instructions.
-- For other installation issues, check the [Svelte README](../../app/svelte/README.md) for additional instructions.
+
+
+- For other installation issues, check the Svelte README files for additional instructions:
+  - [Svelte with Webpack](https://github.com/storybookjs/storybook/tree/next/code/frameworks/svelte-webpack5)
+  - [Svelte with Vite](https://github.com/storybookjs/storybook/tree/next/code/frameworks/svelte-vite)
+  - [SvelteKit](https://github.com/storybookjs/storybook/tree/next/code/frameworks/sveltekit)

--- a/docs/get-started/installation-problems/vue.mdx
+++ b/docs/get-started/installation-problems/vue.mdx
@@ -14,5 +14,8 @@
   npx storybook init --package-manager=npm
   ```
 
-- For other installation issues, check the [Vue 2 README](../../app/vue/README.md), or the [Vue 3 README](../../app/vue3/README.md) for additional instructions.
-- Vue 3 support is under active development, and we encourage feedback and improvements. Check the [contribution guidelines to help us improve it](../../CONTRIBUTING.md).
+- For other installation issues, check the Vue README files for additional instructions:
+  - [Vue 2 with Webpack](https://github.com/storybookjs/storybook/tree/next/code/frameworks/vue-webpack5)
+  - [Vue 2 with Vite](https://github.com/storybookjs/storybook/tree/next/code/frameworks/vue-vite)
+  - [Vue 3 with Webpack](https://github.com/storybookjs/storybook/tree/next/code/frameworks/vue3-webpack5)
+  - [Vue 3 with Vite](https://github.com/storybookjs/storybook/tree/next/code/frameworks/vue3-vite)

--- a/docs/get-started/installation-problems/web-components.mdx
+++ b/docs/get-started/installation-problems/web-components.mdx
@@ -4,4 +4,6 @@
   npx storybook init --type web_components
   ```
 
-- For other installation issues, check the [Web Components README](../../app/web-components/README.md) for additional instructions.
+- For other installation issues, check the Web Components README files for additional instructions:
+  - [Web Components with Webpack](https://github.com/storybookjs/storybook/tree/next/code/frameworks/web-components-webpack5)
+  - [Web Components with Vite](https://github.com/storybookjs/storybook/tree/next/code/frameworks/web-components-vite)


### PR DESCRIPTION
With this pull request, the framework install issues documentation is updated to reflect the changes per the new structure set in place recently.

Addresses and closes #19993

What was done:
- Updated the links of the framework to point at the right place in the monorepo
- Updated Svelte instructions to add more context about the Native format