### PR TITLE
Fix issues with running SSv6

### DIFF
--- a/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -147,8 +147,6 @@ export default async (
 
     previewAnnotations.forEach((previewAnnotationFilename: string | undefined) => {
       if (!previewAnnotationFilename) return;
-      const previewApi = storybookPaths['@storybook/preview-api'];
-      const clientLogger = storybookPaths['@storybook/client-logger'];
 
       // Ensure that relative paths end up mapped to a filename in the cwd, so a later import
       // of the `previewAnnotationFilename` in the template works.
@@ -159,8 +157,6 @@ export default async (
       // file, see https://github.com/storybookjs/storybook/pull/16727#issuecomment-986485173
       virtualModuleMapping[entryFilename] = interpolate(entryTemplate, {
         previewAnnotationFilename,
-        previewApi,
-        clientLogger,
       });
       entries.push(entryFilename);
     });

--- a/code/lib/builder-webpack5/templates/virtualModuleEntry.template.js
+++ b/code/lib/builder-webpack5/templates/virtualModuleEntry.template.js
@@ -9,7 +9,7 @@ import {
   addArgsEnhancer,
   addArgTypesEnhancer,
   setGlobalRender,
-} from '{{previewApi}}';
+} from '@storybook/preview-api';
 import * as previewAnnotations from '{{previewAnnotationFilename}}';
 
 Object.keys(previewAnnotations).forEach((key) => {

--- a/code/ui/manager/src/components/preview/preview.tsx
+++ b/code/ui/manager/src/components/preview/preview.tsx
@@ -71,11 +71,15 @@ const createCanvas = (id: string, baseUrl = 'iframe.html', withLoader = true): A
 
           useEffect(() => {
             if (global.CONFIG_TYPE === 'DEVELOPMENT') {
-              const channel = addons.getServerChannel();
+              try {
+                const channel = addons.getServerChannel();
 
-              channel.on(PREVIEW_BUILDER_PROGRESS, (options) => {
-                setProgress(options);
-              });
+                channel.on(PREVIEW_BUILDER_PROGRESS, (options) => {
+                  setProgress(options);
+                });
+              } catch {
+                //
+              }
             }
           }, []);
 


### PR DESCRIPTION
Issue: #20252 

## What I did

- Fixed issue with v6 entrypoint template interpolation
- Don't listen to server channel if it doesn't exist.

## How to test

Run any WP sandbox in v6 mode.