### PR TITLE
Fix: fonts missing/warnings

### DIFF
--- a/code/lib/core-server/src/presets/common-preset.ts
+++ b/code/lib/core-server/src/presets/common-preset.ts
@@ -25,7 +25,7 @@ const defaultFavicon = require.resolve('@storybook/core-server/public/favicon.sv
 export const staticDirs: PresetPropertyFn<'staticDirs'> = async (values = []) => [
   {
     from: join(dirname(require.resolve('@storybook/manager/package.json')), 'static'),
-    to: '/sb-manager-assets',
+    to: '/sb-common-assets',
   },
   ...values,
 ];


### PR DESCRIPTION
Resolves https://github.com/storybookjs/storybook/issues/20938
Resolves https://github.com/storybookjs/storybook/issues/21017


## What I did

The static path configuration for common assets (for fonts) was configured wrong, I fixed it.

## How to test

Fonts should load correctly now, on both the manager and preview.
No error/warnings should show.