### PR TITLE
CLI: generate main config with default exports

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,7 @@
 - [From version 6.5.x to 7.0.0](#from-version-65x-to-700)
   - [7.0 breaking changes](#70-breaking-changes)
     - [Dropped support for Node 15 and below](#dropped-support-for-node-15-and-below)
+    - [ESM format in Main.js](#esm-format-in-mainjs)
     - [Modern browser support](#modern-browser-support)
     - [React peer dependencies required](#react-peer-dependencies-required)
     - [start-storybook / build-storybook binaries removed](#start-storybook--build-storybook-binaries-removed)
@@ -289,6 +290,48 @@ For avoiding that, this change passes the mapped args instead of raw args at `re
 #### Dropped support for Node 15 and below
 
 Storybook 7.0 requires **Node 16** or above. If you are using an older version of Node, you will need to upgrade or keep using Storybook 6 in the meantime.
+
+#### ESM format in Main.js
+
+Storybook 7.0 supports ESM in `.storybook/main.js`, and the configurations can be part of a default export. The default export will be the recommended way going forward.
+
+If your main.js file looks like this:
+
+```js
+module.exports = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  framework: { name: '@storybook/react-vite' },
+};
+```
+
+Or like this:
+
+```js
+export const stories = ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'];
+export const framework = { name: '@storybook/react-vite' };
+```
+
+Please migrate them to be default exported instead:
+
+```js
+const config = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  framework: { name: '@storybook/react-vite' },
+};
+export default config;
+```
+
+For Typescript users, we introduced types for that default export, so you can import it in your main.ts file. The `StorybookConfig` type will come from the Storybook package for the framework you are using, which relates to the package in the "framework" field you have in your main.ts file. For example, if you are using React Vite, you will import it from `@storybook/react-vite`:
+
+```ts
+import { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  framework: { name: '@storybook/react-vite' },
+};
+export default config;
+```
 
 #### Modern browser support
 

--- a/code/lib/cli/src/generators/ANGULAR/index.ts
+++ b/code/lib/cli/src/generators/ANGULAR/index.ts
@@ -56,12 +56,15 @@ const generator: Generator<{ projectName: string }> = async (
       .join('');
 
     fs.writeFileSync(
-      `${storybookFolder}/main.js`,
+      `${storybookFolder}/main.ts`,
       dedent(`
-        const mainRoot = require('${rootReferencePathFromStorybookFolder}../.storybook/main.js');
-        module.exports = {
+        import { StorybookConfig } from'@storybook/angular';
+        import mainRoot from'${rootReferencePathFromStorybookFolder}../.storybook/main';
+        
+        const config: StorybookConfig = {
           ...mainRoot
         };
+        export default config;
       `)
     );
   }

--- a/code/lib/cli/src/generators/SVELTE/index.ts
+++ b/code/lib/cli/src/generators/SVELTE/index.ts
@@ -4,7 +4,6 @@ import type { Generator } from '../types';
 const generator: Generator = async (packageManager, npmOptions, options) => {
   await baseGenerator(packageManager, npmOptions, options, 'svelte', {
     extensions: ['js', 'jsx', 'ts', 'tsx', 'svelte'],
-    commonJs: true,
   });
 };
 

--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -243,7 +243,7 @@ export async function baseGenerator(
     });
   }
 
-  await configurePreview({ frameworkPreviewParts, storybookConfigFolder });
+  await configurePreview({ frameworkPreviewParts, storybookConfigFolder, language });
 
   // FIXME: temporary workaround for https://github.com/storybookjs/storybook/issues/17516
   if (

--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -229,6 +229,7 @@ export async function baseGenerator(
       docs: { autodocs: 'tag' },
       addons: pnp ? addons.map(wrapForPnp) : addons,
       extensions,
+      language,
       commonJs,
       ...(staticDir ? { staticDirs: [path.join('..', staticDir)] } : null),
       ...extraMain,

--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -25,7 +25,6 @@ const defaultOptions: FrameworkOptions = {
   framework: undefined,
   extensions: undefined,
   componentsDestinationPath: undefined,
-  commonJs: false,
   storybookConfigFolder: '.storybook',
 };
 
@@ -123,13 +122,7 @@ const hasFrameworkTemplates = (framework?: SupportedFrameworks) =>
 export async function baseGenerator(
   packageManager: JsPackageManager,
   npmOptions: NpmOptions,
-  {
-    language,
-    builder = CoreBuilder.Webpack5,
-    pnp,
-    commonJs,
-    frameworkPreviewParts,
-  }: GeneratorOptions,
+  { language, builder = CoreBuilder.Webpack5, pnp, frameworkPreviewParts }: GeneratorOptions,
   renderer: SupportedRenderers,
   options: FrameworkOptions = defaultOptions,
   framework?: SupportedFrameworks
@@ -230,7 +223,6 @@ export async function baseGenerator(
       addons: pnp ? addons.map(wrapForPnp) : addons,
       extensions,
       language,
-      commonJs,
       ...(staticDir ? { staticDirs: [path.join('..', staticDir)] } : null),
       ...extraMain,
       ...(type !== 'framework'

--- a/code/lib/cli/src/generators/configure.ts
+++ b/code/lib/cli/src/generators/configure.ts
@@ -8,6 +8,7 @@ interface ConfigureMainOptions {
   commonJs?: boolean;
   staticDirs?: string[];
   storybookConfigFolder: string;
+  language: SupportedLanguage;
   /**
    * Extra values for main.js
    *
@@ -27,6 +28,7 @@ export interface FrameworkPreviewParts {
 interface ConfigurePreviewOptions {
   frameworkPreviewParts?: FrameworkPreviewParts;
   storybookConfigFolder: string;
+  language: SupportedLanguage;
 }
 
 export async function configureMain({
@@ -70,8 +72,12 @@ export async function configureMain({
 }
 
 export async function configurePreview(options: ConfigurePreviewOptions) {
-  const { prefix = '' } = options?.frameworkPreviewParts || {};
-  const previewPath = `./${options.storybookConfigFolder}/preview.js`;
+  const { prefix = '' } = options.frameworkPreviewParts || {};
+  const isTypescript =
+    options.language === SupportedLanguage.TYPESCRIPT ||
+    options.language === SupportedLanguage.TYPESCRIPT_LEGACY;
+
+  const previewPath = `./${options.storybookConfigFolder}/preview.${isTypescript ? 'ts' : 'js'}`;
 
   // If the framework template included a preview then we have nothing to do
   if (await fse.pathExists(previewPath)) {

--- a/code/lib/cli/src/generators/configure.ts
+++ b/code/lib/cli/src/generators/configure.ts
@@ -50,8 +50,7 @@ export async function configureMain({
   const tsTemplate = dedent`<<import>>const config<<type>> = <<mainContents>>;
   export default config;`;
 
-  const jsTemplate = dedent`const config = <<mainContents>>
-  export default config;`;
+  const jsTemplate = dedent`export default <<mainContents>>;`;
 
   const finalTemplate = isTypescript ? tsTemplate : jsTemplate;
 
@@ -62,9 +61,7 @@ export async function configureMain({
 
   await fse.writeFile(
     `./${storybookConfigFolder}/main.${isTypescript ? 'ts' : 'js'}`,
-    dedent`
-      ${mainJsContents}
-    `,
+    dedent(mainJsContents),
     { encoding: 'utf8' }
   );
 }

--- a/code/lib/cli/src/generators/configure.ts
+++ b/code/lib/cli/src/generators/configure.ts
@@ -5,7 +5,6 @@ import { SupportedLanguage } from '../project_types';
 interface ConfigureMainOptions {
   addons: string[];
   extensions?: string[];
-  commonJs?: boolean;
   staticDirs?: string[];
   storybookConfigFolder: string;
   language: SupportedLanguage;
@@ -34,7 +33,6 @@ interface ConfigurePreviewOptions {
 export async function configureMain({
   addons,
   extensions = ['js', 'jsx', 'ts', 'tsx'],
-  commonJs = false,
   storybookConfigFolder,
   language,
   ...custom

--- a/code/lib/cli/src/generators/types.ts
+++ b/code/lib/cli/src/generators/types.ts
@@ -9,7 +9,6 @@ export type GeneratorOptions = {
   builder: Builder;
   linkable: boolean;
   pnp: boolean;
-  commonJs: boolean;
   frameworkPreviewParts?: FrameworkPreviewParts;
 };
 
@@ -25,7 +24,6 @@ export interface FrameworkOptions {
   extraMain?: any;
   extensions?: string[];
   framework?: Record<string, any>;
-  commonJs?: boolean;
   storybookConfigFolder?: string;
   componentsDestinationPath?: string;
 }
@@ -50,7 +48,6 @@ export type CommandOptions = {
   yes?: boolean;
   builder?: Builder;
   linkable?: boolean;
-  commonJs?: boolean;
   disableTelemetry?: boolean;
   enableCrashReports?: boolean;
   debug?: boolean;

--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -61,7 +61,6 @@ const installStorybook = <Project extends ProjectType>(
     language,
     builder: options.builder || detectBuilder(packageManager),
     linkable: !!options.linkable,
-    commonJs: options.commonJs,
     pnp: options.usePnp,
   };
 
@@ -294,7 +293,6 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
   const done = commandLog(infoText);
 
   const packageJson = packageManager.retrievePackageJson();
-  const isEsm = packageJson && packageJson.type === 'module';
 
   try {
     if (projectTypeProvided) {
@@ -329,10 +327,11 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
     return;
   }
 
-  const installResult = await installStorybook(projectType as ProjectType, packageManager, {
-    ...options,
-    ...(isEsm ? { commonJs: true } : undefined),
-  }).catch((e) => {
+  const installResult = await installStorybook(
+    projectType as ProjectType,
+    packageManager,
+    options
+  ).catch((e) => {
     process.exit();
   });
 

--- a/code/lib/cli/templates/angular/template-csf/.storybook/tsconfig.json
+++ b/code/lib/cli/templates/angular/template-csf/.storybook/tsconfig.json
@@ -5,6 +5,6 @@
     "allowSyntheticDefaultImports": true
   },
   "exclude": ["../src/test.ts", "../src/**/*.spec.ts"],
-  "include": ["../src/**/*"],
+  "include": ["../src/**/*", "./preview.ts"],
   "files": ["./typings.d.ts"]
 }

--- a/code/lib/cli/templates/angular/template-csf/.storybook/tsconfig.json
+++ b/code/lib/cli/templates/angular/template-csf/.storybook/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.app.json",
   "compilerOptions": {
     "types": ["node"],
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
   },
   "exclude": ["../src/test.ts", "../src/**/*.spec.ts"],
   "include": ["../src/**/*", "./preview.ts"],


### PR DESCRIPTION
Issue: #20554 

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

The format of `main.js` coming from Storybook's `init` command changes from:
```js
module.exports = {
  "stories": [
    "../src/**/*.mdx",
    "../src/**/*.stories.@(js|jsx|ts|tsx)"
  ],
  "addons": [
    "@storybook/addon-links",
    "@storybook/addon-essentials",
    "@storybook/addon-interactions"
  ],
  "framework": {
    "name": "@storybook/react-webpack5",
    "options": {}
  },
  "docs": {
    "autodocs": "tag"
  }
};
```

to 
```js
export default {
  "stories": [
    "../src/**/*.mdx",
    "../src/**/*.stories.@(js|jsx|ts|tsx)"
  ],
  "addons": [
    "@storybook/addon-links",
    "@storybook/addon-essentials",
    "@storybook/addon-interactions"
  ],
  "framework": {
    "name": "@storybook/react-vite",
    "options": {}
  },
  "docs": {
    "autodocs": "tag"
  }
};
```

Additionally, it will generate `main.ts` and `preview.ts` in typescript projects, always importing from the framework which the CLI generates the project with:
```js
import { StorybookConfig } from '@storybook/react-webpack5';

const config: StorybookConfig = {
  "stories": [
    "../src/**/*.mdx",
    "../src/**/*.stories.@(js|jsx|ts|tsx)"
  ],
  "addons": [
    "@storybook/addon-links",
    "@storybook/addon-essentials",
    "@storybook/addon-interactions"
  ],
  "framework": {
    "name": "@storybook/react-webpack5",
    "options": {}
  },
  "docs": {
    "autodocs": "tag"
  }
};
export default config;
```

## How to test


1. Bootstrap the packages with `yarn task`
2. Check a project that does not have Storybook, e.g. any of the `before-storybook` directories here: https://github.com/storybookjs/sandboxes
3. Run `sb init` using the built library from this branch, in the directory of that project: `<path-to-storybook>/code/lib/cli/bin/index.js init`
4. Check whether `main` and `preview` files got generated correctly
5. Check whether Storybook runs fine

#### Special scenarios, apart from the basic ones:
1. Angular. There is the generation of main.ts in the higher level of a single-project angular workspace, but there's also the generation of main.ts in a lower level of a multi-project angular workspace. There were more changes for angular as it involved improving the generated `tsconfig` file under `.storybook` dir
2. Svelte(kit). Before, we were forced to generate a `main.cjs` for compatibility purposes. I removed that logic and it should behave like any other project.


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
