### PR TITLE
Chore: (Docs) Adds Missing Web component snippets

### DIFF
--- a/docs/addons/addons-api.md
+++ b/docs/addons/addons-api.md
@@ -235,6 +235,8 @@ Let's say you've got a story like this:
     'vue/button-story-with-addon-example.js.mdx',
     'angular/button-story-with-addon-example.ts.mdx',
     'svelte/button-story-with-addon-example.js.mdx',
+    'web-components/button-story-with-addon-example.js.mdx',
+    'web-components/button-story-with-addon-example.ts.mdx',
   ]}
   usesCsf3
   csf2Path="addons/addons-api#snippet-button-story-with-addon-example"

--- a/docs/addons/writing-addons.md
+++ b/docs/addons/writing-addons.md
@@ -200,6 +200,8 @@ When Storybook was initialized, it provided a small set of example stories. Chan
     'vue/button-story-with-addon-example.js.mdx',
     'angular/button-story-with-addon-example.ts.mdx',
     'svelte/button-story-with-addon-example.js.mdx',
+    'web-components/button-story-with-addon-example.js.mdx',
+    'web-components/button-story-with-addon-example.ts.mdx',
   ]}
   usesCsf3
   csf2Path="addons/writing-addons#snippet-button-story-with-addon-example"

--- a/docs/api/csf.md
+++ b/docs/api/csf.md
@@ -47,6 +47,8 @@ With CSF, every named export in the file represents a story object by default.
     'vue/my-component-story-basic-and-props.js.mdx',
     'svelte/my-component-story-basic-and-props.js.mdx',
     'angular/my-component-story-basic-and-props.ts.mdx',
+    'web-components/my-component-story-basic-and-props.js.mdx',
+    'web-components/my-component-story-basic-and-props.ts.mdx',
   ]}
   usesCsf3
   csf2Path="api/csf#snippet-my-component-story-basic-and-props"
@@ -98,6 +100,8 @@ Consider Storybook’s ["Button" example](../writing-stories/introduction.md#def
     'vue/button-story-click-handler.3.js.mdx',
     'svelte/button-story-click-handler.js.mdx',
     'angular/button-story-click-handler.ts.mdx',
+    'web-components/button-story-click-handler.js.mdx',
+    'web-components/button-story-click-handler.ts.mdx',
   ]}
   usesCsf3
   csf2Path="api/csf#snippet-button-story-click-handler"
@@ -116,6 +120,8 @@ Now consider the same example, re-written with args:
     'vue/button-story-click-handler-args.3.js.mdx',
     'angular/button-story-click-handler-args.ts.mdx',
     'svelte/button-story-click-handler-args.js.mdx',
+    'web-components/button-story-click-handler-args.js.mdx',
+    'web-components/button-story-click-handler-args.ts.mdx',
   ]}
   usesCsf3
   csf2Path="api/csf#snippet-button-story-click-handler-args"
@@ -132,6 +138,8 @@ Or even more simply:
     'react/button-story-click-handler-simplificated.js.mdx',
     'angular/button-story-click-handler-simplificated.ts.mdx',
     'vue/button-story-click-handler-simplificated.js.mdx',
+    'web-components/button-story-click-handler-simplificated.js.mdx',
+    'web-components/button-story-click-handler-simplificated.ts.mdx',
   ]}
   usesCsf3
   csf2Path="api/csf#snippet-button-story-click-handler-simplificated"
@@ -183,6 +191,7 @@ Starting in Storybook 6.4, you can write your stories as JavaScript objects, red
    'vue/component-story-with-custom-render-function.ts.mdx',
    'preact/component-story-with-custom-render-function.js.mdx',
    'web-components/component-story-with-custom-render-function.js.mdx',
+   'web-components/component-story-with-custom-render-function.ts.mdx',
   ]}
   usesCsf3
 />
@@ -233,7 +242,9 @@ Consider the following story file:
     'vue/my-component-story-with-nonstory.2.js.mdx',
     'vue/my-component-story-with-nonstory.3.js.mdx',
     'svelte/my-component-story-with-nonstory.js.mdx',
-    'angular/my-component-story-with-nonstory.ts.mdx'
+    'angular/my-component-story-with-nonstory.ts.mdx',
+    'web-components/my-component-story-with-nonstory.js.mdx',
+    'web-components/my-component-story-with-nonstory.ts.mdx',
   ]}
   usesCsf3
   csf2Path="api/csf#snippet-my-component-story-with-nonstory"
@@ -270,6 +281,7 @@ In CSF 2, the named exports are always functions that instantiate a component, a
     'vue/csf-2-example-starter.ts-3.ts.mdx',
     'angular/csf-2-example-starter.ts.mdx',
     'web-components/csf-2-example-starter.js.mdx',
+    'web-components/csf-2-example-starter.ts.mdx',
   ]}
 />
 
@@ -288,6 +300,8 @@ Here's the CSF 3 equivalent:
     'vue/csf-3-example-starter.ts-2.ts.mdx',
     'vue/csf-3-example-starter.ts-3.ts.mdx',
     'angular/csf-3-example-starter.ts.mdx',
+    'web-components/csf-3-example-starter.js.mdx',
+    'web-components/csf-3-example-starter.ts.mdx',
   ]}
 />
 
@@ -344,6 +358,7 @@ Let's start with a simple CSF 2 story function:
     'vue/csf-2-example-story.3.js.mdx',
     'angular/csf-2-example-story.ts.mdx',
     'web-components/csf-2-example-story.js.mdx',
+    'web-components/csf-2-example-story.ts.mdx',
   ]}
 />
 
@@ -360,6 +375,7 @@ Now, let's rewrite it as a story object in CSF 3 with an explicit `render` funct
     'vue/csf-3-example-render.3.js.mdx',
     'angular/csf-3-example-render.ts.mdx',
     'web-components/csf-3-example-render.js.mdx',
+    'web-components/csf-3-example-render.ts.mdx',
   ]}
 />
 

--- a/docs/configure/environment-variables.md
+++ b/docs/configure/environment-variables.md
@@ -57,6 +57,7 @@ Then you can access this environment variable anywhere, even within your stories
     'vue/my-component-with-env-variables.ts-3.ts.mdx',
     'angular/my-component-with-env-variables.ts.mdx',
     'web-components/my-component-with-env-variables.js.mdx',
+    'web-components/my-component-with-env-variables.ts.mdx',
     'svelte/my-component-with-env-variables.js.mdx',
   ]}
   usesCsf3

--- a/docs/configure/images-and-assets.md
+++ b/docs/configure/images-and-assets.md
@@ -22,6 +22,8 @@ Afterward, you can use any asset in your stories:
     'vue/component-story-static-asset-with-import.ts-3.ts.mdx',
     'angular/component-story-static-asset-with-import.ts.mdx',
     'svelte/component-story-static-asset-with-import.js.mdx',
+    'web-components/component-story-static-asset-with-import.js.mdx',
+    'web-components/component-story-static-asset-with-import.ts.mdx',
   ]}
   usesCsf3
   csf2Path="configure/images-and-assets#snippet-component-story-static-asset-with-import"
@@ -57,6 +59,8 @@ Here `../public` is your static directory. Now use it in a component or story li
     'vue/component-story-static-asset-without-import.ts.mdx',
     'angular/component-story-static-asset-without-import.ts.mdx',
     'svelte/component-story-static-asset-without-import.js.mdx',
+    'web-components/component-story-static-asset-without-import.js.mdx',
+    'web-components/component-story-static-asset-without-import.ts.mdx',
   ]}
   usesCsf3
   csf2Path="configure/images-and-assets#snippet-component-story-static-asset-without-import"
@@ -106,6 +110,8 @@ Upload your files to an online CDN and reference them. In this example, we’re 
     'vue/component-story-static-asset-cdn.ts.mdx',
     'angular/component-story-static-asset-cdn.ts.mdx',
     'svelte/component-story-static-asset-cdn.js.mdx',
+    'web-components/component-story-static-asset-cdn.js.mdx',
+    'web-components/component-story-static-asset-cdn.ts.mdx',
   ]}
   usesCsf3
   csf2Path="configure/images-and-assets#snippet-component-story-static-asset-cdn"

--- a/docs/essentials/controls.md
+++ b/docs/essentials/controls.md
@@ -128,6 +128,8 @@ Until now, we only used auto-generated controls based on the component we're wri
     'vue/table-story-fully-customize-controls.3.js.mdx',
     'vue/table-story-fully-customize-controls.ts-3.ts.mdx',
     'angular/table-story-fully-customize-controls.ts.mdx',
+    'web-components/table-story-fully-customize-controls.js.mdx',
+    'web-components/table-story-fully-customize-controls.ts.mdx',
   ]}
   usesCsf3
   csf2Path="essentials/controls#snippet-table-story-fully-customize-controls"
@@ -159,6 +161,8 @@ One way to deal with this is to use primitive values (e.g., strings) as arg valu
     'vue/component-story-custom-args-complex.ts-3.ts.mdx',
     'angular/component-story-custom-args-complex.ts.mdx',
     'svelte/component-story-custom-args-complex.js.mdx',
+    'web-components/component-story-custom-args-complex.js.mdx',
+    'web-components/component-story-custom-args-complex.ts.mdx',
   ]}
   usesCsf3
   csf2Path="essentials/controls#snippet-component-story-custom-args-complex"

--- a/docs/essentials/toolbars-and-globals.md
+++ b/docs/essentials/toolbars-and-globals.md
@@ -108,6 +108,7 @@ Using the example above, you can modify any story to retrieve the **Locale** `gl
     'angular/my-component-story-use-globaltype.ts.mdx',
     'svelte/my-component-story-use-globaltype.js.mdx',
     'web-components/my-component-story-use-globaltype.js.mdx',
+    'web-components/my-component-story-use-globaltype.ts.mdx',
   ]}
   usesCsf3
   csf2Path="essentials/toolbars-and-globals#snippet-my-component-story-use-globaltype"
@@ -128,6 +129,7 @@ Using the example above, you can modify any story to retrieve the **Locale** `gl
     'angular/my-component-story-use-globaltype-backwards-compat.ts.mdx',
     'svelte/my-component-story-use-globaltype-backwards-compat.js.mdx',
     'web-components/my-component-story-use-globaltype-backwards-compat.js.mdx',
+    'web-components/my-component-story-use-globaltype-backwards-compat.ts.mdx',
   ]}
 />
 

--- a/docs/essentials/viewport.md
+++ b/docs/essentials/viewport.md
@@ -125,6 +125,7 @@ Update your story through [parameters](../writing-stories/parameters.md) to incl
     'vue/my-component-story-configure-viewports.ts.mdx',
     'angular/my-component-story-configure-viewports.ts.mdx',
     'web-components/my-component-story-configure-viewports.js.mdx',
+    'web-components/my-component-story-configure-viewports.ts.mdx',
     'svelte/my-component-story-configure-viewports.js.mdx',
   ]}
   usesCsf3

--- a/docs/sharing/design-integrations.md
+++ b/docs/sharing/design-integrations.md
@@ -106,6 +106,8 @@ In Storybook, add a new [parameter](../writing-stories/parameters.md) named `des
     'vue/component-story-figma-integration.ts.mdx',
     'angular/component-story-figma-integration.ts.mdx',
     'svelte/component-story-figma-integration.js.mdx',
+    'web-components/component-story-figma-integration.js.mdx',
+    'web-components/component-story-figma-integration.ts.mdx',
   ]}
   usesCsf3
   csf2Path="sharing/design-integrations#snippet-component-story-figma-integration"

--- a/docs/snippets/web-components/button-component-with-proptypes.js.mdx
+++ b/docs/snippets/web-components/button-component-with-proptypes.js.mdx
@@ -1,9 +1,33 @@
 ```js
 // Button.js
 
-import { html } from 'lit-html';
+import { LitElement, html } from 'lit';
 
-export const Button = ({ isDisabled, content }) => {
-  return html` <button type="button" ?disabled=${isDisabled}>${label}</button> `;
-};
+/**
+ * @prop {string} content - The display label of the button
+ * @prop {boolean} isDisabled - Checks if the button should be disabled
+ * @summary This is a custom button element
+ * @tag custom-button
+ */
+
+export class CustomButton extends LitElement {
+  static get properties() {
+    return {
+      content: { type: String },
+      isDisabled: { type: Boolean },
+    };
+  }
+
+  constructor() {
+    super();
+    this.content = 'One';
+    this.isDisabled = false;
+  }
+
+  render() {
+    return html` <button type="button" ?disabled=${this.isDisabled}>${this.content}</button> `;
+  }
+}
+
+customElements.define('custom-button', CustomButton);
 ```

--- a/docs/snippets/web-components/button-component-with-proptypes.js.mdx
+++ b/docs/snippets/web-components/button-component-with-proptypes.js.mdx
@@ -1,0 +1,9 @@
+```js
+// Button.js
+
+import { html } from 'lit-html';
+
+export const Button = ({ isDisabled, content }) => {
+  return html` <button type="button" ?disabled=${isDisabled}>${label}</button> `;
+};
+```

--- a/docs/snippets/web-components/button-component-with-proptypes.ts.mdx
+++ b/docs/snippets/web-components/button-component-with-proptypes.ts.mdx
@@ -1,20 +1,25 @@
 ```ts
 // Button.ts
 
-import { html } from 'lit-html';
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 
-export interface ButtonProps {
-  /**
-   Checks if the button should be disabled
-  */
-  isDisabled?: boolean;
-  /**
-  The display content of the button
-  */
-  content: string;
+/**
+ * @prop {string} content - The display label of the button
+ * @prop {boolean} isDisabled - Checks if the button should be disabled
+ * @summary This is a custom button element
+ * @tag custom-button
+ */
+
+@customElement('custom-button')
+export class CustomButton extends LitElement {
+  @property()
+  content?: string = 'One';
+  @property()
+  isDisabled?: boolean = false;
+
+  render() {
+    return html` <button type="button" ?disabled=${this.isDisabled}>${this.content}</button> `;
+  }
 }
-
-export const Button = ({ isDisabled, content }: ButtonProps) => {
-  return html` <button type="button" ?disabled=${isDisabled}>${label}</button> `;
-};
 ```

--- a/docs/snippets/web-components/button-component-with-proptypes.ts.mdx
+++ b/docs/snippets/web-components/button-component-with-proptypes.ts.mdx
@@ -1,0 +1,20 @@
+```ts
+// Button.ts
+
+import { html } from 'lit-html';
+
+export interface ButtonProps {
+  /**
+   Checks if the button should be disabled
+  */
+  isDisabled?: boolean;
+  /**
+  The display content of the button
+  */
+  content: string;
+}
+
+export const Button = ({ isDisabled, content }: ButtonProps) => {
+  return html` <button type="button" ?disabled=${isDisabled}>${label}</button> `;
+};
+```

--- a/docs/snippets/web-components/button-story-auto-docs.js.mdx
+++ b/docs/snippets/web-components/button-story-auto-docs.js.mdx
@@ -1,0 +1,29 @@
+```js
+// Button.stories.js
+
+import { Button } from './Button';
+
+export default {
+  title: 'Button',
+  render: (args) => Button(args),
+  //👇 Enables auto-generated documentation for the component story
+  tags: ['docsPage'],
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+};
+
+export const Primary = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+
+export const Secondary = {
+  args: {
+    ...Primary.args,
+    primary: false,
+  },
+};
+```

--- a/docs/snippets/web-components/button-story-auto-docs.js.mdx
+++ b/docs/snippets/web-components/button-story-auto-docs.js.mdx
@@ -1,11 +1,9 @@
 ```js
 // Button.stories.js
 
-import { Button } from './Button';
-
 export default {
   title: 'Button',
-  render: (args) => Button(args),
+  component: 'custom-button',
   //👇 Enables auto-generated documentation for the component story
   tags: ['docsPage'],
   argTypes: {

--- a/docs/snippets/web-components/button-story-auto-docs.ts.mdx
+++ b/docs/snippets/web-components/button-story-auto-docs.ts.mdx
@@ -2,12 +2,10 @@
 // Button.stories.ts
 
 import type { Meta, StoryObj } from '@storybook/web-components';
-import type { ButtonProps } from './Button';
-import { Button } from './Button';
 
-const Meta: Meta<ButtonProps> = {
+const Meta: Meta = {
   title: 'Button',
-  render: (args) => Button(args),
+  component: 'custom-button',
   //👇 Enables auto-generated documentation for the component story
   tags: ['docsPage'],
   argTypes: {
@@ -16,7 +14,7 @@ const Meta: Meta<ButtonProps> = {
 };
 
 export default meta;
-type Story = StoryObj<ButtonProps>;
+type Story = StoryObj;
 
 export const Primary: Story = {
   args: {

--- a/docs/snippets/web-components/button-story-auto-docs.ts.mdx
+++ b/docs/snippets/web-components/button-story-auto-docs.ts.mdx
@@ -1,0 +1,34 @@
+```ts
+// Button.stories.ts
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+import type { ButtonProps } from './Button';
+import { Button } from './Button';
+
+const Meta: Meta<ButtonProps> = {
+  title: 'Button',
+  render: (args) => Button(args),
+  //👇 Enables auto-generated documentation for the component story
+  tags: ['docsPage'],
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<ButtonProps>;
+
+export const Primary: Story = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    ...Primary.args,
+    primary: false,
+  },
+};
+```

--- a/docs/snippets/web-components/button-story-click-handler-args.js.mdx
+++ b/docs/snippets/web-components/button-story-click-handler-args.js.mdx
@@ -1,0 +1,22 @@
+```js
+// Button.stories.js
+
+import { html } from 'lit-html';
+
+import { Button } from './Button';
+
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Button',
+  render: (args) => Button(args),
+};
+
+export const Text = {
+  render: ({ label, onClick }) => html`<button label="${label}" @click=${onClick}></button>`,
+  args: {
+    label: 'Hello',
+    onClick: action('clicked'),
+  },
+};
+```

--- a/docs/snippets/web-components/button-story-click-handler-args.js.mdx
+++ b/docs/snippets/web-components/button-story-click-handler-args.js.mdx
@@ -3,17 +3,16 @@
 
 import { html } from 'lit-html';
 
-import { Button } from './Button';
-
 import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Button',
-  render: (args) => Button(args),
+  component: 'custom-button',
 };
 
 export const Text = {
-  render: ({ label, onClick }) => html`<button label="${label}" @click=${onClick}></button>`,
+  render: ({ label, onClick }) =>
+    html`<custom-button label="${label}" @click=${onClick}></custom-button>`,
   args: {
     label: 'Hello',
     onClick: action('clicked'),

--- a/docs/snippets/web-components/button-story-click-handler-args.ts.mdx
+++ b/docs/snippets/web-components/button-story-click-handler-args.ts.mdx
@@ -1,0 +1,28 @@
+```ts
+// Button.stories.ts
+
+import { html } from 'lit-html';
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import { action } from '@storybook/addon-actions';
+
+import type { ButtonProps } from './Button';
+import { Button } from './Button';
+
+const meta: Meta<ButtonProps> = {
+  title: 'Button',
+  render: (args) => Button(args),
+};
+
+export default meta;
+type Story = StoryObj<ButtonProps>;
+
+export const Text: Story = {
+  render: ({ label, onClick }) => html`<button label="${label}" @click=${onClick}></button>`,
+  args: {
+    label: 'Hello',
+    onClick: action('clicked'),
+  },
+};
+```

--- a/docs/snippets/web-components/button-story-click-handler-args.ts.mdx
+++ b/docs/snippets/web-components/button-story-click-handler-args.ts.mdx
@@ -7,19 +7,17 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 
 import { action } from '@storybook/addon-actions';
 
-import type { ButtonProps } from './Button';
-import { Button } from './Button';
-
-const meta: Meta<ButtonProps> = {
+const meta: Meta = {
   title: 'Button',
-  render: (args) => Button(args),
+  component: 'custom-button',
 };
 
 export default meta;
-type Story = StoryObj<ButtonProps>;
+type Story = StoryObj;
 
 export const Text: Story = {
-  render: ({ label, onClick }) => html`<button label="${label}" @click=${onClick}></button>`,
+  render: ({ label, onClick }) =>
+    html`<custom-button label="${label}" @click=${onClick}></custom-button>`,
   args: {
     label: 'Hello',
     onClick: action('clicked'),

--- a/docs/snippets/web-components/button-story-click-handler-simplificated.js.mdx
+++ b/docs/snippets/web-components/button-story-click-handler-simplificated.js.mdx
@@ -1,11 +1,9 @@
 ```js
 // Button.stories.js
 
-import { Button } from './Button';
-
 export default {
   title: 'Button',
-  render: (args) => Button(args),
+  component: 'custom-button',
   argTypes: {
     onClick: { action: 'onClick' },
   },

--- a/docs/snippets/web-components/button-story-click-handler-simplificated.js.mdx
+++ b/docs/snippets/web-components/button-story-click-handler-simplificated.js.mdx
@@ -1,0 +1,17 @@
+```js
+// Button.stories.js
+
+import { Button } from './Button';
+
+export default {
+  title: 'Button',
+  render: (args) => Button(args),
+  argTypes: {
+    onClick: { action: 'onClick' },
+  },
+};
+
+export const Text = {
+  args: {...},
+};
+```

--- a/docs/snippets/web-components/button-story-click-handler-simplificated.ts.mdx
+++ b/docs/snippets/web-components/button-story-click-handler-simplificated.ts.mdx
@@ -1,0 +1,23 @@
+```ts
+// Button.stories.ts
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { ButtonProps } from './Button';
+import { Button } from './Button';
+
+const meta: Meta<ButtonProps> = {
+  title: 'Button',
+  render: (args) => Button(args),
+  argTypes: {
+    onClick: { action: 'onClick' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<ButtonProps>;
+
+export const Text: Story = {
+    args:{...},
+};
+```

--- a/docs/snippets/web-components/button-story-click-handler-simplificated.ts.mdx
+++ b/docs/snippets/web-components/button-story-click-handler-simplificated.ts.mdx
@@ -3,19 +3,16 @@
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { ButtonProps } from './Button';
-import { Button } from './Button';
-
-const meta: Meta<ButtonProps> = {
+const meta: Meta = {
   title: 'Button',
-  render: (args) => Button(args),
+  component: 'custom-button',
   argTypes: {
     onClick: { action: 'onClick' },
   },
 };
 
 export default meta;
-type Story = StoryObj<ButtonProps>;
+type Story = StoryObj;
 
 export const Text: Story = {
     args:{...},

--- a/docs/snippets/web-components/button-story-click-handler.js.mdx
+++ b/docs/snippets/web-components/button-story-click-handler.js.mdx
@@ -1,0 +1,18 @@
+```js
+// Button.stories.js
+
+import { html } from 'lit-html';
+
+import { Button } from './Button';
+
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Button',
+  render: (args) => Button(args),
+};
+
+export const Text = {
+  render: () => html`<button label="Hello" @click=${action('clicked')}></button>`,
+};
+```

--- a/docs/snippets/web-components/button-story-click-handler.js.mdx
+++ b/docs/snippets/web-components/button-story-click-handler.js.mdx
@@ -3,16 +3,14 @@
 
 import { html } from 'lit-html';
 
-import { Button } from './Button';
-
 import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Button',
-  render: (args) => Button(args),
+  component: 'custom-button',
 };
 
 export const Text = {
-  render: () => html`<button label="Hello" @click=${action('clicked')}></button>`,
+  render: () => html`<custom-button label="Hello" @click=${action('clicked')}></custom-button>`,
 };
 ```

--- a/docs/snippets/web-components/button-story-click-handler.ts.mdx
+++ b/docs/snippets/web-components/button-story-click-handler.ts.mdx
@@ -1,0 +1,24 @@
+```ts
+// Button.stories.ts
+
+import { html } from 'lit-html';
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import { action } from '@storybook/addon-actions';
+
+import type { ButtonProps } from './Button';
+import { Button } from './Button';
+
+const meta: Meta<ButtonProps> = {
+  title: 'Button',
+  render: (args) => Button(args),
+};
+
+export default meta;
+type Story = StoryObj<ButtonProps>;
+
+export const Text: Story = {
+  render: () => html`<button label="Hello" @click=${action('clicked')}></button>`,
+};
+```

--- a/docs/snippets/web-components/button-story-click-handler.ts.mdx
+++ b/docs/snippets/web-components/button-story-click-handler.ts.mdx
@@ -7,18 +7,15 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 
 import { action } from '@storybook/addon-actions';
 
-import type { ButtonProps } from './Button';
-import { Button } from './Button';
-
-const meta: Meta<ButtonProps> = {
+const meta: Meta = {
   title: 'Button',
-  render: (args) => Button(args),
+  component: 'custom-button',
 };
 
 export default meta;
-type Story = StoryObj<ButtonProps>;
+type Story = StoryObj;
 
 export const Text: Story = {
-  render: () => html`<button label="Hello" @click=${action('clicked')}></button>`,
+  render: () => html`<custom-button label="Hello" @click=${action('clicked')}></custom-button>`,
 };
 ```

--- a/docs/snippets/web-components/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/web-components/button-story-with-addon-example.js.mdx
@@ -1,0 +1,25 @@
+```js
+// Button.stories.js
+
+import { Button } from './Button';
+
+export default {
+  title: 'Button',
+  render: (args) => Button(args),
+  //👇 Creates specific parameters for the story
+  parameters: {
+    myAddon: {
+      data: 'This data is passed to the addon',
+    },
+  },
+};
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * to learn how to use render functions.
+ */
+export const Basic = {
+  render: () => Button({ label: "Hello" }),
+};
+```

--- a/docs/snippets/web-components/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/web-components/button-story-with-addon-example.js.mdx
@@ -1,11 +1,11 @@
 ```js
 // Button.stories.js
 
-import { Button } from './Button';
+import { html } from 'lit-html';
 
 export default {
   title: 'Button',
-  render: (args) => Button(args),
+  component: 'custom-button',
   //👇 Creates specific parameters for the story
   parameters: {
     myAddon: {
@@ -20,6 +20,6 @@ export default {
  * to learn how to use render functions.
  */
 export const Basic = {
-  render: () => Button({ label: 'Hello' }),
+  render: () => html`<custom-button label="Hello"></custom-button>`,
 };
 ```

--- a/docs/snippets/web-components/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/web-components/button-story-with-addon-example.js.mdx
@@ -20,6 +20,6 @@ export default {
  * to learn how to use render functions.
  */
 export const Basic = {
-  render: () => Button({ label: "Hello" }),
+  render: () => Button({ label: 'Hello' }),
 };
 ```

--- a/docs/snippets/web-components/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/web-components/button-story-with-addon-example.ts.mdx
@@ -3,12 +3,11 @@
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { ButtonProps } from './Button';
-import { Button } from './Button';
+import { html } from 'lit-html';
 
-const meta: Meta<ButtonProps> = {
+const meta: Meta = {
   title: 'Button',
-  render: (args) => Button(args),
+  component: 'custom-button',
   //👇 Creates specific parameters for the story
   parameters: {
     myAddon: {
@@ -18,7 +17,7 @@ const meta: Meta<ButtonProps> = {
 };
 
 export default meta;
-type Story = StoryObj<ButtonProps>;
+type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
@@ -26,6 +25,6 @@ type Story = StoryObj<ButtonProps>;
  * to learn how to use render functions.
  */
 export const Basic: Story = {
-  render: () => Button({ label: 'Hello' }),
+  render: () => html`<custom-button label="Hello"></custom-button>`,
 };
 ```

--- a/docs/snippets/web-components/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/web-components/button-story-with-addon-example.ts.mdx
@@ -1,0 +1,31 @@
+```ts
+// Button.stories.ts
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { ButtonProps } from './Button';
+import { Button } from './Button';
+
+const meta: Meta<ButtonProps> = {
+  title: 'Button',
+  render: (args) => Button(args),
+  //👇 Creates specific parameters for the story
+  parameters: {
+    myAddon: {
+      data: 'This data is passed to the addon',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<ButtonProps>;
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * to learn how to use render functions.
+ */
+export const Basic: Story = {
+  render: () => Button({ label: 'Hello' }),
+};
+```

--- a/docs/snippets/web-components/component-story-figma-integration.js.mdx
+++ b/docs/snippets/web-components/component-story-figma-integration.js.mdx
@@ -1,0 +1,22 @@
+```js
+// MyComponent.stories.js
+
+import { withDesign } from 'storybook-addon-designs';
+
+import { MyComponent } from './MyComponent';
+
+export default {
+  title: 'FigmaExample',
+  render: (args) => MyComponent(args),
+  decorators: [withDesign],
+};
+
+export const Example = {
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/Sample-File',
+    },
+  },
+};
+```

--- a/docs/snippets/web-components/component-story-figma-integration.js.mdx
+++ b/docs/snippets/web-components/component-story-figma-integration.js.mdx
@@ -3,11 +3,9 @@
 
 import { withDesign } from 'storybook-addon-designs';
 
-import { MyComponent } from './MyComponent';
-
 export default {
   title: 'FigmaExample',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
   decorators: [withDesign],
 };
 

--- a/docs/snippets/web-components/component-story-figma-integration.ts.mdx
+++ b/docs/snippets/web-components/component-story-figma-integration.ts.mdx
@@ -1,0 +1,29 @@
+```ts
+// MyComponent.stories.ts
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import { withDesign } from 'storybook-addon-designs';
+
+import type { MyComponentProps } from './MyComponent';
+
+import { MyComponent } from './MyComponent';
+
+const meta: Meta<MyComponentProps> = {
+  title: 'FigmaExample',
+  render: (args) => MyComponent(args),
+  decorators: [withDesign],
+};
+
+export default meta;
+type Story = StoryObj<MyComponentProps>;
+
+export const Example: Story = {
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/Sample-File',
+    },
+  },
+};
+```

--- a/docs/snippets/web-components/component-story-figma-integration.ts.mdx
+++ b/docs/snippets/web-components/component-story-figma-integration.ts.mdx
@@ -5,18 +5,14 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 
 import { withDesign } from 'storybook-addon-designs';
 
-import type { MyComponentProps } from './MyComponent';
-
-import { MyComponent } from './MyComponent';
-
-const meta: Meta<MyComponentProps> = {
+const meta: Meta = {
   title: 'FigmaExample',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
   decorators: [withDesign],
 };
 
 export default meta;
-type Story = StoryObj<MyComponentProps>;
+type Story = StoryObj;
 
 export const Example: Story = {
   parameters: {

--- a/docs/snippets/web-components/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-cdn.js.mdx
@@ -1,10 +1,12 @@
 ```js
 // MyComponent.stories.js
 
-import { MyComponent } from './my-component';
+import { html } from 'lit-html';
+
+import { MyComponent } from './MyComponent';
 
 export default {
-  title: 'MyComponent',
+  title: 'img',
   render: (args) => MyComponent(args),
 };
 
@@ -13,9 +15,10 @@ export default {
  * See https://storybook.js.org/docs/7.0/web-components/api/csf
  * to learn how to use render functions.
  */
-export const ExampleStory = {
-  args: {
-    propertyA: process.env.STORYBOOK_DATA_KEY,
-  },
+export const WithAnImage = {
+  render: () => html`<img
+    src="https://storybook.js.org/images/placeholders/350x150.png"
+    alt="My CDN placeholder"
+  />`,
 };
 ```

--- a/docs/snippets/web-components/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-cdn.js.mdx
@@ -3,11 +3,9 @@
 
 import { html } from 'lit-html';
 
-import { MyComponent } from './MyComponent';
-
 export default {
   title: 'img',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 /*

--- a/docs/snippets/web-components/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-cdn.ts.mdx
@@ -5,16 +5,13 @@ import { html } from 'lit-html';
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { MyComponentProps } from './MyComponent';
-import { MyComponent } from './MyComponent';
-
-const meta: Meta<MyComponentProps> = {
+const meta: Meta = {
   title: 'img',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export default meta;
-type Story = StoryObj<MyComponentProps>;
+type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.

--- a/docs/snippets/web-components/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-cdn.ts.mdx
@@ -1,0 +1,30 @@
+```ts
+// MyComponent.stories.ts
+
+import { html } from 'lit-html';
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { MyComponentProps } from './MyComponent';
+import { MyComponent } from './MyComponent';
+
+const meta: Meta<MyComponentProps> = {
+  title: 'img',
+  render: (args) => MyComponent(args),
+};
+
+export default meta;
+type Story = StoryObj<MyComponentProps>;
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * to learn how to use render functions.
+ */
+export const WithAnImage: Story = {
+  render: () => html`<img
+    src="https://storybook.js.org/images/placeholders/350x150.png"
+    alt="My CDN placeholder"
+  />`,
+};
+```

--- a/docs/snippets/web-components/component-story-static-asset-with-import.js.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-with-import.js.mdx
@@ -3,13 +3,11 @@
 
 import { html } from 'lit-html';
 
-import { MyComponent } from './MyComponent';
-
 import imageFile from './static/image.png';
 
 export default {
   title: 'img',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 const image = {

--- a/docs/snippets/web-components/component-story-static-asset-with-import.js.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-with-import.js.mdx
@@ -1,11 +1,20 @@
 ```js
 // MyComponent.stories.js
 
-import { MyComponent } from './my-component';
+import { html } from 'lit-html';
+
+import { MyComponent } from './MyComponent';
+
+import imageFile from './static/image.png';
 
 export default {
-  title: 'MyComponent',
+  title: 'img',
   render: (args) => MyComponent(args),
+};
+
+const image = {
+  src: imageFile,
+  alt: 'my image',
 };
 
 /*
@@ -13,9 +22,7 @@ export default {
  * See https://storybook.js.org/docs/7.0/web-components/api/csf
  * to learn how to use render functions.
  */
-export const ExampleStory = {
-  args: {
-    propertyA: process.env.STORYBOOK_DATA_KEY,
-  },
+export const WithAnImage = {
+  render: () => html`<img src="${image.src}" alt="${image.alt}" /> `,
 };
 ```

--- a/docs/snippets/web-components/component-story-static-asset-with-import.ts.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-with-import.ts.mdx
@@ -5,14 +5,11 @@ import { html } from 'lit-html';
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { MyComponentProps } from './MyComponent';
-import { MyComponent } from './MyComponent';
-
 import imageFile from './static/image.png';
 
-const meta: Meta<MyComponentProps> = {
+const meta: Meta = {
   title: 'img',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 const image = {
@@ -21,7 +18,7 @@ const image = {
 };
 
 export default meta;
-type Story = StoryObj<MyComponentProps>;
+type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.

--- a/docs/snippets/web-components/component-story-static-asset-with-import.ts.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-with-import.ts.mdx
@@ -1,0 +1,34 @@
+```ts
+// MyComponent.stories.ts
+
+import { html } from 'lit-html';
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { MyComponentProps } from './MyComponent';
+import { MyComponent } from './MyComponent';
+
+import imageFile from './static/image.png';
+
+const meta: Meta<MyComponentProps> = {
+  title: 'img',
+  render: (args) => MyComponent(args),
+};
+
+const image = {
+  src: imageFile,
+  alt: 'my image',
+};
+
+export default meta;
+type Story = StoryObj<MyComponentProps>;
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * to learn how to use render functions.
+ */
+export const WithAnImage: Story = {
+  render: () => html`<img src="${image.src}" alt="${image.alt}" />`,
+};
+```

--- a/docs/snippets/web-components/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-without-import.js.mdx
@@ -1,0 +1,17 @@
+```js
+// MyComponent.stories.js
+
+import { html } from 'lit-html';
+
+import { MyComponent } from './MyComponent';
+
+export default {
+  title: 'img',
+  render: (args) => MyComponent(args),
+};
+
+// Assume image.png is located in the "public" directory.
+export const WithAnImage = {
+  render: () => html`<img src="/image.png" alt="image" />`,
+};
+```

--- a/docs/snippets/web-components/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-without-import.js.mdx
@@ -3,11 +3,9 @@
 
 import { html } from 'lit-html';
 
-import { MyComponent } from './MyComponent';
-
 export default {
   title: 'img',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 // Assume image.png is located in the "public" directory.

--- a/docs/snippets/web-components/component-story-static-asset-without-import.ts.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-without-import.ts.mdx
@@ -5,16 +5,13 @@ import { html } from 'lit-html';
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { MyComponentProps } from './MyComponent';
-import { MyComponent } from './MyComponent';
-
-const meta: Meta<MyComponentProps> = {
+const meta: Meta = {
   title: 'img',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export default meta;
-type Story = StoryObj<MyComponentProps>;
+type Story = StoryObj;
 
 // Assume image.png is located in the "public" directory.
 export const WithAnImage: Story = {

--- a/docs/snippets/web-components/component-story-static-asset-without-import.ts.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-without-import.ts.mdx
@@ -1,0 +1,23 @@
+```ts
+// MyComponent.stories.ts
+
+import { html } from 'lit-html';
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { MyComponentProps } from './MyComponent';
+import { MyComponent } from './MyComponent';
+
+const meta: Meta<MyComponentProps> = {
+  title: 'img',
+  render: (args) => MyComponent(args),
+};
+
+export default meta;
+type Story = StoryObj<MyComponentProps>;
+
+// Assume image.png is located in the "public" directory.
+export const WithAnImage: Story = {
+  render: () => html`<img src="/image.png" alt="image" />`,
+};
+```

--- a/docs/snippets/web-components/component-story-with-accessibility.js.mdx
+++ b/docs/snippets/web-components/component-story-with-accessibility.js.mdx
@@ -1,11 +1,9 @@
 ```js
 // Button.stories.js
 
-import { Button } from './Button';
-
 export default {
   title: 'Accessibility testing',
-  render: (args) => Button(args),
+  component: 'custom-button',
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/docs/snippets/web-components/component-story-with-accessibility.js.mdx
+++ b/docs/snippets/web-components/component-story-with-accessibility.js.mdx
@@ -1,0 +1,29 @@
+```js
+// Button.stories.js
+
+import { Button } from './Button';
+
+export default {
+  title: 'Accessibility testing',
+  render: (args) => Button(args),
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+};
+
+// This is an accessible story
+export const Accessible = {
+  args: {
+    primary: false,
+    label: 'Button',
+  },
+};
+
+// This is not
+export const Inaccessible = {
+  args: {
+    ...Accessible.args,
+    backgroundColor: 'red',
+  },
+};
+```

--- a/docs/snippets/web-components/component-story-with-accessibility.ts.mdx
+++ b/docs/snippets/web-components/component-story-with-accessibility.ts.mdx
@@ -1,0 +1,35 @@
+```ts
+// Button.stories.ts
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { ButtonProps } from './Button';
+import { Button } from './Button';
+
+const meta: Meta<ButtonProps> = {
+  title: 'Accessibility testing',
+  render: (args) => Button(args),
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<ButtonProps>;
+
+// This is an accessible story
+export const Accessible: Story = {
+  args: {
+    primary: false,
+    label: 'Button',
+  },
+};
+
+// This is not
+export const Inaccessible: Story = {
+  args: {
+    ...Accessible.args,
+    backgroundColor: 'red',
+  },
+};
+```

--- a/docs/snippets/web-components/component-story-with-accessibility.ts.mdx
+++ b/docs/snippets/web-components/component-story-with-accessibility.ts.mdx
@@ -3,19 +3,16 @@
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { ButtonProps } from './Button';
-import { Button } from './Button';
-
-const meta: Meta<ButtonProps> = {
+const meta: Meta = {
   title: 'Accessibility testing',
-  render: (args) => Button(args),
+  component: 'custom-button',
   argTypes: {
     backgroundColor: { control: 'color' },
   },
 };
 
 export default meta;
-type Story = StoryObj<ButtonProps>;
+type Story = StoryObj;
 
 // This is an accessible story
 export const Accessible: Story = {

--- a/docs/snippets/web-components/component-story-with-custom-render-function.js.mdx
+++ b/docs/snippets/web-components/component-story-with-custom-render-function.js.mdx
@@ -3,11 +3,9 @@
 
 import { html } from 'lit-html';
 
-import { MyComponent } from './MyComponent';
-import { Layout } from './Layout';
 export default {
   title: 'MyComponent',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 // This story uses a render function to fully control how the component renders.

--- a/docs/snippets/web-components/component-story-with-custom-render-function.ts.mdx
+++ b/docs/snippets/web-components/component-story-with-custom-render-function.ts.mdx
@@ -5,20 +5,13 @@ import { html } from 'lit-html';
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { MyComponentProps } from './MyComponent';
-import type { LayoutProps } from './Layout';
-
-import { MyComponent } from './MyComponent';
-
-import { Layout } from './Layout';
-
-const meta: Meta<MyComponentProps> = {
+const meta: Meta = {
   title: 'MyComponent',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export default meta;
-type Story = StoryObj<MyComponentProps>;
+type Story = StoryObj;
 
 // This story uses a render function to fully control how the component renders.
 export const Example: Story = {

--- a/docs/snippets/web-components/component-story-with-custom-render-function.ts.mdx
+++ b/docs/snippets/web-components/component-story-with-custom-render-function.ts.mdx
@@ -1,17 +1,27 @@
-```js
-// MyComponent.stories.js
+```ts
+// MyComponent.stories.ts
 
 import { html } from 'lit-html';
 
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { MyComponentProps } from './MyComponent';
+import type { LayoutProps } from './Layout';
+
 import { MyComponent } from './MyComponent';
+
 import { Layout } from './Layout';
-export default {
+
+const meta: Meta<MyComponentProps> = {
   title: 'MyComponent',
   render: (args) => MyComponent(args),
 };
 
+export default meta;
+type Story = StoryObj<MyComponentProps>;
+
 // This story uses a render function to fully control how the component renders.
-export const Example = {
+export const Example: Story = {
   render: () => html`
     <layout>
       <header>

--- a/docs/snippets/web-components/csf-2-example-starter.js.mdx
+++ b/docs/snippets/web-components/csf-2-example-starter.js.mdx
@@ -3,8 +3,6 @@
 
 import { html } from 'lit-html';
 
-import './custom-button';
-
 export default {
   title: 'custom-button',
   component: 'custom-button',

--- a/docs/snippets/web-components/csf-2-example-starter.ts.mdx
+++ b/docs/snippets/web-components/csf-2-example-starter.ts.mdx
@@ -5,8 +5,6 @@ import { html } from 'lit-html';
 
 import { Meta, Story } from '@storybook/web-components';
 
-import './custom-button';
-
 export default {
   title: 'custom-button',
   component: 'custom-button',

--- a/docs/snippets/web-components/csf-2-example-starter.ts.mdx
+++ b/docs/snippets/web-components/csf-2-example-starter.ts.mdx
@@ -1,16 +1,18 @@
-```js
+```ts
 // CSF 2
 
 import { html } from 'lit-html';
+
+import { Meta, Story } from '@storybook/web-components';
 
 import './custom-button';
 
 export default {
   title: 'custom-button',
   component: 'custom-button',
-};
+} as Meta;
 
-export const Primary = ({ primary }) => html`<custom-button ?primary=${primary}></custom-button>`;
+export const Primary: Story = ({ primary }) => html`<custom-button ?primary=${primary}></custom-button>`;
 Primary.args = {
   primary: true,
 };

--- a/docs/snippets/web-components/csf-2-example-starter.ts.mdx
+++ b/docs/snippets/web-components/csf-2-example-starter.ts.mdx
@@ -12,7 +12,8 @@ export default {
   component: 'custom-button',
 } as Meta;
 
-export const Primary: Story = ({ primary }) => html`<custom-button ?primary=${primary}></custom-button>`;
+export const Primary: Story = ({ primary }) =>
+  html`<custom-button ?primary=${primary}></custom-button>`;
 Primary.args = {
   primary: true,
 };

--- a/docs/snippets/web-components/csf-2-example-story.ts.mdx
+++ b/docs/snippets/web-components/csf-2-example-story.ts.mdx
@@ -1,8 +1,8 @@
-```js
+```ts
 // CSF 2
 
 // Other imports and story implementation
 
-export const Default = ({ primary, backgroundColor, size, label }) =>
+export const Default: Story = ({ primary, backgroundColor, size, label }) =>
   html`<custom-button ?primary="${primary}" size="${size}" label="${label}"></custom-button>`;
 ```

--- a/docs/snippets/web-components/csf-3-example-render.js.mdx
+++ b/docs/snippets/web-components/csf-3-example-render.js.mdx
@@ -4,6 +4,6 @@
 // Other imports and story implementation
 
 export const Default = {
-  render: (args) => Button(args),
+  render: (args) => html`<custom-button label="Hello" @click=${action('clicked')}></custom-button>`,
 };
 ```

--- a/docs/snippets/web-components/csf-3-example-render.ts.mdx
+++ b/docs/snippets/web-components/csf-3-example-render.ts.mdx
@@ -3,7 +3,7 @@
 
 // Other imports and story implementation
 
-export const Default = {
+export const Default: Story = {
   render: (args) => Button(args),
 };
 ```

--- a/docs/snippets/web-components/csf-3-example-render.ts.mdx
+++ b/docs/snippets/web-components/csf-3-example-render.ts.mdx
@@ -4,6 +4,6 @@
 // Other imports and story implementation
 
 export const Default: Story = {
-  render: (args) => Button(args),
+  render: (args) => html`<custom-button label="Hello" @click=${action('clicked')}></custom-button>`,
 };
 ```

--- a/docs/snippets/web-components/csf-3-example-starter.js.mdx
+++ b/docs/snippets/web-components/csf-3-example-starter.js.mdx
@@ -1,9 +1,7 @@
 ```js
 // CSF 3
 
-import { Button } from './Button';
-
-export default { title: 'Button', render: (args) => Button(args) };
+export default { title: 'Button', component: 'custom-button', };
 
 export const Primary = { args: { primary: true } };
 ```

--- a/docs/snippets/web-components/csf-3-example-starter.js.mdx
+++ b/docs/snippets/web-components/csf-3-example-starter.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // CSF 3
 
-export default { title: 'Button', component: 'custom-button', };
+export default { title: 'Button', component: 'custom-button' };
 
 export const Primary = { args: { primary: true } };
 ```

--- a/docs/snippets/web-components/csf-3-example-starter.js.mdx
+++ b/docs/snippets/web-components/csf-3-example-starter.js.mdx
@@ -1,0 +1,9 @@
+```js
+// CSF 3
+
+import { Button } from './Button';
+
+export default { title: 'Button', render: (args) => Button(args) };
+
+export const Primary = { args: { primary: true } };
+```

--- a/docs/snippets/web-components/csf-3-example-starter.ts.mdx
+++ b/docs/snippets/web-components/csf-3-example-starter.ts.mdx
@@ -1,0 +1,15 @@
+```ts
+// CSF 3
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { ButtonProps } from './Button';
+import { Button } from './Button';
+
+const meta: Meta<ButtonProps> = { title: 'Button', render: (args) => Button(args) };
+
+export default meta;
+type Story = StoryObj<ButtonProps>;
+
+export const Primary: Story = { args: { primary: true } };
+```

--- a/docs/snippets/web-components/csf-3-example-starter.ts.mdx
+++ b/docs/snippets/web-components/csf-3-example-starter.ts.mdx
@@ -3,7 +3,7 @@
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-const meta: Meta = { title: 'Button', component: 'custom-button', };
+const meta: Meta = { title: 'Button', component: 'custom-button' };
 
 export default meta;
 type Story = StoryObj;

--- a/docs/snippets/web-components/csf-3-example-starter.ts.mdx
+++ b/docs/snippets/web-components/csf-3-example-starter.ts.mdx
@@ -3,13 +3,10 @@
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { ButtonProps } from './Button';
-import { Button } from './Button';
-
-const meta: Meta<ButtonProps> = { title: 'Button', render: (args) => Button(args) };
+const meta: Meta = { title: 'Button', component: 'custom-button', };
 
 export default meta;
-type Story = StoryObj<ButtonProps>;
+type Story = StoryObj;
 
 export const Primary: Story = { args: { primary: true } };
 ```

--- a/docs/snippets/web-components/my-component-story-basic-and-props.js.mdx
+++ b/docs/snippets/web-components/my-component-story-basic-and-props.js.mdx
@@ -1,0 +1,18 @@
+```js
+// MyComponent.stories.js
+
+import { html } from 'lit-html';
+
+import { MyComponent } from './MyComponent';
+
+export default {
+  title: 'Path/To/MyComponent',
+  render: (args) => MyComponent(args),
+};
+
+export const Basic = {};
+
+export const WithProp = {
+  render: () => html`<my-component prop="value" />`,
+};
+```

--- a/docs/snippets/web-components/my-component-story-basic-and-props.js.mdx
+++ b/docs/snippets/web-components/my-component-story-basic-and-props.js.mdx
@@ -3,11 +3,9 @@
 
 import { html } from 'lit-html';
 
-import { MyComponent } from './MyComponent';
-
 export default {
   title: 'Path/To/MyComponent',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export const Basic = {};

--- a/docs/snippets/web-components/my-component-story-basic-and-props.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-basic-and-props.ts.mdx
@@ -5,16 +5,13 @@ import { html } from 'lit-html';
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { MyComponentProps } from './MyComponent';
-import { MyComponent } from './MyComponent';
-
-const meta: Meta<MyComponentProps> = {
+const meta: Meta = {
   title: 'Path/To/MyComponent',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export default meta;
-type Story = StoryObj<MyComponentProps>;
+type Story = StoryObj;
 
 export const Basic: Story = {};
 

--- a/docs/snippets/web-components/my-component-story-basic-and-props.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-basic-and-props.ts.mdx
@@ -1,0 +1,24 @@
+```ts
+// MyComponent.stories.ts
+
+import { html } from 'lit-html';
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { MyComponentProps } from './MyComponent';
+import { MyComponent } from './MyComponent';
+
+const meta: Meta<MyComponentProps> = {
+  title: 'Path/To/MyComponent',
+  render: (args) => MyComponent(args),
+};
+
+export default meta;
+type Story = StoryObj<MyComponentProps>;
+
+export const Basic: Story = {};
+
+export const WithProp: Story = {
+  render: () => html`<my-component prop="value" />`,
+};
+```

--- a/docs/snippets/web-components/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/web-components/my-component-story-configure-viewports.js.mdx
@@ -1,12 +1,11 @@
 ```js
 // MyComponent.stories.js
 
-import { MyComponent } from './MyComponent';
-
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 export default {
   title: 'MyComponent',
+  component: 'my-component',
   parameters: {
     //👇 The viewports object from the Essentials addon
     viewport: {
@@ -24,7 +23,6 @@ export default {
  * to learn how to use render functions.
  */
 export const MyStory = {
-  render: () => MyComponent(),
   parameters: {
     viewport: {
       defaultViewport: 'iphonex',

--- a/docs/snippets/web-components/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-configure-viewports.ts.mdx
@@ -1,11 +1,15 @@
-```js
-// MyComponent.stories.js
+```ts
+// MyComponent.stories.ts
 
-import { MyComponent } from './MyComponent';
+import type { Meta, StoryObj } from '@storybook/web-components';
 
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
-export default {
+import type { MyComponentProps } from './MyComponent';
+
+import { MyComponent } from './MyComponent';
+
+const meta: Meta<MyComponentProps> = {
   title: 'MyComponent',
   parameters: {
     //👇 The viewports object from the Essentials addon
@@ -17,6 +21,9 @@ export default {
     },
   },
 };
+
+export default meta;
+type Story = StoryObj<MyComponentProps>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.

--- a/docs/snippets/web-components/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-configure-viewports.ts.mdx
@@ -5,12 +5,9 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
-import type { MyComponentProps } from './MyComponent';
-
-import { MyComponent } from './MyComponent';
-
-const meta: Meta<MyComponentProps> = {
+const meta: Meta = {
   title: 'MyComponent',
+  component: 'my-component',
   parameters: {
     //👇 The viewports object from the Essentials addon
     viewport: {
@@ -23,15 +20,14 @@ const meta: Meta<MyComponentProps> = {
 };
 
 export default meta;
-type Story = StoryObj<MyComponentProps>;
+type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
  * See https://storybook.js.org/docs/7.0/web-components/api/csf
  * to learn how to use render functions.
  */
-export const MyStory = {
-  render: () => MyComponent(),
+export const MyStory: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'iphonex',

--- a/docs/snippets/web-components/my-component-story-use-globaltype-backwards-compat.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-use-globaltype-backwards-compat.ts.mdx
@@ -3,14 +3,14 @@
 
 import { html } from 'lit-html';
 
-import { Story } from '@storybook/web-components';
+import { StoryObj } from '@storybook/web-components';
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
  * See https://storybook.js.org/docs/7.0/web-components/api/csf
  * to learn how to use render functions.
  */
-export const StoryWithLocale: Story = {
+export const StoryWithLocale: StoryObj = {
   render: ({ globals: { locale } }) => {
     const caption = getCaptionForLocale(locale);
     return html`<p>${caption}</p>`;

--- a/docs/snippets/web-components/my-component-story-use-globaltype-backwards-compat.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-use-globaltype-backwards-compat.ts.mdx
@@ -1,14 +1,16 @@
-```js
-// MyComponent.stories.js
+```ts
+// MyComponent.stories.ts
 
 import { html } from 'lit-html';
+
+import { Story } from '@storybook/web-components';
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
  * See https://storybook.js.org/docs/7.0/web-components/api/csf
  * to learn how to use render functions.
  */
-export const StoryWithLocale = {
+export const StoryWithLocale: Story = {
   render: ({ globals: { locale } }) => {
     const caption = getCaptionForLocale(locale);
     return html`<p>${caption}</p>`;

--- a/docs/snippets/web-components/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/web-components/my-component-story-use-globaltype.js.mdx
@@ -3,11 +3,9 @@
 
 import { html } from 'lit-html';
 
-import { MyComponent } from './MyComponent';
-
 export default {
   title: 'MyComponent',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 const getCaptionForLocale = (locale) => {

--- a/docs/snippets/web-components/my-component-story-use-globaltype.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-use-globaltype.ts.mdx
@@ -1,6 +1,8 @@
 ```ts
 // MyComponent.stories.ts
 
+import { html } from 'lit-html';
+
 import type { Meta, StoryObj } from '@storybook/web-components';
 
 import type { MyComponentProps } from './MyComponent';

--- a/docs/snippets/web-components/my-component-story-use-globaltype.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-use-globaltype.ts.mdx
@@ -5,13 +5,9 @@ import { html } from 'lit-html';
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { MyComponentProps } from './MyComponent';
-
-import { MyComponent } from './MyComponent';
-
-const meta: Meta<MyComponentProps> = {
+const meta: Meta = {
   title: 'MyComponent',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 const getCaptionForLocale = (locale) => {
@@ -30,7 +26,7 @@ const getCaptionForLocale = (locale) => {
 };
 
 export default meta;
-type Story = StoryObj<MyComponentProps>;
+type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.

--- a/docs/snippets/web-components/my-component-story-use-globaltype.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-use-globaltype.ts.mdx
@@ -1,11 +1,13 @@
-```js
-// MyComponent.stories.js
+```ts
+// MyComponent.stories.ts
 
-import { html } from 'lit-html';
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { MyComponentProps } from './MyComponent';
 
 import { MyComponent } from './MyComponent';
 
-export default {
+const meta: Meta<MyComponentProps> = {
   title: 'MyComponent',
   render: (args) => MyComponent(args),
 };
@@ -25,12 +27,15 @@ const getCaptionForLocale = (locale) => {
   }
 };
 
+export default meta;
+type Story = StoryObj<MyComponentProps>;
+
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
  * See https://storybook.js.org/docs/7.0/web-components/api/csf
  * to learn how to use render functions.
  */
-export const StoryWithLocale = {
+export const StoryWithLocale: Story = {
   render: (args, { globals: { locale } }) => {
     const caption = getCaptionForLocale(locale);
     return html`<p>${caption}</p>`;

--- a/docs/snippets/web-components/my-component-story-with-nonstory.js.mdx
+++ b/docs/snippets/web-components/my-component-story-with-nonstory.js.mdx
@@ -1,11 +1,9 @@
 ```js
 // MyComponent.stories.js
 
-import { MyComponent } from './MyComponent';
-
 export default {
   title: 'MyComponent',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
   includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
   excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
 };

--- a/docs/snippets/web-components/my-component-story-with-nonstory.js.mdx
+++ b/docs/snippets/web-components/my-component-story-with-nonstory.js.mdx
@@ -1,0 +1,27 @@
+```js
+// MyComponent.stories.js
+
+import { MyComponent } from './MyComponent';
+
+export default {
+  title: 'MyComponent',
+  render: (args) => MyComponent(args),
+  includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
+  excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
+};
+
+export const simpleData = { foo: 1, bar: 'baz' };
+export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
+
+export const SimpleStory = {
+  args: {
+    data: simpleData,
+  },
+};
+
+export const ComplexStory = {
+  args: {
+    data: complexData,
+  },
+};
+```

--- a/docs/snippets/web-components/my-component-story-with-nonstory.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-with-nonstory.ts.mdx
@@ -3,12 +3,9 @@
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { MyComponentProps } from './MyComponent';
-import { MyComponent } from './MyComponent';
-
-const meta: Meta<MyComponentProps> = {
+const meta: Meta = {
   title: 'MyComponent',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
   includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
   excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
 };
@@ -17,7 +14,7 @@ export const simpleData = { foo: 1, bar: 'baz' };
 export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
 
 export default meta;
-type Story = StoryObj<MyComponentProps>;
+type Story = StoryObj;
 
 export const SimpleStory: Story = {
   args: {

--- a/docs/snippets/web-components/my-component-story-with-nonstory.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-with-nonstory.ts.mdx
@@ -1,0 +1,33 @@
+```ts
+// MyComponent.stories.ts
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { MyComponentProps } from './MyComponent';
+import { MyComponent } from './MyComponent';
+
+const meta: Meta<MyComponentProps> = {
+  title: 'MyComponent',
+  render: (args) => MyComponent(args),
+  includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
+  excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
+};
+
+export const simpleData = { foo: 1, bar: 'baz' };
+export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
+
+export default meta;
+type Story = StoryObj<MyComponentProps>;
+
+export const SimpleStory: Story = {
+  args: {
+    data: simpleData,
+  },
+};
+
+export const ComplexStory: Story = {
+  args: {
+    data: complexData,
+  },
+};
+```

--- a/docs/snippets/web-components/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/web-components/my-component-with-env-variables.js.mdx
@@ -8,11 +8,6 @@ export default {
   render: (args) => MyComponent(args),
 };
 
-/*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
- * to learn how to use render functions.
- */
 export const ExampleStory = {
   args: {
     propertyA: process.env.STORYBOOK_DATA_KEY,

--- a/docs/snippets/web-components/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/web-components/my-component-with-env-variables.js.mdx
@@ -1,11 +1,9 @@
 ```js
 // MyComponent.stories.js
 
-import { MyComponent } from './my-component';
-
 export default {
   title: 'MyComponent',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export const ExampleStory = {

--- a/docs/snippets/web-components/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/web-components/my-component-with-env-variables.ts.mdx
@@ -3,16 +3,13 @@
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { MyComponentProps } from './MyComponent';
-import { MyComponent } from './MyComponent';
-
-export default {
+const meta: Meta = {
   title: 'MyComponent',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export default meta;
-type Story = StoryObj<MyComponentProps>;
+type Story = StoryObj;
 
 export const ExampleStory: Story = {
   args: {

--- a/docs/snippets/web-components/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/web-components/my-component-with-env-variables.ts.mdx
@@ -1,0 +1,22 @@
+```ts
+// MyComponent.stories.ts
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { MyComponentProps } from './MyComponent';
+import { MyComponent } from './MyComponent';
+
+export default {
+  title: 'MyComponent',
+  render: (args) => MyComponent(args),
+};
+
+export default meta;
+type Story = StoryObj<MyComponentProps>;
+
+export const ExampleStory: Story = {
+  args: {
+    propertyA: process.env.STORYBOOK_DATA_KEY,
+  },
+};
+```

--- a/docs/snippets/web-components/storybook-addon-a11y-disable.js.mdx
+++ b/docs/snippets/web-components/storybook-addon-a11y-disable.js.mdx
@@ -1,0 +1,19 @@
+```js
+// MyComponent.stories.js
+
+import { MyComponent } from './MyComponent';
+
+export default {
+  title: 'Disable a11y addon',
+  render: (args) => MyComponent(args),
+};
+
+export const ExampleStory = {
+  parameters: {
+    a11y: {
+      // This option disables all a11y checks on this story
+      disable: true,
+    },
+  },
+};
+```

--- a/docs/snippets/web-components/storybook-addon-a11y-disable.js.mdx
+++ b/docs/snippets/web-components/storybook-addon-a11y-disable.js.mdx
@@ -1,11 +1,9 @@
 ```js
 // MyComponent.stories.js
 
-import { MyComponent } from './MyComponent';
-
 export default {
   title: 'Disable a11y addon',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export const ExampleStory = {

--- a/docs/snippets/web-components/storybook-addon-a11y-disable.ts.mdx
+++ b/docs/snippets/web-components/storybook-addon-a11y-disable.ts.mdx
@@ -3,16 +3,13 @@
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { MyComponent } from './MyComponent';
-import { MyComponent } from './MyComponent';
-
-const meta: Meta<MyComponent> = {
+const meta: Meta = {
   title: 'Disable a11y addon',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export default meta;
-type Story = StoryObj<MyComponent>;
+type Story = StoryObj;
 
 export const ExampleStory: Story = {
   parameters: {

--- a/docs/snippets/web-components/storybook-addon-a11y-disable.ts.mdx
+++ b/docs/snippets/web-components/storybook-addon-a11y-disable.ts.mdx
@@ -1,0 +1,25 @@
+```ts
+// MyComponent.stories.ts
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { MyComponent } from './MyComponent';
+import { MyComponent } from './MyComponent';
+
+const meta: Meta<MyComponent> = {
+  title: 'Disable a11y addon',
+  render: (args) => MyComponent(args),
+};
+
+export default meta;
+type Story = StoryObj<MyComponent>;
+
+export const ExampleStory: Story = {
+  parameters: {
+    a11y: {
+      // This option disables all a11y checks on this story
+      disable: true,
+    },
+  },
+};
+```

--- a/docs/snippets/web-components/storybook-addon-a11y-story-config.js.mdx
+++ b/docs/snippets/web-components/storybook-addon-a11y-story-config.js.mdx
@@ -1,11 +1,9 @@
 ```js
 // MyComponent.stories.js
 
-import { MyComponent } from './MyComponent';
-
 export default {
   title: 'Configure a11y addon',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export const ExampleStory = {

--- a/docs/snippets/web-components/storybook-addon-a11y-story-config.js.mdx
+++ b/docs/snippets/web-components/storybook-addon-a11y-story-config.js.mdx
@@ -1,0 +1,34 @@
+```js
+// MyComponent.stories.js
+
+import { MyComponent } from './MyComponent';
+
+export default {
+  title: 'Configure a11y addon',
+  render: (args) => MyComponent(args),
+};
+
+export const ExampleStory = {
+  parameters: {
+    a11y: {
+      element: '#storybook-root',
+      config: {
+        rules: [
+          {
+            // The autocomplete rule will not run based on the CSS selector provided
+            id: 'autocomplete-valid',
+            selector: '*:not([autocomplete="nope"])',
+          },
+          {
+            // Setting the enabled option to false will disable checks for this particular rule on all stories.
+            id: 'image-alt',
+            enabled: false,
+          },
+        ],
+      },
+      options: {},
+      manual: true,
+    },
+  },
+};
+```

--- a/docs/snippets/web-components/storybook-addon-a11y-story-config.ts.mdx
+++ b/docs/snippets/web-components/storybook-addon-a11y-story-config.ts.mdx
@@ -1,0 +1,40 @@
+```ts
+// MyComponent.stories.ts
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import type { MyComponent } from './MyComponent';
+import { MyComponent } from './MyComponent';
+
+const meta: Meta<MyComponent> = {
+  title: 'Configure a11y addon',
+  render: (args) => MyComponent(args),
+};
+
+export default meta;
+type Story = StoryObj<MyComponent>;
+
+export const ExampleStory: Story = {
+  parameters: {
+    a11y: {
+      element: '#storybook-root',
+      config: {
+        rules: [
+          {
+            // The autocomplete rule will not run based on the CSS selector provided
+            id: 'autocomplete-valid',
+            selector: '*:not([autocomplete="nope"])',
+          },
+          {
+            // Setting the enabled option to false will disable checks for this particular rule on all stories.
+            id: 'image-alt',
+            enabled: false,
+          },
+        ],
+      },
+      options: {},
+      manual: true,
+    },
+  },
+};
+```

--- a/docs/snippets/web-components/storybook-addon-a11y-story-config.ts.mdx
+++ b/docs/snippets/web-components/storybook-addon-a11y-story-config.ts.mdx
@@ -3,16 +3,13 @@
 
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import type { MyComponent } from './MyComponent';
-import { MyComponent } from './MyComponent';
-
-const meta: Meta<MyComponent> = {
+const meta: Meta = {
   title: 'Configure a11y addon',
-  render: (args) => MyComponent(args),
+  component: 'my-component',
 };
 
 export default meta;
-type Story = StoryObj<MyComponent>;
+type Story = StoryObj;
 
 export const ExampleStory: Story = {
   parameters: {

--- a/docs/snippets/web-components/table-story-fully-customize-controls.js.mdx
+++ b/docs/snippets/web-components/table-story-fully-customize-controls.js.mdx
@@ -1,0 +1,45 @@
+```js
+// Table.stories.js
+
+import { html } from 'lit-html';
+import { repeat } from 'lit/directives/repeat.js';
+
+import { Table } from './Table';
+
+export default {
+  title: 'Custom Table',
+  render: (args) => Table(args),
+};
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * to learn how to use render functions.
+ */
+export const TableStory = {
+  render: ({ data, size }) => {
+    return html`
+      <table>
+        <tbody>
+          ${repeat(
+            data,
+            (row, rowIndex) =>
+              html`
+                <tr>
+                  ${repeat(row, (col, colIndex) => html`<td>${data[rowIndex][colIndex]}</td>`)}
+                </tr>
+              `
+          )}
+        </tbody>
+      </table>
+    `;
+  },
+  args: {
+    data: [
+      [1, 2, 3],
+      [4, 5, 6],
+    ],
+    size: 'large',
+  },
+};
+```

--- a/docs/snippets/web-components/table-story-fully-customize-controls.js.mdx
+++ b/docs/snippets/web-components/table-story-fully-customize-controls.js.mdx
@@ -4,11 +4,9 @@
 import { html } from 'lit-html';
 import { repeat } from 'lit/directives/repeat.js';
 
-import { Table } from './Table';
-
 export default {
   title: 'Custom Table',
-  render: (args) => Table(args),
+  component: 'custom-table',
 };
 
 /*

--- a/docs/snippets/web-components/table-story-fully-customize-controls.ts.mdx
+++ b/docs/snippets/web-components/table-story-fully-customize-controls.ts.mdx
@@ -1,0 +1,51 @@
+```ts
+// Table.stories.ts
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import { html } from 'lit-html';
+import { repeat } from 'lit/directives/repeat.js';
+
+import type { TableProps } from './Table';
+import { Table } from './Table';
+
+const meta: Meta<TableProps> = {
+  title: 'Custom Table',
+  render: (args) => Table(args),
+};
+
+export default meta;
+type Story = StoryObj<TableProps>;
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * to learn how to use render functions.
+ */
+export const TableStory: Story = {
+  render: ({ data, size }) => {
+    return html`
+      <table>
+        <tbody>
+          ${repeat(
+            data,
+            (row, rowIndex) =>
+              html`
+                <tr>
+                  ${repeat(row, (col, colIndex) => html`<td>${data[rowIndex][colIndex]}</td>`)}
+                </tr>
+              `
+          )}
+        </tbody>
+      </table>
+    `;
+  },
+  args: {
+    data: [
+      [1, 2, 3],
+      [4, 5, 6],
+    ],
+    size: 'large',
+  },
+};
+```

--- a/docs/snippets/web-components/table-story-fully-customize-controls.ts.mdx
+++ b/docs/snippets/web-components/table-story-fully-customize-controls.ts.mdx
@@ -6,16 +6,13 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { repeat } from 'lit/directives/repeat.js';
 
-import type { TableProps } from './Table';
-import { Table } from './Table';
-
-const meta: Meta<TableProps> = {
+const meta: Meta = {
   title: 'Custom Table',
-  render: (args) => Table(args),
+  component: 'custom-table',
 };
 
 export default meta;
-type Story = StoryObj<TableProps>;
+type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.

--- a/docs/writing-docs/doc-block-argstable.md
+++ b/docs/writing-docs/doc-block-argstable.md
@@ -23,6 +23,8 @@ This is extremely useful, but it can be further expanded. Additional information
     'vue/button-component-with-proptypes.2.mdx',
     'vue/button-component-with-proptypes.3.mdx',
     'svelte/button-component-with-proptypes.js.mdx',
+    'web-components/button-component-with-proptypes.js.mdx',
+    'web-components/button-component-with-proptypes.ts.mdx',
   ]}
 />
 
@@ -126,6 +128,8 @@ You can also extend the ArgsTable's customization by grouping related `argTypes`
     'vue/button-implementation.2.mdx',
     'vue/button-implementation.3.mdx',
     'svelte/button-implementation.js.mdx',
+    'web-components/button-implementation.js.mdx',
+    'web-components/button-implementation.ts.mdx',
   ]}
 />
 

--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -24,6 +24,8 @@ To enable auto-generated documentation for your stories, you'll need to add the 
     'vue/button-story-auto-docs.ts.mdx',
     'angular/button-story-auto-docs.ts.mdx',
     'svelte/button-story-auto-docs.js.mdx',
+    'web-components/button-story-auto-docs.js.mdx',
+    'web-components/button-story-auto-docs.ts.mdx',
   ]}
 />
 

--- a/docs/writing-tests/accessibility-testing.md
+++ b/docs/writing-tests/accessibility-testing.md
@@ -65,6 +65,8 @@ Storybook's a11y addon runs [Axe](https://github.com/dequelabs/axe-core) on the 
     'vue/component-story-with-accessibility.2.js.mdx',
     'vue/component-story-with-accessibility.3.js.mdx',
     'svelte/component-story-with-accessibility.js.mdx',
+    'web-components/component-story-with-accessibility.js.mdx',
+    'web-components/component-story-with-accessibility.ts.mdx',
   ]}
   usesCsf3
   csf2Path="writing-tests/accessibility-testing#snippet-component-story-with-accessibility"
@@ -121,6 +123,8 @@ Customize the a11y ruleset at the story level by updating your story to include 
     'angular/storybook-addon-a11y-story-config.ts.mdx',
     'vue/storybook-addon-a11y-story-config.js.mdx',
     'svelte/storybook-addon-a11y-story-config.js.mdx',
+    'web-components/storybook-addon-a11y-story-config.js.mdx',
+    'web-components/storybook-addon-a11y-story-config.ts.mdx',
   ]}
   usesCsf3
   csf2Path="writing-tests/accessibility-testing#snippet-storybook-addon-a11y-story-config"
@@ -141,6 +145,8 @@ Disable accessibility testing for stories or components by adding the following 
    'angular/storybook-addon-a11y-disable.ts.mdx',
    'vue/storybook-addon-a11y-disable.js.mdx',
    'svelte/storybook-addon-a11y-disable.js.mdx',
+   'web-components/storybook-addon-a11y-disable.js.mdx',
+   'web-components/storybook-addon-a11y-disable.ts.mdx',
   ]}
   usesCsf3
   csf2Path="writing-tests/accessibility-testing#snippet-storybook-addon-a11y-disable"


### PR DESCRIPTION
This pull request will contain the work related to adding the missing Web Components snippets.

Page snippets added:
- Writing Docs (AutoDocs) 
- Writing Docs (Doc Blocks ArgTable)
- Sharing (Design Integrations)
- Essentials:
     - Controls
     - Viewports
     - Toolbars and globals
- Addons
   - Write an addon
   - Addons API
- Configure
   - Images and assets
   - Environment variables
- Writing tests
   - A11y
- API 
   - CSF