### PR TITLE
Build: Remove the non-cross-platform dash-S option

### DIFF
--- a/scripts/prepare/facade.ts
+++ b/scripts/prepare/facade.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S ../../node_modules/.bin/ts-node
+#!/usr/bin/env ../../node_modules/.bin/ts-node
 
 import { join, parse } from 'path';
 import fs from 'fs-extra';


### PR DESCRIPTION
Issue: build failures on windows

## What I did

Remove a CLI flag that doesn't work on windows