### PR TITLE
CSF-tools: Fix ConfigFile string literal property handling

### DIFF
--- a/code/lib/csf-tools/src/ConfigFile.test.ts
+++ b/code/lib/csf-tools/src/ConfigFile.test.ts
@@ -769,11 +769,13 @@ describe('ConfigFile', () => {
 
           const config: StorybookConfig = {
             framework: { name: 'foo', options: { bar: require('baz') } },
+            "otherField": { "name": 'foo', options: { bar: require('baz') } },
           }
           export default config;
         `;
         const config = loadConfig(source).parse();
         expect(config.getNameFromPath(['framework'])).toEqual('foo');
+        expect(config.getNameFromPath(['otherField'])).toEqual('foo');
       });
 
       it(`returns undefined when accessing a field that does not exist`, () => {
@@ -812,12 +814,17 @@ describe('ConfigFile', () => {
             addons: [
               'foo',
               { name: 'bar', options: {} },
-            ]
+            ],
+            "otherField": [
+              "foo",
+              { "name": 'bar', options: {} },
+            ],
           }
           export default config;
         `;
         const config = loadConfig(source).parse();
         expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
+        expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
       });
     });
 

--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -315,6 +315,7 @@ export class ConfigFile {
       value = node.value;
     } else if (t.isObjectExpression(node)) {
       node.properties.forEach((prop) => {
+        // { framework: { name: 'value' } }
         if (
           t.isObjectProperty(prop) &&
           t.isIdentifier(prop.key) &&
@@ -323,6 +324,16 @@ export class ConfigFile {
           if (t.isStringLiteral(prop.value)) {
             value = prop.value.value;
           }
+        }
+
+        // { "framework": { "name": "value" } }
+        if (
+          t.isObjectProperty(prop) &&
+          t.isStringLiteral(prop.key) &&
+          prop.key.value === 'name' &&
+          t.isStringLiteral(prop.value)
+        ) {
+          value = prop.value.value;
         }
       });
     }


### PR DESCRIPTION
Issue: N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

I noticed that some automigrations were failing in the [sandboxes](https://github.com/storybookjs/sandboxes/blob/next/angular-cli/14-ts/after-storybook/migration-storybook.log) repo (yay automigration.log file), and the reason is that the generated main.js contains a format which was unsupported in the new `getNameFromPath` function in csf-tools. This PR fixes that.

## How to test

This is covered in unit tests, but feel free to compile CLI and run `sb automigrate` in a sandbox

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
