### PR TITLE
Core: Fix conflicting staticDirs case when -s flag is used

### DIFF
--- a/code/lib/core-server/src/build-static.ts
+++ b/code/lib/core-server/src/build-static.ts
@@ -23,6 +23,7 @@ import {
   resolveAddonName,
 } from '@storybook/core-common';
 
+import isEqual from 'lodash/isEqual.js';
 import { outputStats } from './utils/output-stats';
 import {
   copyAllStaticFiles,
@@ -33,6 +34,7 @@ import { extractStoriesJson, convertToIndexV3 } from './utils/stories-json';
 import { extractStorybookMetadata } from './utils/metadata';
 import { StoryIndexGenerator } from './utils/StoryIndexGenerator';
 import { summarizeIndex } from './utils/summarizeIndex';
+import { defaultStaticDirs } from './utils/constants';
 
 export type BuildStaticStandaloneOptions = CLIOptions &
   LoadOptions &
@@ -114,7 +116,7 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
     features,
   };
 
-  if (staticDirs && options.staticDir) {
+  if (options.staticDir && !isEqual(staticDirs, defaultStaticDirs)) {
     throw new Error(dedent`
       Conflict when trying to read staticDirs:
       * Storybook's configuration option: 'staticDirs'


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21564

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed conflicting staticDirs case when -s flag is used

## How to test

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Change build script to use -s flag
3. Run storybook build -> Does not fail anymore

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
