### PR TITLE
CLI: Fix MDX codemod to update imports even when no stories are extracted

### DIFF
--- a/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
@@ -15,22 +15,39 @@ beforeEach(() => {
   fs.existsSync.mockImplementation(() => false);
 });
 
-test('drop invalid story nodes', () => {
+test('update import even when no stories can be extracted', () => {
   const input = dedent`
-      import { Meta } from '@storybook/addon-docs';
+      import { Heading } from '@storybook/addon-docs';
 
-      <Meta title="Foobar" />
-      
-      <Story>No name!</Story>  
-      
-      <Story name="Primary">Story</Story>
-     
+      <Heading />     
     `;
 
   const mdx = jscodeshift({ source: input, path: 'Foobar.stories.mdx' });
 
   expect(mdx).toMatchInlineSnapshot(`
-    import { Meta } from '@storybook/addon-docs';
+    import { Heading } from '@storybook/blocks';
+
+    <Heading />
+
+  `);
+});
+
+test('drop invalid story nodes', () => {
+  const input = dedent`
+      import { Meta, Story } from '@storybook/addon-docs';
+
+      <Meta title="Foobar" />
+      
+      <Story>No name!</Story>  
+      
+      <Story name="Primary">Story</Story>     
+    `;
+
+  const mdx = jscodeshift({ source: input, path: 'Foobar.stories.mdx' });
+
+  expect(mdx).toMatchInlineSnapshot(`
+    import { Meta, Story } from '@storybook/blocks';
+    import * as FoobarStories from './Foobar.stories';
 
     <Meta of={FoobarStories} />
 


### PR DESCRIPTION
Closes #21542


## What I did

* Make sure MDX codemod always update imports even when no stories are extracted

## How to test

See updated unit tests

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
