### PR TITLE
Vite: Fix glob path creation for Windows

### DIFF
--- a/code/lib/builder-vite/src/list-stories.ts
+++ b/code/lib/builder-vite/src/list-stories.ts
@@ -1,4 +1,5 @@
-import * as posixPath from 'node:path/posix'; // Glob requires forward-slashes
+import * as path from 'path';
+import slash from 'slash';
 import { promise as glob } from 'glob-promise';
 import { normalizeStories } from '@storybook/core-common';
 
@@ -11,10 +12,10 @@ export async function listStories(options: Options) {
         configDir: options.configDir,
         workingDir: options.configDir,
       }).map(({ directory, files }) => {
-        const pattern = posixPath.join(directory, files);
+        const pattern = slash(path.join(directory, files));
 
         return glob(
-          posixPath.isAbsolute(pattern) ? pattern : posixPath.join(options.configDir, pattern),
+          path.isAbsolute(pattern) ? pattern : path.join(options.configDir, pattern),
           {
             follow: true,
           }

--- a/code/lib/builder-vite/src/list-stories.ts
+++ b/code/lib/builder-vite/src/list-stories.ts
@@ -12,11 +12,12 @@ export async function listStories(options: Options) {
         configDir: options.configDir,
         workingDir: options.configDir,
       }).map(({ directory, files }) => {
-        const pattern = slash(path.join(directory, files));
+        const pattern = path.join(directory, files);
+        const absolutePattern = path.isAbsolute(pattern)
+          ? pattern
+          : path.join(options.configDir, pattern);
 
-        return glob(path.isAbsolute(pattern) ? pattern : path.join(options.configDir, pattern), {
-          follow: true,
-        });
+        return glob(slash(absolutePattern), { follow: true });
       })
     )
   ).reduce((carry, stories) => carry.concat(stories), []);

--- a/code/lib/builder-vite/src/list-stories.ts
+++ b/code/lib/builder-vite/src/list-stories.ts
@@ -14,12 +14,9 @@ export async function listStories(options: Options) {
       }).map(({ directory, files }) => {
         const pattern = slash(path.join(directory, files));
 
-        return glob(
-          path.isAbsolute(pattern) ? pattern : path.join(options.configDir, pattern),
-          {
-            follow: true,
-          }
-        );
+        return glob(path.isAbsolute(pattern) ? pattern : path.join(options.configDir, pattern), {
+          follow: true,
+        });
       })
     )
   ).reduce((carry, stories) => carry.concat(stories), []);


### PR DESCRIPTION
Closes #21101 

## What I did

use the slash package instead of posix path

## How to test

1. check out the repository in windows
2. run yarn task --task build --template react-vite/default-ts --start-from=install
3. it should work

-->

## Checklist

**Help**: not sure about how to test this

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
