### PR TITLE
Core: Change warnings to throwing when hitting duplicates in the index

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -942,7 +942,7 @@ describe('StoryIndexGenerator', () => {
     });
 
     describe('duplicates', () => {
-      it('warns when two MDX entries reference the same CSF file without a name', async () => {
+      it('errors when two MDX entries reference the same CSF file without a name', async () => {
         const docsErrorSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
           './errors/**/A.mdx',
           options
@@ -954,25 +954,12 @@ describe('StoryIndexGenerator', () => {
         );
         await generator.initialize();
 
-        expect(Object.keys((await generator.getIndex()).entries)).toMatchInlineSnapshot(`
-          Array [
-            "a--story-one",
-            "componentreference--docs",
-            "a--metaof",
-            "notitle--docs",
-            "a--second-docs",
-            "docs2-yabbadabbadooo--docs",
-            "a--docs",
-          ]
-        `);
-
-        expect(logger.warn).toHaveBeenCalledTimes(1);
-        expect(jest.mocked(logger.warn).mock.calls[0][0]).toMatchInlineSnapshot(
-          `"🚨 You have two component docs pages with the same name A:docs. Use \`<Meta of={} name=\\"Other Name\\">\` to distinguish them."`
+        await expect(generator.getIndex()).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Unable to index ./errors/A.mdx,./errors/duplicate/A.mdx"`
         );
       });
 
-      it('warns when a MDX entry has the same name as a story', async () => {
+      it('errors when a MDX entry has the same name as a story', async () => {
         const docsErrorSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
           './errors/MetaOfClashingName.mdx',
           options
@@ -984,24 +971,12 @@ describe('StoryIndexGenerator', () => {
         );
         await generator.initialize();
 
-        expect(Object.keys((await generator.getIndex()).entries)).toMatchInlineSnapshot(`
-          Array [
-            "a--story-one",
-            "componentreference--docs",
-            "a--metaof",
-            "notitle--docs",
-            "a--second-docs",
-            "docs2-yabbadabbadooo--docs",
-          ]
-        `);
-
-        expect(logger.warn).toHaveBeenCalledTimes(1);
-        expect(jest.mocked(logger.warn).mock.calls[0][0]).toMatchInlineSnapshot(
-          `"🚨 You have a story for A with the same name as your component docs page (Story One), so the docs page is being dropped. Use \`<Meta of={} name=\\"Other Name\\">\` to distinguish them."`
+        await expect(generator.getIndex()).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Unable to index ./src/A.stories.js,./errors/MetaOfClashingName.mdx"`
         );
       });
 
-      it('warns when a story has the default docs name', async () => {
+      it('errors when a story has the default docs name', async () => {
         const docsErrorSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
           './errors/A.mdx',
           options
@@ -1016,23 +991,11 @@ describe('StoryIndexGenerator', () => {
         );
         await generator.initialize();
 
-        expect(Object.keys((await generator.getIndex()).entries)).toMatchInlineSnapshot(`
-          Array [
-            "a--story-one",
-            "componentreference--story-one",
-            "a--metaof",
-            "notitle--story-one",
-            "a--second-docs",
-            "docs2-yabbadabbadooo--story-one",
-          ]
-        `);
-
-        expect(logger.warn).toHaveBeenCalledTimes(1);
-        expect(jest.mocked(logger.warn).mock.calls[0][0]).toMatchInlineSnapshot(
-          `"🚨 You have a story for A with the same name as your default docs entry name (Story One), so the docs page is being dropped. Consider changing the story name."`
+        await expect(generator.getIndex()).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Unable to index ./src/A.stories.js,./errors/A.mdx"`
         );
       });
-      it('warns when two duplicate stories exists, with duplicated entries details', async () => {
+      it('errors when two duplicate stories exists, with duplicated entries details', async () => {
         const generator = new StoryIndexGenerator([storiesSpecifier, docsSpecifier], {
           ...options,
         });
@@ -1049,7 +1012,7 @@ describe('StoryIndexGenerator', () => {
         }).toThrowErrorMatchingInlineSnapshot(`"Duplicate stories with id: StoryId"`);
       });
 
-      it('DOES NOT warns when the same MDX file matches two specifiers', async () => {
+      it('DOES NOT error when the same MDX file matches two specifiers', async () => {
         const generator = new StoryIndexGenerator(
           [storiesSpecifier, docsSpecifier, docsSpecifier],
           options

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -418,19 +418,22 @@ export class StoryIndexGenerator {
         ? `component docs page`
         : `automatically generated docs page`;
       if (betterEntry.name === this.options.docs.defaultName) {
-        logger.warn(
-          `🚨 You have a story for ${betterEntry.title} with the same name as your default docs entry name (${betterEntry.name}), so the docs page is being dropped. Consider changing the story name.`
+        throw new IndexingError(
+          `You have a story for ${betterEntry.title} with the same name as your default docs entry name (${betterEntry.name}), so the docs page is being dropped. Consider changing the story name.`,
+          [firstEntry.importPath, secondEntry.importPath]
         );
       } else {
-        logger.warn(
-          `🚨 You have a story for ${betterEntry.title} with the same name as your ${worseDescriptor} (${worseEntry.name}), so the docs page is being dropped. ${changeDocsName}`
+        throw new IndexingError(
+          `You have a story for ${betterEntry.title} with the same name as your ${worseDescriptor} (${worseEntry.name}), so the docs page is being dropped. ${changeDocsName}`,
+          [firstEntry.importPath, secondEntry.importPath]
         );
       }
     } else if (isMdxEntry(betterEntry)) {
       // Both entries are MDX but pointing at the same place
       if (isMdxEntry(worseEntry)) {
-        logger.warn(
-          `🚨 You have two component docs pages with the same name ${betterEntry.title}:${betterEntry.name}. ${changeDocsName}`
+        throw new IndexingError(
+          `You have two component docs pages with the same name ${betterEntry.title}:${betterEntry.name}. ${changeDocsName}`,
+          [firstEntry.importPath, secondEntry.importPath]
         );
       }
 


### PR DESCRIPTION
Closes #21478

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Change warnings to errors in the index when you have duplicates.

## How to test

- See unit tests
- See repro on issue.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
