### PR TITLE
Migration: Update autodocs migration to deal with `docs.docsPage`

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/autodocs-true.ts
+++ b/code/lib/cli/src/automigrate/fixes/autodocs-true.ts
@@ -53,7 +53,7 @@ export const autodocsTrue: Fix<AutodocsTrueFrameworkRunOptions> = {
   },
 
   prompt({ value }) {
-    const AutodocsTrueFormatted = chalk.cyan(
+    const autodocsFormatted = chalk.cyan(
       `docs: { autodocs: ${JSON.stringify(value ?? true)} }`
     );
 
@@ -66,7 +66,7 @@ export const autodocsTrue: Fix<AutodocsTrueFrameworkRunOptions> = {
 
       Based on your prior configuration,  we can set the \`docs.autodocs\` to keep your old behaviour:
 
-      ${AutodocsTrueFormatted}
+      ${autodocsFormatted}
 
       ${
         value === 'tag' &&

--- a/code/lib/cli/src/automigrate/fixes/autodocs-true.ts
+++ b/code/lib/cli/src/automigrate/fixes/autodocs-true.ts
@@ -4,6 +4,7 @@ import { dedent } from 'ts-dedent';
 import type { ConfigFile } from '@storybook/csf-tools';
 import { readConfig, writeConfig } from '@storybook/csf-tools';
 import { getStorybookInfo } from '@storybook/core-common';
+import type { StorybookConfig } from '@storybook/types';
 
 import type { Fix } from '../types';
 
@@ -11,6 +12,7 @@ const logger = console;
 
 interface AutodocsTrueFrameworkRunOptions {
   main: ConfigFile;
+  value?: StorybookConfig['docs']['autodocs'];
 }
 
 /**
@@ -32,11 +34,50 @@ export const autodocsTrue: Fix<AutodocsTrueFrameworkRunOptions> = {
     const main = await readConfig(mainConfig);
     const docs = main.getFieldValue(['docs']);
 
+    const docsPageToAutodocsMapping = {
+      true: 'tag',
+      automatic: true,
+      false: false,
+    };
+    if (docs?.docsPage) {
+      const oldValue = docs?.docsPage.toString();
+      if (!(oldValue in docsPageToAutodocsMapping))
+        throw new Error(`Unexpected value for docs.docsPage: ${oldValue}`);
+      return {
+        main,
+        value: docsPageToAutodocsMapping[oldValue as keyof typeof docsPageToAutodocsMapping],
+      };
+    }
+
     return docs?.autodocs === undefined ? { main } : null;
   },
 
-  prompt() {
-    const AutodocsTrueFormatted = chalk.cyan(`docs: { autodocs: true }`);
+  prompt({ value }) {
+    const AutodocsTrueFormatted = chalk.cyan(
+      `docs: { autodocs: ${JSON.stringify(value ?? true)} }`
+    );
+
+    if (value) {
+      return dedent`
+      We've changed the configuration of autodocs (previous docsPage), so now the value:
+        - docs.autodocs: true -- means automatically create docs for every CSF file
+        - docs.autodocs: 'tag' -- means only create autodocs for CSF files with the 'autodocs' tag
+        - docs.autodocs: false -- means never create autodocs
+
+      Based on your prior configuration,  we can set the \`docs.autodocs\` to keep your old behaviour:
+
+      ${AutodocsTrueFormatted}
+
+      ${
+        value === 'tag' &&
+        `NOTE: it is important you change all CSF files to use the 'autodocs' tag rather than the 'docsPage' tag.`
+      }
+
+      More info: ${chalk.yellow(
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#autodocs'
+      )}
+    `;
+    }
 
     return dedent`
       We've detected that your main.js configuration file has not configured autodocs. In 6.x we
@@ -51,10 +92,11 @@ export const autodocsTrue: Fix<AutodocsTrueFrameworkRunOptions> = {
     `;
   },
 
-  async run({ result: { main }, dryRun }) {
+  async run({ result: { main, value }, dryRun }) {
     logger.info(`✅ Setting 'docs.autodocs' to true in main.js`);
     if (!dryRun) {
-      main.setFieldValue(['docs', 'autodocs'], true);
+      main.removeField(['docs', 'docsPage']);
+      main.setFieldValue(['docs', 'autodocs'], value ?? true);
       await writeConfig(main);
     }
   },

--- a/code/lib/cli/src/automigrate/fixes/autodocs-true.ts
+++ b/code/lib/cli/src/automigrate/fixes/autodocs-true.ts
@@ -35,7 +35,7 @@ export const autodocsTrue: Fix<AutodocsTrueFrameworkRunOptions> = {
     const docs = main.getFieldValue(['docs']);
 
     const docsPageToAutodocsMapping = {
-      true: 'tag',
+      true: 'tag' as const,
       automatic: true,
       false: false,
     };
@@ -53,9 +53,7 @@ export const autodocsTrue: Fix<AutodocsTrueFrameworkRunOptions> = {
   },
 
   prompt({ value }) {
-    const autodocsFormatted = chalk.cyan(
-      `docs: { autodocs: ${JSON.stringify(value ?? true)} }`
-    );
+    const autodocsFormatted = chalk.cyan(`docs: { autodocs: ${JSON.stringify(value ?? true)} }`);
 
     if (value) {
       return dedent`
@@ -84,7 +82,7 @@ export const autodocsTrue: Fix<AutodocsTrueFrameworkRunOptions> = {
       we defaulted to having a autodocs for every story, in 7.x you need to opt in per-component.
       However, we can set the \`docs.autodocs\` to true to approximate the old behaviour:
 
-      ${AutodocsTrueFormatted}
+      ${autodocsFormatted}
 
       More info: ${chalk.yellow(
         'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#autodocs'


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/pull/20364#issuecomment-1362453379

## What I did

Updated the `docs.autodocs` migration to convert/copy over the old value and warn if you need to change tags.

## How to test

Run migration against some converted and unconverted projects.