### PR TITLE
Vite: Use posix paths for glob

### DIFF
--- a/code/lib/builder-vite/src/list-stories.ts
+++ b/code/lib/builder-vite/src/list-stories.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as posixPath from 'node:path/posix'; // Glob requires forward-slashes
 import { promise as glob } from 'glob-promise';
 import { normalizeStories } from '@storybook/core-common';
 
@@ -11,11 +11,14 @@ export async function listStories(options: Options) {
         configDir: options.configDir,
         workingDir: options.configDir,
       }).map(({ directory, files }) => {
-        const pattern = path.join(directory, files);
+        const pattern = posixPath.join(directory, files);
 
-        return glob(path.isAbsolute(pattern) ? pattern : path.join(options.configDir, pattern), {
-          follow: true,
-        });
+        return glob(
+          posixPath.isAbsolute(pattern) ? pattern : posixPath.join(options.configDir, pattern),
+          {
+            follow: true,
+          }
+        );
       })
     )
   ).reduce((carry, stories) => carry.concat(stories), []);


### PR DESCRIPTION
Closes https://github.com/storybookjs/builder-vite/issues/554

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

New vite projects are failing in Windows because of a change in an updated `glob` package which enforces forward-slashes for glob paths.

So, we'll use `path.posix` to join paths in the vite builder for globs.

## How to test

I don't have access to a windows box, so I'm not able to test.  And we don't test Windows in CI.  I'm hoping that maybe @joshwooding or someone else can help test this out.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [X] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
