### PR TITLE
Build: minor fixes

### DIFF
--- a/code/lib/builder-webpack5/src/index.ts
+++ b/code/lib/builder-webpack5/src/index.ts
@@ -179,7 +179,7 @@ const starter: StarterFunction = async function* starterGeneratorFn({
   router.use(`/sb-preview`, express.static(previewDirOrigin, { immutable: true, maxAge: '5m' }));
 
   router.use(compilation);
-  router.use(webpackHotMiddleware(compiler as any));
+  router.use(webpackHotMiddleware(compiler, { log: false }));
 
   const stats = await new Promise<Stats>((ready, stop) => {
     compilation?.waitUntilValid(ready as any);

--- a/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -78,6 +78,7 @@ export default async (
     docsOptions,
     entries,
     nonNormalizedStories,
+    modulesCount = 1000,
   ] = await Promise.all([
     presets.apply<CoreConfig>('core'),
     presets.apply('frameworkOptions'),
@@ -87,8 +88,9 @@ export default async (
     presets.apply('previewBody'),
     presets.apply<string>('previewMainTemplate'),
     presets.apply<DocsOptions>('docs'),
-    presets.apply<string[]>('entries', [], options),
-    presets.apply('stories', [], options),
+    presets.apply<string[]>('entries', []),
+    presets.apply('stories', []),
+    options.cache?.get('modulesCount').catch(() => {}),
   ]);
 
   const stories = normalizeStories(nonNormalizedStories, {
@@ -271,7 +273,7 @@ export default async (
       new ProvidePlugin({ process: require.resolve('process/browser.js') }),
       isProd ? null : new HotModuleReplacementPlugin(),
       new CaseSensitivePathsPlugin(),
-      quiet ? null : new ProgressPlugin({}),
+      quiet ? null : new ProgressPlugin({ modulesCount }),
       shouldCheckTs ? new ForkTsCheckerWebpackPlugin(tsCheckOptions) : null,
     ].filter(Boolean),
     module: {

--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -58,6 +58,7 @@
     "file-system-cache": "^2.0.0",
     "find-up": "^5.0.0",
     "fs-extra": "^11.1.0",
+    "glob": "^7.2.0",
     "glob-promise": "^4.2.0",
     "handlebars": "^4.7.7",
     "lazy-universal-dotenv": "^4.0.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6076,6 +6076,7 @@ __metadata:
     file-system-cache: ^2.0.0
     find-up: ^5.0.0
     fs-extra: ^11.1.0
+    glob: ^7.2.0
     glob-promise: ^4.2.0
     handlebars: ^4.7.7
     lazy-universal-dotenv: ^4.0.0

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -106,7 +106,7 @@
     "find-up": "^5.0.0",
     "fs-extra": "^10.1.0",
     "github-release-from-changelog": "^2.1.1",
-    "glob": "^7.1.6",
+    "glob": "^7.2.0",
     "http-server": "^0.12.3",
     "husky": "^4.3.7",
     "jest": "^29.3.1",

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -31,7 +31,7 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
 export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
   const command = [
     touch('yarn.lock'),
-    touch('yarnrc.yml'),
+    touch('.yarnrc.yml'),
     `yarn set version berry`,
     // Use the global cache so we aren't re-caching dependencies each time we run sandbox
     `yarn config set enableGlobalCache true`,

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -2822,7 +2822,7 @@ __metadata:
     find-up: ^5.0.0
     fs-extra: ^10.1.0
     github-release-from-changelog: ^2.1.1
-    glob: ^7.1.6
+    glob: ^7.2.0
     http-server: ^0.12.3
     husky: ^4.3.7
     jest: ^29.3.1
@@ -7858,7 +7858,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.2.0":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:


### PR DESCRIPTION
I noticed we could use the same cache to improve the progress report in the command-line as we use in the server-channel progress reporter.

I also noticed a yarn config file being generated wrong in sandboxes.