### PR TITLE
CLI: Add React peer dep runtime check

### DIFF
--- a/code/lib/cli/src/build.ts
+++ b/code/lib/cli/src/build.ts
@@ -2,8 +2,11 @@ import { sync as readUpSync } from 'read-pkg-up';
 import { logger } from '@storybook/node-logger';
 import { buildStaticStandalone, withTelemetry } from '@storybook/core-server';
 import { cache } from '@storybook/core-common';
+import { ensureReactPeerDeps } from './ensure-react-peer-deps';
 
 export const build = async (cliOptions: any) => {
+  ensureReactPeerDeps();
+
   try {
     const options = {
       ...cliOptions,

--- a/code/lib/cli/src/dev.ts
+++ b/code/lib/cli/src/dev.ts
@@ -3,9 +3,12 @@ import { sync as readUpSync } from 'read-pkg-up';
 import { logger, instance as npmLog } from '@storybook/node-logger';
 import { buildDevStandalone, withTelemetry } from '@storybook/core-server';
 import { cache } from '@storybook/core-common';
+import { ensureReactPeerDeps } from './ensure-react-peer-deps';
 
 export const dev = async (cliOptions: any) => {
   process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
+  ensureReactPeerDeps();
 
   try {
     const options = {

--- a/code/lib/cli/src/ensure-react-peer-deps.ts
+++ b/code/lib/cli/src/ensure-react-peer-deps.ts
@@ -8,7 +8,22 @@ export function ensureReactPeerDeps() {
   } catch (e) {
     logger.error(dedent`
       Starting in 7.0, react and react-dom are now required peer dependencies of Storybook.
-      Please install react and react-dom in your project.
+      https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-peer-dependencies-required
+
+      It seems, that you haven't run Storybook's CLI to upgrade to the latest version.
+      The upgrade command will install the required peer dependencies for you and will take 
+      care of other important auto migrations as well.
+
+      If you want to upgrade to the latest prerelease version, please run:
+
+      $ npx storybook@next upgrade --prerelease
+
+      Otherwise, please run:
+
+      $ npx storybook upgrade
+
+      If you do not want to use the upgrade commands, 
+      please install react and react-dom in your project manually.
 
       npm:
       $ npm add react react-dom --dev

--- a/code/lib/cli/src/ensure-react-peer-deps.ts
+++ b/code/lib/cli/src/ensure-react-peer-deps.ts
@@ -1,0 +1,24 @@
+import { logger } from '@storybook/node-logger';
+import dedent from 'ts-dedent';
+
+export function ensureReactPeerDeps() {
+  try {
+    require.resolve('react');
+    require.resolve('react-dom');
+  } catch (e) {
+    logger.error(dedent`
+      Starting in 7.0, react and react-dom are now required peer dependencies of Storybook.
+      Please install react and react-dom in your project.
+
+      npm:
+      $ npm add react react-dom --dev
+
+      yarn:
+      $ yarn add react react-dom --dev
+
+      pnpm:
+      $ pnpm add react react-dom --dev
+    `);
+    process.exit(1);
+  }
+}

--- a/code/lib/cli/src/ensure-react-peer-deps.ts
+++ b/code/lib/cli/src/ensure-react-peer-deps.ts
@@ -10,7 +10,7 @@ export function ensureReactPeerDeps() {
       Starting in 7.0, react and react-dom are now required peer dependencies of Storybook.
       https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-peer-dependencies-required
 
-      It seems, that you haven't run Storybook's CLI to upgrade to the latest version.
+      It seems that you haven't run Storybook's CLI to upgrade to the latest version.
       The upgrade command will install the required peer dependencies for you and will take 
       care of other important auto migrations as well.
 


### PR DESCRIPTION
Issue: #20203

## What I did

Adding a peer dep error when react and react-dom are not installed.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
