### PR TITLE
Csf-tools: Fix error handling for storySort variable references

### DIFF
--- a/code/lib/csf-tools/src/getStorySortParameter.test.ts
+++ b/code/lib/csf-tools/src/getStorySortParameter.test.ts
@@ -212,5 +212,30 @@ describe('getStorySortParameter', () => {
         }"
       `);
     });
+
+    it('order var', () => {
+      expect(() =>
+        getStorySortParameter(dedent`
+          const order = [];
+          export const parameters = {
+            options: {
+              storySort: {
+                method: "",
+                order,
+                locales: "",
+              }
+            },
+          };
+      `)
+      ).toThrowErrorMatchingInlineSnapshot(`
+        "Unexpected 'order'. Parameter 'options.storySort' should be defined inline e.g.:
+
+        export const parameters = {
+          options: {
+            storySort: <array | object | function>
+          }
+        }"
+      `);
+    });
   });
 });

--- a/code/lib/csf-tools/src/getStorySortParameter.ts
+++ b/code/lib/csf-tools/src/getStorySortParameter.ts
@@ -36,7 +36,7 @@ const parseValue = (expr: t.Expression): any => {
     // @ts-expect-error (Converted from ts-ignore)
     return expr.value;
   }
-  throw new Error(`Unknown node type ${expr}`);
+  return unsupported(expr.type, true);
 };
 
 const unsupported = (unexpectedVar: string, isError: boolean) => {

--- a/code/lib/csf-tools/src/getStorySortParameter.ts
+++ b/code/lib/csf-tools/src/getStorySortParameter.ts
@@ -36,7 +36,10 @@ const parseValue = (expr: t.Expression): any => {
     // @ts-expect-error (Converted from ts-ignore)
     return expr.value;
   }
-  return unsupported(expr.type, true);
+  if (t.isIdentifier(expr)) {
+    return unsupported(expr.name, true);
+  }
+  throw new Error(`Unknown node type ${expr.type}`);
 };
 
 const unsupported = (unexpectedVar: string, isError: boolean) => {


### PR DESCRIPTION
Closes #20883

## What I did

Provide a better error messages for storySort values that reference variables, which is not handled.

## How to test

See repro in #20883

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
