### PR TITLE
fix CI after github.com SSH change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,8 @@ executors:
     resource_class: <<parameters.class>>
 
 orbs:
-  git-shallow-clone: guitarrapc/git-shallow-clone@2.4.1
-  browser-tools: circleci/browser-tools@1.4.0
+  git-shallow-clone: guitarrapc/git-shallow-clone@2.5.0
+  browser-tools: circleci/browser-tools@1.4.1
   discord: antonioned/discord@0.1.0
   codecov: codecov/codecov@3.2.4
 


### PR DESCRIPTION
CI is broken over this change upstream: 
https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/