### PR TITLE
add children to CanvasProps

### DIFF
--- a/code/ui/blocks/src/blocks/Canvas.tsx
+++ b/code/ui/blocks/src/blocks/Canvas.tsx
@@ -15,10 +15,11 @@ export { SourceState };
 type CanvasProps = Omit<PurePreviewProps, 'isExpanded' | 'isLoading'> & {
   withSource?: SourceState;
   mdxSource?: string;
+  children?: ReactNode;
 };
 
 const usePreviewProps = (
-  { withSource, mdxSource, children, ...props }: CanvasProps & { children?: ReactNode },
+  { withSource, mdxSource, children, ...props }: CanvasProps,
   docsContext: DocsContextProps<Renderer>,
   sourceContext: SourceContextProps
 ) => {


### PR DESCRIPTION
Issue:
The children prop has been removed from `react.FC` in React 18 [ref](https://solverfox.dev/writing/no-implicit-children/). this causes the following TS error when using the Canvas component with children:
`TS2559: Type '{ children: Element[]; }' has no properties in common with type 'IntrinsicAttributes'`

## What I did
Added `children?: ReactNode` to CanvasProps

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
