### PR TITLE
Addon-docs: Restore deprecated blocks entry point

### DIFF
--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -41,6 +41,11 @@
       "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
+    "./blocks": {
+      "require": "./dist/blocks.js",
+      "import": "./dist/blocks.mjs",
+      "types": "./dist/blocks.d.ts"
+    },
     "./dist/preview": {
       "require": "./dist/preview.js",
       "import": "./dist/preview.mjs",
@@ -132,6 +137,7 @@
       "./src/index.ts",
       "./src/preset.ts",
       "./src/preview.ts",
+      "./src/blocks.ts",
       "./src/shims/mdx-react-shim.ts"
     ]
   },

--- a/code/addons/docs/src/blocks.ts
+++ b/code/addons/docs/src/blocks.ts
@@ -1,0 +1,7 @@
+import { deprecate } from '@storybook/client-logger';
+
+deprecate(
+  "Import from '@storybook/addon-docs/blocks' is deprecated. Please import from '@storybook/blocks' instead."
+);
+
+export * from '@storybook/blocks';


### PR DESCRIPTION
Issue: #20149 

## What I did

Until we have an automigration, add back blocks entry point

Self-merging @tmeasday 

## How to test

- Run a sandbox
- Change the import in an MDX file to `addon-docs/blocks`
- Verify that it doesn't break and there's a deprecation warning in the browser console
