### PR TITLE
SvelteKit: Disable failing `vite-plugin-sveltekit-guard`

### DIFF
--- a/code/frameworks/sveltekit/src/preset.ts
+++ b/code/frameworks/sveltekit/src/preset.ts
@@ -15,12 +15,11 @@ export const viteFinal: NonNullable<StorybookConfig['viteFinal']> = async (confi
 
   let { plugins = [] } = baseConfig;
 
-  // Remove vite-plugin-svelte-kit from plugins if using SvelteKit
-  // see https://github.com/storybookjs/storybook/issues/19280#issuecomment-1281204341
+  // disable specific plugins that are not compatible with Storybook
   plugins = (
     await withoutVitePlugins(plugins, [
-      // @sveltejs/kit@1.0.0-next.587 and later
       'vite-plugin-sveltekit-compile',
+      'vite-plugin-sveltekit-guard',
     ])
   ).concat(configOverrides());
 


### PR DESCRIPTION
This PR fixes an issue where SvelteKit projects couldn't be built because an internal SvelteKit Vite plugin depends on a property existing, that is being disabled by Storybook.

This disables `vite-plugin-sveltekit-guard`.

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
