### PR TITLE
Vite: Detect React SWC plugin

### DIFF
--- a/code/frameworks/react-vite/src/preset.ts
+++ b/code/frameworks/react-vite/src/preset.ts
@@ -11,7 +11,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets 
   const { plugins = [] } = config;
 
   // Add react plugin if not present
-  if (!(await hasVitePlugins(plugins, ['vite:react-babel']))) {
+  if (!(await hasVitePlugins(plugins, ['vite:react-babel', 'vite:react-swc']))) {
     const { default: react } = await import('@vitejs/plugin-react');
     plugins.push(react());
   }


### PR DESCRIPTION
Issue:

There's now two vite plugins for react, one with babel, and one with SWC.  We were not detecting the swc plugin, so ended up adding the fallback babel version, which conflicted and caused errors

## What I did

Detect the swc react vite plugin.

## How to test

Do we want a sandbox for this?

```
npm create vite // ---> choose react,  TypeScript + SWC
npx sb@next init
// build react-vite, copy the dist in, it works.
```

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
