### PR TITLE
CLI: sb migrate csf-2-to-3 doesn't work glob that uses multiple file extension 

### DIFF
--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -60,6 +60,7 @@
     "util": "^0.12.4"
   },
   "devDependencies": {
+    "@types/jscodeshift": "^0.11.6",
     "jest": "^29.3.1",
     "jest-specific-snapshot": "^7.0.0",
     "typescript": "~4.9.3"

--- a/code/lib/codemod/src/index.js
+++ b/code/lib/codemod/src/index.js
@@ -59,7 +59,17 @@ export async function runCodemod(codemod, { glob, logger, dryRun, rename, parser
     const parserArgs = inferredParser ? ['--parser', inferredParser] : [];
     spawnSync(
       'npx',
-      ['jscodeshift', '-t', `${TRANSFORM_DIR}/${codemod}.js`, ...parserArgs, ...files],
+      [
+        'jscodeshift',
+        // this makes sure codeshift doesn't transform our own source code with babel
+        // which is faster, and also makes sure the user won't see babel messages such as:
+        // [BABEL] Note: The code generator has deoptimised the styling of repo/node_modules/prettier/index.js as it exceeds the max of 500KB.
+        '--no-babel',
+        '-t',
+        `${TRANSFORM_DIR}/${codemod}.js`,
+        ...parserArgs,
+        ...files,
+      ],
       {
         stdio: 'inherit',
         shell: true,

--- a/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
@@ -7,8 +7,10 @@ expect.addSnapshotSerializer({
   test: () => true,
 });
 
-const jsTransform = (source: string) => _transform({ source }, null, {}).trim();
-const tsTransform = (source: string) => _transform({ source }, null, { parser: 'tsx' }).trim();
+const jsTransform = (source: string) =>
+  _transform({ source, path: 'Component.stories.js' }, null, {}).trim();
+const tsTransform = (source: string) =>
+  _transform({ source, path: 'Component.stories.ts' }, null, { parser: 'tsx' }).trim();
 
 describe('csf-2-to-3', () => {
   describe('javascript', () => {

--- a/code/lib/codemod/src/transforms/csf-2-to-3.ts
+++ b/code/lib/codemod/src/transforms/csf-2-to-3.ts
@@ -181,4 +181,6 @@ function transform({ source }: { source: string }, api: any, options: { parser?:
   });
 }
 
+export const parser = 'tsx';
+
 export default transform;

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6238,6 +6238,7 @@ __metadata:
     "@storybook/csf-tools": 7.0.0-beta.12
     "@storybook/node-logger": 7.0.0-beta.12
     "@storybook/types": 7.0.0-beta.12
+    "@types/jscodeshift": ^0.11.6
     cross-spawn: ^7.0.3
     globby: ^11.0.2
     jest: ^29.3.1
@@ -8572,6 +8573,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jscodeshift@npm:^0.11.6":
+  version: 0.11.6
+  resolution: "@types/jscodeshift@npm:0.11.6"
+  dependencies:
+    ast-types: ^0.14.1
+    recast: ^0.20.3
+  checksum: 1d204a4c3d9f52669e315dfbc1e65434ec55ee884574306d35048b89ef83b625c64d510228b6aabbd4248af566e02e0ce9de0aa8ccdfff696c69fbaced7007e7
+  languageName: node
+  linkType: hard
+
 "@types/jsdom@npm:^16.2.4":
   version: 16.2.15
   resolution: "@types/jsdom@npm:16.2.15"
@@ -10878,7 +10889,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-types@npm:0.14.2, ast-types@npm:^0.14.2":
+"ast-types@npm:0.14.2, ast-types@npm:^0.14.1, ast-types@npm:^0.14.2":
   version: 0.14.2
   resolution: "ast-types@npm:0.14.2"
   dependencies:
@@ -28137,7 +28148,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"recast@npm:^0.20.4":
+"recast@npm:^0.20.3, recast@npm:^0.20.4":
   version: 0.20.5
   resolution: "recast@npm:0.20.5"
   dependencies:


### PR DESCRIPTION
Issues: https://github.com/storybookjs/storybook/issues/20265

What I did:

* This makes tsx the default parser for csf-2-to-3. The tsx parser adds the neccesary jsx and typescript plugin to babel to parse tsx files.

* Don't transform storybook source code with babel when running jscodeshift. To make it faster, and less noisy messages of: 

```
[BABEL] Note: The code generator has deoptimised the styling of ... as it exceeds the max of 500KB.
```

* Inferring the prettier parser from the filepath, which work the same if you use prettier from the command line. And also don't fail when prettier has errors. 

I tried setting tsx the default parser for all codemods, but this doesn't work for all codemods for some reason. It seems a bit odd as I don't understand how adding the typescript plugin would affect the AST of non typescript files. 

This also means that some codemods can not be used for TS files. Even when manually overriding the parser. Probably it is best, for new codemods, to always default to the "tsx" parser, so that we make sure it works with that config.

How to test:

* Run "sb migrate csf-2-to-3 --glob="**/src/**/*.stories.*" and see it works on TS and JS files!