### PR TITLE
Tab UI Improvements

### DIFF
--- a/code/addons/a11y/src/components/VisionSimulator.tsx
+++ b/code/addons/a11y/src/components/VisionSimulator.tsx
@@ -141,7 +141,7 @@ export const VisionSimulator = () => {
           });
           return <TooltipLinkList links={colorList} />;
         }}
-        closeOnClick
+        closeOnOutsideClick
         onDoubleClick={() => setFilter(null)}
       >
         <IconButton key="filter" active={!!filter} title="Vision simulator">

--- a/code/addons/backgrounds/src/containers/BackgroundSelector.tsx
+++ b/code/addons/backgrounds/src/containers/BackgroundSelector.tsx
@@ -117,7 +117,7 @@ export const BackgroundSelector: FC = memo(function BackgroundSelector() {
       <WithTooltip
         placement="top"
         trigger="click"
-        closeOnClick
+        closeOnOutsideClick
         tooltip={({ onHide }) => {
           return (
             <TooltipLinkList

--- a/code/addons/toolbars/src/components/ToolbarMenuList.tsx
+++ b/code/addons/toolbars/src/components/ToolbarMenuList.tsx
@@ -84,7 +84,7 @@ export const ToolbarMenuList: FC<ToolbarMenuListProps> = withKeyboardCycle(
             });
           return <TooltipLinkList links={links} />;
         }}
-        closeOnClick
+        closeOnOutsideClick
       >
         <ToolbarMenuButton
           active={hasGlobalValue}

--- a/code/addons/viewport/src/Tool.tsx
+++ b/code/addons/viewport/src/Tool.tsx
@@ -184,7 +184,7 @@ export const ViewportTool: FC = memo(
           tooltip={({ onHide }) => (
             <TooltipLinkList links={toLinks(list, item, setState, state, onHide)} />
           )}
-          closeOnClick
+          closeOnOutsideClick
         >
           <IconButtonWithLabel
             key="viewport"

--- a/code/e2e-tests/addon-backgrounds.spec.ts
+++ b/code/e2e-tests/addon-backgrounds.spec.ts
@@ -14,7 +14,7 @@ test.describe('addon-backgrounds', () => {
     const sbPage = new SbPage(page);
 
     await sbPage.navigateToStory('example/button', 'primary');
-    await sbPage.selectToolbar('[title="Change the background of the preview"]', '#dark');
+    await sbPage.selectToolbar('[title="Change the background of the preview"]', '#list-item-dark');
 
     await expect(sbPage.getCanvasBodyElement()).toHaveCSS('background-color', 'rgb(51, 51, 51)');
   });

--- a/code/e2e-tests/addon-viewport.spec.ts
+++ b/code/e2e-tests/addon-viewport.spec.ts
@@ -15,7 +15,7 @@ test.describe('addon-viewport', () => {
 
     // Click on viewport button and select small mobile
     await sbPage.navigateToStory('example/button', 'primary');
-    await sbPage.selectToolbar('[title="Change the size of the preview"]', '#mobile1');
+    await sbPage.selectToolbar('[title="Change the size of the preview"]', '#list-item-mobile1');
 
     // Check that Button story is still displayed
     await expect(sbPage.previewRoot()).toContainText('Button');

--- a/code/ui/blocks/src/components/ArgsTable/ArgValue.tsx
+++ b/code/ui/blocks/src/components/ArgsTable/ArgValue.tsx
@@ -160,11 +160,11 @@ const ArgSummary: FC<ArgSummaryProps> = ({ value, initialExpandedArgs }) => {
 
   return (
     <WithTooltipPure
-      closeOnClick
+      closeOnOutsideClick
       trigger="click"
       placement="bottom"
-      tooltipShown={isOpen}
-      onVisibilityChange={(isVisible) => {
+      visible={isOpen}
+      onVisibleChange={(isVisible) => {
         setIsOpen(isVisible);
       }}
       tooltip={

--- a/code/ui/blocks/src/controls/Color.tsx
+++ b/code/ui/blocks/src/controls/Color.tsx
@@ -322,8 +322,8 @@ export const ColorControl: FC<ColorControlProps> = ({
       <PickerTooltip
         trigger="click"
         startOpen={startOpen}
-        closeOnClick
-        onVisibilityChange={() => addPreset(color)}
+        closeOnOutsideClick
+        onVisibleChange={() => addPreset(color)}
         tooltip={
           <TooltipContent>
             <Picker

--- a/code/ui/components/package.json
+++ b/code/ui/components/package.json
@@ -54,6 +54,7 @@
     "@storybook/theming": "7.0.0-beta.38",
     "@storybook/types": "7.0.0-beta.38",
     "memoizerific": "^1.11.3",
+    "use-resize-observer": "^9.1.0",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {

--- a/code/ui/components/src/bar/bar.tsx
+++ b/code/ui/components/src/bar/bar.tsx
@@ -9,7 +9,7 @@ export interface SideProps {
   right?: boolean;
 }
 
-const Side = styled.div<SideProps>(
+export const Side = styled.div<SideProps>(
   {
     display: 'flex',
     whiteSpace: 'nowrap',

--- a/code/ui/components/src/bar/bar.tsx
+++ b/code/ui/components/src/bar/bar.tsx
@@ -7,6 +7,7 @@ import { ScrollArea } from '../ScrollArea/ScrollArea';
 export interface SideProps {
   left?: boolean;
   right?: boolean;
+  scrollable?: boolean;
 }
 
 export const Side = styled.div<SideProps>(
@@ -14,10 +15,10 @@ export const Side = styled.div<SideProps>(
     display: 'flex',
     whiteSpace: 'nowrap',
     flexBasis: 'auto',
-    flexShrink: 0,
     marginLeft: 3,
     marginRight: 3,
   },
+  ({ scrollable }) => (scrollable ? { flexShrink: 0 } : {}),
   ({ left }) =>
     left
       ? {
@@ -38,18 +39,25 @@ export const Side = styled.div<SideProps>(
 );
 Side.displayName = 'Side';
 
-const UnstyledBar: FC<ComponentProps<typeof ScrollArea>> = ({ children, className }) => (
-  <ScrollArea horizontal vertical={false} className={className}>
-    {children}
-  </ScrollArea>
-);
-export const Bar = styled(UnstyledBar)<{ border?: boolean }>(
-  ({ theme }) => ({
+const UnstyledBar: FC<ComponentProps<typeof ScrollArea> & { scrollable?: boolean }> = ({
+  children,
+  className,
+  scrollable,
+}) =>
+  scrollable ? (
+    <ScrollArea vertical={false} className={className}>
+      {children}
+    </ScrollArea>
+  ) : (
+    <div className={className}>{children}</div>
+  );
+export const Bar = styled(UnstyledBar)<{ border?: boolean; scrollable?: boolean }>(
+  ({ theme, scrollable = true }) => ({
     color: theme.barTextColor,
     width: '100%',
     height: 40,
     flexShrink: 0,
-    overflow: 'auto',
+    overflow: scrollable ? 'auto' : 'hidden',
     overflowY: 'hidden',
   }),
   ({ theme, border = false }) =>
@@ -72,9 +80,8 @@ const BarInner = styled.div<{ bgColor: string }>(({ bgColor }) => ({
   backgroundColor: bgColor || '',
 }));
 
-export interface FlexBarProps {
+export interface FlexBarProps extends ComponentProps<typeof Bar> {
   border?: boolean;
-  children?: any;
   backgroundColor?: string;
 }
 
@@ -83,7 +90,9 @@ export const FlexBar: FC<FlexBarProps> = ({ children, backgroundColor, ...rest }
   return (
     <Bar {...rest}>
       <BarInner bgColor={backgroundColor}>
-        <Side left>{left}</Side>
+        <Side scrollable={rest.scrollable} left>
+          {left}
+        </Side>
         {right ? <Side right>{right}</Side> : null}
       </BarInner>
     </Bar>

--- a/code/ui/components/src/bar/button.tsx
+++ b/code/ui/components/src/bar/button.tsx
@@ -7,6 +7,7 @@ import { auto } from '@popperjs/core';
 interface BarButtonProps
   extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
   href?: void;
+  target?: void;
 }
 interface BarLinkProps
   extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {

--- a/code/ui/components/src/bar/button.tsx
+++ b/code/ui/components/src/bar/button.tsx
@@ -10,17 +10,30 @@ interface BarButtonProps
 }
 interface BarLinkProps
   extends DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
+  disabled?: void;
   href: string;
 }
 
-const ButtonOrLink = ({ children, ...restProps }: BarButtonProps | BarLinkProps) =>
-  restProps.href != null ? (
-    <a {...(restProps as BarLinkProps)}>{children}</a>
+const ButtonOrLink = React.forwardRef<
+  HTMLAnchorElement | HTMLButtonElement,
+  BarLinkProps | BarButtonProps
+>(({ children, ...restProps }, ref) => {
+  return restProps.href != null ? (
+    <a ref={ref as React.ForwardedRef<HTMLAnchorElement>} {...(restProps as BarLinkProps)}>
+      {children}
+    </a>
   ) : (
-    <button type="button" {...(restProps as BarButtonProps)}>
+    <button
+      ref={ref as React.ForwardedRef<HTMLButtonElement>}
+      type="button"
+      {...(restProps as BarButtonProps)}
+    >
       {children}
     </button>
   );
+});
+
+ButtonOrLink.displayName = 'ButtonOrLink';
 
 export interface TabButtonProps {
   active?: boolean;

--- a/code/ui/components/src/hooks/useOnWindowResize.tsx
+++ b/code/ui/components/src/hooks/useOnWindowResize.tsx
@@ -1,9 +1,0 @@
-import { useEffect } from 'react';
-
-export function useOnWindowResize(cb: (ev: UIEvent) => void) {
-  useEffect(() => {
-    window.addEventListener('resize', cb);
-
-    return () => window.removeEventListener('resize', cb);
-  }, [cb]);
-}

--- a/code/ui/components/src/hooks/useOnWindowResize.tsx
+++ b/code/ui/components/src/hooks/useOnWindowResize.tsx
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+
+export function useOnWindowResize(cb: (ev: UIEvent) => void) {
+  useEffect(() => {
+    window.addEventListener('resize', cb);
+
+    return () => window.removeEventListener('resize', cb);
+  }, [cb]);
+}

--- a/code/ui/components/src/tabs/tabs.helpers.tsx
+++ b/code/ui/components/src/tabs/tabs.helpers.tsx
@@ -1,0 +1,34 @@
+import { styled } from '@storybook/theming';
+import type { ReactElement } from 'react';
+import React, { Children } from 'react';
+
+export interface VisuallyHiddenProps {
+  active?: boolean;
+}
+
+export const VisuallyHidden = styled.div<VisuallyHiddenProps>(({ active }) =>
+  active ? { display: 'block' } : { display: 'none' }
+);
+
+export const childrenToList = (children: any, selected: string) =>
+  Children.toArray(children).map(
+    ({ props: { title, id, color, children: childrenOfChild } }: ReactElement, index) => {
+      const content = Array.isArray(childrenOfChild) ? childrenOfChild[0] : childrenOfChild;
+      return {
+        active: selected ? id === selected : index === 0,
+        title,
+        id,
+        color,
+        render:
+          typeof content === 'function'
+            ? content
+            : ({ active, key }: any) => (
+                <VisuallyHidden key={key} active={active} role="tabpanel">
+                  {content}
+                </VisuallyHidden>
+              ),
+      };
+    }
+  );
+
+export type ChildrenList = ReturnType<typeof childrenToList>;

--- a/code/ui/components/src/tabs/tabs.hooks.tsx
+++ b/code/ui/components/src/tabs/tabs.hooks.tsx
@@ -1,0 +1,174 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { sanitize } from '@storybook/csf';
+import { styled } from '@storybook/theming';
+import { TabButton } from '../bar/button';
+import { useOnWindowResize } from '../hooks/useOnWindowResize';
+import { TooltipLinkList } from '../tooltip/TooltipLinkList';
+import { WithTooltip } from '../tooltip/WithTooltip';
+import type { ChildrenList } from './tabs.helpers';
+import type { Link } from '../tooltip/TooltipLinkList';
+
+const CollapseIcon = styled.span<{ isActive: boolean }>(({ theme, isActive }) => ({
+  display: 'inline-block',
+  width: 0,
+  height: 0,
+  marginLeft: 8,
+  color: isActive ? theme.color.secondary : theme.color.mediumdark,
+  borderRight: '3px solid transparent',
+  borderLeft: `3px solid transparent`,
+  borderTop: '3px solid',
+  transition: 'transform .1s ease-out',
+}));
+
+const AddonButton = styled(TabButton)<{ preActive: boolean }>(({ active, theme, preActive }) => {
+  return `
+    color: ${preActive || active ? theme.color.secondary : theme.color.mediumdark};
+    &:hover {
+      color: ${theme.color.secondary};
+      .addon-collapsible-icon {
+        color: ${theme.color.secondary};
+      }
+    }
+  `;
+});
+
+export function useList(list: ChildrenList) {
+  const tabBarRef = useRef<HTMLDivElement>();
+  const addonsRef = useRef<HTMLButtonElement>();
+  const tabRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  const [visibleList, setVisibleList] = useState(list);
+  const [invisibleList, setInvisibleList] = useState<ChildrenList>([]);
+  const previousList = useRef<ChildrenList>(list);
+
+  const AddonTab = useCallback(
+    ({
+      menuName,
+      actions,
+    }: {
+      menuName: string;
+      actions?: {
+        onSelect: (id: string) => void;
+      } & Record<string, any>;
+    }) => {
+      const isAddonsActive = invisibleList.some(({ active }) => active);
+      const [isTooltipVisible, setTooltipVisible] = useState(false);
+      return (
+        <>
+          <WithTooltip
+            interactive
+            withArrows={false}
+            visible={isTooltipVisible}
+            onVisibleChange={setTooltipVisible}
+            delayHide={100}
+            tooltip={
+              <TooltipLinkList
+                links={invisibleList.map(({ title, id, color, active }) => {
+                  const tabTitle = typeof title === 'function' ? title() : title;
+                  return {
+                    id,
+                    title: tabTitle,
+                    color,
+                    active,
+                    onClick: (e) => {
+                      e.preventDefault();
+                      actions.onSelect(id);
+                    },
+                  } as Link;
+                })}
+              />
+            }
+          >
+            <AddonButton
+              ref={addonsRef}
+              active={isAddonsActive}
+              preActive={isTooltipVisible}
+              style={{ visibility: invisibleList.length ? 'visible' : 'hidden' }}
+              className="tabbutton"
+              type="button"
+              role="tab"
+            >
+              {menuName}
+              <CollapseIcon
+                className="addon-collapsible-icon"
+                isActive={isAddonsActive || isTooltipVisible}
+              />
+            </AddonButton>
+          </WithTooltip>
+          {invisibleList.map(({ title, id, color }) => {
+            const tabTitle = typeof title === 'function' ? title() : title;
+            return (
+              <TabButton
+                id={`tabbutton-${sanitize(tabTitle)}`}
+                style={{ visibility: 'hidden' }}
+                tabIndex={-1}
+                ref={(ref: HTMLButtonElement) => {
+                  tabRefs.current.set(tabTitle, ref);
+                }}
+                className="tabbutton"
+                type="button"
+                key={id}
+                textColor={color}
+                role="tab"
+              >
+                {tabTitle}
+              </TabButton>
+            );
+          })}
+        </>
+      );
+    },
+    [invisibleList]
+  );
+
+  const setTabLists = useCallback(() => {
+    // get x and width from tabBarRef div
+    const { x, width } = tabBarRef.current.getBoundingClientRect();
+    const { width: widthAddonsTab } = addonsRef.current.getBoundingClientRect();
+    const rightBorder = invisibleList.length ? x + width - widthAddonsTab : x + width;
+
+    const newVisibleList: ChildrenList = [];
+
+    let widthSum = 0;
+
+    const newInvisibleList = list.filter((item) => {
+      const { title } = item;
+      const tabTitle = typeof title === 'function' ? title() : title;
+      const tabButton = tabRefs.current.get(tabTitle);
+
+      if (!tabButton) {
+        return false;
+      }
+      const { width: tabWidth } = tabButton.getBoundingClientRect();
+
+      const crossBorder = x + widthSum + tabWidth > rightBorder;
+
+      if (!crossBorder) {
+        newVisibleList.push(item);
+      }
+
+      widthSum += tabWidth;
+
+      return crossBorder;
+    });
+
+    if (newVisibleList.length !== visibleList.length || previousList.current !== list) {
+      setVisibleList(newVisibleList);
+      setInvisibleList(newInvisibleList);
+      previousList.current = list;
+    }
+  }, [invisibleList.length, list, visibleList]);
+
+  useOnWindowResize(setTabLists);
+
+  useLayoutEffect(setTabLists, [setTabLists]);
+
+  return {
+    tabRefs,
+    addonsRef,
+    tabBarRef,
+    visibleList,
+    invisibleList,
+    AddonTab,
+  };
+}

--- a/code/ui/components/src/tabs/tabs.hooks.tsx
+++ b/code/ui/components/src/tabs/tabs.hooks.tsx
@@ -105,7 +105,7 @@ export function useList(list: ChildrenList) {
                 style={{ visibility: 'hidden' }}
                 tabIndex={-1}
                 ref={(ref: HTMLButtonElement) => {
-                  tabRefs.current.set(title, ref);
+                  tabRefs.current.set(id, ref);
                 }}
                 className="tabbutton"
                 type="button"
@@ -134,8 +134,8 @@ export function useList(list: ChildrenList) {
     let widthSum = 0;
 
     const newInvisibleList = list.filter((item) => {
-      const { title } = item;
-      const tabButton = tabRefs.current.get(title);
+      const { id } = item;
+      const tabButton = tabRefs.current.get(id);
 
       if (!tabButton) {
         return false;

--- a/code/ui/components/src/tabs/tabs.hooks.tsx
+++ b/code/ui/components/src/tabs/tabs.hooks.tsx
@@ -87,6 +87,7 @@ export function useList(list: ChildrenList) {
               active={isAddonsActive}
               preActive={isTooltipVisible}
               style={{ visibility: invisibleList.length ? 'visible' : 'hidden' }}
+              aria-hidden={!invisibleList.length}
               className="tabbutton"
               type="button"
               role="tab"
@@ -103,6 +104,7 @@ export function useList(list: ChildrenList) {
               <TabButton
                 id={`tabbutton-${sanitize(title)}`}
                 style={{ visibility: 'hidden' }}
+                aria-hidden
                 tabIndex={-1}
                 ref={(ref: HTMLButtonElement) => {
                   tabRefs.current.set(id, ref);

--- a/code/ui/components/src/tabs/tabs.hooks.tsx
+++ b/code/ui/components/src/tabs/tabs.hooks.tsx
@@ -125,6 +125,9 @@ export function useList(list: ChildrenList) {
 
   const setTabLists = useCallback(() => {
     // get x and width from tabBarRef div
+    if (!tabBarRef.current || !addonsRef.current) {
+      return;
+    }
     const { x, width } = tabBarRef.current.getBoundingClientRect();
     const { width: widthAddonsTab } = addonsRef.current.getBoundingClientRect();
     const rightBorder = invisibleList.length ? x + width - widthAddonsTab : x + width;

--- a/code/ui/components/src/tabs/tabs.stories.tsx
+++ b/code/ui/components/src/tabs/tabs.stories.tsx
@@ -120,20 +120,7 @@ const content = Object.entries(panels).map(([k, v]) => (
 
 export default {
   title: 'Tabs',
-  decorators: [
-    (story) => (
-      <div
-        style={{
-          position: 'relative',
-          height: 'calc(100vh - 20px)',
-          width: 'calc(100vw - 20px)',
-          margin: 10,
-        }}
-      >
-        {story()}
-      </div>
-    ),
-  ],
+  decorators: [(story) => <div>{story()}</div>],
   args: {
     menuName: 'Addons',
   },

--- a/code/ui/components/src/tabs/tabs.stories.tsx
+++ b/code/ui/components/src/tabs/tabs.stories.tsx
@@ -1,3 +1,4 @@
+import { expect } from '@storybook/jest';
 import type { Key } from 'react';
 import React, { Fragment } from 'react';
 import { action } from '@storybook/addon-actions';
@@ -199,15 +200,19 @@ export const StatefulDynamicWithOpenTooltip = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await new Promise((res) =>
-      // The timeout is necessary to wait for Storybook to adjust the viewport
-      setTimeout(async () => {
-        const addonsTab = canvas.getByText('Addons');
-        fireEvent(addonsTab, new MouseEvent('mouseenter', { bubbles: true }));
-        await waitFor(() => screen.getByTestId('tooltip'));
-        res(undefined);
-      }, 500)
-    );
+
+    await waitFor(async () => {
+      await expect(canvas.getAllByRole('tab')).toHaveLength(3);
+      await expect(canvas.getByRole('tab', { name: /Addons/ })).toBeInTheDocument();
+    });
+
+    const addonsTab = await canvas.findByRole('tab', { name: /Addons/ });
+
+    await waitFor(async () => {
+      await fireEvent(addonsTab, new MouseEvent('mouseenter', { bubbles: true }));
+      const tooltip = await screen.getByTestId('tooltip');
+      await expect(tooltip).toBeInTheDocument();
+    });
   },
   render: (args) => (
     <TabsState initial="test1" {...args}>

--- a/code/ui/components/src/tabs/tabs.stories.tsx
+++ b/code/ui/components/src/tabs/tabs.stories.tsx
@@ -1,8 +1,9 @@
-import type { ComponentProps, Key } from 'react';
+import type { Key } from 'react';
 import React, { Fragment } from 'react';
 import { action } from '@storybook/addon-actions';
 import { logger } from '@storybook/client-logger';
-import type { Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { within, fireEvent, waitFor, screen, getByText } from '@storybook/testing-library';
 import { Tabs, TabsState, TabWrapper } from './tabs';
 
 const colours = Array.from(new Array(15), (val, index) => index).map((i) =>
@@ -67,7 +68,7 @@ const panels: Panels = {
     ),
   },
   test3: {
-    title: 'Tab with scroll!',
+    title: 'Tab title #3',
     render: ({ active, key }) =>
       active ? (
         <div id="test3" key={key}>
@@ -133,10 +134,15 @@ export default {
       </div>
     ),
   ],
-} as Meta;
+  args: {
+    menuName: 'Addons',
+  },
+} satisfies Meta<typeof TabsState>;
+
+type Story = StoryObj<typeof TabsState>;
 
 export const StatefulStatic = {
-  render: (args: ComponentProps<typeof TabsState>) => (
+  render: (args) => (
     <TabsState initial="test2" {...args}>
       <div id="test1" title="With a function">
         {({ active, selected }: { active: boolean; selected: string }) =>
@@ -148,10 +154,10 @@ export const StatefulStatic = {
       </div>
     </TabsState>
   ),
-};
+} satisfies Story;
 
 export const StatefulStaticWithSetButtonTextColors = {
-  render: (args: ComponentProps<typeof TabsState>) => (
+  render: (args) => (
     <div>
       <TabsState initial="test2" {...args}>
         <div id="test1" title="With a function" color="#e00000">
@@ -165,9 +171,10 @@ export const StatefulStaticWithSetButtonTextColors = {
       </TabsState>
     </div>
   ),
-};
+} satisfies Story;
+
 export const StatefulStaticWithSetBackgroundColor = {
-  render: (args: ComponentProps<typeof TabsState>) => (
+  render: (args) => (
     <div>
       <TabsState initial="test2" backgroundColor="rgba(0,0,0,.05)" {...args}>
         <div id="test1" title="With a function" color="#e00000">
@@ -181,11 +188,28 @@ export const StatefulStaticWithSetBackgroundColor = {
       </TabsState>
     </div>
   ),
-};
+} satisfies Story;
 
-export const StatefulDynamic = {
-  render: (args: ComponentProps<typeof TabsState>) => (
-    <TabsState initial="test3" {...args}>
+export const StatefulDynamicWithOpenTooltip = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile2',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await new Promise((res) =>
+      // The timeout is necessary to wait for Storybook to adjust the viewport
+      setTimeout(async () => {
+        const addonsTab = canvas.getByText('Addons');
+        fireEvent(addonsTab, new MouseEvent('mouseenter', { bubbles: true }));
+        await waitFor(() => screen.getByTestId('tooltip'));
+        res(undefined);
+      }, 500)
+    );
+  },
+  render: (args) => (
+    <TabsState initial="test1" {...args}>
       {Object.entries(panels).map(([k, v]) => (
         <div key={k} id={k} title={v.title}>
           {v.render}
@@ -193,16 +217,47 @@ export const StatefulDynamic = {
       ))}
     </TabsState>
   ),
-};
+} satisfies Story;
+
+export const StatefulDynamicWithSelectedAddon = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile2',
+    },
+  },
+  play: async (context) => {
+    await StatefulDynamicWithOpenTooltip.play(context);
+
+    const popperContainer = screen.getByTestId('tooltip');
+    const tab4 = getByText(popperContainer, 'Tab title #4', {});
+    fireEvent(tab4, new MouseEvent('click', { bubbles: true }));
+    await waitFor(() => screen.getByText('CONTENT 4'));
+
+    // reopen the tooltip
+    await StatefulDynamicWithOpenTooltip.play(context);
+  },
+  render: (args) => (
+    <TabsState initial="test1" {...args}>
+      {Object.entries(panels).map(([k, v]) => (
+        <div key={k} id={k} title={v.title}>
+          {v.render}
+        </div>
+      ))}
+    </TabsState>
+  ),
+} satisfies Story;
+
 export const StatefulNoInitial = {
-  render: (args: ComponentProps<typeof TabsState>) => <TabsState {...args}>{content}</TabsState>,
-};
+  render: (args) => <TabsState {...args}>{content}</TabsState>,
+} satisfies Story;
+
 export const StatelessBordered = {
-  render: (args: ComponentProps<typeof TabsState>) => (
+  render: (args) => (
     <Tabs
       bordered
       absolute={false}
       selected="test3"
+      menuName="Addons"
       actions={{
         onSelect,
       }}
@@ -211,11 +266,13 @@ export const StatelessBordered = {
       {content}
     </Tabs>
   ),
-};
+} satisfies Story;
+
 export const StatelessWithTools = {
-  render: (args: ComponentProps<typeof TabsState>) => (
+  render: (args) => (
     <Tabs
       selected="test3"
+      menuName="Addons"
       actions={{
         onSelect,
       }}
@@ -234,12 +291,14 @@ export const StatelessWithTools = {
       {content}
     </Tabs>
   ),
-};
+} satisfies Story;
+
 export const StatelessAbsolute = {
-  render: (args: ComponentProps<typeof TabsState>) => (
+  render: (args) => (
     <Tabs
       absolute
       selected="test3"
+      menuName="Addons"
       actions={{
         onSelect,
       }}
@@ -248,12 +307,14 @@ export const StatelessAbsolute = {
       {content}
     </Tabs>
   ),
-};
+} satisfies Story;
+
 export const StatelessAbsoluteBordered = {
-  render: (args: ComponentProps<typeof TabsState>) => (
+  render: (args) => (
     <Tabs
       absolute
       bordered
+      menuName="Addons"
       selected="test3"
       actions={{
         onSelect,
@@ -263,16 +324,18 @@ export const StatelessAbsoluteBordered = {
       {content}
     </Tabs>
   ),
-};
+} satisfies Story;
+
 export const StatelessEmpty = {
-  render: (args: ComponentProps<typeof TabsState>) => (
+  render: (args) => (
     <Tabs
       actions={{
         onSelect,
       }}
       bordered
+      menuName="Addons"
       absolute
       {...args}
     />
   ),
-};
+} satisfies Story;

--- a/code/ui/components/src/tabs/tabs.stories.tsx
+++ b/code/ui/components/src/tabs/tabs.stories.tsx
@@ -120,7 +120,20 @@ const content = Object.entries(panels).map(([k, v]) => (
 
 export default {
   title: 'Tabs',
-  decorators: [(story) => <div>{story()}</div>],
+  decorators: [
+    (story) => (
+      <div
+        style={{
+          position: 'relative',
+          height: 'calc(100vh - 20px)',
+          width: 'calc(100vw - 20px)',
+          margin: 10,
+        }}
+      >
+        {story()}
+      </div>
+    ),
+  ],
   args: {
     menuName: 'Addons',
   },

--- a/code/ui/components/src/tabs/tabs.stories.tsx
+++ b/code/ui/components/src/tabs/tabs.stories.tsx
@@ -182,6 +182,7 @@ export const StatefulDynamicWithOpenTooltip = {
     viewport: {
       defaultViewport: 'mobile2',
     },
+    chromatic: { viewports: [414] },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -211,6 +212,7 @@ export const StatefulDynamicWithSelectedAddon = {
     viewport: {
       defaultViewport: 'mobile2',
     },
+    chromatic: { viewports: [414] },
   },
   play: async (context) => {
     await StatefulDynamicWithOpenTooltip.play(context);

--- a/code/ui/components/src/tabs/tabs.tsx
+++ b/code/ui/components/src/tabs/tabs.tsx
@@ -5,7 +5,7 @@ import { sanitize } from '@storybook/csf';
 
 import { Placeholder } from '../placeholder/placeholder';
 import { TabButton } from '../bar/button';
-import { Side } from '../bar/bar';
+import { FlexBar, Side } from '../bar/bar';
 import type { ChildrenList } from './tabs.helpers';
 import { childrenToList, VisuallyHidden } from './tabs.helpers';
 import { useList } from './tabs.hooks';
@@ -40,15 +40,6 @@ const Wrapper = styled.div<WrapperProps>(
         }
 );
 
-const WrapperChildren = styled.div<{ backgroundColor: string }>(({ theme, backgroundColor }) => ({
-  color: theme.barTextColor,
-  display: 'flex',
-  width: '100%',
-  height: 40,
-  boxShadow: `${theme.appBorderColor}  0 -1px 0 0 inset`,
-  background: backgroundColor ?? theme.barBg,
-}));
-
 export const TabBar = styled.div({
   overflow: 'hidden',
 
@@ -58,12 +49,6 @@ export const TabBar = styled.div({
 
   whiteSpace: 'nowrap',
   flexGrow: 1,
-});
-
-const TabBarSide = styled(Side)({
-  flexGrow: 1,
-  flexShrink: 1,
-  maxWidth: '100%',
 });
 
 TabBar.displayName = 'TabBar';
@@ -159,36 +144,34 @@ export const Tabs: FC<TabsProps> = memo(
 
     return list.length ? (
       <Wrapper absolute={absolute} bordered={bordered} id={htmlId}>
-        <WrapperChildren backgroundColor={backgroundColor}>
-          <TabBarSide left>
-            <TabBar ref={tabBarRef} role="tablist">
-              {visibleList.map(({ title, id, active, color }) => {
-                return (
-                  <TabButton
-                    id={`tabbutton-${sanitize(title)}`}
-                    ref={(ref: HTMLButtonElement) => {
-                      tabRefs.current.set(id, ref);
-                    }}
-                    className={`tabbutton ${active ? 'tabbutton-active' : ''}`}
-                    type="button"
-                    key={id}
-                    active={active}
-                    textColor={color}
-                    onClick={(e: MouseEvent) => {
-                      e.preventDefault();
-                      actions.onSelect(id);
-                    }}
-                    role="tab"
-                  >
-                    {title}
-                  </TabButton>
-                );
-              })}
-              <AddonTab menuName={menuName} actions={actions} />
-            </TabBar>
-          </TabBarSide>
+        <FlexBar scrollable={false} border backgroundColor={backgroundColor}>
+          <TabBar style={{ whiteSpace: 'normal' }} ref={tabBarRef} role="tablist">
+            {visibleList.map(({ title, id, active, color }) => {
+              return (
+                <TabButton
+                  id={`tabbutton-${sanitize(title)}`}
+                  ref={(ref: HTMLButtonElement) => {
+                    tabRefs.current.set(id, ref);
+                  }}
+                  className={`tabbutton ${active ? 'tabbutton-active' : ''}`}
+                  type="button"
+                  key={id}
+                  active={active}
+                  textColor={color}
+                  onClick={(e: MouseEvent) => {
+                    e.preventDefault();
+                    actions.onSelect(id);
+                  }}
+                  role="tab"
+                >
+                  {title}
+                </TabButton>
+              );
+            })}
+            <AddonTab menuName={menuName} actions={actions} />
+          </TabBar>
           {tools ? <Side right>{tools}</Side> : null}
-        </WrapperChildren>
+        </FlexBar>
         <Content id="panel-tab-content" bordered={bordered} absolute={absolute}>
           {list.map(({ id, active, render }) => render({ key: id, active }))}
         </Content>

--- a/code/ui/components/src/tabs/tabs.tsx
+++ b/code/ui/components/src/tabs/tabs.tsx
@@ -1,11 +1,14 @@
-import type { FC, MouseEvent, ReactElement, ReactNode } from 'react';
-import React, { Children, Component, Fragment, memo } from 'react';
+import type { FC, MouseEvent, ReactNode } from 'react';
+import React, { useMemo, Component, Fragment, memo } from 'react';
 import { styled } from '@storybook/theming';
 import { sanitize } from '@storybook/csf';
 
 import { Placeholder } from '../placeholder/placeholder';
-import { FlexBar } from '../bar/bar';
 import { TabButton } from '../bar/button';
+import { Side } from '../bar/bar';
+import type { ChildrenList } from './tabs.helpers';
+import { childrenToList, VisuallyHidden } from './tabs.helpers';
+import { useList } from './tabs.hooks';
 
 export interface WrapperProps {
   bordered?: boolean;
@@ -37,8 +40,19 @@ const Wrapper = styled.div<WrapperProps>(
         }
 );
 
+const WrapperChildren = styled.div<{ backgroundColor: string }>(({ theme, backgroundColor }) => ({
+  color: theme.barTextColor,
+  display: 'flex',
+  width: '100%',
+  height: 40,
+  boxShadow: `${theme.appBorderColor}  0 -1px 0 0 inset`,
+  background: backgroundColor ?? theme.barBg,
+}));
+
 export const TabBar = styled.div({
   overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  flexGrow: 1,
 
   '&:first-of-type': {
     marginLeft: -3,
@@ -89,14 +103,6 @@ const Content = styled.div<ContentProps>(
       : {}
 );
 
-export interface VisuallyHiddenProps {
-  active?: boolean;
-}
-
-const VisuallyHidden = styled.div<VisuallyHiddenProps>(({ active }) =>
-  active ? { display: 'block' } : { display: 'none' }
-);
-
 export interface TabWrapperProps {
   active: boolean;
   render?: () => JSX.Element;
@@ -109,27 +115,6 @@ export const TabWrapper: FC<TabWrapperProps> = ({ active, render, children }) =>
 
 export const panelProps = {};
 
-const childrenToList = (children: any, selected: string) =>
-  Children.toArray(children).map(
-    ({ props: { title, id, color, children: childrenOfChild } }: ReactElement, index) => {
-      const content = Array.isArray(childrenOfChild) ? childrenOfChild[0] : childrenOfChild;
-      return {
-        active: selected ? id === selected : index === 0,
-        title,
-        id,
-        color,
-        render:
-          typeof content === 'function'
-            ? content
-            : ({ active, key }: any) => (
-                <VisuallyHidden key={key} active={active} role="tabpanel">
-                  {content}
-                </VisuallyHidden>
-              ),
-      };
-    }
-  );
-
 export interface TabsProps {
   children?: FuncChildren[] | ReactNode;
   id?: string;
@@ -141,21 +126,41 @@ export interface TabsProps {
   backgroundColor?: string;
   absolute?: boolean;
   bordered?: boolean;
+  menuName: string;
 }
 
 export const Tabs: FC<TabsProps> = memo(
-  ({ children, selected, actions, absolute, bordered, tools, backgroundColor, id: htmlId }) => {
-    const list = childrenToList(children, selected);
+  ({
+    children,
+    selected,
+    actions,
+    absolute,
+    bordered,
+    tools,
+    backgroundColor,
+    id: htmlId,
+    menuName,
+  }) => {
+    const list = useMemo<ChildrenList>(
+      () => childrenToList(children, selected),
+      [children, selected]
+    );
+
+    const { visibleList, tabBarRef, tabRefs, AddonTab } = useList(list);
 
     return list.length ? (
       <Wrapper absolute={absolute} bordered={bordered} id={htmlId}>
-        <FlexBar border backgroundColor={backgroundColor}>
-          <TabBar role="tablist">
-            {list.map(({ title, id, active, color }) => {
+        <WrapperChildren backgroundColor={backgroundColor}>
+          <TabBar ref={tabBarRef} role="tablist">
+            {visibleList.map(({ title, id, active, color }, index) => {
               const tabTitle = typeof title === 'function' ? title() : title;
+
               return (
                 <TabButton
                   id={`tabbutton-${sanitize(tabTitle)}`}
+                  ref={(ref: HTMLButtonElement) => {
+                    tabRefs.current.set(tabTitle, ref);
+                  }}
                   className={`tabbutton ${active ? 'tabbutton-active' : ''}`}
                   type="button"
                   key={id}
@@ -171,9 +176,10 @@ export const Tabs: FC<TabsProps> = memo(
                 </TabButton>
               );
             })}
+            <AddonTab menuName={menuName} actions={actions} />
           </TabBar>
-          {tools ? <Fragment>{tools}</Fragment> : null}
-        </FlexBar>
+          {tools ? <Side right>{tools}</Side> : null}
+        </WrapperChildren>
         <Content id="panel-tab-content" bordered={bordered} absolute={absolute}>
           {list.map(({ id, active, render }) => render({ key: id, active }))}
         </Content>
@@ -203,6 +209,7 @@ export interface TabsStateProps {
   absolute: boolean;
   bordered: boolean;
   backgroundColor: string;
+  menuName: string;
 }
 
 export interface TabsStateState {
@@ -216,6 +223,7 @@ export class TabsState extends Component<TabsStateProps, TabsStateState> {
     absolute: false,
     bordered: false,
     backgroundColor: '',
+    menuName: undefined,
   };
 
   constructor(props: TabsStateProps) {
@@ -231,7 +239,7 @@ export class TabsState extends Component<TabsStateProps, TabsStateState> {
   };
 
   render() {
-    const { bordered = false, absolute = false, children, backgroundColor } = this.props;
+    const { bordered = false, absolute = false, children, backgroundColor, menuName } = this.props;
     const { selected } = this.state;
     return (
       <Tabs
@@ -239,6 +247,7 @@ export class TabsState extends Component<TabsStateProps, TabsStateState> {
         absolute={absolute}
         selected={selected}
         backgroundColor={backgroundColor}
+        menuName={menuName}
         actions={this.handlers}
       >
         {children}

--- a/code/ui/components/src/tabs/tabs.tsx
+++ b/code/ui/components/src/tabs/tabs.tsx
@@ -53,10 +53,6 @@ export const TabBar = styled.div({
   overflow: 'hidden',
   whiteSpace: 'nowrap',
   flexGrow: 1,
-
-  '&:first-of-type': {
-    marginLeft: -3,
-  },
 });
 
 export interface ContentProps {

--- a/code/ui/components/src/tabs/tabs.tsx
+++ b/code/ui/components/src/tabs/tabs.tsx
@@ -152,12 +152,12 @@ export const Tabs: FC<TabsProps> = memo(
       <Wrapper absolute={absolute} bordered={bordered} id={htmlId}>
         <WrapperChildren backgroundColor={backgroundColor}>
           <TabBar ref={tabBarRef} role="tablist">
-            {visibleList.map(({ title, id, active, color }, index) => {
+            {visibleList.map(({ title, id, active, color }) => {
               return (
                 <TabButton
                   id={`tabbutton-${sanitize(title)}`}
                   ref={(ref: HTMLButtonElement) => {
-                    tabRefs.current.set(title, ref);
+                    tabRefs.current.set(id, ref);
                   }}
                   className={`tabbutton ${active ? 'tabbutton-active' : ''}`}
                   type="button"

--- a/code/ui/components/src/tabs/tabs.tsx
+++ b/code/ui/components/src/tabs/tabs.tsx
@@ -120,7 +120,7 @@ export interface TabsProps {
   backgroundColor?: string;
   absolute?: boolean;
   bordered?: boolean;
-  menuName: string;
+  menuName?: string;
 }
 
 export const Tabs: FC<TabsProps> = memo(
@@ -184,13 +184,14 @@ export const Tabs: FC<TabsProps> = memo(
   }
 );
 Tabs.displayName = 'Tabs';
-(Tabs as any).defaultProps = {
+Tabs.defaultProps = {
   id: null,
   children: null,
   tools: null,
   selected: null,
   absolute: false,
   bordered: false,
+  menuName: 'Tabs',
 };
 
 type FuncChildren = ({ active }: { active: boolean }) => JSX.Element;

--- a/code/ui/components/src/tabs/tabs.tsx
+++ b/code/ui/components/src/tabs/tabs.tsx
@@ -51,9 +51,22 @@ const WrapperChildren = styled.div<{ backgroundColor: string }>(({ theme, backgr
 
 export const TabBar = styled.div({
   overflow: 'hidden',
+
+  '&:first-of-type': {
+    marginLeft: -3,
+  },
+
   whiteSpace: 'nowrap',
   flexGrow: 1,
 });
+
+const TabBarSide = styled(Side)({
+  flexGrow: 1,
+  flexShrink: 1,
+  maxWidth: '100%',
+});
+
+TabBar.displayName = 'TabBar';
 
 export interface ContentProps {
   absolute?: boolean;
@@ -147,31 +160,33 @@ export const Tabs: FC<TabsProps> = memo(
     return list.length ? (
       <Wrapper absolute={absolute} bordered={bordered} id={htmlId}>
         <WrapperChildren backgroundColor={backgroundColor}>
-          <TabBar ref={tabBarRef} role="tablist">
-            {visibleList.map(({ title, id, active, color }) => {
-              return (
-                <TabButton
-                  id={`tabbutton-${sanitize(title)}`}
-                  ref={(ref: HTMLButtonElement) => {
-                    tabRefs.current.set(id, ref);
-                  }}
-                  className={`tabbutton ${active ? 'tabbutton-active' : ''}`}
-                  type="button"
-                  key={id}
-                  active={active}
-                  textColor={color}
-                  onClick={(e: MouseEvent) => {
-                    e.preventDefault();
-                    actions.onSelect(id);
-                  }}
-                  role="tab"
-                >
-                  {title}
-                </TabButton>
-              );
-            })}
-            <AddonTab menuName={menuName} actions={actions} />
-          </TabBar>
+          <TabBarSide left>
+            <TabBar ref={tabBarRef} role="tablist">
+              {visibleList.map(({ title, id, active, color }) => {
+                return (
+                  <TabButton
+                    id={`tabbutton-${sanitize(title)}`}
+                    ref={(ref: HTMLButtonElement) => {
+                      tabRefs.current.set(id, ref);
+                    }}
+                    className={`tabbutton ${active ? 'tabbutton-active' : ''}`}
+                    type="button"
+                    key={id}
+                    active={active}
+                    textColor={color}
+                    onClick={(e: MouseEvent) => {
+                      e.preventDefault();
+                      actions.onSelect(id);
+                    }}
+                    role="tab"
+                  >
+                    {title}
+                  </TabButton>
+                );
+              })}
+              <AddonTab menuName={menuName} actions={actions} />
+            </TabBar>
+          </TabBarSide>
           {tools ? <Side right>{tools}</Side> : null}
         </WrapperChildren>
         <Content id="panel-tab-content" bordered={bordered} absolute={absolute}>

--- a/code/ui/components/src/tabs/tabs.tsx
+++ b/code/ui/components/src/tabs/tabs.tsx
@@ -153,13 +153,11 @@ export const Tabs: FC<TabsProps> = memo(
         <WrapperChildren backgroundColor={backgroundColor}>
           <TabBar ref={tabBarRef} role="tablist">
             {visibleList.map(({ title, id, active, color }, index) => {
-              const tabTitle = typeof title === 'function' ? title() : title;
-
               return (
                 <TabButton
-                  id={`tabbutton-${sanitize(tabTitle)}`}
+                  id={`tabbutton-${sanitize(title)}`}
                   ref={(ref: HTMLButtonElement) => {
-                    tabRefs.current.set(tabTitle, ref);
+                    tabRefs.current.set(title, ref);
                   }}
                   className={`tabbutton ${active ? 'tabbutton-active' : ''}`}
                   type="button"
@@ -172,7 +170,7 @@ export const Tabs: FC<TabsProps> = memo(
                   }}
                   role="tab"
                 >
-                  {tabTitle}
+                  {title}
                 </TabButton>
               );
             })}

--- a/code/ui/components/src/tabs/tabs.tsx
+++ b/code/ui/components/src/tabs/tabs.tsx
@@ -5,7 +5,7 @@ import { sanitize } from '@storybook/csf';
 
 import { Placeholder } from '../placeholder/placeholder';
 import { TabButton } from '../bar/button';
-import { FlexBar, Side } from '../bar/bar';
+import { FlexBar } from '../bar/bar';
 import type { ChildrenList } from './tabs.helpers';
 import { childrenToList, VisuallyHidden } from './tabs.helpers';
 import { useList } from './tabs.hooks';
@@ -170,7 +170,7 @@ export const Tabs: FC<TabsProps> = memo(
             })}
             <AddonTab menuName={menuName} actions={actions} />
           </TabBar>
-          {tools ? <Side right>{tools}</Side> : null}
+          {tools}
         </FlexBar>
         <Content id="panel-tab-content" bordered={bordered} absolute={absolute}>
           {list.map(({ id, active, render }) => render({ key: id, active }))}

--- a/code/ui/components/src/tooltip/ListItem.tsx
+++ b/code/ui/components/src/tooltip/ListItem.tsx
@@ -68,7 +68,7 @@ const Right = styled.span<RightProps>(
             opacity: 1,
           },
           '& path': {
-            fill: theme.color.primary,
+            fill: theme.color.secondary,
           },
         }
       : {}

--- a/code/ui/components/src/tooltip/ListItem.tsx
+++ b/code/ui/components/src/tooltip/ListItem.tsx
@@ -23,7 +23,7 @@ const Title = styled(({ active, loading, disabled, ...rest }: TitleProps) => <sp
   ({ active, theme }) =>
     active
       ? {
-          color: theme.color.primary,
+          color: theme.color.secondary,
           fontWeight: theme.typography.weight.bold,
         }
       : {},
@@ -97,7 +97,7 @@ const CenterText = styled.span<CenterTextProps>(
   ({ active, theme }) =>
     active
       ? {
-          color: theme.color.primary,
+          color: theme.color.secondary,
         }
       : {},
   ({ theme, disabled }) =>

--- a/code/ui/components/src/tooltip/Tooltip.tsx
+++ b/code/ui/components/src/tooltip/Tooltip.tsx
@@ -121,13 +121,17 @@ export interface TooltipProps {
   arrowProps?: any;
   placement?: string;
   color?: keyof Color;
+  withArrows?: boolean;
 }
 
 export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
-  ({ placement, hasChrome, children, arrowProps, tooltipRef, color, ...props }, ref) => {
+  (
+    { placement, hasChrome, children, arrowProps, tooltipRef, color, withArrows = true, ...props },
+    ref
+  ) => {
     return (
-      <Wrapper hasChrome={hasChrome} ref={ref} {...props} color={color}>
-        {hasChrome && <Arrow placement={placement} {...arrowProps} color={color} />}
+      <Wrapper data-testid="tooltip" hasChrome={hasChrome} ref={ref} {...props} color={color}>
+        {hasChrome && withArrows && <Arrow placement={placement} {...arrowProps} color={color} />}
         {children}
       </Wrapper>
     );

--- a/code/ui/components/src/tooltip/TooltipLinkList.tsx
+++ b/code/ui/components/src/tooltip/TooltipLinkList.tsx
@@ -29,7 +29,7 @@ export interface TooltipLinkListProps {
 }
 
 const Item: FC<TooltipLinkListProps['links'][number]> = (props) => {
-  const { LinkWrapper, onClick: onClickFromProps, ...rest } = props;
+  const { LinkWrapper, onClick: onClickFromProps, id, ...rest } = props;
   const { title, href, active } = rest;
   const onClick = useCallback(
     (event: SyntheticEvent) => {
@@ -45,6 +45,7 @@ const Item: FC<TooltipLinkListProps['links'][number]> = (props) => {
       title={title}
       active={active}
       href={href}
+      id={`list-item-${id}`}
       LinkWrapper={LinkWrapper}
       {...rest}
       {...(hasOnClick ? { onClick } : {})}

--- a/code/ui/components/src/tooltip/WithTooltip.stories.tsx
+++ b/code/ui/components/src/tooltip/WithTooltip.stories.tsx
@@ -112,7 +112,7 @@ export const SimpleClickCloseOnClick: StoryObj<ComponentProps<typeof WithTooltip
   args: {
     placement: 'top',
     trigger: 'click',
-    closeOnClick: true,
+    closeOnOutsideClick: true,
   },
   render: (args) => (
     <WithTooltip tooltip={<Tooltip />} {...args}>

--- a/code/ui/components/src/tooltip/WithTooltip.tsx
+++ b/code/ui/components/src/tooltip/WithTooltip.tsx
@@ -36,6 +36,18 @@ export interface WithTooltipPureProps
   children: ReactNode;
   onDoubleClick?: () => void;
   /**
+   * @deprecated use `defaultVisible` property instead. This property will be removed in SB 8.0
+   */
+  tooltipShown?: boolean;
+  /**
+   * @deprecated use `closeOnOutsideClick` property instead. This property will be removed in SB 8.0
+   */
+  closeOnClick?: boolean;
+  /**
+   * @deprecated use `onVisibleChange` property instead. This property will be removed in SB 8.0
+   */
+  onVisibilityChange?: (visibility: boolean) => void | boolean;
+  /**
    * If `true`, a click outside the trigger element closes the tooltip
    * @default false
    */
@@ -55,6 +67,9 @@ const WithTooltipPure: FC<WithTooltipPureProps> = ({
   children,
   closeOnTriggerHidden,
   mutationObserverOptions,
+  closeOnClick,
+  tooltipShown,
+  onVisibilityChange,
   defaultVisible,
   delayHide,
   visible,
@@ -78,12 +93,15 @@ const WithTooltipPure: FC<WithTooltipPureProps> = ({
     {
       trigger,
       placement,
-      defaultVisible,
+      defaultVisible: defaultVisible ?? tooltipShown,
       delayHide,
       interactive,
-      closeOnOutsideClick,
+      closeOnOutsideClick: closeOnOutsideClick ?? closeOnClick,
       closeOnTriggerHidden,
-      onVisibleChange,
+      onVisibleChange: (_isVisible) => {
+        onVisibilityChange?.(_isVisible);
+        onVisibleChange?.(_isVisible);
+      },
       delayShow,
       followCursor,
       mutationObserverOptions,

--- a/code/ui/components/src/tooltip/WithTooltip.tsx
+++ b/code/ui/components/src/tooltip/WithTooltip.tsx
@@ -4,90 +4,117 @@ import ReactDOM from 'react-dom';
 import { styled } from '@storybook/theming';
 import { global } from '@storybook/global';
 
-import type { TriggerType } from 'react-popper-tooltip';
+import type { Config as ReactPopperTooltipConfig, PopperOptions } from 'react-popper-tooltip';
 import { usePopperTooltip } from 'react-popper-tooltip';
-import type { Modifier, Placement } from '@popperjs/core';
 import { Tooltip } from './Tooltip';
 
 const { document } = global;
 
 // A target that doesn't speak popper
-const TargetContainer = styled.div<{ mode: string }>`
+const TargetContainer = styled.div<{ trigger: ReactPopperTooltipConfig['trigger'] }>`
   display: inline-block;
-  cursor: ${(props) => (props.mode === 'hover' ? 'default' : 'pointer')};
+  cursor: ${(props) =>
+    props.trigger === 'hover' || props.trigger.includes('hover') ? 'default' : 'pointer'};
 `;
 
-const TargetSvgContainer = styled.g<{ mode: string }>`
-  cursor: ${(props) => (props.mode === 'hover' ? 'default' : 'pointer')};
+const TargetSvgContainer = styled.g<{ trigger: ReactPopperTooltipConfig['trigger'] }>`
+  cursor: ${(props) =>
+    props.trigger === 'hover' || props.trigger.includes('hover') ? 'default' : 'pointer'};
 `;
 
 interface WithHideFn {
   onHide: () => void;
 }
 
-export interface WithTooltipPureProps {
+export interface WithTooltipPureProps
+  extends Omit<ReactPopperTooltipConfig, 'closeOnOutsideClick'>,
+    PopperOptions {
   svg?: boolean;
-  trigger?: TriggerType;
-  closeOnClick?: boolean;
-  placement?: Placement;
-  modifiers?: Array<Partial<Modifier<string, {}>>>;
+  withArrows?: boolean;
   hasChrome?: boolean;
   tooltip: ReactNode | ((p: WithHideFn) => ReactNode);
   children: ReactNode;
-  tooltipShown?: boolean;
-  onVisibilityChange?: (visibility: boolean) => void | boolean;
   onDoubleClick?: () => void;
+  /**
+   * If `true`, a click outside the trigger element closes the tooltip
+   * @default false
+   */
+  closeOnOutsideClick?: boolean;
 }
 
 // Pure, does not bind to the body
 const WithTooltipPure: FC<WithTooltipPureProps> = ({
   svg,
   trigger,
-  closeOnClick,
+  closeOnOutsideClick,
   placement,
-  modifiers,
   hasChrome,
+  withArrows,
+  offset,
   tooltip,
   children,
-  tooltipShown,
-  onVisibilityChange,
+  closeOnTriggerHidden,
+  mutationObserverOptions,
+  defaultVisible,
+  delayHide,
+  visible,
+  interactive,
+  delayShow,
+  modifiers,
+  strategy,
+  followCursor,
+  onVisibleChange,
   ...props
 }) => {
   const Container = svg ? TargetSvgContainer : TargetContainer;
-  const { getArrowProps, getTooltipProps, setTooltipRef, setTriggerRef, visible, state } =
-    usePopperTooltip(
-      {
-        trigger,
-        placement,
-        defaultVisible: tooltipShown,
-        closeOnOutsideClick: closeOnClick,
-        onVisibleChange: onVisibilityChange,
-      },
-      {
-        modifiers,
-      }
-    );
+  const {
+    getArrowProps,
+    getTooltipProps,
+    setTooltipRef,
+    setTriggerRef,
+    visible: isVisible,
+    state,
+  } = usePopperTooltip(
+    {
+      trigger,
+      placement,
+      defaultVisible,
+      delayHide,
+      interactive,
+      closeOnOutsideClick,
+      closeOnTriggerHidden,
+      onVisibleChange,
+      delayShow,
+      followCursor,
+      mutationObserverOptions,
+      visible,
+      offset,
+    },
+    {
+      modifiers,
+      strategy,
+    }
+  );
+
+  const tooltipComponent = (
+    <Tooltip
+      placement={state?.placement}
+      ref={setTooltipRef}
+      hasChrome={hasChrome}
+      arrowProps={getArrowProps()}
+      withArrows={withArrows}
+      {...getTooltipProps()}
+    >
+      {typeof tooltip === 'function' ? tooltip({ onHide: () => onVisibleChange(false) }) : tooltip}
+    </Tooltip>
+  );
 
   return (
     <>
-      <Container mode={trigger} ref={setTriggerRef as any} {...props}>
+      <Container trigger={trigger} ref={setTriggerRef as any} {...props}>
         {children}
       </Container>
-      {visible &&
-        ReactDOM.createPortal(
-          <Tooltip
-            placement={state?.placement}
-            ref={setTooltipRef}
-            hasChrome={hasChrome}
-            arrowProps={getArrowProps()}
-            {...getTooltipProps()}
-          >
-            {typeof tooltip === 'function'
-              ? tooltip({ onHide: () => onVisibilityChange(false) })
-              : tooltip}
-          </Tooltip>,
-          document.body
-        )}
+      {isVisible && ReactDOM.createPortal(tooltipComponent, document.body)}
     </>
   );
 };
@@ -95,7 +122,7 @@ const WithTooltipPure: FC<WithTooltipPureProps> = ({
 WithTooltipPure.defaultProps = {
   svg: false,
   trigger: 'hover',
-  closeOnClick: false,
+  closeOnOutsideClick: false,
   placement: 'top',
   modifiers: [
     {
@@ -118,17 +145,18 @@ WithTooltipPure.defaultProps = {
     },
   ],
   hasChrome: true,
-  tooltipShown: false,
+  defaultVisible: false,
 };
 
 const WithToolTipState: FC<
-  WithTooltipPureProps & {
+  Omit<WithTooltipPureProps, 'onVisibleChange'> & {
     startOpen?: boolean;
+    onVisibleChange?: (visible: boolean) => void | boolean;
   }
-> = ({ startOpen = false, onVisibilityChange: onChange, ...rest }) => {
+> = ({ startOpen = false, onVisibleChange: onChange, ...rest }) => {
   const [tooltipShown, setTooltipShown] = useState(startOpen);
-  const onVisibilityChange: (visibility: boolean) => void = useCallback(
-    (visibility) => {
+  const onVisibilityChange = useCallback(
+    (visibility: boolean) => {
       if (onChange && onChange(visibility) === false) return;
       setTooltipShown(visibility);
     },
@@ -176,11 +204,7 @@ const WithToolTipState: FC<
   });
 
   return (
-    <WithTooltipPure
-      {...rest}
-      tooltipShown={tooltipShown}
-      onVisibilityChange={onVisibilityChange}
-    />
+    <WithTooltipPure {...rest} defaultVisible={tooltipShown} onVisibleChange={onVisibilityChange} />
   );
 };
 

--- a/code/ui/components/tsconfig.json
+++ b/code/ui/components/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["react-syntax-highlighter", "jest"]
+    "types": ["react-syntax-highlighter", "jest", "testing-library__jest-dom"]
   },
   "include": ["src/**/*"]
 }

--- a/code/ui/manager/src/components/hooks/useMedia.tsx
+++ b/code/ui/manager/src/components/hooks/useMedia.tsx
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+const useMediaQuery = (query: string) => {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    if (media.matches !== matches) {
+      setMatches(media.matches);
+    }
+    const listener = () => setMatches(media.matches);
+    window.addEventListener('resize', listener);
+    return () => window.removeEventListener('resize', listener);
+  }, [matches, query]);
+
+  return matches;
+};
+
+export default useMediaQuery;

--- a/code/ui/manager/src/components/notifications/NotificationItem.tsx
+++ b/code/ui/manager/src/components/notifications/NotificationItem.tsx
@@ -106,7 +106,6 @@ const DismissButtonWrapper = styled(IconButton)(({ theme }) => ({
 const DismissNotificationItem: FC<{
   onDismiss: () => void;
 }> = ({ onDismiss }) => (
-  // @ts-expect-error (we need to improve the types of IconButton)
   <DismissButtonWrapper
     title="Dismiss notification"
     onClick={(e: SyntheticEvent) => {

--- a/code/ui/manager/src/components/panel/panel.stories.tsx
+++ b/code/ui/manager/src/components/panel/panel.stories.tsx
@@ -13,7 +13,7 @@ export default {
 };
 
 export const Default = () => {
-  const [selectedPanel, setSelectedPanel] = useState('test10');
+  const [selectedPanel, setSelectedPanel] = useState('test2');
   return (
     <Panel
       absolute={false}

--- a/code/ui/manager/src/components/panel/panel.stories.tsx
+++ b/code/ui/manager/src/components/panel/panel.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import Panel from './panel';
 import { panels, shortcuts } from '../layout/app.mockdata';
@@ -12,15 +12,18 @@ export default {
   component: Panel,
 };
 
-export const Default = () => (
-  <Panel
-    absolute={false}
-    panels={panels}
-    actions={{ onSelect, toggleVisibility, togglePosition }}
-    selectedPanel="test2"
-    shortcuts={shortcuts}
-  />
-);
+export const Default = () => {
+  const [selectedPanel, setSelectedPanel] = useState('test10');
+  return (
+    <Panel
+      absolute={false}
+      panels={panels}
+      actions={{ onSelect: setSelectedPanel, toggleVisibility, togglePosition }}
+      selectedPanel={selectedPanel}
+      shortcuts={shortcuts}
+    />
+  );
+};
 
 export const NoPanels = () => (
   <Panel

--- a/code/ui/manager/src/components/panel/panel.tsx
+++ b/code/ui/manager/src/components/panel/panel.tsx
@@ -67,6 +67,7 @@ const AddonPanel = React.memo<{
     <Tabs
       absolute={absolute}
       {...(selectedPanel ? { selected: selectedPanel } : {})}
+      menuName="Addons"
       actions={actions}
       tools={
         <Fragment>

--- a/code/ui/manager/src/components/panel/panel.tsx
+++ b/code/ui/manager/src/components/panel/panel.tsx
@@ -90,7 +90,7 @@ const AddonPanel = React.memo<{
       id="storybook-panel-root"
     >
       {Object.entries(panels).map(([k, v]) => (
-        <SafeTab key={k} id={k} title={v.title}>
+        <SafeTab key={k} id={k} title={typeof v.title === 'function' ? v.title() : v.title}>
           {v.render}
         </SafeTab>
       ))}

--- a/code/ui/manager/src/components/panel/panel.tsx
+++ b/code/ui/manager/src/components/panel/panel.tsx
@@ -1,16 +1,9 @@
 import type { ReactElement } from 'react';
 import React, { Component, Fragment } from 'react';
-import { styled } from '@storybook/theming';
 import { Tabs, Icons, IconButton } from '@storybook/components';
 import type { State } from '@storybook/manager-api';
 import { shortcutToHumanString } from '@storybook/manager-api';
-
-const DesktopOnlyIconButton = styled(IconButton)({
-  // Hides full screen icon at mobile breakpoint defined in app.js
-  '@media (max-width: 599px)': {
-    display: 'none',
-  },
-});
+import useMediaQuery from '../hooks/useMedia';
 
 export interface SafeTabProps {
   title: (() => string) | string;
@@ -63,39 +56,46 @@ const AddonPanel = React.memo<{
     selectedPanel = null,
     panelPosition = 'right',
     absolute = true,
-  }) => (
-    <Tabs
-      absolute={absolute}
-      {...(selectedPanel ? { selected: selectedPanel } : {})}
-      menuName="Addons"
-      actions={actions}
-      tools={
-        <Fragment>
-          <DesktopOnlyIconButton
-            key="position"
-            onClick={actions.togglePosition}
-            title={`Change addon orientation [${shortcutToHumanString(shortcuts.panelPosition)}]`}
-          >
-            <Icons icon={panelPosition === 'bottom' ? 'sidebaralt' : 'bottombar'} />
-          </DesktopOnlyIconButton>
-          <DesktopOnlyIconButton
-            key="visibility"
-            onClick={actions.toggleVisibility}
-            title={`Hide addons [${shortcutToHumanString(shortcuts.togglePanel)}]`}
-          >
-            <Icons icon="close" />
-          </DesktopOnlyIconButton>
-        </Fragment>
-      }
-      id="storybook-panel-root"
-    >
-      {Object.entries(panels).map(([k, v]) => (
-        <SafeTab key={k} id={k} title={typeof v.title === 'function' ? v.title() : v.title}>
-          {v.render}
-        </SafeTab>
-      ))}
-    </Tabs>
-  )
+  }) => {
+    const isTablet = useMediaQuery('(min-width: 599px)');
+    return (
+      <Tabs
+        absolute={absolute}
+        {...(selectedPanel ? { selected: selectedPanel } : {})}
+        menuName="Addons"
+        actions={actions}
+        tools={
+          isTablet ? (
+            <Fragment>
+              <IconButton
+                key="position"
+                onClick={actions.togglePosition}
+                title={`Change addon orientation [${shortcutToHumanString(
+                  shortcuts.panelPosition
+                )}]`}
+              >
+                <Icons icon={panelPosition === 'bottom' ? 'sidebaralt' : 'bottombar'} />
+              </IconButton>
+              <IconButton
+                key="visibility"
+                onClick={actions.toggleVisibility}
+                title={`Hide addons [${shortcutToHumanString(shortcuts.togglePanel)}]`}
+              >
+                <Icons icon="close" />
+              </IconButton>
+            </Fragment>
+          ) : undefined
+        }
+        id="storybook-panel-root"
+      >
+        {Object.entries(panels).map(([k, v]) => (
+          <SafeTab key={k} id={k} title={typeof v.title === 'function' ? v.title() : v.title}>
+            {v.render}
+          </SafeTab>
+        ))}
+      </Tabs>
+    );
+  }
 );
 
 AddonPanel.displayName = 'AddonPanel';

--- a/code/ui/manager/src/components/sidebar/Menu.tsx
+++ b/code/ui/manager/src/components/sidebar/Menu.tsx
@@ -104,7 +104,7 @@ export const SidebarMenu: FC<{
     <WithTooltip
       placement="top"
       trigger="click"
-      closeOnClick
+      closeOnOutsideClick
       tooltip={({ onHide }) => <SidebarMenuList onHide={onHide} menu={menu} />}
     >
       <SidebarIconButton title="Shortcuts" aria-label="Shortcuts" highlighted={isHighlighted}>
@@ -121,7 +121,7 @@ export const ToolbarMenu: FC<{
     <WithTooltip
       placement="bottom"
       trigger="click"
-      closeOnClick
+      closeOnOutsideClick
       modifiers={[
         {
           name: 'flip',

--- a/code/ui/manager/src/components/sidebar/RefBlocks.tsx
+++ b/code/ui/manager/src/components/sidebar/RefBlocks.tsx
@@ -170,7 +170,6 @@ export const ErrorBlock: FC<{ error: Error }> = ({ error }) => (
         <br />
         <WithTooltip
           trigger="click"
-          closeOnClick={false}
           tooltip={
             <ErrorDisplay>
               <ErrorFormatter error={error} />

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -3076,6 +3076,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@juggle/resize-observer@npm:^3.3.1":
+  version: 3.4.0
+  resolution: "@juggle/resize-observer@npm:3.4.0"
+  checksum: 12930242357298c6f2ad5d4ec7cf631dfb344ca7c8c830ab7f64e6ac11eb1aae486901d8d880fd08fb1b257800c160a0da3aee1e7ed9adac0ccbb9b7c5d93347
+  languageName: node
+  linkType: hard
+
 "@leichtgewicht/ip-codec@npm:^2.0.1":
   version: 2.0.4
   resolution: "@leichtgewicht/ip-codec@npm:2.0.4"
@@ -6018,6 +6025,7 @@ __metadata:
     react-textarea-autosize: ^8.3.0
     ts-dedent: ^2.0.0
     typescript: ~4.9.3
+    use-resize-observer: ^9.1.0
     util-deprecate: ^1.0.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -27842,6 +27850,18 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 1958886fc35262d973f5cd4ce16acd6ce3a66707a72761c93abd1b5ae64e1a11efa83f68e6c8c9bf1647628037980ce59df64cba50adb36bd4071851e70527d2
+  languageName: node
+  linkType: hard
+
+"use-resize-observer@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "use-resize-observer@npm:9.1.0"
+  dependencies:
+    "@juggle/resize-observer": ^3.3.1
+  peerDependencies:
+    react: 16.8.0 - 18
+    react-dom: 16.8.0 - 18
+  checksum: 6ccdeb09fe20566ec182b1635a22f189e13d46226b74610432590e69b31ef5d05d069badc3306ebd0d2bb608743b17981fb535763a1d7dc2c8ae462ee8e5999c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves https://github.com/storybookjs/storybook/issues/20829
Resolves https://github.com/storybookjs/storybook/issues/19989

See: https://www.notion.so/chromatic-ui/Storybook-7-0-UI-update-421d43aa8f9248b29c9dbfa3fdb25dd3#4e86aa0af1af46bab881bae4828a8fd7

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

I have improved the Addons Tabs by removing the horizontal scrolling. I have introduced an "Addons" Tooltip instead.

**Constraints:**

I also wanted to take care of smooth tab navigation for accessibility reasons. And although `react-popper-tooltip` supports `focus` triggers, it does not trigger the tooltip on tab focus. Additionally, it is not that easy to continue tabbing into the tooltip. To make that work, we would have to change the tooltip's DOM order a bit and add some tabIndex properties to the items. I tried a lot but failed to integrate tabbing across the tooltip boundary properly. Will invest some time at a later point to properly handle tabbing. 

Tabbing into the Tooltip is also blocked by: https://github.com/mohsinulhaq/react-popper-tooltip/issues/147


## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story
4. Reduce the Addons Panel's size and look at the Tabs. As soon as there is not enough space anymore, a new "Addons" Tab will appear, and the remaining Tabs are grouped within a Tooltip.

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
