### PR TITLE
CLI: Install @storybook/blocks package in mdx-to-csf codemod

### DIFF
--- a/code/lib/cli/src/migrate.ts
+++ b/code/lib/cli/src/migrate.ts
@@ -1,11 +1,28 @@
 import { listCodemods, runCodemod } from '@storybook/codemod';
+import { JsPackageManagerFactory } from './js-package-manager';
+import { getStorybookVersionSpecifier } from './helpers';
 
-export async function migrate(migration: any, { glob, dryRun, list, rename, logger, parser }: any) {
+const logger = console;
+
+export async function migrate(migration: any, { glob, dryRun, list, rename, parser }: any) {
   if (list) {
     listCodemods().forEach((key: any) => logger.log(key));
   } else if (migration) {
+    if (migration === 'mdx-to-csf' && !dryRun) {
+      await addStorybookBlocksPackage();
+    }
     await runCodemod(migration, { glob, dryRun, logger, rename, parser });
   } else {
     throw new Error('Migrate: please specify a migration name or --list');
   }
+}
+
+export async function addStorybookBlocksPackage() {
+  const packageManager = JsPackageManagerFactory.getPackageManager();
+  const packageJson = packageManager.retrievePackageJson();
+  const versionToInstall = getStorybookVersionSpecifier(packageManager.retrievePackageJson());
+  logger.info(`✅ Adding "@storybook/blocks" package`);
+  await packageManager.addDependencies({ installAsDevDependencies: true, packageJson }, [
+    `@storybook/blocks@${versionToInstall}`,
+  ]);
 }


### PR DESCRIPTION
Closes #21544

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This installs the @storybook/blocks package in the mdx-to-csf codemod. 

## How to test

Migrate a storybook 6 project to storybook 7, and then run the new codemod. You should see a message that @storybook/blocks get installed, and also see that in your package.json/node_modules.

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
