### PR TITLE
Addon-docs: Fix issue with unattached `.mdx` files

### DIFF
--- a/code/addons/docs/template/stories/stories-mdx/unattached.stories.mdx
+++ b/code/addons/docs/template/stories/stories-mdx/unattached.stories.mdx
@@ -1,0 +1,5 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="stories-mdx/unattached" />
+
+# Unattached `stories.mdx` file

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.test.ts
@@ -1,5 +1,5 @@
 import { Channel } from '@storybook/channels';
-import type { Renderer } from '@storybook/types';
+import type { CSFFile, Renderer } from '@storybook/types';
 import type { StoryStore } from '../../store';
 
 import { DocsContext } from './DocsContext';
@@ -7,6 +7,30 @@ import { csfFileParts } from './test-utils';
 
 const channel = new Channel();
 const renderStoryToElement = jest.fn();
+
+describe('referenceCSFFile', () => {
+  it('deals with unattached "docsOnly" csf files', () => {
+    const unattachedCsfFile = {
+      stories: {
+        'meta--page': {
+          id: 'meta--page',
+          name: 'Page',
+          parameters: { docsOnly: true },
+          moduleExport: {},
+        },
+      },
+      meta: { id: 'meta', title: 'Meta' },
+      moduleExports: {},
+    } as CSFFile;
+
+    const store = {
+      componentStoriesFromCSFFile: () => [],
+    } as unknown as StoryStore<Renderer>;
+    const context = new DocsContext(channel, store, renderStoryToElement, [unattachedCsfFile]);
+
+    expect(() => context.storyById()).toThrow(/No primary story/);
+  });
+});
 
 describe('resolveModuleExport', () => {
   const { story, csfFile, storyExport, metaExport, moduleExports, component } = csfFileParts();

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
@@ -58,11 +58,9 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
 
     const stories = this.store.componentStoriesFromCSFFile({ csfFile });
 
-    Object.values(csfFile.stories).forEach((annotation) => {
+    stories.forEach((story) => {
+      const annotation = csfFile.stories[story.id];
       this.storyIdToCSFFile.set(annotation.id, csfFile);
-      const story = stories.find((s) => s.id === annotation.id);
-      if (!story)
-        throw new Error(`Unexpected missing story ${annotation.id} from referenced CSF file.`);
       this.exportToStory.set(annotation.moduleExport, story);
     });
   }

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/test-utils.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/test-utils.ts
@@ -15,7 +15,7 @@ export function csfFileParts() {
   const story = { id: 'meta--story', moduleExport: storyExport } as PreparedStory;
   const meta = { id: 'meta', title: 'Meta', component, moduleExports } as CSFFile['meta'];
   const csfFile = {
-    stories: { story: storyAnnotations },
+    stories: { 'meta--story': storyAnnotations },
     meta,
     moduleExports,
   } as CSFFile;


### PR DESCRIPTION
Issue: #20587 


## What I did

Fix issue with `.stories.mdx` -- the problem comes from a story appearing the CSF File (the `--page` story) that we filter out of the index. We just needed to be a little more careful in the docs context to take that into account.

## How to test

Visit http://localhost:6006/?path=/docs/addons-docs-stories-mdx-unattached--docs

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
