### PR TITLE
CLI: Require main.js without cache in automigrations

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/mdx-gfm.ts
+++ b/code/lib/cli/src/automigrate/fixes/mdx-gfm.ts
@@ -61,10 +61,12 @@ export const mdxgfm: Fix<Options> = {
 
   async run({ packageManager, dryRun, mainConfigPath, skipInstall }) {
     if (!dryRun) {
+      const packageJson = packageManager.retrievePackageJson();
       const versionToInstall = getStorybookVersionSpecifier(packageManager.retrievePackageJson());
-      await packageManager.addDependencies({ installAsDevDependencies: true, skipInstall }, [
-        `@storybook/addon-mdx-gfm@${versionToInstall}`,
-      ]);
+      await packageManager.addDependencies(
+        { installAsDevDependencies: true, skipInstall, packageJson },
+        [`@storybook/addon-mdx-gfm@${versionToInstall}`]
+      );
 
       await updateMainConfig({ mainConfigPath, dryRun }, async (main) => {
         const addonsToAdd = ['@storybook/addon-mdx-gfm'];

--- a/code/lib/cli/src/automigrate/helpers/mainConfigFile.ts
+++ b/code/lib/cli/src/automigrate/helpers/mainConfigFile.ts
@@ -30,7 +30,7 @@ export const getStorybookData = async ({
 
   let mainConfig: StorybookConfig;
   try {
-    mainConfig = await loadMainConfig({ configDir });
+    mainConfig = await loadMainConfig({ configDir, noCache: true });
   } catch (err) {
     throw new Error(
       dedent`Unable to find or evaluate ${chalk.blue(mainConfigPath)}: ${err.message}`

--- a/code/lib/core-common/src/utils/load-main-config.ts
+++ b/code/lib/core-common/src/utils/load-main-config.ts
@@ -5,10 +5,18 @@ import { validateConfigurationFiles } from './validate-configuration-files';
 
 export async function loadMainConfig({
   configDir = '.storybook',
+  noCache = false,
 }: {
   configDir: string;
+  noCache?: boolean;
 }): Promise<StorybookConfig> {
   await validateConfigurationFiles(configDir);
 
-  return serverRequire(path.resolve(configDir, 'main'));
+  const mainJsPath = path.resolve(configDir, 'main');
+
+  if (noCache && require.cache[require.resolve(mainJsPath)]) {
+    delete require.cache[require.resolve(mainJsPath)];
+  }
+
+  return serverRequire(mainJsPath);
 }


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Automigrations were failing sometimes because when the first automigration required main.js, it was put into cache, and the subsequent automigration would require a cached version of main.js, without the changes from previous automigrations, leading to errors like:

```
missing-babelrc:
Cannot read properties of undefined (reading 'name')
```

## How to test

1. Bootstrap the libs
2. Go to [a SB 6 project](https://github.com/storybookjs/design-system)
3. Try to automigrate it
4. It should be successful. Before, it'd error with the message from above


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
