### PR TITLE
Blocks: ignore known blocks with global CSS selector

### DIFF
--- a/code/ui/blocks/src/components/DocsPage.tsx
+++ b/code/ui/blocks/src/components/DocsPage.tsx
@@ -30,6 +30,7 @@ const UNSTYLED_SELECTORS = [
   '.docblock-icongallery',
   '.docblock-emptyblock',
   '.docblock-typeset',
+  '.docblock-colorpalette',
 ].join(', ');
 const toGlobalSelector = (element: string): string =>
   `& :where(${element}:not(${UNSTYLED_SELECTORS}, :where(${UNSTYLED_SELECTORS}) ${element}))`;

--- a/code/ui/blocks/src/components/DocsPage.tsx
+++ b/code/ui/blocks/src/components/DocsPage.tsx
@@ -24,6 +24,12 @@ const UNSTYLED_SELECTORS = [
   '.sb-story',
   '.docblock-source',
   '.sb-anchor',
+  '.docblock-argstable',
+  '.sbdocs-title',
+  '.sbdocs-subtitle',
+  '.docblock-icongallery',
+  '.docblock-emptyblock',
+  '.docblock-typeset',
 ].join(', ');
 const toGlobalSelector = (element: string): string =>
   `& :where(${element}:not(${UNSTYLED_SELECTORS}, :where(${UNSTYLED_SELECTORS}) ${element}))`;

--- a/code/ui/blocks/src/components/DocsPage.tsx
+++ b/code/ui/blocks/src/components/DocsPage.tsx
@@ -23,7 +23,6 @@ const UNSTYLED_SELECTORS = [
   '.sbdocs-pre',
   '.sb-story',
   '.docblock-source',
-  '.sb-anchor',
   '.docblock-argstable',
   '.sbdocs-title',
   '.sbdocs-subtitle',


### PR DESCRIPTION
Fixes #20251

## What I did

Added all known classes from SB blocks to ignore list for the global docs styles.

Also removed the anchor from ignore list, because it caused descriptions in autodocs to follow the theme even though docs are always light theme.

## How to test

See autodocs and ColorPalette story in published SB.