### PR TITLE
Build: remove preact-webpack5 from babelrc automigration

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/missing-babelrc.ts
+++ b/code/lib/cli/src/automigrate/fixes/missing-babelrc.ts
@@ -17,7 +17,6 @@ const frameworksThatNeedBabelConfig = [
   '@storybook/react-webpack5',
   '@storybook/vue-webpack5',
   '@storybook/vue3-webpack5',
-  '@storybook/preact-webpack5',
   '@storybook/html-webpack5',
 ];
 


### PR DESCRIPTION
Issue: N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

Removed preact-webpack5 as it apparently does not need a babelrc config

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
