### PR TITLE
Build: remove borders in task error message

### DIFF
--- a/scripts/task.ts
+++ b/scripts/task.ts
@@ -437,8 +437,7 @@ async function run() {
 
         if (process.env.CI) {
           logger.error(
-            boxen(
-              dedent`
+            dedent`
                 To reproduce this error locally, run:
 
                   ${getCommand('yarn task', options, {
@@ -453,8 +452,7 @@ async function run() {
                     ...allOptionValues,
                     startFrom: 'auto',
                   })}`,
-              { borderStyle: 'round', padding: 1, borderColor: '#F1618C' } as any
-            )
+            { borderStyle: 'round', padding: 1, borderColor: '#F1618C' }
           );
         }
 

--- a/scripts/task.ts
+++ b/scripts/task.ts
@@ -438,21 +438,20 @@ async function run() {
         if (process.env.CI) {
           logger.error(
             dedent`
-                To reproduce this error locally, run:
+              To reproduce this error locally, run:
 
-                  ${getCommand('yarn task', options, {
-                    ...allOptionValues,
-                    link: true,
-                    startFrom: 'auto',
-                  })}
-                
-                Note this uses locally linking which in rare cases behaves differently to CI. For a closer match, run:
-                
-                  ${getCommand('yarn task', options, {
-                    ...allOptionValues,
-                    startFrom: 'auto',
-                  })}`,
-            { borderStyle: 'round', padding: 1, borderColor: '#F1618C' }
+              ${getCommand('yarn task', options, {
+                ...allOptionValues,
+                link: true,
+                startFrom: 'auto',
+              })}
+              
+              Note this uses locally linking which in rare cases behaves differently to CI. For a closer match, run:
+              
+              ${getCommand('yarn task', options, {
+                ...allOptionValues,
+                startFrom: 'auto',
+              })}`
           );
         }
 


### PR DESCRIPTION
Issue: N/A

## What I did

Got rid of this very annoying issue:
![2022-12-16 12 34 18](https://user-images.githubusercontent.com/1671563/208089588-87e7aac9-db57-426b-bc0e-4006bcc81afd.gif)


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
