### PR TITLE
Docs: Error if you try to index an MDX file in ssv6

### DIFF
--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -401,6 +401,7 @@ const internalTemplates = {
       mainConfig: {
         features: {
           storyStoreV7: false,
+          storyStoreV7MdxErrors: false,
         },
       },
     },
@@ -413,6 +414,7 @@ const internalTemplates = {
       mainConfig: {
         features: {
           storyStoreV7: false,
+          storyStoreV7MdxErrors: false,
         },
       },
     },

--- a/code/lib/preview-api/src/modules/client-api/StoryStoreFacade.ts
+++ b/code/lib/preview-api/src/modules/client-api/StoryStoreFacade.ts
@@ -141,15 +141,17 @@ export class StoryStoreFacade<TRenderer extends Renderer> {
   // NOTE: we could potentially share some of this code with the stories.json generation
   addStoriesFromExports(fileName: Path, fileExports: ModuleExports) {
     if (fileName.match(/\.mdx$/) && !fileName.match(/\.stories\.mdx$/)) {
-      throw new Error(dedent`
+      if (FEATURES?.storyStoreV7MdxErrors !== false) {
+        throw new Error(dedent`
         Cannot index \`.mdx\` file (\`${fileName}\`) in \`storyStoreV7: false\` mode.
 
         The legacy story store does not support new-style \`.mdx\` files. If the file above
         is not intended to be indexed (i.e. displayed as an entry in the sidebar), either
         exclude it from your \`stories\` glob, or add <Meta isTemplate /> to it.
-
+        
         If you wanted to index the file, you'll need to name it \`stories.mdx\` and stick to the
         legacy (6.x) MDX API, or use the new store.`);
+      }
     }
 
     // if the export haven't changed since last time we added them, this is a no-op

--- a/code/lib/preview-api/src/modules/client-api/StoryStoreFacade.ts
+++ b/code/lib/preview-api/src/modules/client-api/StoryStoreFacade.ts
@@ -141,7 +141,7 @@ export class StoryStoreFacade<TRenderer extends Renderer> {
   // NOTE: we could potentially share some of this code with the stories.json generation
   addStoriesFromExports(fileName: Path, fileExports: ModuleExports) {
     if (fileName.match(/\.mdx$/) && !fileName.match(/\.stories\.mdx$/)) {
-      if (FEATURES?.storyStoreV7MdxErrors !== false) {
+      if (global.FEATURES?.storyStoreV7MdxErrors !== false) {
         throw new Error(dedent`
         Cannot index \`.mdx\` file (\`${fileName}\`) in \`storyStoreV7: false\` mode.
 

--- a/code/lib/preview-api/src/modules/client-api/StoryStoreFacade.ts
+++ b/code/lib/preview-api/src/modules/client-api/StoryStoreFacade.ts
@@ -141,7 +141,15 @@ export class StoryStoreFacade<TRenderer extends Renderer> {
   // NOTE: we could potentially share some of this code with the stories.json generation
   addStoriesFromExports(fileName: Path, fileExports: ModuleExports) {
     if (fileName.match(/\.mdx$/) && !fileName.match(/\.stories\.mdx$/)) {
-      return;
+      throw new Error(dedent`
+        Cannot index \`.mdx\` file (\`${fileName}\`) in \`storyStoreV7: false\` mode.
+
+        The legacy story store does not support new-style \`.mdx\` files. If the file above
+        is not intended to be indexed (i.e. displayed as an entry in the sidebar), either
+        exclude it from your \`stories\` glob, or add <Meta isTemplate /> to it.
+
+        If you wanted to index the file, you'll need to name it \`stories.mdx\` and stick to the
+        legacy (6.x) MDX API, or use the new store.`);
     }
 
     // if the export haven't changed since last time we added them, this is a no-op

--- a/code/lib/preview-api/src/modules/core-client/start.test.ts
+++ b/code/lib/preview-api/src/modules/core-client/start.test.ts
@@ -4,7 +4,7 @@
  */
 
 // import { describe, it, beforeAll, beforeEach, afterAll, afterEach, jest } from '@jest/globals';
-import { STORY_RENDERED, STORY_UNCHANGED, SET_INDEX } from '@storybook/core-events';
+import { STORY_RENDERED, STORY_UNCHANGED, SET_INDEX, CONFIG_ERROR } from '@storybook/core-events';
 
 import type { ModuleExports, Path } from '@storybook/types';
 import { global } from '@storybook/global';
@@ -1004,6 +1004,34 @@ describe('start', () => {
 
         // Wait a second to let the docs "render" finish (and maybe throw)
         await waitForQuiescence();
+      });
+
+      it('errors on .mdx files', async () => {
+        const renderToCanvas = jest.fn();
+
+        const { configure } = start(renderToCanvas);
+
+        configure(
+          'test',
+          makeRequireContext({
+            './Introduction.mdx': {
+              default: () => 'some mdx function',
+            },
+          })
+        );
+
+        await waitForEvents([CONFIG_ERROR]);
+        expect(mockChannel.emit.mock.calls.find((call) => call[0] === CONFIG_ERROR)?.[1])
+          .toMatchInlineSnapshot(`
+          [Error: Cannot index \`.mdx\` file (\`./Introduction.mdx\`) in \`storyStoreV7: false\` mode.
+
+          The legacy story store does not support new-style \`.mdx\` files. If the file above
+          is not intended to be indexed (i.e. displayed as an entry in the sidebar), either
+          exclude it from your \`stories\` glob, or add <Meta isTemplate /> to it.
+
+          If you wanted to index the file, you'll need to name it \`stories.mdx\` and stick to the
+          legacy (6.x) MDX API, or use the new store.]
+        `);
       });
     });
   });

--- a/code/lib/preview-api/src/typings.d.ts
+++ b/code/lib/preview-api/src/typings.d.ts
@@ -10,6 +10,7 @@ declare module '@aw-web-design/x-default-browser';
 declare var FEATURES:
   | {
       storyStoreV7?: boolean;
+      storyStoreV7MdxErrors?: boolean;
       breakingChangesV7?: boolean;
       argTypeTargetsV7?: boolean;
       legacyMdx1?: boolean;

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -295,6 +295,12 @@ export interface StorybookConfig {
     storyStoreV7?: boolean;
 
     /**
+     * Do not throw errors if using `.mdx` files in SSv7
+     * (for internal use in sandboxes)
+     */
+    storyStoreV7MdxErrors?: boolean;
+
+    /**
      * Enable a set of planned breaking changes for SB7.0
      */
     breakingChangesV7?: boolean;


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Introduce a proper error that's thrown when you try and index a `.mdx` file in v6 (unsupported).

## How to test

Run a sandbox in v6 mode.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
