### PR TITLE
CLI: Fix performance regression of storybook dev

### DIFF
--- a/code/lib/cli/src/generators/configure.ts
+++ b/code/lib/cli/src/generators/configure.ts
@@ -1,6 +1,5 @@
 import fse from 'fs-extra';
 import { dedent } from 'ts-dedent';
-import prettier from 'prettier';
 import { externalFrameworks, SupportedLanguage } from '../project_types';
 
 interface ConfigureMainOptions {
@@ -97,6 +96,8 @@ export async function configureMain({
     .replace('<<type>>', isTypescript ? ': StorybookConfig' : '')
     .replace('<<mainContents>>', mainContents);
 
+  const prettier = (await import('prettier')).default;
+
   const mainPath = `./${storybookConfigFolder}/main.${isTypescript ? 'ts' : 'js'}`;
   const prettyMain = prettier.format(dedent(mainJsContents), {
     ...prettier.resolveConfig.sync(process.cwd()),
@@ -158,6 +159,8 @@ export async function configurePreview(options: ConfigurePreviewOptions) {
     `
     .replace('  \n', '')
     .trim();
+
+  const prettier = (await import('prettier')).default;
 
   const prettyPreview = prettier.format(preview, {
     ...prettier.resolveConfig.sync(process.cwd()),


### PR DESCRIPTION
Closes #21264

## What I did

Load prettier async, as it causes performance regressions for all other scripts when loaded sync.

## How to test

Check our benchmarks timings going down again!

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
