### PR TITLE
Core: Wrap manager entries to handle exports

### DIFF
--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -23,6 +23,7 @@ import type {
 import { getData } from './utils/data';
 import { safeResolve } from './utils/safeResolve';
 import { readOrderedFiles } from './utils/files';
+import { wrapManagerEntries } from './utils/managerEntries';
 
 let compilation: Compilation;
 let asyncIterator: ReturnType<StarterFunction> | ReturnType<BuilderFunction>;
@@ -34,10 +35,14 @@ export const getConfig: ManagerBuilder['getConfig'] = async (options) => {
     getTemplatePath('addon.tsconfig.json'),
   ]);
 
+  const entryPoints = customManagerEntryPoint
+    ? [...addonsEntryPoints, customManagerEntryPoint]
+    : addonsEntryPoints;
+
+  const realEntryPoints = await wrapManagerEntries(entryPoints);
+
   return {
-    entryPoints: customManagerEntryPoint
-      ? [...addonsEntryPoints, customManagerEntryPoint]
-      : addonsEntryPoints,
+    entryPoints: realEntryPoints,
     outdir: join(options.outputDir || './', 'sb-addons'),
     format: 'esm',
     write: false,

--- a/code/lib/builder-manager/src/utils/managerEntries.ts
+++ b/code/lib/builder-manager/src/utils/managerEntries.ts
@@ -1,0 +1,32 @@
+import { join, parse, relative } from 'path';
+import fs from 'fs-extra';
+import os from 'os';
+
+/**
+ * Manager entries should be **self-invoking** bits of code.
+ * They can of-course import from modules, and ESbuild will bundle all of that into a single file.
+ * But they should not export anything. However this can't be enforced, so what we do is wrap the given file, in a bit of code like this:
+ *
+ * ```js
+ * import '<<file>>';
+ * ```
+ *
+ * That way we are indicating to ESbuild that we do not care about this files exports, and they will be dropped in the bundle.
+ *
+ * We do all of that so we can wrap a try-catch around the code.
+ * That would have been invalid syntax had the export statements been left in place.
+ *
+ * We need to wrap each managerEntry with a try-catch because if we do not, a failing managerEntry can stop execution of other managerEntries.
+ */
+export async function wrapManagerEntries(entrypoints: string[]) {
+  return Promise.all(
+    entrypoints.map(async (entry) => {
+      const { name, dir } = parse(entry);
+      const location = join(os.tmpdir(), relative(process.cwd(), dir), `${name}-bundle.mjs`);
+      await fs.ensureFile(location);
+      await fs.writeFile(location, `import '${entry}';`);
+
+      return location;
+    })
+  );
+}


### PR DESCRIPTION
Issue: managerEntries must not break when one of them exports something

## What I did

Wrap each managerEntry with:
```ts
import '<<>>';
```

...so exports from them get eleminated.

Therefore it's safe to wrap the code with a try-catch.