### PR TITLE
Maintenance: Provide packageManager when copying template files

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 installStatePath: ./.yarn/root-install-state.gz
 
+nodeLinker: node-modules
+
 yarnPath: .yarn/releases/yarn-3.4.1.cjs

--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -311,6 +311,7 @@ export async function baseGenerator(
     const templateLocation = hasFrameworkTemplates(framework) ? framework : rendererId;
     await copyTemplateFiles({
       renderer: templateLocation,
+      packageManager,
       language,
       destination: componentsDestinationPath,
     });

--- a/code/lib/cli/src/helpers.test.ts
+++ b/code/lib/cli/src/helpers.test.ts
@@ -32,6 +32,10 @@ jest.mock('path', () => {
   };
 });
 
+const packageManagerMock = {
+  retrievePackageJson: () => ({ dependencies: {}, devDependencies: {} }),
+} as JsPackageManager;
+
 describe('Helpers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -80,7 +84,11 @@ describe('Helpers', () => {
         (filePath) =>
           componentsDirectory.includes(filePath) || filePath === '@storybook/react/template/cli'
       );
-      await helpers.copyTemplateFiles({ renderer: 'react', language });
+      await helpers.copyTemplateFiles({
+        renderer: 'react',
+        language,
+        packageManager: packageManagerMock,
+      });
 
       const copySpy = jest.spyOn(fse, 'copy');
       expect(copySpy).toHaveBeenNthCalledWith(
@@ -99,7 +107,11 @@ describe('Helpers', () => {
     (fse.pathExists as jest.Mock).mockImplementation((filePath) => {
       return filePath === '@storybook/react/template/cli' || filePath === './src';
     });
-    await helpers.copyTemplateFiles({ renderer: 'react', language: SupportedLanguage.JAVASCRIPT });
+    await helpers.copyTemplateFiles({
+      renderer: 'react',
+      language: SupportedLanguage.JAVASCRIPT,
+      packageManager: packageManagerMock,
+    });
     expect(fse.copy).toHaveBeenCalledWith(expect.anything(), './src/stories', expect.anything());
   });
 
@@ -107,7 +119,11 @@ describe('Helpers', () => {
     (fse.pathExists as jest.Mock).mockImplementation((filePath) => {
       return filePath === '@storybook/react/template/cli';
     });
-    await helpers.copyTemplateFiles({ renderer: 'react', language: SupportedLanguage.JAVASCRIPT });
+    await helpers.copyTemplateFiles({
+      renderer: 'react',
+      language: SupportedLanguage.JAVASCRIPT,
+      packageManager: packageManagerMock,
+    });
     expect(fse.copy).toHaveBeenCalledWith(expect.anything(), './stories', expect.anything());
   });
 
@@ -115,7 +131,11 @@ describe('Helpers', () => {
     const renderer = 'unknown renderer' as SupportedRenderers;
     const expectedMessage = `Unsupported renderer: ${renderer}`;
     await expect(
-      helpers.copyTemplateFiles({ renderer, language: SupportedLanguage.JAVASCRIPT })
+      helpers.copyTemplateFiles({
+        renderer,
+        language: SupportedLanguage.JAVASCRIPT,
+        packageManager: packageManagerMock,
+      })
     ).rejects.toThrowError(expectedMessage);
   });
 

--- a/code/lib/cli/src/helpers.ts
+++ b/code/lib/cli/src/helpers.ts
@@ -187,7 +187,7 @@ export function copyTemplate(templateRoot: string, destination = '.') {
 }
 
 type CopyTemplateFilesOptions = {
-  packageManager?: JsPackageManager;
+  packageManager: JsPackageManager;
   renderer: SupportedFrameworks | SupportedRenderers;
   language: SupportedLanguage;
   includeCommonAssets?: boolean;

--- a/scripts/sandbox-generators/generate-sandboxes.ts
+++ b/scripts/sandbox-generators/generate-sandboxes.ts
@@ -219,7 +219,7 @@ export const options = createOptions({
 export const generate = async ({
   template,
   localRegistry,
-  debug,
+  debug = process.env.ACTIONS_RUNNER_DEBUG === 'true',
 }: OptionValues<typeof options>) => {
   const generatorConfigs = Object.entries(sandboxTemplates)
     .map(([dirName, configuration]) => ({


### PR DESCRIPTION
This fixes the `generate-repros` workflow, which has been failing for a few days: https://github.com/storybookjs/storybook/actions/workflows/generate-repros.yml by a [regression](https://github.com/storybookjs/storybook/commit/d2c23c82abd09e2faac6355d761df7f1c7d99621) last week

