### PR TITLE
Migrations: Add `preact-vite` to new frameworks automigration.

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.test.ts
@@ -252,6 +252,33 @@ describe('new-frameworks fix', () => {
           })
         );
       });
+
+      it('should update to @storybook/preact-vite', async () => {
+        const packageJson = {
+          dependencies: {
+            '@storybook/preact': '^7.0.0-alpha.0',
+            '@storybook/builder-vite': '^0.0.2',
+            vite: '3.0.0',
+          },
+        };
+        await expect(
+          checkNewFrameworks({
+            packageJson,
+            main: {
+              framework: '@storybook/preact',
+              core: {
+                builder: '@storybook/builder-vite',
+              },
+            },
+          })
+        ).resolves.toEqual(
+          expect.objectContaining({
+            frameworkPackage: '@storybook/preact-vite',
+            dependenciesToAdd: ['@storybook/preact-vite'],
+            dependenciesToRemove: ['@storybook/builder-vite'],
+          })
+        );
+      });
     });
   });
 });

--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
@@ -18,6 +18,7 @@ const packagesMap: Record<string, { webpack5?: string; vite?: string }> = {
   },
   '@storybook/preact': {
     webpack5: '@storybook/preact-webpack5',
+    vite: '@storybook/preact-vite',
   },
   '@storybook/server': {
     webpack5: '@storybook/server-webpack5',


### PR DESCRIPTION
Test from https://github.com/storybookjs/storybook/pull/19432/files#diff-c336d43073bdac851f061678667b52fdef5e703aa2527548da23887acd552861

