### PR TITLE
Fix: pathing of managerEntries containing long paths with hidden folders

### DIFF
--- a/code/lib/builder-manager/src/utils/managerEntries.ts
+++ b/code/lib/builder-manager/src/utils/managerEntries.ts
@@ -1,7 +1,18 @@
 import findCacheDirectory from 'find-cache-dir';
 import fs from 'fs-extra';
-import { join, parse, relative } from 'node:path';
+import { join, parse, relative, sep } from 'node:path';
 import slash from 'slash';
+
+const sanitizeBase = (path: string) => {
+  return path.replaceAll('.', '').replaceAll('@', '').replaceAll(sep, '-').replaceAll('/', '-');
+};
+
+const sanitizeFinal = (path: string) => {
+  const sections = path.split(/-?node_modules-?/);
+
+  return sections[sections.length - 1].replaceAll('storybook-addon-', '').replaceAll('dist-', '');
+};
+
 /**
  * Manager entries should be **self-invoking** bits of code.
  * They can of-course import from modules, and ESbuild will bundle all of that into a single file.
@@ -20,7 +31,7 @@ import slash from 'slash';
  */
 export async function wrapManagerEntries(entrypoints: string[]) {
   return Promise.all(
-    entrypoints.map(async (entry) => {
+    entrypoints.map(async (entry, i) => {
       const { name, dir } = parse(entry);
       const cacheLocation = findCacheDirectory({ name: 'sb-manager' });
 
@@ -28,7 +39,12 @@ export async function wrapManagerEntries(entrypoints: string[]) {
         throw new Error('Could not create/find cache directory');
       }
 
-      const location = join(cacheLocation, relative(process.cwd(), dir), `${name}-bundle.mjs`);
+      const base = relative(process.cwd(), dir);
+      const location = join(
+        cacheLocation,
+        sanitizeFinal(`${sanitizeBase(base)}-${i}/${sanitizeBase(name)}-bundle.mjs`)
+      );
+
       await fs.ensureFile(location);
       await fs.writeFile(location, `import '${slash(entry)}';`);
 

--- a/code/lib/builder-manager/src/utils/managerEntries.ts
+++ b/code/lib/builder-manager/src/utils/managerEntries.ts
@@ -42,7 +42,7 @@ export async function wrapManagerEntries(entrypoints: string[]) {
       const base = relative(process.cwd(), dir);
       const location = join(
         cacheLocation,
-        sanitizeFinal(`${sanitizeBase(base)}-${i}/${sanitizeBase(name)}-bundle.mjs`)
+        sanitizeFinal(join(`${sanitizeBase(base)}-${i}`, `${sanitizeBase(name)}-bundle.mjs`))
       );
 
       await fs.ensureFile(location);


### PR DESCRIPTION
Issue: #20427
Issue: #20513

## What I did

- Ensured that when writing files to the cache wrapping managerEntries, to flatten the directory structure, removing special characters such as `@` and `.` which might have meaning in the file-system.
- Strip away some redundant path info
- Ensure each entry is unique by adding the index into the path