### PR TITLE
Core: Undo AST main.js check in validateConfigFile

### DIFF
--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.20.2",
-    "@storybook/csf-tools": "7.0.0-beta.43",
     "@storybook/node-logger": "7.0.0-beta.43",
     "@storybook/types": "7.0.0-beta.43",
     "@types/babel__core": "^7.1.20",

--- a/code/lib/core-common/src/utils/validate-configuration-files.ts
+++ b/code/lib/core-common/src/utils/validate-configuration-files.ts
@@ -2,7 +2,6 @@ import { dedent } from 'ts-dedent';
 import { promise as glob } from 'glob-promise';
 import path from 'path';
 import slash from 'slash';
-import { readConfig } from '@storybook/csf-tools';
 import { once } from '@storybook/node-logger';
 
 import { boost } from './interpret-files';
@@ -25,13 +24,5 @@ export async function validateConfigurationFiles(configDir: string) {
       No configuration files have been found in your configDir (${path.resolve(configDir)}).
       Storybook needs "main.js" file, please add it.
     `);
-  } else {
-    const main = await readConfig(mainConfigPath);
-    if (!main.hasDefaultExport) {
-      once.warn(dedent`
-        Your main.js is not using a default export, which is the recommended format. Please update it.
-        For more info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#esm-format-in-mainjs
-      `);
-    }
   }
 }

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6068,7 +6068,6 @@ __metadata:
   resolution: "@storybook/core-common@workspace:lib/core-common"
   dependencies:
     "@babel/core": ^7.20.2
-    "@storybook/csf-tools": 7.0.0-beta.43
     "@storybook/node-logger": 7.0.0-beta.43
     "@storybook/types": 7.0.0-beta.43
     "@types/babel__core": ^7.1.20


### PR DESCRIPTION
Closes #20940

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

#20802 introduced unintended side effects, and the check will be moved into an automigration.
For now, we remove the code which is causing breakage.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
