### PR TITLE
Vite: Fix react-vite and projects with absolute path preview entries on Windows

### DIFF
--- a/code/lib/builder-vite/src/utils/process-preview-annotation.ts
+++ b/code/lib/builder-vite/src/utils/process-preview-annotation.ts
@@ -1,7 +1,7 @@
 import type { PreviewAnnotation } from '@storybook/types';
 import { resolve, isAbsolute, relative } from 'path';
 import slash from 'slash';
-import { transformAbsPath } from './transform-abs-path';
+import { stripAbsNodeModulesPath } from '@storybook/core-common';
 
 /**
  * Preview annotations can take several forms, and vite needs them to be
@@ -29,8 +29,9 @@ export function processPreviewAnnotation(path: PreviewAnnotation | undefined, pr
 
   // For addon dependencies that use require.resolve(), we need to convert to a bare path
   // so that vite will process it as a dependency (cjs -> esm, etc).
+  // TODO: Evaluate if searching for node_modules in a yarn pnp environment is correct
   if (path.includes('node_modules')) {
-    return transformAbsPath(path);
+    return stripAbsNodeModulesPath(path);
   }
 
   // resolve absolute paths relative to project root

--- a/code/lib/core-common/src/index.ts
+++ b/code/lib/core-common/src/index.ts
@@ -31,5 +31,6 @@ export * from './utils/template';
 export * from './utils/validate-config';
 export * from './utils/validate-configuration-files';
 export * from './utils/satisfies';
+export * from './utils/strip-abs-node-modules-path';
 
 export { createFileSystemCache } from './utils/file-cache';

--- a/code/lib/core-common/src/presets.ts
+++ b/code/lib/core-common/src/presets.ts
@@ -14,6 +14,7 @@ import { join, parse } from 'path';
 import { loadCustomPresets } from './utils/load-custom-presets';
 import { safeResolve, safeResolveFrom } from './utils/safeResolve';
 import { interopRequireDefault } from './utils/interpret-require';
+import { stripAbsNodeModulesPath } from './utils/strip-abs-node-modules-path';
 
 const isObject = (val: unknown): val is Record<string, any> =>
   val != null && typeof val === 'object' && Array.isArray(val) === false;
@@ -149,7 +150,13 @@ export const resolveAddonName = (
         ? {
             previewAnnotations: [
               previewFileAbsolute
-                ? { bare: previewFile, absolute: previewFileAbsolute }
+                ? {
+                    // TODO: Evaluate if searching for node_modules in a yarn pnp environment is correct
+                    bare: previewFile.includes('node_modules')
+                      ? stripAbsNodeModulesPath(previewFile)
+                      : previewFile,
+                    absolute: previewFileAbsolute,
+                  }
                 : previewFile,
             ],
           }

--- a/code/lib/core-common/src/utils/strip-abs-node-modules-path.ts
+++ b/code/lib/core-common/src/utils/strip-abs-node-modules-path.ts
@@ -1,9 +1,14 @@
 import path from 'path';
-import { normalizePath } from 'vite';
+import slash from 'slash';
+
+function normalizePath(id: string) {
+  return path.posix.normalize(slash(id));
+}
 
 // We need to convert from an absolute path, to a traditional node module import path,
 // so that vite can correctly pre-bundle/optimize
-export function transformAbsPath(absPath: string) {
+export function stripAbsNodeModulesPath(absPath: string) {
+  // TODO: Evaluate if searching for node_modules in a yarn pnp environment is correct
   const splits = absPath.split(`node_modules${path.sep}`);
   // Return everything after the final "node_modules/"
   const module = normalizePath(splits[splits.length - 1]);


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fix vite-react-sandbox development on Windows machines

## How to test

1. Run a vite-react sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts` on a Windows machine. Storybook should start up properly.


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
