### PR TITLE
Core: Fix `manager.js` ignored when `sideEffects:false` in `package.json`

### DIFF
--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -48,6 +48,7 @@ export const getConfig: ManagerBuilder['getConfig'] = async (options) => {
     outdir: join(options.outputDir || './', 'sb-addons'),
     format: 'esm',
     write: false,
+    ignoreAnnotations: true,
     resolveExtensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx'],
     outExtension: { '.js': '.mjs' },
     loader: {


### PR DESCRIPTION
Closes #

## What I did

Add esbuild config to ignore side-effect:false in the user's package.json

see: https://esbuild.github.io/api/#ignore-annotations

## How to test

- Add a manager.js file to a project using storybook
- Add a console.log('HELLO') in this manager.js
- Set side-effects: false in package.json
- start storybook
- expect to see "HELLO" in the console in the manager frame