### PR TITLE
Don't export renderer from framework

### DIFF
--- a/code/frameworks/nextjs/src/index.ts
+++ b/code/frameworks/nextjs/src/index.ts
@@ -1,2 +1,1 @@
-export * from '@storybook/react';
 export * from './types';


### PR DESCRIPTION
Nextjs exports the react renderer from the framework. It should only export main.ts config type.