### PR TITLE
Csf Tools: Fix overriding scalar named export values

### DIFF
--- a/code/lib/csf-tools/src/ConfigFile.test.ts
+++ b/code/lib/csf-tools/src/ConfigFile.test.ts
@@ -262,6 +262,17 @@ describe('ConfigFile', () => {
           };
         `);
       });
+      it('found top-level scalar', () => {
+        expect(
+          setField(
+            ['foo'],
+            'baz',
+            dedent`
+              export const foo = 'bar';
+            `
+          )
+        ).toMatchInlineSnapshot(`export const foo = 'baz';`);
+      });
       it('found object', () => {
         expect(
           setField(


### PR DESCRIPTION
Closes #21127

## What I did

Update ConfigFile's `setFieldNode` method to handle setting named exports that are scalars

## How to test

- [ ] See attached unit tests

```
sb automigrate bare-mdx-stories-glob
```
in a project with:
```
export const stories = ['./Introduction.stories.mdx', '../src/App.stories.tsx']
```
