### PR TITLE
fix: Args bool type will be string type after refresh page

### DIFF
--- a/code/lib/preview-api/src/modules/preview-web/PreviewWithSelection.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWithSelection.tsx
@@ -30,6 +30,7 @@ import type {
   DocsIndexEntry,
 } from '@storybook/types';
 
+import cloneDeep from 'lodash/cloneDeep';
 import type { MaybePromise } from './Preview';
 import { Preview } from './Preview';
 
@@ -46,6 +47,20 @@ const globalWindow = globalThis;
 function focusInInput(event: Event) {
   const target = event.target as Element;
   return /input|textarea/i.test(target.tagName) || target.getAttribute('contenteditable') !== null;
+}
+
+function convertStringBooleanToBoolean(args: Args, argTypes: any) {
+  if (Object.keys(argTypes).length === 0 || Object.keys(args).length === 0) {
+    return args;
+  }
+  const result = cloneDeep(args);
+  Object.keys(args).forEach((name) => {
+    const targetTypeIsBoolean = argTypes[name].control?.type === 'boolean';
+    if (targetTypeIsBoolean) {
+      result[name] = args[name] === 'true';
+    }
+  });
+  return result;
 }
 
 export const AUTODOCS_TAG = 'autodocs';
@@ -334,7 +349,11 @@ export class PreviewWithSelection<TFramework extends Renderer> extends Preview<T
 
     if (persistedArgs && isStoryRender(render)) {
       if (!render.story) throw new Error('Render has not been prepared!');
-      this.storyStore.args.updateFromPersisted(render.story, persistedArgs);
+      const { argTypes } = this.storyStore.getStoryContext(render.story);
+      this.storyStore.args.updateFromPersisted(
+        render.story,
+        convertStringBooleanToBoolean(persistedArgs, argTypes)
+      );
     }
 
     // Don't re-render the story if nothing has changed to justify it


### PR DESCRIPTION
Closes #20960 

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Convert string boolean type to boolean type.

<!-- Briefly describe what your PR does -->

## How to test
You select `boolean type` in `ADDONS controls/basics/Undefined` then refresh page args boolean type will be converted string type.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
