### PR TITLE
Vite: Add react docgen types

### DIFF
--- a/code/frameworks/react-vite/src/types.ts
+++ b/code/frameworks/react-vite/src/types.ts
@@ -1,5 +1,9 @@
-import type { StorybookConfig as StorybookConfigBase } from '@storybook/types';
+import type {
+  StorybookConfig as StorybookConfigBase,
+  TypescriptOptions as TypescriptOptionsBase,
+} from '@storybook/types';
 import type { StorybookConfigVite, BuilderOptions } from '@storybook/builder-vite';
+import type docgenTypescript from '@joshwooding/vite-plugin-react-docgen-typescript';
 
 type FrameworkName = '@storybook/react-vite';
 type BuilderName = '@storybook/builder-vite';
@@ -25,6 +29,19 @@ type StorybookConfigFramework = {
   };
 };
 
+type TypescriptOptions = TypescriptOptionsBase & {
+  /**
+   * Sets the type of Docgen when working with React and TypeScript
+   *
+   * @default `'react-docgen-typescript'`
+   */
+  reactDocgen: 'react-docgen-typescript' | 'react-docgen' | false;
+  /**
+   * Configures `@joshwooding/vite-plugin-react-docgen-typescript`
+   */
+  reactDocgenTypescriptOptions: Parameters<typeof docgenTypescript>;
+};
+
 /**
  * The interface for Storybook configuration in `main.ts` files.
  */
@@ -33,4 +50,6 @@ export type StorybookConfig = Omit<
   keyof StorybookConfigVite | keyof StorybookConfigFramework
 > &
   StorybookConfigVite &
-  StorybookConfigFramework;
+  StorybookConfigFramework & {
+    typescript?: Partial<TypescriptOptions>;
+  };

--- a/code/frameworks/react-vite/src/types.ts
+++ b/code/frameworks/react-vite/src/types.ts
@@ -39,7 +39,7 @@ type TypescriptOptions = TypescriptOptionsBase & {
   /**
    * Configures `@joshwooding/vite-plugin-react-docgen-typescript`
    */
-  reactDocgenTypescriptOptions: Parameters<typeof docgenTypescript>;
+  reactDocgenTypescriptOptions: Parameters<typeof docgenTypescript>[0];
 };
 
 /**


### PR DESCRIPTION
Closes #20789

## What I did

Adds types for react docgen options to the react-vite framework

## How to test

Generate a sandbox for react-vite/default-ts, add an option in the main.ts like:

```ts
typescript: {
	reactDocgen: false
}
```

it should not error.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
