### PR TITLE
Set default height of inline stories to 100%

### DIFF
--- a/code/addons/docs/angular/README.md
+++ b/code/addons/docs/angular/README.md
@@ -239,7 +239,7 @@ And for `MDX` you can modify it as an attribute on the `Story` element:
 
 Storybook Docs renders all Angular stories inline by default.
 
-However, you can render stories in an iframe, with a default height of `100px` (configurable using the `docs.story.iframeHeight` story parameter), by using the `docs.story.inline` parameter.
+However, you can render stories in an iframe, with a default height of `100%` (configurable using the `docs.story.iframeHeight` story parameter), by using the `docs.story.inline` parameter.
 
 To do so for all stories, update `.storybook/preview.js`:
 

--- a/code/ui/blocks/src/blocks/Story.tsx
+++ b/code/ui/blocks/src/blocks/Story.tsx
@@ -90,16 +90,16 @@ export type StoryProps = (StoryDefProps | StoryRefProps) & StoryParameters;
 export const getStoryId = (props: StoryProps, context: DocsContextProps): StoryId => {
   const { id, of, meta, story } = props as StoryRefProps;
   if (id) {
-    deprecate(dedent`Referencing stories by \`id\` is deprecated, please use \`of\` instead. 
-    
+    deprecate(dedent`Referencing stories by \`id\` is deprecated, please use \`of\` instead.
+
       Please refer to the migration guide: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#story-block'`);
     return id;
   }
 
   const { name } = props as StoryDefProps;
   if (name) {
-    deprecate(dedent`Referencing stories by \`name\` is deprecated, please use \`of\` instead. 
-    
+    deprecate(dedent`Referencing stories by \`name\` is deprecated, please use \`of\` instead.
+
       Please refer to the migration guide: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#story-block'`);
     return context.storyIdByName(name);
   }
@@ -143,15 +143,15 @@ export const getStoryProps = <TFramework extends Renderer>(
     autoplay?: boolean;
   };
   if (typeof inlineStories !== 'undefined')
-    deprecate(dedent`The \`docs.inlineStories\` parameter is deprecated, use \`docs.story.inline\` instead. 
-    
+    deprecate(dedent`The \`docs.inlineStories\` parameter is deprecated, use \`docs.story.inline\` instead.
+
       Please refer to the migration guide: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#autodocs-changes'
     `);
   const inline = props.inline ?? storyParameters.inline ?? inlineStories ?? false;
 
   if (typeof iframeHeight !== 'undefined') {
-    deprecate(dedent`The \`docs.iframeHeight\` parameter is deprecated, use \`docs.story.iframeHeight\` instead. 
-    
+    deprecate(dedent`The \`docs.iframeHeight\` parameter is deprecated, use \`docs.story.iframeHeight\` instead.
+
       Please refer to the migration guide: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#autodocs-changes'
     `);
   }
@@ -177,7 +177,7 @@ export const getStoryProps = <TFramework extends Renderer>(
     storyParameters.height ??
     storyParameters.iframeHeight ??
     iframeHeight ??
-    '100px';
+    '100%';
   return {
     story,
     inline: false,


### PR DESCRIPTION
Issue: #15577 

## What I did

This PR changes the default height of inline stories, which are used to render Angular stories, from 100px to 100%. This avoids vertical scrollbars for Angular stories that are higher than 100px.

## How to test

- `yarn start`
- Look at any inline story that does not have an explicit height

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md) (not applicable)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
