### PR TITLE
Support Angular 15.0.4

### DIFF
--- a/code/frameworks/angular/src/server/plugins/storybook-normalize-angular-entry-plugin.js
+++ b/code/frameworks/angular/src/server/plugins/storybook-normalize-angular-entry-plugin.js
@@ -25,23 +25,28 @@ export default class StorybookNormalizeAngularEntryPlugin {
   }
 
   apply(compiler) {
-    const webpackOptions = compiler.options;
-    const entry =
-      typeof webpackOptions.entry === 'function' ? webpackOptions.entry() : webpackOptions.entry;
+    compiler.hooks.environment.tap(PLUGIN_NAME, () => {
+      const webpackOptions = compiler.options;
+      const entry =
+        typeof webpackOptions.entry === 'function' ? webpackOptions.entry() : webpackOptions.entry;
 
-    webpackOptions.entry = async () => {
-      const entryResult = await entry;
+      webpackOptions.entry = async () => {
+        const entryResult = await entry;
 
-      if (entryResult.main && entryResult.styles) {
-        return {
-          main: {
-            import: Array.from(new Set([...entryResult.main.import, ...entryResult.styles.import])),
-          },
-        };
-      }
+        if (entryResult.main && entryResult.styles) {
+          return {
+            main: {
+              import: Array.from(
+                new Set([...entryResult.main.import, ...entryResult.styles.import])
+              ),
+            },
+          };
+        }
 
-      return entry;
-    };
+        return entry;
+      };
+    });
+
     compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
       this.compilation = compilation;
     });


### PR DESCRIPTION
Issue: N/A

## What I did

Angular changed the manipulation behavior in https://github.com/angular/angular-cli/commit/ccc8e0350810d123269f55de29acd7964e663f7e#. The webpack plugin adjusts the webpack entry while preparing the webpack [compiler environment ](https://webpack.js.org/api/compiler-hooks/#environment). The Storybook plugin overwrites webpack.entry earlier, which caused the issue. Now the timing is adjusted and it will overwrite the webpack.entry output of Angular's `Styles Webpack Plugin`.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
