### PR TITLE
CLI: Automigration to update `mdx` stories config

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.test.ts
@@ -1,0 +1,140 @@
+/* eslint-disable no-underscore-dangle */
+/// <reference types="@types/jest" />;
+
+import type { StorybookConfig } from '@storybook/types';
+import path from 'path';
+import type { JsPackageManager, PackageJson } from '../../js-package-manager';
+import { bareMdxStoriesGlob } from './bare-mdx-stories-glob';
+
+// eslint-disable-next-line global-require, jest/no-mocks-import
+jest.mock('fs-extra', () => require('../../../../../__mocks__/fs-extra'));
+
+const checkBareMdxStoriesGlob = async ({
+  packageJson,
+  main,
+}: {
+  packageJson: PackageJson;
+  main?: Partial<StorybookConfig>;
+}) => {
+  if (main) {
+    // eslint-disable-next-line global-require
+    require('fs-extra').__setMockFiles({
+      [path.join('.storybook', 'main.js')]: `module.exports = ${JSON.stringify(main)};`,
+    });
+  } else {
+    // eslint-disable-next-line global-require
+    require('fs-extra').__setMockFiles({});
+  }
+  const packageManager = {
+    retrievePackageJson: () => ({ dependencies: {}, devDependencies: {}, ...packageJson }),
+  } as JsPackageManager;
+
+  return bareMdxStoriesGlob.check({ packageManager });
+};
+
+describe('bare-mdx fix', () => {
+  describe('should no-op', () => {
+    it('in SB < v7.0.0', async () => {
+      const packageJson = {
+        dependencies: { '@storybook/react': '^6.2.0' },
+      };
+      const main = { stories: ['../**/*.stories.mdx'] };
+      await expect(checkBareMdxStoriesGlob({ packageJson, main })).resolves.toBeFalsy();
+    });
+
+    describe('in SB >= v7.0.0', () => {
+      it('without main', async () => {
+        const packageJson = {
+          dependencies: { '@storybook/react': '^7.0.0' },
+        };
+        await expect(checkBareMdxStoriesGlob({ packageJson })).rejects.toThrow();
+      });
+
+      it('without stories field in main', async () => {
+        const packageJson = {
+          dependencies: { '@storybook/react': '^7.0.0' },
+        };
+        const main = {};
+        await expect(checkBareMdxStoriesGlob({ packageJson, main })).rejects.toThrow();
+      });
+    });
+  });
+  describe('should fix', () => {
+    it.each([
+      {
+        existingStoriesEntries: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+        expectedStoriesEntries: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+      },
+      {
+        existingStoriesEntries: ['../src/**/*.stories.*'],
+        expectedStoriesEntries: ['../src/**/*.stories.*', '../src/**/*.mdx'],
+      },
+      {
+        existingStoriesEntries: ['../src/**/*.stories.@(mdx|js|jsx|ts|tsx)'],
+        expectedStoriesEntries: ['../src/**/*.stories.@(js|jsx|ts|tsx)', '../src/**/*.mdx'],
+      },
+      {
+        existingStoriesEntries: ['../src/**/*.stories.@(js|jsx|mdx|ts|tsx)'],
+        expectedStoriesEntries: ['../src/**/*.stories.@(js|jsx|ts|tsx)', '../src/**/*.mdx'],
+      },
+      {
+        existingStoriesEntries: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+        expectedStoriesEntries: ['../src/**/*.stories.@(js|jsx|ts|tsx)', '../src/**/*.mdx'],
+      },
+    ])(
+      'strings: $existingStoriesEntries',
+      async ({ existingStoriesEntries, expectedStoriesEntries }) => {
+        const packageJson = {
+          dependencies: { '@storybook/react': '^7.0.0' },
+        };
+        const main = {
+          stories: existingStoriesEntries,
+        };
+        await expect(checkBareMdxStoriesGlob({ packageJson, main })).resolves.toMatchObject({
+          existingStoriesEntries,
+          nextStoriesEntries: expectedStoriesEntries,
+        });
+      }
+    );
+    it.each([
+      {
+        existingStoriesEntries: [{ directory: '../src/**' }],
+        expectedStoriesEntries: [{ directory: '../src/**' }],
+      },
+      {
+        existingStoriesEntries: [{ directory: '../src/**', files: '*.stories.mdx' }],
+        expectedStoriesEntries: [{ directory: '../src/**', files: '*.mdx' }],
+      },
+      {
+        existingStoriesEntries: [{ directory: '../src/**', files: '*.stories.*' }],
+        expectedStoriesEntries: [
+          { directory: '../src/**', files: '*.stories.*' },
+          { directory: '../src/**', files: '*.mdx' },
+        ],
+      },
+      {
+        existingStoriesEntries: [
+          { directory: '../src/**', files: '*.stories.@(js|jsx|ts|tsx|mdx)' },
+        ],
+        expectedStoriesEntries: [
+          { directory: '../src/**', files: '*.stories.@(js|jsx|ts|tsx)' },
+          { directory: '../src/**', files: '*.mdx' },
+        ],
+      },
+    ])(
+      'specifiers: $existingStoriesEntries.0.files',
+      async ({ existingStoriesEntries, expectedStoriesEntries }) => {
+        const packageJson = {
+          dependencies: { '@storybook/react': '^7.0.0' },
+        };
+        const main = {
+          stories: existingStoriesEntries,
+        };
+        await expect(checkBareMdxStoriesGlob({ packageJson, main })).resolves.toMatchObject({
+          existingStoriesEntries,
+          nextStoriesEntries: expectedStoriesEntries,
+        });
+      }
+    );
+  });
+});

--- a/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.test.ts
@@ -4,6 +4,7 @@
 import type { StorybookConfig } from '@storybook/types';
 import path from 'path';
 import type { JsPackageManager, PackageJson } from '../../js-package-manager';
+import { ansiRegex } from '../helpers/cleanLog';
 import type { BareMdxStoriesGlobRunOptions } from './bare-mdx-stories-glob';
 import { bareMdxStoriesGlob } from './bare-mdx-stories-glob';
 
@@ -179,26 +180,26 @@ describe('bare-mdx fix', () => {
         ],
       } as BareMdxStoriesGlobRunOptions);
 
-      expect(result).toMatchInlineSnapshot(`
+      expect(result.replaceAll(ansiRegex(), '')).toMatchInlineSnapshot(`
         "We've detected your project has one or more globs in your 'stories' config that matches .stories.mdx files:
-          [36m\\"../src/**/*.stories.@(js|jsx|mdx|ts|tsx)\\"[39m
-          [36m{[39m
-          [36m  \\"directory\\": \\"../src/**\\",[39m
-          [36m  \\"files\\": \\"*.stories.mdx\\"[39m
-          [36m}[39m
+          \\"../src/**/*.stories.@(js|jsx|mdx|ts|tsx)\\"
+          {
+            \\"directory\\": \\"../src/**\\",
+            \\"files\\": \\"*.stories.mdx\\"
+          }
 
         In Storybook 7, we have deprecated defining stories in MDX files, and consequently have changed the suffix to simply .mdx.
 
         We can automatically migrate your 'stories' config to include any .mdx file instead of just .stories.mdx.
         That would result in the following 'stories' config:
-          [36m\\"../src/**/*.mdx\\"[39m
-          [36m\\"../src/**/*.stories.@(js|jsx|ts|tsx)\\"[39m
-          [36m{[39m
-          [36m  \\"directory\\": \\"../src/**\\",[39m
-          [36m  \\"files\\": \\"*.mdx\\"[39m
-          [36m}[39m
+          \\"../src/**/*.mdx\\"
+          \\"../src/**/*.stories.@(js|jsx|ts|tsx)\\"
+          {
+            \\"directory\\": \\"../src/**\\",
+            \\"files\\": \\"*.mdx\\"
+          }
 
-        To learn more about this change, see: [33mhttps://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files[39m"
+        To learn more about this change, see: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files"
       `);
     });
   });

--- a/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.test.ts
@@ -101,19 +101,19 @@ describe('bare-mdx fix', () => {
       },
       {
         existingStoriesEntries: ['../src/**/*.stories.*'],
-        expectedStoriesEntries: ['../src/**/*.stories.*', '../src/**/*.mdx'],
+        expectedStoriesEntries: ['../src/**/*.@(mdx|stories.*)'],
       },
       {
         existingStoriesEntries: ['../src/**/*.stories.@(mdx|js|jsx|ts|tsx)'],
-        expectedStoriesEntries: ['../src/**/*.stories.@(js|jsx|ts|tsx)', '../src/**/*.mdx'],
+        expectedStoriesEntries: ['../src/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
       },
       {
         existingStoriesEntries: ['../src/**/*.stories.@(js|jsx|mdx|ts|tsx)'],
-        expectedStoriesEntries: ['../src/**/*.stories.@(js|jsx|ts|tsx)', '../src/**/*.mdx'],
+        expectedStoriesEntries: ['../src/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
       },
       {
         existingStoriesEntries: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
-        expectedStoriesEntries: ['../src/**/*.stories.@(js|jsx|ts|tsx)', '../src/**/*.mdx'],
+        expectedStoriesEntries: ['../src/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
       },
     ])(
       'strings: $existingStoriesEntries',
@@ -137,18 +137,14 @@ describe('bare-mdx fix', () => {
       },
       {
         existingStoriesEntries: [{ directory: '../src/**', files: '*.stories.*' }],
-        expectedStoriesEntries: [
-          { directory: '../src/**', files: '*.stories.*' },
-          { directory: '../src/**', files: '*.mdx' },
-        ],
+        expectedStoriesEntries: [{ directory: '../src/**', files: '*.@(mdx|stories.*)' }],
       },
       {
         existingStoriesEntries: [
           { directory: '../src/**', files: '*.stories.@(js|jsx|ts|tsx|mdx)' },
         ],
         expectedStoriesEntries: [
-          { directory: '../src/**', files: '*.stories.@(js|jsx|ts|tsx)' },
-          { directory: '../src/**', files: '*.mdx' },
+          { directory: '../src/**', files: '*.@(mdx|stories.@(js|jsx|ts|tsx))' },
         ],
       },
     ])(

--- a/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.test.ts
@@ -59,6 +59,24 @@ describe('bare-mdx fix', () => {
         await expect(checkBareMdxStoriesGlob({ packageJson, main })).rejects.toThrow();
       });
 
+      it('with variable references in stories field', async () => {
+        // eslint-disable-next-line global-require
+        require('fs-extra').__setMockFiles({
+          [path.join('.storybook', 'main.js')]: `
+          const globVar = '../**/*.stories.mdx';
+          module.exports = { stories: [globVar] };`,
+        });
+
+        const packageManager = {
+          retrievePackageJson: () => ({
+            dependencies: { '@storybook/react': '^7.0.0' },
+            devDependencies: {},
+          }),
+        } as unknown as JsPackageManager;
+
+        await expect(bareMdxStoriesGlob.check({ packageManager })).rejects.toThrow();
+      });
+
       it('without .stories.mdx in globs', async () => {
         const packageJson = {
           dependencies: { '@storybook/react': '^7.0.0' },

--- a/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.test.ts
@@ -4,6 +4,7 @@
 import type { StorybookConfig } from '@storybook/types';
 import path from 'path';
 import type { JsPackageManager, PackageJson } from '../../js-package-manager';
+import type { BareMdxStoriesGlobRunOptions } from './bare-mdx-stories-glob';
 import { bareMdxStoriesGlob } from './bare-mdx-stories-glob';
 
 // eslint-disable-next-line global-require, jest/no-mocks-import
@@ -57,6 +58,20 @@ describe('bare-mdx fix', () => {
         const main = {};
         await expect(checkBareMdxStoriesGlob({ packageJson, main })).rejects.toThrow();
       });
+
+      it('without .stories.mdx in globs', async () => {
+        const packageJson = {
+          dependencies: { '@storybook/react': '^7.0.0' },
+        };
+        const main = {
+          stories: [
+            '../src/**/*.stories.@(js|jsx|ts|tsx)',
+            { directory: '../**', files: '*.stories.@(js|jsx|ts|tsx)' },
+            { directory: '../**' },
+          ],
+        };
+        await expect(checkBareMdxStoriesGlob({ packageJson, main })).resolves.toBeFalsy();
+      });
     });
   });
   describe('should fix', () => {
@@ -98,10 +113,6 @@ describe('bare-mdx fix', () => {
     );
     it.each([
       {
-        existingStoriesEntries: [{ directory: '../src/**' }],
-        expectedStoriesEntries: [{ directory: '../src/**' }],
-      },
-      {
         existingStoriesEntries: [{ directory: '../src/**', files: '*.stories.mdx' }],
         expectedStoriesEntries: [{ directory: '../src/**', files: '*.mdx' }],
       },
@@ -136,5 +147,41 @@ describe('bare-mdx fix', () => {
         });
       }
     );
+
+    it('prompts', () => {
+      const result = bareMdxStoriesGlob.prompt({
+        existingStoriesEntries: [
+          '../src/**/*.stories.@(js|jsx|mdx|ts|tsx)',
+          { directory: '../src/**', files: '*.stories.mdx' },
+        ],
+        nextStoriesEntries: [
+          '../src/**/*.mdx',
+          '../src/**/*.stories.@(js|jsx|ts|tsx)',
+          { directory: '../src/**', files: '*.mdx' },
+        ],
+      } as BareMdxStoriesGlobRunOptions);
+
+      expect(result).toMatchInlineSnapshot(`
+        "We've detected your project has one or more globs in your 'stories' config that matches .stories.mdx files:
+          [36m\\"../src/**/*.stories.@(js|jsx|mdx|ts|tsx)\\"[39m
+          [36m{[39m
+          [36m  \\"directory\\": \\"../src/**\\",[39m
+          [36m  \\"files\\": \\"*.stories.mdx\\"[39m
+          [36m}[39m
+
+        In Storybook 7, we have deprecated defining stories in MDX files, and consequently have changed the suffix to simply .mdx.
+
+        We can automatically migrate your 'stories' config to include any .mdx file instead of just .stories.mdx.
+        That would result in the following 'stories' config:
+          [36m\\"../src/**/*.mdx\\"[39m
+          [36m\\"../src/**/*.stories.@(js|jsx|ts|tsx)\\"[39m
+          [36m{[39m
+          [36m  \\"directory\\": \\"../src/**\\",[39m
+          [36m  \\"files\\": \\"*.mdx\\"[39m
+          [36m}[39m
+
+        To learn more about this change, see: [33mhttps://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files[39m"
+      `);
+    });
   });
 });

--- a/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.ts
+++ b/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.ts
@@ -58,14 +58,30 @@ export const bareMdxStoriesGlob: Fix<BareMdxStoriesGlobRunOptions> = {
 
     const main = await readConfig(mainConfig);
 
-    const existingStoriesEntries = main.getFieldValue(['stories']) as StoriesEntry[];
+    let existingStoriesEntries;
+
+    try {
+      existingStoriesEntries = main.getFieldValue(['stories']) as StoriesEntry[];
+    } catch (e) {
+      throw new Error(dedent`
+      ❌ Unable to determine Storybook stories globs, skipping ${chalk.cyan(fixId)} fix.
+      
+      In Storybook 7, we have deprecated defining stories in MDX files, and consequently have changed the suffix to simply .mdx.
+
+      We were unable to automatically migrate your 'stories' config to include any .mdx file instead of just .stories.mdx.
+      We suggest you make this change manually.
+
+      To learn more about this change, see: ${chalk.yellow(
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files'
+      )}
+      `);
+    }
 
     if (!existingStoriesEntries) {
-      logger.warn(dedent`
+      throw new Error(dedent`
       ❌ Unable to determine Storybook stories globs, skipping ${chalk.cyan(fixId)} fix.
       🤔 Are you running automigrate from your project directory?
     `);
-      return null;
     }
 
     const nextStoriesEntries: StoriesEntry[] = [];

--- a/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.ts
+++ b/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.ts
@@ -63,6 +63,10 @@ export const bareMdxStoriesGlob: Fix<BareMdxStoriesGlobRunOptions> = {
     try {
       existingStoriesEntries = main.getFieldValue(['stories']) as StoriesEntry[];
     } catch (e) {
+      // throws in next null check below
+    }
+
+    if (!existingStoriesEntries) {
       throw new Error(dedent`
       ❌ Unable to determine Storybook stories globs, skipping ${chalk.cyan(fixId)} fix.
       
@@ -75,13 +79,6 @@ export const bareMdxStoriesGlob: Fix<BareMdxStoriesGlobRunOptions> = {
         'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files'
       )}
       `);
-    }
-
-    if (!existingStoriesEntries) {
-      throw new Error(dedent`
-      ❌ Unable to determine Storybook stories globs, skipping ${chalk.cyan(fixId)} fix.
-      🤔 Are you running automigrate from your project directory?
-    `);
     }
 
     const nextStoriesEntries: StoriesEntry[] = [];

--- a/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.ts
+++ b/code/lib/cli/src/automigrate/fixes/bare-mdx-stories-glob.ts
@@ -1,0 +1,101 @@
+import chalk from 'chalk';
+import dedent from 'ts-dedent';
+import semver from 'semver';
+import type { ConfigFile } from '@storybook/csf-tools';
+import { readConfig, writeConfig } from '@storybook/csf-tools';
+import { getStorybookInfo } from '@storybook/core-common';
+import type { StoriesEntry } from 'lib/types/src';
+import type { Fix } from '../types';
+
+const logger = console;
+
+const fixId = 'bare-mdx-stories-glob';
+
+const getNextGlobs = (glob: string) => {
+  const nextGlobs: string[] = [];
+  const regexMatch = glob.match(/(.*)\.stories\.@\(.*mdx.*\)$/i);
+  if (regexMatch) {
+    nextGlobs.push(glob.replaceAll('mdx|', '').replaceAll('|mdx', ''));
+    nextGlobs.push(`${regexMatch[1]}.mdx`);
+    return nextGlobs;
+  }
+  nextGlobs.push(glob.replaceAll('.stories.mdx', '.mdx'));
+  if (glob.includes('.stories.*')) {
+    // add a second entry similar to the existing *.stories.*, but for *.mdx
+    nextGlobs.push(glob.replaceAll('.stories.*', '.mdx'));
+  }
+  return nextGlobs;
+};
+
+export const bareMdxStoriesGlob: Fix = {
+  id: fixId,
+  async check({ packageManager }) {
+    const packageJson = packageManager.retrievePackageJson();
+
+    const { mainConfig, version: storybookVersion } = getStorybookInfo(packageJson);
+    if (!mainConfig) {
+      logger.warn('Unable to find storybook main.js config, skipping');
+      return null;
+    }
+
+    const sbVersionCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
+    if (!sbVersionCoerced) {
+      throw new Error(dedent`
+        ❌ Unable to determine storybook version.
+        🤔 Are you running automigrate from your project directory?
+      `);
+    }
+
+    if (!semver.gte(sbVersionCoerced, '7.0.0')) {
+      return null;
+    }
+
+    const existingStoriesEntries = (await readConfig(mainConfig)).getFieldValue([
+      'stories',
+    ]) as StoriesEntry[];
+
+    if (!existingStoriesEntries) {
+      logger.warn(dedent`
+      ❌ Unable to determine Storybook stories globs, skipping ${chalk.cyan(fixId)} fix.
+      🤔 Are you running automigrate from your project directory?
+    `);
+      return null;
+    }
+
+    console.log('LOG: existing');
+    console.dir(existingStoriesEntries, { depth: 5 });
+
+    const nextStoriesEntries: StoriesEntry[] = [];
+
+    existingStoriesEntries.forEach((entry) => {
+      const isSpecifier = typeof entry !== 'string';
+      const glob = isSpecifier ? entry.files : entry;
+
+      if (!glob) {
+        // storySpecifier without the 'files' property. Just add the existing to the next list
+        nextStoriesEntries.push(entry);
+        return;
+      }
+
+      const nextGlobs = getNextGlobs(glob);
+      if (isSpecifier) {
+        nextStoriesEntries.push(...nextGlobs.map((nextGlob) => ({ ...entry, files: nextGlob })));
+      } else {
+        nextStoriesEntries.push(...nextGlobs);
+      }
+    });
+
+    console.log('LOG: next');
+    console.dir(nextStoriesEntries, { depth: 5 });
+
+    return { existingStoriesEntries, nextStoriesEntries };
+
+    // show existing globs
+    // show how we plan to change them
+    // show what the existing target matches
+    // show what the new target will match
+  },
+  prompt() {
+    return 'yay';
+  },
+};

--- a/code/lib/cli/src/automigrate/fixes/index.ts
+++ b/code/lib/cli/src/automigrate/fixes/index.ts
@@ -18,6 +18,7 @@ import { sveltekitFramework } from './sveltekit-framework';
 import { addReact } from './add-react';
 import { nodeJsRequirement } from './nodejs-requirement';
 import { missingBabelRc } from './missing-babelrc';
+import { bareMdxStoriesGlob } from './bare-mdx-stories-glob';
 
 export * from '../types';
 
@@ -37,6 +38,7 @@ export const fixes: Fix[] = [
   nextjsFramework,
   removedGlobalClientAPIs,
   mdx1to2,
+  bareMdxStoriesGlob,
   autodocsTrue,
   addReact,
   missingBabelRc,

--- a/code/lib/cli/src/automigrate/helpers/cleanLog.ts
+++ b/code/lib/cli/src/automigrate/helpers/cleanLog.ts
@@ -1,10 +1,20 @@
 import { EOL } from 'os';
 
+// copied from https://github.com/chalk/ansi-regex
+// the package is ESM only so not compatible with jest
+export const ansiRegex = ({ onlyFirst = false } = {}) => {
+  const pattern = [
+    '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
+  ].join('|');
+
+  return new RegExp(pattern, onlyFirst ? undefined : 'g');
+};
+
 export const cleanLog = (str: string) =>
   str
     // remove chalk ANSI colors
-    // eslint-disable-next-line no-control-regex
-    .replace(/\u001b\[.*?m/g, '')
+    .replace(ansiRegex(), '')
     // fix boxen output
     .replace(/╮│/g, '╮\n│')
     .replace(/││/g, '│\n│')


### PR DESCRIPTION
Fixes #20249

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR introduces an automigration that migrates `stories` glob that matches `*.stories.mdx` to match `*.mdx`. It also migrates story specifiers.

The prompt shows the existing `stories` config and what it would change to. I've also considered showing a before and after list of actual files it would match, so the user can visually inspect what the actual consequences are.
I'm unsure if it's worth the effort or if this is okay.

<!-- Briefly describe what your PR does -->

## How to test

1. Create a sandbox
2. Modify `stories` config to be something like `['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)']`
3. Compile the project
3. Run the CLI with `../code/lib/cli/bin/index.js automigrate`
4. See the prompt and the changes

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [X] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
