### PR TITLE
Fix: ensure manager entries load even if preceding ones failed

### DIFF
--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -77,6 +77,14 @@ export const getConfig: ManagerBuilder['getConfig'] = async (options) => {
       globalExternals(definitions),
       pnpPlugin(),
     ],
+
+    banner: {
+      js: 'try{',
+    },
+    footer: {
+      js: '}catch(e){ console.log("ONE OF YOUR MANAGER-ENTRIES FAILED: " + import.meta.url) }',
+    },
+
     define: {
       'process.env.NODE_ENV': "'production'",
       'process.env': '{}',

--- a/code/lib/builder-manager/templates/template.ejs
+++ b/code/lib/builder-manager/templates/template.ejs
@@ -38,9 +38,20 @@
     <script type="module">
       import './sb-manager/runtime.mjs';
 
-      <% files.js.forEach(file => { %>
-      import './<%= file %>';
-      <% }); %>
+      const addons = [
+        <% files.js.forEach(file => { %>
+        './<%= file %>',
+        <% }); %>
+      ];
+
+      /* error handling of manager-addons being broken */
+      const results = await Promise.allSettled(addons.map(addon => import(addon))).then(results => {
+        results.forEach((result, index) => {
+          if(result.status =='rejected'){
+            console.error(`loading ${addons[index]} failed to load correctly`);
+          }
+        })
+      });
     </script>    
   </body>
 </html>

--- a/code/lib/builder-manager/templates/template.ejs
+++ b/code/lib/builder-manager/templates/template.ejs
@@ -8,7 +8,6 @@
     <link rel="icon" type="image/svg+xml" href="./favicon.svg">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <link href="./sb-preview/runtime.mjs" rel="preload" as="script">
 
     <% if (typeof head !== 'undefined') { %> <%- head %> <% } %>
 
@@ -38,20 +37,11 @@
     <script type="module">
       import './sb-manager/runtime.mjs';
 
-      const addons = [
-        <% files.js.forEach(file => { %>
-        './<%= file %>',
-        <% }); %>
-      ];
-
-      /* error handling of manager-addons being broken */
-      const results = await Promise.allSettled(addons.map(addon => import(addon))).then(results => {
-        results.forEach((result, index) => {
-          if(result.status =='rejected'){
-            console.error(`loading ${addons[index]} failed to load correctly`);
-          }
-        })
-      });
+      <% files.js.forEach(file => { %>
+      import '<%= file %>';
+      <% }); %>     
     </script>    
+
+    <link href="./sb-preview/runtime.mjs" rel="preload" as="script">
   </body>
 </html>


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/20285

## What I did

I changed the generated code loading managerEntries so there's error handling