### PR TITLE
Core: improve manager-entries failure message

### DIFF
--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -82,7 +82,7 @@ export const getConfig: ManagerBuilder['getConfig'] = async (options) => {
       js: 'try{',
     },
     footer: {
-      js: '}catch(e){ console.log("ONE OF YOUR MANAGER-ENTRIES FAILED: " + import.meta.url) }',
+      js: '}catch(e){ console.error("[Storybook] One of your manager-entries failed: " + import.meta.url); throw e; }',
     },
 
     define: {

--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -82,7 +82,7 @@ export const getConfig: ManagerBuilder['getConfig'] = async (options) => {
       js: 'try{',
     },
     footer: {
-      js: '}catch(e){ console.error("[Storybook] One of your manager-entries failed: " + import.meta.url); throw e; }',
+      js: '}catch(e){ console.error("[Storybook] One of your manager-entries failed: " + import.meta.url, e); }',
     },
 
     define: {


### PR DESCRIPTION
Issue: N/A

## What I did

This PR improves the error message when manager entries (e.g. addons that use manager) are broken

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
