### PR TITLE
Chore: (Docs) Removes deprecated `--no-manager-cache` flag from the documentation

### DIFF
--- a/docs/addons/addon-knowledge-base.md
+++ b/docs/addons/addon-knowledge-base.md
@@ -115,8 +115,6 @@ If you're developing a standalone addon, add a new script to `package.json` with
 
 If you're developing a local Storybook addon built on top of an existing Storybook installation, HMR (hot module replacement) is available out of the box.
 
-If you don't see the changes being reflected, add the flag `--no-manager-cache` to the `storybook` script and restart Storybook.
-
 ### Composing addons in presets
 
 If you're working on a preset that loads third-party addons, which you don't have control over, and you need access to certain features (e.g., decorators) or provide additional configurations. In that case, you'll need to update your preset to the following to allow you to load and configure the other addons:

--- a/docs/api/cli-options.md
+++ b/docs/api/cli-options.md
@@ -37,12 +37,7 @@ Usage: start-storybook [options]
 | `--debug-webpack`               | Display final webpack configurations for debugging purposes<br/>`start-storybook --debug-webpack`                                                                           |
 | `--webpack-stats-json`          | Write Webpack Stats JSON to disk<br/>`start-storybook --webpack-stats-json /tmp/webpack-stats`                                                                              |
 | `--docs`                        | Starts Storybook in documentation mode. Learn more about it in [here](../writing-docs/build-documentation.md#preview-storybooks-documentation)<br/>`start-storybook --docs` |
-| `--no-manager-cache`            | Disables Storybook's manager caching mechanism. See note below<br/>`start-storybook --no-manager-cache`                                                                     |
 | `--disable-telemetry`           | Disables Storybook's telemetry. Learn more about it [here](../configure/telemetry.md)<br/>`start-storybook --disable-telemetry`                                             |
-
-<div class="aside">
-💡 The flag <code>--no-manager-cache</code> disables the internal caching of Storybook and can severely impact your Storybook loading time, so only use it when you need to refresh Storybook's UI, such as when editing themes.
-</div>
 
 <div class="aside" id="static-dir-deprecation">
 

--- a/docs/writing-docs/build-documentation.md
+++ b/docs/writing-docs/build-documentation.md
@@ -11,14 +11,10 @@ At any point during your development, you can preview the documentation you've w
 ```json
 {
   "scripts": {
-    "storybook-docs": "storybook dev --docs --no-manager-cache"
+    "storybook-docs": "storybook dev --docs"
   }
 }
 ```
-
-<div class="aside">
-💡 The <code>--no-manager-cache</code> flag is required to generate a successful preview of the documentation. But it comes with a cost as you're disabling Storybook's internal caching mechanism which can lead to increased loading times.
-</div>
 
 Depending on your configuration, when you execute the `storybook-docs` script. Storybook will be put into documentation mode and will generate a different build.
 


### PR DESCRIPTION
With this pull request, references to the `--no-manager-cache` are removed from the documentation as the flag will no longer be featured by the CLI.

Follows up on #20895

@ndelangen let me know once your pr is merged so that I can merge this one to align the documentation with the CLI. Thanks in advance