### PR TITLE
Docs: Fix one final usage of `@storybook/addon-docs/blocks`

### DIFF
--- a/docs/snippets/angular/loader-story.mdx.mdx
+++ b/docs/snippets/angular/loader-story.mdx.mdx
@@ -1,7 +1,7 @@
 ```md
 <!-- TodoItem.stories.mdx -->
 
-import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { Meta, Story } from '@storybook/blocks';
 
 import { TodoItem } from './TodoItem';
 


### PR DESCRIPTION
Issue: NA

Looks like we had just one place where we hadn't updated this.