### PR TITLE
Types: Add Addon_OptionsParameterV7 type

### DIFF
--- a/code/lib/types/src/modules/addons.ts
+++ b/code/lib/types/src/modules/addons.ts
@@ -63,6 +63,15 @@ export interface Addon_OptionsParameter extends Object {
   [key: string]: any;
 }
 
+export interface Addon_OptionsParameterV7 extends Object {
+  storySort?: Addon_StorySortParameterV7;
+  theme?: {
+    base: string;
+    brandTitle?: string;
+  };
+  [key: string]: any;
+}
+
 export type Addon_StoryContext<TRenderer extends Renderer = Renderer> =
   StoryContextForFramework<TRenderer>;
 export type Addon_StoryContextUpdate = Partial<Addon_StoryContext>;


### PR DESCRIPTION
Issue:

I noticed we only expose an options parameter type for non-V7. 

## What I did

I'm not sure what the plan is for these types, but it seems like we should export a V7 type, to match up with `Addon_StorySortParameterV7`. 

## How to test

- CI

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
