### PR TITLE
Pin rollup version to 3.19.1

### DIFF
--- a/code/addons/docs/src/DocsRenderer.tsx
+++ b/code/addons/docs/src/DocsRenderer.tsx
@@ -53,7 +53,6 @@ export class DocsRenderer<TRenderer extends Renderer> {
           .then(({ MDXProvider }) =>
             // We use a `key={}` here to reset the `hasError` state each time we render ErrorBoundary
             renderElement(
-              // @ts-expect-error TODO: remove this, we shouldn't have to ignore it
               <ErrorBoundary showException={reject} key={Math.random()}>
                 <MDXProvider components={components}>
                   <Docs context={context} docsParameter={docsParameter} />

--- a/code/addons/docs/src/DocsRenderer.tsx
+++ b/code/addons/docs/src/DocsRenderer.tsx
@@ -53,6 +53,7 @@ export class DocsRenderer<TRenderer extends Renderer> {
           .then(({ MDXProvider }) =>
             // We use a `key={}` here to reset the `hasError` state each time we render ErrorBoundary
             renderElement(
+              // @ts-expect-error TODO: remove this, we shouldn't have to ignore it
               <ErrorBoundary showException={reject} key={Math.random()}>
                 <MDXProvider components={components}>
                   <Docs context={context} docsParameter={docsParameter} />

--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -59,14 +59,14 @@
     "glob": "^8.1.0",
     "glob-promise": "^6.0.2",
     "magic-string": "^0.27.0",
-    "rollup": "^2.25.0 || ^3.3.0",
+    "rollup": "^2.25.0 || >=3.3.0 < 3.20.0",
     "slash": "^3.0.0"
   },
   "devDependencies": {
     "@storybook/mdx1-csf": ">=1.0.0-next.1",
     "@types/express": "^4.17.13",
     "@types/node": "^16.0.0",
-    "rollup": "^3.0.0",
+    "rollup": "3.19.1",
     "typescript": "~4.9.3",
     "vite": "^4.0.4"
   },

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2061,7 +2061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.21.0
   resolution: "@babel/runtime@npm:7.21.0"
   dependencies:
@@ -3619,10 +3619,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lit-labs/ssr-dom-shim@npm:^1.0.0, @lit-labs/ssr-dom-shim@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@lit-labs/ssr-dom-shim@npm:1.1.0"
-  checksum: 8187448c730e280dbe1766dae47a9b2fba4e075294e381cff915f7c7370b10f780487cd3ab100d4d25d4d897adbd7a329f49b26493cf8ad43d1872052b576c59
+"@lit-labs/ssr-dom-shim@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@lit-labs/ssr-dom-shim@npm:1.0.0"
+  checksum: 7829bf644a5e49599bfb8d9a8ae13ef77abc5e6122675adf7abdb190407bc109bca797fe80667ff5313a209480d4eac24a6efc2ac2eddc1fdf6f26391e2c1c61
   languageName: node
   linkType: hard
 
@@ -3928,18 +3928,19 @@ __metadata:
   linkType: hard
 
 "@npmcli/git@npm:^4.0.0":
-  version: 4.0.4
-  resolution: "@npmcli/git@npm:4.0.4"
+  version: 4.0.3
+  resolution: "@npmcli/git@npm:4.0.3"
   dependencies:
     "@npmcli/promise-spawn": ^6.0.0
     lru-cache: ^7.4.4
+    mkdirp: ^1.0.4
     npm-pick-manifest: ^8.0.0
     proc-log: ^3.0.0
     promise-inflight: ^1.0.1
     promise-retry: ^2.0.1
     semver: ^7.3.5
     which: ^3.0.0
-  checksum: 42a2a600c380adf141b6fe01a41ebbaab4c0f5541af58a79e66d7c62acca08ec1f5a9f0a636e3c63dad47000c4a80496b912f18a3af58f1a40624f283ef3fd00
+  checksum: 6786ce44e7e97d41ae1fb5c522ad8e55fa491f7229b31a9c1a92e922a5590ec00a4a733537bca00d3096bf87c145d2f3b69ddf68037a293844eef1c864d2553d
   languageName: node
   linkType: hard
 
@@ -4172,8 +4173,8 @@ __metadata:
   linkType: hard
 
 "@nrwl/nx-cloud@npm:^15.0.2":
-  version: 15.2.4
-  resolution: "@nrwl/nx-cloud@npm:15.2.4"
+  version: 15.2.3
+  resolution: "@nrwl/nx-cloud@npm:15.2.3"
   dependencies:
     axios: ^0.21.2
     chalk: 4.1.0
@@ -4185,7 +4186,7 @@ __metadata:
     yargs-parser: ">=21.0.1"
   bin:
     nx-cloud: bin/nx-cloud.js
-  checksum: a3cd051e4ae48a55056624826d11ff08e618654210c954fa76b49100b8de1c1048097c8168f79f5b0802ebebe253a0cb7061c0202d696442f48954cffd0d51a7
+  checksum: c3cc6a227b7729f20261020824d61da25c0c22f59fc305cc727a782cbf812c2d074d819a1aed9606928ee9c10d57cd4f333240640282394d6a0ea5d9e6f1c1fa
   languageName: node
   linkType: hard
 
@@ -7822,12 +7823,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tufjs/models@npm:1.0.1":
-  version: 1.0.1
-  resolution: "@tufjs/models@npm:1.0.1"
+"@tufjs/models@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@tufjs/models@npm:1.0.0"
   dependencies:
-    minimatch: ^7.4.2
-  checksum: f9b7f0d06f54dfc27dd6d492674c11d87c38239714ad6edf2a845770cf5f1f0f4921ef6974041a8aeb1923a50598639579498ed5130e1e43bcefa8015b41e7da
+    minimatch: ^6.1.0
+  checksum: 9500eab7b3aa69fed1443db6634dca2e84b655f7c5c2d21f92d2421a9bf3bd194f8fedbcd1b537c1cd62ab4ca04219a2b12f1402d7b69db3a6ff22552ac6163a
   languageName: node
   linkType: hard
 
@@ -8568,18 +8569,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:>=16":
-  version: 18.0.28
-  resolution: "@types/react@npm:18.0.28"
-  dependencies:
-    "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: 6d94ec25c18b39aac687814b3a717e767f2fba3289c3b682caa4d0182160a72a9816a612b5a207c8ea73f1d288019f56f3d08742ac7cfff91719abb77da9d11a
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^16, @types/react@npm:^16.14.34":
+"@types/react@npm:*, @types/react@npm:>=16, @types/react@npm:^16, @types/react@npm:^16.14.34":
   version: 16.14.35
   resolution: "@types/react@npm:16.14.35"
   dependencies:
@@ -11463,7 +11453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:17.0.4":
+"cacache@npm:17.0.4, cacache@npm:^17.0.0":
   version: 17.0.4
   resolution: "cacache@npm:17.0.4"
   dependencies:
@@ -11533,27 +11523,6 @@ __metadata:
     tar: ^6.1.11
     unique-filename: ^2.0.0
   checksum: cdf6836e1c457d2a5616abcaf5d8240c0346b1f5bd6fdb8866b9d84b6dff0b54e973226dc11e0d099f35394213d24860d1989c8358d2a41b39eb912b3000e749
-  languageName: node
-  linkType: hard
-
-"cacache@npm:^17.0.0":
-  version: 17.0.5
-  resolution: "cacache@npm:17.0.5"
-  dependencies:
-    "@npmcli/fs": ^3.1.0
-    fs-minipass: ^3.0.0
-    glob: ^9.3.1
-    lru-cache: ^7.7.1
-    minipass: ^4.0.0
-    minipass-collect: ^1.0.2
-    minipass-flush: ^1.0.5
-    minipass-pipeline: ^1.2.4
-    p-map: ^4.0.0
-    promise-inflight: ^1.0.1
-    ssri: ^10.0.0
-    tar: ^6.1.11
-    unique-filename: ^3.0.0
-  checksum: e8a91ee6123e8e289545db101a9ba73c3385afdb49a596be790ce17340cfe08258434f26c3ff28b9cd1dad168f4bf0b0582f0b22dd6ba656f2ffc90a5be12663
   languageName: node
   linkType: hard
 
@@ -13799,9 +13768,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.284":
-  version: 1.4.335
-  resolution: "electron-to-chromium@npm:1.4.335"
-  checksum: d0ff0c169a268f979ab1680be31993a2a3f5c35473c636bd76bf9f0d7e6650b059b16739be8cbe37d688c3923d537d0439a64275e71a4b3e0004c270c5b5f2d0
+  version: 1.4.334
+  resolution: "electron-to-chromium@npm:1.4.334"
+  checksum: 2d1e4a6b26508f3c4622a0cab5dfc16102d1d561417e2ad4f0ad0bf4c618fe6c17072e54b0a48a0e05688fe177b6ae2f6df50764e5922547046e8fb7aff87100
   languageName: node
   linkType: hard
 
@@ -16599,18 +16568,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^9.3.0, glob@npm:^9.3.1":
-  version: 9.3.1
-  resolution: "glob@npm:9.3.1"
-  dependencies:
-    fs.realpath: ^1.0.0
-    minimatch: ^7.4.1
-    minipass: ^4.2.4
-    path-scurry: ^1.6.1
-  checksum: ec0f941634400ba3a8de5421228b8956cd2d06ebcbabddcde3bc8cff222ad7db1072661b63fa3ab933734507d3637187a82ef30f02e9440a19d6e793feb49f80
-  languageName: node
-  linkType: hard
-
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -17648,11 +17605,11 @@ __metadata:
   linkType: hard
 
 "ignore-walk@npm:^6.0.0":
-  version: 6.0.2
-  resolution: "ignore-walk@npm:6.0.2"
+  version: 6.0.1
+  resolution: "ignore-walk@npm:6.0.1"
   dependencies:
-    minimatch: ^7.4.2
-  checksum: aa510785eec78dc4f4754e5be043bd131c774f3a9264e240da04f5490be091c90395eac61f66236f42583458dc816828ed978a61123f33e7f5eb5d7865647431
+    minimatch: ^6.1.6
+  checksum: 48949c131779d032b0b45aa97bf9e14df04225ab8ca5a69f1adf875767fa7fec86d503c6a11c87b52dc23bd696ab5c3b352dd4289ee0df3be1705b71b52c0949
   languageName: node
   linkType: hard
 
@@ -20342,22 +20299,21 @@ __metadata:
   linkType: hard
 
 "lit-element@npm:^3.2.0":
-  version: 3.3.0
-  resolution: "lit-element@npm:3.3.0"
+  version: 3.2.2
+  resolution: "lit-element@npm:3.2.2"
   dependencies:
-    "@lit-labs/ssr-dom-shim": ^1.1.0
     "@lit/reactive-element": ^1.3.0
-    lit-html: ^2.7.0
-  checksum: 1428ed1a75f5898e727a7453fbd06554eeac8e783eef353d56d69cb2cda899d3988d72b742e99c553b83b0ffe209b568d5ad73b78655fc1fa733c5a9989b86aa
+    lit-html: ^2.2.0
+  checksum: 516897ef91838a77bbf80473ff05e4f39e768c383786910acd44717510e71d1a582435fdbae28ae54bd6f62c613917bbeb9a30aacd020a75270ea897b24c1cf8
   languageName: node
   linkType: hard
 
-"lit-html@npm:^2.3.0, lit-html@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "lit-html@npm:2.7.0"
+"lit-html@npm:^2.2.0, lit-html@npm:^2.3.0":
+  version: 2.6.1
+  resolution: "lit-html@npm:2.6.1"
   dependencies:
     "@types/trusted-types": ^2.0.2
-  checksum: c75f75a111378b56c8a07bbdd2d8324487eb144935d3b799fcfec48ed668764e0c6ceca4fad580ec125ff4742487ec8805bd8e38ad6cc745f5df85a61e46f5b5
+  checksum: df5d137e9c7956b6e639e9eeed13050b201895bb69683713135526e67d526c01f74276fb0083daf69135903288ef497febdb3b8613b5080336e4fa29e5f5f063
   languageName: node
   linkType: hard
 
@@ -20789,7 +20745,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.14.1, lru-cache@npm:^7.4.4, lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
+"lru-cache@npm:^7.4.4, lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
   checksum: b3a452b491433db885beed95041eb104c157ef7794b9c9b4d647be503be91769d11206bb573849a16b4cc0d03cbd15ffd22df7960997788b74c1d399ac7a4fed
@@ -22038,21 +21994,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^6.1.6":
+"minimatch@npm:^6.1.0, minimatch@npm:^6.1.6":
   version: 6.2.0
   resolution: "minimatch@npm:6.2.0"
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 0884fcf2dd6d3cb5b76e21c33e1797f32c6d4bdd3cefe693ea4f8bb829734b2ca0eee94f0a4f622e9f9fa305f838d2b4f5251df38fcbf98bf1a03a0d07d4ce2d
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^7.4.1, minimatch@npm:^7.4.2":
-  version: 7.4.2
-  resolution: "minimatch@npm:7.4.2"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: 6deed7078b84934179cec0cc0b46d27b76f995deda7f5d1833f376d8e4c062f4df08f4d979899109b4304fae975b0ebd877aa2a8a94b70ad76d640bf44c070e2
   languageName: node
   linkType: hard
 
@@ -22174,7 +22121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^4.0.0, minipass@npm:^4.0.2, minipass@npm:^4.2.4":
+"minipass@npm:^4.0.0":
   version: 4.2.5
   resolution: "minipass@npm:4.2.5"
   checksum: 98ef3a4f0e7cbb2a152139069fd48eca331296948946c69fd569eee24d875e1dbbe989609b561b9ff8ecdc3438f46ed6c287efd150facd7d374a8fd6ba689d02
@@ -22831,11 +22778,11 @@ __metadata:
   linkType: hard
 
 "npm-install-checks@npm:^6.0.0":
-  version: 6.1.0
-  resolution: "npm-install-checks@npm:6.1.0"
+  version: 6.0.0
+  resolution: "npm-install-checks@npm:6.0.0"
   dependencies:
     semver: ^7.1.1
-  checksum: a8354280109359be50cb32de6e3ba23bfeb78086438da7c664d124c44d0e9045ebc23fe258c26782f07e7f948453b8f94cb27b6239b6c79168c0fda402cc605b
+  checksum: 6cac8854ba8927b7b46ef996bfcb0561048b7d4c377b1a7d133d5d324cc9a8c1727cff15fa3bf5039f197553e7ce45196f174c37cf8173582a21fa8dea928664
   languageName: node
   linkType: hard
 
@@ -24029,16 +23976,6 @@ __metadata:
   dependencies:
     path-root-regex: ^0.1.0
   checksum: aed5cd290df84c46c7730f6a363e95e47a23929b51ab068a3818d69900da3e89dc154cdfd0c45c57b2e02f40c094351bc862db70c2cb00b7e6bd47039a227813
-  languageName: node
-  linkType: hard
-
-"path-scurry@npm:^1.6.1":
-  version: 1.6.1
-  resolution: "path-scurry@npm:1.6.1"
-  dependencies:
-    lru-cache: ^7.14.1
-    minipass: ^4.0.2
-  checksum: 5fe11e99b9ddd93ca384846057fe45843e5b88564ea0acf227c58fbc635ccd93a2a491588677649f54bb68067418331b8c914e027bd66fb980a5a7f007a62fe7
   languageName: node
   linkType: hard
 
@@ -25521,15 +25458,15 @@ __metadata:
   linkType: hard
 
 "react-textarea-autosize@npm:^8.3.0":
-  version: 8.4.1
-  resolution: "react-textarea-autosize@npm:8.4.1"
+  version: 8.4.0
+  resolution: "react-textarea-autosize@npm:8.4.0"
   dependencies:
-    "@babel/runtime": ^7.20.13
+    "@babel/runtime": ^7.10.2
     use-composed-ref: ^1.3.0
     use-latest: ^1.2.1
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 76d77ccfaf6515daba0b6e711bb1930dfc3f01494a71a0fc0f76b686af6847f071837eb3b2ae066cfa51dfcb223f8fc9d951971e1e87ef86bbf018bbfb25ce0d
+  checksum: cef5cc06e353c50db19689f4c61260572fea6a48a4b3d7600a1e0b69f20b33b5899db15f272c402c649c999d76834ad11de63f0053c1edab5ae72b05661e22c8
   languageName: node
   linkType: hard
 
@@ -25603,14 +25540,14 @@ __metadata:
   linkType: hard
 
 "read-package-json@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "read-package-json@npm:6.0.1"
+  version: 6.0.0
+  resolution: "read-package-json@npm:6.0.0"
   dependencies:
-    glob: ^9.3.0
+    glob: ^8.0.1
     json-parse-even-better-errors: ^3.0.0
     normalize-package-data: ^5.0.0
     npm-normalize-package-bin: ^3.0.0
-  checksum: 2e5fecce76a2d47ed4d413d16c63278d41ff6d2b7eaff53b20405285d3b4733d20adbe388c766a8ded464cc57c70c57791110e3741d2c6d5d25b63fcbef7bca7
+  checksum: c3137d1c5574df1d89d30470ca0546fd2167c1da78b5b1b77a936d64b937a49e6966a100fdd34281a7030d83b42774751e7c32126493d2beee016a23588a00e2
   languageName: node
   linkType: hard
 
@@ -29088,12 +29025,12 @@ __metadata:
   linkType: hard
 
 "tuf-js@npm:^1.0.0":
-  version: 1.1.2
-  resolution: "tuf-js@npm:1.1.2"
+  version: 1.1.1
+  resolution: "tuf-js@npm:1.1.1"
   dependencies:
-    "@tufjs/models": 1.0.1
+    "@tufjs/models": 1.0.0
     make-fetch-happen: ^11.0.1
-  checksum: ea071f223730f8a743fbc2f1852d1c5b1a55a83162701a43051a812f27a923f745098555d7f44fad7cea4c2810eff2f4f73dd5c67d7d708ebaabeb51c23c51bb
+  checksum: ca2b9d085aadee856cfde743015d7d89377161a2417d7f3b29298ef3754a86b25e0a9927375cd4fd9b64ab059cc13b3026d893f205f9ed1b229f1f4ed123eb4c
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2061,7 +2061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.21.0
   resolution: "@babel/runtime@npm:7.21.0"
   dependencies:
@@ -3619,10 +3619,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lit-labs/ssr-dom-shim@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@lit-labs/ssr-dom-shim@npm:1.0.0"
-  checksum: 7829bf644a5e49599bfb8d9a8ae13ef77abc5e6122675adf7abdb190407bc109bca797fe80667ff5313a209480d4eac24a6efc2ac2eddc1fdf6f26391e2c1c61
+"@lit-labs/ssr-dom-shim@npm:^1.0.0, @lit-labs/ssr-dom-shim@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@lit-labs/ssr-dom-shim@npm:1.1.0"
+  checksum: 8187448c730e280dbe1766dae47a9b2fba4e075294e381cff915f7c7370b10f780487cd3ab100d4d25d4d897adbd7a329f49b26493cf8ad43d1872052b576c59
   languageName: node
   linkType: hard
 
@@ -3928,19 +3928,18 @@ __metadata:
   linkType: hard
 
 "@npmcli/git@npm:^4.0.0":
-  version: 4.0.3
-  resolution: "@npmcli/git@npm:4.0.3"
+  version: 4.0.4
+  resolution: "@npmcli/git@npm:4.0.4"
   dependencies:
     "@npmcli/promise-spawn": ^6.0.0
     lru-cache: ^7.4.4
-    mkdirp: ^1.0.4
     npm-pick-manifest: ^8.0.0
     proc-log: ^3.0.0
     promise-inflight: ^1.0.1
     promise-retry: ^2.0.1
     semver: ^7.3.5
     which: ^3.0.0
-  checksum: 6786ce44e7e97d41ae1fb5c522ad8e55fa491f7229b31a9c1a92e922a5590ec00a4a733537bca00d3096bf87c145d2f3b69ddf68037a293844eef1c864d2553d
+  checksum: 42a2a600c380adf141b6fe01a41ebbaab4c0f5541af58a79e66d7c62acca08ec1f5a9f0a636e3c63dad47000c4a80496b912f18a3af58f1a40624f283ef3fd00
   languageName: node
   linkType: hard
 
@@ -4173,8 +4172,8 @@ __metadata:
   linkType: hard
 
 "@nrwl/nx-cloud@npm:^15.0.2":
-  version: 15.2.3
-  resolution: "@nrwl/nx-cloud@npm:15.2.3"
+  version: 15.2.4
+  resolution: "@nrwl/nx-cloud@npm:15.2.4"
   dependencies:
     axios: ^0.21.2
     chalk: 4.1.0
@@ -4186,7 +4185,7 @@ __metadata:
     yargs-parser: ">=21.0.1"
   bin:
     nx-cloud: bin/nx-cloud.js
-  checksum: c3cc6a227b7729f20261020824d61da25c0c22f59fc305cc727a782cbf812c2d074d819a1aed9606928ee9c10d57cd4f333240640282394d6a0ea5d9e6f1c1fa
+  checksum: a3cd051e4ae48a55056624826d11ff08e618654210c954fa76b49100b8de1c1048097c8168f79f5b0802ebebe253a0cb7061c0202d696442f48954cffd0d51a7
   languageName: node
   linkType: hard
 
@@ -5719,7 +5718,7 @@ __metadata:
     glob: ^8.1.0
     glob-promise: ^6.0.2
     magic-string: ^0.27.0
-    rollup: ^3.0.0
+    rollup: 3.19.1
     slash: ^3.0.0
     typescript: ~4.9.3
     vite: ^4.0.4
@@ -7823,12 +7822,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tufjs/models@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@tufjs/models@npm:1.0.0"
+"@tufjs/models@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@tufjs/models@npm:1.0.1"
   dependencies:
-    minimatch: ^6.1.0
-  checksum: 9500eab7b3aa69fed1443db6634dca2e84b655f7c5c2d21f92d2421a9bf3bd194f8fedbcd1b537c1cd62ab4ca04219a2b12f1402d7b69db3a6ff22552ac6163a
+    minimatch: ^7.4.2
+  checksum: f9b7f0d06f54dfc27dd6d492674c11d87c38239714ad6edf2a845770cf5f1f0f4921ef6974041a8aeb1923a50598639579498ed5130e1e43bcefa8015b41e7da
   languageName: node
   linkType: hard
 
@@ -8569,7 +8568,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:>=16, @types/react@npm:^16, @types/react@npm:^16.14.34":
+"@types/react@npm:*, @types/react@npm:>=16":
+  version: 18.0.28
+  resolution: "@types/react@npm:18.0.28"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: 6d94ec25c18b39aac687814b3a717e767f2fba3289c3b682caa4d0182160a72a9816a612b5a207c8ea73f1d288019f56f3d08742ac7cfff91719abb77da9d11a
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^16, @types/react@npm:^16.14.34":
   version: 16.14.35
   resolution: "@types/react@npm:16.14.35"
   dependencies:
@@ -11453,7 +11463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:17.0.4, cacache@npm:^17.0.0":
+"cacache@npm:17.0.4":
   version: 17.0.4
   resolution: "cacache@npm:17.0.4"
   dependencies:
@@ -11523,6 +11533,27 @@ __metadata:
     tar: ^6.1.11
     unique-filename: ^2.0.0
   checksum: cdf6836e1c457d2a5616abcaf5d8240c0346b1f5bd6fdb8866b9d84b6dff0b54e973226dc11e0d099f35394213d24860d1989c8358d2a41b39eb912b3000e749
+  languageName: node
+  linkType: hard
+
+"cacache@npm:^17.0.0":
+  version: 17.0.5
+  resolution: "cacache@npm:17.0.5"
+  dependencies:
+    "@npmcli/fs": ^3.1.0
+    fs-minipass: ^3.0.0
+    glob: ^9.3.1
+    lru-cache: ^7.7.1
+    minipass: ^4.0.0
+    minipass-collect: ^1.0.2
+    minipass-flush: ^1.0.5
+    minipass-pipeline: ^1.2.4
+    p-map: ^4.0.0
+    promise-inflight: ^1.0.1
+    ssri: ^10.0.0
+    tar: ^6.1.11
+    unique-filename: ^3.0.0
+  checksum: e8a91ee6123e8e289545db101a9ba73c3385afdb49a596be790ce17340cfe08258434f26c3ff28b9cd1dad168f4bf0b0582f0b22dd6ba656f2ffc90a5be12663
   languageName: node
   linkType: hard
 
@@ -13768,9 +13799,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.284":
-  version: 1.4.334
-  resolution: "electron-to-chromium@npm:1.4.334"
-  checksum: 2d1e4a6b26508f3c4622a0cab5dfc16102d1d561417e2ad4f0ad0bf4c618fe6c17072e54b0a48a0e05688fe177b6ae2f6df50764e5922547046e8fb7aff87100
+  version: 1.4.335
+  resolution: "electron-to-chromium@npm:1.4.335"
+  checksum: d0ff0c169a268f979ab1680be31993a2a3f5c35473c636bd76bf9f0d7e6650b059b16739be8cbe37d688c3923d537d0439a64275e71a4b3e0004c270c5b5f2d0
   languageName: node
   linkType: hard
 
@@ -16568,6 +16599,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^9.3.0, glob@npm:^9.3.1":
+  version: 9.3.1
+  resolution: "glob@npm:9.3.1"
+  dependencies:
+    fs.realpath: ^1.0.0
+    minimatch: ^7.4.1
+    minipass: ^4.2.4
+    path-scurry: ^1.6.1
+  checksum: ec0f941634400ba3a8de5421228b8956cd2d06ebcbabddcde3bc8cff222ad7db1072661b63fa3ab933734507d3637187a82ef30f02e9440a19d6e793feb49f80
+  languageName: node
+  linkType: hard
+
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -17605,11 +17648,11 @@ __metadata:
   linkType: hard
 
 "ignore-walk@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "ignore-walk@npm:6.0.1"
+  version: 6.0.2
+  resolution: "ignore-walk@npm:6.0.2"
   dependencies:
-    minimatch: ^6.1.6
-  checksum: 48949c131779d032b0b45aa97bf9e14df04225ab8ca5a69f1adf875767fa7fec86d503c6a11c87b52dc23bd696ab5c3b352dd4289ee0df3be1705b71b52c0949
+    minimatch: ^7.4.2
+  checksum: aa510785eec78dc4f4754e5be043bd131c774f3a9264e240da04f5490be091c90395eac61f66236f42583458dc816828ed978a61123f33e7f5eb5d7865647431
   languageName: node
   linkType: hard
 
@@ -20299,21 +20342,22 @@ __metadata:
   linkType: hard
 
 "lit-element@npm:^3.2.0":
-  version: 3.2.2
-  resolution: "lit-element@npm:3.2.2"
+  version: 3.3.0
+  resolution: "lit-element@npm:3.3.0"
   dependencies:
+    "@lit-labs/ssr-dom-shim": ^1.1.0
     "@lit/reactive-element": ^1.3.0
-    lit-html: ^2.2.0
-  checksum: 516897ef91838a77bbf80473ff05e4f39e768c383786910acd44717510e71d1a582435fdbae28ae54bd6f62c613917bbeb9a30aacd020a75270ea897b24c1cf8
+    lit-html: ^2.7.0
+  checksum: 1428ed1a75f5898e727a7453fbd06554eeac8e783eef353d56d69cb2cda899d3988d72b742e99c553b83b0ffe209b568d5ad73b78655fc1fa733c5a9989b86aa
   languageName: node
   linkType: hard
 
-"lit-html@npm:^2.2.0, lit-html@npm:^2.3.0":
-  version: 2.6.1
-  resolution: "lit-html@npm:2.6.1"
+"lit-html@npm:^2.3.0, lit-html@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "lit-html@npm:2.7.0"
   dependencies:
     "@types/trusted-types": ^2.0.2
-  checksum: df5d137e9c7956b6e639e9eeed13050b201895bb69683713135526e67d526c01f74276fb0083daf69135903288ef497febdb3b8613b5080336e4fa29e5f5f063
+  checksum: c75f75a111378b56c8a07bbdd2d8324487eb144935d3b799fcfec48ed668764e0c6ceca4fad580ec125ff4742487ec8805bd8e38ad6cc745f5df85a61e46f5b5
   languageName: node
   linkType: hard
 
@@ -20745,7 +20789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.4.4, lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
+"lru-cache@npm:^7.14.1, lru-cache@npm:^7.4.4, lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
   checksum: b3a452b491433db885beed95041eb104c157ef7794b9c9b4d647be503be91769d11206bb573849a16b4cc0d03cbd15ffd22df7960997788b74c1d399ac7a4fed
@@ -21994,12 +22038,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^6.1.0, minimatch@npm:^6.1.6":
+"minimatch@npm:^6.1.6":
   version: 6.2.0
   resolution: "minimatch@npm:6.2.0"
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 0884fcf2dd6d3cb5b76e21c33e1797f32c6d4bdd3cefe693ea4f8bb829734b2ca0eee94f0a4f622e9f9fa305f838d2b4f5251df38fcbf98bf1a03a0d07d4ce2d
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^7.4.1, minimatch@npm:^7.4.2":
+  version: 7.4.2
+  resolution: "minimatch@npm:7.4.2"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 6deed7078b84934179cec0cc0b46d27b76f995deda7f5d1833f376d8e4c062f4df08f4d979899109b4304fae975b0ebd877aa2a8a94b70ad76d640bf44c070e2
   languageName: node
   linkType: hard
 
@@ -22121,7 +22174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^4.0.0":
+"minipass@npm:^4.0.0, minipass@npm:^4.0.2, minipass@npm:^4.2.4":
   version: 4.2.5
   resolution: "minipass@npm:4.2.5"
   checksum: 98ef3a4f0e7cbb2a152139069fd48eca331296948946c69fd569eee24d875e1dbbe989609b561b9ff8ecdc3438f46ed6c287efd150facd7d374a8fd6ba689d02
@@ -22778,11 +22831,11 @@ __metadata:
   linkType: hard
 
 "npm-install-checks@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "npm-install-checks@npm:6.0.0"
+  version: 6.1.0
+  resolution: "npm-install-checks@npm:6.1.0"
   dependencies:
     semver: ^7.1.1
-  checksum: 6cac8854ba8927b7b46ef996bfcb0561048b7d4c377b1a7d133d5d324cc9a8c1727cff15fa3bf5039f197553e7ce45196f174c37cf8173582a21fa8dea928664
+  checksum: a8354280109359be50cb32de6e3ba23bfeb78086438da7c664d124c44d0e9045ebc23fe258c26782f07e7f948453b8f94cb27b6239b6c79168c0fda402cc605b
   languageName: node
   linkType: hard
 
@@ -23976,6 +24029,16 @@ __metadata:
   dependencies:
     path-root-regex: ^0.1.0
   checksum: aed5cd290df84c46c7730f6a363e95e47a23929b51ab068a3818d69900da3e89dc154cdfd0c45c57b2e02f40c094351bc862db70c2cb00b7e6bd47039a227813
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "path-scurry@npm:1.6.1"
+  dependencies:
+    lru-cache: ^7.14.1
+    minipass: ^4.0.2
+  checksum: 5fe11e99b9ddd93ca384846057fe45843e5b88564ea0acf227c58fbc635ccd93a2a491588677649f54bb68067418331b8c914e027bd66fb980a5a7f007a62fe7
   languageName: node
   linkType: hard
 
@@ -25458,15 +25521,15 @@ __metadata:
   linkType: hard
 
 "react-textarea-autosize@npm:^8.3.0":
-  version: 8.4.0
-  resolution: "react-textarea-autosize@npm:8.4.0"
+  version: 8.4.1
+  resolution: "react-textarea-autosize@npm:8.4.1"
   dependencies:
-    "@babel/runtime": ^7.10.2
+    "@babel/runtime": ^7.20.13
     use-composed-ref: ^1.3.0
     use-latest: ^1.2.1
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: cef5cc06e353c50db19689f4c61260572fea6a48a4b3d7600a1e0b69f20b33b5899db15f272c402c649c999d76834ad11de63f0053c1edab5ae72b05661e22c8
+  checksum: 76d77ccfaf6515daba0b6e711bb1930dfc3f01494a71a0fc0f76b686af6847f071837eb3b2ae066cfa51dfcb223f8fc9d951971e1e87ef86bbf018bbfb25ce0d
   languageName: node
   linkType: hard
 
@@ -25540,14 +25603,14 @@ __metadata:
   linkType: hard
 
 "read-package-json@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "read-package-json@npm:6.0.0"
+  version: 6.0.1
+  resolution: "read-package-json@npm:6.0.1"
   dependencies:
-    glob: ^8.0.1
+    glob: ^9.3.0
     json-parse-even-better-errors: ^3.0.0
     normalize-package-data: ^5.0.0
     npm-normalize-package-bin: ^3.0.0
-  checksum: c3137d1c5574df1d89d30470ca0546fd2167c1da78b5b1b77a936d64b937a49e6966a100fdd34281a7030d83b42774751e7c32126493d2beee016a23588a00e2
+  checksum: 2e5fecce76a2d47ed4d413d16c63278d41ff6d2b7eaff53b20405285d3b4733d20adbe388c766a8ded464cc57c70c57791110e3741d2c6d5d25b63fcbef7bca7
   languageName: node
   linkType: hard
 
@@ -26596,7 +26659,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^3.0.0, rollup@npm:^3.18.0":
+"rollup@npm:3.19.1":
+  version: 3.19.1
+  resolution: "rollup@npm:3.19.1"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 1bfb191c2d0d84263f9de9ff7c73d41c65cf74920f3222be4324c88fe11a5a2c87b286cd1791b4977758265ac174d6ba94a0eab3c32ca05a7320ee043a1bc3e9
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^3.18.0":
   version: 3.20.0
   resolution: "rollup@npm:3.20.0"
   dependencies:
@@ -29011,12 +29088,12 @@ __metadata:
   linkType: hard
 
 "tuf-js@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "tuf-js@npm:1.1.1"
+  version: 1.1.2
+  resolution: "tuf-js@npm:1.1.2"
   dependencies:
-    "@tufjs/models": 1.0.0
+    "@tufjs/models": 1.0.1
     make-fetch-happen: ^11.0.1
-  checksum: ca2b9d085aadee856cfde743015d7d89377161a2417d7f3b29298ef3754a86b25e0a9927375cd4fd9b64ab059cc13b3026d893f205f9ed1b229f1f4ed123eb4c
+  checksum: ea071f223730f8a743fbc2f1852d1c5b1a55a83162701a43051a812f27a923f745098555d7f44fad7cea4c2810eff2f4f73dd5c67d7d708ebaabeb51c23c51bb
   languageName: node
   linkType: hard
 

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -23,7 +23,7 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
   packageJson.resolutions = {
     ...storybookVersions,
     'enhanced-resolve': '~5.10.0', // TODO, remove this
-    vite: '4.1.4',
+    rollup: '3.19.1',
     // this is for our CI test, ensure we use the same version as docker image, it should match version specified in `./code/package.json` and `.circleci/config.yml`
     '@playwright/test': '1.31.1',
     playwright: '1.31.1',


### PR DESCRIPTION
Closes #

Attempting to get `next` green again in CI, by pinning rollup to `3.19.1`, the version prior to that which was released yesterday (`3.20.0`), which I suspect is causing our problems.

## What I did

I also needed to hack in a TS ignore, and I regenerated the lockfile.

And I unpinned Vite, which had no effect: https://github.com/storybookjs/storybook/pull/21715

## How to test

It's not possible to test locally, it seems.  But hopefully CI will show us.

I wonder if we need to try to limit ourselves to a single CPU locally, somehow, to me more like CI… 🤔 

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [X] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [X] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
