### PR TITLE
Chore: (Docs- API) Adds missing Typescript example

### DIFF
--- a/docs/api/csf.md
+++ b/docs/api/csf.md
@@ -352,7 +352,8 @@ In CSF 3, we can spread the `Primary` object to carry over all its annotations:
 
 <CodeSnippets
   paths={[
-    'common/csf-3-example-primary-dark-story.js.mdx'
+    'common/csf-3-example-primary-dark-story.js.mdx',
+    'common/csf-3-example-primary-dark-story.ts.mdx',
   ]}
 />
 

--- a/docs/snippets/common/csf-3-example-primary-dark-story.ts.mdx
+++ b/docs/snippets/common/csf-3-example-primary-dark-story.ts.mdx
@@ -1,0 +1,7 @@
+```ts
+// CSF 3
+export const PrimaryOnDark: Story = {
+  ...Primary,
+  parameters: { background: { default: 'dark' } },
+};
+```


### PR DESCRIPTION
With this small pull request, the API documentation is updated to include a missing TypeScript example. 

Closes #21679