### PR TITLE
SvelteKit: Only disable SSR when building, not serving

### DIFF
--- a/code/frameworks/sveltekit/src/plugins/config-overrides.ts
+++ b/code/frameworks/sveltekit/src/plugins/config-overrides.ts
@@ -4,7 +4,7 @@ export function configOverrides() {
   return {
     // SvelteKit sets SSR, we need it to be false when building
     name: 'storybook:sveltekit-overrides',
-    apply: (_, { command }) => command === 'build',
+    apply: 'build',
     config: () => {
       return { build: { ssr: false } };
     },

--- a/code/frameworks/sveltekit/src/plugins/config-overrides.ts
+++ b/code/frameworks/sveltekit/src/plugins/config-overrides.ts
@@ -2,14 +2,11 @@ import type { Plugin } from 'vite';
 
 export function configOverrides() {
   return {
+    // SvelteKit sets SSR, we need it to be false when building
     name: 'storybook:sveltekit-overrides',
-    config: (conf) => {
-      // Some versions of sveltekit set ssr, we need it to be false
-      if (conf.build?.ssr) {
-        // eslint-disable-next-line no-param-reassign
-        conf.build.ssr = false;
-      }
-      return conf;
+    apply: (_, { command }) => command === 'build',
+    config: () => {
+      return { build: { ssr: false } };
     },
   } satisfies Plugin;
 }


### PR DESCRIPTION
Closes #21053

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

In #20804 we disabled SSR because Storybook can't be built with SSR enabled.

That broke HMR, so now we're only disabling SSR at build time, not when serving.

I'm unsure why it broke HMR, but it's not SvelteKit related, as it also breaks HMR to add that disable-SSR plugin to a plain Svelte-Vite project.

It looks like the Svelte Vite plugin is using the SSR setting to handle HMR differently, so maybe that's the culprit. 

https://github.com/sveltejs/vite-plugin-svelte/blob/main/packages/vite-plugin-svelte/src/handle-hot-update.ts#L61-L65
<!-- Briefly describe what your PR does -->

## How to test

1. Create a SvelteKit sandbox with `yarn task --task sandbox --start-from auto --template svelte-kit/skeleton-ts`
2. Start it and open a story.
3. Make changes to the story, and see that they are reflected in the UI.
3. Make changes to the component, and see that they are reflected in the UI.
4. Build the Storybook to ensure it can still be built.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
