### PR TITLE
Csf-plugin: Move source to docs.source.originalSource

### DIFF
--- a/code/lib/csf-tools/src/enrichCsf.test.ts
+++ b/code/lib/csf-tools/src/enrichCsf.test.ts
@@ -36,9 +36,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -64,9 +67,12 @@ describe('enrichCsf', () => {
         };
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "args => <Button {...args} />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "args => <Button {...args} />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -92,9 +98,12 @@ describe('enrichCsf', () => {
         };
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "{\\n  parameters: {\\n    foo: 'bar'\\n  }\\n}",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "{\\n  parameters: {\\n    foo: 'bar'\\n  }\\n}",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -116,16 +125,22 @@ describe('enrichCsf', () => {
         export const B = {};
         A.parameters = {
           ...A.parameters,
-          storySource: {
-            source: "{}",
-            ...A.parameters?.storySource
+          docs: {
+            ...A.parameters?.docs,
+            source: {
+              originalSource: "{}",
+              ...A.parameters?.docs?.source
+            }
           }
         };
         B.parameters = {
           ...B.parameters,
-          storySource: {
-            source: "{}",
-            ...B.parameters?.storySource
+          docs: {
+            ...B.parameters?.docs,
+            source: {
+              originalSource: "{}",
+              ...B.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -150,9 +165,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -175,9 +193,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -200,12 +221,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
-          },
           docs: {
             ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            },
             description: {
               story: "The most basic button",
               ...Basic.parameters?.docs?.description
@@ -240,12 +261,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
-          },
           docs: {
             ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            },
             description: {
               story: "The most basic button\\n\\nIn a block!",
               ...Basic.parameters?.docs?.description
@@ -280,12 +301,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
-          },
           docs: {
             ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            },
             description: {
               story: "- A bullet list\\n  - A sub-bullet\\n- A second bullet",
               ...Basic.parameters?.docs?.description
@@ -314,9 +335,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -339,9 +363,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -371,9 +398,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -411,9 +441,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -451,9 +484,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -489,9 +525,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -528,9 +567,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -564,9 +606,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);
@@ -625,9 +670,12 @@ describe('enrichCsf', () => {
         export const Basic = () => <Button />;
         Basic.parameters = {
           ...Basic.parameters,
-          storySource: {
-            source: "() => <Button />",
-            ...Basic.parameters?.storySource
+          docs: {
+            ...Basic.parameters?.docs,
+            source: {
+              originalSource: "() => <Button />",
+              ...Basic.parameters?.docs?.source
+            }
           }
         };
       `);

--- a/code/lib/csf-tools/src/enrichCsf.ts
+++ b/code/lib/csf-tools/src/enrichCsf.ts
@@ -16,22 +16,29 @@ export const enrichCsfStory = (csf: CsfFile, key: string, options?: EnrichCsfOpt
   const parameters = [];
   const originalParameters = t.memberExpression(t.identifier(key), t.identifier('parameters'));
   parameters.push(t.spreadElement(originalParameters));
+  const optionalDocs = t.optionalMemberExpression(
+    originalParameters,
+    t.identifier('docs'),
+    false,
+    true
+  );
+  const extraDocsParameters = [];
 
-  // storySource: { source: %%source%% },
+  // docs: { source: { source: %%source%% } },
   if (source) {
-    const optionalStorySource = t.optionalMemberExpression(
-      originalParameters,
-      t.identifier('storySource'),
+    const optionalSource = t.optionalMemberExpression(
+      optionalDocs,
+      t.identifier('source'),
       false,
       true
     );
 
-    parameters.push(
+    extraDocsParameters.push(
       t.objectProperty(
-        t.identifier('storySource'),
+        t.identifier('source'),
         t.objectExpression([
-          t.objectProperty(t.identifier('source'), t.stringLiteral(source)),
-          t.spreadElement(optionalStorySource),
+          t.objectProperty(t.identifier('originalSource'), t.stringLiteral(source)),
+          t.spreadElement(optionalSource),
         ])
       )
     );
@@ -39,37 +46,30 @@ export const enrichCsfStory = (csf: CsfFile, key: string, options?: EnrichCsfOpt
 
   // docs: { description: { story: %%description%% } },
   if (description) {
-    const optionalDocs = t.optionalMemberExpression(
-      originalParameters,
-      t.identifier('docs'),
-      false,
-      true
-    );
-
     const optionalDescription = t.optionalMemberExpression(
       optionalDocs,
       t.identifier('description'),
       false,
       true
     );
-
-    parameters.push(
+    extraDocsParameters.push(
       t.objectProperty(
-        t.identifier('docs'),
+        t.identifier('description'),
         t.objectExpression([
-          t.spreadElement(optionalDocs),
-          t.objectProperty(
-            t.identifier('description'),
-            t.objectExpression([
-              t.objectProperty(t.identifier('story'), t.stringLiteral(description)),
-              t.spreadElement(optionalDescription),
-            ])
-          ),
+          t.objectProperty(t.identifier('story'), t.stringLiteral(description)),
+          t.spreadElement(optionalDescription),
         ])
       )
     );
   }
-  if (parameters.length > 1) {
+
+  if (extraDocsParameters.length > 0) {
+    parameters.push(
+      t.objectProperty(
+        t.identifier('docs'),
+        t.objectExpression([t.spreadElement(optionalDocs), ...extraDocsParameters])
+      )
+    );
     const addParameter = t.expressionStatement(
       t.assignmentExpression('=', originalParameters, t.objectExpression(parameters))
     );


### PR DESCRIPTION
Issue: N/A
Telescopes on https://github.com/storybookjs/storybook/pull/20603

## What I did

CSF-plugin extracts the original story source from the CSF file and writes it into the parameters for the story for use in the source block.

Originally, it wrote to the `storySource.source` parameter for historical reasons. This used to be provided by `source-loader`, which was shared between `addon-docs` and `addon-storysource`.

Now, `csf-plugin` makes `addon-docs` completely independent from `addon-storysource`, so we can refactor the Source block in https://github.com/storybookjs/storybook/pull/20603 to use a different parameter.

This PR writes to `docs.source.originalSource`. https://github.com/storybookjs/storybook/pull/20603 will also need to be updated accordingly.

## How to test

- [ ] See attached unit tests

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
