### PR TITLE
CLI: Don't inline template functions in CSF2 to 3 codemod

### DIFF
--- a/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
@@ -136,10 +136,56 @@ describe('csf-2-to-3', () => {
         `)
       ).toMatchInlineSnapshot(`
         export default { title: 'Cat' };
+        const Template = (args) => <Cat {...args} />;
 
         export const A = {
-          render: (args) => <Cat {...args} />,
+          render: Template,
           args: { isPrimary: false },
+        };
+      `);
+    });
+
+    it('should reuse the template when there are multiple Template.bind references but no component defined', () => {
+      expect(
+        jsTransform(dedent`
+          export default { title: 'Cat' };
+          const Template = (args) => <Cat {...args} />;
+
+          export const A = Template.bind({});
+          A.args = { isPrimary: false };
+          
+          export const B = Template.bind({});
+          B.args = { isPrimary: true };
+          
+                    
+          export const C = Template.bind({});
+          C.args = { bla: true };
+          
+          export const D = Template.bind({});
+          D.args = { bla: false };
+        `)
+      ).toMatchInlineSnapshot(`
+        export default { title: 'Cat' };
+        const Template = (args) => <Cat {...args} />;
+
+        export const A = {
+          render: Template,
+          args: { isPrimary: false },
+        };
+
+        export const B = {
+          render: Template,
+          args: { isPrimary: true },
+        };
+
+        export const C = {
+          render: Template,
+          args: { bla: true },
+        };
+
+        export const D = {
+          render: Template,
+          args: { bla: false },
         };
       `);
     });
@@ -162,12 +208,16 @@ describe('csf-2-to-3', () => {
       ).toMatchInlineSnapshot(`
         export default { title: 'Cat', component: Cat };
 
+        const Template = (args) => <Cat {...args} />;
+
         export const A = {
           args: { isPrimary: false },
         };
 
+        const Template2 = (args) => <Banana {...args} />;
+
         export const B = {
-          render: (args) => <Banana {...args} />,
+          render: Template2,
           args: { isPrimary: true },
         };
       `);

--- a/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
@@ -407,5 +407,55 @@ describe('csf-2-to-3', () => {
         };
       `);
     });
+
+    it('should keep Story type when used', () => {
+      expect(
+        tsTransform(dedent`
+          import { Story, Meta } from '@storybook/react'
+          
+          export default {
+            component: Cat,
+          } satisfies Meta
+          
+          const Template: Story = () => <div>Hello World</div>;
+          
+          export const Default = Template.bind({})
+        `)
+      ).toMatchInlineSnapshot(`
+        import { Story, Meta } from '@storybook/react';
+
+        export default {
+          component: Cat,
+        } satisfies Meta;
+
+        const Template: Story = () => <div>Hello World</div>;
+
+        export const Default = {
+          render: Template,
+        };
+      `);
+    });
+
+    it('should update types correctly', () => {
+      expect(
+        tsTransform(dedent`
+          import { ComponentStory, ComponentMeta } from '@storybook/react'
+
+          export default {
+            component: Cat,
+          } as ComponentMeta<typeof Cat>
+
+          export const Default: ComponentStory<typeof Cat> = (args) => <Cat {...args} />
+        `)
+      ).toMatchInlineSnapshot(`
+        import { StoryObj, Meta } from '@storybook/react';
+
+        export default {
+          component: Cat,
+        } as Meta<typeof Cat>;
+
+        export const Default: StoryObj<typeof Cat> = {};
+      `);
+    });
   });
 });

--- a/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
@@ -408,7 +408,7 @@ describe('csf-2-to-3', () => {
       `);
     });
 
-    it('should keep Story type when used', () => {
+    it('migrate Story type to StoryFn when used in an not exported Template function', () => {
       expect(
         tsTransform(dedent`
           import { Story, Meta } from '@storybook/react'

--- a/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
@@ -422,39 +422,17 @@ describe('csf-2-to-3', () => {
           export const Default = Template.bind({})
         `)
       ).toMatchInlineSnapshot(`
-        import { Story, Meta } from '@storybook/react';
+        import { StoryFn, Meta } from '@storybook/react';
 
         export default {
           component: Cat,
         } satisfies Meta;
 
-        const Template: Story = () => <div>Hello World</div>;
+        const Template: StoryFn = () => <div>Hello World</div>;
 
         export const Default = {
           render: Template,
         };
-      `);
-    });
-
-    it('should update types correctly', () => {
-      expect(
-        tsTransform(dedent`
-          import { ComponentStory, ComponentMeta } from '@storybook/react'
-
-          export default {
-            component: Cat,
-          } as ComponentMeta<typeof Cat>
-
-          export const Default: ComponentStory<typeof Cat> = (args) => <Cat {...args} />
-        `)
-      ).toMatchInlineSnapshot(`
-        import { StoryObj, Meta } from '@storybook/react';
-
-        export default {
-          component: Cat,
-        } as Meta<typeof Cat>;
-
-        export const Default: StoryObj<typeof Cat> = {};
       `);
     });
   });

--- a/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
@@ -208,8 +208,6 @@ describe('csf-2-to-3', () => {
       ).toMatchInlineSnapshot(`
         export default { title: 'Cat', component: Cat };
 
-        const Template = (args) => <Cat {...args} />;
-
         export const A = {
           args: { isPrimary: false },
         };

--- a/code/lib/codemod/src/transforms/csf-2-to-3.ts
+++ b/code/lib/codemod/src/transforms/csf-2-to-3.ts
@@ -179,8 +179,6 @@ export default function transform(info: FileInfo, api: API, options: { parser?: 
     }
   });
 
-  importHelper.removeDeprecatedStoryImport();
-
   csf._ast.program.body = csf._ast.program.body.reduce((acc, stmt) => {
     const statement = stmt as t.Statement;
     // remove story annotations & template declarations
@@ -201,6 +199,7 @@ export default function transform(info: FileInfo, api: API, options: { parser?: 
   }, []);
 
   upgradeDeprecatedTypes(file);
+  importHelper.removeDeprecatedStoryImport();
   removeUnusedTemplates(csf);
 
   let output = recast.print(csf._ast, {}).code;


### PR DESCRIPTION
Closes #21460

## What I did

* Made sure to not inline template functions in CSF2 to 3 codemod

The problem is that those template functions can be rather big. Also, someone might reference the Template function in other ways than Template.bind which can lead to runtime failures

## How to test

* See the added unit test

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`


