### PR TITLE
Build: add slash to fix windows test

### DIFF
--- a/code/lib/core-common/src/utils/__tests__/paths.test.ts
+++ b/code/lib/core-common/src/utils/__tests__/paths.test.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import findUp from 'find-up';
+import slash from 'slash';
 import { normalizeStoryPath, getProjectRoot } from '../paths';
 
 jest.mock('find-up');
@@ -49,7 +50,7 @@ describe('getProjectRoot', () => {
       name === ('.git' as any) ? '/path/to/root' : undefined
     );
 
-    expect(getProjectRoot()).toBe('/path/to');
+    expect(slash(getProjectRoot())).toBe('/path/to');
   });
 
   it('should return the root directory containing a .svn directory if there is no .git directory', () => {
@@ -57,7 +58,7 @@ describe('getProjectRoot', () => {
       name === ('.svn' as any) ? '/path/to/root' : undefined
     );
 
-    expect(getProjectRoot()).toBe('/path/to');
+    expect(slash(getProjectRoot())).toBe('/path/to');
   });
 
   it('should return the root directory containing a .yarn directory if there is no .git or .svn directory', () => {
@@ -65,6 +66,6 @@ describe('getProjectRoot', () => {
       name === ('.yarn' as any) ? '/path/to/root' : undefined
     );
 
-    expect(getProjectRoot()).toBe('/path/to');
+    expect(slash(getProjectRoot())).toBe('/path/to');
   });
 });


### PR DESCRIPTION
This fixes the unit test on windows: 
https://github.com/storybookjs/storybook/actions/runs/4375061805/jobs/7655282195
https://github.com/storybookjs/storybook/actions/runs/4373557011/jobs/7651878656