### PR TITLE
Docs: Allow ArgTable usage unattached

### DIFF
--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.test.ts
@@ -36,8 +36,10 @@ describe('resolveOf', () => {
   const { story, csfFile, storyExport, metaExport, moduleExports, component } = csfFileParts();
 
   describe('attached', () => {
+    const projectAnnotations = { render: jest.fn() };
     const store = {
       componentStoriesFromCSFFile: () => [story],
+      projectAnnotations,
     } as unknown as StoryStore<Renderer>;
     const context = new DocsContext(channel, store, renderStoryToElement, [csfFile]);
     context.attachCSFFile(csfFile);
@@ -47,15 +49,27 @@ describe('resolveOf', () => {
     });
 
     it('works for meta exports', () => {
-      expect(context.resolveOf(metaExport)).toEqual({ type: 'meta', csfFile });
+      expect(context.resolveOf(metaExport)).toEqual({
+        type: 'meta',
+        csfFile,
+        preparedMeta: expect.any(Object),
+      });
     });
 
     it('works for full module exports', () => {
-      expect(context.resolveOf(moduleExports)).toEqual({ type: 'meta', csfFile });
+      expect(context.resolveOf(moduleExports)).toEqual({
+        type: 'meta',
+        csfFile,
+        preparedMeta: expect.any(Object),
+      });
     });
 
     it('works for components', () => {
-      expect(context.resolveOf(component)).toEqual({ type: 'component', component });
+      expect(context.resolveOf(component)).toEqual({
+        type: 'component',
+        component,
+        projectAnnotations: expect.objectContaining(projectAnnotations),
+      });
     });
 
     it('finds primary story', () => {
@@ -63,11 +77,19 @@ describe('resolveOf', () => {
     });
 
     it('finds attached CSF file', () => {
-      expect(context.resolveOf('meta')).toEqual({ type: 'meta', csfFile });
+      expect(context.resolveOf('meta')).toEqual({
+        type: 'meta',
+        csfFile,
+        preparedMeta: expect.any(Object),
+      });
     });
 
     it('finds attached component', () => {
-      expect(context.resolveOf('component')).toEqual({ type: 'component', component });
+      expect(context.resolveOf('component')).toEqual({
+        type: 'component',
+        component,
+        projectAnnotations: expect.objectContaining(projectAnnotations),
+      });
     });
 
     describe('validation allowed', () => {
@@ -76,17 +98,26 @@ describe('resolveOf', () => {
       });
 
       it('works for meta exports', () => {
-        expect(context.resolveOf(metaExport, ['meta'])).toEqual({ type: 'meta', csfFile });
+        expect(context.resolveOf(metaExport, ['meta'])).toEqual({
+          type: 'meta',
+          csfFile,
+          preparedMeta: expect.any(Object),
+        });
       });
 
       it('works for full module exports', () => {
-        expect(context.resolveOf(moduleExports, ['meta'])).toEqual({ type: 'meta', csfFile });
+        expect(context.resolveOf(moduleExports, ['meta'])).toEqual({
+          type: 'meta',
+          csfFile,
+          preparedMeta: expect.any(Object),
+        });
       });
 
       it('works for components', () => {
         expect(context.resolveOf(component, ['component'])).toEqual({
           type: 'component',
           component,
+          projectAnnotations: expect.objectContaining(projectAnnotations),
         });
       });
 
@@ -95,13 +126,18 @@ describe('resolveOf', () => {
       });
 
       it('finds attached CSF file', () => {
-        expect(context.resolveOf('meta', ['meta'])).toEqual({ type: 'meta', csfFile });
+        expect(context.resolveOf('meta', ['meta'])).toEqual({
+          type: 'meta',
+          csfFile,
+          preparedMeta: expect.any(Object),
+        });
       });
 
       it('finds attached component', () => {
         expect(context.resolveOf('component', ['component'])).toEqual({
           type: 'component',
           component,
+          projectAnnotations: expect.objectContaining(projectAnnotations),
         });
       });
     });
@@ -140,8 +176,10 @@ describe('resolveOf', () => {
   });
 
   describe('unattached', () => {
+    const projectAnnotations = { render: jest.fn() };
     const store = {
       componentStoriesFromCSFFile: () => [story],
+      projectAnnotations,
     } as unknown as StoryStore<Renderer>;
     const context = new DocsContext(channel, store, renderStoryToElement, [csfFile]);
 
@@ -150,15 +188,27 @@ describe('resolveOf', () => {
     });
 
     it('works for meta exports', () => {
-      expect(context.resolveOf(metaExport)).toEqual({ type: 'meta', csfFile });
+      expect(context.resolveOf(metaExport)).toEqual({
+        type: 'meta',
+        csfFile,
+        preparedMeta: expect.any(Object),
+      });
     });
 
     it('works for full module exports', () => {
-      expect(context.resolveOf(moduleExports)).toEqual({ type: 'meta', csfFile });
+      expect(context.resolveOf(moduleExports)).toEqual({
+        type: 'meta',
+        csfFile,
+        preparedMeta: expect.any(Object),
+      });
     });
 
     it('works for components', () => {
-      expect(context.resolveOf(component)).toEqual({ type: 'component', component });
+      expect(context.resolveOf(component)).toEqual({
+        type: 'component',
+        component,
+        projectAnnotations: expect.objectContaining(projectAnnotations),
+      });
     });
 
     it('throws for primary story', () => {

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
@@ -9,10 +9,12 @@ import type {
   StoryName,
   ResolvedModuleExportType,
   ResolvedModuleExportFromType,
+  EnhancedResolvedModuleExportType,
 } from '@storybook/types';
 import type { Channel } from '@storybook/channels';
 
 import type { StoryStore } from '../../store';
+import { prepareMeta } from '../../store';
 import type { DocsContextProps } from './DocsContextProps';
 
 export class DocsContext<TRenderer extends Renderer> implements DocsContextProps<TRenderer> {
@@ -165,7 +167,29 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
         )}`
       );
     }
-    return resolved;
+
+    switch (resolved.type) {
+      case 'component': {
+        return {
+          ...resolved,
+          projectAnnotations: this.projectAnnotations,
+        } as EnhancedResolvedModuleExportType<TType, TRenderer>;
+      }
+      case 'meta': {
+        return {
+          ...resolved,
+          preparedMeta: prepareMeta(
+            resolved.csfFile.meta,
+            this.projectAnnotations,
+            resolved.csfFile.moduleExports.default
+          ),
+        } as EnhancedResolvedModuleExportType<TType, TRenderer>;
+      }
+      case 'story':
+      default: {
+        return resolved as EnhancedResolvedModuleExportType<TType, TRenderer>;
+      }
+    }
   }
 
   storyIdByName = (storyName: StoryName) => {

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
@@ -9,7 +9,6 @@ import type {
   StoryName,
   ResolvedModuleExportType,
   ResolvedModuleExportFromType,
-  EnhancedResolvedModuleExportType,
 } from '@storybook/types';
 import type { Channel } from '@storybook/channels';
 
@@ -173,7 +172,7 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
         return {
           ...resolved,
           projectAnnotations: this.projectAnnotations,
-        } as EnhancedResolvedModuleExportType<TType, TRenderer>;
+        };
       }
       case 'meta': {
         return {
@@ -183,11 +182,11 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
             this.projectAnnotations,
             resolved.csfFile.moduleExports.default
           ),
-        } as EnhancedResolvedModuleExportType<TType, TRenderer>;
+        };
       }
       case 'story':
       default: {
-        return resolved as EnhancedResolvedModuleExportType<TType, TRenderer>;
+        return resolved;
       }
     }
   }

--- a/code/lib/types/src/modules/docs.ts
+++ b/code/lib/types/src/modules/docs.ts
@@ -7,6 +7,7 @@ import type {
   PreparedStory,
   NormalizedProjectAnnotations,
   RenderContext,
+  PreparedMeta,
 } from './story';
 
 export type RenderContextCallbacks<TRenderer extends Renderer> = Pick<
@@ -21,14 +22,6 @@ export type StoryRenderOptions = {
 
 export type ResolvedModuleExportType = 'component' | 'meta' | 'story';
 
-export type ResolvedModuleExportFromType<
-  TType extends ResolvedModuleExportType,
-  TRenderer extends Renderer = Renderer
-> = TType extends 'component'
-  ? { type: 'component'; component: TRenderer['component'] }
-  : TType extends 'meta'
-  ? { type: 'meta'; csfFile: CSFFile<TRenderer> }
-  : { type: 'story'; story: PreparedStory<TRenderer> };
 /**
  * What do we know about an of={} call?
  *
@@ -37,6 +30,19 @@ export type ResolvedModuleExportFromType<
  *   - story === `PreparedStory`
  * But these shorthands capture the idea of what is being talked about
  */
+export type ResolvedModuleExportFromType<
+  TType extends ResolvedModuleExportType,
+  TRenderer extends Renderer = Renderer
+> = TType extends 'component'
+  ? {
+      type: 'component';
+      component: TRenderer['component'];
+      projectAnnotations: NormalizedProjectAnnotations<Renderer>;
+    }
+  : TType extends 'meta'
+  ? { type: 'meta'; csfFile: CSFFile<TRenderer>; preparedMeta: PreparedMeta }
+  : { type: 'story'; story: PreparedStory<TRenderer> };
+
 export type ResolvedModuleExport<TRenderer extends Renderer = Renderer> = {
   type: ResolvedModuleExportType;
 } & (

--- a/code/ui/blocks/src/blocks/ArgsTable.tsx
+++ b/code/ui/blocks/src/blocks/ArgsTable.tsx
@@ -219,14 +219,17 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   `);
   const context = useContext(DocsContext);
 
-  let primaryStory;
+  let parameters: Parameters;
+  let component: any;
+  let subcomponents: Record<string, any>;
   try {
-    primaryStory = context.storyById();
+    ({ parameters, component, subcomponents } = context.storyById());
   } catch (err) {
-    // It is OK to use the ArgsTable unattached, we don't have this information
+    const { of } = props as OfProps;
+    ({
+      projectAnnotations: { parameters },
+    } = context.resolveOf(of, ['component']));
   }
-
-  const { parameters, component, subcomponents } = primaryStory || { parameters: {} as Parameters };
 
   const { include, exclude, components, sort: sortProp } = props as ComponentsProps;
   const { story: storyName } = props as StoryProps;

--- a/code/ui/blocks/src/blocks/Canvas.tsx
+++ b/code/ui/blocks/src/blocks/Canvas.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/destructuring-assignment */
 import React, { Children, useContext } from 'react';
 import type { FC, ReactElement, ReactNode } from 'react';
-import type { ModuleExport, ModuleExports, Renderer } from '@storybook/types';
+import type { ModuleExport, ModuleExports, PreparedStory, Renderer } from '@storybook/types';
 import { deprecate } from '@storybook/client-logger';
 import dedent from 'ts-dedent';
 import type { Layout, PreviewProps as PurePreviewProps } from '../components';
@@ -157,7 +157,7 @@ export const Canvas: FC<CanvasProps & DeprecatedCanvasProps> = (props) => {
   const { children, of, source } = props;
   const { isLoading, previewProps } = useDeprecatedPreviewProps(props, docsContext, sourceContext);
 
-  let story;
+  let story: PreparedStory;
   let sourceProps;
   /**
    * useOf and useSourceProps will throw if they can't find the story, in the scenario where

--- a/code/ui/blocks/src/blocks/useOf.ts
+++ b/code/ui/blocks/src/blocks/useOf.ts
@@ -1,4 +1,9 @@
-import type { DocsContextProps, ModuleExport, ResolvedModuleExportType } from '@storybook/types';
+import type {
+  DocsContextProps,
+  ModuleExport,
+  ResolvedModuleExportType,
+  ResolvedModuleExportFromType,
+} from '@storybook/types';
 import { useContext } from 'react';
 import { DocsContext } from './DocsContext';
 
@@ -13,7 +18,7 @@ export type Of = Parameters<DocsContextProps['resolveOf']>[0];
 export const useOf = <TType extends ResolvedModuleExportType>(
   moduleExportOrType: ModuleExport | TType,
   validTypes?: TType[]
-): ReturnType<DocsContextProps['resolveOf']> => {
+): ResolvedModuleExportFromType<TType> => {
   const context = useContext(DocsContext);
   return context.resolveOf(moduleExportOrType, validTypes);
 };

--- a/code/ui/blocks/src/blocks/useOf.ts
+++ b/code/ui/blocks/src/blocks/useOf.ts
@@ -1,9 +1,4 @@
-import type {
-  DocsContextProps,
-  ModuleExport,
-  Renderer,
-  ResolvedModuleExportType,
-} from '@storybook/types';
+import type { DocsContextProps, ModuleExport, ResolvedModuleExportType } from '@storybook/types';
 import { useContext } from 'react';
 import { DocsContext } from './DocsContext';
 

--- a/code/ui/blocks/src/blocks/useOf.ts
+++ b/code/ui/blocks/src/blocks/useOf.ts
@@ -1,28 +1,13 @@
 import type {
   DocsContextProps,
   ModuleExport,
-  NormalizedProjectAnnotations,
-  PreparedMeta,
   Renderer,
-  ResolvedModuleExportFromType,
   ResolvedModuleExportType,
 } from '@storybook/types';
-import { prepareMeta } from '@storybook/preview-api';
 import { useContext } from 'react';
 import { DocsContext } from './DocsContext';
 
 export type Of = Parameters<DocsContextProps['resolveOf']>[0];
-
-export type EnhancedResolvedModuleExportType<
-  TType extends ResolvedModuleExportType,
-  TRenderer extends Renderer = Renderer
-> = TType extends 'component'
-  ? ResolvedModuleExportFromType<TType, TRenderer> & {
-      projectAnnotations: NormalizedProjectAnnotations<Renderer>;
-    }
-  : TType extends 'meta'
-  ? ResolvedModuleExportFromType<TType, TRenderer> & { preparedMeta: PreparedMeta }
-  : ResolvedModuleExportFromType<TType, TRenderer>;
 
 /**
  * A hook to resolve the `of` prop passed to a block.
@@ -30,36 +15,10 @@ export type EnhancedResolvedModuleExportType<
  * if the resolved module is a meta it will include a preparedMeta property similar to a preparedStory
  * if the resolved module is a component it will include the project annotations
  */
-export const useOf = <
-  TType extends ResolvedModuleExportType,
-  TRenderer extends Renderer = Renderer
->(
+export const useOf = <TType extends ResolvedModuleExportType>(
   moduleExportOrType: ModuleExport | TType,
   validTypes?: TType[]
-): EnhancedResolvedModuleExportType<TType, TRenderer> => {
+): ReturnType<DocsContextProps['resolveOf']> => {
   const context = useContext(DocsContext);
-  const resolved = context.resolveOf(moduleExportOrType, validTypes);
-
-  switch (resolved.type) {
-    case 'component': {
-      return {
-        ...resolved,
-        projectAnnotations: context.projectAnnotations,
-      } as EnhancedResolvedModuleExportType<TType, TRenderer>;
-    }
-    case 'meta': {
-      return {
-        ...resolved,
-        preparedMeta: prepareMeta(
-          resolved.csfFile.meta,
-          context.projectAnnotations,
-          resolved.csfFile.moduleExports.default
-        ),
-      } as EnhancedResolvedModuleExportType<TType, TRenderer>;
-    }
-    case 'story':
-    default: {
-      return resolved as EnhancedResolvedModuleExportType<TType, TRenderer>;
-    }
-  }
+  return context.resolveOf(moduleExportOrType, validTypes);
 };


### PR DESCRIPTION
Closes #21366

## What I did

Rework legacy `ArgsTable` to work even if `storyById()` throws (unattached).

## How to test

1. `yarn task --task dev --template lit-vite/default-ts`
2. Add `<ArgsTable of="button" />` to `Introduction.mdx`
3. Visit http://localhost:6006/?path=/docs/example-introduction--docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
