### PR TITLE
Telemetry: Replace isomorphic-unfetch with node-fetch in telemetry

### DIFF
--- a/code/lib/telemetry/package.json
+++ b/code/lib/telemetry/package.json
@@ -45,12 +45,13 @@
   "dependencies": {
     "@storybook/client-logger": "7.0.0-beta.64",
     "@storybook/core-common": "7.0.0-beta.64",
+    "@types/node-fetch": "^2.5.7",
     "chalk": "^4.1.0",
     "detect-package-manager": "^2.0.1",
     "fetch-retry": "^5.0.2",
     "fs-extra": "^11.1.0",
-    "isomorphic-unfetch": "^3.1.0",
     "nanoid": "^3.3.1",
+    "node-fetch": "^2.6.7",
     "read-pkg-up": "^7.0.1"
   },
   "devDependencies": {

--- a/code/lib/telemetry/src/telemetry.test.ts
+++ b/code/lib/telemetry/src/telemetry.test.ts
@@ -1,12 +1,12 @@
 /// <reference types="@types/jest" />;
 
-import fetch from 'isomorphic-unfetch';
+import fetch from 'node-fetch';
 
 import { sendTelemetry } from './telemetry';
 
-jest.mock('isomorphic-unfetch');
+jest.mock('node-fetch');
 
-const fetchMock = fetch as jest.Mock;
+const fetchMock = fetch as any as jest.Mock;
 
 beforeEach(() => {
   fetchMock.mockResolvedValue({ status: 200 });

--- a/code/lib/telemetry/src/telemetry.ts
+++ b/code/lib/telemetry/src/telemetry.ts
@@ -1,4 +1,4 @@
-import originalFetch from 'isomorphic-unfetch';
+import originalFetch from 'node-fetch';
 import retry from 'fetch-retry';
 import { nanoid } from 'nanoid';
 import type { Options, TelemetryData } from './types';
@@ -7,7 +7,7 @@ import { set as saveToCache } from './event-cache';
 
 const URL = process.env.STORYBOOK_TELEMETRY_URL || 'https://storybook.js.org/event-log';
 
-const fetch = retry(originalFetch);
+const fetch = retry(originalFetch as any);
 
 let tasks: Promise<any>[] = [];
 
@@ -55,7 +55,7 @@ export async function sendTelemetry(
     if (options.immediate) {
       await Promise.all(tasks);
     } else {
-      await request;
+      console.log(await request);
     }
 
     await saveToCache(eventType, body);

--- a/code/lib/telemetry/src/telemetry.ts
+++ b/code/lib/telemetry/src/telemetry.ts
@@ -55,7 +55,7 @@ export async function sendTelemetry(
     if (options.immediate) {
       await Promise.all(tasks);
     } else {
-      console.log(await request);
+      await request;
     }
 
     await saveToCache(eventType, body);

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7106,12 +7106,13 @@ __metadata:
   dependencies:
     "@storybook/client-logger": 7.0.0-beta.64
     "@storybook/core-common": 7.0.0-beta.64
+    "@types/node-fetch": ^2.5.7
     chalk: ^4.1.0
     detect-package-manager: ^2.0.1
     fetch-retry: ^5.0.2
     fs-extra: ^11.1.0
-    isomorphic-unfetch: ^3.1.0
     nanoid: ^3.3.1
+    node-fetch: ^2.6.7
     read-pkg-up: ^7.0.1
     typescript: ~4.9.3
   languageName: unknown


### PR DESCRIPTION
Closes #21432

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Switch `node-fetch` in for telemetry. 


## How to test

1. Run `yarn ts-node event-log-collector` from the scripts directory
2. Run a sandbox.
3. Check it works
4. Add `res.status(503)` to the `server.post('/event-log', ...`
5. Check it retries.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
