### PR TITLE
CLI: Use correct package manager for automigrate

### DIFF
--- a/code/lib/cli/src/add.ts
+++ b/code/lib/cli/src/add.ts
@@ -74,11 +74,12 @@ export async function add(
   addon: string,
   options: { useNpm: boolean; packageManager: PackageManagerName; skipPostinstall: boolean }
 ) {
-  const { useNpm, packageManager: pkgMgr } = options;
-  if (useNpm) {
+  let { packageManager: pkgMgr } = options;
+  if (options.useNpm) {
     useNpmWarning();
+    pkgMgr = 'npm';
   }
-  const packageManager = JsPackageManagerFactory.getPackageManager({ useNpm, force: pkgMgr });
+  const packageManager = JsPackageManagerFactory.getPackageManager({ force: pkgMgr });
   const packageJson = packageManager.retrievePackageJson();
   const [addonName, versionSpecifier] = getVersionSpecifier(addon);
 

--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -266,11 +266,13 @@ const projectTypeInquirer = async (
 };
 
 async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<void> {
-  const { useNpm, packageManager: pkgMgr } = options;
-  if (useNpm) {
+  let { packageManager: pkgMgr } = options;
+  if (options.useNpm) {
     useNpmWarning();
+
+    pkgMgr = 'npm';
   }
-  const packageManager = JsPackageManagerFactory.getPackageManager({ useNpm, force: pkgMgr });
+  const packageManager = JsPackageManagerFactory.getPackageManager({ force: pkgMgr });
   const welcomeMessage = 'storybook init - the simplest way to add a Storybook to your project.';
   logger.log(chalk.inverse(`\n ${welcomeMessage} \n`));
 
@@ -327,7 +329,7 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
     telemetry('init', { projectType });
   }
 
-  await automigrate({ yes: options.yes || process.env.CI === 'true', useNpm, force: pkgMgr });
+  await automigrate({ yes: options.yes || process.env.CI === 'true', packageManager: pkgMgr });
 
   logger.log('\nTo run your Storybook, type:\n');
   codeLog([packageManager.getRunStorybookCommand()]);

--- a/code/lib/cli/src/js-package-manager/JsPackageManagerFactory.test.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManagerFactory.test.ts
@@ -16,12 +16,6 @@ findUpSyncMock.mockReturnValue(undefined);
 describe('JsPackageManagerFactory', () => {
   describe('getPackageManager', () => {
     describe('return an NPM proxy', () => {
-      it('when `useNpm` option is used', () => {
-        expect(JsPackageManagerFactory.getPackageManager({ useNpm: true })).toBeInstanceOf(
-          NPMProxy
-        );
-      });
-
       it('when `force` option is `npm`', () => {
         expect(JsPackageManagerFactory.getPackageManager({ force: 'npm' })).toBeInstanceOf(
           NPMProxy

--- a/code/lib/cli/src/js-package-manager/JsPackageManagerFactory.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManagerFactory.ts
@@ -14,10 +14,10 @@ import { Yarn1Proxy } from './Yarn1Proxy';
 
 export class JsPackageManagerFactory {
   public static getPackageManager(
-    { force, useNpm }: { force?: PackageManagerName; useNpm?: boolean } = {},
+    { force }: { force?: PackageManagerName } = {},
     cwd?: string
   ): JsPackageManager {
-    if (useNpm || force === 'npm') {
+    if (force === 'npm') {
       return new NPMProxy({ cwd });
     }
     if (force === 'pnpm') {

--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -158,8 +158,10 @@ export const doUpgrade = async ({
 }: UpgradeOptions) => {
   if (useNpm) {
     useNpmWarning();
+    // eslint-disable-next-line no-param-reassign
+    pkgMgr = 'npm';
   }
-  const packageManager = JsPackageManagerFactory.getPackageManager({ useNpm, force: pkgMgr });
+  const packageManager = JsPackageManagerFactory.getPackageManager({ force: pkgMgr });
 
   const beforeVersion = await getStorybookCoreVersion();
 
@@ -206,7 +208,7 @@ export const doUpgrade = async ({
   let automigrationResults;
   if (!skipCheck) {
     checkVersionConsistency();
-    automigrationResults = await automigrate({ dryRun, yes, useNpm, force: pkgMgr });
+    automigrationResults = await automigrate({ dryRun, yes, packageManager: pkgMgr });
   }
 
   if (!options.disableTelemetry) {


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/17870

## What I did

My previous PR, https://github.com/storybookjs/storybook/pull/19425, introduced a `--package-manager` option to the CLI, but it missed handling the option in automigrate when run directly (vs as part of `init`).  This fixes it so that running `npx sb@next automigrate --package-manager=npm` (or the deprecated way, `npx sb@next automigrate --use-npm`) works correctly.

## How to test

We have some unit tests, but they don't cover `automigrate()` itself.  I tested by creating a project, adding storybook, adding eslint and an `eslintrc.js` file, building the changes here in this branch, copying over the `dist` file into the project, and running `npx storybook@next automigrate --use-npm eslintPlugin`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
