### PR TITLE
Add `defaultOrientation` parameter to viewport addon.

### DIFF
--- a/code/addons/viewport/src/Tool.tsx
+++ b/code/addons/viewport/src/Tool.tsx
@@ -127,12 +127,13 @@ export const ViewportTool: FC = memo(
   withTheme(({ theme }: { theme: Theme }) => {
     const {
       viewports = MINIMAL_VIEWPORTS,
+      defaultOrientation = 'portrait',
       defaultViewport = responsiveViewport.id,
       disable,
     } = useParameter<ViewportAddonParameter>(PARAM_KEY, {});
     const [state, setState] = useAddonState<ViewportToolState>(ADDON_ID, {
       selected: defaultViewport,
-      isRotated: false,
+      isRotated: defaultOrientation === 'landscape',
     });
 
     const list = toList(viewports);

--- a/code/addons/viewport/src/models/ViewportAddonParameter.ts
+++ b/code/addons/viewport/src/models/ViewportAddonParameter.ts
@@ -2,6 +2,7 @@ import type { ViewportMap } from './Viewport';
 
 export interface ViewportAddonParameter {
   disable?: boolean;
+  defaultOrientation: 'portrait' | 'landscape';
   defaultViewport?: string;
   viewports?: ViewportMap;
 }

--- a/code/addons/viewport/src/models/ViewportAddonParameter.ts
+++ b/code/addons/viewport/src/models/ViewportAddonParameter.ts
@@ -2,7 +2,7 @@ import type { ViewportMap } from './Viewport';
 
 export interface ViewportAddonParameter {
   disable?: boolean;
-  defaultOrientation: 'portrait' | 'landscape';
+  defaultOrientation?: 'portrait' | 'landscape';
   defaultViewport?: string;
   viewports?: ViewportMap;
 }


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Add `defaultOrientation` to `@storybook/addon-viewport` parameters for setting the default orientation.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
