### PR TITLE
Chore: (Docs) Fix API CLI options documentation

### DIFF
--- a/docs/api/cli-options.md
+++ b/docs/api/cli-options.md
@@ -5,7 +5,9 @@ title: 'CLI options'
 Storybook comes with two CLI utilities: [`start-storybook`](#start-storybook) and [`build-storybook`](#build-storybook).
 
 <div class="aside">
+
 Storybook collects completely anonymous data to help us improve user experience. Participation is optional, and you may [opt-out](../configure/telemetry.md#how-to-opt-out) if you'd not like to share any information.
+
 </div>
 
 Pass these commands the following options to alter Storybook's behavior.


### PR DESCRIPTION
With this small pull request, the documentation is updated to accurately display the link to the telemetry docs in the API (CLI Options) page.

Addresses and closes #20445