### PR TITLE
Initialize .storybook folder without references to root for Angular sub projects

### DIFF
--- a/code/lib/telemetry/src/storybook-metadata.ts
+++ b/code/lib/telemetry/src/storybook-metadata.ts
@@ -181,6 +181,10 @@ export const getStorybookMetadata = async (_configDir?: string) => {
   }
 
   const { packageJson = {} } = readPkgUp.sync({ cwd: process.cwd(), normalize: false }) || {};
+  // TODO: improve the way configDir is extracted, as a "storybook" script might not be present
+  // Scenarios:
+  // 1. user changed it to something else e.g. "storybook:dev"
+  // 2. they are using angular/nx where the storybook config is defined somewhere else
   const configDir =
     (_configDir ||
       (getStorybookConfiguration(


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

If Storybook was initialized in one of the Angular sub-projects and a `.storybook/main.js` file already existed, it was created as a reference to avoid code duplication. As discussed with @yannbf this is a bad idea, because codemods and automigrations will have a hard time figuring out, what exactly to do.

If Storybook is initialized at a non-root Angular project, a clean `.storybook` folder will be created and its `main.js` file will not have any references to the root `.storybook/main.js` file anymore.

## How to test

1. Run a Angular sandbox `yarn task --task sandbox --template angular-cli/default-ts --no-link`
2. Go to the sandbox and create another Angular application in the Angular workspace: `ng generate application new-application`
3. Run `<storybook-root>/code/lib/cli/bin/index.js init` in the sandbox's root
3. Check, whether the `main.ts` file in `sandbox/angular-cli-default-ts/projects/new-application/.storybook` has no references to the root `.storybook/main.ts`.
4. Run Storybook and check whether it works: `ng run new-application:storybook`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
