### PR TITLE
Fix Angular bug where forRoot() is called twice

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
@@ -128,11 +128,14 @@ export abstract class AbstractRenderer {
       // Providers for BrowserAnimations & NoopAnimationsModule
       analyzedMetadata.singletons,
       importProvidersFrom(
-        ...analyzedMetadata.imports.filter((imported) => {
-          const { isStandalone } = PropertyExtractor.analyzeDecorators(imported);
-          return !isStandalone;
-        })
+        ...analyzedMetadata.imports
+          .filter((imported) => {
+            const { isStandalone } = PropertyExtractor.analyzeDecorators(imported);
+            return !isStandalone;
+          })
+          .map((imported) => imported.ngModule || imported)
       ),
+      ...analyzedMetadata.imports.flatMap((imported) => imported.providers).filter(Boolean),
       analyzedMetadata.providers,
       storyPropsProvider(newStoryProps$),
     ].filter(Boolean);

--- a/code/frameworks/angular/src/client/angular-beta/StorybookWrapperComponent.ts
+++ b/code/frameworks/angular/src/client/angular-beta/StorybookWrapperComponent.ts
@@ -65,6 +65,7 @@ export const createStorybookWrapperComponent = (
       declarations,
       imports,
       exports: [...declarations, ...imports],
+      providers,
     })
     class StorybookComponentModule {}
 
@@ -77,7 +78,6 @@ export const createStorybookWrapperComponent = (
     template,
     standalone: true,
     imports: [ngModule],
-    providers,
     styles,
     schemas: moduleMetadata.schemas,
   })


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fix Angular bug where ModuleWithProviders are called twice via `forRoot()` API.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
