### PR TITLE
Fix mdx-to-csf codemod blocks imports

### DIFF
--- a/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
@@ -138,6 +138,30 @@ test('convert correct story nodes', () => {
   `);
 });
 
+test('convert addon-docs imports', () => {
+  const input = dedent`
+      import { Meta } from '@storybook/addon-docs';
+      import { Story } from '@storybook/addon-docs/blocks';
+
+      <Meta title="Foobar" />
+      
+      <Story name="Primary">Story</Story>
+    `;
+
+  const mdx = jscodeshift({ source: input, path: 'Foobar.stories.mdx' });
+
+  expect(mdx).toMatchInlineSnapshot(`
+    import { Meta } from '@storybook/blocks';
+    import { Story } from '@storybook/blocks';
+    import * as FoobarStories from './Foobar.stories';
+
+    <Meta of={FoobarStories} />
+
+    <Story of={FoobarStories.Primary} />
+
+  `);
+});
+
 test('convert story nodes with spaces', () => {
   const input = dedent`
       import { Meta, Story } from '@storybook/addon-docs';

--- a/code/lib/codemod/src/transforms/mdx-to-csf.ts
+++ b/code/lib/codemod/src/transforms/mdx-to-csf.ts
@@ -75,8 +75,8 @@ export function transform(source: string, baseName: string): [mdx: string, csf: 
   // rewrite addon docs import
   visit(root, ['mdxjsEsm'], (node: MdxjsEsm) => {
     node.value = node.value
-      .replaceAll('@storybook/addon-docs', '@storybook/blocks')
-      .replaceAll('@storybook/addon-docs/blocks', '@storybook/blocks');
+      .replaceAll('@storybook/addon-docs/blocks', '@storybook/blocks')
+      .replaceAll('@storybook/addon-docs', '@storybook/blocks');
   });
 
   const file = getEsmAst(root);


### PR DESCRIPTION
Closes #21332

## What I did

Make sure to replace the import:
@storybook/addon-docs/blocks
To:
@storybook/blocks

Currently it is replaced to:
@storybook/blocks/blocks

## How to test

See the changed unit tests

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
