### PR TITLE
Docs: Re-render MDX files when you fix a thrown error.

### DIFF
--- a/code/addons/docs/src/DocsRenderer.tsx
+++ b/code/addons/docs/src/DocsRenderer.tsx
@@ -51,8 +51,9 @@ export class DocsRenderer<TRenderer extends Renderer> {
       return new Promise((resolve, reject) => {
         import('@mdx-js/react')
           .then(({ MDXProvider }) =>
+            // We use a `key={}` here to reset the `hasError` state each time we render ErrorBoundary
             renderElement(
-              <ErrorBoundary showException={reject}>
+              <ErrorBoundary showException={reject} key={Math.random()}>
                 <MDXProvider components={components}>
                   <Docs context={context} docsParameter={docsParameter} />
                 </MDXProvider>


### PR DESCRIPTION
Closes #21440

## What I did

Reset the error state on the docs renderer error boundary each time we render it.

## How to test

1. Add to `Introduction.mdx`:

```mdx
import {Meta, Story } from '@storybook/blocks';
import * as ButtonStories from './Button.stories';

<Meta of={ButtonStories} />
<Story of={ButtonStories.Primar} />
```

2. Check it shows an error

3. Fix it (add a `y` to `Primar`)

4. Check it renders.

5. Try various combinations of multiple errors + multiple successes.


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
