### PR TITLE
Tech: ESLint allow devDependencies imports in prebundled packages

### DIFF
--- a/code/.eslintrc.js
+++ b/code/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   rules: {
     'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
+    'eslint-comments/no-unused-disable': 'error',
     'react-hooks/rules-of-hooks': 'off',
     'jest/no-done-callback': 'off',
     '@typescript-eslint/dot-notation': [

--- a/code/.eslintrc.js
+++ b/code/.eslintrc.js
@@ -67,15 +67,14 @@ module.exports = {
       },
     },
     {
-      // this package uses pre-bundling, dependencies will be bundled, and will be in devDepenencies
-      files: [
-        '**/lib/theming/**/*',
-        '**/lib/router/**/*',
-        '**/ui/manager/**/*',
-        '**/ui/components/**/*',
-      ],
+      // these packages use pre-bundling, dependencies will be bundled, and will be in devDepenencies
+      files: ['addons/**/*', 'frameworks/**/*', 'lib/**/*', 'renderers/**/*', 'ui/**/*'],
+      excludedFiles: ['frameworks/angular/**/*', 'frameworks/ember/**/*', 'lib/core-server/**/*'],
       rules: {
-        'import/no-extraneous-dependencies': ['error', { bundledDependencies: false }],
+        'import/no-extraneous-dependencies': [
+          'error',
+          { bundledDependencies: false, devDependencies: true },
+        ],
       },
     },
     {

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -104,6 +104,7 @@
     "@jest/transform": "^29.3.1",
     "@mdx-js/react": "^2.1.5",
     "@storybook/blocks": "7.0.0-beta.16",
+    "@storybook/client-logger": "7.0.0-beta.16",
     "@storybook/components": "7.0.0-beta.16",
     "@storybook/csf-plugin": "7.0.0-beta.16",
     "@storybook/csf-tools": "7.0.0-beta.16",

--- a/code/addons/interactions/src/components/MethodCall.tsx
+++ b/code/addons/interactions/src/components/MethodCall.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ObjectInspector } from '@devtools-ds/object-inspector';
 import type { Call, CallRef, ElementRef } from '@storybook/instrumenter';
 import { useTheme } from '@storybook/theming';

--- a/code/lib/builder-webpack5/src/index.ts
+++ b/code/lib/builder-webpack5/src/index.ts
@@ -10,7 +10,6 @@ import express from 'express';
 import fs from 'fs-extra';
 import { PREVIEW_BUILDER_PROGRESS } from '@storybook/core-events';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import prettyTime from 'pretty-hrtime';
 
 export * from './types';

--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -2,9 +2,9 @@
 import fs from 'fs-extra';
 
 import * as t from '@babel/types';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import * as generate from '@babel/generator';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import * as traverse from '@babel/traverse';
 import { babelParse } from './babelParse';
 

--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -3,9 +3,9 @@ import fs from 'fs-extra';
 import { dedent } from 'ts-dedent';
 
 import * as t from '@babel/types';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import * as generate from '@babel/generator';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import * as traverse from '@babel/traverse';
 import { toId, isExportStory, storyNameFromExport } from '@storybook/csf';
 import type { Tag, StoryAnnotations, ComponentAnnotations } from '@storybook/types';

--- a/code/lib/csf-tools/src/babelParse.ts
+++ b/code/lib/csf-tools/src/babelParse.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as parser from '@babel/parser';
 
 export const babelParse = (code: string) =>

--- a/code/lib/csf-tools/src/enrichCsf.ts
+++ b/code/lib/csf-tools/src/enrichCsf.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import * as t from '@babel/types';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import * as generate from '@babel/generator';
 import type { CsfFile } from './CsfFile';
 

--- a/code/lib/csf-tools/src/getStorySortParameter.ts
+++ b/code/lib/csf-tools/src/getStorySortParameter.ts
@@ -1,7 +1,7 @@
 import * as t from '@babel/types';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import * as traverse from '@babel/traverse';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import * as generate from '@babel/generator';
 import { dedent } from 'ts-dedent';
 import { babelParse } from './babelParse';

--- a/code/lib/preview-api/src/modules/preview-web/WebView.ts
+++ b/code/lib/preview-api/src/modules/preview-web/WebView.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { global } from '@storybook/global';
 import { logger } from '@storybook/client-logger';
 import AnsiToHtml from 'ansi-to-html';

--- a/code/lib/preview/src/globals/runtime.ts
+++ b/code/lib/preview/src/globals/runtime.ts
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
 import * as ADDONS from '@storybook/preview-api/dist/addons';
 import * as CHANNEL_POSTMESSAGE from '@storybook/channel-postmessage';
 import * as CHANNEL_WEBSOCKET from '@storybook/channel-websocket';

--- a/code/renderers/web-components/template/components/Button.js
+++ b/code/renderers/web-components/template/components/Button.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { global as globalThis } from '@storybook/global';
 import { html, LitElement } from 'lit';
 

--- a/code/renderers/web-components/template/components/Form.js
+++ b/code/renderers/web-components/template/components/Form.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { global as globalThis } from '@storybook/global';
 import { html, LitElement } from 'lit';
 

--- a/code/renderers/web-components/template/components/Html.js
+++ b/code/renderers/web-components/template/components/Html.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { global as globalThis } from '@storybook/global';
 import { LitElement } from 'lit';
 

--- a/code/renderers/web-components/template/components/Pre.js
+++ b/code/renderers/web-components/template/components/Pre.js
@@ -1,6 +1,7 @@
 import { global as globalThis } from '@storybook/global';
 import { html, LitElement } from 'lit';
-import { styleMap } from 'lit-html/directives/style-map';
+// eslint-disable-next-line import/extensions
+import { styleMap } from 'lit-html/directives/style-map.js';
 
 const { customElements } = globalThis;
 

--- a/code/renderers/web-components/template/components/Pre.js
+++ b/code/renderers/web-components/template/components/Pre.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/extensions, import/no-extraneous-dependencies */
 import { global as globalThis } from '@storybook/global';
 import { html, LitElement } from 'lit';
 import { styleMap } from 'lit-html/directives/style-map.js';

--- a/code/renderers/web-components/template/components/Pre.js
+++ b/code/renderers/web-components/template/components/Pre.js
@@ -1,6 +1,6 @@
 import { global as globalThis } from '@storybook/global';
 import { html, LitElement } from 'lit';
-import { styleMap } from 'lit-html/directives/style-map.js';
+import { styleMap } from 'lit-html/directives/style-map';
 
 const { customElements } = globalThis;
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5486,6 +5486,7 @@ __metadata:
     "@jest/transform": ^29.3.1
     "@mdx-js/react": ^2.1.5
     "@storybook/blocks": 7.0.0-beta.16
+    "@storybook/client-logger": 7.0.0-beta.16
     "@storybook/components": 7.0.0-beta.16
     "@storybook/csf-plugin": 7.0.0-beta.16
     "@storybook/csf-tools": 7.0.0-beta.16


### PR DESCRIPTION
Issue:

## What I did

I saw a bunch of disable comments for `eslint-import/no-extraneous-deps` because we pre-bundle most packages, which means we can use dependencies from `devDependencies`, not just `dependencies`.  

This updates the eslint config to allow devDependencies to be used in all but ember, angular, and core-server (which don't pre-bundle).  It also enables the `eslint-comments/no-unused-disable` rule, to help find previously-disabled imports.

## How to test

- linting in CI

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
