### PR TITLE
Tech: change to a regular dependencies removing peerDep warnings

### DIFF
--- a/code/presets/react-webpack/package.json
+++ b/code/presets/react-webpack/package.json
@@ -77,7 +77,8 @@
     "babel-plugin-react-docgen": "^4.2.1",
     "fs-extra": "^11.1.0",
     "react-refresh": "^0.11.0",
-    "semver": "^7.3.7"
+    "semver": "^7.3.7",
+    "webpack": "5"
   },
   "devDependencies": {
     "typescript": "~4.9.3"
@@ -85,8 +86,7 @@
   "peerDependencies": {
     "@babel/core": "^7.11.5",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "webpack": "5"
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@babel/core": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6639,11 +6639,11 @@ __metadata:
     react-refresh: ^0.11.0
     semver: ^7.3.7
     typescript: ~4.9.3
+    webpack: 5
   peerDependencies:
     "@babel/core": ^7.11.5
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    webpack: 5
   peerDependenciesMeta:
     "@babel/core":
       optional: true


### PR DESCRIPTION
replaces: https://github.com/storybookjs/storybook/pull/21223

## What I did

I changed the peerDep to a regular dep