### PR TITLE
Blocks: fix controls not populated with default values from JSDoc

### DIFF
--- a/code/ui/blocks/src/components/ArgsTable/ArgControl.tsx
+++ b/code/ui/blocks/src/components/ArgsTable/ArgControl.tsx
@@ -65,6 +65,17 @@ export const ArgControl: FC<ArgControlProps> = ({ row, arg, updateArgs }) => {
 
   if (!control || control.disable) return <NoControl />;
 
+  // if the value is undefined and there is a default value, use it
+  let value = boxedValue?.value;
+  const defaultValue = row.table?.defaultValue;
+  if (value === undefined && defaultValue?.summary !== undefined) {
+    try {
+      value = JSON.parse(defaultValue.summary);
+    } catch {
+      value = defaultValue.summary;
+    }
+  }
+
   // row.name is a display name and not a suitable DOM input id or name - i might contain whitespace etc.
   // row.key is a hash key and therefore a much safer choice
   const props = { name: key, argType: row, value: boxedValue.value, onChange, onBlur, onFocus };

--- a/code/ui/blocks/src/components/ArgsTable/ArgControl.tsx
+++ b/code/ui/blocks/src/components/ArgsTable/ArgControl.tsx
@@ -71,7 +71,7 @@ export const ArgControl: FC<ArgControlProps> = ({ row, arg, updateArgs }) => {
   if (value === undefined && defaultValue?.summary !== undefined) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-implied-eval
-      value = Function(...[], `return ${defaultValue.summary}`)();
+      value = Function(`return ${defaultValue.summary}`)();
     } catch {
       value = defaultValue.summary;
     }

--- a/code/ui/blocks/src/components/ArgsTable/ArgControl.tsx
+++ b/code/ui/blocks/src/components/ArgsTable/ArgControl.tsx
@@ -70,7 +70,8 @@ export const ArgControl: FC<ArgControlProps> = ({ row, arg, updateArgs }) => {
   const defaultValue = row.table?.defaultValue;
   if (value === undefined && defaultValue?.summary !== undefined) {
     try {
-      value = JSON.parse(defaultValue.summary);
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      value = Function(...[], `return ${defaultValue.summary}`)();
     } catch {
       value = defaultValue.summary;
     }
@@ -78,7 +79,7 @@ export const ArgControl: FC<ArgControlProps> = ({ row, arg, updateArgs }) => {
 
   // row.name is a display name and not a suitable DOM input id or name - i might contain whitespace etc.
   // row.key is a hash key and therefore a much safer choice
-  const props = { name: key, argType: row, value: boxedValue.value, onChange, onBlur, onFocus };
+  const props = { name: key, argType: row, value, onChange, onBlur, onFocus };
   const Control = Controls[control.type] || NoControl;
   return <Control {...props} {...control} controlType={control.type} />;
 };


### PR DESCRIPTION
Closes #21300 

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

* [x] read `argsTable[controlName].table.defaultValue.summary` and use it as the initial value for controls when first loading a story/docs page.

## How to test

* [ ] CI Passes.
* [ ] Validate controls have initial values either in auto-docs page or a story controls panel.
