### PR TITLE
fix: remove standalone and export build from core-server

### DIFF
--- a/code/lib/core-server/src/index.ts
+++ b/code/lib/core-server/src/index.ts
@@ -6,3 +6,4 @@ export { getPreviewHeadTemplate, getPreviewBodyTemplate } from '@storybook/core-
 export * from './build-static';
 export * from './build-dev';
 export * from './withTelemetry';
+export { default as build } from './standalone';

--- a/code/lib/core-server/standalone.js
+++ b/code/lib/core-server/standalone.js
@@ -1,3 +1,0 @@
-const build = require('./dist/cjs/standalone').default;
-
-module.exports = build;


### PR DESCRIPTION
## What I did

* Export `build` from `core-server`
* Delete `standalone.js` since it's not exported anywhere



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203655622874014