### PR TITLE
UI: Disable React.strictmode to avoid findNode deprecation warnings

### DIFF
--- a/code/ui/manager/src/index.tsx
+++ b/code/ui/manager/src/index.tsx
@@ -32,13 +32,11 @@ export interface RootProps {
 }
 
 export const Root: FC<RootProps> = ({ provider }) => (
-  <React.StrictMode key="container">
-    <HelmetProvider key="helmet.Provider">
-      <LocationProvider key="location.provider">
-        <Main provider={provider} />
-      </LocationProvider>
-    </HelmetProvider>
-  </React.StrictMode>
+  <HelmetProvider key="helmet.Provider">
+    <LocationProvider key="location.provider">
+      <Main provider={provider} />
+    </LocationProvider>
+  </HelmetProvider>
 );
 
 const Main: FC<{ provider: Provider }> = ({ provider }) => {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/20140

## What I did

I disabled strict-mode, in the manager, this way there's no error/warnings coming from react.