### PR TITLE
CLI: Add prop-types dependency if not using TypeScript

### DIFF
--- a/code/lib/cli/src/generators/REACT/index.ts
+++ b/code/lib/cli/src/generators/REACT/index.ts
@@ -1,8 +1,19 @@
+import { detectLanguage } from '../../detect';
+import { SupportedLanguage } from '../../project_types';
 import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  await baseGenerator(packageManager, npmOptions, options, 'react');
+  // Add prop-types dependency if not using TypeScript
+  const extraPackages = [];
+  const language = detectLanguage();
+  if (language === SupportedLanguage.JAVASCRIPT) {
+    extraPackages.push('prop-types');
+  }
+
+  await baseGenerator(packageManager, npmOptions, options, 'react', {
+    extraPackages,
+  });
 };
 
 export default generator;

--- a/code/lib/cli/src/generators/REACT/index.ts
+++ b/code/lib/cli/src/generators/REACT/index.ts
@@ -5,11 +5,8 @@ import type { Generator } from '../types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
   // Add prop-types dependency if not using TypeScript
-  const extraPackages = [];
   const language = detectLanguage();
-  if (language === SupportedLanguage.JAVASCRIPT) {
-    extraPackages.push('prop-types');
-  }
+  const extraPackages = language === SupportedLanguage.JAVASCRIPT ? ['prop-types'] : [];
 
   await baseGenerator(packageManager, npmOptions, options, 'react', {
     extraPackages,


### PR DESCRIPTION
Issue:

We haven't been adding `prop-types` to React JS projects, even though the example components use it.  This breaks in yarn pnp and pnpm.

## What I did

If the detected language is JavaScript (not TypeScript), we'll add `prop-types` to the dependencies that are installed during storybook init. 

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
