### PR TITLE
Update addon-actions peerdependency in nextjs package.json

### DIFF
--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -87,7 +87,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.11.5",
-    "@storybook/addon-actions": "7.0.0-alpha.43",
+    "@storybook/addon-actions": "7.0.0-beta.12",
     "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -87,7 +87,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.11.5",
-    "@storybook/addon-actions": "7.0.0-beta.12",
+    "@storybook/addon-actions": "^7.0.0-beta.12",
     "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6791,7 +6791,7 @@ __metadata:
     webpack: ^5.65.0
   peerDependencies:
     "@babel/core": ^7.11.5
-    "@storybook/addon-actions": 7.0.0-alpha.43
+    "@storybook/addon-actions": 7.0.0-beta.12
     next: ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6766,7 +6766,7 @@ __metadata:
     webpack: ^5.65.0
   peerDependencies:
     "@babel/core": ^7.11.5
-    "@storybook/addon-actions": 7.0.0-beta.12
+    "@storybook/addon-actions": ^7.0.0-beta.12
     next: ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0


### PR DESCRIPTION
Issue:
https://github.com/storybookjs/storybook/issues/20323

## What I did
I bumped the version of the `@storybook/addon-actions` package to the latest one in the peerDependencies of nextjs `package.json`

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
