### PR TITLE
feat: expose port from buildDevStandalone

### DIFF
--- a/code/frameworks/angular/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.ts
@@ -106,8 +106,8 @@ function commandBuilder(
       return standaloneOptions;
     }),
     switchMap((standaloneOptions) => runInstance(standaloneOptions)),
-    map(() => {
-      return { success: true };
+    map((port: number) => {
+      return { success: true, info: { port } };
     })
   );
 }
@@ -132,10 +132,10 @@ async function setup(options: StorybookBuilderOptions, context: BuilderContext) 
   };
 }
 function runInstance(options: StandaloneOptions) {
-  return new Observable<void>((observer) => {
+  return new Observable<number>((observer) => {
     // This Observable intentionally never complete, leaving the process running ;)
     buildDevStandalone(options as any).then(
-      () => observer.next(),
+      ({ port }) => observer.next(port),
       (error) => observer.error(buildStandaloneErrorHandler(error))
     );
   });

--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -28,7 +28,9 @@ import { updateCheck } from './utils/update-check';
 import { getServerPort, getServerChannelUrl } from './utils/server-address';
 import { getManagerBuilder, getPreviewBuilder } from './utils/get-builders';
 
-export async function buildDevStandalone(options: CLIOptions & LoadOptions & BuilderOptions) {
+export async function buildDevStandalone(
+  options: CLIOptions & LoadOptions & BuilderOptions
+): Promise<{ port: number }> {
   const { packageJson, versionUpdates, releaseNotes } = options;
   const { version } = packageJson;
 
@@ -156,21 +158,21 @@ export async function buildDevStandalone(options: CLIOptions & LoadOptions & Bui
     // eslint-disable-next-line no-console
     console.log(problems.map((p) => p.stack));
     process.exit(problems.length > 0 ? 1 : 0);
-    return;
+  } else {
+    const name =
+      frameworkName.split('@storybook/').length > 1
+        ? frameworkName.split('@storybook/')[1]
+        : frameworkName;
+
+    outputStartupInformation({
+      updateInfo: versionCheck,
+      version,
+      name,
+      address,
+      networkAddress,
+      managerTotalTime,
+      previewTotalTime,
+    });
   }
-
-  const name =
-    frameworkName.split('@storybook/').length > 1
-      ? frameworkName.split('@storybook/')[1]
-      : frameworkName;
-
-  outputStartupInformation({
-    updateInfo: versionCheck,
-    version,
-    name,
-    address,
-    networkAddress,
-    managerTotalTime,
-    previewTotalTime,
-  });
+  return { port };
 }

--- a/code/lib/core-server/src/withTelemetry.ts
+++ b/code/lib/core-server/src/withTelemetry.ts
@@ -61,7 +61,7 @@ async function getErrorLevel({ cliOptions, presetOptions }: TelemetryOptions): P
 export async function withTelemetry(
   eventType: EventType,
   options: TelemetryOptions,
-  run: () => Promise<void>
+  run: () => Promise<any>
 ) {
   if (!options.cliOptions.disableTelemetry)
     telemetry('boot', { eventType }, { stripMetadata: true });


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/20509
## What I did

* Return port information from `buildDevStandalone`

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
