### PR TITLE
Svelte: Remove babel/core peer dep

### DIFF
--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -68,7 +68,6 @@
     "typescript": "~4.9.3"
   },
   "peerDependencies": {
-    "@babel/core": "*",
     "svelte": "^3.1.0"
   },
   "engines": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7593,7 +7593,6 @@ __metadata:
     type-fest: 2.19.0
     typescript: ~4.9.3
   peerDependencies:
-    "@babel/core": "*"
     svelte: ^3.1.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Issue: N/A


<img width="636" alt="image" src="https://user-images.githubusercontent.com/4616705/212899517-b9a9a38b-d18a-47ab-815d-f83197b8478f.png">

https://discord.com/channels/486522875931656193/495147526278610945/1064676166092476566

## What I did

I have removed `babel/core` from `peerDependencies`, as it is no longer used at all in this package.

## How to test

CI should be sufficient.  After the release, we can install storybook in a svelte project with pnpm and verify no dep warnings.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
