### PR TITLE
CLI: Remove the workspace root flag from the install command for yarn2

### DIFF
--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
@@ -27,7 +27,7 @@ describe('Yarn 2 Proxy', () => {
 
       yarn2Proxy.installDependencies();
 
-      expect(executeCommandSpy).toHaveBeenCalledWith('yarn', ['install', '-W'], expect.any(String));
+      expect(executeCommandSpy).toHaveBeenCalledWith('yarn', ['install'], expect.any(String));
     });
   });
 
@@ -69,7 +69,7 @@ describe('Yarn 2 Proxy', () => {
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
         'yarn',
-        ['add', '-W', '-D', '@storybook/preview-api'],
+        ['add', '-D', '@storybook/preview-api'],
         expect.any(String)
       );
     });
@@ -83,7 +83,7 @@ describe('Yarn 2 Proxy', () => {
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
         'yarn',
-        ['remove', '-W', '@storybook/preview-api'],
+        ['remove', '@storybook/preview-api'],
         expect.any(String)
       );
     });

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -10,29 +10,8 @@ export class Yarn2Proxy extends JsPackageManager {
   getInstallArgs(): string[] {
     if (!this.installArgs) {
       this.installArgs = [];
-
-      if (this.detectWorkspaceRoot()) {
-        this.installArgs.push('-W');
-      }
     }
     return this.installArgs;
-  }
-
-  detectWorkspaceRoot() {
-    const { workspaces } = this.readPackageJson();
-
-    if (Array.isArray(workspaces)) {
-      return workspaces.length > 0;
-    }
-
-    if (workspaces && typeof workspaces === 'object') {
-      if (workspaces.packages) {
-        return workspaces.packages.length > 0;
-      }
-      return false;
-    }
-
-    return false;
   }
 
   initPackageJson() {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21345


## What I did

I removed the `-w` flag for yarn2, which apparently isn't needed it at all.