### PR TITLE
Core: Print errors in `withTelemetry` before prompting

### DIFF
--- a/code/frameworks/angular/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.ts
@@ -17,7 +17,7 @@ import { buildStaticStandalone, withTelemetry } from '@storybook/core-server';
 import { StyleElement } from '@angular-devkit/build-angular/src/builders/browser/schema';
 import { StandaloneOptions } from '../utils/standalone-options';
 import { runCompodoc } from '../utils/run-compodoc';
-import { buildStandaloneErrorHandler } from '../utils/build-standalone-errors-handler';
+import { errorSummary, printErrorDetails } from '../utils/error-handler';
 
 export type StorybookBuilderOptions = JsonObject & {
   browserTarget?: string | null;
@@ -121,8 +121,9 @@ function runInstance(options: StandaloneBuildOptions) {
       {
         cliOptions: options,
         presetOptions: { ...options, corePresets: [], overridePresets: [] },
+        printError: printErrorDetails,
       },
       () => buildStaticStandalone(options)
     )
-  ).pipe(catchError((error: any) => throwError(buildStandaloneErrorHandler(error))));
+  ).pipe(catchError((error: any) => throwError(errorSummary(error))));
 }

--- a/code/frameworks/angular/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.ts
@@ -17,7 +17,7 @@ import { buildDevStandalone, withTelemetry } from '@storybook/core-server';
 import { StyleElement } from '@angular-devkit/build-angular/src/builders/browser/schema';
 import { StandaloneOptions } from '../utils/standalone-options';
 import { runCompodoc } from '../utils/run-compodoc';
-import { buildStandaloneErrorHandler } from '../utils/build-standalone-errors-handler';
+import { printErrorDetails, errorSummary } from '../utils/error-handler';
 
 export type StorybookBuilderOptions = JsonObject & {
   browserTarget?: string | null;
@@ -139,12 +139,13 @@ function runInstance(options: StandaloneOptions) {
       {
         cliOptions: options,
         presetOptions: { ...options, corePresets: [], overridePresets: [] },
+        printError: printErrorDetails,
       },
-      () =>
-        buildDevStandalone(options).then(
-          ({ port }) => observer.next(port),
-          (error) => observer.error(buildStandaloneErrorHandler(error))
-        )
-    );
+      () => buildDevStandalone(options)
+    )
+      .then(({ port }) => observer.next(port))
+      .catch((error) => {
+        observer.error(errorSummary(error));
+      });
   });
 }

--- a/code/frameworks/angular/src/builders/utils/error-handler.ts
+++ b/code/frameworks/angular/src/builders/utils/error-handler.ts
@@ -1,7 +1,7 @@
 import { logger, instance as npmLog } from '@storybook/node-logger';
 import { dedent } from 'ts-dedent';
 
-export const buildStandaloneErrorHandler = (error: any): any => {
+export const printErrorDetails = (error: any): void => {
   // Duplicate code for Standalone error handling
   // Source: https://github.com/storybookjs/storybook/blob/39c7ba09ad84fbd466f9c25d5b92791a5450b9f6/lib/core-server/src/build-dev.ts#L136
   npmLog.heading = '';
@@ -19,6 +19,9 @@ export const buildStandaloneErrorHandler = (error: any): any => {
   }
 
   logger.line();
+};
+
+export const errorSummary = (error: any): string => {
   return error.close
     ? dedent`
       FATAL broken build!, will close the process,

--- a/code/lib/cli/src/build.ts
+++ b/code/lib/cli/src/build.ts
@@ -1,24 +1,18 @@
 import { sync as readUpSync } from 'read-pkg-up';
-import { logger } from '@storybook/node-logger';
 import { buildStaticStandalone, withTelemetry } from '@storybook/core-server';
 import { cache } from '@storybook/core-common';
 
 export const build = async (cliOptions: any) => {
-  try {
-    const options = {
-      ...cliOptions,
-      configDir: cliOptions.configDir || './.storybook',
-      outputDir: cliOptions.outputDir || './storybook-static',
-      ignorePreview: !!cliOptions.previewUrl && !cliOptions.forceBuildPreview,
-      configType: 'PRODUCTION',
-      cache,
-      packageJson: readUpSync({ cwd: __dirname }).packageJson,
-    };
-    await withTelemetry('build', { cliOptions, presetOptions: options }, () =>
-      buildStaticStandalone(options)
-    );
-  } catch (err) {
-    logger.error(err);
-    process.exit(1);
-  }
+  const options = {
+    ...cliOptions,
+    configDir: cliOptions.configDir || './.storybook',
+    outputDir: cliOptions.outputDir || './storybook-static',
+    ignorePreview: !!cliOptions.previewUrl && !cliOptions.forceBuildPreview,
+    configType: 'PRODUCTION',
+    cache,
+    packageJson: readUpSync({ cwd: __dirname }).packageJson,
+  };
+  await withTelemetry('build', { cliOptions, presetOptions: options }, () =>
+    buildStaticStandalone(options)
+  );
 };

--- a/code/lib/cli/src/dev.ts
+++ b/code/lib/cli/src/dev.ts
@@ -4,51 +4,49 @@ import { logger, instance as npmLog } from '@storybook/node-logger';
 import { buildDevStandalone, withTelemetry } from '@storybook/core-server';
 import { cache } from '@storybook/core-common';
 
-export const dev = async (cliOptions: any) => {
-  process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+function printError(error: any) {
+  // this is a weird bugfix, somehow 'node-pre-gyp' is polluting the npmLog header
+  npmLog.heading = '';
 
-  try {
-    const options = {
-      ...cliOptions,
-      configDir: cliOptions.configDir || './.storybook',
-      configType: 'DEVELOPMENT',
-      ignorePreview: !!cliOptions.previewUrl && !cliOptions.forceBuildPreview,
-      cache,
-      packageJson: readUpSync({ cwd: __dirname }).packageJson,
-    };
-    await withTelemetry('dev', { cliOptions, presetOptions: options }, () =>
-      buildDevStandalone(options)
-    );
-  } catch (error) {
-    // this is a weird bugfix, somehow 'node-pre-gyp' is polluting the npmLog header
-    npmLog.heading = '';
-
-    if (error instanceof Error) {
-      if ((error as any).error) {
-        logger.error((error as any).error);
-      } else if ((error as any).stats && (error as any).stats.compilation.errors) {
-        (error as any).stats.compilation.errors.forEach((e: any) => logger.plain(e));
-      } else {
-        logger.error(error as any);
-      }
-    } else if (error.compilation?.errors) {
-      error.compilation.errors.forEach((e: any) => logger.plain(e));
+  if (error instanceof Error) {
+    if ((error as any).error) {
+      logger.error((error as any).error);
+    } else if ((error as any).stats && (error as any).stats.compilation.errors) {
+      (error as any).stats.compilation.errors.forEach((e: any) => logger.plain(e));
+    } else {
+      logger.error(error as any);
     }
+  } else if (error.compilation?.errors) {
+    error.compilation.errors.forEach((e: any) => logger.plain(e));
+  }
 
-    logger.line();
-    logger.warn(
-      error.close
-        ? dedent`
+  logger.line();
+  logger.warn(
+    error.close
+      ? dedent`
           FATAL broken build!, will close the process,
           Fix the error below and restart storybook.
         `
-        : dedent`
+      : dedent`
           Broken build, fix the error above.
           You may need to refresh the browser.
         `
-    );
-    logger.line();
+  );
+  logger.line();
+}
 
-    process.exit(1);
-  }
+export const dev = async (cliOptions: any) => {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
+  const options = {
+    ...cliOptions,
+    configDir: cliOptions.configDir || './.storybook',
+    configType: 'DEVELOPMENT',
+    ignorePreview: !!cliOptions.previewUrl && !cliOptions.forceBuildPreview,
+    cache,
+    packageJson: readUpSync({ cwd: __dirname }).packageJson,
+  };
+  await withTelemetry('dev', { cliOptions, presetOptions: options, printError }, () =>
+    buildDevStandalone(options)
+  );
 };

--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -49,10 +49,7 @@ command('init')
   .option('-b --builder <webpack5 | vite>', 'Builder library')
   .option('-l --linkable', 'Prepare installation for link (contributor helper)')
   .action((options: CommandOptions) => {
-    initiate(options, pkg).catch((err) => {
-      logger.error(err);
-      process.exit(1);
-    });
+    initiate(options, pkg).catch(() => process.exit(1));
   });
 
 command('add <addon>')
@@ -82,7 +79,7 @@ command('upgrade')
   .option('-p --prerelease', 'Upgrade to the pre-release packages')
   .option('-s --skip-check', 'Skip postinstall version and automigration checks')
   .option('-c, --config-dir <dir-name>', 'Directory where to load Storybook configurations from')
-  .action((options: UpgradeOptions) => upgrade(options));
+  .action(async (options: UpgradeOptions) => upgrade(options).catch(() => process.exit(1)));
 
 command('info')
   .description('Prints debugging information about the local environment')
@@ -215,7 +212,7 @@ command('dev')
   )
   .option('--force-build-preview', 'Build the preview iframe even if you are using --preview-url')
   .option('--docs', 'Build a documentation-only site using addon-docs')
-  .action((options) => {
+  .action(async (options) => {
     logger.setLevel(program.loglevel);
     consoleLogger.log(chalk.bold(`${pkg.name} v${pkg.version}`) + chalk.reset('\n'));
 
@@ -233,7 +230,7 @@ command('dev')
       program.port = parseInt(program.port, 10);
     }
 
-    dev({ ...options, packageJson: pkg });
+    await dev({ ...options, packageJson: pkg }).catch(() => process.exit(1));
   });
 
 command('build')
@@ -250,7 +247,7 @@ command('build')
   )
   .option('--force-build-preview', 'Build the preview iframe even if you are using --preview-url')
   .option('--docs', 'Build a documentation-only site using addon-docs')
-  .action((options) => {
+  .action(async (options) => {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production';
     logger.setLevel(program.loglevel);
     consoleLogger.log(chalk.bold(`${pkg.name} v${pkg.version}\n`));
@@ -263,7 +260,7 @@ command('build')
       configDir: 'SBCONFIG_CONFIG_DIR',
     });
 
-    build({ ...options, packageJson: pkg });
+    await build({ ...options, packageJson: pkg }).catch(() => process.exit(1));
   });
 
 program.on('command:*', ([invalidCmd]) => {

--- a/code/lib/core-server/src/withTelemetry.ts
+++ b/code/lib/core-server/src/withTelemetry.ts
@@ -19,7 +19,7 @@ const promptCrashReports = async () => {
   const { enableCrashReports } = await prompts({
     type: 'confirm',
     name: 'enableCrashReports',
-    message: `Would you like to send crash reports to Storybook?`,
+    message: `Would you like to help improve Storybook by sending anonymous crash reports?`,
     initial: true,
   });
 
@@ -90,16 +90,16 @@ export async function sendTelemetryError(
   }
 }
 
-export async function withTelemetry(
+export async function withTelemetry<T>(
   eventType: EventType,
   options: TelemetryOptions,
-  run: () => Promise<any>
-) {
+  run: () => Promise<T>
+): Promise<T> {
   if (!options.cliOptions.disableTelemetry)
     telemetry('boot', { eventType }, { stripMetadata: true });
 
   try {
-    await run();
+    return await run();
   } catch (error) {
     const { printError = logger.error } = options;
     printError(error);

--- a/code/lib/core-server/src/withTelemetry.ts
+++ b/code/lib/core-server/src/withTelemetry.ts
@@ -3,10 +3,12 @@ import type { CLIOptions, CoreConfig } from '@storybook/types';
 import { loadAllPresets, cache } from '@storybook/core-common';
 import { telemetry, getPrecedingUpgrade, oneWayHash } from '@storybook/telemetry';
 import type { EventType } from '@storybook/telemetry';
+import { logger } from '@storybook/node-logger';
 
 type TelemetryOptions = {
   cliOptions: CLIOptions;
   presetOptions?: Parameters<typeof loadAllPresets>[0];
+  printError?: (err: any) => void;
 };
 
 const promptCrashReports = async () => {
@@ -99,6 +101,9 @@ export async function withTelemetry(
   try {
     await run();
   } catch (error) {
+    const { printError = logger.error } = options;
+    printError(error);
+
     await sendTelemetryError(error, eventType, options);
     throw error;
   }


### PR DESCRIPTION
Closes #21310

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Print errors in `withTelemetry` allow configuring formatting.
- Also always `exit(1)` in `generate.ts`
- Note previously upgrade didn't print errors or `exit(1)`. This is a change I could undo.

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/132554/223031572-f1bed6b4-05c3-43b5-9b40-c1f184320b09.png">

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
