### PR TITLE
Core: Fix project root detection in yarn PnP without git

### DIFF
--- a/code/lib/core-common/src/utils/__tests__/paths.test.ts
+++ b/code/lib/core-common/src/utils/__tests__/paths.test.ts
@@ -1,5 +1,8 @@
 import path from 'path';
-import { normalizeStoryPath } from '../paths';
+import findUp from 'find-up';
+import { normalizeStoryPath, getProjectRoot } from '../paths';
+
+jest.mock('find-up');
 
 describe('paths - normalizeStoryPath()', () => {
   it('returns a path starting with "./" unchanged', () => {
@@ -35,5 +38,33 @@ describe('paths - normalizeStoryPath()', () => {
   it('adds "./" to a hidden file', () => {
     const filename = `.Comp.story.js`;
     expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+  });
+});
+
+describe('getProjectRoot', () => {
+  const mockedFindUp = findUp as jest.Mocked<typeof findUp>;
+
+  it('should return the root directory containing a .git directory', () => {
+    mockedFindUp.sync.mockImplementation((name) =>
+      name === ('.git' as any) ? '/path/to/root' : undefined
+    );
+
+    expect(getProjectRoot()).toBe('/path/to');
+  });
+
+  it('should return the root directory containing a .svn directory if there is no .git directory', () => {
+    mockedFindUp.sync.mockImplementation((name) =>
+      name === ('.svn' as any) ? '/path/to/root' : undefined
+    );
+
+    expect(getProjectRoot()).toBe('/path/to');
+  });
+
+  it('should return the root directory containing a .yarn directory if there is no .git or .svn directory', () => {
+    mockedFindUp.sync.mockImplementation((name) =>
+      name === ('.yarn' as any) ? '/path/to/root' : undefined
+    );
+
+    expect(getProjectRoot()).toBe('/path/to');
   });
 });

--- a/code/lib/core-common/src/utils/paths.ts
+++ b/code/lib/core-common/src/utils/paths.ts
@@ -6,13 +6,21 @@ export const getProjectRoot = () => {
   try {
     const found = findUp.sync('.git', { type: 'directory' });
     if (found) {
-      result = result || path.join(found, '..');
+      result = path.join(found, '..');
     }
   } catch (e) {
     //
   }
   try {
     const found = findUp.sync('.svn', { type: 'directory' });
+    if (found) {
+      result = result || path.join(found, '..');
+    }
+  } catch (e) {
+    //
+  }
+  try {
+    const found = findUp.sync('.yarn', { type: 'directory' });
     if (found) {
       result = result || path.join(found, '..');
     }


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21420

## What I did

add support for yarn pnp installed workspace root
add tests
