### PR TITLE
Core: Fix missing dependency for core-server

### DIFF
--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -65,6 +65,7 @@
     "@storybook/csf-tools": "7.0.0-beta.43",
     "@storybook/docs-mdx": "next",
     "@storybook/global": "^5.0.0",
+    "@storybook/manager": "7.0.0-beta.43",
     "@storybook/node-logger": "7.0.0-beta.43",
     "@storybook/preview-api": "7.0.0-beta.43",
     "@storybook/telemetry": "7.0.0-beta.43",

--- a/code/lib/core-server/src/typings.d.ts
+++ b/code/lib/core-server/src/typings.d.ts
@@ -1,11 +1,8 @@
 declare module 'lazy-universal-dotenv';
 declare module 'pnp-webpack-plugin';
-declare module '@storybook/theming/paths';
-declare module '@storybook/manager/paths';
 declare module 'better-opn';
 declare module 'open';
 declare module '@aw-web-design/x-default-browser';
-declare module '@storybook/manager';
 declare module '@discoveryjs/json-ext';
 declare module 'watchpack';
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6127,6 +6127,7 @@ __metadata:
     "@storybook/csf-tools": 7.0.0-beta.43
     "@storybook/docs-mdx": next
     "@storybook/global": ^5.0.0
+    "@storybook/manager": 7.0.0-beta.43
     "@storybook/node-logger": 7.0.0-beta.43
     "@storybook/preview-api": 7.0.0-beta.43
     "@storybook/telemetry": 7.0.0-beta.43


### PR DESCRIPTION
## What I did

Fix a missing dependency for core-server, as it references to manager package now, we need to add a dependency for it.

## How to test

CI should be green.
The problem this PR solves can only be tested when a strict package manager is used like yarn with pnp mode.