### PR TITLE
Core: Allow cts/mts file extensions for config files

### DIFF
--- a/code/lib/core-common/src/utils/__tests__/interpret-files.test.ts
+++ b/code/lib/core-common/src/utils/__tests__/interpret-files.test.ts
@@ -44,5 +44,25 @@ describe('interpret-files', () => {
     expect(file).toBeUndefined();
   });
 
+  it('will interpret file as file.mts when it exists in fs', () => {
+    mock({
+      'path/to/file.mts': 'ts file contents',
+    });
+
+    const file = getInterpretedFile('path/to/file');
+
+    expect(file).toEqual('path/to/file.mts');
+  });
+
+  it('will interpret file as file.cts when it exists in fs', () => {
+    mock({
+      'path/to/file.cts': 'ts file contents',
+    });
+
+    const file = getInterpretedFile('path/to/file');
+
+    expect(file).toEqual('path/to/file.cts');
+  });
+
   afterEach(mock.restore);
 });

--- a/code/lib/core-common/src/utils/interpret-files.ts
+++ b/code/lib/core-common/src/utils/interpret-files.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 
-export const boost = new Set(['.js', '.jsx', '.ts', '.tsx', '.cjs', '.mjs']);
+export const boost = new Set(['.js', '.jsx', '.ts', '.tsx', '.cts', '.mts', '.cjs', '.mjs']);
 
 function sortExtensions() {
   return [...Array.from(boost)];


### PR DESCRIPTION
Relates to https://github.com/storybookjs/storybook/issues/16948 but doesn't fully address it.

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

<!-- Briefly describe what your PR does -->

When validating the presence of the config files, we check for files matching certain allowed file extensions. This list includes "cjs" and "mjs", but not the TypeScript variants "cts" and "mts". I've expanded the list of extensions.

## How to test

<!-- Please include the steps to test your changes here. For example:

I've added test coverage to match the existing coverage. This pull request does not necessarily add full TypeScript ESM support, but rather removes one of the blockers by allowing the file extension. I do want to ultimately contribute full TypeScript + ESM support, so if it's preferred to have a single larger pull request that contains all of those changes, I can look at doing so.

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
