### PR TITLE
Chore (Docs) Fix the Preview type snippets in the migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -327,7 +327,9 @@ The `Preview` type will come from the Storybook package for the **renderer** you
 import { Preview } from '@storybook/react';
 
 const preview: Preview = {
-  actions: { argTypesRegex: '^on[A-Z].*' },
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+  },
 };
 export default preview;
 ```
@@ -337,7 +339,9 @@ In JavaScript projects using `preview.js`, it's also possible to use the `Previe
 ```ts
 /** @type { import('@storybook/react').Preview } */
 const preview: Preview = {
-  actions: { argTypesRegex: '^on[A-Z].*' },
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+  },
 };
 export default preview;
 ```


### PR DESCRIPTION
With this pull request, the migration guide is updated to showcase the correct usage of the Preview type.

Follows up on #21254