### PR TITLE
Fix preloading for manager and preview 2

### DIFF
--- a/code/lib/builder-manager/templates/template.ejs
+++ b/code/lib/builder-manager/templates/template.ejs
@@ -16,12 +16,6 @@
     <link rel="preload" href="./sb-common-assets/nunito-sans-bold.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="./sb-common-assets/fonts.css" />
 
-    <link href="./sb-manager/runtime.mjs" rel="modulepreload" as="script" />
-
-    <% files.js.forEach(file => { %>
-      <link href="<%= file %>" rel="modulepreload" as="script" />
-    <% }); %>
-
 
     <% if (typeof head !== 'undefined') { %> <%- head %> <% } %>
 

--- a/code/lib/builder-manager/templates/template.ejs
+++ b/code/lib/builder-manager/templates/template.ejs
@@ -16,6 +16,13 @@
     <link rel="preload" href="./sb-common-assets/nunito-sans-bold.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="./sb-common-assets/fonts.css" />
 
+    <link href="./sb-manager/runtime.mjs" rel="modulepreload" as="script" />
+
+    <% files.js.forEach(file => { %>
+      <link href="<%= file %>" rel="modulepreload" as="script" />
+    <% }); %>
+
+
     <% if (typeof head !== 'undefined') { %> <%- head %> <% } %>
 
     <style>
@@ -49,6 +56,6 @@
       <% }); %>
     </script>
 
-    <link href="./sb-preview/runtime.mjs" rel="preload" as="script" />
+    <link href="./sb-preview/runtime.mjs" rel="prefetch" as="script" />
   </body>
 </html>


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I have changed the way of how the sb-preview/runtime.mjs gets preloaded. Using [preloading](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload) resulted in a browser warning because the resource was not loaded after a couple of seconds after the window.load event.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
