### PR TITLE
Feature: add super early node version check

### DIFF
--- a/code/lib/cli/bin/index.js
+++ b/code/lib/cli/bin/index.js
@@ -1,3 +1,9 @@
 #!/usr/bin/env node
 
+const majorNodeVersion = parseInt(process.version.toString().replace('v', '').split('.')[0], 10);
+if (majorNodeVersion < 16) {
+  console.error('To run storybook you need to have node 16 or higher');
+  process.exit(1);
+}
+
 require('../dist/generate.js');


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/20948

## What I did

Add a early proces.exit ir node version is not high enough

## How to test

Run storybook in node < 16

I've tested this code myself by changing the required major version, then running in node 16.