### PR TITLE
Make the viewport addon compatible with composition.

### DIFF
--- a/code/addons/viewport/src/Tool.tsx
+++ b/code/addons/viewport/src/Tool.tsx
@@ -58,7 +58,6 @@ const toLinks = memoize(50)((list: ViewportItem[], active: LinkBase, set, state,
     .filter(Boolean);
 });
 
-const iframeId = 'storybook-preview-iframe';
 const wrapperId = 'storybook-preview-wrapper';
 
 interface LinkBase {
@@ -208,7 +207,7 @@ export const ViewportTool: FC = memo(
           <ActiveViewportSize>
             <Global
               styles={{
-                [`#${iframeId}`]: {
+                [`iframe[data-is-storybook="true"]`]: {
                   margin: `auto`,
                   transition: 'width .3s, height .3s',
                   position: 'relative',


### PR DESCRIPTION
So the current viewport addon uses the hardcoded DOM id of the preview iframe for changing the size: `#storybook-preview-iframe`. This means it will never change the size of any ref iframes. This PR fixes that by changing the selector to `iframe[data-is-storybook="true"]`.

With help from @ndelangen :)