### PR TITLE
Docs: Fix attachment logic

### DIFF
--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -642,7 +642,7 @@ describe('PreviewWeb', () => {
       });
     });
 
-    describe('template docs entries', () => {
+    describe('CSF docs entries', () => {
       it('always renders in docs viewMode', async () => {
         document.location.search = '?id=component-one--docs';
         await createAndRenderPreview();
@@ -679,7 +679,7 @@ describe('PreviewWeb', () => {
         expect(importFn).toHaveBeenCalledWith('./src/ExtraComponentOne.stories.js');
       });
 
-      it('renders with componentStories loaded from both story files', async () => {
+      it('renders with componentStories loaded from the attached CSF file', async () => {
         document.location.search = '?id=component-one--docs&viewMode=docs';
         await createAndRenderPreview();
 

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.test.ts
@@ -1,31 +1,15 @@
 import { Channel } from '@storybook/channels';
-import type { Renderer, CSFFile, PreparedStory } from '@storybook/types';
+import type { Renderer } from '@storybook/types';
 import type { StoryStore } from '../../store';
 
 import { DocsContext } from './DocsContext';
+import { csfFileParts } from './test-utils';
 
 const channel = new Channel();
 const renderStoryToElement = jest.fn();
 
 describe('resolveModuleExport', () => {
-  // These compose the raw exports of the CSF file
-  const component = {};
-  const metaExport = { component };
-  const storyExport = {};
-  const moduleExports = { default: metaExport, story: storyExport };
-
-  // This is the prepared story + CSF file after SB has processed them
-  const storyAnnotations = {
-    id: 'meta--story',
-    moduleExport: storyExport,
-  } as CSFFile['stories'][string];
-  const story = { id: 'meta--story', moduleExport: storyExport } as PreparedStory;
-  const meta = { id: 'meta', title: 'Meta', component, moduleExports } as CSFFile['meta'];
-  const csfFile = {
-    stories: { story: storyAnnotations },
-    meta,
-    moduleExports,
-  } as CSFFile;
+  const { story, csfFile, storyExport, metaExport, moduleExports, component } = csfFileParts();
 
   const store = {
     componentStoriesFromCSFFile: () => [story],

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/test-utils.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/test-utils.ts
@@ -1,0 +1,33 @@
+import type { CSFFile, PreparedStory } from '@storybook/types';
+
+export function csfFileParts() {
+  // These compose the raw exports of the CSF file
+  const component = {};
+  const metaExport = { component };
+  const storyExport = {};
+  const moduleExports = { default: metaExport, story: storyExport };
+
+  // This is the prepared story + CSF file after SB has processed them
+  const storyAnnotations = {
+    id: 'meta--story',
+    moduleExport: storyExport,
+  } as CSFFile['stories'][string];
+  const story = { id: 'meta--story', moduleExport: storyExport } as PreparedStory;
+  const meta = { id: 'meta', title: 'Meta', component, moduleExports } as CSFFile['meta'];
+  const csfFile = {
+    stories: { story: storyAnnotations },
+    meta,
+    moduleExports,
+  } as CSFFile;
+
+  return {
+    component,
+    metaExport,
+    storyExport,
+    moduleExports,
+    storyAnnotations,
+    story,
+    meta,
+    csfFile,
+  };
+}

--- a/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.test.ts
@@ -1,9 +1,16 @@
 import { Channel } from '@storybook/channels';
-import type { Renderer, DocsIndexEntry } from '@storybook/types';
+import type {
+  Renderer,
+  DocsIndexEntry,
+  PreparedStory,
+  ModuleExports,
+  CSFFile,
+} from '@storybook/types';
 import type { StoryStore } from '../../store';
 import { PREPARE_ABORTED } from './Render';
 
 import { CsfDocsRender } from './CsfDocsRender';
+import { csfFileParts } from '../docs-context/test-utils';
 
 const entry = {
   type: 'docs',
@@ -23,28 +30,47 @@ const createGate = (): [Promise<any | undefined>, (_?: any) => void] => {
   return [gate, openGate];
 };
 
-describe('CsfDocsRender', () => {
-  it('throws PREPARE_ABORTED if torndown during prepare', async () => {
-    const [importGate, openImportGate] = createGate();
-    const mockStore = {
-      loadEntry: jest.fn(async () => {
-        await importGate;
-        return {};
-      }),
-    };
+it('throws PREPARE_ABORTED if torndown during prepare', async () => {
+  const [importGate, openImportGate] = createGate();
+  const mockStore = {
+    loadEntry: jest.fn(async () => {
+      await importGate;
+      return {};
+    }),
+  };
 
-    const render = new CsfDocsRender(
-      new Channel(),
-      mockStore as unknown as StoryStore<Renderer>,
-      entry
-    );
+  const render = new CsfDocsRender(
+    new Channel(),
+    mockStore as unknown as StoryStore<Renderer>,
+    entry
+  );
 
-    const preparePromise = render.prepare();
+  const preparePromise = render.prepare();
 
-    render.teardown();
+  render.teardown();
 
-    openImportGate();
+  openImportGate();
 
-    await expect(preparePromise).rejects.toThrowError(PREPARE_ABORTED);
-  });
+  await expect(preparePromise).rejects.toThrowError(PREPARE_ABORTED);
+});
+
+it('attached immediately', async () => {
+  const { story, csfFile, moduleExports } = csfFileParts();
+
+  const store = {
+    loadEntry: () => ({
+      entryExports: moduleExports,
+      csfFiles: [],
+    }),
+    processCSFFileWithCache: () => csfFile,
+    componentStoriesFromCSFFile: () => [story],
+    storyFromCSFFile: () => story,
+  } as unknown as StoryStore<Renderer>;
+
+  const render = new CsfDocsRender(new Channel(), store, entry);
+  await render.prepare();
+
+  const context = render.docsContext(jest.fn());
+
+  expect(context.storyById()).toEqual(story);
 });

--- a/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts
@@ -85,19 +85,28 @@ export class CsfDocsRender<TRenderer extends Renderer> implements Render<TRender
     );
   }
 
+  docsContext(renderStoryToElement: DocsContextProps['renderStoryToElement']) {
+    if (!this.csfFiles) throw new Error('Cannot render docs before preparing');
+    const docsContext = new DocsContext<TRenderer>(
+      this.channel,
+      this.store,
+      renderStoryToElement,
+      this.csfFiles
+    );
+    // All referenced CSF files should be attached for CSF docs
+    //  - When you create two CSF files that both reference the same title, they are combined into
+    //    a single CSF docs entry with a `storiesImport` defined.
+    this.csfFiles.forEach((csfFile) => docsContext.attachCSFFile(csfFile));
+    return docsContext;
+  }
+
   async renderToElement(
     canvasElement: TRenderer['canvasElement'],
     renderStoryToElement: DocsContextProps['renderStoryToElement']
   ) {
     if (!this.story || !this.csfFiles) throw new Error('Cannot render docs before preparing');
 
-    const docsContext = new DocsContext<TRenderer>(
-      this.channel,
-      this.store,
-      renderStoryToElement,
-      this.csfFiles,
-      true
-    );
+    const docsContext = this.docsContext(renderStoryToElement);
 
     const { docs: docsParameter } = this.story.parameters || {};
 

--- a/code/lib/preview-api/src/modules/preview-web/render/MdxDocsRender.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/MdxDocsRender.ts
@@ -69,6 +69,19 @@ export class MdxDocsRender<TRenderer extends Renderer> implements Render<TRender
     );
   }
 
+  docsContext(renderStoryToElement: DocsContextProps['renderStoryToElement']) {
+    if (!this.csfFiles) throw new Error('Cannot render docs before preparing');
+
+    // NOTE we do *not* attach any CSF file yet. We wait for `setMeta`
+    // ie the CSF file is attached via `<Meta of={} />`
+    return new DocsContext<TRenderer>(
+      this.channel,
+      this.store,
+      renderStoryToElement,
+      this.csfFiles
+    );
+  }
+
   async renderToElement(
     canvasElement: TRenderer['canvasElement'],
     renderStoryToElement: DocsContextProps['renderStoryToElement']
@@ -76,16 +89,9 @@ export class MdxDocsRender<TRenderer extends Renderer> implements Render<TRender
     if (!this.exports || !this.csfFiles || !this.store.projectAnnotations)
       throw new Error('Cannot render docs before preparing');
 
-    const docsContext = new DocsContext<TRenderer>(
-      this.channel,
-      this.store,
-      renderStoryToElement,
-      this.csfFiles,
-      false
-    );
+    const docsContext = this.docsContext(renderStoryToElement);
 
     const { docs } = this.store.projectAnnotations.parameters || {};
-
     if (!docs)
       throw new Error(
         `Cannot render a story in viewMode=docs if \`@storybook/addon-docs\` is not installed`

--- a/code/ui/.storybook/preview.tsx
+++ b/code/ui/.storybook/preview.tsx
@@ -127,7 +127,7 @@ export const loaders = [
       preview.renderStoryToElement.bind(preview),
       csfFiles
     );
-    if (!attached && csfFiles[0]) {
+    if (attached && csfFiles[0]) {
       docsContext.attachCSFFile(csfFiles[0]);
     }
     return { docsContext };

--- a/code/ui/.storybook/preview.tsx
+++ b/code/ui/.storybook/preview.tsx
@@ -102,7 +102,7 @@ export const loaders = [
    * }
    * The DocsContext will then be added via the decorator below.
    */
-  async ({ parameters: { relativeCsfPaths } }) => {
+  async ({ parameters: { relativeCsfPaths, attached = true } }) => {
     if (!relativeCsfPaths) return {};
     const csfFiles = await Promise.all(
       (relativeCsfPaths as string[]).map(async (blocksRelativePath) => {
@@ -121,15 +121,16 @@ export const loaders = [
         return preview.storyStore.loadCSFFileByStoryId(entry.id);
       })
     );
-    return {
-      docsContext: new DocsContext(
-        channel,
-        preview.storyStore,
-        preview.renderStoryToElement.bind(preview),
-        csfFiles,
-        false
-      ),
-    };
+    const docsContext = new DocsContext(
+      channel,
+      preview.storyStore,
+      preview.renderStoryToElement.bind(preview),
+      csfFiles
+    );
+    if (!attached && csfFiles[0]) {
+      docsContext.attachCSFFile(csfFiles[0]);
+    }
+    return { docsContext };
   },
 ];
 

--- a/code/ui/blocks/src/blocks/external/ExternalDocsContext.ts
+++ b/code/ui/blocks/src/blocks/external/ExternalDocsContext.ts
@@ -16,18 +16,19 @@ export class ExternalDocsContext<TRenderer extends Renderer> extends DocsContext
     public renderStoryToElement: DocsContextProps['renderStoryToElement'],
     private processMetaExports: (metaExports: ModuleExports) => CSFFile<TRenderer>
   ) {
-    super(channel, store, renderStoryToElement, [], true);
+    super(channel, store, renderStoryToElement, []);
   }
 
   setMeta = (metaExports: ModuleExports) => {
     const csfFile = this.processMetaExports(metaExports);
-    this.referenceCSFFile(csfFile, true);
+    this.referenceCSFFile(csfFile);
+    super.setMeta(metaExports);
   };
 
   resolveModuleExport(moduleExport: ModuleExport, metaExports?: ModuleExports) {
     if (metaExports) {
       const csfFile = this.processMetaExports(metaExports);
-      this.referenceCSFFile(csfFile, false);
+      this.referenceCSFFile(csfFile);
     }
 
     // This will end up looking up the story/component id in the CSF file referenced above or via setMeta()


### PR DESCRIPTION
Telescoping on https://github.com/storybookjs/storybook/pull/20517

## What I did

Rationalized how attachment works:

- For CSF (template) files, we attach to the (one or more) CSF files we are templating, immediately. (You can have more than one with autodocs and stories spread over > 1 CSF file.

- For MDX files, we attach when you call `<Meta of={} />`.

## How to test

- See unit tests
- Check doc blocks stories
- Check docs pages