### PR TITLE
fix: Storybook does not respect BROWSER env var

### DIFF
--- a/code/lib/core-server/src/utils/open-in-browser.ts
+++ b/code/lib/core-server/src/utils/open-in-browser.ts
@@ -5,14 +5,28 @@ import getDefaultBrowser from '@aw-web-design/x-default-browser';
 import { dedent } from 'ts-dedent';
 
 export function openInBrowser(address: string) {
+  const browserEnvVar = process.env.BROWSER;
+  const userBrowserIsChrome =
+    browserEnvVar === 'chrome' ||
+    browserEnvVar === 'chromium' ||
+    browserEnvVar === 'brave' ||
+    browserEnvVar === 'com.brave.browser';
+
+  const openOptions = browserEnvVar ? { app: { name: browserEnvVar } } : {};
   getDefaultBrowser(async (err: any, res: any) => {
     try {
-      if (res && (res.isChrome || res.isChromium || res.identity === 'com.brave.browser')) {
+      if (
+        res &&
+        (res.isChrome ||
+          res.isChromium ||
+          res.identity === 'com.brave.browser' ||
+          userBrowserIsChrome)
+      ) {
         // We use betterOpn for Chrome because it is better at handling which chrome tab
         // or window the preview loads in.
         betterOpn(address);
       } else {
-        await open(address);
+        await open(address, openOptions);
       }
     } catch (error) {
       logger.error(dedent`


### PR DESCRIPTION
Storybook does not respect BROWSER env var if default browser is not chromium based.

Re-doing this pr because some weirdness happened on the last attempt.

Closes #21343

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This commit adds a check for the environment variable, and passes it to the `open` package as an argument if the specified browser is not chromium based.

Changes are in `code/lib/core-server/src/utils/open-in-browser.ts`


## How to test

<!-- Please include the steps to test your changes here. For example:

1. Set the system default browser to something not based on chromium (eg: safari)
2. launch storybook with the BROWSER env var set to something other than the system seting (eg `BROWSER=firefox yarn storybook`
3. see that storybook opens in the specified browser

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
