### PR TITLE
Bug: fix an issue where port can be NaN

### DIFF
--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -226,8 +226,10 @@ command('dev')
       ci: 'CI',
     });
 
-    // eslint-disable-next-line no-param-reassign
-    options.port = parseInt(`${options.port}`, 10);
+    if (parseInt(`${options.port}`, 10)) {
+      // eslint-disable-next-line no-param-reassign
+      options.port = parseInt(`${options.port}`, 10);
+    }
 
     await dev({ ...options, packageJson: pkg }).catch(() => process.exit(1));
   });


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21553

## What I did

I found that if options.port is not set, it can cause a warning:

```
✔ Port NaN is not available. Would you like to run Storybook on port 51224 instead? … yes
```