### PR TITLE
Chore: (Vue 3) template CSS fix

### DIFF
--- a/code/renderers/vue3/template/cli/ts-3-8/Button.vue
+++ b/code/renderers/vue3/template/cli/ts-3-8/Button.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts" setup>
-import "./buttons.css"
+import "./button.css"
 import { computed } from 'vue';
 
 const props = withDefaults(defineProps<{


### PR DESCRIPTION
With this small pull request, the Vue 3 CLI TypeScript template is updated to reference the CSS file correctly since is currently trying to import `buttons.css` when it should be `button.css`.

Closes #21670

Based on the issue attached to this pull request, it would be in our best interest to release a version as soon as possible to prevent issues like this one from being raised in the issue tracker or unwarranted questions in our social media channels.

cc @shilman @ndelangen @chakAs3 
