### PR TITLE
Docs: Allow dark theme in fenced code blocks

### DIFF
--- a/code/addons/actions/src/runtime/action.ts
+++ b/code/addons/actions/src/runtime/action.ts
@@ -20,8 +20,7 @@ const isReactSyntheticEvent = (e: unknown): e is SyntheticEvent =>
 const serializeArg = <T>(a: T) => {
   if (isReactSyntheticEvent(a)) {
     const e: SyntheticEvent = Object.create(
-      // @ts-expect-error (Converted from ts-ignore)
-      a.constructor.prototype,
+      a?.constructor.prototype,
       Object.getOwnPropertyDescriptors(a)
     );
     e.persist();

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -124,7 +124,9 @@
   "devDependencies": {
     "react": "^16.14.0",
     "react-dom": "^16.8.0",
-    "typescript": "~4.9.3"
+    "remark-mdx": "^2.3.0",
+    "typescript": "~4.9.3",
+    "unist-util-visit": "^4.1.2"
   },
   "peerDependencies": {
     "@storybook/mdx1-csf": ">=1.0.0-0",

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -59,6 +59,7 @@ async function webpack(
       visit(tree, 'element', (node: any) => {
         const metastring = node.data?.meta;
         if (node.tagName === 'code' && metastring) {
+          // eslint-disable-next-line no-param-reassign
           node.properties = {
             ...node.properties,
             metastring,

--- a/code/addons/docs/template/stories/docs2/CodeBlocks.mdx
+++ b/code/addons/docs/template/stories/docs2/CodeBlocks.mdx
@@ -1,0 +1,35 @@
+import { Meta, Source } from '@storybook/addon-docs';
+
+<Meta title="Code Blocks" />
+
+### Fenced Code
+
+~~~md
+```js
+let foo;
+```
+~~~
+
+### Fenced Code with dark theme
+
+~~~md dark
+```js dark
+let foo;
+```
+~~~
+
+### Source Block
+
+<Source language="jsx" code={`
+  <Source language="jsx" code={snippet}></Source>
+`}>
+</Source>
+
+### Source Block with dark theme
+
+<Source language="jsx" dark code={`
+  <Source language="jsx" dark code={snippet}></Source>
+`}>
+</Source>
+
+

--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -66,8 +66,10 @@
     "@storybook/mdx1-csf": ">=1.0.0-next.1",
     "@types/express": "^4.17.13",
     "@types/node": "^16.0.0",
+    "remark-mdx": "^2.3.0",
     "rollup": "^3.0.0",
     "typescript": "~4.9.3",
+    "unist-util-visit": "^4.1.2",
     "vite": "^4.0.4"
   },
   "peerDependencies": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5107,9 +5107,11 @@ __metadata:
     react: ^16.14.0
     react-dom: ^16.8.0
     remark-external-links: ^8.0.0
+    remark-mdx: ^2.3.0
     remark-slug: ^6.0.0
     ts-dedent: ^2.0.0
     typescript: ~4.9.3
+    unist-util-visit: ^4.1.2
   peerDependencies:
     "@storybook/mdx1-csf": ">=1.0.0-0"
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -26222,7 +26224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remark-mdx@npm:^2.2.1":
+"remark-mdx@npm:^2.2.1, remark-mdx@npm:^2.3.0":
   version: 2.3.0
   resolution: "remark-mdx@npm:2.3.0"
   dependencies:

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5713,9 +5713,11 @@ __metadata:
     glob: ^8.1.0
     glob-promise: ^6.0.2
     magic-string: ^0.27.0
+    remark-mdx: ^2.3.0
     rollup: ^3.0.0
     slash: ^3.0.0
     typescript: ~4.9.3
+    unist-util-visit: ^4.1.2
     vite: ^4.0.4
   peerDependencies:
     "@preact/preset-vite": "*"

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -174,53 +174,17 @@ function addEsbuildLoaderToStories(mainConfig: ConfigFile) {
             target: 'es2015',
           },
         },
-        // Handle MDX files per the addon-docs presets (ish)
-        {
-          test: [/\\/template-stories\\//],
-          include: [/\\.stories\\.mdx$/],
-          use: [
-            {
-              loader: '${babelLoaderPath}',
-              options: {
-                babelrc: false,
-                configFile: false,
-                plugins: ['${jsxPluginPath}'],
-              }
-            },
-            {
-              loader: '${storiesMdxLoaderPath}',
-              options: {
-                skipCsf: false,
-              }
-            }
-          ],
-        },
-        {
-          test: [/\\/template-stories\\//],
-          include: [/\\.mdx$/],
-          exclude: [/\\.stories\\.mdx$/],
-          use: [
-            {
-              loader: '${babelLoaderPath}',
-              options: {
-                babelrc: false,
-                configFile: false,
-                plugins: ['${jsxPluginPath}'],
-              }
-            },
-            {
-              loader: '${storiesMdxLoaderPath}',
-              options: {
-                skipCsf: true,
-              }
-            }
-          ],
-        },
         // Ensure no other loaders from the framework apply
-        ...config.module.rules.map(rule => ({
-          ...rule,
-          exclude: [/\\/template-stories\\//].concat(rule.exclude || []),
-        })),
+        ...config.module.rules.map((rule: any) => {
+          if (rule?.test?.toString().includes('mdx')) {
+            return rule;
+          } else {
+            return { 
+              ...rule,
+              exclude: [/\/template-stories\//].concat(rule.exclude || [])
+            };
+          }
+        }),
       ],
     },
   })`;


### PR DESCRIPTION
Closes #20639

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## Describing the issue
- Using a fenced code like ` ```javascript dark ` used to work with v6.5 because Storybook was using `mdx1-csf` library which in turn was using `@mdx-js/mdx` to populate the meta attributes of code fences.
- This behavior does not work anymore with v7.0 because we don't involve `@mdx-js/mdx` anymore, we have to come up with another solution.
- `remark-mdx-code-meta` was suggested by @JReinhold as a workaround along with another direction of using a rehype plugin thru https://mdxjs.com/guides/syntax-highlighting/#syntax-highlighting-with-the-meta-field.
- The use of `remark-mdx-code-meta` proved non-useful and we had to introduce a rehype plugin to fix the issue instead.


## What I did

* [x] introduced a new rehype plugin with the sole purpose to mimic the way `@mdx-js/mdx` works.

## How to test

* [ ] CI Passes.
