### PR TITLE
CSF-plugin: Fix sourcemaps

### DIFF
--- a/code/lib/csf-plugin/src/index.ts
+++ b/code/lib/csf-plugin/src/index.ts
@@ -18,7 +18,7 @@ export const unplugin = createUnplugin<CsfPluginOptions>((options) => {
       try {
         const csf = loadCsf(code, { makeTitle: (userTitle) => userTitle || 'default' }).parse();
         enrichCsf(csf, options);
-        return formatCsf(csf);
+        return formatCsf(csf, { sourceMaps: true });
       } catch (err: any) {
         // This can be called on legacy storiesOf files, so just ignore
         // those errors. But warn about other errors.

--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -537,5 +537,5 @@ export const readCsf = async (fileName: string, options: CsfOptions) => {
 export const writeCsf = async (csf: CsfFile, fileName?: string) => {
   const fname = fileName || csf._fileName;
   if (!fname) throw new Error('Please specify a fileName for writeCsf');
-  await fs.writeFile(fileName as string, await formatCsf(csf));
+  await fs.writeFile(fileName as string, (await formatCsf(csf)) as string);
 };

--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -517,8 +517,15 @@ export const loadCsf = (code: string, options: CsfOptions) => {
   return new CsfFile(ast, options);
 };
 
-export const formatCsf = (csf: CsfFile) => {
-  const { code } = generate.default(csf._ast, {});
+interface FormatOptions {
+  sourceMaps?: boolean;
+}
+export const formatCsf = (csf: CsfFile, options: FormatOptions = { sourceMaps: false }) => {
+  const result = generate.default(csf._ast, options);
+  if (options.sourceMaps) {
+    return result;
+  }
+  const { code } = result;
   return code;
 };
 


### PR DESCRIPTION
Closes N/A

## What I did

Added sourcemap support for CSF-plugin using Babel's built in sourcemap support.

## How to test

In a Vite project before the fix, it will output the following warnings:

```
the transformation. Consult the plugin documentation for help
rendering chunks (108)...Sourcemap is likely to be incorrect: a plugin (unplugin-csf) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
rendering chunks (114)...Sourcemap is likely to be incorrect: a plugin (unplugin-csf) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

After the change, the warnings go away.
