### PR TITLE
Fix 'yarn build' command on windows systems

### DIFF
--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /* eslint-disable global-require */
-const { resolve, join } = require('path');
+const { resolve, join, posix, sep } = require('path');
 const { readJSON } = require('fs-extra');
 
 const getStorybookPackages = async () => {
@@ -119,11 +119,15 @@ async function run() {
   }
 
   selection?.filter(Boolean).forEach(async (v) => {
-    const commmand = (await readJSON(resolve(v.location, 'package.json'))).scripts.prep;
+    const commmand = (await readJSON(resolve(v.location, 'package.json'))).scripts.prep
+      .split(posix.sep)
+      .join(sep);
+
     const cwd = resolve(__dirname, '..', 'code', v.location);
     const { execaCommand } = await import('execa');
+    const tsNode = require.resolve('ts-node/dist/bin');
     const sub = execaCommand(
-      `${commmand}${watchMode ? ' --watch' : ''}${prodMode ? ' --optimized' : ''}`,
+      `node ${tsNode} ${commmand}${watchMode ? ' --watch' : ''}${prodMode ? ' --optimized' : ''}`,
       {
         cwd,
         buffer: false,


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I fixed the `yarn build` command on Windows machines.

<!-- Briefly describe what your PR does -->

## How to test


1. Run `yarn build` on a Windows machine. It should not break anymore.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
