### PR TITLE
Source-loader: Fix export default variable references

### DIFF
--- a/code/__mocks__/inject-decorator.ts.csf-meta-var.txt
+++ b/code/__mocks__/inject-decorator.ts.csf-meta-var.txt
@@ -1,0 +1,15 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import { Button } from "@storybook/react/demo";
+
+const meta = {
+  title: "Button",
+  excludeStories: ["text"],
+  includeStories: /emoji.*/
+};
+
+export default meta;
+
+export const text = () => (
+  <Button onClick={action("clicked")}>Hello Button</Button>
+);

--- a/code/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf-meta-var.test.js.posix.snapshot
+++ b/code/lib/source-loader/src/abstract-syntax-tree/__snapshots__/inject-decorator.csf-meta-var.test.js.posix.snapshot
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`inject-decorator positive - ts - csf includes storySource parameter in the default exported variable 1`] = `
+"import React from \\"react\\";
+import { action } from \\"@storybook/addon-actions\\";
+import { Button } from \\"@storybook/react/demo\\";
+
+const meta = {parameters: {\\"storySource\\":{\\"source\\":\\"import React from \\\\\\"react\\\\\\";\\\\nimport { action } from \\\\\\"@storybook/addon-actions\\\\\\";\\\\nimport { Button } from \\\\\\"@storybook/react/demo\\\\\\";\\\\n\\\\nconst meta = {\\\\n  title: \\\\\\"Button\\\\\\",\\\\n  excludeStories: [\\\\\\"text\\\\\\"],\\\\n  includeStories: /emoji.*/\\\\n};\\\\n\\\\nexport default meta;\\\\n\\\\nexport const text = () => (\\\\n  <Button onClick={action(\\\\\\"clicked\\\\\\")}>Hello Button</Button>\\\\n);\\\\n\\",\\"locationsMap\\":{\\"text\\":{\\"startLoc\\":{\\"col\\":20,\\"line\\":13},\\"endLoc\\":{\\"col\\":1,\\"line\\":15},\\"startBody\\":{\\"col\\":20,\\"line\\":13},\\"endBody\\":{\\"col\\":1,\\"line\\":15}}}},},
+  title: \\"Button\\",
+  excludeStories: [\\"text\\"],
+  includeStories: /emoji.*/
+};
+
+export default meta;
+
+export const text = () => (
+  <Button onClick={action(\\"clicked\\")}>Hello Button</Button>
+);
+"
+`;

--- a/code/lib/source-loader/src/abstract-syntax-tree/inject-decorator.csf.test.js
+++ b/code/lib/source-loader/src/abstract-syntax-tree/inject-decorator.csf.test.js
@@ -25,6 +25,23 @@ describe('inject-decorator', () => {
         )
       );
     });
+
+    it('includes storySource parameter in the default exported variable', () => {
+      const mockFilePath = './__mocks__/inject-decorator.ts.csf-meta-var.txt';
+      const source = fs.readFileSync(mockFilePath, 'utf-8');
+      const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+        parser: 'typescript',
+      });
+
+      expect(result.source).toMatchSpecificSnapshot(
+        path.join(snapshotDir, `inject-decorator.csf-meta-var.test.js.${SNAPSHOT_OS}.snapshot`)
+      );
+      expect(result.source).toEqual(
+        expect.stringContaining(
+          'const meta = {parameters: {"storySource":{"source":"import React from'
+        )
+      );
+    });
   });
 
   describe('injectStoryParameters - ts - csf', () => {


### PR DESCRIPTION
Issue: #20421 

## What I did

Fixed `source-loader` to handle the pattern:

```js
const meta = { ... };
export default meta;

// ...stories
```

I did this because we're now using this pattern in our CLI template stories & as the recommended pattern in 7.0. Even though we're not actively maintaining/developing source-loader, this is a very basic fix.

## How to test

- [ ] See attached unit test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)
