### PR TITLE
Update link to homepage for addons

### DIFF
--- a/code/addons/a11y/package.json
+++ b/code/addons/a11y/package.json
@@ -11,7 +11,7 @@
     "verify",
     "test"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/a11y",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/a11y",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/actions/package.json
+++ b/code/addons/actions/package.json
@@ -7,7 +7,7 @@
     "essentials",
     "data-state"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/actions",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/actions",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/backgrounds/package.json
+++ b/code/addons/backgrounds/package.json
@@ -10,7 +10,7 @@
     "essentials",
     "design"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/backgrounds",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/backgrounds",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/controls/package.json
+++ b/code/addons/controls/package.json
@@ -11,7 +11,7 @@
     "essentials",
     "data-state"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/addons/controls",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/controls",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/docs/README.md
+++ b/code/addons/docs/README.md
@@ -1,5 +1,5 @@
 <center>
-  <img src="https://raw.githubusercontent.com/storybookjs/storybook/main/addons/docs/docs/media/hero.png" width="100%" />
+  <img src="https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/docs/docs/media/hero.png" width="100%" />
 </center>
 
 # Storybook Docs
@@ -33,7 +33,7 @@ When you [install Docs](#installation), every story gets a `DocsPage`. `DocsPage
 Click on the `Docs` tab to see it:
 
 <center>
-  <img src="https://raw.githubusercontent.com/storybookjs/storybook/main/addons/docs/docs/media/docs-tab.png" width="100%" />
+  <img src="https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/docs/docs/media/docs-tab.png" width="100%" />
 </center>
 
 For more information on how it works, see the [`DocsPage` reference](https://github.com/storybookjs/storybook/blob/next/code/addons/docs/docs/docspage.md).
@@ -67,7 +67,7 @@ markdown documentation.
 And here's how that's rendered in Storybook:
 
 <center>
-  <img src="https://raw.githubusercontent.com/storybookjs/storybook/main/addons/docs/docs/media/mdx-simple.png" width="100%" />
+  <img src="https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/docs/docs/media/mdx-simple.png" width="100%" />
 </center>
 
 For more information on `MDX`, see the [`MDX` reference](https://github.com/storybookjs/storybook/blob/next/code/addons/docs/docs/mdx.md).

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -10,7 +10,7 @@
     "essentials",
     "organize"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/docs",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/docs",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/essentials/package.json
+++ b/code/addons/essentials/package.json
@@ -7,7 +7,7 @@
     "essentials",
     "storybook"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/essentials",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/essentials",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/highlight/package.json
+++ b/code/addons/highlight/package.json
@@ -8,7 +8,7 @@
     "style",
     "appearance"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/highlight",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/highlight",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/interactions/package.json
+++ b/code/addons/interactions/package.json
@@ -7,7 +7,7 @@
     "data-state",
     "test"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/interactions",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/interactions",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/jest/package.json
+++ b/code/addons/jest/package.json
@@ -12,7 +12,7 @@
     "unit-testing",
     "test"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/jest",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/jest",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/links/README.md
+++ b/code/addons/links/README.md
@@ -144,4 +144,4 @@ It accepts all the props the `a` element does, plus `story` and `kind`. It the `
 </LinkTo>
 ```
 
-To implement such a component for another framework, you need to add special handling for `click` event on native `a` element. See [`RoutedLink` sources](https://github.com/storybookjs/storybook/blob/main/addons/links/src/react/components/RoutedLink.tsx) for reference.
+To implement such a component for another framework, you need to add special handling for `click` event on native `a` element. See [`RoutedLink` sources](https://github.com/storybookjs/storybook/blob/next/code/addons/links/src/react/components/RoutedLink.tsx) for reference.

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -7,7 +7,7 @@
     "storybook",
     "organize"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/links",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/links",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/measure/package.json
+++ b/code/addons/measure/package.json
@@ -9,7 +9,7 @@
     "CSS",
     "design"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/measure",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/measure",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/outline/package.json
+++ b/code/addons/outline/package.json
@@ -12,7 +12,7 @@
     "storybook-addon",
     "style"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/outline",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/outline",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/storyshots-core/package.json
+++ b/code/addons/storyshots-core/package.json
@@ -7,7 +7,7 @@
     "storybook",
     "test"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/storyshots-core",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/storyshots-core",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/storyshots-puppeteer/package.json
+++ b/code/addons/storyshots-puppeteer/package.json
@@ -6,7 +6,7 @@
     "addon",
     "storybook"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/storyshots-puppeteer",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/storyshots-puppeteer",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/storysource/README.md
+++ b/code/addons/storysource/README.md
@@ -52,7 +52,7 @@ export default {
 };
 ```
 
-To customize the `source-loader`, pass `loaderOptions`. Valid configurations are documented in the [`source-loader` README](https://github.com/storybookjs/storybook/tree/main/lib/source-loader/README.md#options).
+To customize the `source-loader`, pass `loaderOptions`. Valid configurations are documented in the [`source-loader` README](https://github.com/storybookjs/storybook/tree/next/code/lib/source-loader/README.md#options).
 
 ## Theming
 

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -7,7 +7,7 @@
     "storybook",
     "code"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/storysource",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/storysource",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/toolbars/README.md
+++ b/code/addons/toolbars/README.md
@@ -40,6 +40,6 @@ The primary difference between the two packages is that `addon-toolbars` makes u
 
 - **Standardization**. Args are built into Storybook in 6.x. Since `addon-toolbars` is based on args, you don't need to learn any addon-specific APIs to use it.
 
-- **Ergonomics**. Global args are easy to consume [in stories](https://storybook.js.org/docs/react/essentials/toolbars-and-globals#consuming-globals-from-within-a-story), in [Storybook Docs](https://github.com/storybookjs/storybook/tree/main/addons/docs), or even in other addons.
+- **Ergonomics**. Global args are easy to consume [in stories](https://storybook.js.org/docs/react/essentials/toolbars-and-globals#consuming-globals-from-within-a-story), in [Storybook Docs](https://github.com/storybookjs/storybook/tree/next/code/addons/docs), or even in other addons.
 
 * **Framework compatibility**. Args are completely framework-independent, so `addon-toolbars` is compatible with React, Vue, Angular, etc. out of the box with no framework logic needed in the addon.

--- a/code/addons/toolbars/package.json
+++ b/code/addons/toolbars/package.json
@@ -11,7 +11,7 @@
     "test",
     "essentials"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/addons/toolbars",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/toolbars",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/viewport/package.json
+++ b/code/addons/viewport/package.json
@@ -8,7 +8,7 @@
     "style",
     "essentials"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/main/addons/viewport",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/viewport",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },


### PR DESCRIPTION
## What I did
- Update the homepage link for the addon package.json files as it was breaking images and READMEs in NPM and the integration catalog

## How to test
- Opened the links to confirm they went where we expected

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
