### PR TITLE
CLI: Do not use legacy-peer-deps for npm

### DIFF
--- a/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
@@ -47,16 +47,12 @@ describe('NPM Proxy', () => {
       });
     });
     describe('npm7', () => {
-      it('should run `npm install --legacy-peer-deps`', () => {
+      it('should run `npm install`', () => {
         const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('7.1.0');
 
         npmProxy.installDependencies();
 
-        expect(executeCommandSpy).toHaveBeenLastCalledWith(
-          'npm',
-          ['install', '--legacy-peer-deps'],
-          expect.any(String)
-        );
+        expect(executeCommandSpy).toHaveBeenLastCalledWith('npm', ['install'], expect.any(String));
       });
     });
   });
@@ -83,7 +79,7 @@ describe('NPM Proxy', () => {
 
         expect(executeCommandSpy).toHaveBeenLastCalledWith(
           'npm',
-          ['install', '--legacy-peer-deps', '-D', '@storybook/preview-api'],
+          ['install', '-D', '@storybook/preview-api'],
           expect.any(String)
         );
       });
@@ -112,7 +108,7 @@ describe('NPM Proxy', () => {
 
         expect(executeCommandSpy).toHaveBeenLastCalledWith(
           'npm',
-          ['uninstall', '--legacy-peer-deps', '@storybook/preview-api'],
+          ['uninstall', '@storybook/preview-api'],
           expect.any(String)
         );
       });

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -26,38 +26,16 @@ export class NPMProxy extends JsPackageManager {
     return this.executeCommand('npm', ['--version']);
   }
 
-  hasLegacyPeerDeps() {
-    const result = this.executeCommand('npm', [
-      'config',
-      'get',
-      'legacy-peer-deps',
-      '--location=project',
-    ]);
-    return result.trim() === 'true';
-  }
-
-  setLegacyPeerDeps() {
-    this.executeCommand('npm', ['config', 'set', 'legacy-peer-deps=true', '--location=project']);
-  }
-
-  needsLegacyPeerDeps(version: string) {
-    return semver.gte(version, '7.0.0') && !this.hasLegacyPeerDeps();
-  }
-
   getInstallArgs(): string[] {
     if (!this.installArgs) {
-      this.installArgs = this.needsLegacyPeerDeps(this.getNpmVersion())
-        ? ['install', '--legacy-peer-deps']
-        : ['install'];
+      this.installArgs = ['install'];
     }
     return this.installArgs;
   }
 
   getUninstallArgs(): string[] {
     if (!this.uninstallArgs) {
-      this.uninstallArgs = this.needsLegacyPeerDeps(this.getNpmVersion())
-        ? ['uninstall', '--legacy-peer-deps']
-        : ['uninstall'];
+      this.uninstallArgs = ['uninstall'];
     }
     return this.uninstallArgs;
   }

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -1,5 +1,3 @@
-import semver from 'semver';
-
 import { JsPackageManager } from './JsPackageManager';
 import type { PackageJson } from './PackageJson';
 


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/18298

## What I did

Removed the use of `--legacy-peer-deps` from npm commands, since it is no longer needed with storybook 7.0+.  The npm7 migration was removed previously.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
