### PR TITLE
CLI: Add peer dependency on react

### DIFF
--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -88,6 +88,10 @@
     "strip-json-comments": "^3.1.1",
     "typescript": "~4.9.3"
   },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6264,6 +6264,9 @@ __metadata:
     ts-dedent: ^2.0.0
     typescript: ~4.9.3
     util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   bin:
     getstorybook: ./bin/index.js
     sb: ./bin/index.js


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/20454

## What I did

If we want to check that react is installed by trying to require it, we need to establish a peer dependency on react from the CLI so that yarn pnp and pnpm can work correctly.

The alternative would be to do the react check from some other package that already has the peer dependencies set up, but the CLI seems like the best place.

## How to test

Hmmm, not sure...

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
