### PR TITLE
Update Install page to show sandboxes

### DIFF
--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -2,6 +2,8 @@
 title: 'Install Storybook'
 ---
 
+import { Sandboxes } from '../../../components/screens/DocsScreen/sandboxes';
+
 Use the Storybook CLI to install it in a single command. Run this inside your _existing project’s_ root directory:
 
 <!-- prettier-ignore-start -->
@@ -35,6 +37,16 @@ Storybook needs to be installed into a project that is already set up with a fra
 - Or any other tooling available.
 
 </details>
+
+## Cloud sandboxes
+
+If you would rather explore Storybook in a ready-to-go environment, you can use one of the following sandboxes:
+
+<Sandboxes />
+
+Don't see the sandbox you're looking for? We also have a [list of all available sandboxes](https://storybook.new).
+
+## What does the CLI do?
 
 Storybook will look into your project's dependencies during its install process and provide you with the best configuration available.
 


### PR DESCRIPTION
## What I did

Update content of _Install Storybook_ docs page to use the Sandboxes component (see [corresponding `frontpage` PR](https://github.com/storybookjs/frontpage/pull/506))

![](https://user-images.githubusercontent.com/486540/226656390-4b8e56b8-58aa-487c-8e08-ab5414124bee.png)

## How to test

1. In `frontpage`, check out the `kylegach/dx-468-idea-demo-projects-for-storybook-via` branch ([see related PR](https://github.com/storybookjs/frontpage/pull/506))
    - It'll error because the Sandboxes component isn't available otherwise
2. Extract the docs for this branch: `yarn extract-monorepo-docs kylegach/dx-468-idea-demo-projects-for-storybook-via`
3. Start the site: `GATSBY_SKIP_ADDON_PAGES=true yarn start`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
