### PR TITLE
Blocks: Use example Button for stories

### DIFF
--- a/code/ui/.storybook/main.ts
+++ b/code/ui/.storybook/main.ts
@@ -20,7 +20,7 @@ const allStories = [
 ];
 
 /**
- * match all stories in blocks/src/blocks and blocks/src/controls EXCEPT blocks/src/blocks/internal
+ * match all stories in blocks/src/blocks, blocks/src/controls and blocks/src/examples EXCEPT blocks/src/blocks/internal
  * Examples:
  *
  * src/blocks/Canvas.stories.tsx - MATCH
@@ -38,8 +38,8 @@ const allStories = [
  * src/components/ColorPalette.tsx - IGNORED, not story
  */
 const blocksOnlyStories = [
-  '../blocks/src/@(blocks|controls)/!(internal)/**/*.@(mdx|stories.@(tsx|ts|jsx|js))',
-  '../blocks/src/@(blocks|controls)/*.@(mdx|stories.@(tsx|ts|jsx|js))',
+  '../blocks/src/@(blocks|controls|examples)/!(internal)/**/*.@(mdx|stories.@(tsx|ts|jsx|js))',
+  '../blocks/src/@(blocks|controls|examples)/*.@(mdx|stories.@(tsx|ts|jsx|js))',
 ];
 
 const config: StorybookConfig = {

--- a/code/ui/blocks/src/blocks/Canvas.stories.tsx
+++ b/code/ui/blocks/src/blocks/Canvas.stories.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Canvas, SourceState } from './Canvas';
 import { Story as StoryComponent } from './Story';
-import * as BooleanStories from '../controls/Boolean.stories';
+import * as ButtonStories from '../examples/Button.stories';
 
 const meta: Meta<typeof Canvas> = {
   component: Canvas,
   parameters: {
-    relativeCsfPaths: ['../controls/Boolean.stories'],
+    relativeCsfPaths: ['../examples/Button.stories'],
   },
   render: (args) => {
     return (
       <Canvas {...args}>
-        <StoryComponent of={BooleanStories.Undefined} />
+        <StoryComponent of={ButtonStories.Primary} />
       </Canvas>
     );
   },
@@ -39,10 +39,13 @@ export const WithMdxSource: Story = {
   name: 'With MDX Source',
   args: {
     withSource: SourceState.OPEN,
-    mdxSource: `const thisIsCustomSource = true;
-if (isSyntaxHighlighted) {
-  console.log('syntax highlighting is working');
-}`,
+    mdxSource: `<Button
+  label="Button"
+  primary
+  onClick={() => {
+    console.log('this is custom source for the source viewer')
+  }}
+/>`,
   },
 };
 
@@ -64,7 +67,7 @@ export const WithAdditionalActions: Story = {
         title: 'Open in GitHub',
         onClick: () => {
           window.open(
-            'https://github.com/storybookjs/storybook/blob/next/code/ui/blocks/src/controls/Boolean.stories.tsx',
+            'https://github.com/storybookjs/storybook/blob/next/code/ui/blocks/src/examples/Button.stories.tsx',
             '_blank'
           );
         },
@@ -108,7 +111,7 @@ export const ClassName: Story = {
         `}
       </style>
       <Canvas {...args}>
-        <StoryComponent of={BooleanStories.Undefined} />
+        <StoryComponent of={ButtonStories.Primary} />
       </Canvas>
     </>
   ),

--- a/code/ui/blocks/src/blocks/Canvas.stories.tsx
+++ b/code/ui/blocks/src/blocks/Canvas.stories.tsx
@@ -34,7 +34,6 @@ export const WithSourceClosed: Story = {
   },
 };
 
-// TODO: what is the purpose of mdxSource exactly?
 export const WithMdxSource: Story = {
   name: 'With MDX Source',
   args: {

--- a/code/ui/blocks/src/blocks/Description.stories.tsx
+++ b/code/ui/blocks/src/blocks/Description.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Description } from './Description';
-import { BooleanControl } from '../controls/Boolean';
+import { Button } from '../examples/Button';
 
 const meta: Meta<typeof Description> = {
   component: Description,
   parameters: {
-    relativeCsfPaths: ['../controls/Boolean.stories'],
+    relativeCsfPaths: ['../examples/Button.stories'],
     controls: {
       include: [],
       hideNoControlsWarning: true,
@@ -16,8 +16,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const BooleanControlJSDoc: Story = {
+export const ButtonComponent: Story = {
   args: {
-    of: BooleanControl,
+    of: Button,
   },
 };

--- a/code/ui/blocks/src/blocks/Story.stories.tsx
+++ b/code/ui/blocks/src/blocks/Story.stories.tsx
@@ -40,7 +40,7 @@ export const Id: Story = {
 
 export const Name: Story = {
   args: {
-    name: 'True',
+    name: 'Secondary',
   },
 };
 

--- a/code/ui/blocks/src/blocks/Story.stories.tsx
+++ b/code/ui/blocks/src/blocks/Story.stories.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Story as StoryComponent } from './Story';
-import * as BooleanStories from '../controls/Boolean.stories';
+import * as ButtonStories from '../examples/Button.stories';
 
 const meta: Meta<typeof StoryComponent> = {
   component: StoryComponent,
   parameters: {
-    relativeCsfPaths: ['../controls/Boolean.stories', '../blocks/Story.stories'],
+    relativeCsfPaths: ['../examples/Button.stories', '../blocks/Story.stories'],
   },
 };
 export default meta;
@@ -17,14 +17,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Of: Story = {
   args: {
-    of: BooleanStories.Undefined,
+    of: ButtonStories.Primary,
   },
 };
 
 export const OfWithMeta: Story = {
   args: {
-    of: BooleanStories.True,
-    meta: BooleanStories.default,
+    of: ButtonStories.Secondary,
+    meta: ButtonStories.default,
   },
 };
 
@@ -102,7 +102,7 @@ export const IframeWithHeight: Story = {
 
 export const WithDefaultInteractions: Story = {
   args: {
-    of: BooleanStories.Toggling,
+    of: ButtonStories.Clicking,
   },
   parameters: {
     chromatic: { delay: 500 },
@@ -110,13 +110,9 @@ export const WithDefaultInteractions: Story = {
 };
 export const WithInteractionsAutoplayInStory: Story = {
   args: {
-    of: BooleanStories.TogglingInDocs,
+    of: ButtonStories.ClickingInDocs,
   },
   parameters: {
     chromatic: { delay: 500 },
   },
 };
-
-// TODO: types suggest that <Story /> can take ProjectAnnotations, but it doesn't seem to do anything with them
-// Such as parameters, decorators, etc.
-// they seem to be taken from the story itself, and not from the <Story /> call

--- a/code/ui/blocks/src/blocks/internal/InternalCanvas.stories.tsx
+++ b/code/ui/blocks/src/blocks/internal/InternalCanvas.stories.tsx
@@ -6,18 +6,18 @@ import { userEvent, waitFor, within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import { Canvas } from '../Canvas';
 import { Story as StoryComponent } from '../Story';
-import * as BooleanStories from '../../controls/Boolean.stories';
+import * as ButtonStories from '../../examples/Button.stories';
 
 const meta: Meta<typeof Canvas> = {
   title: 'Blocks/Internal/Canvas',
   component: Canvas,
   parameters: {
-    relativeCsfPaths: ['../controls/Boolean.stories'],
+    relativeCsfPaths: ['../examples/Button.stories'],
   },
   render: (args) => {
     return (
       <Canvas {...args}>
-        <StoryComponent of={BooleanStories.Undefined} />
+        <StoryComponent of={ButtonStories.Primary} />
       </Canvas>
     );
   },
@@ -52,8 +52,8 @@ export const MultipleChildren: Story = {
   render: (args) => {
     return (
       <Canvas {...args}>
-        <StoryComponent of={BooleanStories.True} />
-        <StoryComponent of={BooleanStories.False} />
+        <StoryComponent of={ButtonStories.Secondary} />
+        <StoryComponent of={ButtonStories.Large} />
       </Canvas>
     );
   },
@@ -67,8 +67,8 @@ export const MultipleChildrenColumns: Story = {
   render: (args) => {
     return (
       <Canvas {...args}>
-        <StoryComponent of={BooleanStories.True} />
-        <StoryComponent of={BooleanStories.False} />
+        <StoryComponent of={ButtonStories.Secondary} />
+        <StoryComponent of={ButtonStories.Large} />
       </Canvas>
     );
   },
@@ -82,15 +82,15 @@ export const MultipleChildrenThreeColumns: Story = {
   render: (args) => {
     return (
       <Canvas {...args}>
-        <StoryComponent of={BooleanStories.True} />
-        <StoryComponent of={BooleanStories.True} />
-        <StoryComponent of={BooleanStories.True} />
-        <StoryComponent of={BooleanStories.False} />
-        <StoryComponent of={BooleanStories.False} />
-        <StoryComponent of={BooleanStories.False} />
-        <StoryComponent of={BooleanStories.Undefined} />
-        <StoryComponent of={BooleanStories.Undefined} />
-        <StoryComponent of={BooleanStories.Undefined} />
+        <StoryComponent of={ButtonStories.Secondary} />
+        <StoryComponent of={ButtonStories.Secondary} />
+        <StoryComponent of={ButtonStories.Secondary} />
+        <StoryComponent of={ButtonStories.Large} />
+        <StoryComponent of={ButtonStories.Large} />
+        <StoryComponent of={ButtonStories.Large} />
+        <StoryComponent of={ButtonStories.Primary} />
+        <StoryComponent of={ButtonStories.Primary} />
+        <StoryComponent of={ButtonStories.Primary} />
       </Canvas>
     );
   },
@@ -102,10 +102,10 @@ export const MixedChildrenStories: Story = {
   render: (args) => {
     return (
       <Canvas {...args}>
-        <h1>Headline for Boolean Controls true</h1>
-        <StoryComponent of={BooleanStories.True} />
-        <h1>Headline for Boolean Controls undefined</h1>
-        <StoryComponent of={BooleanStories.Undefined} />
+        <h1>Headline for secondary Button</h1>
+        <StoryComponent of={ButtonStories.Secondary} />
+        <h1>Headline for primary Button</h1>
+        <StoryComponent of={ButtonStories.Primary} />
       </Canvas>
     );
   },

--- a/code/ui/blocks/src/blocks/internal/InternalDescription.stories.tsx
+++ b/code/ui/blocks/src/blocks/internal/InternalDescription.stories.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Description, DescriptionType } from '../Description';
-import { BooleanControl } from '../../controls/Boolean';
+import { Button } from '../../examples/Button';
 
 const meta: Meta<typeof Description> = {
   title: 'Blocks/Internal/Description',
   component: Description,
   parameters: {
-    relativeCsfPaths: ['../controls/Boolean.stories'],
+    relativeCsfPaths: ['../examples/Button.stories'],
   },
   args: {
-    of: BooleanControl,
+    of: Button,
   },
 };
 export default meta;

--- a/code/ui/blocks/src/examples/Button.stories.tsx
+++ b/code/ui/blocks/src/examples/Button.stories.tsx
@@ -1,4 +1,9 @@
+import { expect } from '@storybook/jest';
 import type { Meta, StoryObj } from '@storybook/react';
+import { within, fireEvent } from '@storybook/testing-library';
+import { addons } from '@storybook/preview-api';
+import { RESET_STORY_ARGS, STORY_ARGS_UPDATED } from '@storybook/core-events';
+import React from 'react';
 import { Button } from './Button';
 
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
@@ -8,6 +13,12 @@ const meta = {
   tags: ['autodocs'],
   argTypes: {
     backgroundColor: { control: 'color' },
+  },
+  parameters: {
+    // these are to test the deprecated features of the Description block
+    notes: 'These are notes for the Button stories',
+    info: 'This is info for the Button stories',
+    jsx: { useBooleanShorthandSyntax: false },
   },
 } satisfies Meta<typeof Button>;
 
@@ -39,5 +50,45 @@ export const Small: Story = {
   args: {
     size: 'small',
     label: 'Button',
+  },
+};
+
+export const Clicking: Story = {
+  args: {
+    primary: true,
+    label: 'Increment',
+  },
+  render: (args) => {
+    const [count, setCount] = React.useState(0);
+    return (
+      <>
+        <Button {...args} onClick={() => setCount(count + 1)} />
+        <div style={{ padding: '1rem' }}>Click count: {count}</div>
+      </>
+    );
+  },
+  play: async ({ canvasElement, id }) => {
+    const channel = addons.getChannel();
+
+    channel.emit(RESET_STORY_ARGS, { storyId: id });
+    await new Promise<void>((resolve) => {
+      channel.once(STORY_ARGS_UPDATED, resolve);
+    });
+
+    const canvas = within(canvasElement);
+
+    const button = canvas.getByText('Increment');
+    await fireEvent.click(button);
+
+    expect(canvas.getByText('Click count: 1')).toBeInTheDocument();
+  },
+};
+
+export const ClickingInDocs: Story = {
+  ...Clicking,
+  parameters: {
+    docs: {
+      autoplay: true,
+    },
   },
 };

--- a/code/ui/blocks/src/examples/Button.stories.tsx
+++ b/code/ui/blocks/src/examples/Button.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+// More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
+const meta = {
+  title: 'Example/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
+export const Primary: Story = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    label: 'Button',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'large',
+    label: 'Button',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'small',
+    label: 'Button',
+  },
+};

--- a/code/ui/blocks/src/examples/Button.tsx
+++ b/code/ui/blocks/src/examples/Button.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { styled } from '@storybook/theming';
+
+interface ButtonProps {
+  /**
+   * Is this the principal call to action on the page?
+   */
+  primary?: boolean;
+  /**
+   * What background color to use
+   */
+  backgroundColor?: string;
+  /**
+   * How large should the button be?
+   */
+  size?: 'small' | 'medium' | 'large';
+  /**
+   * Button contents
+   */
+  label: string;
+  /**
+   * Optional click handler
+   */
+  onClick?: () => void;
+}
+
+const StyledButton = styled.button<Omit<ButtonProps, 'label' | 'onClick'>>(
+  ({ primary, size, backgroundColor }) => {
+    const modeStyles = primary
+      ? {
+          color: 'white',
+          backgroundColor: '#1ea7fd',
+        }
+      : {
+          color: '#333',
+          backgroundColor: 'transparent',
+          boxShadow: 'rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset',
+        };
+    const sizeStyles = {
+      small: {
+        fontSize: '12px',
+        padding: '10px 16px',
+      },
+      medium: {
+        fontSize: '14px',
+        padding: '11px 20px',
+      },
+      large: {
+        fontSize: '16px',
+        padding: '12px 24px',
+      },
+    };
+    return {
+      fontFamily: "'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+      fontWeight: 700,
+      border: 0,
+      borderRadius: '3em',
+      cursor: 'pointer',
+      display: 'inline-block',
+      lineHeight: 1,
+      ...modeStyles,
+      ...sizeStyles[size],
+      ...(backgroundColor && { backgroundColor }),
+    };
+  }
+);
+
+/**
+ * # Example button component
+ * Comes in three sizes: `small`, `medium`, and `large`.
+ *
+ * Can be primary or secondary.
+ */
+export const Button = ({
+  primary = false,
+  size = 'medium',
+  backgroundColor,
+  label,
+  ...props
+}: ButtonProps) => (
+  <StyledButton
+    type="button"
+    size={size}
+    primary={primary}
+    backgroundColor={backgroundColor}
+    {...props}
+  >
+    {label}
+  </StyledButton>
+);


### PR DESCRIPTION
This PR introduces the classic example Button (rewritten to Emotion styles), to be used by all the Blocks that refers to components and stories.
This is to simplify the stories and make them easier to understand, as the Boolean stories was a bit confusing.