### PR TITLE
Build: Change `rootDir` in TS plugin

### DIFF
--- a/code/ui/.storybook/main.ts
+++ b/code/ui/.storybook/main.ts
@@ -72,7 +72,9 @@ const config: StorybookConfig = {
         },
       },
       plugins: [
-        configType === 'PRODUCTION' ? pluginTurbosnap({ rootDir: viteConfig.root || '' }) : [],
+        configType === 'PRODUCTION'
+          ? pluginTurbosnap({ rootDir: path.resolve(__dirname, '../..') })
+          : [],
       ],
       optimizeDeps: { force: true },
       build: {


### PR DESCRIPTION
Issue: TS not working for our own project

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above, e.g. #1000, #1001 -->

## What I did

Correct the root path passed to the plugin. Although `viteConfig.root` is incorrect, the vite build appears to use the correct paths so I didn't actually change the value passed to vite (should I?)

## How to test

Make a small change in a PR-- see
- https://github.com/storybookjs/storybook/pull/20912
- https://www.chromatic.com/build?appId=635781f3500dd2c49e189caf&number=2627

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
