### PR TITLE
Core: Remove state deprecation warnings by default

### DIFF
--- a/code/lib/manager-api/src/index.tsx
+++ b/code/lib/manager-api/src/index.tsx
@@ -96,6 +96,7 @@ export type State = layout.SubState &
   globals.SubState &
   RouterData &
   API_OptionsData &
+  DeprecatedState &
   Other;
 
 export type API = addons.SubAPI &
@@ -112,6 +113,21 @@ export type API = addons.SubAPI &
   version.SubAPI &
   url.SubAPI &
   Other;
+
+interface DeprecatedState {
+  /**
+   * @deprecated use index
+   */
+  storiesHash: API_IndexHash;
+  /**
+   * @deprecated use previewInitialized
+   */
+  storiesConfigured: boolean;
+  /**
+   * @deprecated use indexError
+   */
+  storiesFailed?: Error;
+}
 
 interface Other {
   [key: string]: any;

--- a/code/lib/manager-api/src/index.tsx
+++ b/code/lib/manager-api/src/index.tsx
@@ -38,6 +38,7 @@ import {
 } from '@storybook/core-events';
 import type { RouterData } from '@storybook/router';
 import type { Listener } from '@storybook/channels';
+import { deprecate } from '@storybook/client-logger';
 
 import { createContext } from './context';
 import type { Options } from './store';
@@ -318,7 +319,23 @@ function ManagerConsumer<P = Combo>({
 
 export function useStorybookState(): State {
   const { state } = useContext(ManagerContext);
-  return state;
+  return {
+    ...state,
+
+    // deprecated fields for back-compat
+    get storiesHash() {
+      deprecate('state.storiesHash is deprecated, please use state.index');
+      return this.index || {};
+    },
+    get storiesConfigured() {
+      deprecate('state.storiesConfigured is deprecated, please use state.previewInitialized');
+      return this.previewInitialized;
+    },
+    get storiesFailed() {
+      deprecate('state.storiesFailed is deprecated, please use state.indexError');
+      return this.indexError;
+    },
+  };
 }
 export function useStorybookApi(): API {
   const { api } = useContext(ManagerContext);

--- a/code/lib/manager-api/src/modules/stories.ts
+++ b/code/lib/manager-api/src/modules/stories.ts
@@ -56,19 +56,6 @@ type StoryUpdate = Pick<API_StoryEntry, 'parameters' | 'initialArgs' | 'argTypes
 export interface SubState extends API_LoadedRefData {
   storyId: StoryId;
   viewMode: ViewMode;
-
-  /**
-   * @deprecated use index
-   */
-  storiesHash: API_IndexHash;
-  /**
-   * @deprecated use previewInitialized
-   */
-  storiesConfigured: boolean;
-  /**
-   * @deprecated use indexError
-   */
-  storiesFailed?: Error;
 }
 
 export interface SubAPI {

--- a/code/lib/manager-api/src/modules/stories.ts
+++ b/code/lib/manager-api/src/modules/stories.ts
@@ -16,7 +16,7 @@ import {
   CURRENT_STORY_WAS_SET,
   STORY_MISSING,
 } from '@storybook/core-events';
-import { deprecate, logger } from '@storybook/client-logger';
+import { logger } from '@storybook/client-logger';
 
 import type {
   StoryId,
@@ -544,20 +544,6 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
       viewMode: initialViewMode,
       hasCalledSetOptions: false,
       previewInitialized: false,
-
-      // deprecated fields for back-compat
-      get storiesHash() {
-        deprecate('state.storiesHash is deprecated, please use state.index');
-        return this.index || {};
-      },
-      get storiesConfigured() {
-        deprecate('state.storiesConfigured is deprecated, please use state.previewInitialized');
-        return this.previewInitialized;
-      },
-      get storiesFailed() {
-        deprecate('state.storiesFailed is deprecated, please use state.indexError');
-        return this.indexError;
-      },
     },
     init: initModule,
   };

--- a/code/lib/manager-api/src/tests/stories.test.ts
+++ b/code/lib/manager-api/src/tests/stories.test.ts
@@ -85,10 +85,6 @@ function createMockStore(initialState = {}) {
 function initStoriesAndSetState({ store, ...options }: any) {
   const { state, ...result } = initStories({ store, ...options } as any);
 
-  // Remove deprecated fields (which would trigger warnings)
-  delete state.storiesHash;
-  delete state.storiesConfigured;
-  delete state.storiesFailed;
   store?.setState(state);
 
   return { state, ...result };
@@ -119,11 +115,6 @@ describe('stories API', () => {
       storyId: 'id',
       viewMode: 'story',
     } as ModuleArgs);
-
-    // Remove deprecated fields (which would trigger warnings)
-    delete state.storiesHash;
-    delete state.storiesConfigured;
-    delete state.storiesFailed;
 
     expect(state).toEqual({
       previewInitialized: false,


### PR DESCRIPTION
Closes #20728

## What I did

Move deprecation warnings for old state fields so they don't always trigger.

I wanted to have these deprecations be defined in the file that defines the relevant APIs, but it was hard to avoid a getter being called when the substate was being cloned into a larger state. There's probably a tricky way to do it, but I think this is fine. We are only concerned with people calling `useStorybookState` anyway.

## How to test

1. Check for lack of warnings in a sandbox by default
2. Call `useStorybookState().storiesHash` in the manager somewhere, say in `.storybook/manager.jsx`:

```
import React from 'react';
import { useStorybookState, addons, types } from '@storybook/manager-api';

addons.register('xyz', () => {
  addons.add('xyz', {
    type: types.TOOL,
    title: 'test',
    render: () => {
      useStorybookState().storiesHash;
      return <div />;
    }
  });
});
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
