### PR TITLE
CLI: Account for legacy framework values in automigration

### DIFF
--- a/code/lib/cli/src/automigrate/helpers/new-frameworks-utils.test.ts
+++ b/code/lib/cli/src/automigrate/helpers/new-frameworks-utils.test.ts
@@ -129,7 +129,7 @@ describe('getBuilderInfo', () => {
     });
   });
 
-  it('should infer vite info from community framework', async () => {
+  it('should infer vite info from known community frameworks', async () => {
     await expect(
       getBuilderInfo({
         mainConfig: {
@@ -151,6 +151,29 @@ describe('getBuilderInfo', () => {
       name: 'vite',
       options: { foo: 'bar' },
     });
+  });
+
+  it('when main.js has legacy renderer as framework, it should infer vite info from vite config file', async () => {
+    const findUpSpy = jest
+      .spyOn(findUp, 'default')
+      .mockReturnValueOnce(Promise.resolve('vite.config.js'));
+    await expect(getBuilderInfo({ mainConfig: { framework: 'react' } })).resolves.toEqual({
+      name: 'vite',
+      options: {},
+    });
+    expect(findUpSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('when main.js has legacy renderer as framework, it should infer webpack info from webpack config file', async () => {
+    const findUpSpy = jest
+      .spyOn(findUp, 'default')
+      .mockReturnValueOnce(Promise.resolve(undefined))
+      .mockReturnValueOnce(Promise.resolve('webpack.config.js'));
+    await expect(getBuilderInfo({ mainConfig: { framework: 'react' } })).resolves.toEqual({
+      name: 'webpack5',
+      options: {},
+    });
+    expect(findUpSpy).toHaveBeenCalledTimes(2);
   });
 
   it('when main.js has no builder or framework, it should infer vite info from vite config file', async () => {

--- a/code/lib/cli/src/automigrate/helpers/new-frameworks-utils.ts
+++ b/code/lib/cli/src/automigrate/helpers/new-frameworks-utils.ts
@@ -1,3 +1,4 @@
+import { frameworkPackages } from '@storybook/core-common';
 import type { Preset, StorybookConfig } from '@storybook/types';
 import findUp from 'find-up';
 
@@ -83,12 +84,10 @@ export const detectBuilderInfo = async ({
       builderOptions = builder.options || {};
     }
   } else if (framework) {
-    if (typeof framework === 'string') {
-      builderOrFrameworkName = framework;
-    } else {
-      builderOrFrameworkName = framework.name;
-
-      builderOptions = framework.options?.builder || {};
+    const frameworkName = typeof framework === 'string' ? framework : framework.name;
+    if (Object.keys(frameworkPackages).includes(frameworkName)) {
+      builderOrFrameworkName = frameworkName;
+      builderOptions = typeof framework === 'object' ? framework.options?.builder : {};
     }
   }
 

--- a/code/lib/core-common/src/utils/get-storybook-info.ts
+++ b/code/lib/core-common/src/utils/get-storybook-info.ts
@@ -46,7 +46,7 @@ export const frameworkPackages: Record<string, string> = {
   '@storybook/web-components-webpack5': 'web-components-webpack5',
   // community (outside of monorepo)
   'storybook-framework-qwik': 'qwik',
-  'storybook-solidjs': 'solid',
+  'storybook-solidjs-vite': 'solid',
 };
 
 const logger = console;


### PR DESCRIPTION
## What I did

The automigrations were not account for a legacy framework value such as:

```js
export default {
  framework: 'react'
}
```

So this PR fixes that (and fixes a small regression regarding community frameworks)

## How to test

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Change the framework field to `react`
3. Run automigrations

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
