### PR TITLE
Remove inDev flag for preact-vite framework

### DIFF
--- a/code/lib/cli/src/repro-templates.ts
+++ b/code/lib/cli/src/repro-templates.ts
@@ -334,7 +334,6 @@ export const allTemplates = {
   'preact-vite/default-js': {
     name: 'Preact Vite (JS)',
     script: 'yarn create vite . --template preact',
-    inDevelopment: true,
     expected: {
       framework: '@storybook/preact-vite',
       renderer: '@storybook/preact',
@@ -344,7 +343,6 @@ export const allTemplates = {
   'preact-vite/default-ts': {
     name: 'Preact Vite (TS)',
     script: 'yarn create vite . --template preact-ts',
-    inDevelopment: true,
     expected: {
       framework: '@storybook/preact-vite',
       renderer: '@storybook/preact',


### PR DESCRIPTION
## What I did

Removed the `inDevelopment` flag for `preact-vite/default-ts` and `preact-vite/default-js` now that they've been released in the preview, as per the instructions in the documentation.
