### PR TITLE
TypeScript: Add `env` type to BuilderOptions

### DIFF
--- a/code/lib/builder-vite/src/vite-config.test.ts
+++ b/code/lib/builder-vite/src/vite-config.test.ts
@@ -12,7 +12,6 @@ const dummyOptions: Options = {
   configType: 'DEVELOPMENT',
   configDir: '',
   packageJson: {},
-  env: {},
   presets: {
     apply: async (key: string) =>
       ({

--- a/code/lib/builder-vite/src/vite-config.test.ts
+++ b/code/lib/builder-vite/src/vite-config.test.ts
@@ -12,6 +12,7 @@ const dummyOptions: Options = {
   configType: 'DEVELOPMENT',
   configDir: '',
   packageJson: {},
+  env: {},
   presets: {
     apply: async (key: string) =>
       ({

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -168,7 +168,7 @@ export interface BuilderOptions {
   cache?: FileSystemCache;
   configDir: string;
   docsMode?: boolean;
-  env: Record<string, string>;
+  env?: (envs: Record<string, string>) => Record<string, string>;
   features?: StorybookConfig['features'];
   versionCheck?: VersionCheck;
   releaseNotesData?: ReleaseNotesData;

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -168,6 +168,7 @@ export interface BuilderOptions {
   cache?: FileSystemCache;
   configDir: string;
   docsMode?: boolean;
+  env: Record<string, string>;
   features?: StorybookConfig['features'];
   versionCheck?: VersionCheck;
   releaseNotesData?: ReleaseNotesData;


### PR DESCRIPTION
Closes #

Ref: https://github.com/storybookjs/storybook/discussions/17862#discussioncomment-3191192

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I could see that both builders use `options.presets.apply<Record<string, string>>('env')`, but as reported, we did not include `env` in our TS types.  This adds it to `BuilderOptions`.

## How to test

Reference `env` in the config of a TypeScript sandbox.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [X] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
