### PR TITLE
Vite: Fix alias array converted incorrectly to an object

### DIFF
--- a/code/frameworks/vue-vite/src/preset.ts
+++ b/code/frameworks/vue-vite/src/preset.ts
@@ -28,15 +28,23 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets 
 
   plugins.push(vueDocgen());
 
+  const alias =
+    config?.resolve?.alias && Array.isArray(config?.resolve?.alias)
+      ? config.resolve.alias.concat({
+          find: /^vue$/,
+          replacement: 'vue/dist/vue.esm.js',
+        })
+      : {
+          ...config.resolve?.alias,
+          vue: 'vue/dist/vue.esm.js',
+        };
+
   const updated = {
     ...config,
     plugins,
     resolve: {
       ...config.resolve,
-      alias: {
-        ...config.resolve?.alias,
-        vue: 'vue/dist/vue.esm.js',
-      },
+      alias,
     },
   };
   return updated;

--- a/code/frameworks/vue-vite/src/preset.ts
+++ b/code/frameworks/vue-vite/src/preset.ts
@@ -25,12 +25,8 @@ export const typescript: PresetProperty<'typescript', StorybookConfig> = async (
 });
 
 export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets }) => {
-  const { plugins = [] } = config;
-
-  plugins.push(vueDocgen());
-
   return mergeConfig(config, {
-    plugins,
+    plugins: [vueDocgen()],
     resolve: {
       alias: {
         vue: 'vue/dist/vue.esm.js',

--- a/code/frameworks/vue-vite/src/preset.ts
+++ b/code/frameworks/vue-vite/src/preset.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import type { PresetProperty } from '@storybook/types';
+import { mergeConfig } from 'vite';
 import type { StorybookConfig } from './types';
 import { vueDocgen } from './plugins/vue-docgen';
 
@@ -28,24 +29,12 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets 
 
   plugins.push(vueDocgen());
 
-  const alias =
-    config?.resolve?.alias && Array.isArray(config?.resolve?.alias)
-      ? config.resolve.alias.concat({
-          find: /^vue$/,
-          replacement: 'vue/dist/vue.esm.js',
-        })
-      : {
-          ...config.resolve?.alias,
-          vue: 'vue/dist/vue.esm.js',
-        };
-
-  const updated = {
-    ...config,
+  return mergeConfig(config, {
     plugins,
     resolve: {
-      ...config.resolve,
-      alias,
+      alias: {
+        vue: 'vue/dist/vue.esm.js',
+      },
     },
-  };
-  return updated;
+  });
 };

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -20,15 +20,22 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets 
   // Add docgen plugin
   plugins.push(vueDocgen());
 
+  const alias = Array.isArray(config.resolve?.alias)
+    ? config.resolve.alias.concat({
+        find: /^vue$/,
+        replacement: 'vue/dist/vue.esm-bundler.js',
+      })
+    : {
+        ...config.resolve?.alias,
+        vue: 'vue/dist/vue.esm-bundler.js',
+      };
+
   const updated = {
     ...config,
     plugins,
     resolve: {
       ...config.resolve,
-      alias: {
-        ...config.resolve?.alias,
-        vue: 'vue/dist/vue.esm-bundler.js',
-      },
+      alias,
     },
   };
   return updated;

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -1,5 +1,6 @@
 import { hasVitePlugins } from '@storybook/builder-vite';
 import type { PresetProperty } from '@storybook/types';
+import { mergeConfig } from 'vite';
 import type { StorybookConfig } from './types';
 import { vueDocgen } from './plugins/vue-docgen';
 
@@ -20,23 +21,12 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets 
   // Add docgen plugin
   plugins.push(vueDocgen());
 
-  const alias = Array.isArray(config.resolve?.alias)
-    ? config.resolve.alias.concat({
-        find: /^vue$/,
-        replacement: 'vue/dist/vue.esm-bundler.js',
-      })
-    : {
-        ...config.resolve?.alias,
-        vue: 'vue/dist/vue.esm-bundler.js',
-      };
-
-  const updated = {
-    ...config,
+  return mergeConfig(config, {
     plugins,
     resolve: {
-      ...config.resolve,
-      alias,
+      alias: {
+        vue: 'vue/dist/vue.esm-bundler.js',
+      },
     },
-  };
-  return updated;
+  });
 };

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -1,6 +1,6 @@
 import { hasVitePlugins } from '@storybook/builder-vite';
 import type { PresetProperty } from '@storybook/types';
-import { mergeConfig } from 'vite';
+import { mergeConfig, type PluginOption } from 'vite';
 import type { StorybookConfig } from './types';
 import { vueDocgen } from './plugins/vue-docgen';
 
@@ -10,10 +10,10 @@ export const core: PresetProperty<'core', StorybookConfig> = {
 };
 
 export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets }) => {
-  const { plugins = [] } = config;
+  const plugins: PluginOption[] = [];
 
   // Add vue plugin if not present
-  if (!(await hasVitePlugins(plugins, ['vite:vue']))) {
+  if (!(await hasVitePlugins(config.plugins, ['vite:vue']))) {
     const { default: vue } = await import('@vitejs/plugin-vue');
     plugins.push(vue());
   }

--- a/code/lib/react-dom-shim/src/preset.ts
+++ b/code/lib/react-dom-shim/src/preset.ts
@@ -32,14 +32,21 @@ export const viteFinal = async (config: any, options: Options) => {
   const useReact17 = legacyRootApi || !isReact18;
   if (useReact17) return config;
 
+  const alias = Array.isArray(config.resolve?.alias)
+    ? config.resolve.alias.concat({
+        find: /^@storybook\/react-dom-shim$/,
+        replacement: '@storybook/react-dom-shim/dist/react-18',
+      })
+    : {
+        ...config.resolve?.alias,
+        '@storybook/react-dom-shim': '@storybook/react-dom-shim/dist/react-18',
+      };
+
   return {
     ...config,
     resolve: {
       ...config.resolve,
-      alias: {
-        ...config.resolve.alias,
-        '@storybook/react-dom-shim': '@storybook/react-dom-shim/dist/react-18',
-      },
+      alias,
     },
   };
 };


### PR DESCRIPTION
Closes: #21547

## What I did

Check for vite config if `alias` is an Array or an object, and making sure config stays correct.
[Vite alias docs](https://vitejs.dev/config/shared-options.html#resolve-alias)

## How to test

1. Create a project with `vite.config.js` file
2. Add `resolve.alias` of type array
3. Run Storybook
4. Check if the alias you've created works


<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
5. Open Storybook in your browser
6. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests) **(I've tested it only with the React version)**
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
