### PR TITLE
CLI: Improve yarn/pnpm workspaces support for adding dependencies in CLI

### DIFF
--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -6,8 +6,6 @@ export class NPMProxy extends JsPackageManager {
 
   installArgs: string[] | undefined;
 
-  uninstallArgs: string[] | undefined;
-
   initPackageJson() {
     return this.executeCommand('npm', ['init', '-y']);
   }
@@ -26,16 +24,9 @@ export class NPMProxy extends JsPackageManager {
 
   getInstallArgs(): string[] {
     if (!this.installArgs) {
-      this.installArgs = ['install'];
+      this.installArgs = [];
     }
     return this.installArgs;
-  }
-
-  getUninstallArgs(): string[] {
-    if (!this.uninstallArgs) {
-      this.uninstallArgs = ['uninstall'];
-    }
-    return this.uninstallArgs;
   }
 
   public runPackageCommand(command: string, args: string[], cwd?: string): string {
@@ -52,7 +43,7 @@ export class NPMProxy extends JsPackageManager {
   }
 
   protected runInstall(): void {
-    this.executeCommand('npm', this.getInstallArgs(), 'inherit');
+    this.executeCommand('npm', ['install', ...this.getInstallArgs()], 'inherit');
   }
 
   protected runAddDeps(dependencies: string[], installAsDevDependencies: boolean): void {
@@ -62,13 +53,13 @@ export class NPMProxy extends JsPackageManager {
       args = ['-D', ...args];
     }
 
-    this.executeCommand('npm', [...this.getInstallArgs(), ...args], 'inherit');
+    this.executeCommand('npm', ['install', ...this.getInstallArgs(), ...args], 'inherit');
   }
 
   protected runRemoveDeps(dependencies: string[]): void {
     const args = [...dependencies];
 
-    this.executeCommand('npm', [...this.getUninstallArgs(), ...args], 'inherit');
+    this.executeCommand('npm', ['uninstall', ...this.getInstallArgs(), ...args], 'inherit');
   }
 
   protected runGetVersions<T extends boolean>(

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
@@ -42,7 +42,11 @@ describe('Yarn 1 Proxy', () => {
 
       yarn1Proxy.installDependencies();
 
-      expect(executeCommandSpy).toHaveBeenCalledWith('yarn', [], expect.any(String));
+      expect(executeCommandSpy).toHaveBeenCalledWith(
+        'yarn',
+        ['install', '--ignore-workspace-root-check'],
+        expect.any(String)
+      );
     });
   });
 
@@ -69,7 +73,7 @@ describe('Yarn 1 Proxy', () => {
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
         'yarn',
-        ['add', '-D', '--ignore-workspace-root-check', '@storybook/preview-api'],
+        ['add', '--ignore-workspace-root-check', '-D', '@storybook/preview-api'],
         expect.any(String)
       );
     });

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
@@ -4,6 +4,36 @@ import type { PackageJson } from './PackageJson';
 export class Yarn1Proxy extends JsPackageManager {
   readonly type = 'yarn1';
 
+  installArgs: string[] | undefined;
+
+  getInstallArgs(): string[] {
+    if (!this.installArgs) {
+      this.installArgs = [];
+
+      if (this.detectWorkspaceRoot()) {
+        this.installArgs.push('-W');
+      }
+    }
+    return this.installArgs;
+  }
+
+  detectWorkspaceRoot() {
+    const { workspaces } = this.readPackageJson();
+
+    if (Array.isArray(workspaces)) {
+      return workspaces.length > 0;
+    }
+
+    if (workspaces && typeof workspaces === 'object') {
+      if (workspaces.packages) {
+        return workspaces.packages.length > 0;
+      }
+      return false;
+    }
+
+    return false;
+  }
+
   initPackageJson() {
     return this.executeCommand('yarn', ['init', '-y']);
   }
@@ -30,7 +60,7 @@ export class Yarn1Proxy extends JsPackageManager {
   }
 
   protected runInstall(): void {
-    this.executeCommand('yarn', [], 'inherit');
+    this.executeCommand('yarn', ['install', ...this.getInstallArgs()], 'inherit');
   }
 
   protected runAddDeps(dependencies: string[], installAsDevDependencies: boolean): void {
@@ -40,13 +70,13 @@ export class Yarn1Proxy extends JsPackageManager {
       args = ['-D', ...args];
     }
 
-    this.executeCommand('yarn', ['add', ...args], 'inherit');
+    this.executeCommand('yarn', ['add', ...args, ...this.getInstallArgs()], 'inherit');
   }
 
   protected runRemoveDeps(dependencies: string[]): void {
     const args = ['--ignore-workspace-root-check', ...dependencies];
 
-    this.executeCommand('yarn', ['remove', ...args], 'inherit');
+    this.executeCommand('yarn', ['remove', ...args, ...this.getInstallArgs()], 'inherit');
   }
 
   protected runGetVersions<T extends boolean>(

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
@@ -8,30 +8,9 @@ export class Yarn1Proxy extends JsPackageManager {
 
   getInstallArgs(): string[] {
     if (!this.installArgs) {
-      this.installArgs = [];
-
-      if (this.detectWorkspaceRoot()) {
-        this.installArgs.push('-W');
-      }
+      this.installArgs = ['--ignore-workspace-root-check'];
     }
     return this.installArgs;
-  }
-
-  detectWorkspaceRoot() {
-    const { workspaces } = this.readPackageJson();
-
-    if (Array.isArray(workspaces)) {
-      return workspaces.length > 0;
-    }
-
-    if (workspaces && typeof workspaces === 'object') {
-      if (workspaces.packages) {
-        return workspaces.packages.length > 0;
-      }
-      return false;
-    }
-
-    return false;
   }
 
   initPackageJson() {
@@ -64,19 +43,19 @@ export class Yarn1Proxy extends JsPackageManager {
   }
 
   protected runAddDeps(dependencies: string[], installAsDevDependencies: boolean): void {
-    let args = ['--ignore-workspace-root-check', ...dependencies];
+    let args = [...dependencies];
 
     if (installAsDevDependencies) {
       args = ['-D', ...args];
     }
 
-    this.executeCommand('yarn', ['add', ...args, ...this.getInstallArgs()], 'inherit');
+    this.executeCommand('yarn', ['add', ...this.getInstallArgs(), ...args], 'inherit');
   }
 
   protected runRemoveDeps(dependencies: string[]): void {
-    const args = ['--ignore-workspace-root-check', ...dependencies];
+    const args = [...dependencies];
 
-    this.executeCommand('yarn', ['remove', ...args, ...this.getInstallArgs()], 'inherit');
+    this.executeCommand('yarn', ['remove', ...this.getInstallArgs(), ...args], 'inherit');
   }
 
   protected runGetVersions<T extends boolean>(

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
@@ -27,7 +27,7 @@ describe('Yarn 2 Proxy', () => {
 
       yarn2Proxy.installDependencies();
 
-      expect(executeCommandSpy).toHaveBeenCalledWith('yarn', [], expect.any(String));
+      expect(executeCommandSpy).toHaveBeenCalledWith('yarn', ['install', '-W'], expect.any(String));
     });
   });
 
@@ -69,7 +69,7 @@ describe('Yarn 2 Proxy', () => {
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
         'yarn',
-        ['add', '-D', '@storybook/preview-api'],
+        ['add', '-W', '-D', '@storybook/preview-api'],
         expect.any(String)
       );
     });
@@ -83,7 +83,7 @@ describe('Yarn 2 Proxy', () => {
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
         'yarn',
-        ['remove', '@storybook/preview-api'],
+        ['remove', '-W', '@storybook/preview-api'],
         expect.any(String)
       );
     });

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -71,13 +71,13 @@ export class Yarn2Proxy extends JsPackageManager {
       args = ['-D', ...args];
     }
 
-    this.executeCommand('yarn', ['add', ...args, ...this.getInstallArgs()], 'inherit');
+    this.executeCommand('yarn', ['add', ...this.getInstallArgs(), ...args], 'inherit');
   }
 
   protected runRemoveDeps(dependencies: string[]): void {
     const args = [...dependencies];
 
-    this.executeCommand('yarn', ['remove', ...args, ...this.getInstallArgs()], 'inherit');
+    this.executeCommand('yarn', ['remove', ...this.getInstallArgs(), ...args], 'inherit');
   }
 
   protected runGetVersions<T extends boolean>(

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -5,6 +5,36 @@ import type { PackageJson } from './PackageJson';
 export class Yarn2Proxy extends JsPackageManager {
   readonly type = 'yarn2';
 
+  installArgs: string[] | undefined;
+
+  getInstallArgs(): string[] {
+    if (!this.installArgs) {
+      this.installArgs = [];
+
+      if (this.detectWorkspaceRoot()) {
+        this.installArgs.push('-W');
+      }
+    }
+    return this.installArgs;
+  }
+
+  detectWorkspaceRoot() {
+    const { workspaces } = this.readPackageJson();
+
+    if (Array.isArray(workspaces)) {
+      return workspaces.length > 0;
+    }
+
+    if (workspaces && typeof workspaces === 'object') {
+      if (workspaces.packages) {
+        return workspaces.packages.length > 0;
+      }
+      return false;
+    }
+
+    return false;
+  }
+
   initPackageJson() {
     return this.executeCommand('yarn', ['init']);
   }
@@ -31,7 +61,7 @@ export class Yarn2Proxy extends JsPackageManager {
   }
 
   protected runInstall(): void {
-    this.executeCommand('yarn', [], 'inherit');
+    this.executeCommand('yarn', ['install', ...this.getInstallArgs()], 'inherit');
   }
 
   protected runAddDeps(dependencies: string[], installAsDevDependencies: boolean): void {
@@ -41,13 +71,13 @@ export class Yarn2Proxy extends JsPackageManager {
       args = ['-D', ...args];
     }
 
-    this.executeCommand('yarn', ['add', ...args], 'inherit');
+    this.executeCommand('yarn', ['add', ...args, ...this.getInstallArgs()], 'inherit');
   }
 
   protected runRemoveDeps(dependencies: string[]): void {
     const args = [...dependencies];
 
-    this.executeCommand('yarn', ['remove', ...args], 'inherit');
+    this.executeCommand('yarn', ['remove', ...args, ...this.getInstallArgs()], 'inherit');
   }
 
   protected runGetVersions<T extends boolean>(


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/20556

## What I did

- I added detection for workspace root for yarn 1 and yarn 2 and pnpm, to our CLI
- I refactored our code a bit, to use `installArgs` only for addition flags.
- I ended up keeping the existing "ignore workspace" flag for Yarn1.

## How to test

This would require testing outside of the monorepo, in projects setup as a monorepo with the respective package managers.

I'd expect the install step to succeed now, because storybook CLI should now pass the correct flag to the package manager to set it up to allow installation into the workspace root.

I could not find if npm also required such a flag:
https://docs.npmjs.com/cli/v9/commands/npm-install#workspaces