### PR TITLE
Bug: blank page when a ref is missing but specified in url

### DIFF
--- a/code/lib/manager-api/src/modules/stories.ts
+++ b/code/lib/manager-api/src/modules/stories.ts
@@ -134,6 +134,9 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
     },
     resolveStory: (storyId, refId) => {
       const { refs, index } = store.getState();
+      if (refId && !refs[refId]) {
+        return null;
+      }
       if (refId) {
         return refs[refId].index ? refs[refId].index[storyId] : undefined;
       }

--- a/code/ui/manager/src/components/preview/FramesRenderer.tsx
+++ b/code/ui/manager/src/components/preview/FramesRenderer.tsx
@@ -9,8 +9,8 @@ import { IFrame } from './iframe';
 import type { FramesRendererProps } from './utils/types';
 import { stringifyQueryParams } from './utils/stringifyQueryParams';
 
-const getActive = (refId: FramesRendererProps['refId']) => {
-  if (refId) {
+const getActive = (refId: FramesRendererProps['refId'], refs: FramesRendererProps['refs']) => {
+  if (refId && refs[refId]) {
     return `storybook-ref-${refId}`;
   }
 
@@ -55,7 +55,7 @@ export const FramesRenderer: FC<FramesRendererProps> = ({
     ...queryParams,
     ...(version && { version }),
   });
-  const active = getActive(refId);
+  const active = getActive(refId, refs);
 
   const styles = useMemo<CSSObject>(() => {
     // add #root to make the selector high enough in specificity


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21504

## What I did

I fixed the error being throw and return undefined instead in the manager-api code when resolving a story that didn't exists in a ref

I fixed an issue where the canvas would remain blank, because there was no active frame

## How to test

1. Run a sandbox or the core ui storybook
2. Open Storybook in your browser
3. navigate to http://localhost:6006/?path=/docs/design-system2_avatarlist--docs
