### PR TITLE
Core: Fix index error handling

### DIFF
--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -30,12 +30,16 @@ export async function storybookDevServer(options: Options) {
 
   const serverChannel = getServerChannel(server);
 
+  let indexError: Error;
   // try get index generator, if failed, send telemetry without storyCount, then rethrow the error
   const initializedStoryIndexGenerator: Promise<StoryIndexGenerator> = getStoryIndexGenerator(
     features,
     options,
     serverChannel
-  );
+  ).catch((err) => {
+    indexError = err;
+    return undefined;
+  });
 
   app.use(compression({ level: 1 }));
 
@@ -112,11 +116,18 @@ export async function storybookDevServer(options: Options) {
     previewStarted.catch(() => {}).then(() => next());
   });
 
-  Promise.all([initializedStoryIndexGenerator, listening, usingStatics]).then(async () => {
-    if (!options.ci && !options.smokeTest && options.open) {
-      openInBrowser(host ? networkAddress : address);
+  await Promise.all([initializedStoryIndexGenerator, listening, usingStatics]).then(
+    async ([indexGenerator]) => {
+      if (indexGenerator && !options.ci && !options.smokeTest && options.open) {
+        openInBrowser(host ? networkAddress : address);
+      }
     }
-  });
+  );
+  if (indexError) {
+    await managerBuilder?.bail().catch();
+    await previewBuilder?.bail().catch();
+    throw indexError;
+  }
 
   const previewResult = await previewStarted;
 


### PR DESCRIPTION
Fixes #20760

## What I did

Properly catch index errors so that telemetry gets properly sent

## How to test

1. Create a basic sandbox:
`yarn start`

2. Add an MDX2 error somewhere in Intro stories:
```
<a>
  problems
</a>.
```

3. Run storybook with `STORYBOOK_TELEMETRY_DEBUG=1`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)
