### PR TITLE
Fix the @storybook/nextjs image loader

### DIFF
--- a/code/frameworks/nextjs/src/next-image-loader-stub.ts
+++ b/code/frameworks/nextjs/src/next-image-loader-stub.ts
@@ -28,4 +28,4 @@ const nextImageLoaderStub: RawLoaderDefinition<LoaderOptions> = function (conten
 
 nextImageLoaderStub.raw = true;
 
-export default nextImageLoaderStub;
+export = nextImageLoaderStub;


### PR DESCRIPTION
Issue: #20611

This fixes the corrupted images when importing images with the @storybook/nextjs framework. Looking at the file history, it probabily broke with commit 44129a439dfcaeca17a60a54ffe4013e1279f96d.

## What I did

I compared the webpack loader that exists in Next.js with the webpack loader in Storybook, and saw that the definition of 'raw' was different.
When I changed it so it was the same as the Next.js version, the images were not corrupted after a production build anymore.
That however introduced TS errors, so I reverted the export change made in commit 44129a439dfcaeca17a60a54ffe4013e1279f96d to archive the same.

File in Next.js: https://github.com/vercel/next.js/blob/98df70e233e536188a303eacdf27ca2d1f4cfb19/packages/next/src/build/webpack/loaders/next-image-loader.ts

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
_I am not familiar with the Storybook codebase, and because the images are currently broken I assume that there is no test for this yet. I think it is wise to create an E2E test that checks full Next.js compatibility, but I think that is out of scope of this issue._