### PR TITLE
Csf-tools: Add helpers to get name from node path

### DIFF
--- a/code/lib/csf-tools/src/ConfigFile.test.ts
+++ b/code/lib/csf-tools/src/ConfigFile.test.ts
@@ -747,4 +747,65 @@ describe('ConfigFile', () => {
       });
     });
   });
+
+  describe('config helpers', () => {
+    describe('getNameFromPath', () => {
+      it(`supports string literal node`, () => {
+        const source = dedent`
+          import type { StorybookConfig } from '@storybook/react-webpack5';
+
+          const config: StorybookConfig = {
+            framework: 'foo',
+          }
+          export default config;
+        `;
+        const config = loadConfig(source).parse();
+        expect(config.getNameFromPath(['framework'])).toEqual('foo');
+      });
+
+      it(`supports object expression node with name property`, () => {
+        const source = dedent`
+          import type { StorybookConfig } from '@storybook/react-webpack5';
+
+          const config: StorybookConfig = {
+            framework: { name: 'foo', options: {} },
+          }
+          export default config;
+        `;
+        const config = loadConfig(source).parse();
+        expect(config.getNameFromPath(['framework'])).toEqual('foo');
+      });
+
+      it(`returns undefined with unexpected node value`, () => {
+        const source = dedent`
+          import type { StorybookConfig } from '@storybook/react-webpack5';
+
+          const config: StorybookConfig = {
+            framework: makesNoSense(),
+          }
+          export default config;
+        `;
+        const config = loadConfig(source).parse();
+        expect(config.getNameFromPath(['framework'])).toBeUndefined();
+      });
+    });
+
+    describe('getNamesFromPath', () => {
+      it(`supports an array with string literal and object expression with name property`, () => {
+        const source = dedent`
+          import type { StorybookConfig } from '@storybook/react-webpack5';
+
+          const config: StorybookConfig = {
+            addons: [
+              'foo',
+              { name: 'bar', options: {} },
+            ]
+          }
+          export default config;
+        `;
+        const config = loadConfig(source).parse();
+        expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
+      });
+    });
+  });
 });

--- a/code/lib/csf-tools/src/ConfigFile.test.ts
+++ b/code/lib/csf-tools/src/ConfigFile.test.ts
@@ -768,7 +768,7 @@ describe('ConfigFile', () => {
           import type { StorybookConfig } from '@storybook/react-webpack5';
 
           const config: StorybookConfig = {
-            framework: { name: 'foo', options: {} },
+            framework: { name: 'foo', options: { bar: require('baz') } },
           }
           export default config;
         `;
@@ -776,7 +776,7 @@ describe('ConfigFile', () => {
         expect(config.getNameFromPath(['framework'])).toEqual('foo');
       });
 
-      it(`returns undefined with unexpected node value`, () => {
+      it(`throws an error with unexpected node value`, () => {
         const source = dedent`
           import type { StorybookConfig } from '@storybook/react-webpack5';
 
@@ -786,7 +786,9 @@ describe('ConfigFile', () => {
           export default config;
         `;
         const config = loadConfig(source).parse();
-        expect(config.getNameFromPath(['framework'])).toBeUndefined();
+        expect(() => config.getNameFromPath(['framework'])).toThrowError(
+          `The given node must be a string literal or an object expression with a "name" property that is a string literal.`
+        );
       });
     });
 

--- a/code/lib/csf-tools/src/ConfigFile.test.ts
+++ b/code/lib/csf-tools/src/ConfigFile.test.ts
@@ -776,7 +776,18 @@ describe('ConfigFile', () => {
         expect(config.getNameFromPath(['framework'])).toEqual('foo');
       });
 
-      it(`throws an error with unexpected node value`, () => {
+      it(`returns undefined when accessing a field that does not exist`, () => {
+        const source = dedent`
+          import type { StorybookConfig } from '@storybook/react-webpack5';
+
+          const config: StorybookConfig = { }
+          export default config;
+        `;
+        const config = loadConfig(source).parse();
+        expect(config.getNameFromPath(['framework'])).toBeUndefined();
+      });
+
+      it(`throws an error when node is of unexpected type`, () => {
         const source = dedent`
           import type { StorybookConfig } from '@storybook/react-webpack5';
 
@@ -808,6 +819,17 @@ describe('ConfigFile', () => {
         const config = loadConfig(source).parse();
         expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
       });
+    });
+
+    it(`returns undefined when accessing a field that does not exist`, () => {
+      const source = dedent`
+        import type { StorybookConfig } from '@storybook/react-webpack5';
+
+        const config: StorybookConfig = { }
+        export default config;
+      `;
+      const config = loadConfig(source).parse();
+      expect(config.getNamesFromPath(['addons'])).toBeUndefined();
     });
   });
 });

--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -318,6 +318,12 @@ export class ConfigFile {
       });
     }
 
+    if (!value) {
+      throw new Error(
+        `The given node must be a string literal or an object expression with a "${fallbackProperty}" property that is a string literal.`
+      );
+    }
+
     return value;
   }
 

--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -266,8 +266,13 @@ export class ConfigFile {
    * // 2. { framework: { name: 'framework-name', options: {} }
    * getNameFromPath(['framework']) // => 'framework-name'
    */
-  getNameFromPath(path: string[]) {
-    return this._getPresetValue(this.getFieldNode(path), 'name');
+  getNameFromPath(path: string[]): string | undefined {
+    const node = this.getFieldNode(path);
+    if (!node) {
+      return undefined;
+    }
+
+    return this._getPresetValue(node, 'name');
   }
 
   /**
@@ -283,8 +288,12 @@ export class ConfigFile {
    * getNamesFromPath(['addons'])
    *
    */
-  getNamesFromPath(path: string[]) {
+  getNamesFromPath(path: string[]): string[] | undefined {
     const node = this.getFieldNode(path);
+    if (!node) {
+      return undefined;
+    }
+
     const pathNames: string[] = [];
     if (t.isArrayExpression(node)) {
       node.elements.forEach((element) => {


### PR DESCRIPTION
Issue: N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

Most automigrations use `config.getFieldValue` but that's unsafe as it tries to eval the field in order to get its value, and it might break in examples like this:
```js
module.exports = {
  addons: [
    {
      name: 'foo',
      options: {
         bar: require('baz')
      }
}
```

as `require` will be missing in the evaluation context.

This PR introduces two new helpers: `getNameFromPath` and `getNamesFromPaths`, to support simple use cases where we need to get values from nodes that are in either scenario:

```js
1. { node: 'value' }
2. { node: { name: 'value' }
```

Which is common in a singular value in `framework` field, and in a list in the `addons` field.

## How to test

Unit tests should hopefully cover this, but you can change an automigration code to include these helpers instead of using `getFieldValue`, for instance, from:

```js
const frameworkField = main.getFieldValue(['framework']);
const frameworkPackage = typeof frameworkField === 'string' ? frameworkField : frameworkField?.name;
```

to:

```js
const frameworkField = main.getNameFromPath(['framework']);
```

And the result should be the same.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
