### PR TITLE
Feature: Add woff2 support for builder-manager

### DIFF
--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -59,6 +59,7 @@ export const getConfig: ManagerBuilder['getConfig'] = async (options) => {
       '.svg': 'dataurl',
       '.webp': 'dataurl',
       '.webm': 'dataurl',
+      '.woff2': 'dataurl',
     },
     target: ['chrome100'],
     platform: 'browser',


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/20961

## What I did

I added woff2 support to the builder-manager