### PR TITLE
Upgrade jscodeshift to 0.14.0

### DIFF
--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -77,7 +77,7 @@
     "get-port": "^5.1.1",
     "giget": "^1.0.0",
     "globby": "^11.0.2",
-    "jscodeshift": "^0.13.1",
+    "jscodeshift": "^0.14.0",
     "leven": "^3.1.0",
     "prompts": "^2.4.0",
     "puppeteer-core": "^2.1.1",

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -55,7 +55,7 @@
     "@storybook/types": "7.0.0-beta.41",
     "cross-spawn": "^7.0.3",
     "globby": "^11.0.2",
-    "jscodeshift": "^0.13.1",
+    "jscodeshift": "^0.14.0",
     "lodash": "^4.17.21",
     "prettier": "^2.8.0",
     "recast": "^0.23.1",

--- a/code/lib/postinstall/package.json
+++ b/code/lib/postinstall/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "jest": "^29.3.1",
     "jest-specific-snapshot": "^7.0.0",
-    "jscodeshift": "^0.13.1",
+    "jscodeshift": "^0.14.0",
     "typescript": "~4.9.3"
   },
   "publishConfig": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5951,7 +5951,7 @@ __metadata:
     get-port: ^5.1.1
     giget: ^1.0.0
     globby: ^11.0.2
-    jscodeshift: ^0.13.1
+    jscodeshift: ^0.14.0
     leven: ^3.1.0
     prompts: ^2.4.0
     puppeteer-core: ^2.1.1
@@ -6014,7 +6014,7 @@ __metadata:
     globby: ^11.0.2
     jest: ^29.3.1
     jest-specific-snapshot: ^7.0.0
-    jscodeshift: ^0.13.1
+    jscodeshift: ^0.14.0
     lodash: ^4.17.21
     prettier: ^2.8.0
     recast: ^0.23.1
@@ -6572,7 +6572,7 @@ __metadata:
   dependencies:
     jest: ^29.3.1
     jest-specific-snapshot: ^7.0.0
-    jscodeshift: ^0.13.1
+    jscodeshift: ^0.14.0
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft
@@ -18981,6 +18981,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jscodeshift@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "jscodeshift@npm:0.14.0"
+  dependencies:
+    "@babel/core": ^7.13.16
+    "@babel/parser": ^7.13.16
+    "@babel/plugin-proposal-class-properties": ^7.13.0
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.13.8
+    "@babel/plugin-proposal-optional-chaining": ^7.13.12
+    "@babel/plugin-transform-modules-commonjs": ^7.13.8
+    "@babel/preset-flow": ^7.13.13
+    "@babel/preset-typescript": ^7.13.0
+    "@babel/register": ^7.13.16
+    babel-core: ^7.0.0-bridge.0
+    chalk: ^4.1.2
+    flow-parser: 0.*
+    graceful-fs: ^4.2.4
+    micromatch: ^4.0.4
+    neo-async: ^2.5.0
+    node-dir: ^0.1.17
+    recast: ^0.21.0
+    temp: ^0.8.4
+    write-file-atomic: ^2.3.0
+  peerDependencies:
+    "@babel/preset-env": ^7.1.6
+  bin:
+    jscodeshift: bin/jscodeshift.js
+  checksum: dab63bdb4b7e67d79634fcd3f5dc8b227146e9f68aa88700bc49c5a45b6339d05bd934a98aa53d29abd04f81237d010e7e037799471b2aab66ec7b9a7d752786
+  languageName: node
+  linkType: hard
+
 "jsdom@npm:^19.0.0":
   version: 19.0.0
   resolution: "jsdom@npm:19.0.0"
@@ -24152,6 +24183,18 @@ __metadata:
     source-map: ~0.6.1
     tslib: ^2.0.1
   checksum: 7810216ff36c7376eddd66d3ce6b2df421305fdc983f2122711837911712177d52d804419655e1f29d4bb93016c178cffe442af410bdcf726050ca19af6fed32
+  languageName: node
+  linkType: hard
+
+"recast@npm:^0.21.0":
+  version: 0.21.5
+  resolution: "recast@npm:0.21.5"
+  dependencies:
+    ast-types: 0.15.2
+    esprima: ~4.0.0
+    source-map: ~0.6.1
+    tslib: ^2.0.1
+  checksum: a45168c82195f24fa2c70293a624fece0069a2e8e8adb637f9963777735f81cb3bb62e55172db677ec3573b08b2daaf1eddd85b74da6fe0bd37c9b15eeaf94b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes deprecated warning described in #20822

Closes #20822

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Upgraded jscodeshift from ^0.13.1 to ^0.14.0 to remove deprecation warnings.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
