### PR TITLE
feat: allow vue files in importfn

### DIFF
--- a/code/lib/builder-vite/src/codegen-importfn-script.ts
+++ b/code/lib/builder-vite/src/codegen-importfn-script.ts
@@ -29,7 +29,7 @@ async function toImportFn(stories: string[]) {
   const objectEntries = stories.map((file) => {
     const ext = path.extname(file);
     const relativePath = normalizePath(path.relative(process.cwd(), file));
-    if (!['.js', '.jsx', '.ts', '.tsx', '.mdx', '.svelte'].includes(ext)) {
+    if (!['.js', '.jsx', '.ts', '.tsx', '.mdx', '.svelte', '.vue'].includes(ext)) {
       logger.warn(`Cannot process ${ext} file with storyStoreV7: ${relativePath}`);
     }
 


### PR DESCRIPTION
## What I did

If one uses https://github.com/tobiasdiez/storybook-vue-addon/ (which enables stories in native vue format), then one get warnings of the form
```
Cannot process .vue file with storyStoreV7: src/components/Button.stories.vue
```

This is fixed by allowing vue files.
<!-- Briefly describe what your PR does -->

## How to test

I've noticed this issue in the context of  https://github.com/tobiasdiez/storybook-vue-addon/pull/38 (run `pnpm example:vite`)

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
