### PR TITLE
docs: fix `MINIMAL_VIEWPORTS` links

### DIFF
--- a/docs/essentials/viewport.md
+++ b/docs/essentials/viewport.md
@@ -47,7 +47,7 @@ The viewports object needs the following keys:
 
 ### Use a detailed set of devices
 
-By default, Storybook uses a [minimal set of viewports](https://github.com/storybookjs/storybook/blob/master/addons/viewport/src/defaults.ts#L167) to get you started. But you're not restricted to these. The addon offers a more granular list of devices that you can use.
+By default, Storybook uses a [minimal set of viewports](https://github.com/storybookjs/storybook/blob/next/code/addons/viewport/src/defaults.ts#L167) to get you started. But you're not restricted to these. The addon offers a more granular list of devices that you can use.
 
 Change your [`.storybook/preview.js`](../configure/overview.md#configure-story-rendering) to the following:
 
@@ -107,7 +107,7 @@ For instance, if you want to use these two with the minimal set of viewports, yo
 
 <!-- prettier-ignore-end -->
 
-Both viewports (`Kindle Fire 2` and `Kindle Fire HD`) will feature in the list of devices by merging them into the [`MINIMAL_VIEWPORTS`](https://github.com/storybookjs/storybook/blob/master/addons/viewport/src/defaults.ts#L167).
+Both viewports (`Kindle Fire 2` and `Kindle Fire HD`) will feature in the list of devices by merging them into the [`MINIMAL_VIEWPORTS`](https://github.com/storybookjs/storybook/blob/next/code/addons/viewport/src/defaults.ts#L167).
 
 ### Configuring per component or story
 

--- a/docs/essentials/viewport.md
+++ b/docs/essentials/viewport.md
@@ -47,7 +47,7 @@ The viewports object needs the following keys:
 
 ### Use a detailed set of devices
 
-By default, Storybook uses a [minimal set of viewports](https://github.com/storybookjs/storybook/blob/master/addons/viewport/src/defaults.ts#L135) to get you started. But you're not restricted to these. The addon offers a more granular list of devices that you can use.
+By default, Storybook uses a [minimal set of viewports](https://github.com/storybookjs/storybook/blob/master/addons/viewport/src/defaults.ts#L167) to get you started. But you're not restricted to these. The addon offers a more granular list of devices that you can use.
 
 Change your [`.storybook/preview.js`](../configure/overview.md#configure-story-rendering) to the following:
 
@@ -107,7 +107,7 @@ For instance, if you want to use these two with the minimal set of viewports, yo
 
 <!-- prettier-ignore-end -->
 
-Both viewports (`Kindle Fire 2` and `Kindle Fire HD`) will feature in the list of devices by merging them into the [`MINIMAL_VIEWPORTS`](https://github.com/storybookjs/storybook/blob/master/addons/viewport/src/defaults.ts#L135).
+Both viewports (`Kindle Fire 2` and `Kindle Fire HD`) will feature in the list of devices by merging them into the [`MINIMAL_VIEWPORTS`](https://github.com/storybookjs/storybook/blob/master/addons/viewport/src/defaults.ts#L167).
 
 ### Configuring per component or story
 


### PR DESCRIPTION
## What I did

Updated link line to correct line in documentation.

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
