### PR TITLE
CLI: Pass config-dir cli arg from upgrade command to automigration step

### DIFF
--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -144,6 +144,7 @@ export interface UpgradeOptions {
   dryRun: boolean;
   yes: boolean;
   disableTelemetry: boolean;
+  configDir?: string;
 }
 
 export const doUpgrade = async ({
@@ -153,6 +154,7 @@ export const doUpgrade = async ({
   useNpm,
   packageManager: pkgMgr,
   dryRun,
+  configDir,
   yes,
   ...options
 }: UpgradeOptions) => {
@@ -208,7 +210,7 @@ export const doUpgrade = async ({
   let automigrationResults;
   if (!skipCheck) {
     checkVersionConsistency();
-    automigrationResults = await automigrate({ dryRun, yes, packageManager: pkgMgr });
+    automigrationResults = await automigrate({ dryRun, yes, packageManager: pkgMgr, configDir });
   }
 
   if (!options.disableTelemetry) {


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Pass `--config-dir` cli argument from `upgrade` command to `automigrations`.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run the `upgrade` cli on a workspace with no root `.storybook` folder and pass `--config-dir` to the `.storybook` folder path. Like this: `<storybook-folder>/code/lib/cli/bin/index.js upgrade --prerelease --config-dir <path-to-storybook>
2. The error message `[Storybook automigrate] Could not find or evaluate your Storybook main.js config ...` shouldn't occur.

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
