### PR TITLE
CLI: Re-enable vue-vite in new-frameworks automigration

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.test.ts
@@ -103,27 +103,6 @@ describe('new-frameworks fix', () => {
       ).resolves.toBeFalsy();
     });
 
-    // TODO: once we have a @storybook/vue-vite framework, we should remove this test
-    it('in sb 7 with vue and vite', async () => {
-      const packageJson = {
-        dependencies: {
-          '@storybook/vue': '^7.0.0',
-          '@storybook/builder-vite': 'x.y.z',
-        },
-      };
-      await expect(
-        checkNewFrameworks({
-          packageJson,
-          main: {
-            framework: '@storybook/vue',
-            core: {
-              builder: '@storybook/builder-vite',
-            },
-          },
-        })
-      ).resolves.toBeFalsy();
-    });
-
     it('in sb 7 with vite < 3', async () => {
       const packageJson = {
         dependencies: {

--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
@@ -28,8 +28,7 @@ const packagesMap: Record<string, { webpack5?: string; vite?: string }> = {
   },
   '@storybook/vue': {
     webpack5: '@storybook/vue-webpack5',
-    // TODO: bring this back if we ever want to support vue 2 + vite. Else delete this!
-    // vite: '@storybook/vue-vite',
+    vite: '@storybook/vue-vite',
   },
   '@storybook/vue3': {
     webpack5: '@storybook/vue3-webpack5',


### PR DESCRIPTION
Closes #

## What I did

I re-enabled `@storybook/vue-vite` in the CLI.

## How to test

I'm not sure why this was disabled in https://github.com/storybookjs/storybook/pull/19016, and I'm not sure how to test it.  @yannbf maybe you can check if the problem that made you disable it to start with is fixed?

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
