### PR TITLE
Fix HMR issue in Manager UI

### DIFF
--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -52,7 +52,7 @@
     "@rollup/pluginutils": "^4.2.0",
     "@storybook/builder-vite": "7.0.0-beta.29",
     "@storybook/react": "7.0.0-beta.29",
-    "@vitejs/plugin-react": "^3.0.0",
+    "@vitejs/plugin-react": "^3.0.1",
     "ast-types": "^0.14.2",
     "magic-string": "^0.26.1",
     "react-docgen": "6.0.0-alpha.3"

--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -43,6 +43,8 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
+    "@storybook/channel-postmessage": "7.0.0-beta.29",
+    "@storybook/channel-websocket": "7.0.0-beta.29",
     "@storybook/client-logger": "7.0.0-beta.29",
     "@storybook/core-common": "7.0.0-beta.29",
     "@storybook/csf-plugin": "7.0.0-beta.29",

--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -67,7 +67,7 @@
     "@types/node": "^16.0.0",
     "rollup": "^3.0.0",
     "typescript": "~4.9.3",
-    "vite": "^4.0.0"
+    "vite": "^4.0.4"
   },
   "peerDependencies": {
     "@preact/preset-vite": "*",

--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -91,7 +91,7 @@ export async function pluginConfig(options: Options) {
         }
       },
     },
-    viteExternalsPlugin(globals, { useWindow: false }),
+    viteExternalsPlugin(globals, { useWindow: false, disableInServe: true }),
   ] as PluginOption[];
 
   // TODO: framework doesn't exist, should move into framework when/if built

--- a/code/ui/.storybook/main.ts
+++ b/code/ui/.storybook/main.ts
@@ -1,4 +1,6 @@
+import path from 'path';
 import pluginTurbosnap from 'vite-plugin-turbosnap';
+import { mergeConfig } from 'vite';
 import type { StorybookConfig } from '../../frameworks/react-vite';
 
 const isBlocksOnly = process.env.STORYBOOK_BLOCKS_ONLY === 'true';
@@ -60,19 +62,24 @@ const config: StorybookConfig = {
   features: {
     interactionsDebugger: true,
   },
-  viteFinal: (viteConfig, { configType }) => ({
-    ...viteConfig,
-    plugins: [
-      ...(viteConfig.plugins || []),
-      configType === 'PRODUCTION' ? pluginTurbosnap({ rootDir: viteConfig.root || '' }) : [],
-    ],
-    optimizeDeps: { ...viteConfig.optimizeDeps, force: true },
-    build: {
-      ...viteConfig.build,
-      // disable sourcemaps in CI to not run out of memory
-      sourcemap: process.env.CI !== 'true',
-    },
-  }),
+  viteFinal: (viteConfig, { configType }) =>
+    mergeConfig(viteConfig, {
+      resolve: {
+        alias: {
+          ...(configType === 'DEVELOPMENT'
+            ? { '@storybook/components': path.resolve(__dirname, '../components/src') }
+            : {}),
+        },
+      },
+      plugins: [
+        configType === 'PRODUCTION' ? pluginTurbosnap({ rootDir: viteConfig.root || '' }) : [],
+      ],
+      optimizeDeps: { force: true },
+      build: {
+        // disable sourcemaps in CI to not run out of memory
+        sourcemap: process.env.CI !== 'true',
+      },
+    }),
 };
 
 export default config;

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6082,7 +6082,7 @@ __metadata:
     rollup: ^3.0.0
     slash: ^3.0.0
     typescript: ~4.9.3
-    vite: ^4.0.0
+    vite: ^4.0.4
     vite-plugin-externals: ^0.5.1
   peerDependencies:
     "@preact/preset-vite": "*"
@@ -7193,7 +7193,7 @@ __metadata:
     "@storybook/builder-vite": 7.0.0-beta.29
     "@storybook/react": 7.0.0-beta.29
     "@types/node": ^16.0.0
-    "@vitejs/plugin-react": ^3.0.0
+    "@vitejs/plugin-react": ^3.0.1
     ast-types: ^0.14.2
     magic-string: ^0.26.1
     react-docgen: 6.0.0-alpha.3
@@ -9305,7 +9305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react@npm:^3.0.0":
+"@vitejs/plugin-react@npm:^3.0.1":
   version: 3.0.1
   resolution: "@vitejs/plugin-react@npm:3.0.1"
   dependencies:
@@ -29416,7 +29416,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^4.0.0":
+"vite@npm:^4.0.0, vite@npm:^4.0.4":
   version: 4.0.4
   resolution: "vite@npm:4.0.4"
   dependencies:

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6062,6 +6062,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/builder-vite@workspace:lib/builder-vite"
   dependencies:
+    "@storybook/channel-postmessage": 7.0.0-beta.29
+    "@storybook/channel-websocket": 7.0.0-beta.29
     "@storybook/client-logger": 7.0.0-beta.29
     "@storybook/core-common": 7.0.0-beta.29
     "@storybook/csf-plugin": 7.0.0-beta.29


### PR DESCRIPTION
Issue: #20643

HMR in vite dev mode is currently broken. Additionally, added an alias to the configuration of the Manager's Storybook to directly link `@storybook/components` `src` files. This simplifies development a lot.

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
