### PR TITLE
Fix import url on windows

### DIFF
--- a/code/lib/builder-manager/src/utils/managerEntries.ts
+++ b/code/lib/builder-manager/src/utils/managerEntries.ts
@@ -1,6 +1,7 @@
-import { join, parse, relative } from 'path';
-import fs from 'fs-extra';
 import findCacheDirectory from 'find-cache-dir';
+import fs from 'fs-extra';
+import { join, parse, relative } from 'node:path';
+import slash from 'slash';
 /**
  * Manager entries should be **self-invoking** bits of code.
  * They can of-course import from modules, and ESbuild will bundle all of that into a single file.
@@ -29,7 +30,7 @@ export async function wrapManagerEntries(entrypoints: string[]) {
 
       const location = join(cacheLocation, relative(process.cwd(), dir), `${name}-bundle.mjs`);
       await fs.ensureFile(location);
-      await fs.writeFile(location, `import '${entry}';`);
+      await fs.writeFile(location, `import '${slash(entry)}';`);
 
       return location;
     })

--- a/code/lib/core-server/src/utils/get-builders.ts
+++ b/code/lib/core-server/src/utils/get-builders.ts
@@ -1,4 +1,5 @@
-import type { Options, CoreConfig, Builder } from '@storybook/types';
+import type { Builder, CoreConfig, Options } from '@storybook/types';
+import { pathToFileURL } from 'node:url';
 
 export async function getManagerBuilder(): Promise<Builder<unknown>> {
   return import('@storybook/builder-manager');
@@ -17,7 +18,7 @@ export async function getPreviewBuilder(
   } else {
     throw new Error('no builder configured!');
   }
-  const previewBuilder = await import(builderPackage);
+  const previewBuilder = await import(pathToFileURL(builderPackage).href);
   return previewBuilder;
 }
 


### PR DESCRIPTION
Issue: Invalid import url on windows (Fix: #20404 and other bug)

## What I did

I got it to import to the valid path on windows.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
