### PR TITLE
Ensure Angular docsMode flag has effect

### DIFF
--- a/code/frameworks/angular/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.ts
@@ -22,7 +22,7 @@ import { buildStandaloneErrorHandler } from '../utils/build-standalone-errors-ha
 export type StorybookBuilderOptions = JsonObject & {
   browserTarget?: string | null;
   tsConfig?: string;
-  docsMode: boolean;
+  docs: boolean;
   compodoc: boolean;
   compodocArgs: string[];
   styles?: StyleElement[];
@@ -59,7 +59,7 @@ function commandBuilder(
         stylePreprocessorOptions,
         styles,
         configDir,
-        docsMode,
+        docs,
         loglevel,
         outputDir,
         quiet,
@@ -70,7 +70,7 @@ function commandBuilder(
       const standaloneOptions: StandaloneBuildOptions = {
         packageJson: readUpSync({ cwd: __dirname }).packageJson,
         configDir,
-        docsMode,
+        ...(docs ? { docs } : {}),
         loglevel,
         outputDir,
         quiet,

--- a/code/frameworks/angular/src/builders/build-storybook/schema.json
+++ b/code/frameworks/angular/src/builders/build-storybook/schema.json
@@ -34,7 +34,7 @@
       "description": "Suppress verbose build output.",
       "default": false
     },
-    "docsMode": {
+    "docs": {
       "type": "boolean",
       "description": "Starts Storybook in documentation mode. Learn more about it : https://storybook.js.org/docs/react/writing-docs/build-documentation#preview-storybooks-documentation.",
       "default": false
@@ -47,13 +47,19 @@
     "compodocArgs": {
       "type": "array",
       "description": "Compodoc options : https://compodoc.app/guides/options.html. Options `-p` with tsconfig path and `-d` with workspace root is always given.",
-      "default": ["-e", "json"],
+      "default": [
+        "-e",
+        "json"
+      ],
       "items": {
         "type": "string"
       }
     },
     "webpackStatsJson": {
-      "type": ["boolean", "string"],
+      "type": [
+        "boolean",
+        "string"
+      ],
       "description": "Write Webpack Stats JSON to disk",
       "default": false
     },
@@ -104,7 +110,9 @@
             }
           },
           "additionalProperties": false,
-          "required": ["input"]
+          "required": [
+            "input"
+          ]
         },
         {
           "type": "string",

--- a/code/frameworks/angular/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.ts
@@ -22,7 +22,7 @@ import { buildStandaloneErrorHandler } from '../utils/build-standalone-errors-ha
 export type StorybookBuilderOptions = JsonObject & {
   browserTarget?: string | null;
   tsConfig?: string;
-  docsMode: boolean;
+  docs: boolean;
   compodoc: boolean;
   compodocArgs: string[];
   styles?: StyleElement[];
@@ -68,7 +68,7 @@ function commandBuilder(
         styles,
         ci,
         configDir,
-        docsMode,
+        docs,
         host,
         https,
         port,
@@ -84,7 +84,7 @@ function commandBuilder(
         packageJson: readUpSync({ cwd: __dirname }).packageJson,
         ci,
         configDir,
-        docsMode,
+        ...(docs ? { docs } : {}),
         host,
         https,
         port,

--- a/code/frameworks/angular/src/builders/start-storybook/schema.json
+++ b/code/frameworks/angular/src/builders/start-storybook/schema.json
@@ -61,7 +61,7 @@
       "description": "Suppress verbose build output.",
       "default": false
     },
-    "docsMode": {
+    "docs": {
       "type": "boolean",
       "description": "Starts Storybook in documentation mode. Learn more about it : https://storybook.js.org/docs/react/writing-docs/build-documentation#preview-storybooks-documentation.",
       "default": false
@@ -74,7 +74,10 @@
     "compodocArgs": {
       "type": "array",
       "description": "Compodoc options : https://compodoc.app/guides/options.html. Options `-p` with tsconfig path and `-d` with workspace root is always given.",
-      "default": ["-e", "json"],
+      "default": [
+        "-e",
+        "json"
+      ],
       "items": {
         "type": "string"
       }
@@ -126,7 +129,9 @@
             }
           },
           "additionalProperties": false,
-          "required": ["input"]
+          "required": [
+            "input"
+          ]
         },
         {
           "type": "string",

--- a/code/lib/cli/src/build.ts
+++ b/code/lib/cli/src/build.ts
@@ -10,7 +10,6 @@ export const build = async (cliOptions: any) => {
       configDir: cliOptions.configDir || './.storybook',
       outputDir: cliOptions.outputDir || './storybook-static',
       ignorePreview: !!cliOptions.previewUrl && !cliOptions.forceBuildPreview,
-      docsMode: !!cliOptions.docs,
       configType: 'PRODUCTION',
       cache,
       packageJson: readUpSync({ cwd: __dirname }).packageJson,

--- a/code/lib/cli/src/dev.ts
+++ b/code/lib/cli/src/dev.ts
@@ -13,7 +13,6 @@ export const dev = async (cliOptions: any) => {
       configDir: cliOptions.configDir || './.storybook',
       configType: 'DEVELOPMENT',
       ignorePreview: !!cliOptions.previewUrl && !cliOptions.forceBuildPreview,
-      docsMode: !!cliOptions.docs,
       cache,
       packageJson: readUpSync({ cwd: __dirname }).packageJson,
     };

--- a/docs/get-started/installation-problems/angular.mdx
+++ b/docs/get-started/installation-problems/angular.mdx
@@ -38,7 +38,7 @@
 | `"smokeTest"`                | Exit Storybook after successful start. <br/> `"smokeTest": true`                                                                                                                                 |
 | `"ci"`                       | Starts Storybook in CI mode (skips interactive prompts and will not open browser window). <br/> `"ci": true`                                                                                     |
 | `"quiet"`                    | Filters Storybook verbose build output. <br/> `"quiet": true`                                                                                                                                    |
-| `"docsMode"`                 | Starts Storybook in [documentation mode](../writing-docs/build-documentation.md#preview-storybooks-documentation). <br/> `"docsMode": true`                                                      |
+| `"docs"`                     | Starts Storybook in [documentation mode](../writing-docs/build-documentation.md#preview-storybooks-documentation). <br/> `"docs": true`                                                      |
 | `"styles"`                   | Provide the location of the [application's styles](../configure/styling-and-css.md#importing-css-files) to be used with Storybook. <br/> `"styles": ["src/styles.css", "src/styles.scss"]` <br/> |
 | `"stylePreprocessorOptions"` | Provides further customization for style preprocessors resolved to the workspace root. <br/> `"stylePreprocessorOptions": { "includePaths": ["src/styles"] }`                                    |
 


### PR DESCRIPTION
## What I did

Fix what #20608 was setting out to do: Fixing docs generation for Angular. 

#20608 fixed the issue that the angular builders accept a `docsMode` flag, but were internally attempting to read a flag called `docs` to pass that along to `runInstance`, thereby always reading `undefined` and passing it along.

#20608 fixed this successfully, but introduced a new bug: It now passes along the `docsMode` flag, reading the value correctly, but `runInstance` doesn't accept this flag, it looks for a flag called `docs`.
It accepts a type called `StandaloneOptions`, which is a combination of `CLIOptions` and some other types, `CLIOptions` has the optional property `docs` as can be verified here: https://github.com/storybookjs/storybook/blob/next/code/lib/types/src/modules/core-common.ts#L159

I now simply read the `docsMode` flag but pass this along as `docs`. This fixes the generation successfully.
