### PR TITLE
Chore: (Docs) Minor MDX tweaks

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,7 +22,6 @@ Here are some answers to frequently asked questions. If you have a question, you
 - [Is snapshot testing with Storyshots supported for Vue 3?](#is-snapshot-testing-with-storyshots-supported-for-vue-3)
 - [Why aren't my code blocks highlighted with Storybook MDX](#why-arent-my-code-blocks-highlighted-with-storybook-mdx)
 - [Why aren't my MDX 2 stories working in Storybook?](#why-arent-my-mdx-2-stories-working-in-storybook)
-- [Why can't I import my own stories into MDX 2?](#why-cant-i-import-my-own-stories-into-mdx-2)
 - [Why are my mocked GraphQL queries failing with Storybook's MSW addon?](#why-are-my-mocked-graphql-queries-failing-with-storybooks-msw-addon)
 - [Can I use other GraphQL providers with Storybook's MSW addon?](#can-i-use-other-graphql-providers-with-storybooks-msw-addon)
 - [Can I mock GraphQL mutations with Storybook's MSW addon?](#can-i-mock-graphql-mutations-with-storybooks-msw-addon)
@@ -321,47 +320,7 @@ See our documentation on how to customize the [Storyshots configuration](./writi
 
 ### Why aren't my code blocks highlighted with Storybook MDX
 
-Out of the box, Storybook provides syntax highlighting for a set of languages (e.g., Javascript, Markdown, CSS, HTML, Typescript, GraphQL) that you can use with your code blocks. If you're writing your custom code blocks with MDX, you'll need to import the syntax highlighter manually. For example, if you're adding a code block for SCSS, adjust your story to the following:
-
-<!-- prettier-ignore-start -->
-
-<CodeSnippets
-  paths={[
-   'common/my-component-with-custom-syntax-highlight.mdx.mdx',
-  ]}
-/>
-
-<!-- prettier-ignore-end -->
-
-<div class="aside">
-💡 Check <code>react-syntax-highlighter</code>'s <a href="https://github.com/react-syntax-highlighter/react-syntax-highlighter">documentation</a> for a list of available languages.
-</div>
-
-Applying this small change will enable you to add syntax highlight for SCSS or any other language available.
-
-You can also update your [`.storybook/preview.js`](../configure/overview.md#configure-story-rendering) and enable syntax highlighting globally. For example, to add support for SCSS, update your configuration to the following:
-
-<!-- prettier-ignore-start -->
-
-<CodeSnippets
-  paths={[
-   'common/storybook-preview-register-language-globally.js.mdx',
-  ]}
-/>
-
-<!-- prettier-ignore-end -->
-
-Write your documentation as you usually would, and your existing SCSS code blocks will automatically be highlighted when Storybook reloads. For example:
-
-<!-- prettier-ignore-start -->
-
-<CodeSnippets
-  paths={[
-   'common/my-component-with-global-syntax-highlight.mdx.mdx',
-  ]}
-/>
-
-<!-- prettier-ignore-end -->
+Out of the box, Storybook provides syntax highlighting for a set of languages (e.g., Javascript, Markdown, CSS, HTML, Typescript, GraphQL) you can use with your code blocks. Currently, there's a know limitation when you try and register a custom language to get syntax highlighting. We're working on a fix for this And will update this section once it's available.
 
 ### Why aren't my MDX 2 stories working in Storybook?
 
@@ -397,20 +356,6 @@ You'll need to update it to make it compatible with MDX 2.
 ```
 
 See the following [issue](https://github.com/mdx-js/mdx/issues/1945) for more information.
-
-### Why can't I import my own stories into MDX 2?
-
-This is a known issue with MDX 2. We're working to fix it. For now you can apply the following workaround:
-
-```md
-<!-- Button.stories.mdx -->
-
-import { Story } from '@storybook/addon-docs';
-
-import \* as stories from './Button.stories.jsx';
-
-<Story name="Basic" story={stories.Basic} />
-```
 
 ### Why are my mocked GraphQL queries failing with Storybook's MSW addon?
 

--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -4,7 +4,7 @@ title: 'Setup Storybook'
 
 Now that you’ve learned what stories are and how to browse them, let’s demo working on one of your components.
 
-Pick a simple component from your project, like a Button, and write a `.stories.js`, or a `.stories.mdx` file to go along with it. It might look something like this:
+Pick a simple component from your project, like a Button, and write a `.stories.js`, or a `.stories.ts` file to go along with it. It might look something like this:
 
 <!-- prettier-ignore-start -->
 

--- a/docs/writing-docs/mdx.md
+++ b/docs/writing-docs/mdx.md
@@ -71,7 +71,7 @@ The first thing you'll notice is that the component documentation is divided int
 
 Assuming you’re already familiar with writing stories with [CSF](../writing-stories/introduction.md), we can dissect the MDX side of things in greater detail.
 
-The document consists of a number of blocks separated by blank lines. Since MDX mixes a few different languages together, it uses those blank lines to help distinguish where one starts and the next begins. Failing to separate blocks by whitespace can cause (sometimes cryptic) parse errors.
+The document consists of a number of blocks separated by blank lines. Since MDX mixes a few different languages together, it uses those blank lines to help distinguish where one starts, and the next begins. Failing to separate blocks by whitespace can cause (sometimes cryptic) parse errors.
 
 Going through the code blocks in sequence:
 
@@ -106,6 +106,12 @@ Imports the components and stories that will be used in the JSX throughout the r
 />
 
 <!-- prettier-ignore-end -->
+
+<div class="aside">
+
+ℹ️ When providing the `of` prop to the `Meta` block, make sure that you're referencing the [**default export**](../api/csf.md#default-export) of the story file and not the component itself to prevent render issues with the generated documentation.
+
+</div>
 
 The `Meta` block defines where the document will be placed in the sidebar. In this case, it is adjacent to the Checkbox’s stories. By default, the docs sidebar node is titled `"Docs"`, but this can be customized by passing a `name` prop (e.g., `<Meta of={CheckboxStories} name="Info" />`). If you want to place a docs node at an arbitrary point in the navigation hierarchy, you can use the `title` prop (e.g., `<Meta title="path/to/node" />`).
 
@@ -328,7 +334,6 @@ However, cross-linking documentation isn't restricted to documentation pages. Yo
 
 <!--You can also use anchors to target a specific section of a page: -->
 
-
 <div class="aside">
 💡 By applying this pattern with the Controls addon, all anchors will be ignored in Canvas based on how Storybook handles URLs to track the args values.
 </div>
@@ -371,35 +376,21 @@ import Changelog from '../CHANGELOG.md';
 
 ## Troubleshooting
 
-### The migration seems flaky and keeps failing
-
-By default, running the [migration command](#automigration) will try and migrate all existing MDX files in your project according to the MDX 2 specification. However, this might not always be possible, and you might run into issues during the migration. To help you troubleshoot those issues, we've prepared some recommendations that might help you.
-
-Start by running the following command inside your project directory:
-
-```shell
-npx @hipster/mdx2-issue-checker
-```
-
-<div class="aside">
-💡 Depending on the volume, you may be required to run the command multiple times to fix all the issues.
-</div>
-
-When it finishes, it will output the list of files causing issues. You can then use this information to fix the problems manually.
-
-Additionally, if you're working with VSCode, you can add the [MDX extension](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx) and enable MDX experimental support for linting, type checking, and auto-completion by adding the following to your user settings:
-
-```json
-{
-  "mdx.experimentalLanguageServer": true
-}
-```
-
-If you're still encountering issues, we recommend reaching out to the maintainers using the default communication channels (e.g., [Discord server](https://discord.com/channels/486522875931656193/570426522528382976), [GitHub issues](https://github.com/storybookjs/storybook/issues)).
-
 ### The MDX documentation doesn't render in my environment
 
-As Storybook relies on MDX 2 to render documentation, some technical limitations may prevent you from migrating to this version. If that's the case, we support MDX 1 as a fallback. To enable it, you'll need to take some additional steps.
+As Storybook relies on MDX 2 to render documentation, some technical limitations may prevent you from migrating to this version. If that's the case, we've prepared a set of instructions to help you transition to this new version.
+
+#### Storybook doesn't create documentation for my component stories
+
+If you run into a situation where Storybook is not able to able to detect and render the documentation for your component stories, it may be due to a misconfiguration in your Storybook. Check your configuration file (i.e., `.storybook/main.js|ts`) and ensure the `stories` configuration element provides the correct path to your stories location(e.g., `../src/**/*.stories.@(js|jsx|ts|tsx)`).
+
+#### The documentation doesn't render using `stories.mdx`
+
+Starting with Storybook 7.0, we've deprecated documenting stories with the `.stories.mdx` file extension. If you're still using the `stories.mdx` extension, we recommend [migrating](#automigration) as soon as possible to avoid any issues, as the majority of APIs and [Doc Blocks](./doc-blocks.md) used by Storybook were overhauled to support MDX 2 and the new MDX compiler (e.g., the [`Meta`](../api/doc-block-meta.md) block).
+
+#### MDX 1 fallback
+
+If you're still having issues with MDX documentation, you can enable MDX 1 as a fallback. To do so, you'll need to take some additional steps.
 
 Run the following command to install the required dependency.
 
@@ -427,6 +418,32 @@ Update your Storybook configuration (in `.storybook/main.js|ts`), and provide th
 />
 
 <!-- prettier-ignore-end -->
+
+### The migration seems flaky and keeps failing
+
+By default, running the [migration command](#automigration) will try and migrate all existing MDX files in your project according to the MDX 2 specification. However, this might not always be possible, and you might run into issues during the migration. To help you troubleshoot those issues, we've prepared some recommendations that might help you.
+
+Start by running the following command inside your project directory:
+
+```shell
+npx @hipster/mdx2-issue-checker
+```
+
+<div class="aside">
+💡 Depending on the volume, you may be required to run the command multiple times to fix all the issues.
+</div>
+
+When it finishes, it will output the list of files causing issues. You can then use this information to fix the problems manually.
+
+Additionally, if you're working with VSCode, you can add the [MDX extension](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx) and enable MDX experimental support for linting, type checking, and auto-completion by adding the following to your user settings:
+
+```json
+{
+  "mdx.experimentalLanguageServer": true
+}
+```
+
+If you're still encountering issues, we recommend reaching out to the maintainers using the default communication channels (e.g., [Discord server](https://discord.com/channels/486522875931656193/570426522528382976), [GitHub issues](https://github.com/storybookjs/storybook/issues)).
 
 #### Learn more about Storybook documentation
 


### PR DESCRIPTION
With this pull request, the Writing docs / MDX documentation was updated to provide clarity based on the following issue #20496. Also included in this pull request are some tweaks to both the FAQ and Setup page to remove outdated references to `.stories.mdx`. The choice of h4 for the troubleshooting instructions was intentional, allowing it to be linked to our internal packages