### PR TITLE
Fix Next.js type references in Next.js >= 13.2.0

### DIFF
--- a/code/frameworks/nextjs/template/next-env.d.ts
+++ b/code/frameworks/nextjs/template/next-env.d.ts
@@ -1,0 +1,7 @@
+// Reference necessary since Next.js 13.2.0, because types in `next/navigation` are not exported per default, but
+// type references are dynamically created during Next.js start up.
+// See https://github.com/vercel/next.js/commit/cdf1d52d9aed42d01a46539886a4bda14cb77a99
+// for more insights.
+
+/// <reference types="next" />
+/// <reference types="next/navigation-types/navigation" />

--- a/code/frameworks/nextjs/template/stories_default-js/Navigation.stories.jsx
+++ b/code/frameworks/nextjs/template/stories_default-js/Navigation.stories.jsx
@@ -14,7 +14,7 @@ function Component() {
   const segment = useSelectedLayoutSegment();
   const segments = useSelectedLayoutSegments();
 
-  const searchParamsList = Array.from(searchParams.entries());
+  const searchParamsList = searchParams ? Array.from(searchParams.entries()) : [];
 
   const routerActions = [
     {

--- a/code/frameworks/nextjs/template/stories_default-ts/Navigation.stories.tsx
+++ b/code/frameworks/nextjs/template/stories_default-ts/Navigation.stories.tsx
@@ -1,3 +1,4 @@
+// usePathname and useSearchParams are only usable if experimental: {appDir: true} is set in next.config.js
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -7,7 +8,7 @@ function Component() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const searchParamsList = Array.from(searchParams.entries());
+  const searchParamsList = searchParams ? Array.from(searchParams.entries()) : [];
 
   const routerActions = [
     {


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added some type references for Next.js stories, since they are necessary since Next.js 13.2.0, because some types in `next/navigation` are not exported per default, but type references are dynamically created during Next.js start up instead. See https://github.com/vercel/next.js/commit/cdf1d52d9aed42d01a46539886a4bda14cb77a99 for more insights.

## How to test

1. Run a Next.js sandbox: `yarn task --task sandbox --template nextjs/default-ts`
2. Go to your sandbox directory
3. Open `next.config.js` and add `{ experimental: { appDir: true }}` to the configuration
4. Add a empty `app` folder in the sandbox
5. Start Next.js once (`yarn dev`) and abort it after it started successfully
6. A `next-env.d.ts` should be created with these entries:

```tsx
/// <reference types="next" />
/// <reference types="next/image-types/global" />
/// <reference types="next/navigation-types/compat/navigation" />

// NOTE: This file should not be edited
// see https://nextjs.org/docs/basic-features/typescript for more information.

```

7. Open `stories/frameworks/nextjs_default-ts/Navigation.stories.tsx` -> The import shouldn't error.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
