### PR TITLE
Upgrade glob to 8.1.0

### DIFF
--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -57,7 +57,7 @@
     "es-module-lexer": "^0.9.3",
     "express": "^4.17.3",
     "fs-extra": "^11.1.0",
-    "glob": "^7.2.0",
+    "glob": "^8.1.0",
     "glob-promise": "^4.2.0",
     "magic-string": "^0.27.0",
     "rollup": "^2.25.0 || ^3.3.0",

--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -58,7 +58,7 @@
     "file-system-cache": "^2.0.0",
     "find-up": "^5.0.0",
     "fs-extra": "^11.1.0",
-    "glob": "^7.2.0",
+    "glob": "^8.1.0",
     "glob-promise": "^4.2.0",
     "handlebars": "^4.7.7",
     "lazy-universal-dotenv": "^4.0.0",

--- a/code/package.json
+++ b/code/package.json
@@ -226,7 +226,7 @@
     "eslint-plugin-storybook": "^0.6.6",
     "fs-extra": "^11.1.0",
     "github-release-from-changelog": "^2.1.1",
-    "glob": "^7.1.6",
+    "glob": "^8.1.0",
     "http-server": "^0.12.3",
     "husky": "^4.3.7",
     "jest": "^29.3.1",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5777,7 +5777,7 @@ __metadata:
     es-module-lexer: ^0.9.3
     express: ^4.17.3
     fs-extra: ^11.1.0
-    glob: ^7.2.0
+    glob: ^8.1.0
     glob-promise: ^4.2.0
     magic-string: ^0.27.0
     rollup: ^3.0.0
@@ -6084,7 +6084,7 @@ __metadata:
     file-system-cache: ^2.0.0
     find-up: ^5.0.0
     fs-extra: ^11.1.0
-    glob: ^7.2.0
+    glob: ^8.1.0
     glob-promise: ^4.2.0
     handlebars: ^4.7.7
     lazy-universal-dotenv: ^4.0.0
@@ -7112,7 +7112,7 @@ __metadata:
     eslint-plugin-storybook: ^0.6.6
     fs-extra: ^11.1.0
     github-release-from-changelog: ^2.1.1
-    glob: ^7.1.6
+    glob: ^8.1.0
     http-server: ^0.12.3
     husky: ^4.3.7
     jest: ^29.3.1
@@ -16225,7 +16225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.1":
+"glob@npm:^8.0.1, glob@npm:^8.1.0":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
   dependencies:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -106,7 +106,7 @@
     "find-up": "^5.0.0",
     "fs-extra": "^10.1.0",
     "github-release-from-changelog": "^2.1.1",
-    "glob": "^7.2.0",
+    "glob": "^8.1.0",
     "http-server": "^0.12.3",
     "husky": "^4.3.7",
     "jest": "^29.3.1",

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -2822,7 +2822,7 @@ __metadata:
     find-up: ^5.0.0
     fs-extra: ^10.1.0
     github-release-from-changelog: ^2.1.1
-    glob: ^7.2.0
+    glob: ^8.1.0
     http-server: ^0.12.3
     husky: ^4.3.7
     jest: ^29.3.1
@@ -7858,7 +7858,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.2.0":
+"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -7882,6 +7882,19 @@ __metadata:
     minimatch: ^5.0.1
     once: ^1.3.0
   checksum: 07ebaf2ed83e76b10901ec4982040ebd85458b787b4386f751a0514f6c8e416ed6c9eec5a892571eb0ef00b09d1bd451f72b5d9fb7b63770efd400532486e731
+  languageName: node
+  linkType: hard
+
+"glob@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "glob@npm:8.1.0"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^5.0.1
+    once: ^1.3.0
+  checksum: cb0b5cab17a59c57299376abe5646c7070f8acb89df5595b492dba3bfb43d301a46c01e5695f01154e6553168207cb60d4eaf07d3be4bc3eb9b0457c5c561d0f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #20926

## What I did

basicly changed  "glob" package version in mutliple places make it match the one that @storybook/test-runner  requires ` "glob": "^8.1.0"`

## How to test



1. Run a sandbox for template react or vue3 
2. should passe and install deps then run sb


-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
