### PR TITLE
Docs: Remove `DocsOptions.disable`

### DIFF
--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -148,7 +148,6 @@ const storyIndexers = (indexers: StoryIndexer[] | null) => {
 const docs = (docsOptions: DocsOptions) => {
   return {
     ...docsOptions,
-    disable: false,
     defaultName: 'Docs',
     autodocs: 'tag',
   };

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -53,7 +53,7 @@ const options = {
   ] as StoryIndexer[],
   storiesV2Compatibility: false,
   storyStoreV7: true,
-  docs: { disable: false, defaultName: 'docs', autodocs: false },
+  docs: { defaultName: 'docs', autodocs: false },
 };
 
 describe('StoryIndexGenerator', () => {
@@ -263,37 +263,6 @@ describe('StoryIndexGenerator', () => {
                   "story",
                 ],
                 "title": "Page",
-                "type": "story",
-              },
-            },
-            "v": 4,
-          }
-        `);
-      });
-      it('does not add docs entry with docs disabled', async () => {
-        const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
-          './src/A.stories.js',
-          options
-        );
-
-        const generator = new StoryIndexGenerator([specifier], {
-          ...options,
-          docs: { disable: true },
-        });
-        await generator.initialize();
-
-        expect(await generator.getIndex()).toMatchInlineSnapshot(`
-          Object {
-            "entries": Object {
-              "a--story-one": Object {
-                "id": "a--story-one",
-                "importPath": "./src/A.stories.js",
-                "name": "Story One",
-                "tags": Array [
-                  "story-tag",
-                  "story",
-                ],
-                "title": "A",
                 "type": "story",
               },
             },
@@ -838,36 +807,6 @@ describe('StoryIndexGenerator', () => {
             "A",
             "titlePrefix/docs2/Yabbadabbadooo",
           ]
-        `);
-      });
-
-      it('generates no docs entries when docs are disabled', async () => {
-        const generator = new StoryIndexGenerator([storiesSpecifier, docsSpecifier], {
-          ...options,
-          docs: {
-            ...options.docs,
-            disable: true,
-          },
-        });
-        await generator.initialize();
-
-        expect(await generator.getIndex()).toMatchInlineSnapshot(`
-          Object {
-            "entries": Object {
-              "a--story-one": Object {
-                "id": "a--story-one",
-                "importPath": "./src/A.stories.js",
-                "name": "Story One",
-                "tags": Array [
-                  "story-tag",
-                  "story",
-                ],
-                "title": "A",
-                "type": "story",
-              },
-            },
-            "v": 4,
-          }
         `);
       });
 

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -185,11 +185,9 @@ export class StoryIndexGenerator {
       this.isDocsMdx(absolutePath) ? false : this.extractStories(specifier, absolutePath)
     );
 
-    if (!this.options.docs.disable) {
-      await this.updateExtracted(async (specifier, absolutePath) =>
-        this.extractDocs(specifier, absolutePath)
-      );
-    }
+    await this.updateExtracted(async (specifier, absolutePath) =>
+      this.extractDocs(specifier, absolutePath)
+    );
 
     return this.specifiers.flatMap((specifier) => {
       const cache = this.specifierToCache.get(specifier);

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -254,7 +254,7 @@ export class StoryIndexGenerator {
         }
       });
 
-      if (!this.options.docs.disable && csf.stories.length) {
+      if (csf.stories.length) {
         const { autodocs } = this.options.docs;
         const componentAutodocs = componentTags.includes(AUTODOCS_TAG);
         const autodocsOptedIn = autodocs === true || (autodocs === 'tag' && componentAutodocs);

--- a/code/lib/core-server/src/utils/stories-json.test.ts
+++ b/code/lib/core-server/src/utils/stories-json.test.ts
@@ -62,7 +62,7 @@ const getInitializedStoryIndexGenerator = async (
     workingDir,
     storiesV2Compatibility: false,
     storyStoreV7: true,
-    docs: { disable: false, defaultName: 'docs', autodocs: false },
+    docs: { defaultName: 'docs', autodocs: false },
     ...overrides,
   });
   await generator.initialize();

--- a/code/lib/preview-api/src/modules/client-api/StoryStoreFacade.ts
+++ b/code/lib/preview-api/src/modules/client-api/StoryStoreFacade.ts
@@ -201,7 +201,7 @@ export class StoryStoreFacade<TRenderer extends Renderer> {
     const { autodocs } = docsOptions;
     const componentAutodocs = componentTags.includes(AUTODOCS_TAG);
     const autodocsOptedIn = autodocs === true || (autodocs === 'tag' && componentAutodocs);
-    if (!docsOptions.disable && storyExports.length) {
+    if (storyExports.length) {
       if (componentTags.includes(STORIES_MDX_TAG) || autodocsOptedIn) {
         const name = docsOptions.defaultName;
         const docsId = toId(componentId || title, name);

--- a/code/lib/preview-api/src/modules/core-client/start.test.ts
+++ b/code/lib/preview-api/src/modules/core-client/start.test.ts
@@ -34,9 +34,7 @@ jest.mock('@storybook/global', () => ({
     FEATURES: {
       breakingChangesV7: true,
     },
-    DOCS_OPTIONS: {
-      disable: false,
-    },
+    DOCS_OPTIONS: {},
   },
 }));
 
@@ -111,7 +109,7 @@ function makeRequireContext(importMap: Record<Path, ModuleExports>) {
 
 describe('start', () => {
   beforeEach(() => {
-    global.DOCS_OPTIONS = { disable: true };
+    global.DOCS_OPTIONS = {};
     // @ts-expect-error (setting this to undefined is indeed what we want to do)
     global.__STORYBOOK_CLIENT_API__ = undefined;
     // @ts-expect-error (setting this to undefined is indeed what we want to do)
@@ -962,7 +960,7 @@ describe('start', () => {
 
     describe('docs', () => {
       beforeEach(() => {
-        global.DOCS_OPTIONS = { disable: false };
+        global.DOCS_OPTIONS = {};
       });
 
       // NOTE: MDX files are only ever passed as CSF
@@ -1149,7 +1147,7 @@ describe('start', () => {
 
     describe('autodocs', () => {
       beforeEach(() => {
-        global.DOCS_OPTIONS = { disable: false, autodocs: 'tag', defaultName: 'Docs' };
+        global.DOCS_OPTIONS = { autodocs: 'tag', defaultName: 'Docs' };
       });
 
       it('adds stories for each component with autodocs tag', async () => {
@@ -1309,7 +1307,7 @@ describe('start', () => {
     });
     describe('when docsOptions.autodocs = true', () => {
       beforeEach(() => {
-        global.DOCS_OPTIONS = { disable: false, autodocs: true, defaultName: 'Docs' };
+        global.DOCS_OPTIONS = { autodocs: true, defaultName: 'Docs' };
       });
 
       it('adds stories for each component with autodocs tag', async () => {

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -242,10 +242,6 @@ type CoreCommon_StorybookRefs = Record<
 
 export type DocsOptions = {
   /**
-   * Should we disable generate docs entries at all under any circumstances? (i.e. can they be rendered)
-   */
-  disable?: boolean;
-  /**
    * What should we call the generated docs entries?
    */
   defaultName?: string;

--- a/docs/writing-docs/docs-page.md
+++ b/docs/writing-docs/docs-page.md
@@ -57,7 +57,6 @@ By default, Storybook offers zero-config support for documentation and automatic
 
 | Option        | Description                                                                                      |
 | ------------- | ------------------------------------------------------------------------------------------------ |
-| `disable`     | Toggles support for all documentation pages <br/> `docs: { disable:true }`                       |
 | `autodocs`    | Disables auto-generated documentation pages created via `tags` <br/> `docs: { autodocs: false }` |
 | `true`        | Enables auto-generated documentation pages for every component <br/> `docs: { autodocs: true }`  |
 | `defaultName` | Renames the auto-generated documentation page<br/> `docs: { defaultName: 'Documentation' }`      |


### PR DESCRIPTION
Closes #20913 

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Drop `DocsOptions.disable`

## How to test

CI passes?

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
