### PR TITLE
fix: remove unnecessary dependencies in types package

### DIFF
--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -43,11 +43,9 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@babel/core": "^7.12.10",
     "@storybook/channels": "7.0.0-beta.48",
     "@types/babel__core": "^7.0.0",
     "@types/express": "^4.7.0",
-    "express": "^4.17.3",
     "file-system-cache": "^2.0.0"
   },
   "devDependencies": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6798,13 +6798,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/types@workspace:lib/types"
   dependencies:
-    "@babel/core": ^7.12.10
     "@storybook/channels": 7.0.0-beta.48
     "@storybook/csf": next
     "@types/babel__core": ^7.0.0
     "@types/express": ^4.7.0
     "@types/node": ^16.0.0
-    express: ^4.17.3
     file-system-cache: ^2.0.0
     typescript: ~4.9.3
   languageName: unknown


### PR DESCRIPTION
## What I did

The types package already has dependencies on `@types/babel__core` and `@types/express`, so it doesn't need to depend on the actual `@babel/core` and `express` packages as well

<!-- ## How to test

Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
