### PR TITLE
Build: do not treat check as a cache-able operation && cleanup

### DIFF
--- a/code/nx.json
+++ b/code/nx.json
@@ -11,7 +11,7 @@
     "default": {
       "runner": "@nrwl/nx-cloud",
       "options": {
-        "cacheableOperations": ["build", "test", "lint", "package", "prep", "check"],
+        "cacheableOperations": ["prep"],
         "accessToken": "NGVmYTkxMmItYzY3OS00MjkxLTk1ZDktZDFmYTFmNmVlNGY4fHJlYWQ=",
         "canTrackAnalytics": false,
         "showUsageWarnings": true,


### PR DESCRIPTION
I noticed that the `check` operation can be cached, and thus isn't run when the code changes.

That all sounds good, but we need to check type validity over the entire codebase, skipping it can result in missing type issues.