### PR TITLE
fix: use Vite by default for Svelte and Vue

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
@@ -62,12 +62,15 @@ interface NewFrameworkRunOptions {
   };
 }
 
-export const getBuilder = (builder: string | { name: string }) => {
-  if (typeof builder === 'string') {
-    return builder.includes('vite') ? 'vite' : 'webpack5';
+const getBuilder = (builder: string | { name: string }, frameworkPackage: string) => {
+  const name = typeof builder === 'string' ? builder : builder?.name;
+  if (name?.includes('webpack')) {
+    return 'webpack5';
   }
-
-  return builder?.name.includes('vite') ? 'vite' : 'webpack5';
+  if (name?.includes('vite')) {
+    return 'vite';
+  }
+  return frameworkPackage.includes('svelte') || frameworkPackage.includes('vue3') ? 'vite' : 'webpack5';
 };
 
 export const getFrameworkOptions = (framework: string, main: ConfigFile) => {
@@ -140,13 +143,11 @@ export const newFrameworks: Fix<NewFrameworkRunOptions> = {
     }
 
     const builderInfo = {
-      name: getBuilder(builder),
+      name: getBuilder(builder, frameworkPackage),
       options: main.getFieldValue(['core', 'builder', 'options']) || {},
     } as const;
 
     const newFrameworkPackage = packagesMap[frameworkPackage][builderInfo.name];
-
-    // not all frameworks support vite yet e.g. Svelte
     if (!newFrameworkPackage) {
       return null;
     }


### PR DESCRIPTION
## What I did

New Vue and Svelte projects use Vite by default. Those ecosystems are heavily invested in Vite and promote it as the default builder

<!-- 
## How to test

Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [X] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
