### PR TITLE
Build: Remove jest_workaround swc package by adding extra jest.mock functions

### DIFF
--- a/code/jest.config.base.js
+++ b/code/jest.config.base.js
@@ -4,9 +4,6 @@ const path = require('path');
 
 const swcrc = JSON.parse(fs.readFileSync('.swcrc', 'utf8'));
 
-// This is needed for proper jest mocking, see https://github.com/swc-project/swc/discussions/5151#discussioncomment-3149154
-((swcrc.jsc ??= {}).experimental ??= {}).plugins = [['jest_workaround', {}]];
-
 /**
  * TODO: Some windows related tasks are still commented out, because they are behaving differently on
  * a local Windows machine compared to the Windows Server 2022 machine running in GitHub Actions.

--- a/code/lib/cli/src/automigrate/fixes/autodocs-true.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/autodocs-true.test.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/types';
 import type { PackageJson } from '../../js-package-manager';
-import { autodocsTrue } from './autodocs-true';
 import { makePackageManager, mockStorybookData } from '../helpers/testing-helpers';
+import { autodocsTrue } from './autodocs-true';
 
 const checkAutodocs = async ({
   packageJson = {},

--- a/code/lib/cli/src/automigrate/fixes/builder-vite.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/builder-vite.test.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/types';
+import { makePackageManager, mockStorybookData } from '../helpers/testing-helpers';
 import type { PackageJson } from '../../js-package-manager';
 import { builderVite } from './builder-vite';
-import { makePackageManager, mockStorybookData } from '../helpers/testing-helpers';
 
 const checkBuilderVite = async ({
   packageJson = {},

--- a/code/lib/cli/src/automigrate/fixes/cra5.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/cra5.test.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/types';
 import type { PackageJson } from '../../js-package-manager';
-import { cra5 } from './cra5';
 import { makePackageManager, mockStorybookData } from '../helpers/testing-helpers';
+import { cra5 } from './cra5';
 
 const checkCra5 = async ({
   packageJson,

--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.test.ts
@@ -1,11 +1,14 @@
 import type { StorybookConfig } from '@storybook/types';
 import * as findUp from 'find-up';
 import type { PackageJson } from '../../js-package-manager';
+import { makePackageManager, mockStorybookData } from '../helpers/testing-helpers';
 import * as rendererHelpers from '../helpers/detectRenderer';
 import { newFrameworks } from './new-frameworks';
-import { makePackageManager, mockStorybookData } from '../helpers/testing-helpers';
 
 jest.mock('find-up');
+jest.mock('../helpers/detectRenderer', () => ({
+  detectRenderer: jest.fn(jest.requireActual('../helpers/detectRenderer').detectRenderer),
+}));
 
 const checkNewFrameworks = async ({
   packageJson,

--- a/code/lib/cli/src/automigrate/fixes/sb-binary.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-binary.test.ts
@@ -1,5 +1,5 @@
 import type { PackageJson } from '../../js-package-manager';
-import { makePackageManager } from '../helpers/testing-helpers';
+import { makePackageManager, mockStorybookData } from '../helpers/testing-helpers';
 import { sbBinary } from './sb-binary';
 
 const checkStorybookBinary = async ({
@@ -9,6 +9,7 @@ const checkStorybookBinary = async ({
   packageJson: PackageJson;
   storybookVersion?: string;
 }) => {
+  mockStorybookData({ mainConfig: {}, storybookVersion });
   return sbBinary.check({ packageManager: makePackageManager(packageJson) });
 };
 

--- a/code/lib/cli/src/automigrate/fixes/vue3.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/vue3.test.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/types';
 import type { PackageJson } from '../../js-package-manager';
-import { vue3 } from './vue3';
 import { makePackageManager, mockStorybookData } from '../helpers/testing-helpers';
+import { vue3 } from './vue3';
 
 const checkVue3 = async ({
   packageJson,

--- a/code/lib/cli/src/automigrate/fixes/webpack5.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/webpack5.test.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/types';
 import type { PackageJson } from '../../js-package-manager';
-import { webpack5 } from './webpack5';
 import { makePackageManager, mockStorybookData } from '../helpers/testing-helpers';
+import { webpack5 } from './webpack5';
 
 const checkWebpack5 = async ({
   packageJson,

--- a/code/lib/cli/src/automigrate/helpers/testing-helpers.ts
+++ b/code/lib/cli/src/automigrate/helpers/testing-helpers.ts
@@ -2,6 +2,11 @@ import type { JsPackageManager, PackageJson } from '../../js-package-manager';
 import type { GetStorybookData } from './mainConfigFile';
 import * as mainConfigFile from './mainConfigFile';
 
+jest.mock('./mainConfigFile', () => ({
+  ...jest.requireActual('./mainConfigFile'),
+  getStorybookData: jest.fn(),
+}));
+
 jest.mock('@storybook/core-common', () => ({
   ...jest.requireActual('@storybook/core-common'),
   loadMainConfig: jest.fn(),

--- a/code/package.json
+++ b/code/package.json
@@ -241,7 +241,6 @@
     "jest-os-detection": "^1.3.1",
     "jest-serializer-html": "^7.1.0",
     "jest-watch-typeahead": "^2.2.1",
-    "jest_workaround": "^0.1.14",
     "lerna": "^6.4.0",
     "lint-staged": "^10.5.4",
     "lodash": "^4.17.21",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7159,7 +7159,6 @@ __metadata:
     jest-os-detection: ^1.3.1
     jest-serializer-html: ^7.1.0
     jest-watch-typeahead: ^2.2.1
-    jest_workaround: ^0.1.14
     lerna: ^6.4.0
     lint-staged: ^10.5.4
     lodash: ^4.17.21
@@ -19661,16 +19660,6 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: 57a677678b1f9394adf41543a284919fc78e147ccd1dd6c21b263d69127e069331500dbe81d5214daa9facff4a3363e0621fc4786dc0bf568d88533581dc5f65
-  languageName: node
-  linkType: hard
-
-"jest_workaround@npm:^0.1.14":
-  version: 0.1.14
-  resolution: "jest_workaround@npm:0.1.14"
-  peerDependencies:
-    "@swc/core": ^1.3.3
-    "@swc/jest": ^0.2.22
-  checksum: 98f02ade07d2d2befdac5ca27e0b3ea70b86c9b9fa54d21a1b41dee4672333df5d880ccc851771e43c16575f081d02a10d1de06cc90b33bcff7e5822e901815a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
By using jest.mock we don't need the jest_workaround, as we are not mutating es modules anymore. The whole module is replaced by a mock module, so it is immutable again.

We will need something like this anyway, when we are gonna run jest test uing native ESM. At some point we need to do that, as more and more packages are moving to be ESM only.