### PR TITLE
Fix Angular support on Windows when Storystore v7 is disabled

### DIFF
--- a/code/frameworks/angular/src/server/framework-preset-angular-docs.ts
+++ b/code/frameworks/angular/src/server/framework-preset-angular-docs.ts
@@ -1,8 +1,7 @@
-import path from 'path';
 import { StorybookConfig } from '@storybook/types';
 import { hasDocsOrControls } from '@storybook/docs-tools';
 
 export const previewAnnotations: StorybookConfig['previewAnnotations'] = (entry = [], options) => {
   if (!hasDocsOrControls(options)) return entry;
-  return [...entry, path.join(__dirname, '../../dist/client/docs/config')];
+  return [...entry, require.resolve('../client/docs/config')];
 };

--- a/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -1,4 +1,4 @@
-import { dirname, join, resolve } from 'path';
+import { dirname, isAbsolute, join, resolve } from 'path';
 import { DefinePlugin, HotModuleReplacementPlugin, ProgressPlugin, ProvidePlugin } from 'webpack';
 import type { Configuration } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
@@ -112,6 +112,12 @@ export default async (
         if (typeof entry === 'object') {
           return entry.absolute;
         }
+
+        // TODO: Remove as soon as we drop support for disabled StoryStoreV7
+        if (isAbsolute(entry)) {
+          return entry;
+        }
+
         return slash(entry);
       }
     ),


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21685

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed Angular support when storyStore v7 is disabled on Windows machines.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Create a Angular sandbox on a Windows machine
2. Deactivate `storyStorev7` in `main.ts` via `features.storyStorev7`.
2. Open Storybook in your browser -> It shouldn't crash

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
