### PR TITLE
docs(makeDecorator): fix the file path in example code snippet

### DIFF
--- a/docs/snippets/common/storybook-addons-api-makedecorator.js.mdx
+++ b/docs/snippets/common/storybook-addons-api-makedecorator.js.mdx
@@ -1,5 +1,5 @@
 ```js
-// .storybook/my-addon/register.js
+// .storybook/my-addon/decorators/withSomething.js
 
 import { makeDecorator } from '@storybook/addons';
 


### PR DESCRIPTION
<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Documentation fix: this PR fixes the file path noted in the `makeDecorator` code snippet.

**My understanding is:** The decorator should not be defined in `manager.js` (the file path currently mentioned in the example code snippet). Instead, it should be its own module that gets imported by `preview.js` or a story file (depending on which level you want to apply the decorator).


If this fix is correct, it would be great if we could ship it to the main branch (for the current stable 6.5 docs) as well as the `next` branch. Thanks!
