### PR TITLE
Vite: Polyfill global by default

### DIFF
--- a/code/addons/interactions/src/preview.ts
+++ b/code/addons/interactions/src/preview.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 
 import { addons } from '@storybook/preview-api';
+import { global } from '@storybook/global';
 import { FORCE_REMOUNT, STORY_RENDER_PHASE_CHANGED } from '@storybook/core-events';
 import type {
   Renderer,

--- a/code/lib/builder-vite/input/iframe.html
+++ b/code/lib/builder-vite/input/iframe.html
@@ -26,6 +26,7 @@
     // We do this so that "module && module.hot" etc. in Storybook source code
     // doesn't fail (it will simply be disabled)
     window.module = undefined;
+    window.global = window;
   </script>
   <!-- [HEAD HTML SNIPPET HERE] -->
 </head>

--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -258,28 +258,6 @@ export async function baseGenerator(
 
   await configurePreview({ frameworkPreviewParts, storybookConfigFolder, language, rendererId });
 
-  // FIXME: temporary workaround for https://github.com/storybookjs/storybook/issues/17516
-  // Vite workaround regex for internal and external frameworks as f.e:
-  // Internal: @storybook/xxxxx-vite
-  // External: storybook-xxxxx-vite
-  if (
-    frameworkPackages.find(
-      (pkg) =>
-        pkg.match(/^(@storybook\/|storybook).*-vite$/) ||
-        pkg === '@storybook/sveltekit' ||
-        pkg === ''
-    )
-  ) {
-    const previewHead = dedent`
-      <script>
-        window.global = window;
-      </script>
-    `;
-    await fse.writeFile(`${storybookConfigFolder}/preview-head.html`, previewHead, {
-      encoding: 'utf8',
-    });
-  }
-
   const babelDependencies =
     addBabel && builder !== CoreBuilder.Vite
       ? await getBabelDependencies(packageManager, packageJson)


### PR DESCRIPTION
Closes #17516

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Storybook will polyfill global, therefore removing the need to add preview-head.html with a workaround

## How to test

1. Run a sandbox for a vite template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. It should work (without needing preview-head)


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
