### PR TITLE
CLI: add nodejs check in automigrations

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -269,7 +269,7 @@ In the meantime, these migration notes are the best available documentation on t
 
 #### Dropped support for Node 15 and below
 
-Storybook 7.0 requires Node 16 or above. If you are using an older version of Node, you will need to upgrade or keep using Storybook 6 in the meantime.
+Storybook 7.0 requires **Node 16** or above. If you are using an older version of Node, you will need to upgrade or keep using Storybook 6 in the meantime.
 
 #### React peer dependencies required
 
@@ -362,10 +362,10 @@ The named export has been available since 6.0 or earlier, so your updated code w
 #### Modern browser support
 
 Starting in storybook 7.0, storybook will no longer support IE11, amongst other legacy browser versions.
-We now transpile our code with a target of `chrome >= 100` and node code is transpiled with a target of `node >= 14`.
+We now transpile our code with a target of `chrome >= 100` and node code is transpiled with a target of `node >= 16`.
 
-This means code-features such as (but not limited to) `async/await`, arrow-functions, `const`,`let`, etc will exists in the code at runtime, and thus the runtime environment must support it.
-Not just the runtime needs to support it, but some legacy loaders for webpack or other transpilation tools might need to be updated as well. For example certain versions of webpack 4 had parsers that could not parse the new syntax (e.g. optional chaining).
+This means code-features such as (but not limited to) `async/await`, arrow-functions, `const`,`let`, etc will exist in the code at runtime, and thus the runtime environment must support it.
+Not just the runtime needs to support it, but some legacy loaders for webpack or other transpilation tools might need to be updated as well. For example, certain versions of webpack 4 had parsers that could not parse the new syntax (e.g. optional chaining).
 
 Some addons or libraries might depended on this legacy browser support, and thus might break. You might get an error like:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -269,7 +269,7 @@ In the meantime, these migration notes are the best available documentation on t
 
 #### Dropped support for Node 15 and below
 
-Storybook 7.0 requires Node 16 or above. If you are using olders version of Node, you will need to upgrade, or keep using Storybook 6 in the meantime.
+Storybook 7.0 requires Node 16 or above. If you are using an older version of Node, you will need to upgrade or keep using Storybook 6 in the meantime.
 
 #### React peer dependencies required
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 - [From version 6.5.x to 7.0.0](#from-version-65x-to-700)
   - [Alpha release notes](#alpha-release-notes)
   - [7.0 breaking changes](#70-breaking-changes)
+    - [Dropped support for Node 15 and below](#dropped-support-for-node-15-and-below)
     - [React peer dependencies required](#react-peer-dependencies-required)
     - [Postcss removed](#postcss-removed)
     - [Vue3 replaced app export with setup](#vue3-replaced-app-export-with-setup)
@@ -23,10 +24,10 @@
     - [7.0 feature flags removed](#70-feature-flags-removed)
     - [CLI option `--use-npm` deprecated](#cli-option---use-npm-deprecated)
     - [Vite builder uses vite config automatically](#vite-builder-uses-vite-config-automatically)
-    - [Vite cache moved to node_modules/.cache/.vite-storybook](#vite-cache-moved-to-node_modulescachevite-storybook)
+    - [Vite cache moved to node\_modules/.cache/.vite-storybook](#vite-cache-moved-to-node_modulescachevite-storybook)
     - [SvelteKit needs the `@storybook/sveltekit` framework](#sveltekit-needs-the-storybooksveltekit-framework)
     - [Removed docs.getContainer and getPage parameters](#removed-docsgetcontainer-and-getpage-parameters)
-    - [Removed STORYBOOK_REACT_CLASSES global](#removed-storybook_react_classes-global)
+    - [Removed STORYBOOK\_REACT\_CLASSES global](#removed-storybook_react_classes-global)
     - [Icons API changed](#icons-api-changed)
     - ['config' preset entry replaced with 'previewAnnotations'](#config-preset-entry-replaced-with-previewannotations)
     - [Dropped support for Angular 12 and below](#dropped-support-for-angular-12-and-below)
@@ -265,6 +266,10 @@ Storybook 7.0 is in early alpha. During the alpha, we are making a large number 
 In the meantime, these migration notes are the best available documentation on things you should know upgrading to 7.0.
 
 ### 7.0 breaking changes
+
+#### Dropped support for Node 15 and below
+
+Storybook 7.0 requires Node 16 or above. If you are using olders version of Node, you will need to upgrade, or keep using Storybook 6 in the meantime.
 
 #### React peer dependencies required
 

--- a/code/lib/cli/src/automigrate/fixes/index.ts
+++ b/code/lib/cli/src/automigrate/fixes/index.ts
@@ -16,10 +16,12 @@ import { mdx1to2 } from './mdx-1-to-2';
 import { docsPageAutomatic } from './docsPage-automatic';
 import { sveltekitFramework } from './sveltekit-framework';
 import { addReact } from './add-react';
+import { nodeJsRequirement } from './nodejs-requirement';
 
 export * from '../types';
 
 export const fixes: Fix[] = [
+  nodeJsRequirement,
   cra5,
   webpack5,
   angular12,

--- a/code/lib/cli/src/automigrate/fixes/nodejs-requirement.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/nodejs-requirement.test.ts
@@ -1,0 +1,45 @@
+/// <reference types="@types/jest" />;
+
+import type { JsPackageManager } from '../../js-package-manager';
+import { nodeJsRequirement } from './nodejs-requirement';
+
+// eslint-disable-next-line global-require, jest/no-mocks-import
+jest.mock('fs-extra', () => require('../../../../../__mocks__/fs-extra'));
+
+const check = async ({ packageJson = {} }: any) => {
+  const packageManager = {
+    retrievePackageJson: () => ({
+      dependencies: {
+        '@storybook/react': '^7.0.0',
+      },
+      devDependencies: {},
+      ...packageJson,
+    }),
+  } as JsPackageManager;
+  return nodeJsRequirement.check({ packageManager });
+};
+
+const originalNodeVersion = process.version;
+const mockNodeVersion = (version: string) => {
+  Object.defineProperties(process, {
+    version: {
+      value: version,
+    },
+  });
+};
+
+describe('nodejs-requirement fix', () => {
+  afterAll(() => {
+    mockNodeVersion(originalNodeVersion);
+  });
+
+  it('skips when node >= 16.0.0', async () => {
+    mockNodeVersion('16.0.0');
+    await expect(check({})).resolves.toBeNull();
+  });
+
+  it('prompts when node <= 16.0.0', async () => {
+    mockNodeVersion('14.0.0');
+    await expect(check({})).resolves.toEqual({ nodeVersion: '14.0.0' });
+  });
+});

--- a/code/lib/cli/src/automigrate/fixes/nodejs-requirement.ts
+++ b/code/lib/cli/src/automigrate/fixes/nodejs-requirement.ts
@@ -1,0 +1,56 @@
+import chalk from 'chalk';
+import dedent from 'ts-dedent';
+import semver from 'semver';
+import { getStorybookInfo } from '@storybook/core-common';
+import type { Fix } from '../types';
+
+interface NodeJsRequirementOptions {
+  nodeVersion: string;
+}
+
+export const nodeJsRequirement: Fix<NodeJsRequirementOptions> = {
+  id: 'nodejs-requirement',
+  promptOnly: true,
+
+  async check({ packageManager }) {
+    const packageJson = packageManager.retrievePackageJson();
+    const { version: storybookVersion } = getStorybookInfo(packageJson);
+
+    const storybookCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
+    if (!storybookCoerced) {
+      throw new Error(dedent`
+        ❌ Unable to determine storybook version.
+        🤔 Are you running automigrate from your project directory?
+      `);
+    }
+
+    if (!semver.gte(storybookCoerced, '7.0.0')) {
+      return null;
+    }
+
+    const nodeVersion = process.version;
+    if (semver.lt(nodeVersion, '16.0.0')) {
+      return { nodeVersion };
+    }
+
+    return null;
+  },
+  prompt({ nodeVersion }) {
+    return dedent`
+      ${chalk.bold(
+        chalk.red('Attention')
+      )}: We could not automatically make this change. You'll need to do it manually.
+
+      We've detected that you're using Node ${chalk.bold(
+        nodeVersion
+      )} but Storybook 7 only supports Node ${chalk.bold(
+      'v16.0.0'
+    )} and higher. You will either need to upgrade your Node version or keep using an older version of Storybook.
+
+      Please see the migration guide for more information:
+      ${chalk.yellow(
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#dropped-support-for-node-15-and-below'
+      )}
+    `;
+  },
+};

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -162,7 +162,7 @@ export const automigrate = async ({ fixId, dryRun, yes, useNpm, force, list }: F
         }
       }
     } else {
-      fixResults[f.id] ||= FixStatus.UNNECESSARY;
+      fixResults[f.id] = fixResults[f.id] || FixStatus.UNNECESSARY;
     }
   }
 


### PR DESCRIPTION
Issue: N/A

## What I did

This PR adds an automigration to detect node version and guide the user to upgrade it:
<img width="573" alt="image" src="https://user-images.githubusercontent.com/1671563/208667889-bf8ecdb5-07fc-40e6-8f3b-4ccdab43081d.png">


## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
