### PR TITLE
fix: Change deprecated `React.VFC` to `React.FC`

### DIFF
--- a/code/frameworks/nextjs/template/cli/ts-legacy/Page.tsx
+++ b/code/frameworks/nextjs/template/cli/ts-legacy/Page.tsx
@@ -7,7 +7,7 @@ type User = {
   name: string;
 };
 
-export const Page: React.VFC = () => {
+export const Page: React.FC = () => {
   const [user, setUser] = React.useState<User>();
 
   return (

--- a/code/renderers/react/template/cli/ts-legacy/Page.tsx
+++ b/code/renderers/react/template/cli/ts-legacy/Page.tsx
@@ -7,7 +7,7 @@ type User = {
   name: string;
 };
 
-export const Page: React.VFC = () => {
+export const Page: React.FC = () => {
   const [user, setUser] = React.useState<User>();
 
   return (

--- a/code/renderers/react/template/cli/ts/Page.tsx
+++ b/code/renderers/react/template/cli/ts/Page.tsx
@@ -7,7 +7,7 @@ type User = {
   name: string;
 };
 
-export const Page: React.VFC = () => {
+export const Page: React.FC = () => {
   const [user, setUser] = React.useState<User>();
 
   return (

--- a/docs/snippets/common/custom-docs-page.ts-component.ts.mdx
+++ b/docs/snippets/common/custom-docs-page.ts-component.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // CustomDocumentationComponent.ts|tsx
 
-export const CustomDocumentationComponent: React.VFC = () => {
+export const CustomDocumentationComponent: React.FC = () => {
   return (
     <div>
       <h1>Replacing DocsPage with a custom component</h1>


### PR DESCRIPTION
## What I did

React 18 deprecates the type `VFC` (`VoidFunctionComponent`) and it is now equivalent to `FC` (`FunctionalComponent`). Even though we still support React 17 this type is no longer recommended.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L531

Deprecated PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59882

This commit updates the generated files from an installation to use the non-deprecated React type.

There is a different argument to be made to remove `React.FC` completely and just use prop types.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

Use this branch to create a new project (I did Next.js). The created example files will be of type `React.FC` instead of the deprecated type.
