### PR TITLE
CLI: Only run useful automigrations on init

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/index.ts
+++ b/code/lib/cli/src/automigrate/fixes/index.ts
@@ -20,7 +20,7 @@ import { bareMdxStoriesGlob } from './bare-mdx-stories-glob';
 
 export * from '../types';
 
-export const fixes: Fix[] = [
+export const allFixes: Fix[] = [
   nodeJsRequirement,
   cra5,
   webpack5,
@@ -39,3 +39,5 @@ export const fixes: Fix[] = [
   addReact,
   missingBabelRc,
 ];
+
+export const initFixes: Fix[] = [missingBabelRc];

--- a/code/lib/cli/src/automigrate/fixes/index.ts
+++ b/code/lib/cli/src/automigrate/fixes/index.ts
@@ -40,4 +40,4 @@ export const allFixes: Fix[] = [
   missingBabelRc,
 ];
 
-export const initFixes: Fix[] = [missingBabelRc];
+export const initFixes: Fix[] = [missingBabelRc, eslintPlugin];

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -16,7 +16,7 @@ import {
 } from '../js-package-manager';
 
 import type { Fix } from './fixes';
-import { fixes as allFixes } from './fixes';
+import { allFixes } from './fixes';
 import { cleanLog } from './helpers/cleanLog';
 
 const logger = console;
@@ -50,6 +50,7 @@ type FixId = string;
 interface FixOptions {
   fixId?: FixId;
   list?: boolean;
+  fixes?: Fix[];
   yes?: boolean;
   dryRun?: boolean;
   useNpm?: boolean;
@@ -89,6 +90,7 @@ const logAvailableMigrations = () => {
 
 export const automigrate = async ({
   fixId,
+  fixes: inputFixes,
   dryRun,
   yes,
   useNpm,
@@ -109,7 +111,8 @@ export const automigrate = async ({
     pkgMgr = 'npm';
   }
 
-  const fixes = fixId ? allFixes.filter((f) => f.id === fixId) : allFixes;
+  const selectedFixes = inputFixes || allFixes;
+  const fixes = fixId ? selectedFixes.filter((f) => f.id === fixId) : selectedFixes;
 
   if (fixId && fixes.length === 0) {
     logger.info(`📭 No migrations found for ${chalk.magenta(fixId)}.`);

--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -36,6 +36,7 @@ import { JsPackageManagerFactory, useNpmWarning } from './js-package-manager';
 import type { NpmOptions } from './NpmOptions';
 import { automigrate } from './automigrate';
 import type { CommandOptions } from './generators/types';
+import { initFixes } from './automigrate/fixes';
 
 const logger = console;
 
@@ -339,7 +340,11 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
   }
 
   if (projectType !== ProjectType.REACT_NATIVE) {
-    await automigrate({ yes: options.yes || process.env.CI === 'true', packageManager: pkgMgr });
+    await automigrate({
+      yes: options.yes || process.env.CI === 'true',
+      packageManager: pkgMgr,
+      fixes: initFixes,
+    });
   }
 
   logger.log('\nFor more information visit:', chalk.cyan('https://storybook.js.org'));


### PR DESCRIPTION
We don't want to run all automigrations after init, because it's wasteful and we know pretty well, what the output is.

This PR introduced a second list of fixes that should be ran after init.