### PR TITLE
chore(deps): convert `react-textarea-autosize` from `devDependencies` to `dependencies`

### DIFF
--- a/code/ui/components/package.json
+++ b/code/ui/components/package.json
@@ -54,6 +54,7 @@
     "@storybook/theming": "7.0.0-beta.43",
     "@storybook/types": "7.0.0-beta.43",
     "memoizerific": "^1.11.3",
+    "react-textarea-autosize": "^8.3.0",
     "use-resize-observer": "^9.1.0",
     "util-deprecate": "^1.0.2"
   },
@@ -68,7 +69,6 @@
     "prettier": "^2.8.0",
     "react-popper-tooltip": "^4.4.2",
     "react-syntax-highlighter": "^15.4.5",
-    "react-textarea-autosize": "^8.3.0",
     "ts-dedent": "^2.0.0",
     "typescript": "~4.9.3"
   },


### PR DESCRIPTION
Closes #18734

## What I did

* [x] move `react-textarea-autosize` from `devDependencies` to `dependencies`

## How to test

* [ ] CI Passes

