### PR TITLE
Blocks: fix Canvas block support of deprecated props

### DIFF
--- a/code/addons/docs/template/stories/docs2/Canvas.mdx
+++ b/code/addons/docs/template/stories/docs2/Canvas.mdx
@@ -1,0 +1,34 @@
+import { Meta, Canvas, Story } from '@storybook/addon-docs';
+import * as ButtonStories from './button.stories.ts';
+
+<Meta of={ButtonStories} />
+
+### Canvas with deprecated props
+<Canvas withSource="open" mdxSource={`
+    <Canvas withSource="open" mdxSource={\`\`}>
+      <Story name="Basic"/>
+</Canvas>
+`}>
+  <Story name="Basic"/>
+</Canvas>
+
+### Canvas with new props
+
+<Canvas of={ButtonStories.One}
+   sourceState="shown"
+   source={{ code: `
+      <Canvas of={ButtonStories.One}
+        sourceState="shown"
+        source={{ code: \`\`, language: 'jsx', dark: true }}
+/>
+   `}}
+/>
+
+### Canvas with mixed props
+<Canvas withSource="open" source={{code:`
+    <Canvas withSource="open" source={{code:\`\`}}>
+      <Story name="Basic"/>
+</Canvas>
+`}}>
+  <Story name="Basic"/>
+</Canvas>

--- a/code/ui/blocks/src/blocks/Canvas.tsx
+++ b/code/ui/blocks/src/blocks/Canvas.tsx
@@ -99,10 +99,26 @@ const useDeprecatedPreviewProps = (
     children,
     layout: layoutProp,
     ...props
-  }: DeprecatedCanvasProps & { of?: ModuleExport; layout?: Layout },
+  }: DeprecatedCanvasProps & CanvasProps,
   docsContext: DocsContextProps<Renderer>,
   sourceContext: SourceContextProps
 ) => {
+  /* eslint-disable no-param-reassign */
+  mdxSource = mdxSource || props?.source?.code;
+  withSource =
+    withSource ||
+    (() => {
+      switch (props.sourceState) {
+        case 'none':
+          return SourceState.NONE;
+        case 'shown':
+          return SourceState.OPEN;
+        default:
+          return SourceState.CLOSED;
+      }
+    })();
+  /* eslint-enable no-param-reassign */
+
   /*
   get all story IDs by traversing through the children,
   filter out any non-story children (e.g. text nodes)


### PR DESCRIPTION
Closes #21567

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

* [x] enhance the support of deprecated Canvas props, specifically `mdxSource` & `withSource`

## How to test

* [x] CI Passes
* [x] Validate Story `Addons/docs/docs2/button/Canvas` is showing the proper outputs.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
