### PR TITLE
Fix yarn task command on Windows machines

### DIFF
--- a/scripts/utils/touch.ts
+++ b/scripts/utils/touch.ts
@@ -1,0 +1,8 @@
+const isWin = process.platform === 'win32';
+
+export default function touch(filePath: string) {
+  if (isWin) {
+    return `echo. > ${filePath}`;
+  }
+  return `touch ${filePath}`;
+}

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { exec } from './exec';
 // TODO -- should we generate this file a second time outside of CLI?
 import storybookVersions from '../../code/lib/cli/src/versions';
+import touch from './touch';
 
 export type YarnOptions = {
   cwd: string;
@@ -25,8 +26,8 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
 
 export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
   const command = [
-    `touch yarn.lock`,
-    `touch yarnrc.yml`,
+    touch('yarn.lock'),
+    touch('yarnrc.yml'),
     `yarn set version berry`,
     // Use the global cache so we aren't re-caching dependencies each time we run sandbox
     `yarn config set enableGlobalCache true`,


### PR DESCRIPTION
Issue: N/A

## What I did

Fixed `yarn task` sandbox creation on Windows machines

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
