### PR TITLE
Fixed paths in generated main.cjs for the default sandbox on Windows

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -13,6 +13,7 @@ import {
 } from 'fs-extra';
 import { join, resolve, sep } from 'path';
 
+import slash from 'slash';
 import type { Task } from '../task';
 import { executeCLIStep, steps } from '../utils/cli-step';
 import { installYarn2, configureYarn2ForVerdaccio, addPackageResolutions } from '../utils/yarn';
@@ -262,8 +263,8 @@ function addStoriesEntry(mainConfig: ConfigFile, path: string) {
   const stories = mainConfig.getFieldValue(['stories']) as string[];
 
   const entry = {
-    directory: join('../template-stories', path),
-    titlePrefix: path,
+    directory: slash(join('../template-stories', path)),
+    titlePrefix: slash(path),
     files: '**/*.@(mdx|stories.@(js|jsx|ts|tsx))',
   };
 

--- a/scripts/utils/main-js.ts
+++ b/scripts/utils/main-js.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs';
 import { join, resolve } from 'path';
 
+import slash from 'slash';
 import type { ConfigFile } from '../../code/lib/csf-tools';
 import { readConfig } from '../../code/lib/csf-tools';
 import { getInterpretedFile } from '../../code/lib/core-common';
@@ -19,5 +20,5 @@ export async function readMainConfig({ cwd }: { cwd: string }) {
 
 export function addPreviewAnnotations(mainConfig: ConfigFile, paths: string[]) {
   const config = mainConfig.getFieldValue(['previewAnnotations']) as string[];
-  mainConfig.setFieldValue(['previewAnnotations'], [...(config || []), ...paths]);
+  mainConfig.setFieldValue(['previewAnnotations'], [...(config || []), ...paths.map(slash)]);
 }


### PR DESCRIPTION
[See relevant discussion on Discord](https://discord.com/channels/486522875931656193/1066683970214965318)

When generating the default sandbox on a Windows environment, it creates Windows paths in the output `main.cjs`. Those paths are not being resolved into absolute paths from Vite, preventing the example Storybook from starting.

```ts
{
    directory: "../template-stories\\addons\\actions",
    titlePrefix: "addons\\actions",
    files: "**/*.@(mdx|stories.@(js|jsx|ts|tsx))"
}
previewAnnotations: [
  ".\\src\\stories\\components",
  "./template-stories\\lib\\store\\preview.ts",
  "./template-stories\\addons\\toolbars\\preview.ts"
],
```

![image](https://user-images.githubusercontent.com/16818271/213917420-a7d55034-b1f8-494f-819b-1458f9500b6f.png)


## What I did

I simply wrapped several paths with slash so that it actually uses POSIX paths

## How to test

1. Run the default sandbox `yarn install` on Windows
2. See if it works out of the box!

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
