### PR TITLE
Upgrade react-docgen-typescript-plugin

### DIFF
--- a/code/presets/react-webpack/package.json
+++ b/code/presets/react-webpack/package.json
@@ -75,12 +75,12 @@
     "@storybook/docs-tools": "7.0.0-beta.47",
     "@storybook/node-logger": "7.0.0-beta.47",
     "@storybook/react": "7.0.0-beta.47",
-    "@storybook/react-docgen-typescript-plugin": "1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0",
     "@types/node": "^16.0.0",
     "@types/semver": "^7.3.4",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-react-docgen": "^4.2.1",
     "fs-extra": "^11.1.0",
+    "react-docgen-typescript-plugin": "^1.0.5",
     "react-refresh": "^0.11.0",
     "semver": "^7.3.7"
   },

--- a/code/presets/react-webpack/src/framework-preset-react-docs.test.ts
+++ b/code/presets/react-webpack/src/framework-preset-react-docs.test.ts
@@ -1,4 +1,4 @@
-import ReactDocgenTypescriptPlugin from '@storybook/react-docgen-typescript-plugin';
+import ReactDocgenTypescriptPlugin from 'react-docgen-typescript-plugin';
 import type { TypescriptOptions } from '@storybook/core-webpack';
 import * as preset from './framework-preset-react-docs';
 

--- a/code/presets/react-webpack/src/framework-preset-react-docs.ts
+++ b/code/presets/react-webpack/src/framework-preset-react-docs.ts
@@ -1,4 +1,4 @@
-import ReactDocgenTypescriptPlugin from '@storybook/react-docgen-typescript-plugin';
+import ReactDocgenTypescriptPlugin from 'react-docgen-typescript-plugin';
 import { hasDocsOrControls } from '@storybook/docs-tools';
 
 import type { StorybookConfig } from './types';

--- a/code/presets/react-webpack/src/types.ts
+++ b/code/presets/react-webpack/src/types.ts
@@ -3,7 +3,7 @@ import type {
   StorybookConfig as StorybookConfigBase,
   TypescriptOptions as TypescriptOptionsBase,
 } from '@storybook/core-webpack';
-import type { PluginOptions as ReactDocgenTypescriptOptions } from '@storybook/react-docgen-typescript-plugin';
+import type { PluginOptions as ReactDocgenTypescriptOptions } from 'react-docgen-typescript-plugin';
 
 export type { BuilderResult } from '@storybook/core-webpack';
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6074,12 +6074,12 @@ __metadata:
     "@storybook/docs-tools": 7.0.0-beta.47
     "@storybook/node-logger": 7.0.0-beta.47
     "@storybook/react": 7.0.0-beta.47
-    "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0
     "@types/node": ^16.0.0
     "@types/semver": ^7.3.4
     babel-plugin-add-react-displayname: ^0.0.5
     babel-plugin-react-docgen: ^4.2.1
     fs-extra: ^11.1.0
+    react-docgen-typescript-plugin: ^1.0.5
     react-refresh: ^0.11.0
     semver: ^7.3.7
     typescript: ~4.9.3
@@ -6248,24 +6248,6 @@ __metadata:
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft
-
-"@storybook/react-docgen-typescript-plugin@npm:1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0":
-  version: 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0
-  resolution: "@storybook/react-docgen-typescript-plugin@npm:1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0"
-  dependencies:
-    debug: ^4.1.1
-    endent: ^2.0.1
-    find-cache-dir: ^3.3.1
-    flat-cache: ^3.0.4
-    micromatch: ^4.0.2
-    react-docgen-typescript: ^2.1.1
-    tslib: ^2.0.0
-  peerDependencies:
-    typescript: ">= 3.x"
-    webpack: ">= 4"
-  checksum: 2d3ab49e4858d5f28f36b5bd0e30f3d3450bc7d9865cd4fbe65a35085ae63feff9556a3265b594a2c84b03c66f009dc8b057802f3ca0f76b961d51536835cb8f
-  languageName: node
-  linkType: hard
 
 "@storybook/react-vite@workspace:*, @storybook/react-vite@workspace:frameworks/react-vite":
   version: 0.0.0-use.local
@@ -23439,7 +23421,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen-typescript@npm:^2.1.1, react-docgen-typescript@npm:^2.2.2":
+"react-docgen-typescript-plugin@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "react-docgen-typescript-plugin@npm:1.0.5"
+  dependencies:
+    debug: ^4.1.1
+    endent: ^2.0.1
+    find-cache-dir: ^3.3.1
+    flat-cache: ^3.0.4
+    micromatch: ^4.0.2
+    react-docgen-typescript: ^2.2.2
+    tslib: ^2.0.0
+  peerDependencies:
+    typescript: ">= 4.x"
+    webpack: ">= 4"
+  checksum: 007a689f4ae5aae7b1a89b2b54b1e3806e4316677da24977516b794aa9252a16ee1a103fc0b254afb2961530909326df49052ade8dcaf96e6b6ea06adf34f6bd
+  languageName: node
+  linkType: hard
+
+"react-docgen-typescript@npm:^2.2.2":
   version: 2.2.2
   resolution: "react-docgen-typescript@npm:2.2.2"
   peerDependencies:


### PR DESCRIPTION
Closes #19055 

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

We forked `react-docgen-typescript-plugin` since we were having trouble getting changes released. Now the changes are available, so this attempts to replace our fork with the main release.

Self-merging @valentinpalkovic 

## How to test

Open any React/TS sandbox and verify the controls/ArgTypes look correct

## Checklist

This is already tested in CI in various ways


