### PR TITLE
fix: Wrap vite-plugin-external in custom plugin and fix issues

### DIFF
--- a/code/lib/builder-vite/src/plugins/external-globals-plugin.ts
+++ b/code/lib/builder-vite/src/plugins/external-globals-plugin.ts
@@ -1,0 +1,25 @@
+import { globals } from '@storybook/preview/globals';
+import type { Plugin } from 'vite';
+import { viteExternalsPlugin } from 'vite-plugin-externals';
+
+type ConfigHookFn = Extract<
+  ReturnType<typeof viteExternalsPlugin>['config'],
+  (...args: any[]) => any
+>;
+
+export async function externalsGlobalsPlugin() {
+  const plugin = viteExternalsPlugin(globals, { useWindow: false });
+  return {
+    ...plugin,
+    name: 'storybook:external-globals-plugin',
+    // wrap config hook to fix issues from `vite-plugin-externals`
+    async config(...configArgs) {
+      const config = await (plugin.config as ConfigHookFn)(...configArgs);
+      return {
+        resolve: {
+          alias: config?.resolve?.alias,
+        },
+      };
+    },
+  } satisfies Plugin;
+}

--- a/code/lib/builder-vite/src/plugins/index.ts
+++ b/code/lib/builder-vite/src/plugins/index.ts
@@ -3,3 +3,4 @@ export * from './mdx-plugin';
 export * from './strip-story-hmr-boundaries';
 export * from './code-generator-plugin';
 export * from './csf-plugin';
+export * from './external-globals-plugin';

--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -7,9 +7,7 @@ import type {
   UserConfig as ViteConfig,
   InlineConfig,
 } from 'vite';
-import { viteExternalsPlugin } from 'vite-plugin-externals';
 import { isPreservingSymlinks, getFrameworkName, getBuilderOptions } from '@storybook/core-common';
-import { globals } from '@storybook/preview/globals';
 import type { Options } from '@storybook/types';
 import {
   codeGeneratorPlugin,
@@ -17,6 +15,7 @@ import {
   injectExportOrderPlugin,
   mdxPlugin,
   stripStoryHMRBoundary,
+  externalsGlobalsPlugin,
 } from './plugins';
 import type { BuilderOptions } from './types';
 
@@ -93,7 +92,7 @@ export async function pluginConfig(options: Options) {
         }
       },
     },
-    viteExternalsPlugin(globals, { useWindow: false, disableInServe: true }),
+    externalsGlobalsPlugin(),
   ] as PluginOption[];
 
   // TODO: framework doesn't exist, should move into framework when/if built


### PR DESCRIPTION
Issue: #20643

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

Alternate solution for: #20698

## What I did

<!-- Briefly describe what your PR does -->

HMR was broken by `vite-plugin-externals` due to returning the entire config from the config hook instead of the partial config as written in the vite api docs: https://vitejs.dev/guide/api-plugin.html#vite-specific-hooks.

Recreates the same fix as in https://github.com/crcong/vite-plugin-externals/pull/27 by wrapping the plugin in a custom plugin and overriding the result of the config hook.

## How to test

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Build `@storybook/builder-vite`, `yarn build --watch builder-vite` from `code/` directory
3. Open Storybook in your browser
4. Ensure HMR is working
5. Ensure there is not a regression with https://github.com/storybookjs/storybook/issues/20514

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
