### PR TITLE
Vite: Unpin rollup version

### DIFF
--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -59,14 +59,14 @@
     "glob": "^8.1.0",
     "glob-promise": "^6.0.2",
     "magic-string": "^0.27.0",
-    "rollup": "^2.25.0 || >=3.3.0 < 3.20.0",
+    "rollup": "^2.25.0 || ^3.3.0",
     "slash": "^3.0.0"
   },
   "devDependencies": {
     "@storybook/mdx1-csf": ">=1.0.0-next.1",
     "@types/express": "^4.17.13",
     "@types/node": "^16.0.0",
-    "rollup": "3.19.1",
+    "rollup": "^3.20.1",
     "typescript": "~4.9.3",
     "vite": "^4.0.4"
   },

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5718,7 +5718,7 @@ __metadata:
     glob: ^8.1.0
     glob-promise: ^6.0.2
     magic-string: ^0.27.0
-    rollup: 3.19.1
+    rollup: ^3.20.1
     slash: ^3.0.0
     typescript: ~4.9.3
     vite: ^4.0.4
@@ -26704,20 +26704,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:3.19.1":
-  version: 3.19.1
-  resolution: "rollup@npm:3.19.1"
-  dependencies:
-    fsevents: ~2.3.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: 1bfb191c2d0d84263f9de9ff7c73d41c65cf74920f3222be4324c88fe11a5a2c87b286cd1791b4977758265ac174d6ba94a0eab3c32ca05a7320ee043a1bc3e9
-  languageName: node
-  linkType: hard
-
 "rollup@npm:^3.18.0":
   version: 3.20.0
   resolution: "rollup@npm:3.20.0"
@@ -26729,6 +26715,20 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 18977cb98a79cb933860bb750aeba4f6c30731c8b1ffc933b0ec20f90e91b9c24c3b6c0a495db20c02b14425761767ae9b2e4e74c34ed5952b4a278fbf8ab2ab
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^3.20.1":
+  version: 3.20.1
+  resolution: "rollup@npm:3.20.1"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 0202e1f44dd8159cdb8ce9d1888994aad6f729bf656d67759ebd4437cc350b557c235cb4000c00a19d97895bf121965b401700d85e4e2e8808839d0a24712eb2
   languageName: node
   linkType: hard
 

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -23,7 +23,6 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
   packageJson.resolutions = {
     ...storybookVersions,
     'enhanced-resolve': '~5.10.0', // TODO, remove this
-    rollup: '3.19.1',
     // this is for our CI test, ensure we use the same version as docker image, it should match version specified in `./code/package.json` and `.circleci/config.yml`
     '@playwright/test': '1.31.1',
     playwright: '1.31.1',


### PR DESCRIPTION
Closes #

## What I did

This unpins the version of rollup, which was done in https://github.com/storybookjs/storybook/pull/21723.

The rollup issue was fixed in https://github.com/rollup/rollup/pull/4919.

## How to test

CI should pass with the new rollup version.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
