### PR TITLE
Outline: Fix outline initial state

### DIFF
--- a/code/addons/outline/src/OutlineSelector.tsx
+++ b/code/addons/outline/src/OutlineSelector.tsx
@@ -7,7 +7,7 @@ export const OutlineSelector = memo(function OutlineSelector() {
   const [globals, updateGlobals] = useGlobals();
   const api = useStorybookApi();
 
-  const isActive = globals[PARAM_KEY] || false;
+  const isActive = [true, 'true'].includes(globals[PARAM_KEY]);
 
   const toggleOutline = useCallback(
     () =>

--- a/code/addons/outline/src/withOutline.ts
+++ b/code/addons/outline/src/withOutline.ts
@@ -7,7 +7,7 @@ import outlineCSS from './outlineCSS';
 
 export const withOutline = (StoryFn: StoryFunction<Renderer>, context: StoryContext<Renderer>) => {
   const { globals } = context;
-  const isActive = globals[PARAM_KEY] || false;
+  const isActive = [true, 'true'].includes(globals[PARAM_KEY]);
   const isInDocs = context.viewMode === 'docs';
 
   const outlineStyles = useMemo(() => {

--- a/code/addons/outline/src/withOutline.ts
+++ b/code/addons/outline/src/withOutline.ts
@@ -7,7 +7,7 @@ import outlineCSS from './outlineCSS';
 
 export const withOutline = (StoryFn: StoryFunction<Renderer>, context: StoryContext<Renderer>) => {
   const { globals } = context;
-  const isActive = globals[PARAM_KEY] === true;
+  const isActive = globals[PARAM_KEY] || false;
   const isInDocs = context.viewMode === 'docs';
 
   const outlineStyles = useMemo(() => {


### PR DESCRIPTION
`context.globals` is 'true' string while storybook is initialing.

Issue: #

outline state wouldn't restore from globals query like this: `/?path=/story/xxxx&globals=outline:true`.
`context.globals.outline` is `string` true instead of `boolean` true.

## What I did

use `const isActive = globals[PARAM_KEY] || false;` would fix this.

## How to test

1. Turn on outline addon.
2. Reload storybook.

## Checklist


- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
