### PR TITLE
CLI: Remove the deprecated `--no-manager-cache` flag

### DIFF
--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -200,7 +200,6 @@ command('dev')
     'Suppress automatic redirects to the release notes after upgrading',
     true
   )
-  .option('--no-manager-cache', 'Do not cache the manager UI')
   .option('--debug-webpack', 'Display final webpack configurations for debugging purposes')
   .option('--webpack-stats-json [directory]', 'Write Webpack Stats JSON to disk')
   .option(
@@ -244,7 +243,6 @@ command('build')
   )
   .option('--force-build-preview', 'Build the preview iframe even if you are using --preview-url')
   .option('--docs', 'Build a documentation-only site using addon-docs')
-  .option('--no-manager-cache', 'Do not cache the manager UI')
   .action((options) => {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production';
     logger.setLevel(program.loglevel);

--- a/code/package.json
+++ b/code/package.json
@@ -48,7 +48,7 @@
     "storybook:blocks": "STORYBOOK_BLOCKS_ONLY=true yarn storybook:ui",
     "storybook:blocks:build": "STORYBOOK_BLOCKS_ONLY=true yarn storybook:ui:build",
     "storybook:blocks:chromatic": "STORYBOOK_BLOCKS_ONLY=true yarn storybook:ui:chromatic --project-token=${CHROMATIC_TOKEN_STORYBOOK_BLOCKS:-MISSING_PROJECT_TOKEN}",
-    "storybook:ui": "NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" ./lib/cli/bin/index.js dev --port 6006 --config-dir ./ui/.storybook --no-manager-cache",
+    "storybook:ui": "NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" ./lib/cli/bin/index.js dev --port 6006 --config-dir ./ui/.storybook",
     "storybook:ui:build": "NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" ./lib/cli/bin/index.js build --config-dir ./ui/.storybook",
     "storybook:ui:chromatic": "yarn chromatic --build-script-name storybook:ui:build --storybook-config-dir ./ui/.storybook --storybook-base-dir ./code --project-token=${CHROMATIC_TOKEN_STORYBOOK_UI:-MISSING_PROJECT_TOKEN} --only-changed --exit-zero-on-changes --exit-once-uploaded",
     "task": "cd .. && yarn task",

--- a/test-storybooks/ember-cli/package.json
+++ b/test-storybooks/ember-cli/package.json
@@ -6,7 +6,7 @@
     "--build-storybook": "yarn storybook-prebuild && NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" storybook build",
     "build": "ember build --output-path ember-output",
     "dev": "ember serve",
-    "storybook": "yarn build && storybook dev -p 9009 --no-manager-cache",
+    "storybook": "yarn build && storybook dev -p 9009",
     "storybook-prebuild": "yarn build && shx cp -r public/* ember-output",
     "storybook:dev": "yarn dev & NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" storybook dev -p 9009"
   },

--- a/test-storybooks/external-docs/package.json
+++ b/test-storybooks/external-docs/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
-    "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" storybook dev -p 9011 --no-manager-cache -c .storybook"
+    "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" storybook dev -p 9011 -c .storybook"
   },
   "dependencies": {
     "@storybook/addon-docs": "7.0.0-alpha.43",

--- a/test-storybooks/standalone-preview/package.json
+++ b/test-storybooks/standalone-preview/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.0-alpha.43",
   "private": true,
   "scripts": {
-    "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" storybook dev -p 9011 -c ../official-storybook --no-manager-cache --preview-url=http://localhost:1337/external-iframe.html",
+    "storybook": "cross-env STORYBOOK_DISPLAY_WARNING=true DISPLAY_WARNING=true NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" storybook dev -p 9011 -c ../official-storybook --preview-url=http://localhost:1337/external-iframe.html",
     "storybook-preview": "cross-env PREVIEW_URL=external-iframe.html NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" parcel ./storybook.html --port 1337"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes: #20884

## What I did

Remove the CLI flag everywhere