### PR TITLE
Maintenance: fix type errors on automigrate `check` step

### DIFF
--- a/code/lib/cli/src/automigrate/types.ts
+++ b/code/lib/cli/src/automigrate/types.ts
@@ -3,7 +3,7 @@ import type { JsPackageManager } from '../js-package-manager';
 export interface CheckOptions {
   packageManager: JsPackageManager;
   rendererPackage?: string;
-  configDir: string;
+  configDir?: string;
 }
 
 export interface RunOptions<ResultType> {


### PR DESCRIPTION
Fixing a small type issue caused by #20647