### PR TITLE
Documentation: Fix main.ts import for consistency

### DIFF
--- a/docs/snippets/common/storybook-a11y-register.ts.mdx
+++ b/docs/snippets/common/storybook-a11y-register.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],

--- a/docs/snippets/common/storybook-main-add-ts-config.ts.mdx
+++ b/docs/snippets/common/storybook-main-add-ts-config.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
   stories: [],

--- a/docs/snippets/common/storybook-main-baseline-setup.ts.mdx
+++ b/docs/snippets/common/storybook-main-baseline-setup.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],

--- a/docs/snippets/common/storybook-main-disable-telemetry.main-ts.ts.mdx
+++ b/docs/snippets/common/storybook-main-disable-telemetry.main-ts.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],

--- a/docs/snippets/common/storybook-main-extend-ts-config.ts.mdx
+++ b/docs/snippets/common/storybook-main-extend-ts-config.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
   stories: [],

--- a/docs/snippets/common/storybook-main-js-md-files.ts.mdx
+++ b/docs/snippets/common/storybook-main-js-md-files.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
   stories: ['../my-project/src/components/*.@(js|md)'],

--- a/docs/snippets/common/storybook-on-demand-story-loading.ts.mdx
+++ b/docs/snippets/common/storybook-on-demand-story-loading.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
   stories: [],

--- a/docs/snippets/common/storybook-storyloading-custom-logic.ts.mdx
+++ b/docs/snippets/common/storybook-storyloading-custom-logic.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 function findStories() {
   // your custom logic returns a list of files

--- a/docs/snippets/common/storybook-storyloading-with-custom-object.ts.mdx
+++ b/docs/snippets/common/storybook-storyloading-with-custom-object.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
   stories: [

--- a/docs/snippets/common/storybook-storyloading-with-directory.ts.mdx
+++ b/docs/snippets/common/storybook-storyloading-with-directory.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
   // 👇 Storybook will load all existing stories within the MyStories folder

--- a/docs/snippets/common/storybook-telemetry-main-enable-crash-reports.main-ts.ts.mdx
+++ b/docs/snippets/common/storybook-telemetry-main-enable-crash-reports.main-ts.ts.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.ts
 
 // Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-webpack5)
-import type { StorybookConfig } from '@storybook/types';
+import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Some of our examples use:

```js
import type { StorybookConfig } from '@storybook/types';
```

And others use:

```js
import type { StorybookConfig } from '@storybook/your-framework';
```

Switched them all to the latter for consistency.
