### PR TITLE
Docs: Fix example storybook-docs package scripts for v7

### DIFF
--- a/docs/writing-docs/build-documentation.md
+++ b/docs/writing-docs/build-documentation.md
@@ -11,7 +11,7 @@ At any point during your development, you can preview the documentation you've w
 ```json
 {
   "scripts": {
-    "storybook-docs": "start-storybook --docs --no-manager-cache"
+    "storybook-docs": "storybook dev --docs --no-manager-cache"
   }
 }
 ```
@@ -39,7 +39,7 @@ You can also publish your documentation, the same you would [publish](../sharing
 ```json
 {
   "scripts": {
-    "build-storybook-docs": "build-storybook --docs"
+    "build-storybook-docs": "storybook build --docs"
   }
 }
 ```


### PR DESCRIPTION
Issue: 
Example package scripts use the old `start-storybook` & `build-storybook` commands.

## What I did
Updated to use `storybook dev` & `storybook build`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
