### PR TITLE
Viewport: Remove transitions when switching viewports

### DIFF
--- a/code/addons/viewport/src/Tool.tsx
+++ b/code/addons/viewport/src/Tool.tsx
@@ -209,7 +209,7 @@ export const ViewportTool: FC = memo(
               styles={{
                 [`iframe[data-is-storybook="true"]`]: {
                   margin: `auto`,
-                  transition: 'width .3s, height .3s',
+                  transition: 'none',
                   position: 'relative',
                   border: `1px solid black`,
                   boxShadow: '0 0 100px 100vw rgba(0,0,0,0.5)',


### PR DESCRIPTION
As discussed in https://discord.com/channels/486522875931656193/489892645087215636/1075748069016084580 & https://discord.com/channels/486522875931656193/1075807552027230308

This PR removes the `width` & `height` transitions when switching between viewports.
