### PR TITLE
Vite: Make the bail function work if the server fails to start

### DIFF
--- a/code/lib/builder-vite/src/index.ts
+++ b/code/lib/builder-vite/src/index.ts
@@ -69,14 +69,8 @@ function iframeMiddleware(options: ExtendedOptions, server: ViteDevServer): Requ
 
 let server: ViteDevServer;
 
-export async function bail(e?: Error): Promise<void> {
-  try {
-    return await server.close();
-  } catch (err) {
-    console.warn('unable to close vite server');
-  }
-
-  throw e;
+export async function bail(): Promise<void> {
+  return server?.close();
 }
 
 export const start: ViteBuilder['start'] = async ({

--- a/docs/snippets/common/storybook-builder-api-shutdown-server.ts.mdx
+++ b/docs/snippets/common/storybook-builder-api-shutdown-server.ts.mdx
@@ -6,7 +6,7 @@ import { createViteServer } from './vite-server';
 
 let server: ViteDevServer;
 export async function bail(): Promise<void> {
-  return await server?.close();
+  return server?.close();
 }
 
 export const start: ViteBuilder['start'] = async ({ options, server: devServer }) => {

--- a/docs/snippets/common/storybook-builder-api-shutdown-server.ts.mdx
+++ b/docs/snippets/common/storybook-builder-api-shutdown-server.ts.mdx
@@ -6,7 +6,7 @@ import { createViteServer } from './vite-server';
 
 let server: ViteDevServer;
 export async function bail(): Promise<void> {
-  return await server.close();
+  return await server?.close();
 }
 
 export const start: ViteBuilder['start'] = async ({ options, server: devServer }) => {

--- a/docs/snippets/common/storybook-builder-api-shutdown-server.ts.mdx
+++ b/docs/snippets/common/storybook-builder-api-shutdown-server.ts.mdx
@@ -3,19 +3,16 @@
 
 import { createViteServer } from './vite-server';
 
+
+let server: ViteDevServer;
+export async function bail(): Promise<void> {
+  return await server.close();
+}
+
 export const start: ViteBuilder['start'] = async ({ options, server: devServer }) => {
   // Remainder implementation goes here
-
-  const server = await createViteServer(options as ExtendedOptions, devServer);
-  async function bail(e?: Error): Promise<void> {
-    try {
-      return await server.close();
-    } catch (err) {
-      console.warn('unable to close the server');
-    }
-    throw e;
-  }
-
+  server = await createViteServer(options as ExtendedOptions, devServer);
+  
   return {
     bail,
     totalTime: process.hrtime(startTime),


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/20242

## What I did

The `bail` function didn't check the server actually existed. Plus it had some odd behaviour when it errored (catching and then rethrowing an optional error argument, that actually was never defined).

## How to test

Run SB with Vite 4, or simply add a throw to `start()` in `builder-vite/index.ts`