### PR TITLE
Docs:  Fix issue with referencing non-story files with names similar or equal to docs files

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -755,6 +755,17 @@ describe('StoryIndexGenerator', () => {
                 "title": "A",
                 "type": "story",
               },
+              "componentreference--docs": Object {
+                "id": "componentreference--docs",
+                "importPath": "./src/docs2/ComponentReference.mdx",
+                "name": "docs",
+                "storiesImports": Array [],
+                "tags": Array [
+                  "docs",
+                ],
+                "title": "ComponentReference",
+                "type": "docs",
+              },
               "docs2-yabbadabbadooo--docs": Object {
                 "id": "docs2-yabbadabbadooo--docs",
                 "importPath": "./src/docs2/Title.mdx",
@@ -802,6 +813,7 @@ describe('StoryIndexGenerator', () => {
           .toMatchInlineSnapshot(`
           Array [
             "A",
+            "titlePrefix/ComponentReference",
             "A",
             "titlePrefix/NoTitle",
             "A",
@@ -859,6 +871,17 @@ describe('StoryIndexGenerator', () => {
                 ],
                 "title": "A",
                 "type": "story",
+              },
+              "componentreference--info": Object {
+                "id": "componentreference--info",
+                "importPath": "./src/docs2/ComponentReference.mdx",
+                "name": "Info",
+                "storiesImports": Array [],
+                "tags": Array [
+                  "docs",
+                ],
+                "title": "ComponentReference",
+                "type": "docs",
               },
               "docs2-yabbadabbadooo--info": Object {
                 "id": "docs2-yabbadabbadooo--info",
@@ -918,6 +941,7 @@ describe('StoryIndexGenerator', () => {
         expect(Object.keys((await generator.getIndex()).entries)).toMatchInlineSnapshot(`
           Array [
             "a--story-one",
+            "componentreference--docs",
             "a--metaof",
             "notitle--docs",
             "a--second-docs",
@@ -947,6 +971,7 @@ describe('StoryIndexGenerator', () => {
         expect(Object.keys((await generator.getIndex()).entries)).toMatchInlineSnapshot(`
           Array [
             "a--story-one",
+            "componentreference--docs",
             "a--metaof",
             "notitle--docs",
             "a--second-docs",
@@ -978,6 +1003,7 @@ describe('StoryIndexGenerator', () => {
         expect(Object.keys((await generator.getIndex()).entries)).toMatchInlineSnapshot(`
           Array [
             "a--story-one",
+            "componentreference--story-one",
             "a--metaof",
             "notitle--story-one",
             "a--second-docs",
@@ -1037,6 +1063,7 @@ describe('StoryIndexGenerator', () => {
           "a--second-docs",
           "a--story-one",
           "second-nested-g--story-one",
+          "componentreference--docs",
           "notitle--docs",
           "first-nested-deeply-f--story-one",
         ]
@@ -1076,7 +1103,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([storiesSpecifier, docsSpecifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(toId).toHaveBeenCalledTimes(5);
+        expect(toId).toHaveBeenCalledTimes(6);
 
         toIdMock.mockClear();
         await generator.getIndex();
@@ -1135,7 +1162,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([storiesSpecifier, docsSpecifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(toId).toHaveBeenCalledTimes(5);
+        expect(toId).toHaveBeenCalledTimes(6);
 
         generator.invalidate(docsSpecifier, './src/docs2/Title.mdx', false);
 
@@ -1157,7 +1184,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([storiesSpecifier, docsSpecifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(toId).toHaveBeenCalledTimes(5);
+        expect(toId).toHaveBeenCalledTimes(6);
 
         generator.invalidate(storiesSpecifier, './src/A.stories.js', false);
 
@@ -1257,7 +1284,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([docsSpecifier, storiesSpecifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(toId).toHaveBeenCalledTimes(5);
+        expect(toId).toHaveBeenCalledTimes(6);
 
         expect(Object.keys((await generator.getIndex()).entries)).toContain('notitle--docs');
 
@@ -1279,7 +1306,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([docsSpecifier, storiesSpecifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(toId).toHaveBeenCalledTimes(5);
+        expect(toId).toHaveBeenCalledTimes(6);
 
         expect(Object.keys((await generator.getIndex()).entries)).toContain('a--metaof');
 

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -216,7 +216,9 @@ export class StoryIndexGenerator {
     const foundImports = new Set();
     this.specifierToCache.forEach((cache) => {
       const fileNames = Object.keys(cache).filter((fileName) => {
-        const foundImport = absoluteImports.find((storyImport) => fileName.startsWith(storyImport));
+        const foundImport = absoluteImports.find((storyImport) =>
+          fileName.startsWith(`${storyImport}.`)
+        );
         if (foundImport) foundImports.add(foundImport);
         return !!foundImport;
       });
@@ -225,7 +227,9 @@ export class StoryIndexGenerator {
         if (cacheEntry && cacheEntry.type === 'stories') {
           dependencies.push(cacheEntry);
         } else {
-          throw new Error(`Unexpected dependency: ${cacheEntry}`);
+          // If we found a match in the cache that's still null or not a stories file,
+          // it is a docs file and it isn't a dependency / storiesImport.
+          // See https://github.com/storybookjs/storybook/issues/20958
         }
       });
     });

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -217,7 +217,7 @@ export class StoryIndexGenerator {
     this.specifierToCache.forEach((cache) => {
       const fileNames = Object.keys(cache).filter((fileName) => {
         const foundImport = absoluteImports.find((storyImport) =>
-          fileName.startsWith(`${storyImport}.`)
+          fileName.match(new RegExp(`^${storyImport}\\.[^.]+$`))
         );
         if (foundImport) foundImports.add(foundImport);
         return !!foundImport;

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -222,7 +222,7 @@ export class StoryIndexGenerator {
           if (!cacheEntry || cacheEntry.type !== 'stories') return false;
 
           return !!absoluteImports.find((storyImport) =>
-            fileName.match(new RegExp(`^${storyImport}\\.[^.]+$`))
+            fileName.match(new RegExp(`^${storyImport}(\\.[^.]+)?$`))
           );
         })
         .map(([_, cacheEntry]) => cacheEntry as StoriesCacheEntry)

--- a/code/lib/core-server/src/utils/__mockdata__/src/A.js
+++ b/code/lib/core-server/src/utils/__mockdata__/src/A.js
@@ -1,0 +1,2 @@
+// This could be the component for `A.stories.js`
+export const A = {};

--- a/code/lib/core-server/src/utils/__mockdata__/src/docs2/ComponentReference.js
+++ b/code/lib/core-server/src/utils/__mockdata__/src/docs2/ComponentReference.js
@@ -1,0 +1,2 @@
+// This a component that happens to have the same name as an MDX file referencing it
+export const ComponentReference = {};

--- a/code/lib/core-server/src/utils/__mockdata__/src/docs2/ComponentReference.mdx
+++ b/code/lib/core-server/src/utils/__mockdata__/src/docs2/ComponentReference.mdx
@@ -1,0 +1,1 @@
+import ComponentReference from './ComponentReference';

--- a/code/lib/core-server/src/utils/__mockdata__/src/docs2/ComponentReference.mdx
+++ b/code/lib/core-server/src/utils/__mockdata__/src/docs2/ComponentReference.mdx
@@ -1,1 +1,2 @@
 import ComponentReference from './ComponentReference';
+import { A } from '../A';

--- a/code/lib/core-server/src/utils/__mockdata__/src/docs2/ComponentReference.mdx
+++ b/code/lib/core-server/src/utils/__mockdata__/src/docs2/ComponentReference.mdx
@@ -1,2 +1,5 @@
+{/* This will overlap with ComponentReference.mdx (this file). There's not much we can do about this */} 
 import ComponentReference from './ComponentReference';
+
+{/* This prefixes A.stories.ts, we need to make sure we don't get confused. */} 
 import { A } from '../A';

--- a/code/lib/core-server/src/utils/stories-json.test.ts
+++ b/code/lib/core-server/src/utils/stories-json.test.ts
@@ -177,6 +177,17 @@ describe('useStoriesJson', () => {
               "title": "D",
               "type": "story",
             },
+            "docs2-componentreference--docs": Object {
+              "id": "docs2-componentreference--docs",
+              "importPath": "./src/docs2/ComponentReference.mdx",
+              "name": "docs",
+              "storiesImports": Array [],
+              "tags": Array [
+                "docs",
+              ],
+              "title": "docs2/ComponentReference",
+              "type": "docs",
+            },
             "docs2-notitle--docs": Object {
               "id": "docs2-notitle--docs",
               "importPath": "./src/docs2/NoTitle.mdx",
@@ -366,6 +377,23 @@ describe('useStoriesJson', () => {
                 "story",
               ],
               "title": "D",
+            },
+            "docs2-componentreference--docs": Object {
+              "id": "docs2-componentreference--docs",
+              "importPath": "./src/docs2/ComponentReference.mdx",
+              "kind": "docs2/ComponentReference",
+              "name": "docs",
+              "parameters": Object {
+                "__id": "docs2-componentreference--docs",
+                "docsOnly": true,
+                "fileName": "./src/docs2/ComponentReference.mdx",
+              },
+              "storiesImports": Array [],
+              "story": "docs",
+              "tags": Array [
+                "docs",
+              ],
+              "title": "docs2/ComponentReference",
             },
             "docs2-notitle--docs": Object {
               "id": "docs2-notitle--docs",
@@ -655,6 +683,7 @@ describe('useStoriesJson', () => {
       expect(send).toHaveBeenCalledTimes(1);
       expect(send.mock.calls[0][0]).toMatchInlineSnapshot(`
         "Unable to index files:
+        - ./src/docs2/ComponentReference.mdx: You cannot use \`.mdx\` files without using \`storyStoreV7\`.
         - ./src/docs2/MetaOf.mdx: You cannot use \`.mdx\` files without using \`storyStoreV7\`.
         - ./src/docs2/NoTitle.mdx: You cannot use \`.mdx\` files without using \`storyStoreV7\`.
         - ./src/docs2/SecondMetaOf.mdx: You cannot use \`.mdx\` files without using \`storyStoreV7\`.


### PR DESCRIPTION
Closes #20958 

A MDX file can reference a component or other non-story file with the same prefix as an MDX file, which leads to a matching entry in the cache but that entry will not have been processed yet. That's OK, we just assume that import is not a story file (rather than throwing).

- Match file names a little more strictly
- Just continue if we find a matching non-story entry (like we never found it).

<!-- Briefly describe what your PR does -->

## How to test

See test cases and example from issue.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
