### PR TITLE
Vite: Fix storysource addon support

### DIFF
--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -52,6 +52,7 @@
     "@storybook/node-logger": "7.0.0-beta.47",
     "@storybook/preview": "7.0.0-beta.47",
     "@storybook/preview-api": "7.0.0-beta.47",
+    "@storybook/source-loader": "7.0.0-beta.47",
     "@storybook/types": "7.0.0-beta.47",
     "browser-assert": "^1.2.1",
     "es-module-lexer": "^0.9.3",

--- a/code/lib/builder-vite/src/plugins/index.ts
+++ b/code/lib/builder-vite/src/plugins/index.ts
@@ -4,3 +4,4 @@ export * from './strip-story-hmr-boundaries';
 export * from './code-generator-plugin';
 export * from './csf-plugin';
 export * from './external-globals-plugin';
+export * from './source-loader-plugin';

--- a/code/lib/builder-vite/src/plugins/source-loader-plugin.ts
+++ b/code/lib/builder-vite/src/plugins/source-loader-plugin.ts
@@ -1,0 +1,106 @@
+import type { Plugin } from 'vite';
+import sourceLoaderTransform from '@storybook/source-loader';
+import MagicString from 'magic-string';
+import type { ExtendedOptions } from '../types';
+
+const storyPattern = /\.stories\.[jt]sx?$/;
+const storySourcePattern = /var __STORY__ = "(.*)"/;
+const storySourceReplacement = '--STORY_SOURCE_REPLACEMENT--';
+
+const mockClassLoader = (id: string) => ({
+  // eslint-disable-next-line no-console
+  emitWarning: (message: string) => console.warn(message),
+  resourcePath: id,
+  getOptions: () => ({ injectStoryParameters: true }),
+  extension: `.${id.split('.').pop()}`,
+});
+
+// HACK: Until we can support only node 15+ and use string.prototype.replaceAll
+const replaceAll = (str: string, search: string, replacement: string) => {
+  return str.split(search).join(replacement);
+};
+
+export function sourceLoaderPlugin(config: ExtendedOptions): Plugin | Plugin[] {
+  if (config.configType === 'DEVELOPMENT') {
+    return {
+      name: 'storybook:source-loader-plugin',
+      enforce: 'pre',
+      async transform(src: string, id: string) {
+        if (id.match(storyPattern)) {
+          const code: string = await sourceLoaderTransform.call(mockClassLoader(id), src);
+          const s = new MagicString(src);
+          // Entirely replace with new code
+          s.overwrite(0, src.length, code);
+
+          return {
+            code: s.toString(),
+            map: s.generateMap({ hires: true, source: id }),
+          };
+        }
+        return undefined;
+      },
+    };
+  }
+
+  // In production, we need to be fancier, to avoid vite:define plugin from replacing values inside the `__STORY__` string
+  const storySources = new WeakMap<ExtendedOptions, Map<string, string>>();
+
+  return [
+    {
+      name: 'storybook-vite-source-loader-plugin',
+      enforce: 'pre',
+      buildStart() {
+        storySources.set(config, new Map());
+      },
+      async transform(src: string, id: string) {
+        if (id.match(storyPattern)) {
+          let code: string = await sourceLoaderTransform.call(mockClassLoader(id), src);
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          const [_, sourceString] = code.match(storySourcePattern) ?? [null, null];
+          if (sourceString) {
+            const map = storySources.get(config);
+            map?.set(id, sourceString);
+
+            // Remove story source so that it is not processed by vite:define plugin
+            code = replaceAll(code, sourceString, storySourceReplacement);
+          }
+
+          const s = new MagicString(src);
+          // Entirely replace with new code
+          s.overwrite(0, src.length, code);
+
+          return {
+            code: s.toString(),
+            map: s.generateMap(),
+          };
+        }
+        return undefined;
+      },
+    },
+    {
+      name: 'storybook-vite-source-loader-plugin-post',
+      enforce: 'post',
+      buildStart() {
+        storySources.set(config, new Map());
+      },
+      async transform(src: string, id: string) {
+        if (id.match(storyPattern)) {
+          const s = new MagicString(src);
+          const map = storySources.get(config);
+          const storySourceStatement = map?.get(id);
+          // Put the previously-extracted source back in
+          if (storySourceStatement) {
+            const newCode = replaceAll(src, storySourceReplacement, storySourceStatement);
+            s.overwrite(0, src.length, newCode);
+          }
+
+          return {
+            code: s.toString(),
+            map: s.generateMap(),
+          };
+        }
+        return undefined;
+      },
+    },
+  ];
+}

--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -17,6 +17,7 @@ import {
   mdxPlugin,
   stripStoryHMRBoundary,
   externalGlobalsPlugin,
+  sourceLoaderPlugin,
 } from './plugins';
 
 import type { BuilderOptions } from './types';
@@ -77,6 +78,7 @@ export async function pluginConfig(options: Options) {
 
   const plugins = [
     codeGeneratorPlugin(options),
+    sourceLoaderPlugin(options),
     await csfPlugin(options),
     await mdxPlugin(options),
     injectExportOrderPlugin,

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5195,6 +5195,7 @@ __metadata:
     "@storybook/node-logger": 7.0.0-beta.47
     "@storybook/preview": 7.0.0-beta.47
     "@storybook/preview-api": 7.0.0-beta.47
+    "@storybook/source-loader": 7.0.0-beta.47
     "@storybook/types": 7.0.0-beta.47
     "@types/express": ^4.17.13
     "@types/node": ^16.0.0

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -46,10 +46,7 @@ export const essentialsAddons = [
   'viewport',
 ];
 
-export const create: Task['run'] = async (
-  { key, template, sandboxDir },
-  { addon: addons, dryRun, debug, skipTemplateStories }
-) => {
+export const create: Task['run'] = async ({ key, template, sandboxDir }, { dryRun, debug }) => {
   const parentDir = resolve(sandboxDir, '..');
   await ensureDir(parentDir);
 
@@ -68,17 +65,12 @@ export const create: Task['run'] = async (
       debug,
     });
   }
-
-  const cwd = sandboxDir;
-  if (!skipTemplateStories) {
-    for (const addon of addons) {
-      const addonName = `@storybook/addon-${addon}`;
-      await executeCLIStep(steps.add, { argument: addonName, cwd, dryRun, debug });
-    }
-  }
 };
 
-export const install: Task['run'] = async ({ sandboxDir, template }, { link, dryRun, debug }) => {
+export const install: Task['run'] = async (
+  { sandboxDir, template },
+  { link, dryRun, debug, addon: addons, skipTemplateStories }
+) => {
   const cwd = sandboxDir;
   await installYarn2({ cwd, dryRun, debug });
 
@@ -130,6 +122,13 @@ export const install: Task['run'] = async ({ sandboxDir, template }, { link, dry
       await prepareAngularSandbox(cwd);
       break;
     default:
+  }
+
+  if (!skipTemplateStories) {
+    for (const addon of addons) {
+      const addonName = `@storybook/addon-${addon}`;
+      await executeCLIStep(steps.add, { argument: addonName, cwd, dryRun, debug });
+    }
   }
 };
 


### PR DESCRIPTION
Closes #20421 

Self-merging @tmeasday @joshwooding 

## What I did

This PR:
- [x] restores/fixes storysource support for the vite builder.
- [x] fixes extra addon handling in our development sandboxes

There's a bit of history behind this PR. Once upon a time, `addon-docs` and `addon-storysource` both depended on a library called `source-loader` to load & display raw story source.

1. I moved `addon-docs` to a new library called `csf-plugin` here: #19680
2. @joshwooding added `csf-plugin` support for Vite and removed `source-loader` here: https://github.com/storybookjs/storybook/pull/20147
3. I changed the output of `csf-plugin` and updated `addon-docs` in a way that broke `addon-storysource` #20665
4. I made various fixes to `source-loader`/`storysource` to get things working in webpack, e.g. #20688
6. With this change, `addon-storysource` and `addon-docs` are completely separated in both vite & webpack.

The plan is to:
- Potentially move source handling to an "annotations server" that's part of our 7.x/8.0 roadmap
- Create a better replacement for `storysource` that shares code with `addon-docs`
- Deprecate `storysource/source-loader`, and sunset them in 8.0

## How to test

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts --addon storysource`
2. Open Storybook in your browser
3. Access the `Button` stories and view the `Story` tab in the addons panel

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
