### PR TITLE
Docs: Don't allow passing `of={}` with undefined prop

### DIFF
--- a/code/ui/blocks/src/blocks/ArgTypes.stories.tsx
+++ b/code/ui/blocks/src/blocks/ArgTypes.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { ArgTypes } from './ArgTypes';
@@ -33,6 +34,16 @@ export const OfStory: Story = {
   args: {
     of: ExampleStories.NoParameters,
   },
+};
+
+export const OfUndefined: Story = {
+  args: {
+    // @ts-expect-error this is supposed to be undefined
+    // eslint-disable-next-line import/namespace
+    of: ExampleStories.NotDefined,
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
 };
 
 // NOTE: this will throw with no of prop

--- a/code/ui/blocks/src/blocks/ArgTypes.tsx
+++ b/code/ui/blocks/src/blocks/ArgTypes.tsx
@@ -70,5 +70,7 @@ export const ArgTypes: FC<ArgTypesProps> = (props) => {
 
   const filteredArgTypes = filterArgTypes(argTypes, include, exclude);
 
+  if ('of' in props && !props.of) throw new Error('Unexpected `of={}` with undefined prop');
+
   return <PureArgsTable rows={filteredArgTypes} sort={sort} />;
 };

--- a/code/ui/blocks/src/blocks/ArgTypes.tsx
+++ b/code/ui/blocks/src/blocks/ArgTypes.tsx
@@ -60,6 +60,9 @@ function getArgTypesFromResolved(resolved: ReturnType<typeof useOf>, props: ArgT
 
 export const ArgTypes: FC<ArgTypesProps> = (props) => {
   const { of } = props;
+  if ('of' in props && of === undefined) {
+    throw new Error('Unexpected `of={undefined}`, did you mistype a CSF file reference?');
+  }
   const resolved = useOf(of || 'meta');
   const { argTypes, parameters } = getArgTypesFromResolved(resolved, props);
   const argTypesParameters = parameters.docs?.argTypes || ({} as ArgTypesParameters);
@@ -69,8 +72,6 @@ export const ArgTypes: FC<ArgTypesProps> = (props) => {
   const sort = props.sort ?? argTypesParameters.sort;
 
   const filteredArgTypes = filterArgTypes(argTypes, include, exclude);
-
-  if ('of' in props && !props.of) throw new Error('Unexpected `of={}` with undefined prop');
 
   return <PureArgsTable rows={filteredArgTypes} sort={sort} />;
 };

--- a/code/ui/blocks/src/blocks/ArgsTable.tsx
+++ b/code/ui/blocks/src/blocks/ArgsTable.tsx
@@ -226,6 +226,9 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
     ({ parameters, component, subcomponents } = context.storyById());
   } catch (err) {
     const { of } = props as OfProps;
+    if ('of' in props && of === undefined) {
+      throw new Error('Unexpected `of={undefined}`, did you mistype a CSF file reference?');
+    }
     ({
       projectAnnotations: { parameters },
     } = context.resolveOf(of, ['component']));

--- a/code/ui/blocks/src/blocks/Canvas.stories.tsx
+++ b/code/ui/blocks/src/blocks/Canvas.stories.tsx
@@ -33,26 +33,36 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const DefaultAttached: Story = {
+export const OfAttached: Story = {
   args: {
     of: ButtonStories.Primary,
   },
 };
 
-export const DefaultUnattached: Story = {
+export const OfUnattached: Story = {
   args: {
     of: ButtonStories.Primary,
   },
   parameters: { attached: false },
 };
 
-export const DefaultError: Story = {
+export const OfError: Story = {
   args: {
     of: ButtonStories.ErrorStory,
   },
 };
 
-export const UndefinedOf: Story = {};
+export const DefaultAttached: Story = {};
+
+export const OfUndefined: Story = {
+  args: {
+    // @ts-expect-error this is supposed to be undefined
+    // eslint-disable-next-line import/namespace
+    of: ButtonStories.NotDefined,
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
+};
 
 export const PropWithToolbar: Story = {
   name: 'Prop withToolbar = true',

--- a/code/ui/blocks/src/blocks/Canvas.tsx
+++ b/code/ui/blocks/src/blocks/Canvas.tsx
@@ -115,7 +115,10 @@ const useDeprecatedPreviewProps = (
   const stories = useStories(storyIds, docsContext);
   const isLoading = stories.some((s) => !s);
   const sourceProps = useSourceProps(
-    mdxSource ? { code: decodeURI(mdxSource), of: props.of } : { ids: storyIds, of: props.of },
+    {
+      ...(mdxSource ? { code: decodeURI(mdxSource) } : { ids: storyIds }),
+      ...(props.of && { of: props.of }),
+    },
     docsContext,
     sourceContext
   );
@@ -179,7 +182,7 @@ export const Canvas: FC<CanvasProps & DeprecatedCanvasProps> = (props) => {
     }
   }
   try {
-    sourceProps = useSourceProps({ ...source, of }, docsContext, sourceContext);
+    sourceProps = useSourceProps({ ...source, ...(of && { of }) }, docsContext, sourceContext);
   } catch (error) {
     if (!children) {
       hookError = error;

--- a/code/ui/blocks/src/blocks/Canvas.tsx
+++ b/code/ui/blocks/src/blocks/Canvas.tsx
@@ -155,6 +155,10 @@ export const Canvas: FC<CanvasProps & DeprecatedCanvasProps> = (props) => {
   const docsContext = useContext(DocsContext);
   const sourceContext = useContext(SourceContext);
   const { children, of, source } = props;
+  if ('of' in props && of === undefined) {
+    throw new Error('Unexpected `of={undefined}`, did you mistype a CSF file reference?');
+  }
+
   const { isLoading, previewProps } = useDeprecatedPreviewProps(props, docsContext, sourceContext);
 
   let story: PreparedStory;

--- a/code/ui/blocks/src/blocks/Controls.stories.tsx
+++ b/code/ui/blocks/src/blocks/Controls.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Controls } from './Controls';
@@ -28,6 +29,16 @@ export const OfStoryUnattached: Story = {
   args: {
     of: ExampleStories.NoParameters,
   },
+};
+
+export const OfUndefined: Story = {
+  args: {
+    // @ts-expect-error this is supposed to be undefined
+    // eslint-disable-next-line import/namespace
+    of: ExampleStories.NotDefined,
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
 };
 
 export const IncludeProp: Story = {

--- a/code/ui/blocks/src/blocks/Controls.tsx
+++ b/code/ui/blocks/src/blocks/Controls.tsx
@@ -24,6 +24,10 @@ type ControlsProps = ControlsParameters & {
 
 export const Controls: FC<ControlsProps> = (props) => {
   const { of } = props;
+  if ('of' in props && of === undefined) {
+    throw new Error('Unexpected `of={undefined}`, did you mistype a CSF file reference?');
+  }
+
   const context = useContext(DocsContext);
   const { story } = context.resolveOf(of || 'story', ['story']);
   const { parameters, argTypes } = story;

--- a/code/ui/blocks/src/blocks/Description.stories.tsx
+++ b/code/ui/blocks/src/blocks/Description.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Description } from './Description';
 import { Button as ButtonComponent } from '../examples/Button';
@@ -107,8 +108,21 @@ export const OfStoryAsStoryCommentAndParameter: Story = {
   },
   parameters: { relativeCsfPaths: ['../examples/Button.stories'] },
 };
-export const OfUndefinedAttached: Story = {
+export const DefaultAttached: Story = {
   parameters: { relativeCsfPaths: ['../examples/Button.stories'], attached: true },
+};
+export const OfUndefinedAttached: Story = {
+  args: {
+    // @ts-expect-error this is supposed to be undefined
+    // eslint-disable-next-line import/namespace
+    of: DefaultButtonStories.NotDefined,
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    relativeCsfPaths: ['../examples/Button.stories'],
+    attached: true,
+  },
+  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
 };
 export const OfStringComponentAttached: Story = {
   name: 'Of "component" Attached',

--- a/code/ui/blocks/src/blocks/Description.tsx
+++ b/code/ui/blocks/src/blocks/Description.tsx
@@ -125,6 +125,10 @@ const getDescriptionFromDeprecatedProps = (
 
 const DescriptionContainer: FC<DescriptionProps> = (props) => {
   const { of, type, markdown: markdownProp, children } = props;
+
+  if ('of' in props && of === undefined) {
+    throw new Error('Unexpected `of={undefined}`, did you mistype a CSF file reference?');
+  }
   const context = useContext(DocsContext);
   const resolvedOf = useOf(of || 'meta');
   let markdown;

--- a/code/ui/blocks/src/blocks/Source.stories.tsx
+++ b/code/ui/blocks/src/blocks/Source.stories.tsx
@@ -53,6 +53,16 @@ export const Of: Story = {
   },
 };
 
+export const OfUndefined: Story = {
+  args: {
+    // @ts-expect-error this is supposed to be undefined
+    // eslint-disable-next-line import/namespace
+    of: ParametersStories.NotDefined,
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
+};
+
 export const OfTypeProp: Story = {
   args: {
     of: ParametersStories.NoParameters,

--- a/code/ui/blocks/src/blocks/Source.tsx
+++ b/code/ui/blocks/src/blocks/Source.tsx
@@ -126,8 +126,13 @@ export const useSourceProps = (
 
   // The check didn't actually change the type.
   let stories: PreparedStory[] = storiesFromIds as PreparedStory[];
-  if (props.of) {
-    const resolved = docsContext.resolveOf(props.of, ['story']);
+  const { of } = props;
+  if ('of' in props && of === undefined) {
+    throw new Error('Unexpected `of={undefined}`, did you mistype a CSF file reference?');
+  }
+
+  if (of) {
+    const resolved = docsContext.resolveOf(of, ['story']);
     stories = [resolved.story];
   } else if (stories.length === 0) {
     try {

--- a/code/ui/blocks/src/blocks/Story.stories.tsx
+++ b/code/ui/blocks/src/blocks/Story.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Story as StoryBlock } from './Story';
@@ -43,6 +44,16 @@ export const OfError: Story = {
   args: {
     of: ButtonStories.ErrorStory,
   },
+};
+
+export const OfUndefined: Story = {
+  args: {
+    // @ts-expect-error this is supposed to be undefined
+    // eslint-disable-next-line import/namespace
+    of: ButtonStories.NotDefined,
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
 };
 
 export const Inline: Story = {

--- a/code/ui/blocks/src/blocks/Story.tsx
+++ b/code/ui/blocks/src/blocks/Story.tsx
@@ -89,6 +89,10 @@ export type StoryProps = (StoryDefProps | StoryRefProps) & StoryParameters;
 
 export const getStoryId = (props: StoryProps, context: DocsContextProps): StoryId => {
   const { id, of, meta, story } = props as StoryRefProps;
+  if ('of' in props && of === undefined) {
+    throw new Error('Unexpected `of={undefined}`, did you mistype a CSF file reference?');
+  }
+
   if (id) {
     deprecate(dedent`Referencing stories by \`id\` is deprecated, please use \`of\` instead. 
     


### PR DESCRIPTION
Closes #21441

## What I did

As it is easy in MDX to write (e.g.) `<Story of={Something.Undefined} />` and get no prompt from the editor, we need to disambiguate from `<Story />` where we fallback to the primary.

Here we throw if we detect this situation.

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/132554/223404936-79356ec9-ba6f-4fde-810b-f879f8436a5a.png">


## How to test

- See stories.
- Try yourself in a sandbox with some of the blocks.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
