### PR TITLE
Core: Fix storySort parsing in preview.js with default export

### DIFF
--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -10,6 +10,7 @@ import * as traverse from '@babel/traverse';
 import { toId, isExportStory, storyNameFromExport } from '@storybook/csf';
 import type { Tag, StoryAnnotations, ComponentAnnotations } from '@storybook/types';
 import { babelParse } from './babelParse';
+import { findVarInitialization } from './findVarInitialization';
 
 const logger = console;
 
@@ -38,34 +39,6 @@ function parseTags(prop: t.Node) {
     throw new Error(`CSF: Expected tag to be string literal`);
   }) as Tag[];
 }
-
-const findVarInitialization = (identifier: string, program: t.Program) => {
-  let init: t.Expression = null as any;
-  let declarations: t.VariableDeclarator[] = null as any;
-  program.body.find((node: t.Node) => {
-    if (t.isVariableDeclaration(node)) {
-      declarations = node.declarations;
-    } else if (t.isExportNamedDeclaration(node) && t.isVariableDeclaration(node.declaration)) {
-      declarations = node.declaration.declarations;
-    }
-
-    return (
-      declarations &&
-      declarations.find((decl: t.Node) => {
-        if (
-          t.isVariableDeclarator(decl) &&
-          t.isIdentifier(decl.id) &&
-          decl.id.name === identifier
-        ) {
-          init = decl.init as t.Expression;
-          return true; // stop looking
-        }
-        return false;
-      })
-    );
-  });
-  return init;
-};
 
 const formatLocation = (node: t.Node, fileName?: string) => {
   const { line, column } = node.loc?.start || {};

--- a/code/lib/csf-tools/src/findVarInitialization.ts
+++ b/code/lib/csf-tools/src/findVarInitialization.ts
@@ -1,0 +1,29 @@
+import * as t from '@babel/types';
+
+export const findVarInitialization = (identifier: string, program: t.Program) => {
+  let init: t.Expression = null as any;
+  let declarations: t.VariableDeclarator[] = null as any;
+  program.body.find((node: t.Node) => {
+    if (t.isVariableDeclaration(node)) {
+      declarations = node.declarations;
+    } else if (t.isExportNamedDeclaration(node) && t.isVariableDeclaration(node.declaration)) {
+      declarations = node.declaration.declarations;
+    }
+
+    return (
+      declarations &&
+      declarations.find((decl: t.Node) => {
+        if (
+          t.isVariableDeclarator(decl) &&
+          t.isIdentifier(decl.id) &&
+          decl.id.name === identifier
+        ) {
+          init = decl.init as t.Expression;
+          return true; // stop looking
+        }
+        return false;
+      })
+    );
+  });
+  return init;
+};

--- a/code/lib/csf-tools/src/getStorySortParameter.test.ts
+++ b/code/lib/csf-tools/src/getStorySortParameter.test.ts
@@ -2,28 +2,29 @@ import { dedent } from 'ts-dedent';
 import { getStorySortParameter } from './getStorySortParameter';
 
 describe('getStorySortParameter', () => {
-  describe('supported', () => {
-    it('no parameters', () => {
-      expect(
-        getStorySortParameter(dedent`
+  describe('named exports', () => {
+    describe('supported', () => {
+      it('no parameters', () => {
+        expect(
+          getStorySortParameter(dedent`
           export const decorators = [];
         `)
-      ).toBeUndefined();
-    });
+        ).toBeUndefined();
+      });
 
-    it('no storySort parameter', () => {
-      expect(
-        getStorySortParameter(dedent`
+      it('no storySort parameter', () => {
+        expect(
+          getStorySortParameter(dedent`
           export const parameters = {
             layout: 'fullscreen',
           };
         `)
-      ).toBeUndefined();
-    });
+        ).toBeUndefined();
+      });
 
-    it('with wildcards', () => {
-      expect(
-        getStorySortParameter(dedent`
+      it('with wildcards', () => {
+        expect(
+          getStorySortParameter(dedent`
           export const parameters = {
             options: {
               storySort: [
@@ -37,7 +38,7 @@ describe('getStorySortParameter', () => {
             }
           };
         `)
-      ).toMatchInlineSnapshot(`
+        ).toMatchInlineSnapshot(`
         Array [
           "Intro",
           "Pages",
@@ -51,11 +52,11 @@ describe('getStorySortParameter', () => {
           "WIP",
         ]
       `);
-    });
+      });
 
-    it('arrow function', () => {
-      expect(
-        getStorySortParameter(dedent`
+      it('arrow function', () => {
+        expect(
+          getStorySortParameter(dedent`
           export const parameters = {
             options: {
               storySort: (a, b) =>
@@ -65,12 +66,12 @@ describe('getStorySortParameter', () => {
             },
           };
         `)
-      ).toMatchInlineSnapshot(`[Function]`);
-    });
+        ).toMatchInlineSnapshot(`[Function]`);
+      });
 
-    it('function', () => {
-      expect(
-        getStorySortParameter(dedent`
+      it('function', () => {
+        expect(
+          getStorySortParameter(dedent`
           export const parameters = {
             options: {
               storySort: function sortStories(a, b) {
@@ -81,12 +82,12 @@ describe('getStorySortParameter', () => {
             },
           };
         `)
-      ).toMatchInlineSnapshot(`[Function]`);
-    });
+        ).toMatchInlineSnapshot(`[Function]`);
+      });
 
-    it('empty sort', () => {
-      expect(
-        getStorySortParameter(dedent`
+      it('empty sort', () => {
+        expect(
+          getStorySortParameter(dedent`
           export const parameters = {
             options: {
               storySort: {
@@ -97,18 +98,18 @@ describe('getStorySortParameter', () => {
             },
           };
         `)
-      ).toMatchInlineSnapshot(`
+        ).toMatchInlineSnapshot(`
         Object {
           "locales": "",
           "method": "",
           "order": Array [],
         }
       `);
-    });
+      });
 
-    it('parameters typescript', () => {
-      expect(
-        getStorySortParameter(dedent`
+      it('parameters typescript', () => {
+        expect(
+          getStorySortParameter(dedent`
           export const parameters = {
             options: {
               storySort: {
@@ -119,23 +120,45 @@ describe('getStorySortParameter', () => {
             },
           } as Parameters;
         `)
-      ).toMatchInlineSnapshot(`
+        ).toMatchInlineSnapshot(`
         Object {
           "locales": "",
           "method": "",
           "order": Array [],
         }
       `);
-    });
-  });
+      });
 
-  describe('unsupported', () => {
-    it('invalid parameters', () => {
-      expect(() =>
-        getStorySortParameter(dedent`
+      it('parameters typescript satisfies', () => {
+        expect(
+          getStorySortParameter(dedent`
+          export const parameters = {
+            options: {
+              storySort: {
+                method: "",
+                order: [],
+                locales: "",
+              },
+            },
+          } satisfies Parameters;
+        `)
+        ).toMatchInlineSnapshot(`
+        Object {
+          "locales": "",
+          "method": "",
+          "order": Array [],
+        }
+      `);
+      });
+    });
+
+    describe('unsupported', () => {
+      it('invalid parameters', () => {
+        expect(() =>
+          getStorySortParameter(dedent`
           export const parameters = [];
         `)
-      ).toThrowErrorMatchingInlineSnapshot(`
+        ).toThrowErrorMatchingInlineSnapshot(`
         "Unexpected 'parameters'. Parameter 'options.storySort' should be defined inline e.g.:
 
         export const parameters = {
@@ -144,11 +167,11 @@ describe('getStorySortParameter', () => {
           }
         }"
       `);
-    });
+      });
 
-    it('parameters var', () => {
-      expect(
-        getStorySortParameter(dedent`
+      it('parameters var', () => {
+        expect(
+          getStorySortParameter(dedent`
           const parameters = {
             options: {
               storySort: {
@@ -160,12 +183,12 @@ describe('getStorySortParameter', () => {
           };
           export { parameters };
       `)
-      ).toBeUndefined();
-    });
+        ).toBeUndefined();
+      });
 
-    it('options var', () => {
-      expect(() =>
-        getStorySortParameter(dedent`
+      it('options var', () => {
+        expect(() =>
+          getStorySortParameter(dedent`
           const options = {
             storySort: {
               method: "",
@@ -177,7 +200,7 @@ describe('getStorySortParameter', () => {
             options,
           };
       `)
-      ).toThrowErrorMatchingInlineSnapshot(`
+        ).toThrowErrorMatchingInlineSnapshot(`
         "Unexpected 'options'. Parameter 'options.storySort' should be defined inline e.g.:
 
         export const parameters = {
@@ -186,11 +209,11 @@ describe('getStorySortParameter', () => {
           }
         }"
       `);
-    });
+      });
 
-    it('storySort var', () => {
-      expect(() =>
-        getStorySortParameter(dedent`
+      it('storySort var', () => {
+        expect(() =>
+          getStorySortParameter(dedent`
           const storySort = {
             method: "",
             order: [],
@@ -202,7 +225,7 @@ describe('getStorySortParameter', () => {
             },
           };
       `)
-      ).toThrowErrorMatchingInlineSnapshot(`
+        ).toThrowErrorMatchingInlineSnapshot(`
         "Unexpected 'storySort'. Parameter 'options.storySort' should be defined inline e.g.:
 
         export const parameters = {
@@ -211,11 +234,11 @@ describe('getStorySortParameter', () => {
           }
         }"
       `);
-    });
+      });
 
-    it('order var', () => {
-      expect(() =>
-        getStorySortParameter(dedent`
+      it('order var', () => {
+        expect(() =>
+          getStorySortParameter(dedent`
           const order = [];
           export const parameters = {
             options: {
@@ -227,7 +250,7 @@ describe('getStorySortParameter', () => {
             },
           };
       `)
-      ).toThrowErrorMatchingInlineSnapshot(`
+        ).toThrowErrorMatchingInlineSnapshot(`
         "Unexpected 'order'. Parameter 'options.storySort' should be defined inline e.g.:
 
         export const parameters = {
@@ -236,6 +259,143 @@ describe('getStorySortParameter', () => {
           }
         }"
       `);
+      });
+    });
+  });
+
+  describe('default export', () => {
+    describe('supported', () => {
+      it('inline', () => {
+        expect(
+          getStorySortParameter(dedent`
+          export default {
+            parameters: {
+              options: {
+                storySort: [
+                  "Intro",
+                  "*",
+                  "WIP",    
+                ]
+              }
+            }
+          };
+        `)
+        ).toMatchInlineSnapshot(`
+        Array [
+          "Intro",
+          "*",
+          "WIP",
+        ]
+      `);
+      });
+
+      it('inline typescript', () => {
+        expect(
+          getStorySortParameter(dedent`
+          export default {
+            parameters: {
+              options: {
+                storySort: [
+                  "Intro",
+                  "*",
+                  "WIP",    
+                ]
+              }
+            }
+          } satisfies Preview;
+        `)
+        ).toMatchInlineSnapshot(`
+        Array [
+          "Intro",
+          "*",
+          "WIP",
+        ]
+      `);
+      });
+
+      it('variable', () => {
+        expect(
+          getStorySortParameter(dedent`
+          const preview = {
+            parameters: {
+              options: {
+                storySort: [
+                  "Intro",
+                  "*",
+                  "WIP",    
+                ]
+              }
+            }
+          };
+          export default preview;
+        `)
+        ).toMatchInlineSnapshot(`
+        Array [
+          "Intro",
+          "*",
+          "WIP",
+        ]
+      `);
+      });
+
+      it('typescript var', () => {
+        expect(
+          getStorySortParameter(dedent`
+          const preview: Preview = {
+            parameters: {
+              options: {
+                storySort: [
+                  "Intro",
+                  "*",
+                  "WIP",    
+                ]
+              }
+            }
+          };
+          export default preview;
+        `)
+        ).toMatchInlineSnapshot(`
+        Array [
+          "Intro",
+          "*",
+          "WIP",
+        ]
+      `);
+      });
+
+      it('typescript satisfies var', () => {
+        expect(
+          getStorySortParameter(dedent`
+          const preview = {
+            parameters: {
+              options: {
+                storySort: [
+                  "Intro",
+                  "*",
+                  "WIP",    
+                ]
+              }
+            }
+          } satisfies Preview;
+          export default preview;
+        `)
+        ).toMatchInlineSnapshot(`
+        Array [
+          "Intro",
+          "*",
+          "WIP",
+        ]
+      `);
+      });
+    });
+    describe('unsupported', () => {
+      it('bad default epxort', () => {
+        expect(
+          getStorySortParameter(dedent`
+          export default 'foo';
+        `)
+        ).toBeUndefined();
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #21322 

## What I did

- [x] Handle parsing preview.js/preview.ts with default exports`

Self-merging @tmeasday 

## How to test

- [ ] See attached unit tests
- [ ] Try a sandbox with a default export & user-defined storySort

