### PR TITLE
Documentation: Add shard option to the test runner documentation

### DIFF
--- a/docs/writing-tests/test-runner.md
+++ b/docs/writing-tests/test-runner.md
@@ -95,6 +95,7 @@ If you're already using any of those flags in your project, you should be able t
 | `-u`, `--updateSnapshot`        | Use this flag to re-record every snapshot that fails during this test run <br/>`test-storybook -u`                               |
 | `--eject`                       | Creates a local configuration file to override defaults of the test-runner <br/>`test-storybook --eject`                         |
 | `--coverage`                    | Runs [coverage tests](./test-coverage.md) on your stories and components <br/> `test-storybook --coverage`                       |
+| `--shard [index/count]`         | Requires CI. Splits the test suite execution into multiple machines <br/> `test-storybook --shard=1/8`                           |
 
 <!-- prettier-ignore-start -->
 


### PR DESCRIPTION
With this minor pull request, the test runner documentation is updated to feature the shard option introduced by this [pull request](https://github.com/storybookjs/test-runner/pull/243). 

What was done:
- Updated the CLI options table to feature the `shard` option.

Let me know of any feedback so that we're able to merge this in and get parity between the test-runner repository and the official documentation.
