### PR TITLE
CLI: add automigration summary

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/mainjsFramework.ts
+++ b/code/lib/cli/src/automigrate/fixes/mainjsFramework.ts
@@ -31,11 +31,10 @@ export const mainjsFramework: Fix<MainjsFrameworkRunOptions> = {
 
     const storybookCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
     if (!storybookCoerced) {
-      logger.warn(dedent`
-        ❌ Unable to determine storybook version, skipping ${chalk.cyan('mainjsFramework')} fix.
+      throw new Error(dedent`
+        ❌ Unable to determine storybook version.
         🤔 Are you running automigrate from your project directory?
       `);
-      return null;
     }
 
     const main = await readConfig(mainConfig);

--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
@@ -113,11 +113,10 @@ export const newFrameworks: Fix<NewFrameworkRunOptions> = {
 
     const storybookCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
     if (!storybookCoerced) {
-      logger.warn(dedent`
-        ❌ Unable to determine storybook version, skipping ${chalk.cyan('newFrameworks')} fix.
+      throw new Error(dedent`
+        ❌ Unable to determine storybook version.
         🤔 Are you running automigrate from your project directory?
       `);
-      return null;
     }
 
     if (!semver.gte(storybookCoerced, '7.0.0')) {
@@ -151,18 +150,6 @@ export const newFrameworks: Fix<NewFrameworkRunOptions> = {
       return null;
     }
 
-    if (allDeps.vite && semver.lt(semver.coerce(allDeps.vite).version, '3.0.0')) {
-      logger.warn(dedent`
-        ❌ Detected Vite ${
-          allDeps.vite
-        }, which is unsupported in Storybook 7.0, so the ${chalk.cyan(
-        'newFrameworks'
-      )} fix will be skipped.
-      Please upgrade vite to 3.0.0 or higher and rerun this automigration with "npx storybook@future automigrate".
-      `);
-      return null;
-    }
-
     const frameworkOptions =
       // svelte-vite doesn't support svelteOptions so there's no need to move them
       newFrameworkPackage === '@storybook/svelte-vite' ? {} : getFrameworkOptions(framework, main);
@@ -183,6 +170,14 @@ export const newFrameworks: Fix<NewFrameworkRunOptions> = {
       dependenciesToAdd.push(newFrameworkPackage);
     }
 
+    if (allDeps.vite && semver.lt(semver.coerce(allDeps.vite).version, '3.0.0')) {
+      throw new Error(dedent`
+        ❌ Your project should be upgraded to use the framework package ${chalk.bold(newFrameworkPackage)}, but we detected that you are using Vite ${
+          chalk.bold(allDeps.vite)
+        }, which is unsupported in ${chalk.bold('Storybook 7.0')}. Please upgrade Vite to ${chalk.bold('3.0.0 or higher')} and rerun this migration.
+      `);
+    }
+
     return {
       main,
       dependenciesToAdd,
@@ -194,13 +189,15 @@ export const newFrameworks: Fix<NewFrameworkRunOptions> = {
     };
   },
 
-  prompt() {
+  prompt({ frameworkPackage, dependenciesToRemove }) {
     return dedent`
       We've detected you are using an older format of Storybook frameworks and builders.
 
       In Storybook 7, frameworks also specify the builder to be used.
 
-      We can remove the dependencies that are no longer needed and install the new framework that already includes the builder.
+      We can remove the dependencies that are no longer needed: ${chalk.yellow(dependenciesToRemove.join(', '))}
+      
+      And set up the ${chalk.magenta(frameworkPackage)} framework that already includes the builder.
 
       To learn more about the framework field, see: ${chalk.yellow(
         'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#framework-field-mandatory'
@@ -211,7 +208,7 @@ export const newFrameworks: Fix<NewFrameworkRunOptions> = {
       Unless you're using Storybook's Vite builder, this automigration will install a Webpack5-based framework.
       
       If you were using Storybook's Webpack4 builder (default in 6.x, discontinued in 7.0), this could be a breaking
-      change--especially if your project has a custom webpack configuration.
+      change -- especially if your project has a custom webpack configuration.
       
       To learn more about migrating from Webpack4, see: ${chalk.yellow(
         'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#webpack4-support-discontinued'

--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
@@ -172,9 +172,13 @@ export const newFrameworks: Fix<NewFrameworkRunOptions> = {
 
     if (allDeps.vite && semver.lt(semver.coerce(allDeps.vite).version, '3.0.0')) {
       throw new Error(dedent`
-        ❌ Your project should be upgraded to use the framework package ${chalk.bold(newFrameworkPackage)}, but we detected that you are using Vite ${
-          chalk.bold(allDeps.vite)
-        }, which is unsupported in ${chalk.bold('Storybook 7.0')}. Please upgrade Vite to ${chalk.bold('3.0.0 or higher')} and rerun this migration.
+        ❌ Your project should be upgraded to use the framework package ${chalk.bold(
+          newFrameworkPackage
+        )}, but we detected that you are using Vite ${chalk.bold(
+        allDeps.vite
+      )}, which is unsupported in ${chalk.bold(
+        'Storybook 7.0'
+      )}. Please upgrade Vite to ${chalk.bold('3.0.0 or higher')} and rerun this migration.
       `);
     }
 
@@ -195,7 +199,9 @@ export const newFrameworks: Fix<NewFrameworkRunOptions> = {
 
       In Storybook 7, frameworks also specify the builder to be used.
 
-      We can remove the dependencies that are no longer needed: ${chalk.yellow(dependenciesToRemove.join(', '))}
+      We can remove the dependencies that are no longer needed: ${chalk.yellow(
+        dependenciesToRemove.join(', ')
+      )}
       
       And set up the ${chalk.magenta(frameworkPackage)} framework that already includes the builder.
 

--- a/code/lib/cli/src/automigrate/fixes/nextjs-framework.ts
+++ b/code/lib/cli/src/automigrate/fixes/nextjs-framework.ts
@@ -65,11 +65,10 @@ export const nextjsFramework: Fix<NextjsFrameworkRunOptions> = {
 
     const storybookCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
     if (!storybookCoerced) {
-      logger.warn(dedent`
-        ❌ Unable to determine storybook version, skipping ${chalk.cyan('nextjsFramework')} fix.
+      throw new Error(dedent`
+        ❌ Unable to determine storybook version.
         🤔 Are you running automigrate from your project directory?
       `);
-      return null;
     }
 
     if (!semver.gte(storybookCoerced, '7.0.0')) {

--- a/code/lib/cli/src/automigrate/fixes/sb-binary.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-binary.ts
@@ -34,11 +34,10 @@ export const sbBinary: Fix<SbBinaryRunOptions> = {
 
     const storybookCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
     if (!storybookCoerced) {
-      logger.warn(dedent`
-        ❌ Unable to determine storybook version, skipping ${chalk.cyan(this.id)} fix.
+      throw new Error(dedent`
+        ❌ Unable to determine storybook version.
         🤔 Are you running automigrate from your project directory?
       `);
-      return null;
     }
 
     if (semver.lt(storybookCoerced, '7.0.0')) {

--- a/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
@@ -77,11 +77,10 @@ export const sbScripts: Fix<SbScriptsRunOptions> = {
 
     const storybookCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
     if (!storybookCoerced) {
-      logger.warn(dedent`
-        ❌ Unable to determine storybook version, skipping ${chalk.cyan(this.id)} fix.
+      throw new Error(dedent`
+        ❌ Unable to determine storybook version.
         🤔 Are you running automigrate from your project directory?
       `);
-      return null;
     }
 
     if (semver.lt(storybookCoerced, '7.0.0')) {

--- a/code/lib/cli/src/automigrate/fixes/sveltekit-framework.ts
+++ b/code/lib/cli/src/automigrate/fixes/sveltekit-framework.ts
@@ -46,11 +46,10 @@ export const sveltekitFramework: Fix<SvelteKitFrameworkRunOptions> = {
 
     const sbVersionCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
     if (!sbVersionCoerced) {
-      logger.warn(dedent`
-        ❌ Unable to determine Storybook version, skipping ${chalk.cyan(fixId)} fix.
+      throw new Error(dedent`
+        ❌ Unable to determine storybook version.
         🤔 Are you running automigrate from your project directory?
       `);
-      return null;
     }
 
     if (!semver.gte(sbVersionCoerced, '7.0.0')) {

--- a/code/lib/cli/src/automigrate/fixes/webpack5.ts
+++ b/code/lib/cli/src/automigrate/fixes/webpack5.ts
@@ -39,11 +39,10 @@ export const webpack5: Fix<Webpack5RunOptions> & CheckBuilder = {
 
     const storybookCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
     if (!storybookCoerced) {
-      logger.warn(dedent`
-        ❌ Unable to determine storybook version, skipping ${chalk.cyan('webpack5')} fix.
+      throw new Error(dedent`
+        ❌ Unable to determine storybook version.
         🤔 Are you running automigrate from your project directory?
       `);
-      return null;
     }
 
     if (semver.lt(storybookCoerced, '6.3.0')) {

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -89,9 +89,6 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
         fixStatus = FixStatus.SKIPPED;
         logger.info(`Skipping the ${chalk.cyan(f.id)} migration.`);
         logger.info();
-        logger.info(
-          `If you change your mind, run '${chalk.cyan('npx storybook@next automigrate')}'`
-        );
       }
     }
 

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -6,6 +6,7 @@ import { JsPackageManagerFactory, type PackageManagerName } from '../js-package-
 
 import type { Fix } from './fixes';
 import { fixes } from './fixes';
+import dedent from 'ts-dedent';
 
 const logger = console;
 
@@ -33,26 +34,27 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
 
   logger.info('🔎 checking possible migrations..');
   const fixResults = {} as Record<FixId, FixStatus>;
+  const fixSummary = { succeeded: [], failed: {} } as { succeeded: FixId[], failed: Record<FixId, string>};
 
   for (let i = 0; i < filtered.length; i += 1) {
     const f = fixes[i] as Fix;
     let result;
-    let fixStatus;
+    let fixStatus = FixStatus.UNNECESSARY;
+    
     try {
       result = await f.check({ packageManager });
-    } catch (e) {
+    } catch (error) {
+      logger.info(`⚠️  failed to check fix ${chalk.bold(f.id)}`);
       fixStatus = FixStatus.CHECK_FAILED;
-      logger.info(`failed to check fix: ${f.id}`);
+      fixSummary.failed[f.id] = error.message;
     }
-    if (!result) {
-      fixStatus = FixStatus.UNNECESSARY;
-    } else {
-      logger.info(`🔎 found a '${chalk.cyan(f.id)}' migration:`);
-      logger.info();
+
+    if (result) {
+      logger.info(`\n🔎 found a '${chalk.cyan(f.id)}' migration:`);
       const message = f.prompt(result);
 
       logger.info(
-        boxen(message, { borderStyle: 'round', padding: 1, borderColor: '#F1618C' } as any)
+        boxen(message, { borderStyle: 'round', padding: 1, borderColor: '#F1618C' })
       );
 
       let runAnswer: { fix: boolean };
@@ -75,8 +77,10 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
           await f.run({ result, packageManager, dryRun });
           logger.info(`✅ ran ${chalk.cyan(f.id)} migration`);
           fixStatus = FixStatus.SUCCEEDED;
+          fixSummary.succeeded.push(f.id);
         } catch (error) {
           fixStatus = FixStatus.FAILED;
+          fixSummary.failed[f.id] = error.message;
           logger.info(`❌ error when running ${chalk.cyan(f.id)} migration:`);
           logger.info(error);
           logger.info();
@@ -91,12 +95,46 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
       }
     }
 
-    fixResults[f.id] = fixStatus;
+    fixResults[f.id] = fixStatus
   }
 
-  logger.info();
-  logger.info('✅ migration check successfully ran');
-  logger.info();
+  logger.info()
+  logger.info(getMigrationSummary(fixResults, fixSummary));
+  logger.info()
 
   return fixResults;
 };
+
+function getMigrationSummary(fixResults: Record<string, FixStatus>, fixSummary: { succeeded: FixId[]; failed: Record<FixId, string>; }) {
+  const hasNoFixes = Object.values(fixResults).every((r) => r === FixStatus.UNNECESSARY);
+  const hasFailures = Object.values(fixResults).some((r) => r === FixStatus.FAILED || r === FixStatus.CHECK_FAILED);
+  let title = hasNoFixes ? 'No migrations were applicable to your project' : hasFailures ? 'Migration check ran with failures' : 'Migration check ran successfully';
+
+  let successfulFixesMessage = fixSummary.succeeded.length > 0
+    ? `
+      ${chalk.bold('Migrations that succeeded:')}\n\n ${fixSummary.succeeded.map(m => chalk.green(m)).join(', ')}
+    `
+    : '';
+
+  let failedFixesMessage = Object.keys(fixSummary.failed).length > 0
+    ? `
+    ${chalk.bold('Migrations that failed:')}\n ${Object.entries(fixSummary.failed).reduce((acc, [id, error]) => {
+      return acc + `\n${chalk.redBright(id)}:\n${error}`;
+    }, '')}
+    \n`
+    : '';
+
+  const divider = hasNoFixes ? '' : '\n─────────────────────────────────────────────────\n\n';
+
+  let summaryMessage = dedent`
+    ${successfulFixesMessage}${failedFixesMessage}${divider}If you'd like to run the migrations again, you can do so by running '${chalk.cyan('npx storybook@next automigrate')}'
+    
+    The automigrations try to migrate common patterns in your project, but might not contain everything needed to migrate to the latest version of Storybook.
+    
+    Please check the changelog and migration guide for manual migrations and more information: ${chalk.yellow('https://storybook.js.org/migration-guides/7.0')}
+    And reach out on Discord if you need help: ${chalk.yellow('https://discord.gg/storybook')}
+  `;
+
+  return boxen(summaryMessage, { borderStyle: 'round', padding: 1, title, borderColor: hasFailures ? 'red' : 'green' });
+}
+

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -119,7 +119,7 @@ function getMigrationSummary(fixResults: Record<string, FixStatus>, fixSummary: 
   let failedFixesMessage = Object.keys(fixSummary.failed).length > 0
     ? `
     ${chalk.bold('Migrations that failed:')}\n ${Object.entries(fixSummary.failed).reduce((acc, [id, error]) => {
-      return acc + `\n${chalk.redBright(id)}:\n${error}`;
+      return acc + `\n${chalk.redBright(id)}:\n${error}\n`;
     }, '')}
     \n`
     : '';


### PR DESCRIPTION
Issue: #20222

## What I did

Improved the automigration CLI command to provide a summary of what happened.

### Successful migrations

<img width="662" alt="image" src="https://user-images.githubusercontent.com/1671563/207670366-6672f09d-36f3-469c-86ce-a23a20cf66e6.png">

### No migrations applied

<img width="660" alt="image" src="https://user-images.githubusercontent.com/1671563/207668494-5952806e-c3b5-4e4b-9533-b655f2a1d31f.png">

### Migration with some success but also failures

<img width="662" alt="image" src="https://user-images.githubusercontent.com/1671563/207669743-c5221bd9-ee2e-4411-a884-5be6e42d1b94.png">

### Migration with only failures

<img width="663" alt="image" src="https://user-images.githubusercontent.com/1671563/207669850-f0f23440-78f4-48ca-a1d8-9475784e804b.png">

### Migration with multiple failures

In this example, the storybook version specifier is "next", which fails. That's a known bug and we'll fix it in a different PR.

<img width="555" alt="image" src="https://user-images.githubusercontent.com/1671563/207672425-127e6ab4-02b3-4daf-93d9-359b5da43222.png">


----------


Finally, an example with a full output (it's ugly, I know, but we can deal with making the package managers silent later):

<img width="555" alt="image" src="https://user-images.githubusercontent.com/1671563/207670576-1d27780a-11d1-4b2a-834c-01e238784e2e.png">


## How to test

You'll have to build the project, and alias the Storybook CLI binaries to then run in any project of your choosing.

```
alias sb='$HOME/open-source/storybook/code/lib/cli/bin/index.js'

# in whatever project:
sb upgrade --prerelease
```

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
