### PR TITLE
Csf-tools: Add `satisfies` support to ConfigFile

### DIFF
--- a/code/lib/csf-tools/src/ConfigFile.test.ts
+++ b/code/lib/csf-tools/src/ConfigFile.test.ts
@@ -763,6 +763,48 @@ describe('ConfigFile', () => {
         expect(config.getNameFromPath(['framework'])).toEqual('foo');
       });
 
+      describe('satisfies', () => {
+        it(`supports string literal node`, () => {
+          const source = dedent`
+            import type { StorybookConfig } from '@storybook/react-webpack5';
+  
+            const config = {
+              framework: 'foo',
+            } satisfies StorybookConfig
+            export default config;
+          `;
+          const config = loadConfig(source).parse();
+          expect(config.getNameFromPath(['framework'])).toEqual('foo');
+        });
+  
+        it(`supports string literal node without variables`, () => {
+          const source = dedent`
+            import type { StorybookConfig } from '@storybook/react-webpack5';
+  
+            export default {
+              framework: 'foo',
+            } satisfies StorybookConfig;
+          `;
+          const config = loadConfig(source).parse();
+          expect(config.getNameFromPath(['framework'])).toEqual('foo');
+        });
+
+        it(`supports object expression node with name property`, () => {
+          const source = dedent`
+            import type { StorybookConfig } from '@storybook/react-webpack5';
+  
+            const config = {
+              framework: { name: 'foo', options: { bar: require('baz') } },
+              "otherField": { "name": 'foo', options: { bar: require('baz') } },
+            } satisfies StorybookConfig
+            export default config;
+          `;
+          const config = loadConfig(source).parse();
+          expect(config.getNameFromPath(['framework'])).toEqual('foo');
+          expect(config.getNameFromPath(['otherField'])).toEqual('foo');
+        });
+      })
+
       it(`supports object expression node with name property`, () => {
         const source = dedent`
           import type { StorybookConfig } from '@storybook/react-webpack5';
@@ -826,6 +868,49 @@ describe('ConfigFile', () => {
         expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
         expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
       });
+      
+      describe('satisfies', () => {
+        it(`supports an array with string literal and object expression with name property`, () => {
+          const source = dedent`
+            import type { StorybookConfig } from '@storybook/react-webpack5';
+  
+            const config = {
+              addons: [
+                'foo',
+                { name: 'bar', options: {} },
+              ],
+              "otherField": [
+                "foo",
+                { "name": 'bar', options: {} },
+              ],
+            } satisfies StorybookConfig
+            export default config;
+          `;
+          const config = loadConfig(source).parse();
+          expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
+          expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
+        });
+
+        it(`supports an array with string literal and object expression with name property without variable`, () => {
+          const source = dedent`
+            import type { StorybookConfig } from '@storybook/react-webpack5';
+  
+            export default {
+              addons: [
+                'foo',
+                { name: 'bar', options: {} },
+              ],
+              "otherField": [
+                "foo",
+                { "name": 'bar', options: {} },
+              ],
+            } satisfies StorybookConfig;
+          `;
+          const config = loadConfig(source).parse();
+          expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
+          expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
+        });
+      })
     });
 
     it(`returns undefined when accessing a field that does not exist`, () => {

--- a/code/lib/csf-tools/src/ConfigFile.test.ts
+++ b/code/lib/csf-tools/src/ConfigFile.test.ts
@@ -776,7 +776,7 @@ describe('ConfigFile', () => {
           const config = loadConfig(source).parse();
           expect(config.getNameFromPath(['framework'])).toEqual('foo');
         });
-  
+
         it(`supports string literal node without variables`, () => {
           const source = dedent`
             import type { StorybookConfig } from '@storybook/react-webpack5';
@@ -803,7 +803,7 @@ describe('ConfigFile', () => {
           expect(config.getNameFromPath(['framework'])).toEqual('foo');
           expect(config.getNameFromPath(['otherField'])).toEqual('foo');
         });
-      })
+      });
 
       it(`supports object expression node with name property`, () => {
         const source = dedent`
@@ -868,7 +868,7 @@ describe('ConfigFile', () => {
         expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
         expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
       });
-      
+
       describe('satisfies', () => {
         it(`supports an array with string literal and object expression with name property`, () => {
           const source = dedent`
@@ -910,7 +910,7 @@ describe('ConfigFile', () => {
           expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
           expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
         });
-      })
+      });
     });
 
     it(`returns undefined when accessing a field that does not exist`, () => {

--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -139,9 +139,12 @@ export class ConfigFile {
               ? _findVarInitialization(node.declaration.name, parent)
               : node.declaration;
 
-          if (t.isObjectExpression(decl)) {
-            self._exportsObject = decl;
-            decl.properties.forEach((p: t.ObjectProperty) => {
+          if (t.isObjectExpression(decl) || t.isTSSatisfiesExpression(decl)) {
+            const expression = t.isTSSatisfiesExpression(decl)
+              ? (decl.expression as Extract<t.Expression, t.ObjectExpression>)
+              : decl;
+            self._exportsObject = expression;
+            expression.properties.forEach((p: t.ObjectProperty) => {
               const exportName = propKey(p);
               if (exportName) {
                 let exportVal = p.value;

--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -134,17 +134,17 @@ export class ConfigFile {
       ExportDefaultDeclaration: {
         enter({ node, parent }) {
           self.hasDefaultExport = true;
-          const decl =
+          let decl =
             t.isIdentifier(node.declaration) && t.isProgram(parent)
               ? _findVarInitialization(node.declaration.name, parent)
               : node.declaration;
+          if (t.isTSAsExpression(decl) || t.isTSSatisfiesExpression(decl)) {
+            decl = decl.expression;
+          }
 
-          if (t.isObjectExpression(decl) || t.isTSSatisfiesExpression(decl)) {
-            const expression = t.isTSSatisfiesExpression(decl)
-              ? (decl.expression as Extract<t.Expression, t.ObjectExpression>)
-              : decl;
-            self._exportsObject = expression;
-            expression.properties.forEach((p: t.ObjectProperty) => {
+          if (t.isObjectExpression(decl)) {
+            self._exportsObject = decl;
+            decl.properties.forEach((p: t.ObjectProperty) => {
               const exportName = propKey(p);
               if (exportName) {
                 let exportVal = p.value;


### PR DESCRIPTION
Closes #20935 

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

<!-- Briefly describe what your PR does -->
added `satisfies` support to `.storybook/main.ts`:
## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
