### PR TITLE
Telemetry: Hash error messages

### DIFF
--- a/code/lib/core-server/src/withTelemetry.ts
+++ b/code/lib/core-server/src/withTelemetry.ts
@@ -1,7 +1,7 @@
 import prompts from 'prompts';
 import type { CLIOptions, CoreConfig } from '@storybook/types';
 import { loadAllPresets, cache } from '@storybook/core-common';
-import { telemetry, getPrecedingUpgrade } from '@storybook/telemetry';
+import { telemetry, getPrecedingUpgrade, oneWayHash } from '@storybook/telemetry';
 import type { EventType } from '@storybook/telemetry';
 
 type TelemetryOptions = {
@@ -76,7 +76,12 @@ export async function withTelemetry(
 
         await telemetry(
           'error',
-          { eventType, precedingUpgrade, error: errorLevel === 'full' ? error : undefined },
+          {
+            eventType,
+            precedingUpgrade,
+            error: errorLevel === 'full' ? error : undefined,
+            errorHash: oneWayHash(error.message),
+          },
           {
             immediate: true,
             configDir: options.cliOptions.configDir || options.presetOptions?.configDir,

--- a/code/lib/telemetry/src/index.ts
+++ b/code/lib/telemetry/src/index.ts
@@ -5,6 +5,8 @@ import { sendTelemetry } from './telemetry';
 import { notify } from './notify';
 import { sanitizeError } from './sanitize';
 
+export { oneWayHash } from './one-way-hash';
+
 export * from './storybook-metadata';
 
 export * from './types';


### PR DESCRIPTION
## What I did

One way hash of error messages to preserve privacy

## How to test

```
# add an error to main.js
STORYBOOK_TELEMETRY_DEBUG=1 yarn storybook
```
