### PR TITLE
Build: Disable coverage job in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,21 +300,22 @@ jobs:
             - code/coverage
       - report-workflow-on-failure
       - cancel-workflow-on-failure
-  coverage:
-    executor:
-      class: small
-      name: sb_node_16_browsers
-    steps:
-      - git-shallow-clone/checkout_advanced:
-          clone_options: '--depth 1 --verbose'
-      - attach_workspace:
-          at: .
-      - run:
-          name: Upload coverage
-          command: |
-            cd code
-            yarn coverage
-      - report-workflow-on-failure
+  # TODO: Reenable this step once https://github.com/storybookjs/storybook/pull/21633 is done
+  # coverage:
+  #   executor:
+  #     class: small
+  #     name: sb_node_16_browsers
+  #   steps:
+  #     - git-shallow-clone/checkout_advanced:
+  #         clone_options: '--depth 1 --verbose'
+  #     - attach_workspace:
+  #         at: .
+  #     - run:
+  #         name: Upload coverage
+  #         command: |
+  #           cd code
+  #           yarn coverage
+  #     - report-workflow-on-failure
   chromatic-internal-storybooks:
     executor:
       class: medium+
@@ -539,9 +540,9 @@ workflows:
       - chromatic-internal-storybooks:
           requires:
             - build
-      - coverage:
-          requires:
-            - unit-tests
+      # - coverage:
+      #     requires:
+      #       - unit-tests
       - cra-bench:
           requires:
             - build
@@ -589,9 +590,9 @@ workflows:
       - chromatic-internal-storybooks:
           requires:
             - build
-      - coverage:
-          requires:
-            - unit-tests
+      # - coverage:
+      #     requires:
+      #       - unit-tests
       - cra-bench:
           requires:
             - build


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

[Codecov deprecated its lib since 2021](https://about.codecov.io/blog/codecov-uploader-deprecation-plan/) and we didn't notice. The coverage step is now broken. This PR disables it until https://github.com/storybookjs/storybook/pull/21633 fixes it, so we can unblock `next`
