### PR TITLE
Build: pass debug option to sandbox generate task

### DIFF
--- a/scripts/tasks/generate.ts
+++ b/scripts/tasks/generate.ts
@@ -32,6 +32,7 @@ export const generate: Task = {
     await generateRepro({
       template: details.key,
       localRegistry: true,
+      debug: options.debug,
     });
   },
 };


### PR DESCRIPTION
It was just missing (Typescript was complaining)