### PR TITLE
Storysource: Fallback to the `docs.source.originalSource` parameter

### DIFF
--- a/code/addons/storysource/src/StoryPanel.tsx
+++ b/code/addons/storysource/src/StoryPanel.tsx
@@ -44,15 +44,20 @@ interface StoryPanelProps {
 }
 
 interface SourceParams {
-  source: string;
+  source?: string;
   locationsMap?: LocationsMap;
+}
+interface DocsParams {
+  source?: { originalSource?: string };
 }
 export const StoryPanel: React.FC<StoryPanelProps> = ({ api }) => {
   const story = api.getCurrentStoryData();
   const selectedStoryRef = React.useRef<HTMLDivElement>(null);
-  const { source, locationsMap }: SourceParams = useParameter('storySource', {
-    source: 'loading source...',
-  });
+  const { source: loaderSource, locationsMap }: SourceParams = useParameter('storySource', {});
+  const { source: { originalSource: docsSource } = {} }: DocsParams = useParameter('docs', {});
+  // prefer to use the source from source-loader, but fallback to
+  // source provided by csf-plugin for vite usage
+  const source = loaderSource || docsSource || 'loading source...';
   const currentLocation = locationsMap
     ? locationsMap[
         Object.keys(locationsMap).find((key: string) => {


### PR DESCRIPTION
Closes #20421 

## What I did

Fallback to us the source provided by the `docs.source.originalSource` parameter.

There is a long history to this hack of a PR. The TLDR is that:
1. This data should be provided by `source-loader` in the `storySource.source` parameter. However, `source-loader` caused a performance regression in the Vite builder, so I reverted it.
2. In Vite, `csf-plugin` runs always (currently), so we can expect the `docs.source.originalSource` to be there. 

The addon will prefer `storySource.source` for legacy support, but also use `docs.source.originalSource` if it's not there.

Note that in webpack:
- `source-loader` IS run
- `csf-plugin` IS NOT run unless `addon-docs` is enabled

Hopefully this all gets replaced with the annotation server in 7.x...

## How to test

Run a Vite sandbox with the storysource addon:
```
yarn task --task dev --template react-vite/default-ts -a storysource
```

Verify that the code shows up in the `Code` addon panel.

