### PR TITLE
UI: Fix enableShortcuts, exclude it from being persisted

### DIFF
--- a/code/lib/manager-api/src/lib/addons.ts
+++ b/code/lib/manager-api/src/lib/addons.ts
@@ -97,7 +97,11 @@ export class AddonStore {
   setConfig = (value: Addon_Config) => {
     Object.assign(this.config, value);
     if (this.hasChannel()) {
-      this.getChannel().emit(SET_CONFIG, value);
+      this.getChannel().emit(SET_CONFIG, this.config);
+    } else {
+      this.ready().then((channel) => {
+        channel.emit(SET_CONFIG, this.config);
+      });
     }
   };
 

--- a/code/lib/manager-api/src/modules/layout.ts
+++ b/code/lib/manager-api/src/modules/layout.ts
@@ -253,7 +253,7 @@ export const init: ModuleFn = ({ store, provider, singleStory, fullAPI }) => {
     },
   };
 
-  const persisted = pick(store.getState(), 'layout', 'ui', 'selectedPanel');
+  const persisted = pick(store.getState(), 'layout', 'selectedPanel');
 
   return {
     api,


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/6569

## What I did

fix issue where if setConfig is called before channel is setup it no-ops
fix issue where setConfig would not call with full value
fix issue where state.ui is persisted where it should not

## How to test

- set `enableShortcuts: true` in `manager.js`, check if keyboardshortcuts work
- set `enableShortcuts: false` in `manager.js`, check if keyboardshortcuts are indeed no longer working
- set `enableShortcuts: true` in `manager.js`, check if keyboardshortcuts wokring again.

Between each step you will have to restart storybook.