### PR TITLE
CLI: Make missing-babelrc an automatic migration

### DIFF
--- a/code/lib/cli/src/babel-config.ts
+++ b/code/lib/cli/src/babel-config.ts
@@ -2,6 +2,7 @@ import { writeFile, pathExists } from 'fs-extra';
 import { logger } from '@storybook/node-logger';
 import path from 'path';
 import prompts from 'prompts';
+import chalk from 'chalk';
 import { JsPackageManagerFactory } from './js-package-manager';
 
 export const generateStorybookBabelConfigInCWD = async () => {
@@ -19,7 +20,7 @@ export const generateStorybookBabelConfig = async ({ target }: { target: string 
   if (exists) {
     const { overwrite } = await prompts({
       type: 'confirm',
-      initial: true,
+      initial: false,
       name: 'overwrite',
       message: `${fileName} already exists. Would you like overwrite it?`,
     });
@@ -30,16 +31,22 @@ export const generateStorybookBabelConfig = async ({ target }: { target: string 
     }
   }
 
+  logger.info(
+    `The config will contain ${chalk.yellow(
+      '@babel/preset-env'
+    )} and you will be prompted for additional presets, if you wish to add them depending on your project needs.`
+  );
+
   const { typescript, jsx } = await prompts([
     {
       type: 'confirm',
-      initial: true,
+      initial: false,
       name: 'typescript',
       message: `Do you want to add the TypeScript preset?`,
     },
     {
       type: 'confirm',
-      initial: true,
+      initial: false,
       name: 'jsx',
       message: `Do you want to add the React preset?`,
     },


### PR DESCRIPTION
Issue:  https://github.com/storybookjs/storybook/issues/20677

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

The missing-babelrc migration was `promptOnly`, and now can automatically run when the user responds with `yes` instead of asking them to run `npx storybook@next babelrc`.

<img width="535" alt="image" src="https://user-images.githubusercontent.com/1671563/213459719-74ec392c-d17d-47e5-91bc-4249bd5094eb.png">

## How to test

1. Check this branch and compile libraries: `task --task compile`
2. Go to a Storybook project that needs a babelrc file, but don't include it
3. Run `sb automigrate missing-babelrc` and see the automigration in action


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
