### PR TITLE
Tech: add a default background to newly initialized storybooks

### DIFF
--- a/code/lib/cli/src/generators/configure.test.ts
+++ b/code/lib/cli/src/generators/configure.test.ts
@@ -85,6 +85,9 @@ describe('configurePreview', () => {
     expect(previewConfigPath).toEqual('./.storybook/preview.js');
     expect(previewConfigContent).toMatchInlineSnapshot(`
       "export const parameters = {
+        backgrounds: {
+          default: 'light',
+        },
         actions: { argTypesRegex: \\"^on[A-Z].*\\" },
         controls: {
           matchers: {
@@ -108,6 +111,9 @@ describe('configurePreview', () => {
     expect(previewConfigPath).toEqual('./.storybook/preview.ts');
     expect(previewConfigContent).toMatchInlineSnapshot(`
       "export const parameters = {
+        backgrounds: {
+          default: 'light',
+        },
         actions: { argTypesRegex: \\"^on[A-Z].*\\" },
         controls: {
           matchers: {
@@ -150,6 +156,9 @@ describe('configurePreview', () => {
       import docJson from \\"../documentation.json\\";
       setCompodocJson(docJson);
       export const parameters = {
+        backgrounds: {
+          default: 'light',
+        },
         actions: { argTypesRegex: \\"^on[A-Z].*\\" },
         controls: {
           matchers: {

--- a/code/lib/cli/src/generators/configure.ts
+++ b/code/lib/cli/src/generators/configure.ts
@@ -83,6 +83,9 @@ export async function configurePreview(options: ConfigurePreviewOptions) {
   const preview = dedent`
     ${prefix}
     export const parameters = {
+      backgrounds: {
+        default: 'light',
+      },
       actions: { argTypesRegex: "^on[A-Z].*" },
       controls: {
         matchers: {


### PR DESCRIPTION
Closes `we likely have an issue for this?`

> When you init a storybook on a system with dark-mode enabled. The demo components will be presented on a dark background. This is OK for the primary button component, but everything else just doesn't show well on a dark background.
>
> We could make these demo components all respond to the system preference, but these components are throw away for the user, they are just there to not start with an completely empty storybook.
>
> So here's an easy work-around: we set the default background to `light`, as this is how these demo components are intended to be shown on.
>
> In addition this instructs to user how to leverage backgrounds.

## What I did

- Add a backgrounds paramater to the `preview.*`-file generated by `sb init`.
- This parameter sets the background to light, because that's what our demo components need to be shown proper.

This also acts as a learning instrument, so users know this backgrounds feature exists, and makes it easier for them to customize.

## How to test

1. Ensure your system preferences are in dark-mode
1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Look at the Page story, this should now have a light background, and the background toolbar should be active immediatly.
