### PR TITLE
Deps: Upgrade magic-string to 0.27.0

### DIFF
--- a/code/frameworks/html-vite/package.json
+++ b/code/frameworks/html-vite/package.json
@@ -57,7 +57,7 @@
     "@storybook/html": "7.0.0-beta.36",
     "@storybook/node-logger": "7.0.0-beta.36",
     "@storybook/preview-web": "7.0.0-beta.36",
-    "magic-string": "^0.26.1"
+    "magic-string": "^0.27.0"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -54,7 +54,7 @@
     "@storybook/react": "7.0.0-beta.36",
     "@vitejs/plugin-react": "^3.0.1",
     "ast-types": "^0.14.2",
-    "magic-string": "^0.26.1",
+    "magic-string": "^0.27.0",
     "react-docgen": "6.0.0-alpha.3"
   },
   "devDependencies": {

--- a/code/frameworks/svelte-vite/package.json
+++ b/code/frameworks/svelte-vite/package.json
@@ -52,7 +52,7 @@
     "@storybook/node-logger": "7.0.0-beta.36",
     "@storybook/svelte": "7.0.0-beta.36",
     "@sveltejs/vite-plugin-svelte": "^2.0.0",
-    "magic-string": "^0.26.1",
+    "magic-string": "^0.27.0",
     "svelte": "^3.0.0",
     "sveltedoc-parser": "^4.2.1",
     "ts-dedent": "^2.2.0"

--- a/code/frameworks/vue-vite/package.json
+++ b/code/frameworks/vue-vite/package.json
@@ -52,7 +52,7 @@
     "@storybook/core-common": "7.0.0-beta.36",
     "@storybook/core-server": "7.0.0-beta.36",
     "@storybook/vue": "7.0.0-beta.36",
-    "magic-string": "^0.26.1",
+    "magic-string": "^0.27.0",
     "vue-docgen-api": "^4.40.0"
   },
   "devDependencies": {

--- a/code/frameworks/vue3-vite/package.json
+++ b/code/frameworks/vue3-vite/package.json
@@ -52,7 +52,7 @@
     "@storybook/core-server": "7.0.0-beta.36",
     "@storybook/vue3": "7.0.0-beta.36",
     "@vitejs/plugin-vue": "^4.0.0",
-    "magic-string": "^0.26.1",
+    "magic-string": "^0.27.0",
     "vue-docgen-api": "^4.40.0"
   },
   "devDependencies": {

--- a/code/frameworks/web-components-vite/package.json
+++ b/code/frameworks/web-components-vite/package.json
@@ -52,7 +52,7 @@
     "@storybook/core-server": "7.0.0-beta.36",
     "@storybook/node-logger": "7.0.0-beta.36",
     "@storybook/web-components": "7.0.0-beta.36",
-    "magic-string": "^0.26.1"
+    "magic-string": "^0.27.0"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",

--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -59,7 +59,7 @@
     "fs-extra": "^11.1.0",
     "glob": "^7.2.0",
     "glob-promise": "^4.2.0",
-    "magic-string": "^0.26.1",
+    "magic-string": "^0.27.0",
     "rollup": "^2.25.0 || ^3.3.0",
     "slash": "^3.0.0"
   },

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5774,7 +5774,7 @@ __metadata:
     fs-extra: ^11.1.0
     glob: ^7.2.0
     glob-promise: ^4.2.0
-    magic-string: ^0.26.1
+    magic-string: ^0.27.0
     rollup: ^3.0.0
     slash: ^3.0.0
     typescript: ~4.9.3
@@ -6286,7 +6286,7 @@ __metadata:
     "@storybook/node-logger": 7.0.0-beta.36
     "@storybook/preview-web": 7.0.0-beta.36
     "@types/node": ^16.0.0
-    magic-string: ^0.26.1
+    magic-string: ^0.27.0
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft
@@ -6837,7 +6837,7 @@ __metadata:
     "@types/node": ^16.0.0
     "@vitejs/plugin-react": ^3.0.1
     ast-types: ^0.14.2
-    magic-string: ^0.26.1
+    magic-string: ^0.27.0
     react-docgen: 6.0.0-alpha.3
     typescript: ~4.9.3
     vite: ^4.0.0
@@ -7185,7 +7185,7 @@ __metadata:
     "@storybook/svelte": 7.0.0-beta.36
     "@sveltejs/vite-plugin-svelte": ^2.0.0
     "@types/node": ^16.0.0
-    magic-string: ^0.26.1
+    magic-string: ^0.27.0
     svelte: ^3.0.0
     sveltedoc-parser: ^4.2.1
     ts-dedent: ^2.2.0
@@ -7333,7 +7333,7 @@ __metadata:
     "@storybook/core-common": 7.0.0-beta.36
     "@storybook/core-server": 7.0.0-beta.36
     "@storybook/vue": 7.0.0-beta.36
-    magic-string: ^0.26.1
+    magic-string: ^0.27.0
     typescript: ~4.9.3
     vite: ^4.0.0
     vue: ^2.7.10
@@ -7380,7 +7380,7 @@ __metadata:
     "@storybook/vue3": 7.0.0-beta.36
     "@types/node": ^16.0.0
     "@vitejs/plugin-vue": ^4.0.0
-    magic-string: ^0.26.1
+    magic-string: ^0.27.0
     typescript: ~4.9.3
     vite: ^4.0.0
     vue-docgen-api: ^4.40.0
@@ -7470,7 +7470,7 @@ __metadata:
     "@storybook/node-logger": 7.0.0-beta.36
     "@storybook/web-components": 7.0.0-beta.36
     "@types/node": ^16.0.0
-    magic-string: ^0.26.1
+    magic-string: ^0.27.0
     typescript: ~4.9.3
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -20062,7 +20062,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.26.1, magic-string@npm:^0.26.7":
+"magic-string@npm:^0.26.7":
   version: 0.26.7
   resolution: "magic-string@npm:0.26.7"
   dependencies:


### PR DESCRIPTION
Following #20698, [some users reported an error thrown around Magic String's `update` method](https://github.com/storybookjs/storybook/pull/20698#issuecomment-1408389425).

## What I did

It turns out the `update` method was introduced in [version `0.26.6`](https://github.com/Rich-Harris/magic-string/blob/master/CHANGELOG.md#0266-2022-10-05), but Storybook packages [actually set it to `^0.26.1`](https://github.com/storybookjs/storybook/blob/next/code/lib/builder-vite/package.json#L62).

I've opted for 0.27.0 instead of 0.26.6 because it does not seem to have any breaking changes and we could benefit from performance improvements they made.

## How to test

This should be pretty straight-forward. I think the issue does not occur on clean installs because it should already pick `magic-string`'s latest patch. Let's see if CI passes! 

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [X] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
