### PR TITLE
update deprecated pnpx references

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
+++ b/code/lib/cli/src/automigrate/fixes/sb-scripts.ts
@@ -35,7 +35,7 @@ export const getStorybookScripts = (allScripts: Record<string, string>) => {
 
         // in case people have scripts like `yarn start-storybook`
         const isPrependedByPkgManager =
-          previousWord && ['npx', 'run', 'yarn', 'pnpx'].some((cmd) => previousWord.includes(cmd));
+          previousWord && ['npx', 'run', 'yarn', 'pnpx', 'pnpm exec', 'pnpm dlx'].some((cmd) => previousWord.includes(cmd));
 
         if (isSbBinary && !isPrependedByPkgManager) {
           isStorybookScript = true;

--- a/docs/snippets/common/preview-storybook-production-mode.pnpm.js.mdx
+++ b/docs/snippets/common/preview-storybook-production-mode.pnpm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-pnpx http-server ./path/to/build
+pnpm exec http-server ./path/to/build
 ```

--- a/docs/snippets/common/storybook-msw-generate.msw-pnpm.js.mdx
+++ b/docs/snippets/common/storybook-msw-generate.msw-pnpm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-pnpx msw init public/
+pnpm exec msw init public/
 ```

--- a/docs/snippets/common/storybook-upgrade-prerelease.pnpm.js.mdx
+++ b/docs/snippets/common/storybook-upgrade-prerelease.pnpm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-pnpx storybook@next upgrade --prerelease
+pnpm exec storybook@next upgrade --prerelease
 ```


### PR DESCRIPTION
## What I did

I updated snippets containing the deprecated (as of pnpm 7) `pnpx` command in favor of `pnpm exec`.  I also updated the array of script prefixes in sb-scripts.ts > getStorybookScripts()  to include the two additional options.