### PR TITLE
Controls: Fix glitchy range control

### DIFF
--- a/code/ui/blocks/src/controls/Range.tsx
+++ b/code/ui/blocks/src/controls/Range.tsx
@@ -163,6 +163,17 @@ const RangeLabel = styled.span({
   fontVariantNumeric: 'tabular-nums',
 });
 
+const RangeCurrentAndMaxLabel = styled(RangeLabel)<{
+  numberOFDecimalsPlaces: number;
+  max: number;
+}>(({ numberOFDecimalsPlaces, max }) => ({
+  // Fixed width of "current / max" label to avoid slider width changes
+  // 3 = size of separator " / "
+  width: `${numberOFDecimalsPlaces + max.toString().length * 2 + 3}ch`,
+  textAlign: 'right',
+  flexShrink: 0,
+}));
+
 const RangeWrapper = styled.div({
   display: 'flex',
   alignItems: 'center',
@@ -208,9 +219,9 @@ export const RangeControl: FC<RangeProps> = ({
         onChange={handleChange}
         {...{ name, value, min, max, step, onFocus, onBlur }}
       />
-      <RangeLabel>
+      <RangeCurrentAndMaxLabel numberOFDecimalsPlaces={numberOFDecimalsPlaces} max={max}>
         {`${hasValue ? value.toFixed(numberOFDecimalsPlaces) : '--'}`} / {max}
-      </RangeLabel>
+      </RangeCurrentAndMaxLabel>
     </RangeWrapper>
   );
 };


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/21191

## What I did

- Fixed width of `current / max` label width to avoid slider width changing which is the reason of buggy in Range control

## How to test

- Run `yarn storybook:ui` in `code` dir
- Navigate to Range story
- Verify that `Range` works without bug

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.
