### PR TITLE
Ember: Fix broken import

### DIFF
--- a/code/frameworks/ember/package.json
+++ b/code/frameworks/ember/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@babel/core": "*",
-    "@types/ember__component": "4.0.8",
+    "@glimmer/component": "^1.1.2",
     "babel-plugin-ember-modules-api-polyfill": "^2.12.0",
     "babel-plugin-htmlbars-inline-precompile": "2 || 3",
     "ember-source": "~3.28.1",

--- a/code/frameworks/ember/package.json
+++ b/code/frameworks/ember/package.json
@@ -46,9 +46,9 @@
   "peerDependencies": {
     "@babel/core": "*",
     "@glimmer/component": "^1.1.2",
-    "babel-plugin-ember-modules-api-polyfill": "^2.12.0",
-    "babel-plugin-htmlbars-inline-precompile": "2 || 3",
-    "ember-source": "~3.28.1",
+    "babel-plugin-ember-modules-api-polyfill": "^3.0.0",
+    "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+    "ember-source": "^4.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },

--- a/code/frameworks/ember/src/client/preview/render.ts
+++ b/code/frameworks/ember/src/client/preview/render.ts
@@ -1,8 +1,7 @@
 import { global } from '@storybook/global';
 import { dedent } from 'ts-dedent';
 import type { RenderContext } from '@storybook/types';
-// @ts-expect-error (Converted from ts-ignore)
-import Component from '@ember/component'; // eslint-disable-line import/no-unresolved
+import Component from '@glimmer/component';
 import type { OptionsArgs, EmberRenderer } from './types';
 
 const { document } = global;

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5979,9 +5979,9 @@ __metadata:
   peerDependencies:
     "@babel/core": "*"
     "@glimmer/component": ^1.1.2
-    babel-plugin-ember-modules-api-polyfill: ^2.12.0
-    babel-plugin-htmlbars-inline-precompile: 2 || 3
-    ember-source: ~3.28.1
+    babel-plugin-ember-modules-api-polyfill: ^3.0.0
+    babel-plugin-htmlbars-inline-precompile: ^5.0.0
+    ember-source: ^4.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   languageName: unknown

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5978,7 +5978,7 @@ __metadata:
     typescript: ~4.9.3
   peerDependencies:
     "@babel/core": "*"
-    "@types/ember__component": 4.0.8
+    "@glimmer/component": ^1.1.2
     babel-plugin-ember-modules-api-polyfill: ^2.12.0
     babel-plugin-htmlbars-inline-precompile: 2 || 3
     ember-source: ~3.28.1


### PR DESCRIPTION
Hopefully closes #20653 

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Ember [recommends to use `@glimmer/component` rather than `@ember/component`](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-classic-components.md). I switched the import and the package.json accordingly. I believe ember itself somehow import `@glimmer/component` so maybe the peer dependency is not needed. I couldn't launch the project myself locally so let's wait for CI check.

## How to test

- Create a fresh app Ember
```
npx --package ember-cli ember --version #ember-cli: 4.11.0
npx --package ember-cli ember new ember-quickstart
```
- Check Ember app works fine
```
cd ember-quickstart
npm start
```
- Install this storybook PR for Ember
```
npm install --save-dev yannbertrand/storybook#next
```
- Init Storybook
```
npx storybook --version #
npx storybook init
```
- Hopefully this command now works and render something
```
npm run storybook
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
