### PR TITLE
CLI: Install prerelease of @storybook/testing-library in CLI starters

### DIFF
--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -176,7 +176,10 @@ export async function baseGenerator(
 
   if (hasInteractiveStories(rendererId)) {
     addons.push('@storybook/addon-interactions');
-    addonPackages.push('@storybook/addon-interactions', '@storybook/testing-library@next');
+    addonPackages.push(
+      '@storybook/addon-interactions',
+      '@storybook/testing-library@^0.0.14-next.1'
+    );
   }
 
   const files = await fse.readdir(process.cwd());

--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -176,7 +176,7 @@ export async function baseGenerator(
 
   if (hasInteractiveStories(rendererId)) {
     addons.push('@storybook/addon-interactions');
-    addonPackages.push('@storybook/addon-interactions', '@storybook/testing-library');
+    addonPackages.push('@storybook/addon-interactions', '@storybook/testing-library@next');
   }
 
   const files = await fse.readdir(process.cwd());


### PR DESCRIPTION
Issue: #

An older, incompatible version of `@storybook/testing-react` was being installed into 7.0 projects, which came along with old storybook dependencies like `@storybook/api@6.5`

## What I did

I made sure that we install the `next` version of `@storybook/testing-library`.

This saves ~6mb of dependencies in an installed project.  

## How to test

I'm not sure.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [X] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
