### PR TITLE
Chore: (Docs) Removes outdated references for stories.mdx

### DIFF
--- a/docs/snippets/angular/button-story-decorator.ts.mdx
+++ b/docs/snippets/angular/button-story-decorator.ts.mdx
@@ -1,5 +1,5 @@
 ```ts
-// Button.stories.mdx
+// Button.stories.ts
 
 import type { Meta, StoryObj } from '@storybook/angular';
 

--- a/docs/snippets/common/storybook-main-figma-addon-register.js.mdx
+++ b/docs/snippets/common/storybook-main-figma-addon-register.js.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.js|ts
 
 export default {
-  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
     // Other Storybook addons
     'storybook-addon-designs', // 👈 Addon is registered here

--- a/docs/snippets/common/storybook-vite-builder-aliasing.js.mdx
+++ b/docs/snippets/common/storybook-vite-builder-aliasing.js.mdx
@@ -4,7 +4,7 @@
 import { mergeConfig } from 'vite';
 
 export default {
-  stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
   core: {
     builder: '@storybook/builder-vite',

--- a/docs/snippets/common/storybook-vite-builder-config-env.js.mdx
+++ b/docs/snippets/common/storybook-vite-builder-config-env.js.mdx
@@ -4,7 +4,7 @@
 import { mergeConfig } from 'vite';
 
 export default {
-  stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
   core: {
     builder: '@storybook/builder-vite',

--- a/docs/snippets/common/storybook-vite-builder-react-docgen.js.mdx
+++ b/docs/snippets/common/storybook-vite-builder-react-docgen.js.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.js
 
 export default {
-  stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
   core: {
     builder: '@storybook/builder-vite',

--- a/docs/snippets/common/storybook-vite-builder-register.js.mdx
+++ b/docs/snippets/common/storybook-vite-builder-register.js.mdx
@@ -2,7 +2,7 @@
 // .storybook/main.js|ts
 
 export default {
-  stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
   core: {
     builder: '@storybook/builder-vite', // 👈 The builder enabled here.

--- a/docs/snippets/common/storybook-vite-builder-ts-configure.ts.mdx
+++ b/docs/snippets/common/storybook-vite-builder-ts-configure.ts.mdx
@@ -4,7 +4,7 @@
 import type { StorybookConfig } from '@storybook/react-vite'; // your framework
 
 const config: StorybookConfig = {
-  stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
   framework: '@storybook/react-vite',
   async viteFinal(config, options) {


### PR DESCRIPTION
With this pull request, some lingering references to `.stories.mdx` file usage were removed to prevent issues as the option is now deprecated and should not be referenced at all in our documentation.