### PR TITLE
Docs: Don't warn if we find the same entry twice.

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -1029,8 +1029,43 @@ describe('StoryIndexGenerator', () => {
           type: 'story',
         };
         expect(() => {
-          generator.chooseDuplicate(mockEntry, mockEntry);
+          generator.chooseDuplicate(mockEntry, { ...mockEntry, importPath: 'DifferentPath' });
         }).toThrowErrorMatchingInlineSnapshot(`"Duplicate stories with id: StoryId"`);
+      });
+
+      it('DOES NOT warns when the same MDX file matches two specifiers', async () => {
+        const generator = new StoryIndexGenerator(
+          [storiesSpecifier, docsSpecifier, docsSpecifier],
+          options
+        );
+        await generator.initialize();
+
+        expect(Object.keys((await generator.getIndex()).entries)).toMatchInlineSnapshot(`
+          Array [
+            "a--story-one",
+            "componentreference--docs",
+            "a--metaof",
+            "notitle--docs",
+            "a--second-docs",
+            "docs2-yabbadabbadooo--docs",
+          ]
+        `);
+
+        expect(logger.warn).not.toHaveBeenCalled();
+      });
+
+      it('DOES NOT throw when the same CSF file matches two specifiers', async () => {
+        const generator = new StoryIndexGenerator([storiesSpecifier, storiesSpecifier], {
+          ...options,
+        });
+        await generator.initialize();
+        expect(Object.keys((await generator.getIndex()).entries)).toMatchInlineSnapshot(`
+          Array [
+            "a--story-one",
+          ]
+        `);
+
+        expect(logger.warn).not.toHaveBeenCalled();
       });
     });
   });

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -381,6 +381,11 @@ export class StoryIndexGenerator {
   }
 
   chooseDuplicate(firstEntry: IndexEntry, secondEntry: IndexEntry): IndexEntry {
+    // NOTE: it is possible for the same entry to show up twice (if it matches >1 glob). That's OK.
+    if (firstEntry.importPath === secondEntry.importPath) {
+      return firstEntry;
+    }
+
     let firstIsBetter = true;
     if (secondEntry.type === 'story') {
       firstIsBetter = false;


### PR DESCRIPTION
Closes #21373

## What I did

Don't warn if we find the same entry (by import path) twice; this can mean it's specified twice. E.g.

```
    '../src/docs/Introduction.mdx',
    '../src/docs/*.mdx',
```


## How to test

Update a sandbox to include:

```
"stories": ["../src/stories/Introduction.mdx", "../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)", {`
```

Double check it doesn't warn.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
