### PR TITLE
Vite: Fix HMR of preview.js

### DIFF
--- a/code/lib/builder-vite/src/codegen-iframe-script.ts
+++ b/code/lib/builder-vite/src/codegen-iframe-script.ts
@@ -3,7 +3,7 @@ import type { Options, PreviewAnnotation } from '@storybook/types';
 import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
 import { processPreviewAnnotation } from './utils/process-preview-annotation';
 
-export async function generateIframeScriptCode(options: Options) {
+export async function generateIframeScriptCode(options: Options, projectRoot: string) {
   const { presets } = options;
   const rendererName = await getRendererName(options);
 
@@ -12,7 +12,9 @@ export async function generateIframeScriptCode(options: Options) {
     [],
     options
   );
-  const configEntries = [...previewAnnotations].filter(Boolean).map(processPreviewAnnotation);
+  const configEntries = [...previewAnnotations]
+    .filter(Boolean)
+    .map((path) => processPreviewAnnotation(path, projectRoot));
 
   const filesToImport = (files: string[], name: string) =>
     files.map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'${el}'`).join('\n');

--- a/code/lib/builder-vite/src/plugins/code-generator-plugin.ts
+++ b/code/lib/builder-vite/src/plugins/code-generator-plugin.ts
@@ -110,7 +110,7 @@ export function codeGeneratorPlugin(options: Options): Plugin {
         if (storyStoreV7) {
           return generateModernIframeScriptCode(options, projectRoot);
         }
-        return generateIframeScriptCode(options);
+        return generateIframeScriptCode(options, projectRoot);
       }
 
       if (id === iframeId) {

--- a/code/lib/builder-vite/src/plugins/code-generator-plugin.ts
+++ b/code/lib/builder-vite/src/plugins/code-generator-plugin.ts
@@ -20,6 +20,7 @@ import {
 export function codeGeneratorPlugin(options: Options): Plugin {
   const iframePath = require.resolve('@storybook/builder-vite/input/iframe.html');
   let iframeId: string;
+  let projectRoot: string;
 
   // noinspection JSUnusedGlobalSymbols
   return {
@@ -66,6 +67,7 @@ export function codeGeneratorPlugin(options: Options): Plugin {
       }
     },
     configResolved(config) {
+      projectRoot = config.root;
       iframeId = `${config.root}/iframe.html`;
     },
     resolveId(source) {
@@ -87,7 +89,7 @@ export function codeGeneratorPlugin(options: Options): Plugin {
 
       return undefined;
     },
-    async load(id) {
+    async load(id, config) {
       const storyStoreV7 = options.features?.storyStoreV7;
       if (id === virtualStoriesFile) {
         if (storyStoreV7) {
@@ -106,7 +108,7 @@ export function codeGeneratorPlugin(options: Options): Plugin {
 
       if (id === virtualFileId) {
         if (storyStoreV7) {
-          return generateModernIframeScriptCode(options);
+          return generateModernIframeScriptCode(options, projectRoot);
         }
         return generateIframeScriptCode(options);
       }

--- a/code/lib/builder-vite/src/utils/process-preview-annotation.test.ts
+++ b/code/lib/builder-vite/src/utils/process-preview-annotation.test.ts
@@ -1,0 +1,43 @@
+import { processPreviewAnnotation } from './process-preview-annotation';
+import 'jest-os-detection';
+
+describe('processPreviewAnnotation()', () => {
+  it('should pull the `bare` value from an object', () => {
+    const annotation = {
+      bare: '@storybook/addon-links/preview',
+      absolute: '/Users/foo/storybook/node_modules/@storybook/addon-links/dist/preview.mjs',
+    };
+    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook');
+    expect(url).toBe('@storybook/addon-links/preview');
+  });
+
+  it.skipWindows(
+    'should convert absolute filesystem paths into urls relative to project root',
+    () => {
+      const annotation = '/Users/foo/storybook/.storybook/preview.js';
+      const url = processPreviewAnnotation(annotation, '/Users/foo/storybook');
+      expect(url).toBe('/.storybook/preview.js');
+    }
+  );
+
+  it.onWindows(
+    'should convert absolute windows filesystem paths into urls relative to project root',
+    () => {
+      const annotation = 'C:/foo/storybook/.storybook/preview.js';
+      const url = processPreviewAnnotation(annotation, 'C:/foo/storybook');
+      expect(url).toBe('/.storybook/preview.js');
+    }
+  );
+
+  it('should convert relative paths into urls', () => {
+    const annotation = './src/stories/components';
+    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook');
+    expect(url).toBe('/src/stories/components');
+  });
+
+  it('should convert node_modules into bare paths', () => {
+    const annotation = '/Users/foo/storybook/node_modules/storybook-addon/preview';
+    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook');
+    expect(url).toBe('storybook-addon/preview');
+  });
+});

--- a/code/lib/builder-vite/src/utils/process-preview-annotation.test.ts
+++ b/code/lib/builder-vite/src/utils/process-preview-annotation.test.ts
@@ -41,15 +41,27 @@ describe('processPreviewAnnotation()', () => {
     expect(url).toBe('storybook-addon/preview');
   });
 
-  it('should convert relative paths outside the root into absolute', () => {
+  it.skipWindows('should convert relative paths outside the root into absolute', () => {
     const annotation = '../parent.js';
     const url = processPreviewAnnotation(annotation, '/Users/foo/storybook/');
     expect(url).toBe('/Users/foo/parent.js');
   });
 
-  it('should not change absolute paths outside of the project root', () => {
+  it.onWindows('should convert relative paths outside the root into absolute on Windows', () => {
+    const annotation = '../parent.js';
+    const url = processPreviewAnnotation(annotation, 'C:/Users/foo/storybook/');
+    expect(url).toBe('C:/Users/foo/parent.js');
+  });
+
+  it.skipWindows('should not change absolute paths outside of the project root', () => {
     const annotation = '/Users/foo/parent.js';
     const url = processPreviewAnnotation(annotation, '/Users/foo/storybook/');
+    expect(url).toBe(annotation);
+  });
+
+  it.onWindows('should not change Windows absolute paths outside of the project root', () => {
+    const annotation = 'D:/Users/foo/parent.js';
+    const url = processPreviewAnnotation(annotation, 'D:/Users/foo/storybook/');
     expect(url).toBe(annotation);
   });
 });

--- a/code/lib/builder-vite/src/utils/process-preview-annotation.test.ts
+++ b/code/lib/builder-vite/src/utils/process-preview-annotation.test.ts
@@ -7,7 +7,7 @@ describe('processPreviewAnnotation()', () => {
       bare: '@storybook/addon-links/preview',
       absolute: '/Users/foo/storybook/node_modules/@storybook/addon-links/dist/preview.mjs',
     };
-    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook');
+    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook/');
     expect(url).toBe('@storybook/addon-links/preview');
   });
 
@@ -15,7 +15,7 @@ describe('processPreviewAnnotation()', () => {
     'should convert absolute filesystem paths into urls relative to project root',
     () => {
       const annotation = '/Users/foo/storybook/.storybook/preview.js';
-      const url = processPreviewAnnotation(annotation, '/Users/foo/storybook');
+      const url = processPreviewAnnotation(annotation, '/Users/foo/storybook/');
       expect(url).toBe('/.storybook/preview.js');
     }
   );
@@ -31,13 +31,25 @@ describe('processPreviewAnnotation()', () => {
 
   it('should convert relative paths into urls', () => {
     const annotation = './src/stories/components';
-    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook');
+    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook/');
     expect(url).toBe('/src/stories/components');
   });
 
   it('should convert node_modules into bare paths', () => {
     const annotation = '/Users/foo/storybook/node_modules/storybook-addon/preview';
-    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook');
+    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook/');
     expect(url).toBe('storybook-addon/preview');
+  });
+
+  it('should convert relative paths outside the root into absolute', () => {
+    const annotation = '../parent.js';
+    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook/');
+    expect(url).toBe('/Users/foo/parent.js');
+  });
+
+  it('should not change absolute paths outside of the project root', () => {
+    const annotation = '/Users/foo/parent.js';
+    const url = processPreviewAnnotation(annotation, '/Users/foo/storybook/');
+    expect(url).toBe(annotation);
   });
 });

--- a/code/lib/builder-vite/src/utils/process-preview-annotation.ts
+++ b/code/lib/builder-vite/src/utils/process-preview-annotation.ts
@@ -34,20 +34,19 @@ export function processPreviewAnnotation(path: PreviewAnnotation | undefined, pr
   }
 
   // resolve absolute paths relative to project root
-  if (isAbsolute(path)) {
-    return slash(`/${relative(projectRoot, path)}`);
-  }
+  const relativePath = isAbsolute(path) ? slash(relative(projectRoot, path)) : path;
 
   // resolve relative paths into absolute urls
   // note: this only works if vite's projectRoot === cwd.
-  if (path?.startsWith('./')) {
-    return slash(path.replace(/^\.\//, '/'));
+  if (relativePath.startsWith('./')) {
+    return slash(relativePath.replace(/^\.\//, '/'));
   }
 
   // If something is outside of root, convert to absolute.  Uncommon?
-  if (path?.startsWith('../')) {
-    return slash(resolve(path));
+  if (relativePath.startsWith('../')) {
+    return slash(resolve(relativePath));
   }
 
-  return slash(path);
+  // At this point, it must be relative to the root but not start with a ./ or ../
+  return slash(`/${relativePath}`);
 }

--- a/code/lib/builder-vite/src/utils/process-preview-annotation.ts
+++ b/code/lib/builder-vite/src/utils/process-preview-annotation.ts
@@ -44,7 +44,7 @@ export function processPreviewAnnotation(path: PreviewAnnotation | undefined, pr
 
   // If something is outside of root, convert to absolute.  Uncommon?
   if (relativePath.startsWith('../')) {
-    return slash(resolve(relativePath));
+    return slash(resolve(projectRoot, relativePath));
   }
 
   // At this point, it must be relative to the root but not start with a ./ or ../

--- a/code/lib/builder-vite/src/utils/process-preview-annotation.ts
+++ b/code/lib/builder-vite/src/utils/process-preview-annotation.ts
@@ -1,5 +1,5 @@
 import type { PreviewAnnotation } from '@storybook/types';
-import { resolve } from 'path';
+import { resolve, isAbsolute, relative } from 'path';
 import slash from 'slash';
 import { transformAbsPath } from './transform-abs-path';
 
@@ -8,10 +8,9 @@ import { transformAbsPath } from './transform-abs-path';
  * a bit more restrained.
  *
  * For node_modules, we want bare imports (so vite can process them),
- * and for files in the user's source,
- * we want absolute paths.
+ * and for files in the user's source, we want URLs absolute relative to project root.
  */
-export function processPreviewAnnotation(path: PreviewAnnotation | undefined) {
+export function processPreviewAnnotation(path: PreviewAnnotation | undefined, projectRoot: string) {
   // If entry is an object, take the first, which is the
   // bare (non-absolute) specifier.
   // This is so that webpack can use an absolute path, and
@@ -21,10 +20,7 @@ export function processPreviewAnnotation(path: PreviewAnnotation | undefined) {
   if (typeof path === 'object') {
     return path.bare;
   }
-  // resolve relative paths into absolute paths, but don't resolve "bare" imports
-  if (path?.startsWith('./') || path?.startsWith('../')) {
-    return slash(resolve(path));
-  }
+
   // This should not occur, since we use `.filter(Boolean)` prior to
   // calling this function, but this makes typescript happy
   if (!path) {
@@ -35,6 +31,22 @@ export function processPreviewAnnotation(path: PreviewAnnotation | undefined) {
   // so that vite will process it as a dependency (cjs -> esm, etc).
   if (path.includes('node_modules')) {
     return transformAbsPath(path);
+  }
+
+  // resolve absolute paths relative to project root
+  if (isAbsolute(path)) {
+    return slash(`/${relative(projectRoot, path)}`);
+  }
+
+  // resolve relative paths into absolute urls
+  // note: this only works if vite's projectRoot === cwd.
+  if (path?.startsWith('./')) {
+    return slash(path.replace(/^\.\//, '/'));
+  }
+
+  // If something is outside of root, convert to absolute.  Uncommon?
+  if (path?.startsWith('../')) {
+    return slash(resolve(path));
   }
 
   return slash(path);


### PR DESCRIPTION
Closes #21426

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This makes some changes to the way the vite-builder constructs URLs for preview annotations, and how it handles HMR of those annotations.

Previously, we resolved project files into absolute filesystem paths, because relative paths are not resolvable in the virtual file they are imported in: `virtual:/@storybook/builder-vite/vite-app.js`.  

Now, I've made some changes:
	- Relative files starting with `./` will become just `/`.  This works so long as the CWD is the vite project root, which should normally be the case.  We were using CWD in the require.resolve() previously and didn't hear any complaints, so I don't expect any here either.
	- Absolute paths (for example the `.storybook/preview.js`), will be made relative to the vite project root.
	- Relative files starting with `../` will be made absolute as before.  I don't really know what else to do with those, and I _think_ they either won't happen, or this won't cause problems.

That was the first part of this PR.  The second is handling the actual callback to `import.meta.hot.accept`, which as @tmeasday noticed, probably was never getting hit before and was broken.  Vite only gives us the module that actually changed, the rest are `null`, so we can't use that.  I believe it is no problem to reuse the same function that we use on the initial page load to build up the `getProjectAnnotations` function, as Tom suggested.  So that's what I've done here.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. In the sandbox's `.storybook/preview.ts`, add `alert('hi')` somewhere, and save the file.
4. The alert should be shown right away, via HMR.

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
