### PR TITLE
Reverse order of project decorators

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,15 +21,17 @@
     - [Add strict mode](#add-strict-mode)
     - [Babel mode v7 exclusively](#babel-mode-v7-exclusively)
     - [Importing plain markdown files with `transcludeMarkdown` has changed](#importing-plain-markdown-files-with-transcludemarkdown-has-changed)
+  - [7.0 Core changes](#70-core-changes)
     - [7.0 feature flags removed](#70-feature-flags-removed)
     - [Story context is prepared before for supporting fine grained updates](#story-context-is-prepared-before-for-supporting-fine-grained-updates)
+    - [Changed decorator order between preview.js and addons/frameworks](#changed-decorator-order-between-previewjs-and-addonsframeworks)
   - [7.0 core addons changes](#70-core-addons-changes)
     - [Removed auto injection of @storybook/addon-actions decorator](#removed-auto-injection-of-storybookaddon-actions-decorator)
     - [Addon-backgrounds: Removed deprecated grid parameter](#addon-backgrounds-removed-deprecated-grid-parameter)
     - [Addon-a11y: Removed deprecated withA11y decorator](#addon-a11y-removed-deprecated-witha11y-decorator)
   - [7.0 Vite changes](#70-vite-changes)
     - [Vite builder uses Vite config automatically](#vite-builder-uses-vite-config-automatically)
-    - [Vite cache moved to node_modules/.cache/.vite-storybook](#vite-cache-moved-to-node_modulescachevite-storybook)
+    - [Vite cache moved to node\_modules/.cache/.vite-storybook](#vite-cache-moved-to-node_modulescachevite-storybook)
   - [7.0 Webpack changes](#70-webpack-changes)
     - [Webpack4 support discontinued](#webpack4-support-discontinued)
     - [Postcss removed](#postcss-removed)
@@ -72,7 +74,7 @@
     - [Dropped addon-docs manual babel configuration](#dropped-addon-docs-manual-babel-configuration)
     - [Dropped addon-docs manual configuration](#dropped-addon-docs-manual-configuration)
     - [Autoplay in docs](#autoplay-in-docs)
-    - [Removed STORYBOOK_REACT_CLASSES global](#removed-storybook_react_classes-global)
+    - [Removed STORYBOOK\_REACT\_CLASSES global](#removed-storybook_react_classes-global)
   - [7.0 Deprecations and default changes](#70-deprecations-and-default-changes)
     - [storyStoreV7 enabled by default](#storystorev7-enabled-by-default)
     - [`Story` type deprecated](#story-type-deprecated)
@@ -785,6 +787,8 @@ import ReadMe from './README.md?raw';
 
 ```
 
+### 7.0 Core changes
+
 #### 7.0 feature flags removed
 
 Storybook uses temporary feature flags to opt-in to future breaking changes or opt-in to legacy behaviors. For example:
@@ -810,6 +814,19 @@ In 7.0 we've removed the following feature flags:
 This change modifies the way Storybook prepares stories to avoid reactive args to get lost for fine-grained updates JS frameworks as `SolidJS` or `Vue`. That's because those frameworks handle args/props as proxies behind the scenes to make reactivity work. So when `argType` mapping was done in `prepareStory` the Proxies were destroyed and args becomes a plain object again, losing the reactivity.
 
 For avoiding that, this change passes the mapped args instead of raw args at `renderToCanvas` so that the proxies stay intact. Also decorators will benefit from this as well by receiving mapped args instead of raw args.
+
+#### Changed decorator order between preview.js and addons/frameworks
+
+In Storybook 7.0 we have changed the order of decorators being applied to allow you to access context information added by decorators defined in addons/frameworks from decorators defined in `preview.js`. To revert the order to the previous behavior, you can set the `features.legacyDecoratorFileOrder` flag to `true` in your `main.js` file:
+
+```js
+// main.js
+export default {
+  features: {
+    legacyDecoratorFileOrder: true,
+  },
+};
+```
 
 ### 7.0 core addons changes
 

--- a/code/frameworks/nextjs/src/routing/app-router-provider.tsx
+++ b/code/frameworks/nextjs/src/routing/app-router-provider.tsx
@@ -1,8 +1,38 @@
 import React from 'react';
-import { AppRouterContext, LayoutRouterContext } from 'next/dist/shared/lib/app-router-context';
-import { PathnameContext, SearchParamsContext } from 'next/dist/shared/lib/hooks-client-context';
+import type {
+  LayoutRouterContext as TLayoutRouterContext,
+  AppRouterContext as TAppRouterContext,
+} from 'next/dist/shared/lib/app-router-context';
+import type {
+  PathnameContext as TPathnameContext,
+  SearchParamsContext as TSearchParamsContext,
+} from 'next/dist/shared/lib/hooks-client-context';
 import type { FlightRouterState } from 'next/dist/server/app-render';
 import type { RouteParams } from './types';
+
+/**
+ * Normally dynamic imports are necessary because otherwise
+ * older versions of Next.js will throw an error
+ * because AppRouterProviders only exists in Next.js > v13
+ * Using React.lazy though is currently not supported in SB decorators
+ * therefore using the try/catch workaround
+ */
+let AppRouterContext: typeof TAppRouterContext;
+let LayoutRouterContext: typeof TLayoutRouterContext;
+let PathnameContext: typeof TPathnameContext;
+let SearchParamsContext: typeof TSearchParamsContext;
+
+try {
+  AppRouterContext = require('next/dist/shared/lib/app-router-context').AppRouterContext;
+  LayoutRouterContext = require('next/dist/shared/lib/app-router-context').LayoutRouterContext;
+  PathnameContext = require('next/dist/shared/lib/hooks-client-context').PathnameContext;
+  SearchParamsContext = require('next/dist/shared/lib/hooks-client-context').SearchParamsContext;
+} catch {
+  AppRouterContext = React.Fragment as any;
+  LayoutRouterContext = React.Fragment as any;
+  PathnameContext = React.Fragment as any;
+  SearchParamsContext = React.Fragment as any;
+}
 
 type AppRouterProviderProps = {
   action: (name: string) => (...args: any[]) => void;

--- a/code/frameworks/nextjs/src/routing/decorator.tsx
+++ b/code/frameworks/nextjs/src/routing/decorator.tsx
@@ -2,17 +2,10 @@ import * as React from 'react';
 // this will be aliased by webpack at runtime (this is just for typing)
 import type { action as originalAction } from '@storybook/addon-actions';
 import type { Addon_StoryContext } from '@storybook/types';
+import AppRouterProvider from './app-router-provider';
 
 import PageRouterProvider from './page-router-provider';
 import type { RouteParams, NextAppDirectory } from './types';
-
-/**
- * Dynamic import necessary because otherwise
- * older versions of Next.js will throw an error
- * because some imports in './app-router-provider' only exists
- * in Next.js > v13
- */
-const AppRouterProvider = React.lazy(() => import('./app-router-provider'));
 
 let action: typeof originalAction;
 

--- a/code/lib/core-server/src/presets/common-preset.ts
+++ b/code/lib/core-server/src/presets/common-preset.ts
@@ -177,6 +177,7 @@ export const features = async (
   storyStoreV7: true,
   breakingChangesV7: true,
   argTypeTargetsV7: true,
+  legacyDecoratorFileOrder: false,
 });
 
 export const storyIndexers = async (indexers?: StoryIndexer[]) => {

--- a/code/lib/preview-api/src/modules/store/csf/composeConfigs.ts
+++ b/code/lib/preview-api/src/modules/store/csf/composeConfigs.ts
@@ -1,4 +1,5 @@
 import type { Renderer, ModuleExports, ProjectAnnotations } from '@storybook/types';
+import { global } from '@storybook/global';
 
 import { combineParameters } from '../parameters';
 import { composeStepRunners } from './stepRunners';
@@ -12,9 +13,13 @@ export function getField<TFieldType = any>(
 
 export function getArrayField<TFieldType = any>(
   moduleExportList: ModuleExports[],
-  field: string
+  field: string,
+  options: { reverseFileOrder?: boolean } = {}
 ): TFieldType[] {
-  return getField(moduleExportList, field).reduce((a: any, b: any) => [...a, ...b], []);
+  return getField(moduleExportList, field).reduce(
+    (a: any, b: any) => (options.reverseFileOrder ? [...b, ...a] : [...a, ...b]),
+    []
+  );
 }
 
 export function getObjectField<TFieldType = Record<string, any>>(
@@ -39,7 +44,9 @@ export function composeConfigs<TRenderer extends Renderer>(
 
   return {
     parameters: combineParameters(...getField(moduleExportList, 'parameters')),
-    decorators: getArrayField(moduleExportList, 'decorators'),
+    decorators: getArrayField(moduleExportList, 'decorators', {
+      reverseFileOrder: !(global.FEATURES?.legacyDecoratorFileOrder ?? false),
+    }),
     args: getObjectField(moduleExportList, 'args'),
     argsEnhancers: getArrayField(moduleExportList, 'argsEnhancers'),
     argTypes: getObjectField(moduleExportList, 'argTypes'),

--- a/code/lib/preview-api/src/typings.d.ts
+++ b/code/lib/preview-api/src/typings.d.ts
@@ -13,6 +13,7 @@ declare var FEATURES:
       breakingChangesV7?: boolean;
       argTypeTargetsV7?: boolean;
       legacyMdx1?: boolean;
+      legacyDecoratorFileOrder?: boolean;
     }
   | undefined;
 

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -313,6 +313,11 @@ export interface StorybookConfig {
      * Use legacy MDX1, to help smooth migration to 7.0
      */
     legacyMdx1?: boolean;
+
+    /**
+     * Apply decorators from preview.js before decorators from addons or frameworks
+     */
+    legacyDecoratorFileOrder?: boolean;
   };
 
   /**


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21078

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Changed the order of decorators being applied to allow you to access context information added by decorators defined in addons/frameworks from decorators defined in `preview.js`. To revert the order to the previous behavior, you can set the `features.legacyDecoratorFileOrder` flag to `true` in your `main.js` file.

## How to test

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template nextjs/default-ts`
2. Open Storybook in your browser
3. Create the following decorator in `preview.js`:

```tsx
import {useRouter} from 'next/router'

export const decorators = [(StoryFn) => {
  const router = useRouter();
  return <StoryFn />
}]
```
4. The stories shouldn't fail
5. If you want to check, whether the feature flag is working, go to `main.js` and set the `features.legacyDecoratorFileOrder` to `false`. Restart Storybook and all the Stories should break, because `next/router` context is not set up properly due to the fact, that the decorator defined in `preview.js` is initialized first before the one in `@storybook/nextjs`, which is responsible to set up the `next/router` context.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
