### PR TITLE
CLI: add type annotations in javascript main config files

### DIFF
--- a/code/lib/cli/src/generators/configure.test.ts
+++ b/code/lib/cli/src/generators/configure.test.ts
@@ -55,7 +55,7 @@ describe('configureMain', () => {
 
     expect(mainConfigPath).toEqual('./.storybook/main.ts');
     expect(mainConfigContent).toMatchInlineSnapshot(`
-      "import { StorybookConfig } from '@storybook/react-vite';
+      "import type { StorybookConfig } from '@storybook/react-vite';
 
       const config: StorybookConfig = {
         \\"stories\\": [

--- a/code/lib/cli/src/generators/configure.test.ts
+++ b/code/lib/cli/src/generators/configure.test.ts
@@ -1,0 +1,163 @@
+import fse from 'fs-extra';
+import dedent from 'ts-dedent';
+import { SupportedLanguage } from '../project_types';
+import { configureMain, configurePreview } from './configure';
+
+jest.mock('fs-extra');
+
+describe('configureMain', () => {
+  beforeAll(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should generate main.js', async () => {
+    await configureMain({
+      language: SupportedLanguage.JAVASCRIPT,
+      addons: [],
+      storybookConfigFolder: '.storybook',
+      framework: {
+        name: '@storybook/react-vite',
+      },
+    });
+
+    const { calls } = (fse.writeFile as unknown as jest.Mock).mock;
+    const [mainConfigPath, mainConfigContent] = calls[0];
+
+    expect(mainConfigPath).toEqual('./.storybook/main.js');
+    expect(mainConfigContent).toMatchInlineSnapshot(`
+      "/** @type { import('@storybook/react-vite').StorybookConfig } */
+      const config = {
+        \\"stories\\": [
+          \\"../stories/**/*.mdx\\",
+          \\"../stories/**/*.stories.@(js|jsx|ts|tsx)\\"
+        ],
+        \\"addons\\": [],
+        \\"framework\\": {
+          \\"name\\": \\"@storybook/react-vite\\"
+        }
+      };
+      export default config;"
+    `);
+  });
+
+  test('should generate main.ts', async () => {
+    await configureMain({
+      language: SupportedLanguage.TYPESCRIPT,
+      addons: [],
+      storybookConfigFolder: '.storybook',
+      framework: {
+        name: '@storybook/react-vite',
+      },
+    });
+
+    const { calls } = (fse.writeFile as unknown as jest.Mock).mock;
+    const [mainConfigPath, mainConfigContent] = calls[0];
+
+    expect(mainConfigPath).toEqual('./.storybook/main.ts');
+    expect(mainConfigContent).toMatchInlineSnapshot(`
+      "import { StorybookConfig } from '@storybook/react-vite';
+
+      const config: StorybookConfig = {
+        \\"stories\\": [
+          \\"../stories/**/*.mdx\\",
+          \\"../stories/**/*.stories.@(js|jsx|ts|tsx)\\"
+        ],
+        \\"addons\\": [],
+        \\"framework\\": {
+          \\"name\\": \\"@storybook/react-vite\\"
+        }
+      };
+      export default config;"
+    `);
+  });
+});
+
+describe('configurePreview', () => {
+  test('should generate preview.js', async () => {
+    await configurePreview({
+      language: SupportedLanguage.JAVASCRIPT,
+      storybookConfigFolder: '.storybook',
+    });
+
+    const { calls } = (fse.writeFile as unknown as jest.Mock).mock;
+    const [previewConfigPath, previewConfigContent] = calls[0];
+
+    expect(previewConfigPath).toEqual('./.storybook/preview.js');
+    expect(previewConfigContent).toMatchInlineSnapshot(`
+      "export const parameters = {
+        actions: { argTypesRegex: \\"^on[A-Z].*\\" },
+        controls: {
+          matchers: {
+            color: /(background|color)$/i,
+            date: /Date$/,
+          },
+        },
+      }"
+    `);
+  });
+
+  test('should generate preview.ts', async () => {
+    await configurePreview({
+      language: SupportedLanguage.TYPESCRIPT,
+      storybookConfigFolder: '.storybook',
+    });
+
+    const { calls } = (fse.writeFile as unknown as jest.Mock).mock;
+    const [previewConfigPath, previewConfigContent] = calls[0];
+
+    expect(previewConfigPath).toEqual('./.storybook/preview.ts');
+    expect(previewConfigContent).toMatchInlineSnapshot(`
+      "export const parameters = {
+        actions: { argTypesRegex: \\"^on[A-Z].*\\" },
+        controls: {
+          matchers: {
+            color: /(background|color)$/i,
+            date: /Date$/,
+          },
+        },
+      }"
+    `);
+  });
+
+  test('should not do anything if the framework template already included a preview', async () => {
+    (fse.pathExists as unknown as jest.Mock).mockReturnValueOnce(true);
+    await configurePreview({
+      language: SupportedLanguage.TYPESCRIPT,
+      storybookConfigFolder: '.storybook',
+    });
+    expect(fse.writeFile).not.toHaveBeenCalled();
+  });
+
+  test('should add prefix if frameworkParts are passed', async () => {
+    await configurePreview({
+      language: SupportedLanguage.TYPESCRIPT,
+      storybookConfigFolder: '.storybook',
+      frameworkPreviewParts: {
+        prefix: dedent`
+        import { setCompodocJson } from "@storybook/addon-docs/angular";
+        import docJson from "../documentation.json";
+        setCompodocJson(docJson);
+      `,
+      },
+    });
+
+    const { calls } = (fse.writeFile as unknown as jest.Mock).mock;
+    const [previewConfigPath, previewConfigContent] = calls[0];
+
+    expect(previewConfigPath).toEqual('./.storybook/preview.ts');
+    expect(previewConfigContent).toMatchInlineSnapshot(`
+      "import { setCompodocJson } from \\"@storybook/addon-docs/angular\\";
+      import docJson from \\"../documentation.json\\";
+      setCompodocJson(docJson);
+      export const parameters = {
+        actions: { argTypesRegex: \\"^on[A-Z].*\\" },
+        controls: {
+          matchers: {
+            color: /(background|color)$/i,
+            date: /Date$/,
+          },
+        },
+      }"
+    `);
+  });
+});

--- a/code/lib/cli/src/generators/configure.ts
+++ b/code/lib/cli/src/generators/configure.ts
@@ -54,7 +54,7 @@ export async function configureMain({
     .replace(
       '<<import>>',
       isTypescript
-        ? `import { StorybookConfig } from '${custom.framework.name}';\n\n`
+        ? `import type { StorybookConfig } from '${custom.framework.name}';\n\n`
         : `/** @type { import('${custom.framework.name}').StorybookConfig } */\n`
     )
     .replace('<<type>>', isTypescript ? ': StorybookConfig' : '')

--- a/code/lib/cli/src/generators/configure.ts
+++ b/code/lib/cli/src/generators/configure.ts
@@ -47,16 +47,17 @@ export async function configureMain({
   const isTypescript =
     language === SupportedLanguage.TYPESCRIPT || language === SupportedLanguage.TYPESCRIPT_LEGACY;
 
-  const tsTemplate = dedent`<<import>>const config<<type>> = <<mainContents>>;
+  const mainConfigTemplate = dedent`<<import>>const config<<type>> = <<mainContents>>;
   export default config;`;
 
-  const jsTemplate = dedent`export default <<mainContents>>;`;
-
-  const finalTemplate = isTypescript ? tsTemplate : jsTemplate;
-
-  const mainJsContents = finalTemplate
-    .replace('<<import>>', `import { StorybookConfig } from '${custom.framework.name}';\n\n`)
-    .replace('<<type>>', ': StorybookConfig')
+  const mainJsContents = mainConfigTemplate
+    .replace(
+      '<<import>>',
+      isTypescript
+        ? `import { StorybookConfig } from '${custom.framework.name}';\n\n`
+        : `/** @type { import('${custom.framework.name}').StorybookConfig } */\n`
+    )
+    .replace('<<type>>', isTypescript ? ': StorybookConfig' : '')
     .replace('<<mainContents>>', JSON.stringify(config, null, 2));
 
   await fse.writeFile(


### PR DESCRIPTION
Issue: N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

I realized we could get type annotations in javascript for main.js too (thanks @JReinhold)

so this PR changes the generated main.js files to:
```js
/** @type { import('@storybook/react-vite').StorybookConfig } */
export default {
  "stories": [
    "../src/**/*.mdx",
    "../src/**/*.stories.@(js|jsx|ts|tsx)"
  ],
};
```

It also adds tests to the file, which had none so far

## How to test

1. build the cli
2. go to a js project without Storybook
3. <path/to/storybook>/code/lib/cli/index.js init
4. Assess the resulting main.js

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
