### PR TITLE
Fixed IconButton to be in active state when corresponding menu is open

### DIFF
--- a/code/addons/backgrounds/src/containers/BackgroundSelector.tsx
+++ b/code/addons/backgrounds/src/containers/BackgroundSelector.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { Fragment, useCallback, useMemo, memo } from 'react';
+import React, { useState, Fragment, useCallback, useMemo, memo } from 'react';
 import memoize from 'memoizerific';
 
 import { useParameter, useGlobals } from '@storybook/manager-api';
@@ -82,7 +82,7 @@ export const BackgroundSelector: FC = memo(function BackgroundSelector() {
     BACKGROUNDS_PARAM_KEY,
     DEFAULT_BACKGROUNDS_CONFIG
   );
-
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const [globals, updateGlobals] = useGlobals();
 
   const globalsBackgroundColor = globals[BACKGROUNDS_PARAM_KEY]?.value;
@@ -133,11 +133,12 @@ export const BackgroundSelector: FC = memo(function BackgroundSelector() {
             />
           );
         }}
+        onVisibleChange={setIsTooltipVisible}
       >
         <IconButton
           key="background"
           title="Change the background of the preview"
-          active={selectedBackgroundColor !== 'transparent'}
+          active={selectedBackgroundColor !== 'transparent' || isTooltipVisible}
         >
           <Icons icon="photo" />
         </IconButton>

--- a/code/addons/toolbars/src/components/ToolbarMenuList.tsx
+++ b/code/addons/toolbars/src/components/ToolbarMenuList.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useGlobals } from '@storybook/manager-api';
 import { deprecate } from '@storybook/client-logger';
 import { WithTooltip, TooltipLinkList } from '@storybook/components';
@@ -20,6 +20,7 @@ export const ToolbarMenuList: FC<ToolbarMenuListProps> = withKeyboardCycle(
     toolbar: { icon: _icon, items, title: _title, showName, preventDynamicIcon, dynamicTitle },
   }) => {
     const [globals, updateGlobals] = useGlobals();
+    const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
     const currentValue = globals[id];
     const hasGlobalValue = !!currentValue;
@@ -84,9 +85,10 @@ export const ToolbarMenuList: FC<ToolbarMenuListProps> = withKeyboardCycle(
           return <TooltipLinkList links={links} />;
         }}
         closeOnOutsideClick
+        onVisibleChange={setIsTooltipVisible}
       >
         <ToolbarMenuButton
-          active={hasGlobalValue}
+          active={isTooltipVisible || hasGlobalValue}
           description={description || ''}
           icon={icon}
           title={title || ''}

--- a/code/addons/viewport/src/Tool.tsx
+++ b/code/addons/viewport/src/Tool.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-fallthrough */
 import type { ReactNode, FC } from 'react';
-import React, { Fragment, useEffect, useRef, memo } from 'react';
+import React, { useState, Fragment, useEffect, useRef, memo } from 'react';
 import memoize from 'memoizerific';
 
 import { styled, Global, type Theme, withTheme } from '@storybook/theming';
@@ -138,6 +138,7 @@ export const ViewportTool: FC = memo(
 
     const list = toList(viewports);
     const api = useStorybookApi();
+    const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
     if (!list.find((i) => i.id === defaultViewport)) {
       // eslint-disable-next-line no-console
@@ -185,11 +186,12 @@ export const ViewportTool: FC = memo(
             <TooltipLinkList links={toLinks(list, item, setState, state, onHide)} />
           )}
           closeOnOutsideClick
+          onVisibleChange={setIsTooltipVisible}
         >
           <IconButtonWithLabel
             key="viewport"
             title="Change the size of the preview"
-            active={!!styles}
+            active={isTooltipVisible || !!styles}
             onDoubleClick={() => {
               setState({ ...state, selected: responsiveViewport.id });
             }}


### PR DESCRIPTION
Closes #21463


## What I did

Controlled the active state on `IconButton` by taking into account the visibility changes on `WithTooltip`.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for the template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Check that when clicking on (Theme/Locale/Viewport) controls, the Tooltip opens when moving away from the corresponding button this remains active.

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
