### PR TITLE
CLI: execute automigrations when pressing enter in the prompts

### DIFF
--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -66,6 +66,7 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
           type: 'confirm',
           name: 'fix',
           message: `Do you want to run the '${chalk.cyan(f.id)}' migration on your project?`,
+          initial: true,
         });
       }
 


### PR DESCRIPTION
Issue: N/A

## What I did

This PR makes the automigrations execute when users press enter in the prompt

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
