### PR TITLE
Csf Tools: Support satisfies and as TS operator with module.exports

### DIFF
--- a/code/lib/csf-tools/src/ConfigFile.test.ts
+++ b/code/lib/csf-tools/src/ConfigFile.test.ts
@@ -870,45 +870,90 @@ describe('ConfigFile', () => {
       });
 
       describe('satisfies', () => {
-        it(`supports an array with string literal and object expression with name property`, () => {
-          const source = dedent`
-            import type { StorybookConfig } from '@storybook/react-webpack5';
-  
-            const config = {
-              addons: [
-                'foo',
-                { name: 'bar', options: {} },
-              ],
-              "otherField": [
-                "foo",
-                { "name": 'bar', options: {} },
-              ],
-            } satisfies StorybookConfig
-            export default config;
-          `;
-          const config = loadConfig(source).parse();
-          expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
-          expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
+        describe('default export', () => {
+          it(`supports an array with string literal and object expression with name property`, () => {
+            const source = dedent`
+              import type { StorybookConfig } from '@storybook/react-webpack5';
+    
+              const config = {
+                addons: [
+                  'foo',
+                  { name: 'bar', options: {} },
+                ],
+                "otherField": [
+                  "foo",
+                  { "name": 'bar', options: {} },
+                ],
+              } satisfies StorybookConfig
+              export default config;
+            `;
+            const config = loadConfig(source).parse();
+            expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
+            expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
+          });
+
+          it(`supports an array with string literal and object expression with name property without variable`, () => {
+            const source = dedent`
+              import type { StorybookConfig } from '@storybook/react-webpack5';
+    
+              export default {
+                addons: [
+                  'foo',
+                  { name: 'bar', options: {} },
+                ],
+                "otherField": [
+                  "foo",
+                  { "name": 'bar', options: {} },
+                ],
+              } satisfies StorybookConfig;
+            `;
+            const config = loadConfig(source).parse();
+            expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
+            expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
+          });
         });
 
-        it(`supports an array with string literal and object expression with name property without variable`, () => {
-          const source = dedent`
-            import type { StorybookConfig } from '@storybook/react-webpack5';
-  
-            export default {
-              addons: [
-                'foo',
-                { name: 'bar', options: {} },
-              ],
-              "otherField": [
-                "foo",
-                { "name": 'bar', options: {} },
-              ],
-            } satisfies StorybookConfig;
-          `;
-          const config = loadConfig(source).parse();
-          expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
-          expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
+        describe('module exports', () => {
+          it(`supports an array with string literal and object expression with name property`, () => {
+            const source = dedent`
+              import type { StorybookConfig } from '@storybook/react-webpack5';
+    
+              const config = {
+                addons: [
+                  'foo',
+                  { name: 'bar', options: {} },
+                ],
+                "otherField": [
+                  "foo",
+                  { "name": 'bar', options: {} },
+                ],
+              } satisfies StorybookConfig
+              module.exports = config;
+            `;
+            const config = loadConfig(source).parse();
+            expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
+            expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
+          });
+
+          it(`supports an array with string literal and object expression with name property without variable`, () => {
+            const source = dedent`
+              import type { StorybookConfig } from '@storybook/react-webpack5';
+    
+              module.exports = {
+                addons: [
+                  'foo',
+                  { name: 'bar', options: {} },
+                ],
+                "otherField": [
+                  "foo",
+                  { "name": 'bar', options: {} },
+                ],
+              } satisfies StorybookConfig;
+            `;
+            const config = loadConfig(source).parse();
+            expect(config.getNamesFromPath(['addons'])).toEqual(['foo', 'bar']);
+            expect(config.getNamesFromPath(['otherField'])).toEqual(['foo', 'bar']);
+          });
         });
       });
     });

--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -138,6 +138,7 @@ export class ConfigFile {
             t.isIdentifier(node.declaration) && t.isProgram(parent)
               ? _findVarInitialization(node.declaration.name, parent)
               : node.declaration;
+
           if (t.isTSAsExpression(decl) || t.isTSSatisfiesExpression(decl)) {
             decl = decl.expression;
           }
@@ -193,6 +194,11 @@ export class ConfigFile {
               if (t.isIdentifier(right)) {
                 exportObject = _findVarInitialization(right.name, parent as t.Program) as any;
               }
+
+              if (t.isTSAsExpression(exportObject) || t.isTSSatisfiesExpression(exportObject)) {
+                exportObject = exportObject.expression;
+              }
+
               if (t.isObjectExpression(exportObject)) {
                 self._exportsObject = exportObject;
                 (exportObject.properties as t.ObjectProperty[]).forEach((p) => {


### PR DESCRIPTION
## What I did

The way we parse `main.js`, specifically when `module.exports` is used, did not account for either `as` or `satisfies` Typescript operators:

```js
module.exports = {
} as X

// or
const config = {} as X
module.exports = config

// or
module.exports = {
} satisfies X

// or
const config = {} satisfies X
module.exports = config
```

This PR fixes that!

## How to test

Check the unit tests

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
