### PR TITLE
Fixes path for snapshot testing

### DIFF
--- a/docs/frameworks.js
+++ b/docs/frameworks.js
@@ -88,7 +88,7 @@ module.exports = {
         {
           name: 'Storyshots',
           unsupported: ['ember'],
-          path: 'workflows/unit-testing',
+          path: 'writing-tests/snapshot-testing',
         },
         {
           name: 'storysource',


### PR DESCRIPTION
With this pull request, the path used in the frameworks file is updated to point to the right place for snapshot testing. As the current URL is not valid.

@valentinpalkovic I've looped you in this so that you have a bit of context on where/ how to apply the changes that reflect the [API/Framework feature support](https://storybook.js.org/docs/7.0/react/api/frameworks-feature-support) documentation




