### PR TITLE
Addon-docs: Update story index generator

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -164,8 +164,8 @@ export class StoryIndexGenerator {
     );
   }
 
-  isDocsMdx(absolutePath: Path) {
-    return /(?<!\.stories)\.mdx$/i.test(absolutePath);
+  isStoryFile(absolutePath: Path) {
+    return /(\.(js|jsx|ts|tsx)|\.stories\.mdx)$/i.test(absolutePath);
   }
 
   async ensureExtracted(): Promise<IndexEntry[]> {
@@ -174,7 +174,7 @@ export class StoryIndexGenerator {
     // files may use the `<Meta of={XStories} />` syntax, which requires
     // that the story file that contains the meta be processed first.
     await this.updateExtracted(async (specifier, absolutePath) =>
-      this.isDocsMdx(absolutePath) ? false : this.extractStories(specifier, absolutePath)
+      this.isStoryFile(absolutePath) ? this.extractStories(specifier, absolutePath): false
     );
 
     if (!this.options.docs.disable) {

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -174,7 +174,7 @@ export class StoryIndexGenerator {
     // files may use the `<Meta of={XStories} />` syntax, which requires
     // that the story file that contains the meta be processed first.
     await this.updateExtracted(async (specifier, absolutePath) =>
-      this.isStoryFile(absolutePath) ? this.extractStories(specifier, absolutePath): false
+      this.isStoryFile(absolutePath) ? this.extractStories(specifier, absolutePath) : false
     );
 
     if (!this.options.docs.disable) {


### PR DESCRIPTION
## Description
Currently the matcher for CSF stories works with all files including .stories.mdx files but not other .mdx files. 

This behavior actually makes it difficult for developers to import other files as DocsOnly story, for example .md files like README.md & CHANGELOG.md.

For the current time being, the matcher is updated to match to any file with the extensions .js, .jsx, .ts, .tsx along with .stories.mdx.

Please read more about the motivation behind this PR in this article
https://sheriffmoose.medium.com/storybook-markdown-docs-not-mdx-part-2-757463fcad84

## Issue
N/A

## What I did

* [x] change extract stories condition to positive matcher instead of negative matcher

## How to test

* [x] CI passes