### PR TITLE
Fix vue sandbox: remove the lang=ts in a file, that should remain agnostic

### DIFF
--- a/code/renderers/vue3/template/stories/ReactiveArgs.vue
+++ b/code/renderers/vue3/template/stories/ReactiveArgs.vue
@@ -2,7 +2,7 @@
   <button type="button" @click="onClick" :class="classes" :style="style">{{ label }} {{ counter }}</button>
 </template>
 
-<script lang="ts">
+<script>
 import { computed, ref } from 'vue';
 
 export default {


### PR DESCRIPTION
Fixing the CI for vue-cli/default-js

There was a file added that was defining itself to be TypeScript, when it actually wasn't.
It was being used in a sandbox that wasn't setup to handle TS file.
That caused the sanbox build to fail.