### PR TITLE
Csf-plugin: Support meta description comments

### DIFF
--- a/code/lib/csf-tools/src/enrichCsf.ts
+++ b/code/lib/csf-tools/src/enrichCsf.ts
@@ -9,74 +9,127 @@ export interface EnrichCsfOptions {
   disableDescription?: boolean;
 }
 
-export const enrichCsf = (csf: CsfFile, options?: EnrichCsfOptions) => {
-  Object.keys(csf._storyExports).forEach((key) => {
-    const storyExport = csf.getStoryExport(key);
-    const source = !options?.disableSource && extractSource(storyExport);
-    const description =
-      !options?.disableDescription && extractDescription(csf._storyStatements[key]);
-    const parameters = [];
-    const originalParameters = t.memberExpression(t.identifier(key), t.identifier('parameters'));
-    parameters.push(t.spreadElement(originalParameters));
+export const enrichCsfStory = (csf: CsfFile, key: string, options?: EnrichCsfOptions) => {
+  const storyExport = csf.getStoryExport(key);
+  const source = !options?.disableSource && extractSource(storyExport);
+  const description = !options?.disableDescription && extractDescription(csf._storyStatements[key]);
+  const parameters = [];
+  const originalParameters = t.memberExpression(t.identifier(key), t.identifier('parameters'));
+  parameters.push(t.spreadElement(originalParameters));
 
-    // storySource: { source: %%source%% },
-    if (source) {
-      const optionalStorySource = t.optionalMemberExpression(
-        originalParameters,
+  // storySource: { source: %%source%% },
+  if (source) {
+    const optionalStorySource = t.optionalMemberExpression(
+      originalParameters,
+      t.identifier('storySource'),
+      false,
+      true
+    );
+
+    parameters.push(
+      t.objectProperty(
         t.identifier('storySource'),
-        false,
-        true
-      );
+        t.objectExpression([
+          t.objectProperty(t.identifier('source'), t.stringLiteral(source)),
+          t.spreadElement(optionalStorySource),
+        ])
+      )
+    );
+  }
 
-      parameters.push(
-        t.objectProperty(
-          t.identifier('storySource'),
-          t.objectExpression([
-            t.objectProperty(t.identifier('source'), t.stringLiteral(source)),
-            t.spreadElement(optionalStorySource),
-          ])
-        )
-      );
-    }
+  // docs: { description: { story: %%description%% } },
+  if (description) {
+    const optionalDocs = t.optionalMemberExpression(
+      originalParameters,
+      t.identifier('docs'),
+      false,
+      true
+    );
 
-    // docs: { description: { story: %%description%% } },
-    if (description) {
-      const optionalDocs = t.optionalMemberExpression(
-        originalParameters,
+    const optionalDescription = t.optionalMemberExpression(
+      optionalDocs,
+      t.identifier('description'),
+      false,
+      true
+    );
+
+    parameters.push(
+      t.objectProperty(
         t.identifier('docs'),
-        false,
-        true
-      );
+        t.objectExpression([
+          t.spreadElement(optionalDocs),
+          t.objectProperty(
+            t.identifier('description'),
+            t.objectExpression([
+              t.objectProperty(t.identifier('story'), t.stringLiteral(description)),
+              t.spreadElement(optionalDescription),
+            ])
+          ),
+        ])
+      )
+    );
+  }
+  if (parameters.length > 1) {
+    const addParameter = t.expressionStatement(
+      t.assignmentExpression('=', originalParameters, t.objectExpression(parameters))
+    );
+    csf._ast.program.body.push(addParameter);
+  }
+};
 
-      const optionalDescription = t.optionalMemberExpression(
-        optionalDocs,
-        t.identifier('description'),
-        false,
-        true
-      );
+const addComponentDescription = (
+  node: t.ObjectExpression,
+  path: string[],
+  value: t.ObjectProperty
+) => {
+  if (!path.length) {
+    // make this the lowest-priority so that if the user is object-spreading on top of it,
+    // the users' code will "win"
+    const hasExistingComponent = node.properties.find(
+      (p) => t.isObjectProperty(p) && t.isIdentifier(p.key) && p.key.name === 'component'
+    );
+    if (!hasExistingComponent) {
+      node.properties.unshift(value);
+    }
+    return;
+  }
+  const [first, ...rest] = path;
+  const existing = node.properties.find(
+    (p) =>
+      t.isObjectProperty(p) &&
+      t.isIdentifier(p.key) &&
+      p.key.name === first &&
+      t.isObjectExpression(p.value)
+  );
+  let subNode: t.ObjectExpression;
+  if (existing) {
+    subNode = (existing as t.ObjectProperty).value as t.ObjectExpression;
+  } else {
+    subNode = t.objectExpression([]);
+    node.properties.push(t.objectProperty(t.identifier(first), subNode));
+  }
+  addComponentDescription(subNode, rest, value);
+};
 
-      parameters.push(
-        t.objectProperty(
-          t.identifier('docs'),
-          t.objectExpression([
-            t.spreadElement(optionalDocs),
-            t.objectProperty(
-              t.identifier('description'),
-              t.objectExpression([
-                t.objectProperty(t.identifier('story'), t.stringLiteral(description)),
-                t.spreadElement(optionalDescription),
-              ])
-            ),
-          ])
-        )
+export const enrichCsfMeta = (csf: CsfFile, options?: EnrichCsfOptions) => {
+  const description = !options?.disableDescription && extractDescription(csf._metaStatement);
+  // docs: { description: { component: %%description%% } },
+  if (description) {
+    const metaNode = csf._metaNode;
+    if (metaNode && t.isObjectExpression(metaNode)) {
+      addComponentDescription(
+        metaNode,
+        ['parameters', 'docs', 'description'],
+        t.objectProperty(t.identifier('component'), t.stringLiteral(description))
       );
     }
-    if (parameters.length > 1) {
-      const addParameter = t.expressionStatement(
-        t.assignmentExpression('=', originalParameters, t.objectExpression(parameters))
-      );
-      csf._ast.program.body.push(addParameter);
-    }
+  }
+};
+
+export const enrichCsf = (csf: CsfFile, options?: EnrichCsfOptions) => {
+  enrichCsfMeta(csf, options);
+  Object.keys(csf._storyExports).forEach((key) => {
+    enrichCsfStory(csf, key, options);
   });
 };
 

--- a/code/lib/csf-tools/src/enrichCsf.ts
+++ b/code/lib/csf-tools/src/enrichCsf.ts
@@ -83,12 +83,12 @@ const addComponentDescription = (
   value: t.ObjectProperty
 ) => {
   if (!path.length) {
-    // make this the lowest-priority so that if the user is object-spreading on top of it,
-    // the users' code will "win"
     const hasExistingComponent = node.properties.find(
       (p) => t.isObjectProperty(p) && t.isIdentifier(p.key) && p.key.name === 'component'
     );
     if (!hasExistingComponent) {
+      // make this the lowest-priority so that if the user is object-spreading on top of it,
+      // the users' code will "win"
       node.properties.unshift(value);
     }
     return;


### PR DESCRIPTION
Issue: N/A

## What I did

Support component descriptions as JSDoc comments on the `meta` export.

```js
/** some description */
export default { .... }
```

```js
/** some description */
const meta = { ... }
export default meta;
```

## How to test

See attached unit tests.

Or add a description comment to a CSF file that has autodocs.