### PR TITLE
CLI: Update stories glob in mdx codemod and not in mdx automigration

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/index.ts
+++ b/code/lib/cli/src/automigrate/fixes/index.ts
@@ -16,7 +16,6 @@ import { autodocsTrue } from './autodocs-true';
 import { addReact } from './add-react';
 import { nodeJsRequirement } from './nodejs-requirement';
 import { missingBabelRc } from './missing-babelrc';
-import { bareMdxStoriesGlob } from './bare-mdx-stories-glob';
 import { angularBuilders } from './angular-builders';
 import { angularBuildersMultiproject } from './angular-builders-multiproject';
 
@@ -36,7 +35,6 @@ export const allFixes: Fix[] = [
   removedGlobalClientAPIs,
   mdx1to2,
   mdxgfm,
-  bareMdxStoriesGlob,
   autodocsTrue,
   addReact,
   missingBabelRc,

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -10,6 +10,7 @@ import { join } from 'path';
 import { getStorybookInfo, loadMainConfig } from '@storybook/core-common';
 import semver from 'semver';
 import { JsPackageManagerFactory, useNpmWarning } from '../js-package-manager';
+import type { PackageManagerName } from '../js-package-manager';
 
 import type { Fix, FixId, FixOptions, FixSummary } from './fixes';
 import { FixStatus, PreCheckFailure, allFixes } from './fixes';
@@ -99,6 +100,7 @@ export const automigrate = async ({
     await remove(TEMP_LOG_FILE_PATH);
   }
 
+  const packageManager = JsPackageManagerFactory.getPackageManager({ force: pkgMgr });
   const installationMetadata = await packageManager.findInstallations([
     '@storybook/*',
     'storybook',

--- a/code/lib/cli/src/migrate.ts
+++ b/code/lib/cli/src/migrate.ts
@@ -1,9 +1,12 @@
 import { listCodemods, runCodemod } from '@storybook/codemod';
+import { runFixes } from './automigrate';
+import { bareMdxStoriesGlob } from './automigrate/fixes/bare-mdx-stories-glob';
 
 export async function migrate(migration: any, { glob, dryRun, list, rename, logger, parser }: any) {
   if (list) {
     listCodemods().forEach((key: any) => logger.log(key));
   } else if (migration) {
+    await runFixes({ fixes: [bareMdxStoriesGlob] });
     await runCodemod(migration, { glob, dryRun, logger, rename, parser });
   } else {
     throw new Error('Migrate: please specify a migration name or --list');

--- a/code/lib/cli/src/migrate.ts
+++ b/code/lib/cli/src/migrate.ts
@@ -1,11 +1,28 @@
 import { listCodemods, runCodemod } from '@storybook/codemod';
+import { JsPackageManagerFactory } from './js-package-manager';
+import { getStorybookVersionSpecifier } from './helpers';
 
-export async function migrate(migration: any, { glob, dryRun, list, rename, logger, parser }: any) {
+const logger = console;
+
+export async function migrate(migration: any, { glob, dryRun, list, rename, parser }: any) {
   if (list) {
     listCodemods().forEach((key: any) => logger.log(key));
   } else if (migration) {
+    if (migration === 'mdx-to-csf' && !dryRun) {
+      await addStorybookBlocksPackage();
+    }
     await runCodemod(migration, { glob, dryRun, logger, rename, parser });
   } else {
     throw new Error('Migrate: please specify a migration name or --list');
   }
+}
+
+export async function addStorybookBlocksPackage() {
+  const packageManager = JsPackageManagerFactory.getPackageManager();
+  const packageJson = packageManager.retrievePackageJson();
+  const versionToInstall = getStorybookVersionSpecifier(packageManager.retrievePackageJson());
+  logger.info(`✅ Adding "@storybook/blocks" package`);
+  await packageManager.addDependencies({ installAsDevDependencies: true, packageJson }, [
+    `@storybook/blocks@${versionToInstall}`,
+  ]);
 }

--- a/code/lib/cli/src/migrate.ts
+++ b/code/lib/cli/src/migrate.ts
@@ -6,7 +6,9 @@ export async function migrate(migration: any, { glob, dryRun, list, rename, logg
   if (list) {
     listCodemods().forEach((key: any) => logger.log(key));
   } else if (migration) {
-    await runFixes({ fixes: [bareMdxStoriesGlob] });
+    if (migration === 'mdx-to-csf') {
+      await runFixes({ fixes: [bareMdxStoriesGlob] });
+    }
     await runCodemod(migration, { glob, dryRun, logger, rename, parser });
   } else {
     throw new Error('Migrate: please specify a migration name or --list');


### PR DESCRIPTION
closes #21543, closes #21544

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Update the mdx stories glob in the mdx codemod instead of the automigration.
At first I planned to move the logic to the codemod package.

But at some point I realized that I needed to move whole directories of the cli to the common-core package (for example the JSPackageManager files). So instead of decided to simply run the automigration in the migrate.ts file of the cli package.

I splitted the logic of the automigration function, so that you can apply fixes without having to call the whole automigration function.

It looks like this:

<img width="679" alt="image" src="https://user-images.githubusercontent.com/1035299/228502327-d15bb44d-8119-498e-b532-78f5f7225953.png">

<img width="676" alt="image" src="https://user-images.githubusercontent.com/1035299/228502424-de7b7cc0-bb3e-41a5-a1ab-78f0dae1e693.png">


This PR also installs the @storybook/blocks package in the codemod.

## How to test

1. Create a new application for example: yarn create vite . --template react-ts
2. Run sb init on it.
3. Change the main.js file so that it has this glob:
`stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)']`
4. See that the glob gets updated when running
`sb migrate mdx-to-csf --glob="**/src/**/*.stories.mdx"`

Also remove, the `@storybook/blocks` package from your package.json and then see it gets reinstalled by the codemod:

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
