### PR TITLE
CLI: Split sb-scripts into two different migrations

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/index.ts
+++ b/code/lib/cli/src/automigrate/fixes/index.ts
@@ -8,6 +8,7 @@ import { mainjsFramework } from './mainjsFramework';
 import { eslintPlugin } from './eslint-plugin';
 import { builderVite } from './builder-vite';
 import { sbScripts } from './sb-scripts';
+import { sbBinary } from './sb-binary';
 import { newFrameworks } from './new-frameworks';
 import { removedGlobalClientAPIs } from './remove-global-client-apis';
 import { mdx1to2 } from './mdx-1-to-2';
@@ -26,6 +27,7 @@ export const fixes: Fix[] = [
   eslintPlugin,
   sveltekitFramework,
   builderVite,
+  sbBinary,
   sbScripts,
   newFrameworks,
   removedGlobalClientAPIs,

--- a/code/lib/cli/src/automigrate/fixes/sb-binary.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-binary.test.ts
@@ -1,0 +1,77 @@
+import type { JsPackageManager, PackageJson } from '../../js-package-manager';
+import { sbBinary } from './sb-binary';
+
+const checkStorybookBinary = async ({ packageJson }: { packageJson: PackageJson }) => {
+  const packageManager = {
+    retrievePackageJson: () => ({ dependencies: {}, devDependencies: {}, ...packageJson }),
+  } as JsPackageManager;
+  return sbBinary.check({ packageManager });
+};
+
+describe('storybook-binary fix', () => {
+  describe('sb < 7.0', () => {
+    describe('does nothing', () => {
+      const packageJson = { dependencies: { '@storybook/react': '^6.2.0' } };
+      it('should no-op', async () => {
+        await expect(
+          checkStorybookBinary({
+            packageJson,
+          })
+        ).resolves.toBeFalsy();
+      });
+    });
+  });
+
+  describe('sb >= 7.0', () => {
+    it('should add storybook dependency if not present', async () => {
+      const packageJson = {
+        dependencies: {
+          '@storybook/react': '^7.0.0-alpha.0',
+        },
+      };
+      await expect(
+        checkStorybookBinary({
+          packageJson,
+        })
+      ).resolves.toEqual(
+        expect.objectContaining({
+          hasSbBinary: false,
+          hasStorybookBinary: false,
+        })
+      );
+    });
+
+    it('should remove sb dependency if it is present', async () => {
+      const packageJson = {
+        dependencies: {
+          '@storybook/react': '^7.0.0-alpha.0',
+          sb: '6.5.0',
+        },
+      };
+      await expect(
+        checkStorybookBinary({
+          packageJson,
+        })
+      ).resolves.toEqual(
+        expect.objectContaining({
+          hasSbBinary: true,
+          hasStorybookBinary: false,
+        })
+      );
+    });
+
+    it('should no op if storybook is present and sb is not present', async () => {
+      const packageJson = {
+        dependencies: {
+          '@storybook/react': '^7.0.0-alpha.0',
+          storybook: '^7.0.0-alpha.0',
+        },
+      };
+      await expect(
+        checkStorybookBinary({
+          packageJson,
+        })
+      ).resolves.toBeNull();
+    });
+  });
+});

--- a/code/lib/cli/src/automigrate/fixes/sb-binary.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-binary.ts
@@ -1,0 +1,108 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+import semver from 'semver';
+import { getStorybookInfo } from '@storybook/core-common';
+import type { Fix } from '../types';
+import { getStorybookVersionSpecifier } from '../../helpers';
+import type { PackageJsonWithDepsAndDevDeps } from '../../js-package-manager';
+
+interface SbBinaryRunOptions {
+  storybookVersion: string;
+  hasSbBinary: boolean;
+  hasStorybookBinary: boolean;
+  packageJson: PackageJsonWithDepsAndDevDeps;
+}
+
+const logger = console;
+
+/**
+ * Does the user not have storybook dependency?
+ *
+ * If so:
+ * - Add storybook dependency
+ * - If they are using sb dependency, remove it
+ */
+export const sbBinary: Fix<SbBinaryRunOptions> = {
+  id: 'storybook-binary',
+
+  async check({ packageManager }) {
+    const packageJson = packageManager.retrievePackageJson();
+    const { devDependencies, dependencies } = packageJson;
+    const { version: storybookVersion } = getStorybookInfo(packageJson);
+
+    const allDeps = { ...dependencies, ...devDependencies };
+
+    const storybookCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
+    if (!storybookCoerced) {
+      logger.warn(dedent`
+        ❌ Unable to determine storybook version, skipping ${chalk.cyan(this.id)} fix.
+        🤔 Are you running automigrate from your project directory?
+      `);
+      return null;
+    }
+
+    if (semver.lt(storybookCoerced, '7.0.0')) {
+      return null;
+    }
+
+    const hasSbBinary = !!allDeps.sb;
+    const hasStorybookBinary = !!allDeps.storybook;
+
+    if (!hasSbBinary && hasStorybookBinary) {
+      return null;
+    }
+
+    return {
+      hasSbBinary,
+      hasStorybookBinary,
+      storybookVersion,
+      packageJson,
+    };
+  },
+
+  prompt({ storybookVersion, hasSbBinary, hasStorybookBinary }) {
+    const sbFormatted = chalk.cyan(`Storybook ${storybookVersion}`);
+
+    const storybookBinaryMessage = !hasStorybookBinary
+      ? `We've detected you are using ${sbFormatted} without Storybook's ${chalk.magenta(
+          'storybook'
+        )} binary. Starting in Storybook 7.0, it has to be installed.`
+      : '';
+
+    const extraMessage = hasSbBinary
+      ? "You're using the 'sb' binary and it should be replaced, as 'storybook' is the recommended way to run Storybook.\n"
+      : '';
+
+    return dedent`
+      ${storybookBinaryMessage}
+      ${extraMessage}
+
+      More info: ${chalk.yellow(
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#start-storybook--build-storybook-binaries-removed'
+      )}
+      `;
+  },
+
+  async run({ result: { packageJson, hasSbBinary, hasStorybookBinary }, packageManager, dryRun }) {
+    if (hasSbBinary) {
+      logger.info(`✅ Removing 'sb' dependency`);
+      if (!dryRun) {
+        packageManager.removeDependencies({ skipInstall: !hasStorybookBinary, packageJson }, [
+          'sb',
+        ]);
+      }
+    }
+
+    if (!hasStorybookBinary) {
+      logger.log();
+      logger.info(`✅ Adding 'storybook' as dev dependency`);
+      logger.log();
+      if (!dryRun) {
+        const versionToInstall = getStorybookVersionSpecifier(packageJson);
+        packageManager.addDependencies({ installAsDevDependencies: true }, [
+          `storybook@${versionToInstall}`,
+        ]);
+      }
+    }
+  },
+};

--- a/code/lib/cli/src/automigrate/fixes/sb-scripts.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-scripts.test.ts
@@ -12,6 +12,7 @@ describe('getStorybookScripts', () => {
   it('detects default storybook scripts', () => {
     expect(
       getStorybookScripts({
+        'sb:upgrade': 'sb upgrade',
         storybook: 'start-storybook',
         'build-storybook': 'build-storybook',
       })
@@ -23,6 +24,10 @@ describe('getStorybookScripts', () => {
       storybook: {
         before: 'start-storybook',
         after: 'storybook dev',
+      },
+      'sb:upgrade': {
+        before: 'sb upgrade',
+        after: 'storybook upgrade',
       },
     });
   });
@@ -135,27 +140,10 @@ describe('sb-scripts fix', () => {
       const packageJson = {
         dependencies: {
           '@storybook/react': '^7.0.0-alpha.0',
-          storybook: '^7.0.0-alpha.0',
         },
         scripts: {
           storybook: 'storybook dev -p 6006',
           'build-storybook': 'storybook build -o build/storybook',
-        },
-      };
-      it('should no-op', async () => {
-        await expect(
-          checkSbScripts({
-            packageJson,
-          })
-        ).resolves.toBeFalsy();
-      });
-    });
-
-    describe('with storybook lib installed', () => {
-      const packageJson = {
-        dependencies: {
-          '@storybook/react': '^7.0.0-alpha.0',
-          storybook: '^7.0.0-alpha.0',
         },
       };
       it('should no-op', async () => {


### PR DESCRIPTION
Issue: N/A

## What I did

This PR changes the `sb-scripts` migration into two migrations:
- One that takes care of sb binaries
- Another that takes care of sb scripts

This way each migration is more focused, and they can happen independently of each other

Additionally, the sb binaries migration will make sure that `sb` is removed and users always use `storybook` instead. The usage of `sb` in scripts is also updated to `storybook`.

## Use cases

### sb-binary: User does not have `storybook` - it's installed

<img width="709" alt="image" src="https://user-images.githubusercontent.com/1671563/207294351-f78aeaf4-c652-4177-a987-7f00ceb42f7b.png">

### sb-binary: User has `storybook` lib but also `sb` - sb is removed

<img width="706" alt="image" src="https://user-images.githubusercontent.com/1671563/207293759-ff850266-a7e9-4e33-875f-322f7d9076e4.png">

### sb-binary: User does not have `storybook` and does have `sb` - storybook is installed and sb is removed

![image](https://user-images.githubusercontent.com/1671563/207293650-a837b447-d01d-4733-8e64-90b51be698b6.png)

### sb-scripts: Scripts are updated and sb becomes storybook 

![image](https://user-images.githubusercontent.com/1671563/207293621-a17411c3-b6b2-4998-bec3-593932510fc3.png)


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
