### PR TITLE
React: Fix type inconsistencies in composeStories

### DIFF
--- a/code/lib/preview-api/src/modules/store/csf/testing-utils/index.ts
+++ b/code/lib/preview-api/src/modules/store/csf/testing-utils/index.ts
@@ -10,6 +10,7 @@ import type {
   Store_CSFExports,
   StoryContext,
   Parameters,
+  PreparedStoryFn,
 } from '@storybook/types';
 
 import { HooksContext } from '../../../addons';
@@ -35,7 +36,7 @@ export function composeStory<TRenderer extends Renderer = Renderer, TArgs extend
   projectAnnotations: ProjectAnnotations<TRenderer> = GLOBAL_STORYBOOK_PROJECT_ANNOTATIONS,
   defaultConfig: ProjectAnnotations<TRenderer> = {},
   exportsName?: string
-) {
+): PreparedStoryFn<TRenderer, Partial<TArgs>> {
   if (storyAnnotations === undefined) {
     throw new Error('Expected a story but received undefined.');
   }
@@ -84,8 +85,8 @@ export function composeStory<TRenderer extends Renderer = Renderer, TArgs extend
   };
 
   composedStory.storyName = storyName;
-  composedStory.args = story.initialArgs;
-  composedStory.play = story.playFunction as ComposedStoryPlayFn;
+  composedStory.args = story.initialArgs as Partial<TArgs>;
+  composedStory.play = story.playFunction as ComposedStoryPlayFn<TRenderer, Partial<TArgs>>;
   composedStory.parameters = story.parameters as Parameters;
 
   return composedStory;

--- a/code/lib/types/src/modules/composedStory.ts
+++ b/code/lib/types/src/modules/composedStory.ts
@@ -22,14 +22,18 @@ export type Store_CSFExports<TRenderer extends Renderer = Renderer, TArgs extend
   __namedExportsOrder?: string[];
 };
 
-export type ComposedStoryPlayContext = Partial<StoryContext> & Pick<StoryContext, 'canvasElement'>;
+export type ComposedStoryPlayContext<TRenderer extends Renderer = Renderer, TArgs = Args> = Partial<
+  StoryContext<TRenderer, TArgs> & Pick<StoryContext<TRenderer, TArgs>, 'canvasElement'>
+>;
 
-export type ComposedStoryPlayFn = (context: ComposedStoryPlayContext) => Promise<void> | void;
+export type ComposedStoryPlayFn<TRenderer extends Renderer = Renderer, TArgs = Args> = (
+  context: ComposedStoryPlayContext<TRenderer, TArgs>
+) => Promise<void> | void;
 
 export type PreparedStoryFn<TRenderer extends Renderer = Renderer, TArgs = Args> = AnnotatedStoryFn<
   TRenderer,
   TArgs
-> & { play: ComposedStoryPlayFn };
+> & { play: ComposedStoryPlayFn<TRenderer, TArgs>; args: TArgs };
 
 export type ComposedStory<TRenderer extends Renderer = Renderer, TArgs = Args> =
   | StoryFn<TRenderer, TArgs>
@@ -45,7 +49,7 @@ export type StoriesWithPartialProps<TRenderer extends Renderer, TModule> = {
   // @TODO once we can use Typescript 4.0 do this to exclude nonStory exports:
   // replace [K in keyof TModule] with [K in keyof TModule as TModule[K] extends ComposedStory<any> ? K : never]
   [K in keyof TModule]: TModule[K] extends ComposedStory<infer _, infer TProps>
-    ? AnnotatedStoryFn<TRenderer, Partial<TProps>>
+    ? PreparedStoryFn<TRenderer, Partial<TProps>>
     : unknown;
 };
 
@@ -59,7 +63,7 @@ export interface ComposeStoryFn<TRenderer extends Renderer = Renderer, TArgs ext
     (extraArgs: Partial<TArgs>): TRenderer['storyResult'];
     storyName: string;
     args: Args;
-    play: ComposedStoryPlayFn;
+    play: ComposedStoryPlayFn<TRenderer, TArgs>;
     parameters: Parameters;
   };
 }

--- a/code/renderers/react/src/__test__/Button.stories.tsx
+++ b/code/renderers/react/src/__test__/Button.stories.tsx
@@ -12,7 +12,7 @@ export default {
     backgroundColor: { control: 'color' },
     label: { defaultValue: 'Button' },
   },
-} as Meta;
+} as Meta<typeof Button>;
 
 const Template: CSF2Story<ButtonProps> = (args) => <Button {...args} />;
 

--- a/code/renderers/react/src/__test__/Button.stories.tsx
+++ b/code/renderers/react/src/__test__/Button.stories.tsx
@@ -5,14 +5,15 @@ import type { StoryFn as CSF2Story, StoryObj as CSF3Story, Meta } from '..';
 import type { ButtonProps } from './Button';
 import { Button } from './Button';
 
-export default {
+const meta = {
   title: 'Example/Button',
   component: Button,
   argTypes: {
     backgroundColor: { control: 'color' },
-    label: { defaultValue: 'Button' },
   },
-} as Meta<typeof Button>;
+} satisfies Meta<typeof Button>;
+
+export default meta;
 
 const Template: CSF2Story<ButtonProps> = (args) => <Button {...args} />;
 

--- a/code/renderers/react/src/__test__/composeStories.test.tsx
+++ b/code/renderers/react/src/__test__/composeStories.test.tsx
@@ -2,8 +2,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
+import type { Meta } from '@storybook/react';
+import { expectTypeOf } from 'expect-type';
 import { setProjectAnnotations, composeStories, composeStory } from '..';
 
+import type { Button } from './Button';
 import * as stories from './Button.stories';
 
 setProjectAnnotations([]);
@@ -22,7 +25,6 @@ test('renders primary button', () => {
 
 test('reuses args from composed story', () => {
   render(<Secondary />);
-
   const buttonElement = screen.getByRole('button');
   expect(buttonElement.textContent).toEqual(Secondary.args.children);
 });
@@ -84,5 +86,21 @@ describe('CSF3', () => {
 
     const input = screen.getByTestId('input') as HTMLInputElement;
     expect(input.value).toEqual('Hello world!');
+  });
+});
+
+describe('ComposeStories types', () => {
+  test('Should support typescript operators', () => {
+    type ComposeStoriesParam = Parameters<typeof composeStories>[0];
+
+    expectTypeOf({
+      ...stories,
+      default: stories.default as Meta<typeof Button>,
+    }).toMatchTypeOf<ComposeStoriesParam>();
+
+    expectTypeOf({
+      ...stories,
+      default: stories.default satisfies Meta<typeof Button>,
+    }).toMatchTypeOf<ComposeStoriesParam>();
   });
 });

--- a/code/renderers/react/src/testing-api.ts
+++ b/code/renderers/react/src/testing-api.ts
@@ -120,7 +120,7 @@ export function composeStory<TArgs extends Args = Args>(
  * @param csfExports - e.g. (import * as stories from './Button.stories')
  * @param [projectAnnotations] - e.g. (import * as projectAnnotations from '../.storybook/preview') this can be applied automatically if you use `setProjectAnnotations` in your setup files.
  */
-export function composeStories<TModule extends Store_CSFExports<ReactRenderer>>(
+export function composeStories<TModule extends Store_CSFExports<ReactRenderer, any>>(
   csfExports: TModule,
   projectAnnotations?: ProjectAnnotations<ReactRenderer>
 ) {


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I have updated the signature for `composeStories` not to conflict anymore, if the user uses `Meta<typeof Component> on the default export of a stories file.

Additionally, the types of the play function coming from a composed story got updated, so they're accounting for the Renderer and Args, as they were not before.

Related:
- https://discord.com/channels/486522875931656193/1083804434590617670
- https://discord.com/channels/486522875931656193/1083439468658299011/1083439468658299011

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
