### PR TITLE
Maintenance: mention removal of --no-dll flag

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -38,6 +38,7 @@
     - [Addon-a11y: Removed deprecated withA11y decorator](#addon-a11y-removed-deprecated-witha11y-decorator)
     - [Stories glob matches MDX files](#stories-glob-matches-mdx-files)
     - [Add strict mode](#add-strict-mode)
+    - [Removed DLL flags](#removed-dll-flags)
   - [Docs Changes](#docs-changes)
     - [Standalone docs files](#standalone-docs-files)
     - [Referencing stories in docs files](#referencing-stories-in-docs-files)
@@ -740,6 +741,11 @@ export default {
 Starting in 7.0, Storybook's build tools add [`"use strict"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) to the compiled JS output.
 
 If user code in `.storybook/preview.js` or stories relies on "sloppy" mode behavior, it will need to be updated. As a workaround, it is sometimes possible to move the sloppy mode code inside a script tag in `.storybook/preview-head.html`.
+
+#### Removed DLL flags
+
+Earlier versions of Storybook used Webpack DLLs as a performance crutch. In 6.1, we've removed Storybook's built-in DLLs and have deprecated the command-line parameters `--no-dll` and `--ui-dll`. In 7.0 those options are removed.
+
 
 ### Docs Changes
 

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -156,10 +156,7 @@ export interface CLIOptions {
   quiet?: boolean;
   versionUpdates?: boolean;
   releaseNotes?: boolean;
-  dll?: boolean;
   docs?: boolean;
-  docsDll?: boolean;
-  uiDll?: boolean;
   debugWebpack?: boolean;
   webpackStatsJson?: string | boolean;
   outputDir?: string;

--- a/docs/api/cli-options.md
+++ b/docs/api/cli-options.md
@@ -21,7 +21,7 @@ Usage: start-storybook [options]
 | Options                         | Description                                                                                                                                                                 |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--help`                        | Output usage information <br/>`start-storybook --help`                                                                                                                      |
-| `-V`, `--version`               | Output the version number <br/>`start-storybook -V`                                                                                                                         |
+| `-V`, `--version`               | Output the version number <br/>`start-storybook cp-V`                                                                                                                         |
 | `-p`, `--port [number]`         | Port to run Storybook <br/>`start-storybook -p 9009`                                                                                                                        |
 | `-h`, `--host [string]`         | Host to run Storybook <br/>`start-storybook -h my-host.com`                                                                                                                 |
 | `-s`, `--static-dir`            | **Deprecated** [see note](#static-dir-deprecation). Directory where to load static files from, comma-separated list<br/>`start-storybook -s public`                         |
@@ -34,7 +34,6 @@ Usage: start-storybook [options]
 | `--ci`                          | CI mode (skip interactive prompts, don't open browser)<br/>`start-storybook --ci`                                                                                           |
 | `--no-open`                     | Do not open Storybook automatically in the browser<br/>`start-storybook --no-open`                                                                                          |
 | `--quiet`                       | Suppress verbose build output<br/>`start-storybook --quiet`                                                                                                                 |
-| `--no-dll`                      | Do not use dll reference (no-op)<br/>`start-storybook --no-dll`                                                                                                             |
 | `--debug-webpack`               | Display final webpack configurations for debugging purposes<br/>`start-storybook --debug-webpack`                                                                           |
 | `--webpack-stats-json`          | Write Webpack Stats JSON to disk<br/>`start-storybook --webpack-stats-json /tmp/webpack-stats`                                                                              |
 | `--docs`                        | Starts Storybook in documentation mode. Learn more about it in [here](../writing-docs/build-documentation.md#preview-storybooks-documentation)<br/>`start-storybook --docs` |

--- a/docs/api/cli-options.md
+++ b/docs/api/cli-options.md
@@ -66,7 +66,6 @@ Usage: build-storybook [options]
 | `-c`, `--config-dir [dir-name]` | Directory where to load Storybook configurations from<br/>`build-storybook -c .storybook`                                                                                   |
 | `--loglevel [level]`            | Controls level of logging during build.<br/> Available options: `silly`, `verbose`, `info` (default), `warn`, `error`, `silent`<br/>`build-storybook --loglevel warn`       |
 | `--quiet`                       | Suppress verbose build output<br/>`build-storybook --quiet`                                                                                                                 |
-| `--no-dll`                      | Do not use dll reference (no-op)<br/>`build-storybook --no-dll`                                                                                                             |
 | `--debug-webpack`               | Display final webpack configurations for debugging purposes<br/>`build-storybook --debug-webpack`                                                                           |
 | `--webpack-stats-json`          | Write Webpack Stats JSON to disk<br/>`build-storybook --webpack-stats-json /my-storybook/webpack-stats`                                                                     |
 | `--docs`                        | Builds Storybook in documentation mode. Learn more about it in [here](../writing-docs/build-documentation.md#publish-storybooks-documentation)<br/>`build-storybook --docs` |

--- a/docs/api/cli-options.md
+++ b/docs/api/cli-options.md
@@ -21,7 +21,7 @@ Usage: start-storybook [options]
 | Options                         | Description                                                                                                                                                                 |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--help`                        | Output usage information <br/>`start-storybook --help`                                                                                                                      |
-| `-V`, `--version`               | Output the version number <br/>`start-storybook cp-V`                                                                                                                         |
+| `-V`, `--version`               | Output the version number <br/>`start-storybook -V`                                                                                                                         |
 | `-p`, `--port [number]`         | Port to run Storybook <br/>`start-storybook -p 9009`                                                                                                                        |
 | `-h`, `--host [string]`         | Host to run Storybook <br/>`start-storybook -h my-host.com`                                                                                                                 |
 | `-s`, `--static-dir`            | **Deprecated** [see note](#static-dir-deprecation). Directory where to load static files from, comma-separated list<br/>`start-storybook -s public`                         |


### PR DESCRIPTION
`--no-dll` flag is removed in v7

Issue:

## What I did

Remove the `--no-dll` flag from v7 docs

## How to test

- [X] Is this testable with Jest or Chromatic screenshots?
- [X] Does this need a new example in the kitchen sink apps?
- [X] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
