### PR TITLE
Build: fix playwright unsynced version in CI

### DIFF
--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -23,7 +23,7 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
   packageJson.resolutions = {
     ...storybookVersions,
     'enhanced-resolve': '~5.10.0', // TODO, remove this
-    playwright: '1.30.0', // this is for our CI test, ensure we use the same version as docker image
+    playwright: '1.30.0', // this is for our CI test, ensure we use the same version as docker image, it should match version specified in `./code/package.json` and `.circleci/config.yml`
   };
   await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
 };

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -20,7 +20,11 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
 
   const packageJsonPath = path.join(cwd, 'package.json');
   const packageJson = await readJSON(packageJsonPath);
-  packageJson.resolutions = { ...storybookVersions, 'enhanced-resolve': '~5.10.0' };
+  packageJson.resolutions = {
+    ...storybookVersions,
+    'enhanced-resolve': '~5.10.0', // TODO, remove this
+    playwright: '1.30.0', // this is for our CI test, ensure we use the same version as docker image
+  };
   await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
 };
 


### PR DESCRIPTION
# What I did

- add a resolution for playwright to ensure that all sandboxes use the same version as the docker image

This will prevent future failures of our CI caused by mismatching version of playwright