### PR TITLE
CLI: write into a log file if automigrations fail

### DIFF
--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -73,6 +73,7 @@
     "shelljs": "^0.8.5",
     "simple-update-notifier": "^1.0.0",
     "strip-json-comments": "^3.0.1",
+    "tempy": "^1.0.1",
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2"
   },

--- a/code/lib/cli/src/automigrate/helpers/cleanLog.ts
+++ b/code/lib/cli/src/automigrate/helpers/cleanLog.ts
@@ -1,0 +1,12 @@
+import { EOL } from 'os';
+
+export const cleanLog = (str: string) =>
+  str
+    // remove chalk ANSI colors
+    // eslint-disable-next-line no-control-regex
+    .replace(/\u001b\[.*?m/g, '')
+    // fix boxen output
+    .replace(/╮│/g, '╮\n│')
+    .replace(/││/g, '│\n│')
+    .replace(/│╰/g, '│\n╰')
+    .replace(/⚠️ {2}failed to check/g, `${EOL}⚠️  failed to check`);

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -2,13 +2,42 @@
 import prompts from 'prompts';
 import chalk from 'chalk';
 import boxen from 'boxen';
+import { createWriteStream, move, remove } from 'fs-extra';
+import tempy from 'tempy';
 import dedent from 'ts-dedent';
+
+import { join } from 'path';
 import { JsPackageManagerFactory, type PackageManagerName } from '../js-package-manager';
 
 import type { Fix } from './fixes';
 import { fixes } from './fixes';
+import { cleanLog } from './helpers/cleanLog';
 
 const logger = console;
+const LOG_FILE_NAME = 'migration-storybook.log';
+const LOG_FILE_PATH = join(process.cwd(), LOG_FILE_NAME);
+let TEMP_LOG_FILE_PATH = '';
+
+const originalStdOutWrite = process.stdout.write.bind(process.stdout);
+const originalStdErrWrite = process.stderr.write.bind(process.stdout);
+
+const augmentLogsToFile = () => {
+  TEMP_LOG_FILE_PATH = tempy.file({ name: LOG_FILE_NAME });
+  const logStream = createWriteStream(TEMP_LOG_FILE_PATH);
+
+  process.stdout.write = (d: string) => {
+    originalStdOutWrite(d);
+    return logStream.write(cleanLog(d));
+  };
+  process.stderr.write = (d: string) => {
+    return logStream.write(cleanLog(d));
+  };
+};
+
+const cleanup = () => {
+  process.stdout.write = originalStdOutWrite;
+  process.stderr.write = originalStdErrWrite;
+};
 
 type FixId = string;
 
@@ -38,6 +67,7 @@ type FixSummary = {
 };
 
 export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOptions = {}) => {
+  augmentLogsToFile();
   const packageManager = JsPackageManagerFactory.getPackageManager({ useNpm, force });
   const filtered = fixId ? fixes.filter((f) => f.id === fixId) : fixes;
 
@@ -53,6 +83,7 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
       result = await f.check({ packageManager });
     } catch (error) {
       logger.info(`⚠️  failed to check fix ${chalk.bold(f.id)}`);
+      logger.error(`\n${error.stack}`);
       fixSummary.failed[f.id] = error.message;
       fixResults[f.id] = FixStatus.CHECK_FAILED;
     }
@@ -77,6 +108,10 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
           runAnswer = { fix: false };
         } else if (yes) {
           runAnswer = { fix: true };
+          if (f.promptOnly) {
+            fixResults[f.id] = FixStatus.MANUAL_SUCCEEDED;
+            fixSummary.manual.push(f.id);
+          }
         } else if (f.promptOnly) {
           fixResults[f.id] = FixStatus.MANUAL_SUCCEEDED;
           fixSummary.manual.push(f.id);
@@ -148,14 +183,31 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force }: FixOpti
     }
   }
 
+  const hasFailures = Object.values(fixResults).some(
+    (r) => r === FixStatus.FAILED || r === FixStatus.CHECK_FAILED
+  );
+
+  // if migration failed, display a log file in the users cwd
+  if (hasFailures) {
+    await move(TEMP_LOG_FILE_PATH, join(process.cwd(), LOG_FILE_NAME), { overwrite: true });
+  } else {
+    await remove(TEMP_LOG_FILE_PATH);
+  }
+
   logger.info();
-  logger.info(getMigrationSummary(fixResults, fixSummary));
+  logger.info(getMigrationSummary(fixResults, fixSummary, LOG_FILE_PATH));
   logger.info();
+
+  cleanup();
 
   return fixResults;
 };
 
-function getMigrationSummary(fixResults: Record<string, FixStatus>, fixSummary: FixSummary) {
+function getMigrationSummary(
+  fixResults: Record<string, FixStatus>,
+  fixSummary: FixSummary,
+  logFile?: string
+) {
   const hasNoFixes = Object.values(fixResults).every((r) => r === FixStatus.UNNECESSARY);
   const hasFailures = Object.values(fixResults).some(
     (r) => r === FixStatus.FAILED || r === FixStatus.CHECK_FAILED
@@ -185,7 +237,7 @@ function getMigrationSummary(fixResults: Record<string, FixStatus>, fixSummary: 
           },
           ''
         )}
-    `
+    \nYou can find the full logs in ${chalk.cyan(logFile)}\n`
       : '';
 
   const manualFixesMessage =

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -85,9 +85,9 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force, list }: F
     logAvailableMigrations();
     return null;
   }
-  
+
   augmentLogsToFile();
-  
+
   const packageManager = JsPackageManagerFactory.getPackageManager({ useNpm, force });
 
   logger.info('🔎 checking possible migrations..');

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6164,6 +6164,7 @@ __metadata:
     shelljs: ^0.8.5
     simple-update-notifier: ^1.0.0
     strip-json-comments: ^3.1.1
+    tempy: ^1.0.1
     ts-dedent: ^2.0.0
     typescript: ~4.9.3
     util-deprecate: ^1.0.2
@@ -13575,6 +13576,13 @@ __metadata:
   version: 4.1.1
   resolution: "crypto-js@npm:4.1.1"
   checksum: 50cc66a35f2738171d9a6d80c85ba7d00cb6440b756db035ba9ccd03032c0a803029a62969ecd4c844106c980af87687c64b204dd967989379c4f354fb482d37
+  languageName: node
+  linkType: hard
+
+"crypto-random-string@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "crypto-random-string@npm:2.0.0"
+  checksum: 288589b2484fe787f9e146f56c4be90b940018f17af1b152e4dde12309042ff5a2bf69e949aab8b8ac253948381529cc6f3e5a2427b73643a71ff177fa122b37
   languageName: node
   linkType: hard
 
@@ -31140,6 +31148,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"temp-dir@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "temp-dir@npm:2.0.0"
+  checksum: b1df969e3f3f7903f3426861887ed76ba3b495f63f6d0c8e1ce22588679d9384d336df6064210fda14e640ed422e2a17d5c40d901f60e161c99482d723f4d309
+  languageName: node
+  linkType: hard
+
 "temp-write@npm:^3.4.0":
   version: 3.4.0
   resolution: "temp-write@npm:3.4.0"
@@ -31160,6 +31175,19 @@ __metadata:
   dependencies:
     rimraf: ~2.6.2
   checksum: 7f071c963031bfece37e13c5da11e9bb451e4ddfc4653e23e327a2f91594102dc826ef6a693648e09a6e0eb856f507967ec759ae55635e0878091eccf411db37
+  languageName: node
+  linkType: hard
+
+"tempy@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "tempy@npm:1.0.1"
+  dependencies:
+    del: ^6.0.0
+    is-stream: ^2.0.0
+    temp-dir: ^2.0.0
+    type-fest: ^0.16.0
+    unique-string: ^2.0.0
+  checksum: 864a1cf1b5536dc21e84ae45dbbc3ba4dd2c7ec1674d895f99c349cf209df959a53d797ca38d0b2cf69c7684d565fde5cfc67faaa63b7208ffb21d454b957472
   languageName: node
   linkType: hard
 
@@ -31961,6 +31989,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "type-fest@npm:0.16.0"
+  checksum: 6b4d846534e7bcb49a6160b068ffaed2b62570d989d909ac3f29df5ef1e993859f890a4242eebe023c9e923f96adbcb3b3e88a198c35a1ee9a731e147a6839c3
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^0.18.0":
   version: 0.18.1
   resolution: "type-fest@npm:0.18.1"
@@ -32348,6 +32383,15 @@ __metadata:
   dependencies:
     imurmurhash: ^0.1.4
   checksum: 617240eb921af803b47d322d75a71a363dacf2e56c29ae5d1404fad85f64f4ec81ef10ee4fd79215d0202cbe1e5a653edb0558d59c9c81d3bd538c2d58e4c026
+  languageName: node
+  linkType: hard
+
+"unique-string@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unique-string@npm:2.0.0"
+  dependencies:
+    crypto-random-string: ^2.0.0
+  checksum: 11820db0a4ba069d174bedfa96c588fc2c96b083066fafa186851e563951d0de78181ac79c744c1ed28b51f9d82ac5b8196ff3e4560d0178046ef455d8c2244b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did

The automigration command now will suppress errors from the logs, while writing the entire output to a `migration-storybook.log` (to follow `build-storybook.log` convention) file. The log file will only be provided to the user if there are failures, and it will contain all the errors in full.

Here's a comparison logfile <-> command line:

![image](https://user-images.githubusercontent.com/1671563/208126697-496ae274-74d8-47e5-87d0-f6875fd7884b.png)


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
