### PR TITLE
Docs: fix JSDoc example containing TypeScript syntax

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -337,9 +337,9 @@ export default preview;
 
 In JavaScript projects using `preview.js`, it's also possible to use the `Preview` type (for autocompletion, not type safety), via the JSDoc @type tag:
 
-```ts
+```js
 /** @type { import('@storybook/react').Preview } */
-const preview: Preview = {
+const preview = {
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
   },


### PR DESCRIPTION
## What I did

Fixed JSDoc example with accidental TS leftover.

## How to test

Actually I couldn't figure out how to build docs in this project, but it should be obviously correct at a glance.

If there are instructions for building docs somewhere, I'd like to know. But again, not really needed for this change.

## Checklist

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
