### PR TITLE
Angular: Fix webpackStatsJson types in angular-builder

### DIFF
--- a/code/frameworks/angular/src/builders/build-storybook/schema.json
+++ b/code/frameworks/angular/src/builders/build-storybook/schema.json
@@ -53,7 +53,7 @@
       }
     },
     "webpackStatsJson": {
-      "type": "boolean",
+      "type": ["boolean", "string"],
       "description": "Write Webpack Stats JSON to disk",
       "default": false
     },


### PR DESCRIPTION
Issue:

## What I did

Added "string" as a permissible type for the `webpackStatsJson` option of the angular-builder to match the actual allowed type of the option in the CLI ([webpackStatsJson?: string | boolean;](https://github.com/storybookjs/storybook/blob/cc0f9ff96385912a93f4877904d6cb301dc6b480/code/lib/types/src/modules/core-common.ts#L164-L165)).

Without this, the Chromatic builder is failing when the `--only-changed` flag is set, because it passes a string as a value to `webpackStatsJson`. The error given is:

```
Property 'webpackStatsJson' does not match the schema. '/tmp/chromatic--36948-Ir8V9lertIJR' should be a 'boolean'.
```

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
