### PR TITLE
Instrumenter: Remove unused core-js dependency

### DIFF
--- a/code/lib/instrumenter/package.json
+++ b/code/lib/instrumenter/package.json
@@ -47,8 +47,7 @@
     "@storybook/client-logger": "7.0.0-beta.36",
     "@storybook/core-events": "7.0.0-beta.36",
     "@storybook/global": "^5.0.0",
-    "@storybook/preview-api": "7.0.0-beta.36",
-    "core-js": "^3.8.2"
+    "@storybook/preview-api": "7.0.0-beta.36"
   },
   "devDependencies": {
     "typescript": "~4.9.3"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6349,7 +6349,6 @@ __metadata:
     "@storybook/core-events": 7.0.0-beta.36
     "@storybook/global": ^5.0.0
     "@storybook/preview-api": 7.0.0-beta.36
-    core-js: ^3.8.2
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Issue: #

We are adding `core-js` to user's node_modules, and it's a large dependency (~14MB).  

## What I did

Instrumenter was adding it as a dependency, but it's not actually used anywhere in the code, and it should be up to the user to decide if they want to add polyfills.

## How to test

CI should continue to run successfully.  There is one more change needed in order to avoid adding it during installation: https://github.com/storybookjs/lazy-universal-dotenv/pull/2

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [X] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
