### PR TITLE
CLI: fix automigrate filtering

### DIFF
--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -191,6 +191,7 @@ program
   .option('-n --dry-run', 'Only check for fixes, do not actually run them')
   .option('--package-manager <npm|pnpm|yarn1|yarn2>', 'Force package manager')
   .option('-N --use-npm', 'Use npm as package manager (deprecated)')
+  .option('-l --list', 'List available migrations')
   .action(async (fixId, options) => {
     await automigrate({ fixId, ...options }).catch((e) => {
       logger.error(e);


### PR DESCRIPTION
Issue: N/A

## What I did

The filtering of automigrate command was not working as intended. This PR fixes that and adds feedback in case the automigration passed does not exist.

![image](https://user-images.githubusercontent.com/1671563/208456664-1da26ada-f439-4a0a-835a-e7b66157247a.png)

Additionally, it adds a `--list` command to list the available automigrations.

<img width="631" alt="image" src="https://user-images.githubusercontent.com/1671563/208456765-6fa6f42a-80d5-4467-8685-9e3848ee93d4.png">


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
