### PR TITLE
Chore: (Docs) Adds Args Youtube tutorial to the documentation

### DIFF
--- a/docs/writing-stories/args.md
+++ b/docs/writing-stories/args.md
@@ -2,6 +2,8 @@
 title: 'Args'
 ---
 
+<YouTubeCallout id="0gOfS6K0x0E" title="Build better UIs with Storybook Args" />
+
 A story is a component with a set of arguments that define how the component should render. “Args” are Storybook’s mechanism for defining those arguments in a single JavaScript object. Args can be used to dynamically change props, slots, styles, inputs, etc. It allows Storybook and its addons to live edit components. You _do not_ need to modify your underlying component code to use args.
 
 When an arg’s value changes, the component re-renders, allowing you to interact with components in Storybook’s UI via addons that affect args.


### PR DESCRIPTION
With this small pull request the latest tutorial by @chantastic is now included in the official documentation.

What was done:
- Updated the Writing stories / args documentation to feature the Youtube video.

@chantastic when you have a moment, let me know of any feedback so that we can work on it or merge it. Thanks in advance.