### PR TITLE
Sveltekit: Ensure SSR is disabled

### DIFF
--- a/code/frameworks/sveltekit/src/plugins/config-overrides.ts
+++ b/code/frameworks/sveltekit/src/plugins/config-overrides.ts
@@ -1,0 +1,15 @@
+import type { Plugin } from 'vite';
+
+export function configOverrides() {
+  return {
+    name: 'storybook:sveltekit-overrides',
+    config: (conf) => {
+      // Some versions of sveltekit set ssr, we need it to be false
+      if (conf.build?.ssr) {
+        // eslint-disable-next-line no-param-reassign
+        conf.build.ssr = false;
+      }
+      return conf;
+    },
+  } satisfies Plugin;
+}

--- a/code/frameworks/sveltekit/src/preset.ts
+++ b/code/frameworks/sveltekit/src/preset.ts
@@ -2,6 +2,7 @@
 import { viteFinal as svelteViteFinal } from '@storybook/svelte-vite/preset';
 import type { PresetProperty } from '@storybook/types';
 import { withoutVitePlugins } from '@storybook/builder-vite';
+import { configOverrides } from './plugins/config-overrides';
 import { type StorybookConfig } from './types';
 
 export const core: PresetProperty<'core', StorybookConfig> = {
@@ -16,10 +17,12 @@ export const viteFinal: NonNullable<StorybookConfig['viteFinal']> = async (confi
 
   // Remove vite-plugin-svelte-kit from plugins if using SvelteKit
   // see https://github.com/storybookjs/storybook/issues/19280#issuecomment-1281204341
-  plugins = await withoutVitePlugins(plugins, [
-    // @sveltejs/kit@1.0.0-next.587 and later
-    'vite-plugin-sveltekit-compile',
-  ]);
+  plugins = (
+    await withoutVitePlugins(plugins, [
+      // @sveltejs/kit@1.0.0-next.587 and later
+      'vite-plugin-sveltekit-compile',
+    ])
+  ).concat(configOverrides());
 
   return { ...baseConfig, plugins };
 };


### PR DESCRIPTION
Issue: #

Sveltekit recently made a [change](https://github.com/sveltejs/kit/pull/8636) which stopped setting `build.ssr` to `false`, and it is instead now `true` because of https://github.com/sveltejs/kit/blob/ead8fa8f8b7dd7fb73bdd1a6a2c3c2172162a25d/packages/kit/src/exports/vite/index.js#L254.  This causes Vite to throw an error:

```
info => Manager built (78 ms)

vite v4.0.4 building SSR bundle for production...

ERR! Error: rollupOptions.input should not be an html file when building for SSR. Please specify a dedicated SSR entry.
ERR!     at doBuild (file:///Users/jeppe/dev/chromatic/sk-sb-70fail/node_modules/vite/dist/node/chunks/dep-5e7f419b.js:44378:15)
ERR!     at async Module.build (file:///Users/jeppe/dev/chromatic/sk-sb-70fail/node_modules/vite/dist/node/chunks/dep-5e7f419b.js:44347:16)
ERR!     at build (/Users/jeppe/dev/chromatic/sk-sb-70fail/node_modules/@storybook/builder-vite/dist/index.js:162:8154)
```

## What I did

We can't set `build.ssr` to `false` in builder-vite, because then sveltekit will overwrite it.  So we need to use a plugin that's loaded _after_ the sveltekit plugin, which resets `build.ssr` to false, which is what I've done here.

The other option would be for sveltekit to move this config into their `vite-plugin-sveltekit-compile` plugin, but there may be internal pushback against that from the sveltekit team.

## How to test

If the sveltekit sandbox builds, we're good to go.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [X] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [X] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
