### PR TITLE
Svelte/Vite: Prevent crash when no svelte.config file

### DIFF
--- a/code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts
+++ b/code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts
@@ -42,7 +42,7 @@ function getNameFromFilename(filename: string) {
   return base[0].toUpperCase() + base.slice(1);
 }
 
-export function svelteDocgen(svelteOptions: Record<string, any>): PluginOption {
+export function svelteDocgen(svelteOptions: Record<string, any> = {}): PluginOption {
   const cwd = process.cwd();
   const { preprocess: preprocessOptions, logDocgen = false } = svelteOptions;
   const include = /\.(svelte)$/;

--- a/code/frameworks/svelte-vite/src/preset.ts
+++ b/code/frameworks/svelte-vite/src/preset.ts
@@ -14,7 +14,7 @@ export const viteFinal: NonNullable<StorybookConfig['viteFinal']> = async (confi
   // TODO: set up eslint import to use typescript resolver
   // eslint-disable-next-line import/no-unresolved
   const { svelte, loadSvelteConfig } = await import('@sveltejs/vite-plugin-svelte');
-  const svelteConfig = await loadSvelteConfig();
+  const svelteConfig = await loadSvelteConfig() || {};
 
   // Add svelte plugin if the user does not have a Vite config of their own
   if (!(await hasVitePlugins(plugins, ['vite-plugin-svelte']))) {

--- a/code/frameworks/svelte-vite/src/preset.ts
+++ b/code/frameworks/svelte-vite/src/preset.ts
@@ -14,7 +14,7 @@ export const viteFinal: NonNullable<StorybookConfig['viteFinal']> = async (confi
   // TODO: set up eslint import to use typescript resolver
   // eslint-disable-next-line import/no-unresolved
   const { svelte, loadSvelteConfig } = await import('@sveltejs/vite-plugin-svelte');
-  const svelteConfig = (await loadSvelteConfig()) || {};
+  const svelteConfig = await loadSvelteConfig();
 
   // Add svelte plugin if the user does not have a Vite config of their own
   if (!(await hasVitePlugins(plugins, ['vite-plugin-svelte']))) {

--- a/code/frameworks/svelte-vite/src/preset.ts
+++ b/code/frameworks/svelte-vite/src/preset.ts
@@ -14,7 +14,7 @@ export const viteFinal: NonNullable<StorybookConfig['viteFinal']> = async (confi
   // TODO: set up eslint import to use typescript resolver
   // eslint-disable-next-line import/no-unresolved
   const { svelte, loadSvelteConfig } = await import('@sveltejs/vite-plugin-svelte');
-  const svelteConfig = await loadSvelteConfig() || {};
+  const svelteConfig = (await loadSvelteConfig()) || {};
 
   // Add svelte plugin if the user does not have a Vite config of their own
   if (!(await hasVitePlugins(plugins, ['vite-plugin-svelte']))) {


### PR DESCRIPTION
## What I did

The svelteDocgen plugin crashes Storybook if you have no svelte config file defined. It tries to destructure the options, but with no config file, this value is null, causing a crash. Setting an empty object as a fallback looks like it solved the issue.


## How to test

Have no svelte.config.js file. Run storybook. 

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

I havn't done any integration/unit testing here. Just made a quick edit on github to propose a potential fix. If this is an issue for this change I can take a more thorough approach tomorrow.
- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
