### PR TITLE
React: Fix missing framework options in shim

### DIFF
--- a/code/lib/react-dom-shim/src/preset.ts
+++ b/code/lib/react-dom-shim/src/preset.ts
@@ -3,9 +3,8 @@ import type { Options } from '@storybook/types';
 import { version } from 'react-dom/package.json';
 
 export const webpackFinal = async (config: any, options: Options) => {
-  const { legacyRootApi } = await options.presets.apply<{ legacyRootApi?: boolean }>(
-    'frameworkOptions'
-  );
+  const { legacyRootApi } =
+    (await options.presets.apply<{ legacyRootApi?: boolean }>('frameworkOptions')) || {};
 
   const isReact18 = version.startsWith('18') || version.startsWith('0.0.0');
   const useReact17 = legacyRootApi ?? !isReact18;
@@ -24,9 +23,8 @@ export const webpackFinal = async (config: any, options: Options) => {
 };
 
 export const viteFinal = async (config: any, options: Options) => {
-  const { legacyRootApi } = await options.presets.apply<{ legacyRootApi?: boolean }>(
-    'frameworkOptions'
-  );
+  const { legacyRootApi } =
+    (await options.presets.apply<{ legacyRootApi?: boolean }>('frameworkOptions')) || {};
 
   const isReact18 = version.startsWith('18') || version.startsWith('0.0.0');
   const useReact17 = legacyRootApi || !isReact18;

--- a/code/lib/react-dom-shim/src/preset.ts
+++ b/code/lib/react-dom-shim/src/preset.ts
@@ -4,7 +4,7 @@ import { version } from 'react-dom/package.json';
 
 export const webpackFinal = async (config: any, options: Options) => {
   const { legacyRootApi } =
-    (await options.presets.apply<{ legacyRootApi?: boolean }>('frameworkOptions')) || {};
+    (await options.presets.apply<{ legacyRootApi?: boolean } | null>('frameworkOptions')) || {};
 
   const isReact18 = version.startsWith('18') || version.startsWith('0.0.0');
   const useReact17 = legacyRootApi ?? !isReact18;
@@ -24,7 +24,7 @@ export const webpackFinal = async (config: any, options: Options) => {
 
 export const viteFinal = async (config: any, options: Options) => {
   const { legacyRootApi } =
-    (await options.presets.apply<{ legacyRootApi?: boolean }>('frameworkOptions')) || {};
+    (await options.presets.apply<{ legacyRootApi?: boolean } | null>('frameworkOptions')) || {};
 
   const isReact18 = version.startsWith('18') || version.startsWith('0.0.0');
   const useReact17 = legacyRootApi || !isReact18;


### PR DESCRIPTION
Closes #21632

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Don't assume `presets.apply('frameworkOptions')` will return an object, as we explicitly return `null` in some cases:

https://github.com/storybookjs/storybook/blob/bc77248b11f02ceab67eeaf4c5fe721423d72471/code/lib/core-server/src/presets/common-preset.ts#L208

## How to test

Comment out `framework.options` in a vite sandbox.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
