### PR TITLE
Docs: Update MDX `Link` component to be more user friendly

### DIFF
--- a/code/ui/blocks/src/blocks/mdx.tsx
+++ b/code/ui/blocks/src/blocks/mdx.tsx
@@ -1,4 +1,4 @@
-import type { FC, SyntheticEvent } from 'react';
+import type { FC, MouseEvent, SyntheticEvent } from 'react';
 import React, { useContext } from 'react';
 import { NAVIGATE_URL } from '@storybook/core-events';
 import { Code, components, Icons, nameSpaceClassNames } from '@storybook/components';
@@ -101,11 +101,22 @@ export const AnchorMdx: FC<AnchorMdxProps> = (props) => {
       return (
         <A
           href={href}
-          onClick={(event: SyntheticEvent) => {
-            event.preventDefault();
-            // use the A element's href, which has been modified for
-            // local paths without a `?path=` query param prefix
-            navigate(context, event.currentTarget.getAttribute('href'));
+          onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+            // Cmd/Ctrl/Shift/Alt + Click should trigger default browser behaviour. Same applies to non-left clicks
+            const LEFT_BUTTON = 0;
+            const isLeftClick =
+              event.button === LEFT_BUTTON &&
+              !event.altKey &&
+              !event.ctrlKey &&
+              !event.metaKey &&
+              !event.shiftKey;
+
+            if (isLeftClick) {
+              event.preventDefault();
+              // use the A element's href, which has been modified for
+              // local paths without a `?path=` query param prefix
+              navigate(context, event.currentTarget.getAttribute('href'));
+            }
           }}
           target={target}
           {...rest}

--- a/code/ui/components/src/typography/elements/Link.tsx
+++ b/code/ui/components/src/typography/elements/Link.tsx
@@ -8,7 +8,7 @@ export const Link: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
 }) => {
   const isStorybookPath = /^\//.test(input);
   const isAnchorUrl = /^#.*/.test(input);
-  const href = isStorybookPath ? `?path=${input}` : input;
+  const href = isStorybookPath ? `./?path=${input}` : input;
   const target = isAnchorUrl ? '_self' : '_top';
 
   return (


### PR DESCRIPTION
Closes #9502

Note this only affects code like `[text](/story/example-button--docs)`. We cannot influence the behaviour of literal `a` elements in MDX2 (`<a href="./?path=/story/example-button--docs">html anchor link</a>`). Probably the best thing to do is to use a leading `./` for those also, but they will figure a full reload. Probably better to use `[]()` or import our `AnchorMdx` component.

## What I did

1. Update `AnchorMdx` to not intercept right and cmd-clicks, similar to the `LinkTo` component (https://github.com/storybookjs/storybook/pull/21569)

2. Change the generated URL to have a leading `./?path=`. This makes more sense:
 - If the component is used from `https://host/path/to/iframe.html`, this will result in `https:host/path/to/?path=..`. There's no sense in appending `?path=` to an `iframe.html` URL.
 - If the component is used from `https://host/path/to/` (i.e the manager -- is it ever?) this will have the same result.

The only way that could go wrong is if the manager isn't served from the root/`index.html` of a path. I would guess that would likely be a problem anyway.

## How to test

Add to a MDX file in a sandbox:

```mdx
[mdx anchor link](/story/example-button--docs)
```

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
4. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
