### PR TITLE
CLI: Fix new-frameworks automigration in angular projects

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.test.ts
@@ -91,6 +91,18 @@ describe('new-frameworks fix', () => {
       ).resolves.toBeFalsy();
     });
 
+    it('in sb 7 with correct structure already', async () => {
+      const packageJson = { dependencies: { '@storybook/angular': '^7.0.0' } };
+      await expect(
+        checkNewFrameworks({
+          packageJson,
+          main: {
+            framework: '@storybook/angular',
+          },
+        })
+      ).resolves.toBeFalsy();
+    });
+
     // TODO: once we have a @storybook/vue-vite framework, we should remove this test
     it('in sb 7 with vue and vite', async () => {
       const packageJson = {

--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
@@ -183,6 +183,10 @@ export const newFrameworks: Fix<NewFrameworkRunOptions> = {
       `);
     }
 
+    if (!dependenciesToRemove.length && !dependenciesToAdd.length) {
+      return null;
+    }
+
     return {
       main,
       dependenciesToAdd,


### PR DESCRIPTION
Issue: N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

`new-frameworks` automigration was getting triggered unnecessarily in angular projects. This PR makes it only get applied if any dependency is to be added and/or removed. If there are none, then the automigration doesn't need to do anything.

## How to test

It's covered in the tests, but:

1. Run a sandbox for template for angular, e.g. `yarn task --task sandbox --start-from auto --template angular-cli/default-ts`
2. Run sb automigrate newFrameworks
3. It should NOT prompt for newFrameworks


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
