### PR TITLE
CLI: Fix loading main.cjs files in automigration

### DIFF
--- a/code/lib/core-common/src/utils/load-main-config.ts
+++ b/code/lib/core-common/src/utils/load-main-config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import type { StorybookConfig } from '@storybook/types';
-import { serverRequire } from './interpret-require';
+import { serverRequire, serverResolve } from './interpret-require';
 import { validateConfigurationFiles } from './validate-configuration-files';
 
 export async function loadMainConfig({
@@ -12,10 +12,10 @@ export async function loadMainConfig({
 }): Promise<StorybookConfig> {
   await validateConfigurationFiles(configDir);
 
-  const mainJsPath = path.resolve(configDir, 'main');
+  const mainJsPath = serverResolve(path.resolve(configDir, 'main')) as string;
 
-  if (noCache && require.cache[require.resolve(mainJsPath)]) {
-    delete require.cache[require.resolve(mainJsPath)];
+  if (noCache && mainJsPath && require.cache[mainJsPath]) {
+    delete require.cache[mainJsPath];
   }
 
   return serverRequire(mainJsPath);


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

There was an issue with using `require.resolve` in a file that contained `.cjs`extension, not allowing users to migrate their Storybooks

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
