### PR TITLE
Update addon-catalog to integration-catalog

### DIFF
--- a/docs/addons/integration-catalog.md
+++ b/docs/addons/integration-catalog.md
@@ -1,8 +1,12 @@
 ---
-title: 'Add to the addon catalog'
+title: 'Add to the integration catalog'
 ---
 
-Storybook addons are listed in the [catalog](https://storybook.js.org/addons/) and distributed via npm. The catalog is populated by querying npm's registry for Storybook-specific metadata in `package.json`.
+Storybook has two types of integrations, addons and recipes, which are listed in the [integration catalog](https://storybook.js.org/integrations/).
+
+## Addons
+
+Storybook addons are distributed via npm. The catalog is populated by querying npm's registry for Storybook-specific metadata in `package.json`.
 
 Add your addon to the catalog by publishing a npm package that follows these requirements:
 
@@ -17,7 +21,7 @@ Get a refresher on how to [write a Storybook addon](./writing-addons.md).
 
 </div>
 
-## Addon metadata
+### Addon metadata
 
 We rely on metadata to organize your addon in the catalog. You must add the <code>storybook-addons</code> as the first keyword, followed by your addon's category. Additional keywords will be used in search and as tags.
 
@@ -85,3 +89,17 @@ The `package.json` above appears like below in the catalog. See an example of a 
 #### How long does it take for my addon to show up in the catalog?
 
 Once you publish the addon, it will appear in the catalog. There may be a delay between the time you publish your addon and when it's listed in the catalog. If your addon doesn't show up within 24 hours, [open an issue](https://github.com/storybookjs/frontpage/issues).
+
+## Recipes
+
+Recipes are a set of instructions to integrate third-party libraries into Storybook in cases where an addon does not exist or the integration requires some manual effort.
+
+### Who owns them?
+
+Recipes are written and maintained by the Storybook team. We create recipes based on community popularity, tool maturity, and stability of the integration. Our goal is to ensure that recipes continue to work over time.
+
+Not finding the recipe that you want? If it's popular in the community, our docs team will write one. In the mean time, try searching for a solution — it's likely that someone has the same requirements as you do. You can also help us out by writing recipes on your own site which speeds up the research process.
+
+### Request a recipe
+
+If you'd like to request a recipe, head over to the [#maintenance channel](https://discord.com/channels/486522875931656193/490070912448724992) of our community Discord and ask.

--- a/docs/addons/writing-addons.md
+++ b/docs/addons/writing-addons.md
@@ -245,7 +245,7 @@ Now that you've seen how to create a bare-bones addon let's see how to share it 
 
 Reference the [storybook-addon-outline](https://www.npmjs.com/package/storybook-addon-outline) to see a project that meets these requirements.
 
-Learn how to [add to the addon catalog](./addon-catalog.md).
+Learn how to [add to the addon catalog](../addons/integration-catalog.md#addons).
 
 ### More guides and tutorials
 

--- a/docs/toc.js
+++ b/docs/toc.js
@@ -331,7 +331,7 @@ module.exports = {
           type: 'link',
         },
         {
-          pathSegment: 'addon-catalog',
+          pathSegment: 'integration-catalog',
           title: 'Add to catalog',
           type: 'link',
         },


### PR DESCRIPTION
## What I did

`/docs/addons/addon-catalog` -> `/docs/addons/integration-catalog`

(Corresponds to #20108 & #20186 on `next`)

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
