### PR TITLE
Fix handling of inverted yes flag in `task` steps

### DIFF
--- a/docs/snippets/common/storybook-builder-api-shutdown-server.ts.mdx
+++ b/docs/snippets/common/storybook-builder-api-shutdown-server.ts.mdx
@@ -3,7 +3,6 @@
 
 import { createViteServer } from './vite-server';
 
-
 let server: ViteDevServer;
 export async function bail(): Promise<void> {
   return server?.close();
@@ -12,7 +11,7 @@ export async function bail(): Promise<void> {
 export const start: ViteBuilder['start'] = async ({ options, server: devServer }) => {
   // Remainder implementation goes here
   server = await createViteServer(options as ExtendedOptions, devServer);
-  
+
   return {
     bail,
     totalTime: process.hrtime(startTime),

--- a/scripts/utils/cli-step.ts
+++ b/scripts/utils/cli-step.ts
@@ -32,7 +32,7 @@ export const steps = {
     description: 'Initializing Storybook',
     icon: '⚙️',
     options: createOptions({
-      yes: { type: 'boolean', inverse: true },
+      yes: { type: 'boolean' },
       type: { type: 'string' },
       debug: { type: 'boolean' },
     }),

--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -29,7 +29,8 @@ export type BaseOption = {
 export type BooleanOption = BaseOption & {
   type: 'boolean';
   /**
-   * Does this option default true?
+   * If this option is set to true and the option value is false or undefined, the flag `--no-option` will be set.
+   * If the option value is true, the flag `--no-option` is not set.
    */
   inverse?: boolean;
 };


### PR DESCRIPTION
Issue:

Boolean flags got inverted in `yarn task` commands, regardless of whether they were set or not. Inverting should only happen, though, if a value is not set.

## What I did

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
