### PR TITLE
Removes outdated links

### DIFF
--- a/docs/contribute/how-to-contribute.md
+++ b/docs/contribute/how-to-contribute.md
@@ -14,14 +14,9 @@ In the interest of fostering an open and welcoming environment, we as contributo
 - [**Docs**](./documentation-updates.md): Typos, clarifications
 - [**Integrations**](./../api/new-frameworks.md): Integrate Storybook with your favorite library
 - [**Addons**](./../addons/introduction.md): Build an addon and share it with the community
-- [**Examples**](https://github.com/storybookjs/storybook/tree/next/examples/official-storybook): Add an example/test for a feature
 
 ## Not sure how to get started?
 
 - [Chat in Discord #contributing](https://discord.gg/storybook)
 - [Browse "good first issues" to fix](https://github.com/storybookjs/storybook/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [Submit a bug report or feature request](https://github.com/storybookjs/storybook/issues)
-
-## Additional resources
-
-- [**Official Storybook**](https://next--storybookjs.netlify.app/official-storybook/): The Storybook we use to build Storybook


### PR DESCRIPTION
With this small pull request, the links pointing to the Storybook Netlify app were removed same as the examples link as they were removed as part of the internal monorepo restructure. 

