### PR TITLE
Addon-actions: Fix webpack hot reload code in manager bundle

### DIFF
--- a/code/addons/actions/src/containers/ActionLogger/index.tsx
+++ b/code/addons/actions/src/containers/ActionLogger/index.tsx
@@ -5,8 +5,8 @@ import type { API } from '@storybook/manager-api';
 import { STORY_CHANGED } from '@storybook/core-events';
 
 import { ActionLogger as ActionLoggerComponent } from '../../components/ActionLogger';
-import { EVENT_ID } from '../..';
 import type { ActionDisplay } from '../../models';
+import { EVENT_ID } from '../../constants';
 
 interface ActionLoggerProps {
   active: boolean;


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/20644

## What I did

ensure no reference to index of addon-actions for manager

## How to test

Check the dist code of addons/actions/dist/manager.mjs

It should not contain a reference to chunks that contain `module.hot` code.