### PR TITLE
Correctly preserve existing vite envPrefix config

### DIFF
--- a/code/lib/builder-vite/src/vite-config.test.ts
+++ b/code/lib/builder-vite/src/vite-config.test.ts
@@ -1,0 +1,66 @@
+import type { Options, Presets } from '@storybook/types';
+import { loadConfigFromFile } from 'vite';
+import { commonConfig } from './vite-config';
+
+jest.mock('vite', () => ({
+  ...jest.requireActual('vite'),
+  loadConfigFromFile: jest.fn(async () => ({})),
+}));
+const loadConfigFromFileMock = jest.mocked(loadConfigFromFile);
+
+const dummyOptions: Options = {
+  configType: 'DEVELOPMENT',
+  configDir: '/tmp',
+  packageJson: {},
+  presets: {
+    apply: async (key: string) =>
+      ({
+        framework: {
+          name: '',
+        },
+        addons: [],
+        core: {
+          builder: {},
+        },
+      }[key]),
+  } as Presets,
+  presetsList: [],
+};
+
+describe('commonConfig', () => {
+  it('should preserve default envPrefix', async () => {
+    loadConfigFromFileMock.mockReturnValueOnce(
+      Promise.resolve({
+        config: {},
+        path: '',
+        dependencies: [],
+      })
+    );
+    const config = await commonConfig(dummyOptions, 'development');
+    expect(config.envPrefix).toStrictEqual(['VITE_', 'STORYBOOK_']);
+  });
+
+  it('should preserve custom envPrefix string', async () => {
+    loadConfigFromFileMock.mockReturnValueOnce(
+      Promise.resolve({
+        config: { envPrefix: 'SECRET_' },
+        path: '',
+        dependencies: [],
+      })
+    );
+    const config = await commonConfig(dummyOptions, 'development');
+    expect(config.envPrefix).toStrictEqual(['SECRET_', 'STORYBOOK_']);
+  });
+
+  it('should preserve custom envPrefix array', async () => {
+    loadConfigFromFileMock.mockReturnValueOnce(
+      Promise.resolve({
+        config: { envPrefix: ['SECRET_', 'VUE_'] },
+        path: '',
+        dependencies: [],
+      })
+    );
+    const config = await commonConfig(dummyOptions, 'development');
+    expect(config.envPrefix).toStrictEqual(['SECRET_', 'VUE_', 'STORYBOOK_']);
+  });
+});

--- a/code/lib/builder-vite/src/vite-config.test.ts
+++ b/code/lib/builder-vite/src/vite-config.test.ts
@@ -10,7 +10,7 @@ const loadConfigFromFileMock = jest.mocked(loadConfigFromFile);
 
 const dummyOptions: Options = {
   configType: 'DEVELOPMENT',
-  configDir: '/tmp',
+  configDir: '',
   packageJson: {},
   presets: {
     apply: async (key: string) =>
@@ -22,6 +22,7 @@ const dummyOptions: Options = {
         core: {
           builder: {},
         },
+        options: {},
       }[key]),
   } as Presets,
   presetsList: [],

--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -64,7 +64,7 @@ export async function commonConfig(
     },
     // If an envPrefix is specified in the vite config, add STORYBOOK_ to it,
     // otherwise, add VITE_ and STORYBOOK_ so that vite doesn't lose its default.
-    envPrefix: userConfig.envPrefix ? 'STORYBOOK_' : ['VITE_', 'STORYBOOK_'],
+    envPrefix: userConfig.envPrefix ? ['STORYBOOK_'] : ['VITE_', 'STORYBOOK_'],
   };
 
   const config: ViteConfig = mergeConfig(userConfig, sbConfig);


### PR DESCRIPTION
## What I did

I changed the way the `envPrefix` config option in the vite builder is set, as discussed on discord, @IanVS ;-)
Now that it is an array, `mergeConfig` from vite will always prepend any existing `envPrefix` options from the users vite config.

## How to test

I included a unit test which only succeeds with the changes I made.
The dummy options I used there are found mostly through trial and error, because I couldn't understand all the magic and types in `core-commons/preset`. So I am open for any suggestions.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
