### PR TITLE
fix: remove `svelte-options` from `svelte-vite`

### DIFF
--- a/code/frameworks/svelte-vite/src/preset.ts
+++ b/code/frameworks/svelte-vite/src/preset.ts
@@ -1,4 +1,3 @@
-import { hasVitePlugins } from '@storybook/builder-vite';
 import type { PresetProperty } from '@storybook/types';
 import type { StorybookConfig } from './types';
 import { handleSvelteKit } from './utils';

--- a/code/frameworks/svelte-vite/src/preset.ts
+++ b/code/frameworks/svelte-vite/src/preset.ts
@@ -13,18 +13,8 @@ export const viteFinal: NonNullable<StorybookConfig['viteFinal']> = async (confi
   const { plugins = [] } = config;
   // TODO: set up eslint import to use typescript resolver
   // eslint-disable-next-line import/no-unresolved
-  const { svelte, loadSvelteConfig } = await import('@sveltejs/vite-plugin-svelte');
-  const svelteOptions: Record<string, any> = await options.presets.apply(
-    'svelteOptions',
-    {},
-    options
-  );
-  const svelteConfig = { ...(await loadSvelteConfig()), ...svelteOptions };
-
-  // Add svelte plugin if not present
-  if (!(await hasVitePlugins(plugins, ['vite-plugin-svelte']))) {
-    plugins.push(svelte());
-  }
+  const { loadSvelteConfig } = await import('@sveltejs/vite-plugin-svelte');
+  const svelteConfig = await loadSvelteConfig();
 
   // Add docgen plugin
   plugins.push(svelteDocgen(svelteConfig));

--- a/code/frameworks/svelte-vite/src/preset.ts
+++ b/code/frameworks/svelte-vite/src/preset.ts
@@ -1,3 +1,4 @@
+import { hasVitePlugins } from '@storybook/builder-vite';
 import type { PresetProperty } from '@storybook/types';
 import type { StorybookConfig } from './types';
 import { handleSvelteKit } from './utils';
@@ -14,6 +15,11 @@ export const viteFinal: NonNullable<StorybookConfig['viteFinal']> = async (confi
   // eslint-disable-next-line import/no-unresolved
   const { loadSvelteConfig } = await import('@sveltejs/vite-plugin-svelte');
   const svelteConfig = await loadSvelteConfig();
+
+  // Add svelte plugin if the user does not have a Vite config of their own
+  if (!(await hasVitePlugins(plugins, ['vite-plugin-svelte']))) {
+    plugins.push(svelte());
+  }
 
   // Add docgen plugin
   plugins.push(svelteDocgen(svelteConfig));

--- a/code/frameworks/svelte-vite/src/preset.ts
+++ b/code/frameworks/svelte-vite/src/preset.ts
@@ -13,7 +13,7 @@ export const viteFinal: NonNullable<StorybookConfig['viteFinal']> = async (confi
   const { plugins = [] } = config;
   // TODO: set up eslint import to use typescript resolver
   // eslint-disable-next-line import/no-unresolved
-  const { loadSvelteConfig } = await import('@sveltejs/vite-plugin-svelte');
+  const { svelte, loadSvelteConfig } = await import('@sveltejs/vite-plugin-svelte');
   const svelteConfig = await loadSvelteConfig();
 
   // Add svelte plugin if the user does not have a Vite config of their own


### PR DESCRIPTION
## What I did

Removed two unnecessary pieces of functionality. We don't need to add `vite-plugin-svelte` as it will always be present of the user's app won't work. We also don't need to add `svelteOptions` as I believe this was just a holdover from before we loaded the `svelte.config.js` file

<!--## How to test

 Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [X] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
