### PR TITLE
Chore: (Docs) Renaming imports to new package name from @storybook/ui…

### DIFF
--- a/code/ui/manager/README.md
+++ b/code/ui/manager/README.md
@@ -25,17 +25,17 @@ You can configure it by providing a provider API.
 
 ## Usage
 
-First you need to install `@storybook/ui` into your app.
+First you need to install `@storybook/manager` into your app.
 
 ```sh
-yarn add @storybook/ui --dev
+yarn add @storybook/manager --dev
 ```
 
 Then you need to create a Provider class like this:
 
 ```js
 import React from 'react';
-import { Provider } from '@storybook/ui';
+import { Provider } from '@storybook/manager';
 
 export default class MyProvider extends Provider {
   getElements(type) {
@@ -56,7 +56,7 @@ Then you need to initialize the UI like this:
 
 ```js
 import global from 'global';
-import { renderStorybookUI } from '@storybook/ui';
+import { renderStorybookUI } from '@storybook/manager';
 import Provider from './provider';
 
 const { document } = global;
@@ -70,7 +70,7 @@ renderStorybookUI(roolEl, new Provider());
 ### .setOptions()
 
 ```js
-import { Provider } from '@storybook/ui';
+import { Provider } from '@storybook/manager';
 
 class ReactProvider extends Provider {
   handleAPI(api) {
@@ -87,7 +87,7 @@ class ReactProvider extends Provider {
 This API is used to pass the`kind` and `stories` list to storybook-ui.
 
 ```js
-import { Provider } from '@storybook/ui';
+import { Provider } from '@storybook/manager';
 
 class ReactProvider extends Provider {
   handleAPI(api) {
@@ -111,7 +111,7 @@ class ReactProvider extends Provider {
 You can use to listen to the story change and update the preview.
 
 ```js
-import { Provider } from '@storybook/ui';
+import { Provider } from '@storybook/manager';
 
 class ReactProvider extends Provider {
   handleAPI(api) {


### PR DESCRIPTION
Chore: (Docs) Renaming imports to new package name from @storybook/ui to @storybook/manager

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Update documentation. `@storybook/ui` no longer exists in the latest versions.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
