### PR TITLE
Vite: Do not pre-bundle @vitejs/plugin-vue

### DIFF
--- a/code/frameworks/vue3-vite/package.json
+++ b/code/frameworks/vue3-vite/package.json
@@ -51,12 +51,12 @@
     "@storybook/builder-vite": "7.0.0-beta.34",
     "@storybook/core-server": "7.0.0-beta.34",
     "@storybook/vue3": "7.0.0-beta.34",
+    "@vitejs/plugin-vue": "^4.0.0",
     "magic-string": "^0.26.1",
     "vue-docgen-api": "^4.40.0"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
-    "@vitejs/plugin-vue": "^4.0.0",
     "typescript": "~4.9.3",
     "vite": "^4.0.0"
   },
@@ -75,11 +75,6 @@
     "entries": [
       "./src/index.ts",
       "./src/preset.ts"
-    ],
-    "externals": [
-      "util",
-      "tty",
-      "path"
     ],
     "platform": "node"
   },


### PR DESCRIPTION
Issue: #20583


## What I did

Reverts https://github.com/storybookjs/storybook/pull/20343.  This package is not bundle-able, due to its use of `import.meta.env` here: https://github.com/vitejs/vite-plugin-vue/blob/eef8929c95d8b5cce1385a1d5e60da56a8420c0b/packages/plugin-vue/src/compiler.ts#L27.  See https://github.com/evanw/esbuild/issues/2249 for some explanation of why this is not able to be bundled.  

I don't know what exact situation https://github.com/storybookjs/storybook/pull/20343 was attempting to fix, but presumably that will start to be a problem again.  I think we can live with it if it's just a version conflict warning.

## How to test

Create a vue3 sandbox, delete the `vite.config.js` file, start storybook.  Previously it would crash, and now it should work fine.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [X] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
