### PR TITLE
Build: Add check step to `ci:daily` workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,6 +626,9 @@ workflows:
       - lint:
           requires:
             - build
+      - check:
+          requires:
+            - build
       - unit-tests:
           requires:
             - build


### PR DESCRIPTION
We were missing an important check in the `daily` workflow