### PR TITLE
Core: fix storySort not reading from `.mjs` & `.cjs` files

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -590,7 +590,7 @@ export class StoryIndexGenerator {
   }
 
   async getStorySortParameter() {
-    const previewFile = ['js', 'jsx', 'ts', 'tsx']
+    const previewFile = ['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs']
       .map((ext) => path.join(this.options.configDir, `preview.${ext}`))
       .find((fname) => fs.existsSync(fname));
     let storySortParameter;


### PR DESCRIPTION
Closes #20685

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

* [x] add support for reading `preview.mjs` & `preview.cjs` files when reading `storySort` parameter

## How to test

* [ ] CI Passes.