### PR TITLE
Update babelParse to use legacy decorator syntax

### DIFF
--- a/code/lib/csf-tools/src/CsfFile.test.ts
+++ b/code/lib/csf-tools/src/CsfFile.test.ts
@@ -507,6 +507,33 @@ describe('CsfFile', () => {
               __id: foo-bar--a
       `);
     });
+
+    it('support for parameter decorators', () => {
+      expect(
+        parse(dedent`
+        import { Component, Input, Output, EventEmitter, Inject, HostBinding } from '@angular/core';
+        import { CHIP_COLOR } from './chip-color.token';
+
+        @Component({
+          selector: 'storybook-chip',
+        })
+        export class ChipComponent {
+          // The error occurs on the Inject decorator used on a parameter
+          constructor(@Inject(CHIP_COLOR) chipColor: string) {
+            this.backgroundColor = chipColor;
+          }
+        }
+
+        export default {
+          title: 'Chip',
+        }
+      `)
+      ).toMatchInlineSnapshot(`
+      meta:
+        title: Chip
+      stories: []
+      `);
+    });
   });
 
   describe('error handling', () => {

--- a/code/lib/csf-tools/src/babelParse.ts
+++ b/code/lib/csf-tools/src/babelParse.ts
@@ -5,12 +5,7 @@ import type { ParserOptions } from '@babel/parser';
 export const parserOptions: ParserOptions = {
   sourceType: 'module',
   // FIXME: we should get this from the project config somehow?
-  plugins: [
-    'jsx',
-    'typescript',
-    ['decorators', { decoratorsBeforeExport: true }],
-    'classProperties',
-  ],
+  plugins: ['jsx', 'typescript', 'decorators-legacy', 'classProperties'],
   tokens: true,
 };
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21243

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Set up 'legacy-decorator' syntax for babelParser, because it is the only available plugin that supports property decorators (at least, which does not throw an error), which are heavily used in Angular.

As noted [here](https://babel.dev/docs/babel-parser#will-the-babel-parser-support-a-plugin-system), `@babel/parser` does not support registering other plugins only the ones which are integrated into the core of `@babel/parser`.

The `legacy-decorator` plugin uses the original `Stage 1` [proposal](https://github.com/wycats/javascript-decorators/blob/e1bf8d41bfa2591d949dd3bbf013514c8904b913/README.md). Whereas e.g. Typescript uses the `Stage 2` proposal (in Typescript 5.0, even the Stage 3.0 proposal).

It seems that in [Babel 8](https://github.com/babel/babel/issues/10746), the `@babel/plugin-proposal-decorators` get merged into `@babel/parser`, which will very like support `parameter decorators` with the newest decorator Stage 3.0 proposal:

> Add mandatory version option to the decorators plugins, and merge the two plugins in @babel/parser.

## Differences between the proposals

It is essential to know in which particular areas the proposals differ from each other and whether there are any differences by applying decorators by ignoring the internal implementations of decorators, because for AST parsing this is not relevant.

### Differences between Stage 2 / 3 proposal:

- STAGE 3: ES Decorators can decorate private fields
- STAGE 3: ES Decorators can decorate class expressions

### Differences between Stage 1 / 2 proposal:

- Only further restrictions syntax-wise. Stage 1 was richer in syntax, and Stage 2 abandoned some of it.

### Differences between Typescript "experimental" decorators / Stage 2 decorators:

- The Stage 2 proposal does not include parameter decorators

## Impact evaluation:

Opting out for an older decorator proposal might introduce unforeseeable bugs. The babel parser might not be able to parse newer decorator proposal syntax and will likely throw an error.

## Optional: Allow the user to overwrite the basic parsing settings

`postcss-lit` has [implemented](https://github.com/43081j/postcss-lit/pull/45) the possibility to overwrite the default options, passed to the babel parser. Should we do this as well?!

## Alternative: Gently recover from "soft" errors.

We can pass the [option](https://babeljs.io/docs/babel-parser#options) `errorRecovery: true` to the `@babel/parser` to continue parsing the code, if babel can recover from the error state. Then we don't have to opt-out to the old `decorators` proposal and we can still parse the AST without babel throwing a non-recoverable error.

## Mentionable resources

- https://github.com/tc39/proposal-decorators/issues/47 
- Projects/Frameworks, which rely on property decorators: https://docs.google.com/spreadsheets/d/1Yp9vNHJzgo7GyjPntCA8NleM7kbVEilxZttWMF7ZyWE/edit#gid=0

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
