### PR TITLE
Taking care of next/babel preset

### DIFF
--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -59,6 +59,18 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
+    "@babel/plugin-proposal-numeric-separator": "^7.18.6",
+    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+    "@babel/plugin-syntax-bigint": "^7.8.3",
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+    "@babel/plugin-syntax-import-assertions": "^7.20.0",
+    "@babel/plugin-transform-runtime": "^7.21.0",
+    "@babel/preset-env": "^7.20.2",
+    "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "^7.21.0",
+    "@babel/runtime": "^7.21.0",
     "@next/font": "^13.0.7",
     "@storybook/addon-actions": "7.0.0-beta.54",
     "@storybook/builder-webpack5": "7.0.0-beta.54",
@@ -89,6 +101,8 @@
     "@babel/core": "^7.20.5",
     "@babel/types": "^7.20.5",
     "@types/babel__core": "^7",
+    "@types/babel__plugin-transform-runtime": "^7",
+    "@types/babel__preset-env": "^7",
     "next": "^13.0.5",
     "typescript": "^4.9.3",
     "webpack": "^5.65.0"

--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -80,6 +80,7 @@
     "sass-loader": "^12.4.0",
     "semver": "^7.3.5",
     "style-loader": "^3.3.1",
+    "styled-jsx": "5.1.1",
     "ts-dedent": "^2.0.0",
     "tsconfig-paths": "^4.0.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2"

--- a/code/frameworks/nextjs/src/babel/plugins/amp-attributes.ts
+++ b/code/frameworks/nextjs/src/babel/plugins/amp-attributes.ts
@@ -1,0 +1,36 @@
+/* eslint-disable no-continue */
+/* eslint-disable no-restricted-syntax */
+
+import type { NodePath, PluginObj, types } from '@babel/core';
+
+/**
+ * Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/amp-attributes.ts
+ */
+export default function AmpAttributePatcher(): PluginObj {
+  return {
+    visitor: {
+      JSXOpeningElement(path: NodePath<types.JSXOpeningElement>) {
+        const openingElement = path.node;
+
+        const { name, attributes } = openingElement;
+        if (!(name && name.type === 'JSXIdentifier')) {
+          return;
+        }
+
+        if (!name.name.startsWith('amp-')) {
+          return;
+        }
+
+        for (const attribute of attributes) {
+          if (attribute.type !== 'JSXAttribute') {
+            continue;
+          }
+
+          if (attribute.name.name === 'className') {
+            attribute.name.name = 'class';
+          }
+        }
+      },
+    },
+  };
+}

--- a/code/frameworks/nextjs/src/babel/plugins/commonjs.ts
+++ b/code/frameworks/nextjs/src/babel/plugins/commonjs.ts
@@ -1,0 +1,32 @@
+/**
+ * Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/commonjs.ts
+ */
+import type { NodePath, PluginObj, types } from '@babel/core';
+import commonjsPlugin from 'next/dist/compiled/babel/plugin-transform-modules-commonjs';
+
+// Handle module.exports in user code
+export default function CommonJSModulePlugin(...args: any): PluginObj {
+  const commonjs = commonjsPlugin(...args);
+  return {
+    visitor: {
+      Program: {
+        exit(path: NodePath<types.Program>, state) {
+          let foundModuleExports = false;
+          path.traverse({
+            MemberExpression(expressionPath: any) {
+              if (expressionPath.node.object.name !== 'module') return;
+              if (expressionPath.node.property.name !== 'exports') return;
+              foundModuleExports = true;
+            },
+          });
+
+          if (!foundModuleExports) {
+            return;
+          }
+
+          commonjs.visitor.Program.exit.call(this, path, state);
+        },
+      },
+    },
+  };
+}

--- a/code/frameworks/nextjs/src/babel/plugins/jsx-pragma.ts
+++ b/code/frameworks/nextjs/src/babel/plugins/jsx-pragma.ts
@@ -1,0 +1,96 @@
+/* eslint-disable no-nested-ternary */
+/* eslint-disable no-restricted-syntax */
+
+/**
+ * Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/jsx-pragma.ts
+ */
+import type { NodePath, PluginObj, types as BabelTypes } from '@babel/core';
+import jsx from 'next/dist/compiled/babel/plugin-syntax-jsx';
+
+export default function jsxPragma({ types: t }: { types: typeof BabelTypes }): PluginObj<any> {
+  return {
+    inherits: jsx,
+    visitor: {
+      JSXElement(_path, state) {
+        state.set('jsx', true);
+      },
+
+      // Fragment syntax is still JSX since it compiles to createElement(),
+      // but JSXFragment is not a JSXElement
+      JSXFragment(_path, state) {
+        state.set('jsx', true);
+      },
+
+      Program: {
+        exit(path: NodePath<BabelTypes.Program>, state) {
+          if (state.get('jsx')) {
+            const pragma = t.identifier(state.opts.pragma);
+            let importAs = pragma;
+
+            // if there's already a React in scope, use that instead of adding an import
+            const existingBinding =
+              state.opts.reuseImport !== false &&
+              state.opts.importAs &&
+              path.scope.getBinding(state.opts.importAs);
+
+            // var _jsx = _pragma.createElement;
+            if (state.opts.property) {
+              if (state.opts.importAs) {
+                importAs = t.identifier(state.opts.importAs);
+              } else {
+                importAs = path.scope.generateUidIdentifier('pragma');
+              }
+
+              const mapping = t.variableDeclaration('var', [
+                t.variableDeclarator(
+                  pragma,
+                  t.memberExpression(importAs, t.identifier(state.opts.property))
+                ),
+              ]);
+
+              // if the React binding came from a require('react'),
+              // make sure that our usage comes after it.
+              let newPath: NodePath<BabelTypes.VariableDeclaration>;
+
+              if (
+                existingBinding &&
+                t.isVariableDeclarator(existingBinding.path.node) &&
+                t.isCallExpression(existingBinding.path.node.init) &&
+                t.isIdentifier(existingBinding.path.node.init.callee) &&
+                existingBinding.path.node.init.callee.name === 'require'
+              ) {
+                [newPath] = existingBinding.path.parentPath.insertAfter(mapping);
+              } else {
+                [newPath] = path.unshiftContainer('body', mapping);
+              }
+
+              for (const declar of newPath.get('declarations')) {
+                path.scope.registerBinding(newPath.node.kind, declar as NodePath<BabelTypes.Node>);
+              }
+            }
+
+            if (!existingBinding) {
+              const importSpecifier = t.importDeclaration(
+                [
+                  state.opts.import
+                    ? // import { $import as _pragma } from '$module'
+                      t.importSpecifier(importAs, t.identifier(state.opts.import))
+                    : state.opts.importNamespace
+                    ? t.importNamespaceSpecifier(importAs)
+                    : // import _pragma from '$module'
+                      t.importDefaultSpecifier(importAs),
+                ],
+                t.stringLiteral(state.opts.module || 'react')
+              );
+
+              const [newPath] = path.unshiftContainer('body', importSpecifier);
+              for (const specifier of newPath.get('specifiers')) {
+                path.scope.registerBinding('module', specifier as NodePath<BabelTypes.Node>);
+              }
+            }
+          }
+        },
+      },
+    },
+  };
+}

--- a/code/frameworks/nextjs/src/babel/plugins/next-font-unsupported.ts
+++ b/code/frameworks/nextjs/src/babel/plugins/next-font-unsupported.ts
@@ -1,0 +1,21 @@
+import type { NodePath, PluginObj, types } from '@babel/core';
+
+/**
+ * Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/next-font-unsupported.ts
+ */
+export default function NextPageDisallowReExportAllExports(): PluginObj<any> {
+  return {
+    visitor: {
+      ImportDeclaration(path: NodePath<types.ImportDeclaration>) {
+        if (['@next/font/local', '@next/font/google'].includes(path.node.source.value)) {
+          const err = new SyntaxError(
+            `"@next/font" requires SWC although Babel is being used due to a custom babel config being present.\nRead more: https://nextjs.org/docs/messages/babel-font-loader-conflict`
+          );
+          (err as any).code = 'BABEL_PARSE_ERROR';
+          (err as any).loc = path.node.loc?.start ?? path.node.loc?.end ?? path.node.loc;
+          throw err;
+        }
+      },
+    },
+  };
+}

--- a/code/frameworks/nextjs/src/babel/plugins/next-page-config.ts
+++ b/code/frameworks/nextjs/src/babel/plugins/next-page-config.ts
@@ -1,0 +1,170 @@
+/* eslint-disable no-continue */
+/* eslint-disable no-restricted-syntax */
+
+/**
+ * Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/next-page-config.ts
+ */
+import type { NodePath, PluginObj, PluginPass, Visitor } from '@babel/core';
+import { types as BabelTypes } from '@babel/core';
+import type { PageConfig } from 'next/types';
+import { STRING_LITERAL_DROP_BUNDLE } from 'next/constants';
+
+const CONFIG_KEY = 'config';
+
+// replace program path with just a variable with the drop identifier
+function replaceBundle(path: any, t: typeof BabelTypes): void {
+  path.parentPath.replaceWith(
+    t.program(
+      [
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            t.identifier(STRING_LITERAL_DROP_BUNDLE),
+            t.stringLiteral(`${STRING_LITERAL_DROP_BUNDLE} ${Date.now()}`)
+          ),
+        ]),
+      ],
+      []
+    )
+  );
+}
+
+function errorMessage(state: any, details: string): string {
+  const pageName = (state.filename || '').split(state.cwd || '').pop() || 'unknown';
+  return `Invalid page config export found. ${details} in file ${pageName}. See: https://nextjs.org/docs/messages/invalid-page-config`;
+}
+
+interface ConfigState extends PluginPass {
+  bundleDropped?: boolean;
+}
+
+// config to parsing pageConfig for client bundles
+export default function nextPageConfig({ types: t }: { types: typeof BabelTypes }): PluginObj {
+  return {
+    visitor: {
+      Program: {
+        enter(path, state) {
+          path.traverse(
+            {
+              ExportDeclaration(exportPath, exportState) {
+                if (
+                  BabelTypes.isExportNamedDeclaration(exportPath) &&
+                  (exportPath.node as BabelTypes.ExportNamedDeclaration).specifiers?.some(
+                    (specifier) => {
+                      return (
+                        (t.isIdentifier(specifier.exported)
+                          ? specifier.exported.name
+                          : specifier.exported.value) === CONFIG_KEY
+                      );
+                    }
+                  ) &&
+                  BabelTypes.isStringLiteral(
+                    (exportPath.node as BabelTypes.ExportNamedDeclaration).source
+                  )
+                ) {
+                  throw new Error(errorMessage(exportState, 'Expected object but got export from'));
+                }
+              },
+              ExportNamedDeclaration(
+                exportPath: NodePath<BabelTypes.ExportNamedDeclaration>,
+                exportState: any
+              ) {
+                if (
+                  exportState.bundleDropped ||
+                  (!exportPath.node.declaration && exportPath.node.specifiers.length === 0)
+                ) {
+                  return;
+                }
+
+                const config: PageConfig = {};
+                const declarations: BabelTypes.VariableDeclarator[] = [
+                  ...((exportPath.node.declaration as BabelTypes.VariableDeclaration)
+                    ?.declarations || []),
+                  exportPath.scope.getBinding(CONFIG_KEY)?.path
+                    .node as BabelTypes.VariableDeclarator,
+                ].filter(Boolean);
+
+                for (const specifier of exportPath.node.specifiers) {
+                  if (
+                    (t.isIdentifier(specifier.exported)
+                      ? specifier.exported.name
+                      : specifier.exported.value) === CONFIG_KEY
+                  ) {
+                    // export {} from 'somewhere'
+                    if (BabelTypes.isStringLiteral(exportPath.node.source)) {
+                      throw new Error(errorMessage(exportState, `Expected object but got import`));
+                      // import hello from 'world'
+                      // export { hello as config }
+                    } else if (
+                      BabelTypes.isIdentifier((specifier as BabelTypes.ExportSpecifier).local)
+                    ) {
+                      if (
+                        BabelTypes.isImportSpecifier(
+                          exportPath.scope.getBinding(
+                            (specifier as BabelTypes.ExportSpecifier).local.name
+                          )?.path.node
+                        )
+                      ) {
+                        throw new Error(
+                          errorMessage(exportState, `Expected object but got import`)
+                        );
+                      }
+                    }
+                  }
+                }
+
+                for (const declaration of declarations) {
+                  if (
+                    !BabelTypes.isIdentifier(declaration.id, {
+                      name: CONFIG_KEY,
+                    })
+                  ) {
+                    continue;
+                  }
+
+                  let { init } = declaration;
+                  if (BabelTypes.isTSAsExpression(init)) {
+                    init = init.expression;
+                  }
+
+                  if (!BabelTypes.isObjectExpression(init)) {
+                    const got = init ? init.type : 'undefined';
+                    throw new Error(errorMessage(exportState, `Expected object but got ${got}`));
+                  }
+
+                  for (const prop of init.properties) {
+                    if (BabelTypes.isSpreadElement(prop)) {
+                      throw new Error(errorMessage(exportState, `Property spread is not allowed`));
+                    }
+                    const { name } = prop.key as BabelTypes.Identifier;
+                    if (BabelTypes.isIdentifier(prop.key, { name: 'amp' })) {
+                      if (!BabelTypes.isObjectProperty(prop)) {
+                        throw new Error(errorMessage(exportState, `Invalid property "${name}"`));
+                      }
+                      if (
+                        !BabelTypes.isBooleanLiteral(prop.value) &&
+                        !BabelTypes.isStringLiteral(prop.value)
+                      ) {
+                        throw new Error(errorMessage(exportState, `Invalid value for "${name}"`));
+                      }
+                      config.amp = prop.value.value as PageConfig['amp'];
+                    }
+                  }
+                }
+
+                if (config.amp === true) {
+                  if (!exportState.file?.opts?.caller.isDev) {
+                    // don't replace bundle in development so HMR can track
+                    // dependencies and trigger reload when they are changed
+                    replaceBundle(exportPath, t);
+                  }
+                  exportState.bundleDropped = true;
+                }
+              },
+            },
+            state
+          );
+        },
+      },
+    } as Visitor<ConfigState>,
+  };
+}

--- a/code/frameworks/nextjs/src/babel/plugins/next-page-disallow-re-export-all-exports.ts
+++ b/code/frameworks/nextjs/src/babel/plugins/next-page-disallow-re-export-all-exports.ts
@@ -1,0 +1,20 @@
+/**
+ * Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/next-page-disallow-re-export-all-exports.ts
+ */
+import type { NodePath, PluginObj, types } from '@babel/core';
+
+export default function NextPageDisallowReExportAllExports(): PluginObj<any> {
+  return {
+    visitor: {
+      ExportAllDeclaration(path: NodePath<types.ExportAllDeclaration>) {
+        const err = new SyntaxError(
+          `Using \`export * from '...'\` in a page is disallowed. Please use \`export { default } from '...'\` instead.\n` +
+            `Read more: https://nextjs.org/docs/messages/export-all-in-page`
+        );
+        (err as any).code = 'BABEL_PARSE_ERROR';
+        (err as any).loc = path.node.loc?.start ?? path.node.loc?.end ?? path.node.loc;
+        throw err;
+      },
+    },
+  };
+}

--- a/code/frameworks/nextjs/src/babel/plugins/next-ssg-transform.ts
+++ b/code/frameworks/nextjs/src/babel/plugins/next-ssg-transform.ts
@@ -1,0 +1,418 @@
+/* eslint-disable @typescript-eslint/no-loop-func */
+/* eslint-disable no-plusplus */
+/* eslint-disable func-names */
+/* eslint-disable no-nested-ternary */
+/**
+ * Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/next-ssg-transform.ts
+ */
+import type { NodePath, PluginObj, types as BabelTypes } from '@babel/core';
+import { SERVER_PROPS_ID, STATIC_PROPS_ID } from 'next/constants';
+
+export const EXPORT_NAME_GET_STATIC_PROPS = 'getStaticProps';
+export const EXPORT_NAME_GET_STATIC_PATHS = 'getStaticPaths';
+export const EXPORT_NAME_GET_SERVER_PROPS = 'getServerSideProps';
+
+const SERVER_PROPS_SSG_CONFLICT = `You can not use getStaticProps or getStaticPaths with getServerSideProps. To use SSG, please remove getServerSideProps`;
+
+const ssgExports = new Set([
+  EXPORT_NAME_GET_STATIC_PROPS,
+  EXPORT_NAME_GET_STATIC_PATHS,
+  EXPORT_NAME_GET_SERVER_PROPS,
+
+  // legacy methods added so build doesn't fail from importing
+  // server-side only methods
+  `unstable_getStaticProps`,
+  `unstable_getStaticPaths`,
+  `unstable_getServerProps`,
+  `unstable_getServerSideProps`,
+]);
+
+type PluginState = {
+  refs: Set<NodePath<BabelTypes.Identifier>>;
+  isPrerender: boolean;
+  isServerProps: boolean;
+  done: boolean;
+};
+
+function decorateSsgExport(
+  t: typeof BabelTypes,
+  path: NodePath<BabelTypes.Program>,
+  state: PluginState
+): void {
+  const gsspName = state.isPrerender ? STATIC_PROPS_ID : SERVER_PROPS_ID;
+  const gsspId = t.identifier(gsspName);
+
+  const addGsspExport = (
+    exportPath:
+      | NodePath<BabelTypes.ExportDefaultDeclaration>
+      | NodePath<BabelTypes.ExportNamedDeclaration>
+  ): void => {
+    if (state.done) {
+      return;
+    }
+    state.done = true;
+
+    const [pageCompPath] = exportPath.replaceWithMultiple([
+      t.exportNamedDeclaration(
+        t.variableDeclaration(
+          // We use 'var' instead of 'let' or 'const' for ES5 support. Since
+          // this runs in `Program#exit`, no ES2015 transforms (preset env)
+          // will be ran against this code.
+          'var',
+          [t.variableDeclarator(gsspId, t.booleanLiteral(true))]
+        ),
+        [t.exportSpecifier(gsspId, gsspId)]
+      ),
+      exportPath.node,
+    ]);
+    exportPath.scope.registerDeclaration(pageCompPath as NodePath<BabelTypes.Node>);
+  };
+
+  path.traverse({
+    ExportDefaultDeclaration(exportDefaultPath) {
+      addGsspExport(exportDefaultPath);
+    },
+    ExportNamedDeclaration(exportNamedPath) {
+      addGsspExport(exportNamedPath);
+    },
+  });
+}
+
+const isDataIdentifier = (name: string, state: PluginState): boolean => {
+  if (ssgExports.has(name)) {
+    if (name === EXPORT_NAME_GET_SERVER_PROPS) {
+      if (state.isPrerender) {
+        throw new Error(SERVER_PROPS_SSG_CONFLICT);
+      }
+      state.isServerProps = true;
+    } else {
+      if (state.isServerProps) {
+        throw new Error(SERVER_PROPS_SSG_CONFLICT);
+      }
+      state.isPrerender = true;
+    }
+    return true;
+  }
+  return false;
+};
+
+export default function nextTransformSsg({
+  types: t,
+}: {
+  types: typeof BabelTypes;
+}): PluginObj<PluginState> {
+  function getIdentifier(
+    path:
+      | NodePath<BabelTypes.FunctionDeclaration>
+      | NodePath<BabelTypes.FunctionExpression>
+      | NodePath<BabelTypes.ArrowFunctionExpression>
+  ): NodePath<BabelTypes.Identifier> | null {
+    const { parentPath } = path;
+    if (parentPath.type === 'VariableDeclarator') {
+      const pp = parentPath as NodePath<BabelTypes.VariableDeclarator>;
+      const name = pp.get('id');
+      return name.node.type === 'Identifier' ? (name as NodePath<BabelTypes.Identifier>) : null;
+    }
+
+    if (parentPath.type === 'AssignmentExpression') {
+      const pp = parentPath as NodePath<BabelTypes.AssignmentExpression>;
+      const name = pp.get('left');
+      return name.node.type === 'Identifier' ? (name as NodePath<BabelTypes.Identifier>) : null;
+    }
+
+    if (path.node.type === 'ArrowFunctionExpression') {
+      return null;
+    }
+
+    return path.node.id && path.node.id.type === 'Identifier'
+      ? (path.get('id') as NodePath<BabelTypes.Identifier>)
+      : null;
+  }
+
+  function isIdentifierReferenced(ident: NodePath<BabelTypes.Identifier>): boolean {
+    const b = ident.scope.getBinding(ident.node.name);
+    if (b?.referenced) {
+      // Functions can reference themselves, so we need to check if there's a
+      // binding outside the function scope or not.
+      if (b.path.type === 'FunctionDeclaration') {
+        return !b.constantViolations
+          .concat(b.referencePaths)
+          // Check that every reference is contained within the function:
+          .every((ref) => ref.findParent((p) => p === b.path));
+      }
+
+      return true;
+    }
+    return false;
+  }
+
+  function markFunction(
+    path:
+      | NodePath<BabelTypes.FunctionDeclaration>
+      | NodePath<BabelTypes.FunctionExpression>
+      | NodePath<BabelTypes.ArrowFunctionExpression>,
+    state: PluginState
+  ): void {
+    const ident = getIdentifier(path);
+    if (ident?.node && isIdentifierReferenced(ident)) {
+      state.refs.add(ident);
+    }
+  }
+
+  function markImport(
+    path:
+      | NodePath<BabelTypes.ImportSpecifier>
+      | NodePath<BabelTypes.ImportDefaultSpecifier>
+      | NodePath<BabelTypes.ImportNamespaceSpecifier>,
+    state: PluginState
+  ): void {
+    const local = path.get('local') as NodePath<BabelTypes.Identifier>;
+    if (isIdentifierReferenced(local)) {
+      state.refs.add(local);
+    }
+  }
+
+  return {
+    visitor: {
+      Program: {
+        enter(path, state) {
+          state.refs = new Set<NodePath<BabelTypes.Identifier>>();
+          state.isPrerender = false;
+          state.isServerProps = false;
+          state.done = false;
+
+          path.traverse(
+            {
+              VariableDeclarator(variablePath, variableState) {
+                if (variablePath.node.id.type === 'Identifier') {
+                  const local = variablePath.get('id') as NodePath<BabelTypes.Identifier>;
+                  if (isIdentifierReferenced(local)) {
+                    variableState.refs.add(local);
+                  }
+                } else if (variablePath.node.id.type === 'ObjectPattern') {
+                  const pattern = variablePath.get('id') as NodePath<BabelTypes.ObjectPattern>;
+
+                  const properties = pattern.get('properties');
+                  properties.forEach((p) => {
+                    const local = p.get(
+                      p.node.type === 'ObjectProperty'
+                        ? 'value'
+                        : p.node.type === 'RestElement'
+                        ? 'argument'
+                        : (function () {
+                            throw new Error('invariant');
+                          })()
+                    ) as NodePath<BabelTypes.Identifier>;
+                    if (isIdentifierReferenced(local)) {
+                      variableState.refs.add(local);
+                    }
+                  });
+                } else if (variablePath.node.id.type === 'ArrayPattern') {
+                  const pattern = variablePath.get('id') as NodePath<BabelTypes.ArrayPattern>;
+
+                  const elements = pattern.get('elements');
+                  elements.forEach((e) => {
+                    let local: NodePath<BabelTypes.Identifier>;
+                    if (e.node?.type === 'Identifier') {
+                      local = e as NodePath<BabelTypes.Identifier>;
+                    } else if (e.node?.type === 'RestElement') {
+                      local = e.get('argument') as NodePath<BabelTypes.Identifier>;
+                    } else {
+                      return;
+                    }
+
+                    if (isIdentifierReferenced(local)) {
+                      variableState.refs.add(local);
+                    }
+                  });
+                }
+              },
+              FunctionDeclaration: markFunction,
+              FunctionExpression: markFunction,
+              ArrowFunctionExpression: markFunction,
+              ImportSpecifier: markImport,
+              ImportDefaultSpecifier: markImport,
+              ImportNamespaceSpecifier: markImport,
+              ExportNamedDeclaration(exportNamedPath, exportNamedState) {
+                const specifiers = exportNamedPath.get('specifiers');
+                if (specifiers.length) {
+                  specifiers.forEach((s) => {
+                    if (
+                      isDataIdentifier(
+                        t.isIdentifier(s.node.exported)
+                          ? s.node.exported.name
+                          : s.node.exported.value,
+                        exportNamedState
+                      )
+                    ) {
+                      s.remove();
+                    }
+                  });
+
+                  if (exportNamedPath.node.specifiers.length < 1) {
+                    exportNamedPath.remove();
+                  }
+                  return;
+                }
+
+                const decl = exportNamedPath.get('declaration') as NodePath<
+                  BabelTypes.FunctionDeclaration | BabelTypes.VariableDeclaration
+                >;
+                if (decl == null || decl.node == null) {
+                  return;
+                }
+
+                switch (decl.node.type) {
+                  case 'FunctionDeclaration': {
+                    const { name } = decl.node.id!;
+                    if (isDataIdentifier(name, exportNamedState)) {
+                      exportNamedPath.remove();
+                    }
+                    break;
+                  }
+                  case 'VariableDeclaration': {
+                    const inner = decl.get(
+                      'declarations'
+                    ) as NodePath<BabelTypes.VariableDeclarator>[];
+                    inner.forEach((d) => {
+                      if (d.node.id.type !== 'Identifier') {
+                        return;
+                      }
+                      const { name } = d.node.id;
+                      if (isDataIdentifier(name, exportNamedState)) {
+                        d.remove();
+                      }
+                    });
+                    break;
+                  }
+                  default: {
+                    break;
+                  }
+                }
+              },
+            },
+            state
+          );
+
+          if (!state.isPrerender && !state.isServerProps) {
+            return;
+          }
+
+          const { refs } = state;
+          let count: number;
+
+          function sweepFunction(
+            sweepPath:
+              | NodePath<BabelTypes.FunctionDeclaration>
+              | NodePath<BabelTypes.FunctionExpression>
+              | NodePath<BabelTypes.ArrowFunctionExpression>
+          ): void {
+            const ident = getIdentifier(sweepPath);
+            if (ident?.node && refs.has(ident) && !isIdentifierReferenced(ident)) {
+              ++count;
+
+              if (
+                t.isAssignmentExpression(sweepPath.parentPath) ||
+                t.isVariableDeclarator(sweepPath.parentPath)
+              ) {
+                sweepPath.parentPath.remove();
+              } else {
+                sweepPath.remove();
+              }
+            }
+          }
+
+          function sweepImport(
+            sweepPath:
+              | NodePath<BabelTypes.ImportSpecifier>
+              | NodePath<BabelTypes.ImportDefaultSpecifier>
+              | NodePath<BabelTypes.ImportNamespaceSpecifier>
+          ): void {
+            const local = sweepPath.get('local') as NodePath<BabelTypes.Identifier>;
+            if (refs.has(local) && !isIdentifierReferenced(local)) {
+              ++count;
+              sweepPath.remove();
+              if ((sweepPath.parent as BabelTypes.ImportDeclaration).specifiers.length === 0) {
+                sweepPath.parentPath.remove();
+              }
+            }
+          }
+
+          do {
+            (path.scope as any).crawl();
+            count = 0;
+
+            path.traverse({
+              VariableDeclarator(variablePath) {
+                if (variablePath.node.id.type === 'Identifier') {
+                  const local = variablePath.get('id') as NodePath<BabelTypes.Identifier>;
+                  if (refs.has(local) && !isIdentifierReferenced(local)) {
+                    ++count;
+                    variablePath.remove();
+                  }
+                } else if (variablePath.node.id.type === 'ObjectPattern') {
+                  const pattern = variablePath.get('id') as NodePath<BabelTypes.ObjectPattern>;
+
+                  const beforeCount = count;
+                  const properties = pattern.get('properties');
+                  properties.forEach((p) => {
+                    const local = p.get(
+                      p.node.type === 'ObjectProperty'
+                        ? 'value'
+                        : p.node.type === 'RestElement'
+                        ? 'argument'
+                        : (function () {
+                            throw new Error('invariant');
+                          })()
+                    ) as NodePath<BabelTypes.Identifier>;
+
+                    if (refs.has(local) && !isIdentifierReferenced(local)) {
+                      ++count;
+                      p.remove();
+                    }
+                  });
+
+                  if (beforeCount !== count && pattern.get('properties').length < 1) {
+                    variablePath.remove();
+                  }
+                } else if (variablePath.node.id.type === 'ArrayPattern') {
+                  const pattern = variablePath.get('id') as NodePath<BabelTypes.ArrayPattern>;
+
+                  const beforeCount = count;
+                  const elements = pattern.get('elements');
+                  elements.forEach((e) => {
+                    let local: NodePath<BabelTypes.Identifier>;
+                    if (e.node?.type === 'Identifier') {
+                      local = e as NodePath<BabelTypes.Identifier>;
+                    } else if (e.node?.type === 'RestElement') {
+                      local = e.get('argument') as NodePath<BabelTypes.Identifier>;
+                    } else {
+                      return;
+                    }
+
+                    if (refs.has(local) && !isIdentifierReferenced(local)) {
+                      ++count;
+                      e.remove();
+                    }
+                  });
+
+                  if (beforeCount !== count && pattern.get('elements').length < 1) {
+                    variablePath.remove();
+                  }
+                }
+              },
+              FunctionDeclaration: sweepFunction,
+              FunctionExpression: sweepFunction,
+              ArrowFunctionExpression: sweepFunction,
+              ImportSpecifier: sweepImport,
+              ImportDefaultSpecifier: sweepImport,
+              ImportNamespaceSpecifier: sweepImport,
+            });
+          } while (count);
+
+          decorateSsgExport(t, path, state);
+        },
+      },
+    },
+  };
+}

--- a/code/frameworks/nextjs/src/babel/plugins/optimize-hook-destructuring.ts
+++ b/code/frameworks/nextjs/src/babel/plugins/optimize-hook-destructuring.ts
@@ -1,0 +1,70 @@
+/**
+ * Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/optimize-hook-destructuring.ts
+ */
+import type { NodePath, PluginObj, types as BabelTypes } from '@babel/core';
+
+// matches any hook-like (the default)
+const isHook = /^use[A-Z]/;
+
+// matches only built-in hooks provided by React et al
+const isBuiltInHook =
+  /^use(Callback|Context|DebugValue|Effect|ImperativeHandle|LayoutEffect|Memo|Reducer|Ref|State)$/;
+
+export default function optimizeHookDestructuring({
+  types: t,
+}: {
+  types: typeof BabelTypes;
+}): PluginObj<any> {
+  const visitor = {
+    CallExpression(path: NodePath<BabelTypes.CallExpression>, state: any) {
+      const { onlyBuiltIns } = state.opts;
+
+      // if specified, options.lib is a list of libraries that provide hook functions
+      const libs =
+        state.opts.lib &&
+        (state.opts.lib === true ? ['react', 'preact/hooks'] : [].concat(state.opts.lib));
+
+      // skip function calls that are not the init of a variable declaration:
+      if (!t.isVariableDeclarator(path.parent)) return;
+
+      // skip function calls where the return value is not Array-destructured:
+      if (!t.isArrayPattern(path.parent.id)) return;
+
+      // name of the (hook) function being called:
+      const hookName = (path.node.callee as BabelTypes.Identifier).name;
+
+      if (libs) {
+        const binding = path.scope.getBinding(hookName);
+        // not an import
+        if (!binding || binding.kind !== 'module') return;
+
+        const specifier = (binding.path.parent as BabelTypes.ImportDeclaration).source.value;
+        // not a match
+        if (!libs.some((lib: any) => lib === specifier)) return;
+      }
+
+      // only match function calls with names that look like a hook
+      if (!(onlyBuiltIns ? isBuiltInHook : isHook).test(hookName)) return;
+
+      path.parent.id = t.objectPattern(
+        path.parent.id.elements.reduce<Array<BabelTypes.ObjectProperty>>((patterns, element, i) => {
+          if (element === null) {
+            return patterns;
+          }
+
+          return patterns.concat(t.objectProperty(t.numericLiteral(i), element as any));
+        }, [])
+      );
+    },
+  };
+
+  return {
+    name: 'optimize-hook-destructuring',
+    visitor: {
+      // this is a workaround to run before preset-env destroys destructured assignments
+      Program(path, state) {
+        path.traverse(visitor, state);
+      },
+    },
+  };
+}

--- a/code/frameworks/nextjs/src/babel/plugins/react-loadable-plugin.ts
+++ b/code/frameworks/nextjs/src/babel/plugins/react-loadable-plugin.ts
@@ -1,0 +1,184 @@
+/* eslint-disable prefer-destructuring */
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable func-names */
+/**
+ * Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/react-loadable-plugin.ts
+ */
+import type { NodePath, PluginObj, types as BabelTypes } from '@babel/core';
+
+import { relative as relativePath } from 'path';
+
+export default function ({ types: t }: { types: typeof BabelTypes }): PluginObj {
+  return {
+    visitor: {
+      ImportDeclaration(path: NodePath<BabelTypes.ImportDeclaration>, state: any) {
+        const source = path.node.source.value;
+        if (source !== 'next/dynamic') return;
+
+        const defaultSpecifier = path.get('specifiers').find((specifier: any) => {
+          return specifier.isImportDefaultSpecifier();
+        });
+
+        if (!defaultSpecifier) return;
+
+        const bindingName = defaultSpecifier.node.local.name;
+        const binding = path.scope.getBinding(bindingName);
+
+        if (!binding) {
+          return;
+        }
+
+        binding.referencePaths.forEach((refPath: any) => {
+          let callExpression = refPath.parentPath;
+
+          if (callExpression.isMemberExpression() && callExpression.node.computed === false) {
+            const property = callExpression.get('property');
+            if (!Array.isArray(property) && property.isIdentifier({ name: 'Map' })) {
+              callExpression = callExpression.parentPath;
+            }
+          }
+
+          if (!callExpression.isCallExpression()) return;
+
+          const callExpression_ = callExpression as NodePath<BabelTypes.CallExpression>;
+
+          let args = callExpression_.get('arguments');
+          if (args.length > 2) {
+            throw callExpression_.buildCodeFrameError('next/dynamic only accepts 2 arguments');
+          }
+
+          if (!args[0]) {
+            return;
+          }
+
+          let loader;
+          let options;
+
+          if (args[0].isObjectExpression()) {
+            options = args[0];
+          } else {
+            if (!args[1]) {
+              callExpression_.node.arguments.push(t.objectExpression([]));
+            }
+            // This is needed as the code is modified above
+            args = callExpression_.get('arguments');
+            loader = args[0];
+            options = args[1];
+          }
+
+          if (!options.isObjectExpression()) return;
+          const options_ = options as NodePath<BabelTypes.ObjectExpression>;
+
+          const properties = options_.get('properties');
+          const propertiesMap: {
+            [key: string]: NodePath<
+              | BabelTypes.ObjectProperty
+              | BabelTypes.ObjectMethod
+              | BabelTypes.SpreadElement
+              | BabelTypes.BooleanLiteral
+            >;
+          } = {};
+
+          properties.forEach((property) => {
+            const key: any = property.get('key');
+            propertiesMap[key.node.name] = property;
+          });
+
+          if (propertiesMap.loadableGenerated) {
+            return;
+          }
+
+          if (propertiesMap.loader) {
+            loader = propertiesMap.loader.get('value');
+          }
+
+          if (propertiesMap.modules) {
+            loader = propertiesMap.modules.get('value');
+          }
+
+          if (!loader || Array.isArray(loader)) {
+            return;
+          }
+          const dynamicImports: BabelTypes.Expression[] = [];
+          const dynamicKeys: BabelTypes.Expression[] = [];
+
+          if (propertiesMap.ssr) {
+            const ssr = propertiesMap.ssr.get('value');
+            const nodePath = Array.isArray(ssr) ? undefined : ssr;
+
+            if (nodePath) {
+              const nonSSR =
+                nodePath.node.type === 'BooleanLiteral' && nodePath.node.value === false;
+              // If `ssr` is set to `false`, erase the loader for server side
+              if (nonSSR && loader && state.file.opts.caller?.isServer) {
+                loader.replaceWith(t.arrowFunctionExpression([], t.nullLiteral(), true));
+              }
+            }
+          }
+
+          loader.traverse({
+            Import(importPath) {
+              const importArguments = importPath.parentPath.get('arguments');
+              if (!Array.isArray(importArguments)) return;
+              const { node } = importArguments[0];
+              dynamicImports.push(node as any);
+              dynamicKeys.push(
+                t.binaryExpression(
+                  '+',
+                  t.stringLiteral(
+                    `${
+                      state.file.opts.caller?.pagesDir
+                        ? relativePath(state.file.opts.caller.pagesDir, state.file.opts.filename)
+                        : state.file.opts.filename
+                    } -> `
+                  ),
+                  node as any
+                )
+              );
+            },
+          });
+
+          if (!dynamicImports.length) return;
+
+          options.node.properties.push(
+            t.objectProperty(
+              t.identifier('loadableGenerated'),
+              t.objectExpression(
+                state.file.opts.caller?.isDev || state.file.opts.caller?.isServer
+                  ? [t.objectProperty(t.identifier('modules'), t.arrayExpression(dynamicKeys))]
+                  : [
+                      t.objectProperty(
+                        t.identifier('webpack'),
+                        t.arrowFunctionExpression(
+                          [],
+                          t.arrayExpression(
+                            dynamicImports.map((dynamicImport) => {
+                              return t.callExpression(
+                                t.memberExpression(
+                                  t.identifier('require'),
+                                  t.identifier('resolveWeak')
+                                ),
+                                [dynamicImport]
+                              );
+                            })
+                          )
+                        )
+                      ),
+                    ]
+              )
+            )
+          );
+
+          // Turns `dynamic(import('something'))` into `dynamic(() => import('something'))` for backwards compat.
+          // This is the replicate the behavior in versions below Next.js 7 where we magically handled not executing the `import()` too.
+          // We'll deprecate this behavior and provide a codemod for it in 7.1.
+          if (loader.isCallExpression()) {
+            const arrowFunction = t.arrowFunctionExpression([], loader.node);
+            loader.replaceWith(arrowFunction);
+          }
+        });
+      },
+    },
+  };
+}

--- a/code/frameworks/nextjs/src/babel/preset.ts
+++ b/code/frameworks/nextjs/src/babel/preset.ts
@@ -1,0 +1,182 @@
+import type { PluginItem } from '@babel/core';
+import { dirname } from 'path';
+
+const isLoadIntentTest = process.env.NODE_ENV === 'test';
+const isLoadIntentDevelopment = process.env.NODE_ENV === 'development';
+
+type StyledJsxPlugin = [string, any] | string;
+type StyledJsxBabelOptions =
+  | {
+      plugins?: StyledJsxPlugin[];
+      styleModule?: string;
+      'babel-test'?: boolean;
+    }
+  | undefined;
+
+// Resolve styled-jsx plugins
+function styledJsxOptions(options: StyledJsxBabelOptions) {
+  options = options || {};
+  options.styleModule = 'styled-jsx/style';
+
+  if (!Array.isArray(options.plugins)) {
+    return options;
+  }
+
+  options.plugins = options.plugins.map((plugin: StyledJsxPlugin): StyledJsxPlugin => {
+    if (Array.isArray(plugin)) {
+      const [name, pluginOptions] = plugin;
+      return [require.resolve(name), pluginOptions];
+    }
+
+    return require.resolve(plugin);
+  });
+
+  return options;
+}
+
+type NextBabelPresetOptions = {
+  'preset-env'?: any;
+  'preset-react'?: any;
+  'class-properties'?: any;
+  'transform-runtime'?: any;
+  'styled-jsx'?: StyledJsxBabelOptions;
+  'preset-typescript'?: any;
+};
+
+type BabelPreset = {
+  presets?: PluginItem[] | null;
+  plugins?: PluginItem[] | null;
+  sourceType?: 'script' | 'module' | 'unambiguous';
+  overrides?: Array<{ test: RegExp } & Omit<BabelPreset, 'overrides'>>;
+};
+
+// Taken from https://github.com/babel/babel/commit/d60c5e1736543a6eac4b549553e107a9ba967051#diff-b4beead8ad9195361b4537601cc22532R158
+function supportsStaticESM(caller: any): boolean {
+  return !!caller?.supportsStaticESM;
+}
+
+export default (api: any, options: NextBabelPresetOptions = {}): BabelPreset => {
+  const supportsESM = api.caller(supportsStaticESM);
+  const isServer = api.caller((caller: any) => !!caller && caller.isServer);
+  const isCallerDevelopment = api.caller((caller: any) => caller?.isDev);
+
+  // Look at external intent if used without a caller (e.g. via Jest):
+  const isTest = isCallerDevelopment == null && isLoadIntentTest;
+
+  // Look at external intent if used without a caller (e.g. Storybook):
+  const isDevelopment =
+    isCallerDevelopment === true || (isCallerDevelopment == null && isLoadIntentDevelopment);
+
+  const isBabelLoader = api.caller(
+    (caller: any) =>
+      !!caller && (caller.name === 'babel-loader' || caller.name === 'next-babel-turbo-loader')
+  );
+
+  const useJsxRuntime =
+    options['preset-react']?.runtime === 'automatic' ||
+    (Boolean(api.caller((caller: any) => !!caller && caller.hasJsxRuntime)) &&
+      options['preset-react']?.runtime !== 'classic');
+
+  const presetEnvConfig = {
+    // In the test environment `modules` is often needed to be set to true, babel figures that out by itself using the `'auto'` option
+    // In production/development this option is set to `false` so that webpack can handle import/export with tree-shaking
+    modules: 'auto',
+    exclude: ['transform-typeof-symbol'],
+    ...options['preset-env'],
+  };
+
+  // When transpiling for the server or tests, target the current Node version
+  // if not explicitly specified:
+  if (
+    (isServer || isTest) &&
+    (!presetEnvConfig.targets ||
+      !(typeof presetEnvConfig.targets === 'object' && 'node' in presetEnvConfig.targets))
+  ) {
+    presetEnvConfig.targets = {
+      // Targets the current process' version of Node. This requires apps be
+      // built and deployed on the same version of Node.
+      // This is the same as using "current" but explicit
+      node: process.versions.node,
+    };
+  }
+
+  return {
+    sourceType: 'unambiguous',
+    presets: [
+      [require('next/dist/compiled/babel/preset-env'), presetEnvConfig],
+      [
+        require('next/dist/compiled/babel/preset-react'),
+        {
+          // This adds @babel/plugin-transform-react-jsx-source and
+          // @babel/plugin-transform-react-jsx-self automatically in development
+          development: isDevelopment || isTest,
+          ...(useJsxRuntime ? { runtime: 'automatic' } : { pragma: '__jsx' }),
+          ...options['preset-react'],
+        },
+      ],
+      [
+        require('next/dist/compiled/babel/preset-typescript'),
+        { allowNamespaces: true, ...options['preset-typescript'] },
+      ],
+    ],
+    plugins: [
+      !useJsxRuntime && [
+        require('./plugins/jsx-pragma'),
+        {
+          // This produces the following injected import for modules containing JSX:
+          //   import React from 'react';
+          //   var __jsx = React.createElement;
+          module: 'react',
+          importAs: 'React',
+          pragma: '__jsx',
+          property: 'createElement',
+        },
+      ],
+      [
+        require('./plugins/optimize-hook-destructuring'),
+        {
+          // only optimize hook functions imported from React/Preact
+          lib: true,
+        },
+      ],
+      require('next/dist/compiled/babel/plugin-syntax-dynamic-import'),
+      require('next/dist/compiled/babel/plugin-syntax-import-assertions'),
+      require('./plugins/react-loadable-plugin'),
+      [
+        require('next/dist/compiled/babel/plugin-proposal-class-properties'),
+        options['class-properties'] || {},
+      ],
+      [
+        require('next/dist/compiled/babel/plugin-proposal-object-rest-spread'),
+        {
+          useBuiltIns: true,
+        },
+      ],
+      !isServer && [
+        require('next/dist/compiled/babel/plugin-transform-runtime'),
+        {
+          corejs: false,
+          helpers: true,
+          regenerator: true,
+          useESModules: supportsESM && presetEnvConfig.modules !== 'commonjs',
+          absoluteRuntime: isBabelLoader
+            ? dirname(require.resolve('next/dist/compiled/@babel/runtime/package.json'))
+            : undefined,
+          ...options['transform-runtime'],
+        },
+      ],
+      [
+        isTest && options['styled-jsx'] && options['styled-jsx']['babel-test']
+          ? require('styled-jsx/babel-test')
+          : require('styled-jsx/babel'),
+        styledJsxOptions(options['styled-jsx']),
+      ],
+      require('./plugins/amp-attributes'),
+      isServer && require('next/dist/compiled/babel/plugin-syntax-bigint'),
+      // Always compile numeric separator because the resulting number is
+      // smaller.
+      require('next/dist/compiled/babel/plugin-proposal-numeric-separator'),
+      require('next/dist/compiled/babel/plugin-proposal-export-namespace-from'),
+    ].filter(Boolean),
+  };
+};

--- a/code/frameworks/nextjs/src/babel/preset.ts
+++ b/code/frameworks/nextjs/src/babel/preset.ts
@@ -103,9 +103,9 @@ export default (api: any, options: NextBabelPresetOptions = {}): BabelPreset => 
   return {
     sourceType: 'unambiguous',
     presets: [
-      [require('next/dist/compiled/babel/preset-env'), presetEnvConfig],
+      [require('@babel/preset-env'), presetEnvConfig],
       [
-        require('next/dist/compiled/babel/preset-react'),
+        require('@babel/preset-react'),
         {
           // This adds @babel/plugin-transform-react-jsx-source and
           // @babel/plugin-transform-react-jsx-self automatically in development
@@ -115,7 +115,7 @@ export default (api: any, options: NextBabelPresetOptions = {}): BabelPreset => 
         },
       ],
       [
-        require('next/dist/compiled/babel/preset-typescript'),
+        require('@babel/preset-typescript'),
         { allowNamespaces: true, ...options['preset-typescript'] },
       ],
     ],
@@ -139,28 +139,25 @@ export default (api: any, options: NextBabelPresetOptions = {}): BabelPreset => 
           lib: true,
         },
       ],
-      require('next/dist/compiled/babel/plugin-syntax-dynamic-import'),
-      require('next/dist/compiled/babel/plugin-syntax-import-assertions'),
+      require('@babel/plugin-syntax-dynamic-import'),
+      require('@babel/plugin-syntax-import-assertions'),
       require('./plugins/react-loadable-plugin'),
+      [require('@babel/plugin-proposal-class-properties'), options['class-properties'] || {}],
       [
-        require('next/dist/compiled/babel/plugin-proposal-class-properties'),
-        options['class-properties'] || {},
-      ],
-      [
-        require('next/dist/compiled/babel/plugin-proposal-object-rest-spread'),
+        require('@babel/plugin-proposal-object-rest-spread'),
         {
           useBuiltIns: true,
         },
       ],
       !isServer && [
-        require('next/dist/compiled/babel/plugin-transform-runtime'),
+        require('@babel/plugin-transform-runtime'),
         {
           corejs: false,
           helpers: true,
           regenerator: true,
           useESModules: supportsESM && presetEnvConfig.modules !== 'commonjs',
           absoluteRuntime: isBabelLoader
-            ? dirname(require.resolve('next/dist/compiled/@babel/runtime/package.json'))
+            ? dirname(require.resolve('@babel/runtime/package.json'))
             : undefined,
           ...options['transform-runtime'],
         },
@@ -172,11 +169,11 @@ export default (api: any, options: NextBabelPresetOptions = {}): BabelPreset => 
         styledJsxOptions(options['styled-jsx']),
       ],
       require('./plugins/amp-attributes'),
-      isServer && require('next/dist/compiled/babel/plugin-syntax-bigint'),
+      isServer && require('@babel/plugin-syntax-bigint'),
       // Always compile numeric separator because the resulting number is
       // smaller.
-      require('next/dist/compiled/babel/plugin-proposal-numeric-separator'),
-      require('next/dist/compiled/babel/plugin-proposal-export-namespace-from'),
+      require('@babel/plugin-proposal-numeric-separator'),
+      require('@babel/plugin-proposal-export-namespace-from'),
     ].filter(Boolean),
   };
 };

--- a/code/frameworks/nextjs/src/globals.d.ts
+++ b/code/frameworks/nextjs/src/globals.d.ts
@@ -1,0 +1,3 @@
+declare module 'next/dist/compiled';
+declare module 'next/dist/compiled/babel/plugin-transform-modules-commonjs';
+declare module 'next/dist/compiled/babel/plugin-syntax-jsx';

--- a/code/frameworks/nextjs/src/styledJsx/decorator.tsx
+++ b/code/frameworks/nextjs/src/styledJsx/decorator.tsx
@@ -4,8 +4,6 @@ let StyleRegistry: React.FC;
 
 try {
   // next >= v12
-  // This will come from nextjs itself
-  // eslint-disable-next-line import/no-extraneous-dependencies
   StyleRegistry = require('styled-jsx').StyleRegistry;
 } catch {
   // next < v12

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6499,6 +6499,7 @@ __metadata:
     sass-loader: ^12.4.0
     semver: ^7.3.5
     style-loader: ^3.3.1
+    styled-jsx: 5.1.1
     ts-dedent: ^2.0.0
     tsconfig-paths: ^4.0.0
     tsconfig-paths-webpack-plugin: ^3.5.2

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -12,7 +12,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ampproject/remapping@npm:2.2.0, @ampproject/remapping@npm:^2.1.0":
+"@ampproject/remapping@npm:2.2.0, @ampproject/remapping@npm:^2.1.0, @ampproject/remapping@npm:^2.2.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
   dependencies:
@@ -412,9 +412,9 @@ __metadata:
   linkType: hard
 
 "@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.20.1, @babel/compat-data@npm:^7.20.5":
-  version: 7.20.14
-  resolution: "@babel/compat-data@npm:7.20.14"
-  checksum: b35587fe2f90dbf4e07d33fcaaa49fa117313eeb892591fede7679b21f7aff4235735a709fdb771a9a33b9e57d5cebed522108ad1364f6a1abf91cf16ffde1e4
+  version: 7.21.0
+  resolution: "@babel/compat-data@npm:7.21.0"
+  checksum: 69c8ddf229d44dc095ec5282d322fb8ad6ad0565d919c0501dbf474e825722f5d6842268b3f434db8f8463e971d155d83fe02884880f26846ef870f58a935743
   languageName: node
   linkType: hard
 
@@ -465,7 +465,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.20.12, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.0, @babel/core@npm:^7.12.10, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.19.6, @babel/core@npm:^7.20.12, @babel/core@npm:^7.20.2, @babel/core@npm:^7.20.5, @babel/core@npm:^7.3.4, @babel/core@npm:^7.7.5, @babel/core@npm:^7.9.6":
+"@babel/core@npm:7.20.12":
   version: 7.20.12
   resolution: "@babel/core@npm:7.20.12"
   dependencies:
@@ -511,6 +511,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.0, @babel/core@npm:^7.12.10, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.19.6, @babel/core@npm:^7.20.12, @babel/core@npm:^7.20.2, @babel/core@npm:^7.20.5, @babel/core@npm:^7.3.4, @babel/core@npm:^7.7.5, @babel/core@npm:^7.9.6":
+  version: 7.21.0
+  resolution: "@babel/core@npm:7.21.0"
+  dependencies:
+    "@ampproject/remapping": ^2.2.0
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.21.0
+    "@babel/helper-compilation-targets": ^7.20.7
+    "@babel/helper-module-transforms": ^7.21.0
+    "@babel/helpers": ^7.21.0
+    "@babel/parser": ^7.21.0
+    "@babel/template": ^7.20.7
+    "@babel/traverse": ^7.21.0
+    "@babel/types": ^7.21.0
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.2.2
+    semver: ^6.3.0
+  checksum: 90f986b3ca91382a652776f40d970002cfd67df3e082a4b21e1aeaeb5ac2b6abe8ca829e197b1fc35a0483586ad44ff6ace3f68748a3bd51937df0f3aec38ec2
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:7.20.7":
   version: 7.20.7
   resolution: "@babel/generator@npm:7.20.7"
@@ -522,14 +545,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.12.11, @babel/generator@npm:^7.12.5, @babel/generator@npm:^7.19.3, @babel/generator@npm:^7.20.4, @babel/generator@npm:^7.20.7, @babel/generator@npm:^7.7.2, @babel/generator@npm:^7.8.7":
-  version: 7.20.14
-  resolution: "@babel/generator@npm:7.20.14"
+"@babel/generator@npm:^7.12.11, @babel/generator@npm:^7.12.5, @babel/generator@npm:^7.19.3, @babel/generator@npm:^7.20.4, @babel/generator@npm:^7.20.7, @babel/generator@npm:^7.21.0, @babel/generator@npm:^7.21.1, @babel/generator@npm:^7.7.2, @babel/generator@npm:^7.8.7":
+  version: 7.21.1
+  resolution: "@babel/generator@npm:7.21.1"
   dependencies:
-    "@babel/types": ^7.20.7
+    "@babel/types": ^7.21.0
     "@jridgewell/gen-mapping": ^0.3.2
+    "@jridgewell/trace-mapping": ^0.3.17
     jsesc: ^2.5.1
-  checksum: 4b0159f2175cf002a902e0aaa1c3c2af9c98d309394e685bc556cd2c34ccc4ace38a91b919f62effc7e067fadd2ded6cda8630b7c11367a303a2bd67862989b5
+  checksum: 833d115009cd03fc7c2668ab9946607297d1283f3a1c6dcef7edbc76f261a65aee126fbfd720a23031a7557f6d0e305362832ee485096f9f50d9a00fad6e0921
   languageName: node
   linkType: hard
 
@@ -567,25 +591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.20.12, @babel/helper-create-class-features-plugin@npm:^7.20.5, @babel/helper-create-class-features-plugin@npm:^7.20.7":
-  version: 7.20.12
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.20.12"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.18.6
-    "@babel/helper-environment-visitor": ^7.18.9
-    "@babel/helper-function-name": ^7.19.0
-    "@babel/helper-member-expression-to-functions": ^7.20.7
-    "@babel/helper-optimise-call-expression": ^7.18.6
-    "@babel/helper-replace-supers": ^7.20.7
-    "@babel/helper-skip-transparent-expression-wrappers": ^7.20.0
-    "@babel/helper-split-export-declaration": ^7.18.6
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: e17a6e3afa92c5b286093f754efa692a76a5893fe39e66c7b246e3c37db5be43012973975ed1548f1ee6c2713dd88cdb369672460e29be2c072c3cdf930879ef
-  languageName: node
-  linkType: hard
-
-"@babel/helper-create-class-features-plugin@npm:^7.21.0":
+"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.21.0":
   version: 7.21.0
   resolution: "@babel/helper-create-class-features-plugin@npm:7.21.0"
   dependencies:
@@ -604,14 +610,14 @@ __metadata:
   linkType: hard
 
 "@babel/helper-create-regexp-features-plugin@npm:^7.18.6, @babel/helper-create-regexp-features-plugin@npm:^7.20.5":
-  version: 7.20.5
-  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.20.5"
+  version: 7.21.0
+  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.21.0"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.18.6
-    regexpu-core: ^5.2.1
+    regexpu-core: ^5.3.1
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 567132405fc79cd97a656a966d97a76d22cb05dd82b9293952f51ba849b849ba829cf6715bc7c8aa3f3510e1b5aaa798e3216cd92a612e353004c55a407b35cd
+  checksum: b725fbb983f2117cd31857d809b5d8e29e9da0a27f081ba72fe009cb5f0e5525c58fff00ec364de752999677e171bb63038f7ea56535754226bfbb86dfa534b7
   languageName: node
   linkType: hard
 
@@ -647,17 +653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-function-name@npm:^7.18.9, @babel/helper-function-name@npm:^7.19.0":
-  version: 7.19.0
-  resolution: "@babel/helper-function-name@npm:7.19.0"
-  dependencies:
-    "@babel/template": ^7.18.10
-    "@babel/types": ^7.19.0
-  checksum: a4181d23274d926df3a8032fb2ff210b8a27c83fedd9e7bd148a6877cb4070be4caf69ddae1bf29447e1e84da807ff769a31ca661ef55ecd4d4d672073a68c48
-  languageName: node
-  linkType: hard
-
-"@babel/helper-function-name@npm:^7.21.0":
+"@babel/helper-function-name@npm:^7.18.9, @babel/helper-function-name@npm:^7.19.0, @babel/helper-function-name@npm:^7.21.0":
   version: 7.21.0
   resolution: "@babel/helper-function-name@npm:7.21.0"
   dependencies:
@@ -676,16 +672,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-member-expression-to-functions@npm:^7.20.7":
-  version: 7.20.7
-  resolution: "@babel/helper-member-expression-to-functions@npm:7.20.7"
-  dependencies:
-    "@babel/types": ^7.20.7
-  checksum: f2cdaf0b8a280f59904551bf3f1fe39eedf5952a8a9ac61333470f8ee3ef036cd60500401a22494fd10b8ffdb7853d0ac1708870afb2255ebc73d8c43b9a8267
-  languageName: node
-  linkType: hard
-
-"@babel/helper-member-expression-to-functions@npm:^7.21.0":
+"@babel/helper-member-expression-to-functions@npm:^7.20.7, @babel/helper-member-expression-to-functions@npm:^7.21.0":
   version: 7.21.0
   resolution: "@babel/helper-member-expression-to-functions@npm:7.21.0"
   dependencies:
@@ -703,9 +690,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.12.1, @babel/helper-module-transforms@npm:^7.18.6, @babel/helper-module-transforms@npm:^7.19.0, @babel/helper-module-transforms@npm:^7.20.11":
-  version: 7.20.11
-  resolution: "@babel/helper-module-transforms@npm:7.20.11"
+"@babel/helper-module-transforms@npm:^7.12.1, @babel/helper-module-transforms@npm:^7.18.6, @babel/helper-module-transforms@npm:^7.19.0, @babel/helper-module-transforms@npm:^7.20.11, @babel/helper-module-transforms@npm:^7.21.0, @babel/helper-module-transforms@npm:^7.21.2":
+  version: 7.21.2
+  resolution: "@babel/helper-module-transforms@npm:7.21.2"
   dependencies:
     "@babel/helper-environment-visitor": ^7.18.9
     "@babel/helper-module-imports": ^7.18.6
@@ -713,9 +700,9 @@ __metadata:
     "@babel/helper-split-export-declaration": ^7.18.6
     "@babel/helper-validator-identifier": ^7.19.1
     "@babel/template": ^7.20.7
-    "@babel/traverse": ^7.20.10
-    "@babel/types": ^7.20.7
-  checksum: a6cc533c3c9a2ed939f041002c142611a657a6defffda195f56936793f7ceb6c9abcc0c5e77e49da9e1584f60442e04107937394dbd6560d1094cfd7f3a9a152
+    "@babel/traverse": ^7.21.2
+    "@babel/types": ^7.21.2
+  checksum: 35d4508826bae2db69ab6966db1810b5e7b9157e471525ad1f2119e16742bd293da02587bddb2843368dcd411ddd5ae0f212d6381bcf32e1b338a84b5b27ae30
   languageName: node
   linkType: hard
 
@@ -811,14 +798,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-option@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-validator-option@npm:7.18.6"
-  checksum: 7a1452725b87e6b0d26e8a981ad1e19a24d3bb8b17fb25d1254d6d1f3f2f2efd675135417d44f704ea4dd88f854e7a0a31967322dcb3e06fa80fc4fec71853a5
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-option@npm:^7.21.0":
+"@babel/helper-validator-option@npm:^7.18.6, @babel/helper-validator-option@npm:^7.21.0":
   version: 7.21.0
   resolution: "@babel/helper-validator-option@npm:7.21.0"
   checksum: a5efbf3f09f1514d1704f3f7bf0e5fac401fff48a9b84a9eb47a52a4c13beee9802c6cf212a82c5fb95f6cc6b5932cb32e756cf33075be17352f64827a8ec066
@@ -837,14 +817,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.12.5, @babel/helpers@npm:^7.19.0, @babel/helpers@npm:^7.20.7, @babel/helpers@npm:^7.8.4":
-  version: 7.20.13
-  resolution: "@babel/helpers@npm:7.20.13"
+"@babel/helpers@npm:^7.12.5, @babel/helpers@npm:^7.19.0, @babel/helpers@npm:^7.20.7, @babel/helpers@npm:^7.21.0, @babel/helpers@npm:^7.8.4":
+  version: 7.21.0
+  resolution: "@babel/helpers@npm:7.21.0"
   dependencies:
     "@babel/template": ^7.20.7
-    "@babel/traverse": ^7.20.13
-    "@babel/types": ^7.20.7
-  checksum: 63269ec5bbc1f1fc4ccb320152c2d37bcebbc2b812b8c6bba6361e7f91900214f8e8300c08505e7f03c2320ed56e8b08ad77c756f3964d2bab36b705e9fad390
+    "@babel/traverse": ^7.21.0
+    "@babel/types": ^7.21.0
+  checksum: a7415373f1c9b84fe32839d5219c3d695e84b910f49a20786caf3b5a37f5079d26af6a5b36b4f2e3eb450b2413c309785483a8d59246d1326c44184c51c24255
   languageName: node
   linkType: hard
 
@@ -859,12 +839,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.11.5, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.13.12, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.18.4, @babel/parser@npm:^7.19.3, @babel/parser@npm:^7.20.13, @babel/parser@npm:^7.20.3, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.4.5, @babel/parser@npm:^7.6.0, @babel/parser@npm:^7.7.0, @babel/parser@npm:^7.8.6, @babel/parser@npm:^7.8.7, @babel/parser@npm:^7.9.6":
-  version: 7.20.15
-  resolution: "@babel/parser@npm:7.20.15"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.11.5, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.13.12, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.18.4, @babel/parser@npm:^7.19.3, @babel/parser@npm:^7.20.3, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.0, @babel/parser@npm:^7.21.2, @babel/parser@npm:^7.4.5, @babel/parser@npm:^7.6.0, @babel/parser@npm:^7.7.0, @babel/parser@npm:^7.8.6, @babel/parser@npm:^7.8.7, @babel/parser@npm:^7.9.6":
+  version: 7.21.2
+  resolution: "@babel/parser@npm:7.21.2"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 6bea1cedd1c783451984e3c9156052b88f194345ffbfac91e739cbd0d2a7ecb4b46fb027afa4b655d15eed4d0743105e960d93eb3ccc067e24fa2b39e8643861
+  checksum: 03e062d5ee06c73a5ef4f6cb0631a290604c8541e4b8db2824eb0fec412c1604e2e2b1abc034af5acc35564d6a4fb0d749153365d4e602bc94dd0578f3902248
   languageName: node
   linkType: hard
 
@@ -919,30 +899,30 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-proposal-class-static-block@npm:^7.18.6":
-  version: 7.20.7
-  resolution: "@babel/plugin-proposal-class-static-block@npm:7.20.7"
+  version: 7.21.0
+  resolution: "@babel/plugin-proposal-class-static-block@npm:7.21.0"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.20.7
+    "@babel/helper-create-class-features-plugin": ^7.21.0
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/plugin-syntax-class-static-block": ^7.14.5
   peerDependencies:
     "@babel/core": ^7.12.0
-  checksum: 57a47a77a2d3e2506b8eed14f47bb3d495e834ae9bcbc7681f3011dcdf720533fbc9605b61c8711efeded0065ea059f6a2acca708fbc6262a52f284a0328f443
+  checksum: b46eb08badd7943c7bdf06fa6f1bb171e00f26d3c25e912205f735ccc321d1dbe8d023d97491320017e0e5d083b7aab3104f5a661535597d278a6c833c97eb79
   languageName: node
   linkType: hard
 
 "@babel/plugin-proposal-decorators@npm:^7.13.5":
-  version: 7.20.13
-  resolution: "@babel/plugin-proposal-decorators@npm:7.20.13"
+  version: 7.21.0
+  resolution: "@babel/plugin-proposal-decorators@npm:7.21.0"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.20.12
+    "@babel/helper-create-class-features-plugin": ^7.21.0
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/helper-replace-supers": ^7.20.7
     "@babel/helper-split-export-declaration": ^7.18.6
-    "@babel/plugin-syntax-decorators": ^7.19.0
+    "@babel/plugin-syntax-decorators": ^7.21.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 367ea9808619b8fb400e52e35823205b592fc70f98cef7a31b10a2cc960815cb9a1ebbf04ba8448c328bf7e743ed90e773f6332bdc098aa3667b9c10c25d1503
+  checksum: 93f69d7ca1404349c3d5b761ee4d29fcd5f749a528ba25442f86fec6a4ede75d5845d449123f4e29f57a525aa18482b3f651f308bc4e946f8a08db022f93e739
   languageName: node
   linkType: hard
 
@@ -1031,7 +1011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-object-rest-spread@npm:^7.20.2":
+"@babel/plugin-proposal-object-rest-spread@npm:^7.20.2, @babel/plugin-proposal-object-rest-spread@npm:^7.20.7":
   version: 7.20.7
   resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.20.7"
   dependencies:
@@ -1059,15 +1039,15 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-proposal-optional-chaining@npm:^7.13.12, @babel/plugin-proposal-optional-chaining@npm:^7.18.9, @babel/plugin-proposal-optional-chaining@npm:^7.20.7":
-  version: 7.20.7
-  resolution: "@babel/plugin-proposal-optional-chaining@npm:7.20.7"
+  version: 7.21.0
+  resolution: "@babel/plugin-proposal-optional-chaining@npm:7.21.0"
   dependencies:
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/helper-skip-transparent-expression-wrappers": ^7.20.0
     "@babel/plugin-syntax-optional-chaining": ^7.8.3
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 8aa2b9691a61e9780f05b5fc247a9b2944fa0f7841c575b459631cd72a828c4d8062bd12c60859409b4219198c291954e3a03bc570587235f6123728a23cc3ab
+  checksum: b524a61b1de3f3ad287cd1e98c2a7f662178d21cd02205b0d615512e475f0159fa1b569fa7e34c8ed67baef689c0136fa20ba7d1bf058d186d30736a581a723f
   languageName: node
   linkType: hard
 
@@ -1084,16 +1064,16 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-proposal-private-property-in-object@npm:^7.16.5, @babel/plugin-proposal-private-property-in-object@npm:^7.18.6":
-  version: 7.20.5
-  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.20.5"
+  version: 7.21.0
+  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.0"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.18.6
-    "@babel/helper-create-class-features-plugin": ^7.20.5
+    "@babel/helper-create-class-features-plugin": ^7.21.0
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/plugin-syntax-private-property-in-object": ^7.14.5
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 1788a19b305f06db40448af5725d626562b1ba6bdf1de04fb07a75f595dd1c9463649b8fecd32953f80ebff31a71dad97d58bf5a616abaa317195d39c21c0cff
+  checksum: 576ec99964c50435a81dfe4178d064df9aa86628090d69bae8759332b9a2b5a0a8575a6f51db915c3751949cd29990b8b3a80c6afc228a0664f4237b7b60d667
   languageName: node
   linkType: hard
 
@@ -1153,14 +1133,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-decorators@npm:^7.19.0":
-  version: 7.19.0
-  resolution: "@babel/plugin-syntax-decorators@npm:7.19.0"
+"@babel/plugin-syntax-decorators@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/plugin-syntax-decorators@npm:7.21.0"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.19.0
+    "@babel/helper-plugin-utils": ^7.20.2
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 5b3fb71592fe91c68f13dbe7285471adb144583dd80f2274954250501e3f362ebfdab482f8886857f03c8b970c428a572ccbc3a59e2439f6ab92ec0d91c3874b
+  checksum: 4198529415f7ba5ccca1798d062380151f6aa625f7ff5e25bb8925ef818d6ae8cc2f88ac76b63214db741ee678c3ab79831e98e8fb7328c2f4fd5fb340113164
   languageName: node
   linkType: hard
 
@@ -1387,24 +1367,24 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-block-scoping@npm:^7.20.2, @babel/plugin-transform-block-scoping@npm:^7.8.3":
-  version: 7.20.15
-  resolution: "@babel/plugin-transform-block-scoping@npm:7.20.15"
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.21.0"
   dependencies:
     "@babel/helper-plugin-utils": ^7.20.2
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 6cf805f08a87a9e70d19308154286522072f7ad1f6c106fba0f73dcc90674be5315fbbffee4f3040106331a9187fd76ba80e7cca4945ee8621713f28653e5e6f
+  checksum: e06a5017cd4c0dd0b8f5e4dd62853f575b66e6653ef533af7eeca0df7a6e7908bd9dd3c98d4c5dc10830fe53f85d289d337d22448bb6bcdda774df619eb097b5
   languageName: node
   linkType: hard
 
 "@babel/plugin-transform-classes@npm:^7.20.2":
-  version: 7.20.7
-  resolution: "@babel/plugin-transform-classes@npm:7.20.7"
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-classes@npm:7.21.0"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.18.6
     "@babel/helper-compilation-targets": ^7.20.7
     "@babel/helper-environment-visitor": ^7.18.9
-    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-function-name": ^7.21.0
     "@babel/helper-optimise-call-expression": ^7.18.6
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/helper-replace-supers": ^7.20.7
@@ -1412,7 +1392,7 @@ __metadata:
     globals: ^11.1.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 920d6861b366f5abe66106c178c0ae15386b52b3bd95284db632482c217ce7883187603f4014be62dfeada1a70f6370ea6c6ed152e02b81c52a8febbb7c1e20b
+  checksum: d680fb89d2b96f78f5dfce57dae4d39ac07c34bd9f5331edc7ebd941b86637e598f569cf544520029489d9f621158275811552169d12f777504479ba5cae62cf
   languageName: node
   linkType: hard
 
@@ -1475,25 +1455,25 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-flow-strip-types@npm:^7.18.6":
-  version: 7.19.0
-  resolution: "@babel/plugin-transform-flow-strip-types@npm:7.19.0"
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-flow-strip-types@npm:7.21.0"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.19.0
+    "@babel/helper-plugin-utils": ^7.20.2
     "@babel/plugin-syntax-flow": ^7.18.6
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 9b330e14f9e570c33ad7c99d3b250cfa8272df542dcb0cdbd8ad3c62668b651c8c0ca643063ad68a7bebb73b492cc3335a6e6276a48b82f949565c58d614be26
+  checksum: 7d6c6a4de53c4106ed30cd32c769f340d048d7c4d01391eebd3ad71eabbd6910bd1d483bc23eebcfd9bb45d40cb9b743d916c0746cdedd952791a1222620b48c
   languageName: node
   linkType: hard
 
 "@babel/plugin-transform-for-of@npm:^7.18.8":
-  version: 7.18.8
-  resolution: "@babel/plugin-transform-for-of@npm:7.18.8"
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-for-of@npm:7.21.0"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.20.2
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 37708653d9ac69af31f0f5d0abebd726d6b92ba630beed8fea8e1538f035b2877abc0013f26f400ebc23af459fb8e629c83847818614d9fcca086fb5bcd35c4d
+  checksum: 0ca1320975ec5a4c8e7be428c53f5cf6e9363d13bd4e8664c0b430c423c0c1316ad4f4dfc8666e6a17021792d4c72b5b621891d92c8370949a698897fd24aa71
   languageName: node
   linkType: hard
 
@@ -1545,15 +1525,15 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-modules-commonjs@npm:^7.13.8, @babel/plugin-transform-modules-commonjs@npm:^7.19.6, @babel/plugin-transform-modules-commonjs@npm:^7.2.0":
-  version: 7.20.11
-  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.20.11"
+  version: 7.21.2
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.21.2"
   dependencies:
-    "@babel/helper-module-transforms": ^7.20.11
+    "@babel/helper-module-transforms": ^7.21.2
     "@babel/helper-plugin-utils": ^7.20.2
     "@babel/helper-simple-access": ^7.20.2
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: f3a3281c252a978255076ff7274e4ac1ec252e0db4b3d73122c278ce9fd8318179fc804638ce726870146fa0845e2559711453ce7a391dc2a792d96dc0f6b04c
+  checksum: faddf37cab44ad45871ffc38cc17bfbaee301afc3e874652fd36850021e850252570f3b521e0fdbd7098a57016ec72c672b071511949c029b40e1c09b0624869
   languageName: node
   linkType: hard
 
@@ -1674,13 +1654,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-react-jsx-self@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.18.6"
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.21.0"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.20.2
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 3fb17ae87eb264f77c5d1b30f4687f863f849bf4e8892159aee8e6bd069ff66d909f378dffdb7e6e157f9424cfbfe7c48e884aceac39e33f6a8abbdb04f83303
+  checksum: 905117c7832367950b9f2aef2f2392f36981b14b9cc178eb9ef36241022c856ff740b48625638a3bfb9e1f55e7efa42d7aa1cd3576070712de5c66bb11d7215d
   languageName: node
   linkType: hard
 
@@ -1695,22 +1675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx@npm:^7.14.9, @babel/plugin-transform-react-jsx@npm:^7.18.6, @babel/plugin-transform-react-jsx@npm:^7.19.0":
-  version: 7.20.13
-  resolution: "@babel/plugin-transform-react-jsx@npm:7.20.13"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.18.6
-    "@babel/helper-module-imports": ^7.18.6
-    "@babel/helper-plugin-utils": ^7.20.2
-    "@babel/plugin-syntax-jsx": ^7.18.6
-    "@babel/types": ^7.20.7
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 810bc9968f913b23bdf7069c4b221075fbeab9a2656816af2e80fffb288ec0aa04bf75ad1c4ea78b95b30d4b37fcf59dcbd28a722c1be6efa6f7ef6674da0da9
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-jsx@npm:^7.21.0":
+"@babel/plugin-transform-react-jsx@npm:^7.14.9, @babel/plugin-transform-react-jsx@npm:^7.18.6, @babel/plugin-transform-react-jsx@npm:^7.19.0, @babel/plugin-transform-react-jsx@npm:^7.21.0":
   version: 7.21.0
   resolution: "@babel/plugin-transform-react-jsx@npm:7.21.0"
   dependencies:
@@ -1760,7 +1725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:7.19.6, @babel/plugin-transform-runtime@npm:^7.13.9":
+"@babel/plugin-transform-runtime@npm:7.19.6":
   version: 7.19.6
   resolution: "@babel/plugin-transform-runtime@npm:7.19.6"
   dependencies:
@@ -1773,6 +1738,22 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 39c1a7a6421dbd00d599082b4c38ed1b3ba5844af1249d3860d7de7ce7e6451641ee0fc5b237af4a02f5cd77c7896a2b50799d0f90b1b30b6d2cd92061b2fdff
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-runtime@npm:^7.13.9, @babel/plugin-transform-runtime@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-runtime@npm:7.21.0"
+  dependencies:
+    "@babel/helper-module-imports": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.20.2
+    babel-plugin-polyfill-corejs2: ^0.3.3
+    babel-plugin-polyfill-corejs3: ^0.6.0
+    babel-plugin-polyfill-regenerator: ^0.4.1
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b01aecac36fc7aac14b69063641f30b9c75b78c69cb2c985d78a1cd763867b0a6a7ac5cc1dadcb4c6f768a6e17c151cfb38ae8cc71e6f13341c130bc746f831d
   languageName: node
   linkType: hard
 
@@ -1832,20 +1813,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.13.0, @babel/plugin-transform-typescript@npm:^7.18.6":
-  version: 7.20.13
-  resolution: "@babel/plugin-transform-typescript@npm:7.20.13"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.20.12
-    "@babel/helper-plugin-utils": ^7.20.2
-    "@babel/plugin-syntax-typescript": ^7.20.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 3c298015e12472a07097cf1d9050cc0662f3054f0809afca25b9cbddc25a75d2fb75b080ab169de6d0c03b08a0b55d047ce9840ccbcdc51cdcfdb21f696bcf53
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-typescript@npm:^7.21.0":
+"@babel/plugin-transform-typescript@npm:^7.13.0, @babel/plugin-transform-typescript@npm:^7.21.0":
   version: 7.21.0
   resolution: "@babel/plugin-transform-typescript@npm:7.21.0"
   dependencies:
@@ -2020,20 +1988,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.13.0, @babel/preset-typescript@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/preset-typescript@npm:7.18.6"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.18.6
-    "@babel/helper-validator-option": ^7.18.6
-    "@babel/plugin-transform-typescript": ^7.18.6
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2314e0c1fd5d188ca4bdc35f8ab1e9caec3c662673949cf16ae5b29ed27855a5f354a19b736b50e54e099d580f825e39b58db7fd8f8e2c2d38eb22c9fa5910ea
-  languageName: node
-  linkType: hard
-
-"@babel/preset-typescript@npm:^7.21.0":
+"@babel/preset-typescript@npm:^7.13.0, @babel/preset-typescript@npm:^7.18.6, @babel/preset-typescript@npm:^7.21.0":
   version: 7.21.0
   resolution: "@babel/preset-typescript@npm:7.21.0"
   dependencies:
@@ -2047,8 +2002,8 @@ __metadata:
   linkType: hard
 
 "@babel/register@npm:^7.13.16":
-  version: 7.18.9
-  resolution: "@babel/register@npm:7.18.9"
+  version: 7.21.0
+  resolution: "@babel/register@npm:7.21.0"
   dependencies:
     clone-deep: ^4.0.1
     find-cache-dir: ^2.0.0
@@ -2057,7 +2012,7 @@ __metadata:
     source-map-support: ^0.5.16
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: b19c1445adf202732a2e0d554749257da22e56f0fc159709200d962413fbd4e7bd1d684222e60c08a2b8ad8fe511d8699fbc978d92816953fc9cbb6cbcc40d63
+  checksum: 2ab2c8bbf033e8e6bfc22860a9f8efebfae0153d7a862357b9c3b66be90c55318d13bfe8b9066e61df06783b5f0895b3aa6e3282c3c96b986330c1151c52af6c
   languageName: node
   linkType: hard
 
@@ -2069,12 +2024,12 @@ __metadata:
   linkType: hard
 
 "@babel/runtime-corejs3@npm:^7.10.2":
-  version: 7.20.13
-  resolution: "@babel/runtime-corejs3@npm:7.20.13"
+  version: 7.21.0
+  resolution: "@babel/runtime-corejs3@npm:7.21.0"
   dependencies:
     core-js-pure: ^3.25.1
     regenerator-runtime: ^0.13.11
-  checksum: b763ad88a449927b63245a5fc8633910157611db83514a67f1f595d164f2b21fbc7c60bd374853c453c462d46e2e7524b06b758c5c4f31cf9b0f3ea5432756ba
+  checksum: b46896f9a774eeb0e8d2597a0a43a87ede27eebec650b3e17719c14a502289ece95029fe5bc8be84798fb1879b69d54efc1f42c3127f1afaf7778d3b8bb692b5
   languageName: node
   linkType: hard
 
@@ -2105,12 +2060,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
-  version: 7.20.13
-  resolution: "@babel/runtime@npm:7.20.13"
+"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+  version: 7.21.0
+  resolution: "@babel/runtime@npm:7.21.0"
   dependencies:
     regenerator-runtime: ^0.13.11
-  checksum: 4bea540b54d50af157efc6e9117727c0e9a146b9db43fcd89b8f0024c9464620194efc73e57588b4b141974188dc6f9d338319d74b855d32a785bf14a6fd0d6d
+  checksum: 8fc28acf3b353390a8188a63d443719847b24b66028fdc8bb301c08e2ee013b52aaeb9d0e9783fa5dcd72bb3c0172fb647419db32392101001738356bdc1f4ab
   languageName: node
   linkType: hard
 
@@ -2145,36 +2100,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.19.3, @babel/traverse@npm:^7.20.1, @babel/traverse@npm:^7.20.10, @babel/traverse@npm:^7.20.12, @babel/traverse@npm:^7.20.13, @babel/traverse@npm:^7.20.5, @babel/traverse@npm:^7.20.7, @babel/traverse@npm:^7.4.5, @babel/traverse@npm:^7.7.0, @babel/traverse@npm:^7.7.2, @babel/traverse@npm:^7.8.6":
-  version: 7.20.13
-  resolution: "@babel/traverse@npm:7.20.13"
+"@babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.19.3, @babel/traverse@npm:^7.20.1, @babel/traverse@npm:^7.20.12, @babel/traverse@npm:^7.20.5, @babel/traverse@npm:^7.20.7, @babel/traverse@npm:^7.21.0, @babel/traverse@npm:^7.21.2, @babel/traverse@npm:^7.4.5, @babel/traverse@npm:^7.7.0, @babel/traverse@npm:^7.7.2, @babel/traverse@npm:^7.8.6":
+  version: 7.21.2
+  resolution: "@babel/traverse@npm:7.21.2"
   dependencies:
     "@babel/code-frame": ^7.18.6
-    "@babel/generator": ^7.20.7
+    "@babel/generator": ^7.21.1
     "@babel/helper-environment-visitor": ^7.18.9
-    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-function-name": ^7.21.0
     "@babel/helper-hoist-variables": ^7.18.6
     "@babel/helper-split-export-declaration": ^7.18.6
-    "@babel/parser": ^7.20.13
-    "@babel/types": ^7.20.7
+    "@babel/parser": ^7.21.2
+    "@babel/types": ^7.21.2
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: c28c0dfedac0e6298122495eaeeb53016d307088c0cc7bbb4e6f1196bb3670fb771b618be7a5ef2ef5bb17df1bb8f3cff6475380cdcab2d2d57fbe62cabe79e8
+  checksum: 0ed80a28e3cce1f13adce8b0470b346c7c08c2bb9cdaea850bb6bc0bf6dc7d11b1dd76f9a97e092cb41b24eabf1498e93cedc5df8663c5fd26af9c3313df2789
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.11.5, @babel/types@npm:^7.12.7, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.8, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.0, @babel/types@npm:^7.19.3, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.5, @babel/types@npm:^7.20.7, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.6.1, @babel/types@npm:^7.7.0, @babel/types@npm:^7.7.2, @babel/types@npm:^7.8.3, @babel/types@npm:^7.8.6, @babel/types@npm:^7.8.7, @babel/types@npm:^7.9.6":
-  version: 7.20.7
-  resolution: "@babel/types@npm:7.20.7"
-  dependencies:
-    "@babel/helper-string-parser": ^7.19.4
-    "@babel/helper-validator-identifier": ^7.19.1
-    to-fast-properties: ^2.0.0
-  checksum: df0061f306bd95389604075ba5a88e984a801635c70c77b3b6ae8ab44675064b9ef4088c6c78dbf786a28efc662ad37f9c09f8658ba44c12cb8dd6f450a8bde7
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.21.0":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.11.5, @babel/types@npm:^7.12.7, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.8, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.3, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.5, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.0, @babel/types@npm:^7.21.2, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.6.1, @babel/types@npm:^7.7.0, @babel/types@npm:^7.7.2, @babel/types@npm:^7.8.3, @babel/types@npm:^7.8.6, @babel/types@npm:^7.8.7, @babel/types@npm:^7.9.6":
   version: 7.21.2
   resolution: "@babel/types@npm:7.21.2"
   dependencies:
@@ -3592,7 +3536,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.14, @jridgewell/trace-mapping@npm:^0.3.15, @jridgewell/trace-mapping@npm:^0.3.9":
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.14, @jridgewell/trace-mapping@npm:^0.3.15, @jridgewell/trace-mapping@npm:^0.3.17, @jridgewell/trace-mapping@npm:^0.3.9":
   version: 0.3.17
   resolution: "@jridgewell/trace-mapping@npm:0.3.17"
   dependencies:
@@ -6475,6 +6419,18 @@ __metadata:
   resolution: "@storybook/nextjs@workspace:frameworks/nextjs"
   dependencies:
     "@babel/core": ^7.20.5
+    "@babel/plugin-proposal-class-properties": ^7.18.6
+    "@babel/plugin-proposal-export-namespace-from": ^7.18.9
+    "@babel/plugin-proposal-numeric-separator": ^7.18.6
+    "@babel/plugin-proposal-object-rest-spread": ^7.20.7
+    "@babel/plugin-syntax-bigint": ^7.8.3
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-syntax-import-assertions": ^7.20.0
+    "@babel/plugin-transform-runtime": ^7.21.0
+    "@babel/preset-env": ^7.20.2
+    "@babel/preset-react": ^7.18.6
+    "@babel/preset-typescript": ^7.21.0
+    "@babel/runtime": ^7.21.0
     "@babel/types": ^7.20.5
     "@next/font": ^13.0.7
     "@storybook/addon-actions": 7.0.0-beta.54
@@ -6485,6 +6441,8 @@ __metadata:
     "@storybook/preview-api": 7.0.0-beta.54
     "@storybook/react": 7.0.0-beta.54
     "@types/babel__core": ^7
+    "@types/babel__plugin-transform-runtime": ^7
+    "@types/babel__preset-env": ^7
     "@types/node": ^16.0.0
     css-loader: ^6.7.3
     find-up: ^5.0.0
@@ -7940,6 +7898,20 @@ __metadata:
   dependencies:
     "@babel/types": ^7.0.0
   checksum: e0051b450e4ba2df0a7e386f08df902a4e920f6f8d6f185d69ddbe9b0e2e2d3ae434bb51e437bc0fca2a9a0f5dc4ca44d3a1941ef75e74371e8be5bf64416fe4
+  languageName: node
+  linkType: hard
+
+"@types/babel__plugin-transform-runtime@npm:^7":
+  version: 7.9.2
+  resolution: "@types/babel__plugin-transform-runtime@npm:7.9.2"
+  checksum: cee1ef257ef1ddf1ad983ed3f93826f0b51a563067791293c49713d50b721c15f990fd3760230a320426e1d367aa9f66ca35af8f5847daf8ea03588a4053cd6c
+  languageName: node
+  linkType: hard
+
+"@types/babel__preset-env@npm:^7":
+  version: 7.9.2
+  resolution: "@types/babel__preset-env@npm:7.9.2"
+  checksum: 89d389de7fb2b4be8f43b021899b1fd8bdc85e912cc01b1b5a2504b033ada58b034d44131561c56ab6781c31913a21b769d33a05b549549bbc49bb92537e2dfb
   languageName: node
   linkType: hard
 
@@ -26189,9 +26161,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexpu-core@npm:^5.2.1":
-  version: 5.3.0
-  resolution: "regexpu-core@npm:5.3.0"
+"regexpu-core@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "regexpu-core@npm:5.3.1"
   dependencies:
     "@babel/regjsgen": ^0.8.0
     regenerate: ^1.4.2
@@ -26199,7 +26171,7 @@ __metadata:
     regjsparser: ^0.9.1
     unicode-match-property-ecmascript: ^2.0.0
     unicode-match-property-value-ecmascript: ^2.1.0
-  checksum: 56d6c2858085b15df622d6346b47aa73f8c341fe70c8fec46dfff49a0213d9d4f216f6d771364f9e35311b8d99d829dd2dded909fdea8441f5a344bb1cb9c744
+  checksum: 198c15c7277764a43a04e8091a05286d0da335460558cfa37b9dccaa25fb4b031e32889749641c979eb2681f6296b277bbfaf7c3011dbb269fbe61ab3bb521b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves https://github.com/storybookjs/storybook/issues/20087
Resolves https://github.com/storybookjs/storybook/issues/21027

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did:

Moved next/babel preset into codebase to be able to make changes, because it seems that `next/babel` will not be maintained anymore in favour of swc/Turbopack. Also:
- Fixed inconsistent propTypes handling between dev + build modes in NextJs.
- Removed precompiled `@babel/typescript-preset` package from next and use the latest one.

## Background:

The Next.js babel plugin `next/babel` behaves differently in `development` and `production` modes. It removes React propTypes in production, which is bad because Storybook relies on them to correctly infer the right argTypes. I opened a discussion [here](https://github.com/vercel/next.js/discussions/43757) at `@vercel/nextjs` to be able to conditionally still output the proptypes even for a production build. For almost two months nobody replied to this. I assume, that they will not work on any babel-related stuff, because the future at Next.js is Turbopack.

Essentially the `plugin-transform-react-remove-prop-types` plugin applied [here](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/preset.ts#L193) should not be applied on production. 

I tried different approaches: 

1. My first approach was flattening all plugins in `next/babel` preset and removing the superfluous `plugin-transform-react-remove-prop-types` plugin if it is present. The issue is that as soon as I want to look up the babel configuration, I cannot identify a plugin by a specific ID or name, because of how the plugins are set up in `next/babel` (direct require call).

2. The final approach I have decided on, and which was discussed with @shilman, was to actually copy `next/babel` and all of its dependencies to modify that one line and reference the modified `next/babel` preset instead. I really don't like this approach, but I can't think of another solution.

Therefore actually, only the changes in `code/frameworks/nextjs/src/preset.ts` matter. The other files are more or less copied over with some slight type adjustments.

<!-- Briefly describe what your PR does -->

## How to test

The chromatic changes introduced here
https://www.chromatic.com/build?appId=634ff0454a50407deedde524&number=205
should be reverted by
https://www.chromatic.com/build?appId=634ff0d0ec053b270775979d&number=2459

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
