### PR TITLE
use cra/default-ts while vite issue is being resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "start": "yarn task --task dev --template react-vite/default-ts --start-from=install",
+    "start": "yarn task --task dev --template cra/default-ts --start-from=install",
     "task": "echo 'Installing Script Dependencies...'; cd scripts; yarn install >/dev/null; yarn task",
     "get-template": "cd scripts; yarn get-template",
     "get-report-message": "cd scripts; yarn get-report-message",


### PR DESCRIPTION
## What I did

Uses `cra/default-ts` in `yarn start` while MDX issue is being resolved.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
