### PR TITLE
docs(addons/storysource): fix old link to "Theming" image

### DIFF
--- a/code/addons/storysource/README.md
+++ b/code/addons/storysource/README.md
@@ -58,7 +58,7 @@ To customize the `source-loader`, pass `loaderOptions`. Valid configurations are
 
 Storysource will automatically use the light or dark syntax theme based on your storybook theme. See [Theming Storybook](https://storybook.js.org/docs/react/configure/theming) for more information.
 
-![Storysource Light/Dark Themes](https://raw.githubusercontent.com/storybookjs/storybook/next/addons/storysource/docs/theming-light-dark.png)
+![Storysource Light/Dark Themes](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/storysource/docs/theming-light-dark.png)
 
 ## Displaying full source
 


### PR DESCRIPTION
## What I did
The image showing the light and dark syntax themes was not visible on the [Storysource addon page](https://storybook.js.org/addons/@storybook/addon-storysource/).

I have replaced the image path by the one used on the `next` branch. Indeed, it seems that the repository tree was refactored between this branch and the `master` one. 

Maybe other documentations are affected by this problem.

