### PR TITLE
fix(angular): source preview for angular stories does not show proper props values

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.test.ts
@@ -370,7 +370,20 @@ describe('angular source decorator', () => {
       const someDataObject: ISomeInterface = {
         one: 'Hello world',
         two: true,
-        three: ['One', 'Two', 'Three'],
+        three: [
+          `a string literal with "double quotes"`,
+          `a string literal with 'single quotes'`,
+          'a single quoted string with "double quotes"',
+          "a double quoted string with 'single quotes'",
+          // eslint-disable-next-line prettier/prettier
+          'a single quoted string with escaped \'single quotes\'',
+          // eslint-disable-next-line prettier/prettier
+          "a double quoted string with escaped \"double quotes\"",
+          // eslint-disable-next-line no-useless-escape
+          `a string literal with \'escaped single quotes\'`,
+          // eslint-disable-next-line no-useless-escape
+          `a string literal with \"escaped double quotes\"`,
+        ],
       };
 
       const props = {
@@ -383,7 +396,7 @@ describe('angular source decorator', () => {
       // Ideally we should stringify the object, but that could cause the story to break because of unescaped values in the JSON object.
       // This will have to do for now
       expect(source).toEqual(
-        `<doc-button [isDisabled]="false" [label]="'Hello world'" [someDataObject]="{one: 'Hello world',two: true,three: ['One','Two','Three']}"></doc-button>`
+        `<doc-button [isDisabled]="false" [label]="'Hello world'" [someDataObject]="{one: 'Hello world', two: true, three: ['a string literal with \\'double quotes\\'', 'a string literal with \\'single quotes\\'', 'a single quoted string with \\'double quotes\\'', 'a double quoted string with \\'single quotes\\'', 'a single quoted string with escaped \\'single quotes\\'', 'a double quoted string with escaped \\'double quotes\\'', 'a string literal with \\'escaped single quotes\\'', 'a string literal with \\'escaped double quotes\\'']}"></doc-button>`
       );
     });
   });

--- a/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.test.ts
@@ -383,7 +383,7 @@ describe('angular source decorator', () => {
       // Ideally we should stringify the object, but that could cause the story to break because of unescaped values in the JSON object.
       // This will have to do for now
       expect(source).toEqual(
-        `<doc-button [isDisabled]="false" [label]="'Hello world'" [someDataObject]="{'one':'Hello world','two':true,'three':['One','Two','Three']}"></doc-button>`
+        `<doc-button [isDisabled]="false" [label]="'Hello world'" [someDataObject]="{one: 'Hello world',two: true,three: ['One','Two','Three']}"></doc-button>`
       );
     });
   });

--- a/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.test.ts
@@ -274,7 +274,7 @@ describe('angular source decorator', () => {
       const argTypes: ArgTypes = {};
       const source = computesTemplateSourceFromComponent(component, props, argTypes);
       expect(source).toEqual(
-        `<doc-button [counter]="4" accent="High" [isDisabled]="true" label="Hello world"></doc-button>`
+        `<doc-button [counter]="4" [accent]="'High'" [isDisabled]="true" [label]="'Hello world'"></doc-button>`
       );
     });
 
@@ -288,7 +288,7 @@ describe('angular source decorator', () => {
       const argTypes: ArgTypes = {};
       const source = computesTemplateSourceFromComponent(component, props, argTypes);
       expect(source).toEqual(
-        `<doc-button [isDisabled]="true" label="Hello world" (onClick)="onClick($event)"></doc-button>`
+        `<doc-button [isDisabled]="true" [label]="'Hello world'" (onClick)="onClick($event)"></doc-button>`
       );
     });
 
@@ -299,7 +299,7 @@ describe('angular source decorator', () => {
       };
       const argTypes: ArgTypes = {};
       const source = computesTemplateSourceFromComponent(component, props, argTypes);
-      expect(source).toEqual(`<doc-button color="#ffffff"></doc-button>`);
+      expect(source).toEqual(`<doc-button [color]="'#ffffff'"></doc-button>`);
     });
   });
 
@@ -330,7 +330,7 @@ describe('angular source decorator', () => {
       };
       const source = computesTemplateSourceFromComponent(component, props, argTypes);
       expect(source).toEqual(
-        `<doc-button [accent]="ButtonAccent.High" [isDisabled]="false" label="Hello world"></doc-button>`
+        `<doc-button [accent]="'High'" [isDisabled]="false" [label]="'Hello world'"></doc-button>`
       );
     });
 
@@ -360,7 +360,7 @@ describe('angular source decorator', () => {
       };
       const source = computesTemplateSourceFromComponent(component, props, argTypes);
       expect(source).toEqual(
-        `<doc-button accent="High" [isDisabled]="false" label="Hello world"></doc-button>`
+        `<doc-button [accent]="'High'" [isDisabled]="false" [label]="'Hello world'"></doc-button>`
       );
     });
 
@@ -383,7 +383,7 @@ describe('angular source decorator', () => {
       // Ideally we should stringify the object, but that could cause the story to break because of unescaped values in the JSON object.
       // This will have to do for now
       expect(source).toEqual(
-        `<doc-button [isDisabled]="false" label="Hello world" [someDataObject]="someDataObject"></doc-button>`
+        `<doc-button [isDisabled]="false" [label]="'Hello world'" [someDataObject]="{'one':'Hello world','two':true,'three':['One','Two','Three']}"></doc-button>`
       );
     });
   });

--- a/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.ts
+++ b/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.ts
@@ -85,7 +85,9 @@ const createAngularInputProperty = ({
         .replace(/"([^-"]+)":/g, '$1: ')
         .replace(/"/g, "'")
         .replace(/\u2019/g, "\\'")
-        .replace(/\u201D/g, "\\'");
+        .replace(/\u201D/g, "\\'")
+        .split(',')
+        .join(', ');
       break;
     default:
       templateValue = value;

--- a/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.ts
+++ b/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.ts
@@ -73,19 +73,19 @@ const createAngularInputProperty = ({
   value: any;
   argType?: ArgTypes[string];
 }) => {
-  const { name: type = null } = (typeof argType?.type === 'object' && argType?.type) || {};
-  let templateValue = type === 'enum' && value;
-
-  const actualType = type === 'enum' && typeof value;
-  const requiresBrackets = ['object', 'any', 'boolean', 'enum', 'number'].includes(actualType);
-
-  if (typeof value === 'object') {
-    templateValue = propertyName;
+  let templateValue;
+  switch (typeof value) {
+    case 'string':
+      templateValue = `'${value}'`;
+      break;
+    case 'object':
+      templateValue = JSON.stringify(value).replace(/"/g, "'");
+      break;
+    default:
+      templateValue = value;
   }
 
-  return `${requiresBrackets ? '[' : ''}${propertyName}${
-    requiresBrackets ? ']' : ''
-  }="${templateValue}"`;
+  return `[${propertyName}]="${templateValue}"`;
 };
 
 /**

--- a/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.ts
+++ b/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.ts
@@ -79,7 +79,13 @@ const createAngularInputProperty = ({
       templateValue = `'${value}'`;
       break;
     case 'object':
-      templateValue = JSON.stringify(value).replace(/"/g, "'");
+      templateValue = JSON.stringify(value)
+        .replace(/'/g, '\u2019')
+        .replace(/\\"/g, '\u201D')
+        .replace(/"([^-"]+)":/g, '$1: ')
+        .replace(/"/g, "'")
+        .replace(/\u2019/g, "\\'")
+        .replace(/\u201D/g, "\\'");
       break;
     default:
       templateValue = value;


### PR DESCRIPTION
Closes #21066

## What I did

* [x] enforce using brackets as a best practice for inputs in angular components.
* [x] fix values showing as `false` because they don't have `enum` type.
* [x] display string props within single quotes pair.
* [x] display object & array items as JSON strings instead of just a duplicate of `propertyName`.

## Before
![image](https://user-images.githubusercontent.com/1110191/225138039-e8294b36-688e-4ebd-b363-c4e376304da8.png)

## After
![image](https://user-images.githubusercontent.com/1110191/225138095-78210d72-3206-4ca9-84f0-fd50e9d8cc79.png)

## How to test

* [ ] CI Passes

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
