### PR TITLE
CLI: Fix package execution for npm package manager

### DIFF
--- a/code/frameworks/angular/src/builders/utils/run-compodoc.ts
+++ b/code/frameworks/angular/src/builders/utils/run-compodoc.ts
@@ -28,7 +28,11 @@ export const runCompodoc = (
     const packageManager = JsPackageManagerFactory.getPackageManager();
 
     try {
-      const stdout = packageManager.runScript('compodoc', finalCompodocArgs, context.workspaceRoot);
+      const stdout = packageManager.runPackageCommand(
+        'compodoc',
+        finalCompodocArgs,
+        context.workspaceRoot
+      );
 
       context.logger.info(stdout);
       observer.next();

--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -376,7 +376,7 @@ export abstract class JsPackageManager {
   ): // Use generic and conditional type to force `string[]` if fetchAllVersions is true and `string` if false
   Promise<T extends true ? string[] : string>;
 
-  public abstract runScript(script: string, args: string[], cwd?: string): string;
+  public abstract runPackageCommand(command: string, args: string[], cwd?: string): string;
 
   public executeCommand(
     command: string,

--- a/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
@@ -59,14 +59,14 @@ describe('NPM Proxy', () => {
 
   describe('runScript', () => {
     describe('npm6', () => {
-      it('should execute script `npm run compodoc -- -e json -d .`', () => {
+      it('should execute script `npm exec -- compodoc -e json -d .`', () => {
         const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('6.0.0');
 
-        npmProxy.runScript('compodoc', ['-e', 'json', '-d', '.']);
+        npmProxy.runPackageCommand('compodoc', ['-e', 'json', '-d', '.']);
 
         expect(executeCommandSpy).toHaveBeenLastCalledWith(
           'npm',
-          ['run', 'compodoc', '--', '-e', 'json', '-d', '.'],
+          ['exec', '--', 'compodoc', '-e', 'json', '-d', '.'],
           undefined,
           undefined
         );
@@ -76,11 +76,11 @@ describe('NPM Proxy', () => {
       it('should execute script `npm run compodoc -- -e json -d .`', () => {
         const executeCommandSpy = jest.spyOn(npmProxy, 'executeCommand').mockReturnValue('7.1.0');
 
-        npmProxy.runScript('compodoc', ['-e', 'json', '-d', '.']);
+        npmProxy.runPackageCommand('compodoc', ['-e', 'json', '-d', '.']);
 
         expect(executeCommandSpy).toHaveBeenLastCalledWith(
           'npm',
-          ['run', 'compodoc', '--', '-e', 'json', '-d', '.'],
+          ['exec', '--', 'compodoc', '-e', 'json', '-d', '.'],
           undefined,
           undefined
         );

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -38,8 +38,8 @@ export class NPMProxy extends JsPackageManager {
     return this.uninstallArgs;
   }
 
-  public runScript(command: string, args: string[], cwd?: string): string {
-    return this.executeCommand(`npm`, ['run', command, '--', ...args], undefined, cwd);
+  public runPackageCommand(command: string, args: string[], cwd?: string): string {
+    return this.executeCommand(`npm`, ['exec', '--', command, ...args], undefined, cwd);
   }
 
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {

--- a/code/lib/cli/src/js-package-manager/PNPMProxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/PNPMProxy.test.ts
@@ -50,7 +50,7 @@ describe('NPM Proxy', () => {
     it('should execute script `yarn compodoc -- -e json -d .`', () => {
       const executeCommandSpy = jest.spyOn(pnpmProxy, 'executeCommand').mockReturnValue('7.1.0');
 
-      pnpmProxy.runScript('compodoc', ['-e', 'json', '-d', '.']);
+      pnpmProxy.runPackageCommand('compodoc', ['-e', 'json', '-d', '.']);
 
       expect(executeCommandSpy).toHaveBeenLastCalledWith(
         'pnpm',

--- a/code/lib/cli/src/js-package-manager/PNPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/PNPMProxy.ts
@@ -24,7 +24,7 @@ export class PNPMProxy extends JsPackageManager {
     return this.executeCommand('pnpm', ['--version']);
   }
 
-  runScript(command: string, args: string[], cwd?: string): string {
+  runPackageCommand(command: string, args: string[], cwd?: string): string {
     return this.executeCommand(`pnpm`, ['run', command, ...args], undefined, cwd);
   }
 

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
@@ -50,7 +50,7 @@ describe('Yarn 1 Proxy', () => {
     it('should execute script `yarn compodoc -- -e json -d .`', () => {
       const executeCommandSpy = jest.spyOn(yarn1Proxy, 'executeCommand').mockReturnValue('7.1.0');
 
-      yarn1Proxy.runScript('compodoc', ['-e', 'json', '-d', '.']);
+      yarn1Proxy.runPackageCommand('compodoc', ['-e', 'json', '-d', '.']);
 
       expect(executeCommandSpy).toHaveBeenLastCalledWith(
         'yarn',

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
@@ -16,7 +16,7 @@ export class Yarn1Proxy extends JsPackageManager {
     return `yarn ${command}`;
   }
 
-  runScript(command: string, args: string[], cwd?: string): string {
+  runPackageCommand(command: string, args: string[], cwd?: string): string {
     return this.executeCommand(`yarn`, [command, ...args], undefined, cwd);
   }
 

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
@@ -35,7 +35,7 @@ describe('Yarn 2 Proxy', () => {
     it('should execute script `yarn compodoc -- -e json -d .`', () => {
       const executeCommandSpy = jest.spyOn(yarn2Proxy, 'executeCommand').mockReturnValue('7.1.0');
 
-      yarn2Proxy.runScript('compodoc', ['-e', 'json', '-d', '.']);
+      yarn2Proxy.runPackageCommand('compodoc', ['-e', 'json', '-d', '.']);
 
       expect(executeCommandSpy).toHaveBeenLastCalledWith(
         'yarn',

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -17,7 +17,7 @@ export class Yarn2Proxy extends JsPackageManager {
     return `yarn ${command}`;
   }
 
-  runScript(command: string, args: string[], cwd?: string): string {
+  runPackageCommand(command: string, args: string[], cwd?: string): string {
     return this.executeCommand(`yarn`, [command, ...args], undefined, cwd);
   }
 


### PR DESCRIPTION
Issue: N/A

The following command:

```
npm run compodoc -- -p projects/showcase/.storybook/tsconfig.json -e json -d projects/showcase   
```

only works if `compodoc` is set in the script section of the package.json. Instead, we want to call the bin executable. Therefore the command has to be adjusted like this:

```
npm exec -- compodoc -p projects/showcase/.storybook/tsconfig.json -e json -d projects/showcase   
```

Also, renamed function names to match purpose.

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests) -> Testing this is not possible, because we run our sandboxes exclusively with yarn
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
