### PR TITLE
Bug: Fix issue with jest projects matching `ui/node_modules`

### DIFF
--- a/code/jest.config.js
+++ b/code/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
     '<rootDir>/frameworks/!(angular)*',
     '<rootDir>/lib/*',
     '<rootDir>/renderers/*',
-    '<rootDir>/ui/*',
+    '<rootDir>/ui/!(node_modules)*',
   ],
   collectCoverage: false,
   collectCoverageFrom: [


### PR DESCRIPTION
Issue: 

(1) sometimes tests come up twice, both within a project and at the root. They fail in the latter with babel problems

Also there are a bunch of warnings like:

```
● Validation Warning:

  Unknown option "projects" with value ["<rootDir>/addons/*", "<rootDir>/frameworks/!(angular)*", "<rootDir>/lib/*", "<rootDir>/renderers/*", "<rootDir>/ui/*"] was found.
  This is probably a typing mistake. Fixing it will remove this message.

  Configuration Documentation:
  https://jestjs.io/docs/configuration
```

(2) sometimes jest fails completely complaining about duplicate project paths.

The issue comes from the `projects` field matching folders with no `jest.config.js`. I've seen two so far:

- `code/ui/node_modules` - there's a `.cache` in there from running our internal SB.
- `addons/storyshots` - this was recently renamed and sometimes gets left hanging out by git when you switch branches.

## What I did

Ignored the first folder with a glob.

I assume the second problem will go away by itself, I mention it here just in case anyone gets the same issue, so they know to just delete it.

## How to test

Run `yarn test`