### PR TITLE
fix: Rename "Story" tab to "Code"

### DIFF
--- a/code/addons/storysource/src/manager.tsx
+++ b/code/addons/storysource/src/manager.tsx
@@ -6,7 +6,7 @@ import { ADDON_ID, PANEL_ID } from './index';
 
 addons.register(ADDON_ID, (api) => {
   addons.addPanel(PANEL_ID, {
-    title: 'Story',
+    title: 'Code',
     render: ({ active, key }) => (active ? <StoryPanel key={key} api={api} /> : null),
     paramKey: 'storysource',
   });


### PR DESCRIPTION
Closes #20672

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

<!-- Briefly describe what your PR does -->

Renamed "Story" to "Code" as requested in https://github.com/storybookjs/storybook/issues/20672#issuecomment-1399788383 to start a discussion.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

TBD

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`