### PR TITLE
react-vite - (disable) fastRefresh support

### DIFF
--- a/code/frameworks/react-vite/src/types.ts
+++ b/code/frameworks/react-vite/src/types.ts
@@ -9,6 +9,7 @@ type FrameworkName = '@storybook/react-vite';
 type BuilderName = '@storybook/builder-vite';
 
 export type FrameworkOptions = {
+  fastRefresh?: boolean;
   builder?: BuilderOptions;
   strictMode?: boolean;
   /**


### PR DESCRIPTION
Closes #21631

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Because I need to disable `fastRefresh` in project I work because some bugs

## How to test


1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. After first running I used the sandbox itself to test
3. Remove from `vite.config` the `react()` call and add `fastRefresh` to `options` of `framework` both with `true` and `false`
4. Open Storybook in your browser

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["feature request", "bug"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
