### PR TITLE
Angular: Fix isStandaloneComponent check

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/utils/NgComponentAnalyzer.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/NgComponentAnalyzer.test.ts
@@ -268,11 +268,56 @@ describe('isStandaloneComponent', () => {
     expect(isStandaloneComponent(FooPipe)).toEqual(false);
   });
 
-  it('should return false with Directive', () => {
+  it('should return true with a Directive with "standalone: true"', () => {
+    // TODO: `standalone` is only available in Angular v14. Remove cast to `any` once
+    // Angular deps are updated to v14.x.x.
+    @Directive({ standalone: true } as any)
+    class FooDirective {}
+
+    expect(isStandaloneComponent(FooDirective)).toEqual(true);
+  });
+
+  it('should return false with a Directive with "standalone: false"', () => {
+    // TODO: `standalone` is only available in Angular v14. Remove cast to `any` once
+    // Angular deps are updated to v14.x.x.
+    @Directive({ standalone: false } as any)
+    class FooDirective {}
+
+    expect(isStandaloneComponent(FooDirective)).toEqual(false);
+  });
+
+  it('should return false with Directive without the "standalone" property', () => {
     @Directive()
     class FooDirective {}
 
     expect(isStandaloneComponent(FooDirective)).toEqual(false);
+  });
+
+  it('should return true with a Pipe with "standalone: true"', () => {
+    // TODO: `standalone` is only available in Angular v14. Remove cast to `any` once
+    // Angular deps are updated to v14.x.x.
+    @Pipe({ standalone: true } as any)
+    class FooPipe {}
+
+    expect(isStandaloneComponent(FooPipe)).toEqual(true);
+  });
+
+  it('should return false with a Pipe with "standalone: false"', () => {
+    // TODO: `standalone` is only available in Angular v14. Remove cast to `any` once
+    // Angular deps are updated to v14.x.x.
+    @Pipe({ standalone: false } as any)
+    class FooPipe {}
+
+    expect(isStandaloneComponent(FooPipe)).toEqual(false);
+  });
+
+  it('should return false with Pipe without the "standalone" property', () => {
+    @Pipe({
+      name: 'fooPipe',
+    })
+    class FooPipe {}
+
+    expect(isStandaloneComponent(FooPipe)).toEqual(false);
   });
 });
 

--- a/code/frameworks/angular/src/client/angular-beta/utils/NgComponentAnalyzer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/NgComponentAnalyzer.ts
@@ -116,7 +116,11 @@ export const isStandaloneComponent = (component: any): component is Type<unknown
 
   // TODO: `standalone` is only available in Angular v14. Remove cast to `any` once
   // Angular deps are updated to v14.x.x.
-  return (decorators || []).some((d) => d instanceof Component && (d as any).standalone);
+  return (decorators || []).some(
+    (d) =>
+      (d instanceof Component || d instanceof Directive || d instanceof Pipe) &&
+      (d as any).standalone
+  );
 };
 
 /**


### PR DESCRIPTION
Pipes and directives can also be standalone

Issue:
When you add a standalone directive or pipe as storybook component, you get the error message from Angular that a standalone component can't be declared in any NgModule.

## What I did

Changed the isStandaloneComponent check to allow Directive and Pipe.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
