### PR TITLE
Outline: Fixed a typo

### DIFF
--- a/code/addons/outline/src/OutlineSelector.tsx
+++ b/code/addons/outline/src/OutlineSelector.tsx
@@ -19,7 +19,7 @@ export const OutlineSelector = memo(function OutlineSelector() {
 
   useEffect(() => {
     api.setAddonShortcut(ADDON_ID, {
-      label: 'Toggle Measure [O]',
+      label: 'Toggle Outline [O]',
       defaultShortcut: ['O'],
       actionName: 'outline',
       showInMenu: false,


### PR DESCRIPTION
Closes #21321



## What I did

Fixed a typographical error where `Toggle Outline [O]` was written as `Toggle Measure [O]`



## Checklist


- [ ✅] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

