### PR TITLE
fix: Interaction's tooltips don't disappear correctly

### DIFF
--- a/code/addons/interactions/src/components/Subnav.tsx
+++ b/code/addons/interactions/src/components/Subnav.tsx
@@ -132,7 +132,7 @@ export const Subnav: React.FC<SubnavProps> = ({
 
             <StyledSeparator />
 
-            <WithTooltip hasChrome={false} tooltip={<Note note="Go to start" />}>
+            <WithTooltip trigger="hover" hasChrome={false} tooltip={<Note note="Go to start" />}>
               <RewindButton
                 aria-label="Go to start"
                 containsIcon
@@ -143,7 +143,7 @@ export const Subnav: React.FC<SubnavProps> = ({
               </RewindButton>
             </WithTooltip>
 
-            <WithTooltip hasChrome={false} tooltip={<Note note="Go back" />}>
+            <WithTooltip trigger="hover" hasChrome={false} tooltip={<Note note="Go back" />}>
               <StyledIconButton
                 aria-label="Go back"
                 containsIcon
@@ -154,7 +154,7 @@ export const Subnav: React.FC<SubnavProps> = ({
               </StyledIconButton>
             </WithTooltip>
 
-            <WithTooltip hasChrome={false} tooltip={<Note note="Go forward" />}>
+            <WithTooltip trigger="hover" hasChrome={false} tooltip={<Note note="Go forward" />}>
               <StyledIconButton
                 aria-label="Go forward"
                 containsIcon
@@ -165,7 +165,7 @@ export const Subnav: React.FC<SubnavProps> = ({
               </StyledIconButton>
             </WithTooltip>
 
-            <WithTooltip hasChrome={false} tooltip={<Note note="Go to end" />}>
+            <WithTooltip trigger="hover" hasChrome={false} tooltip={<Note note="Go to end" />}>
               <StyledIconButton
                 aria-label="Go to end"
                 containsIcon
@@ -176,7 +176,7 @@ export const Subnav: React.FC<SubnavProps> = ({
               </StyledIconButton>
             </WithTooltip>
 
-            <WithTooltip hasChrome={false} tooltip={<Note note="Rerun" />}>
+            <WithTooltip trigger="hover" hasChrome={false} tooltip={<Note note="Rerun" />}>
               <RerunButton
                 aria-label="Rerun"
                 containsIcon


### PR DESCRIPTION
Issue: [#21076](https://github.com/storybookjs/storybook/issues/21076)

## What I did
Used the props `trigger="hover"` in the `WithToolTip`

## How to test

- Run `yarn start`
- Navigate to any story that contains interactions
- Verify that `tooltips` displays properly
- Demo : https://www.loom.com/share/72cdfb2bc57344e79c9a8ca30116abd4