### PR TITLE
Fix TS5 support in 6.5

### DIFF
--- a/app/react/package.json
+++ b/app/react/package.json
@@ -56,7 +56,7 @@
     "@storybook/csf": "0.0.2--canary.4566f4d.1",
     "@storybook/docs-tools": "6.5.16",
     "@storybook/node-logger": "6.5.16",
-    "@storybook/react-docgen-typescript-plugin": "1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0",
+    "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.630821.0",
     "@storybook/semver": "^7.3.2",
     "@storybook/store": "6.5.16",
     "@types/estree": "^0.0.51",

--- a/lib/core-common/package.json
+++ b/lib/core-common/package.json
@@ -92,7 +92,7 @@
     "webpack": "4"
   },
   "devDependencies": {
-    "@storybook/react-docgen-typescript-plugin": "1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0",
+    "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.630821.0",
     "@types/compression": "^1.7.0",
     "@types/interpret": "^1.1.1",
     "@types/mock-fs": "^4.13.0",


### PR DESCRIPTION
Closes #21642

## What I did

Upgrade `react-docgen-typescript-plugin` to a version that is TS5 compatible

## How to test

Upgrade a React sandbox to TS5 and run Storybook?
