### PR TITLE
CLI: Fix jscodeshift error: env: node\r: No such file or directory

### DIFF
--- a/code/lib/codemod/src/index.js
+++ b/code/lib/codemod/src/index.js
@@ -55,12 +55,17 @@ export async function runCodemod(codemod, { glob, logger, dryRun, rename, parser
 
   const files = await globby([glob, '!**/node_modules', '!**/dist']);
   logger.log(`=> Applying ${codemod}: ${files.length} files`);
-  if (!dryRun) {
+  if (files.length === 0) {
+    logger.log(`=> No matching files for glob: ${glob}`);
+    return;
+  }
+
+  if (!dryRun && files.length > 0) {
     const parserArgs = inferredParser ? ['--parser', inferredParser] : [];
     spawnSync(
-      'npx',
+      'node',
       [
-        'jscodeshift',
+        require.resolve('jscodeshift/bin/jscodeshift'),
         // this makes sure codeshift doesn't transform our own source code with babel
         // which is faster, and also makes sure the user won't see babel messages such as:
         // [BABEL] Note: The code generator has deoptimised the styling of repo/node_modules/prettier/index.js as it exceeds the max of 500KB.


### PR DESCRIPTION
Closes #21061

## What I did

Making sure to run jscodeshift with node as describe here:
https://github.com/facebook/jscodeshift/issues/424

Running node require.resolve('jscodeshift/bin/jscodeshift')

## How to test

Create a sandbox, and run migration against it using the local CLI.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x ] Make sure to add/update documentation regarding your changes
- [x ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
