### PR TITLE
Correctly detect Safari in browser supports CSS Zoom

### DIFF
--- a/code/ui/components/src/Zoom/browserSupportsCssZoom.ts
+++ b/code/ui/components/src/Zoom/browserSupportsCssZoom.ts
@@ -1,7 +1,7 @@
 export function browserSupportsCssZoom(): boolean {
   try {
     // First checks if Safari is being used, because Safari supports zoom, but it's buggy: https://developer.mozilla.org/en-US/docs/Web/CSS/zoom#browser_compatibility
-    if (/safari/i.test(navigator.userAgent)) {
+    if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
       return false;
     }
 


### PR DESCRIPTION
#21138 introduced a bug, because the regex that was trying to detect Safari, also returned true for Chrome, which it shouldn't. This PR fixes that Regex.

See https://github.com/storybookjs/storybook/pull/21138#discussion_r1111985790
<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
