### PR TITLE
docs: replace deprecated pnpm command with newer

### DIFF
--- a/docs/get-started/installation-command-section/html.mdx
+++ b/docs/get-started/installation-command-section/html.mdx
@@ -9,7 +9,7 @@ npx storybook init --type html
 - With pnpm:
 
 ```shell
-pnpx storybook init --type html
+pnpm dlx storybook init --type html
 ```
 
 If you run into issues with the installation, check the [Troubleshooting section](#troubleshooting) below for guidance on how to solve it.

--- a/docs/get-started/installation-command-section/preact.mdx
+++ b/docs/get-started/installation-command-section/preact.mdx
@@ -9,7 +9,7 @@ npx storybook init
 - With pnpm:
 
 ```shell
-pnpx storybook init
+pnpm dlx storybook init
 ```
 
 If you run into issues with the installation, check the [Troubleshooting section](#troubleshooting) below for guidance on how to solve it.

--- a/docs/get-started/installation-command-section/qwik.mdx
+++ b/docs/get-started/installation-command-section/qwik.mdx
@@ -9,7 +9,7 @@ npx storybook init
 - With pnpm:
 
 ```shell
-pnpx storybook init
+pnpm dlx storybook init
 ```
 
 If you run into issues with the installation, check the [Troubleshooting section](#troubleshooting) below for guidance on how to solve it.

--- a/docs/get-started/installation-command-section/react.mdx
+++ b/docs/get-started/installation-command-section/react.mdx
@@ -9,7 +9,7 @@ npx storybook init
 - With pnpm:
 
 ```shell
-pnpx storybook init
+pnpm dlx storybook init
 ```
 
 If you run into issues with the installation, check the [Troubleshooting section](#troubleshooting) below for guidance on how to solve it.

--- a/docs/get-started/installation-command-section/svelte.mdx
+++ b/docs/get-started/installation-command-section/svelte.mdx
@@ -9,7 +9,7 @@ npx storybook init
 - With pnpm:
 
 ```shell
-pnpx storybook init
+pnpm dlx storybook init
 ```
 
 If you run into issues with the installation, check the [Troubleshooting section](#troubleshooting) below for guidance on how to solve it.

--- a/docs/get-started/installation-command-section/vue.mdx
+++ b/docs/get-started/installation-command-section/vue.mdx
@@ -9,7 +9,7 @@ npx storybook init
 - With pnpm:
 
 ```shell
-pnpx storybook init
+pnpm dlx storybook init
 ```
 
 If you run into issues with the installation, check the [Troubleshooting section](#troubleshooting) below for guidance on how to solve it.

--- a/docs/get-started/installation-command-section/web-components.mdx
+++ b/docs/get-started/installation-command-section/web-components.mdx
@@ -9,7 +9,7 @@ npx storybook init
 - With pnpm:
 
 ```shell
-pnpx storybook init
+pnpm dlx storybook init
 ```
 
 If you run into issues with the installation, check the [Troubleshooting section](#troubleshooting) below for guidance on how to solve it.


### PR DESCRIPTION
## What I did

`pnpx` has been deprecated, use `pnpm dlx` instead.

See more on [pnpm docs](https://pnpm.io/6.x/pnpx-cli)

## How to test

No need to test.

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
