### PR TITLE
Docs: Remove warning when browsing away in React

### DIFF
--- a/code/renderers/react/template/stories/teardown.stories.tsx
+++ b/code/renderers/react/template/stories/teardown.stories.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+const LoggingComponent = () => {
+  useEffect(() => {
+    console.log('mounted');
+    return () => {
+      console.log('unmounted');
+    };
+  }, []);
+};
+
+export default {
+  component: LoggingComponent,
+  parameters: {
+    storyshots: { disable: true },
+    chromatic: { disable: true },
+  },
+};
+
+export const Default = {};

--- a/code/renderers/react/template/stories/teardown.stories.tsx
+++ b/code/renderers/react/template/stories/teardown.stories.tsx
@@ -7,10 +7,13 @@ const LoggingComponent = () => {
       console.log('unmounted');
     };
   }, []);
+
+  return 'Component';
 };
 
 export default {
   component: LoggingComponent,
+  tags: ['autodocs'],
   parameters: {
     storyshots: { disable: true },
     chromatic: { disable: true },

--- a/code/ui/blocks/src/components/Story.tsx
+++ b/code/ui/blocks/src/components/Story.tsx
@@ -47,7 +47,9 @@ const InlineStory: FunctionComponent<InlineStoryProps> = (props) => {
     const cleanup = renderStoryToElement(story, element, { autoplay, forceInitialArgs });
     setShowLoader(false);
     return () => {
-      cleanup();
+      // It seems like you are supposed to unmount components outside of `useEffect`:
+      //   https://github.com/facebook/react/issues/25675#issuecomment-1363957941
+      setTimeout(() => cleanup(), 0);
     };
   }, [autoplay, renderStoryToElement, story]);
 


### PR DESCRIPTION
Closes #20731

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Put the `cleanup()` in a timeout, as [advised on the react issue](https://github.com/facebook/react/issues/25675).

Added a story so we can check teardown is still working (only react right now)

## How to test

1. Open a docs page
2. Browse away
3. Check it doesn't log warning
4. Browse away from teardown story in docs + story mode, check it logs `'unmounted'`.
## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
