### PR TITLE
TS: Make sure components with interfaces or no props don't raise decorator assignability issues

### DIFF
--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -49,7 +49,7 @@
     "file-system-cache": "^2.0.0"
   },
   "devDependencies": {
-    "@storybook/csf": "next",
+    "@storybook/csf": "0.0.2--canary.65.ef100c4.0",
     "@types/node": "^16.0.0",
     "typescript": "~4.9.3"
   },

--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -49,7 +49,7 @@
     "file-system-cache": "^2.0.0"
   },
   "devDependencies": {
-    "@storybook/csf": "0.0.2--canary.65.ef100c4.0",
+    "@storybook/csf": "next",
     "@types/node": "^16.0.0",
     "typescript": "~4.9.3"
   },

--- a/code/renderers/react/src/public-types.test.tsx
+++ b/code/renderers/react/src/public-types.test.tsx
@@ -228,3 +228,49 @@ test('StoryObj<typeof meta> is allowed when all arguments are optional', () => {
 test('Meta can be used without generic', () => {
   expectTypeOf({ component: Button }).toMatchTypeOf<Meta>();
 });
+
+test('Props can be defined as interfaces, issue #21768', () => {
+  interface Props {
+    label: string;
+  }
+
+  const Component = ({ label }: Props) => <>{label}</>;
+
+  const withDecorator: Decorator = (Story) => (
+    <>
+      <Story />
+    </>
+  );
+
+  const meta = {
+    component: Component,
+    args: {
+      label: 'label',
+    },
+    decorators: [withDecorator],
+  } satisfies Meta<Props>;
+
+  const Basic: StoryObj<typeof meta> = {};
+
+  type Expected = ReactStory<Props, SetOptional<Props, 'label'>>;
+  expectTypeOf(Basic).toEqualTypeOf<Expected>();
+});
+
+test('Components without Props can be used, issue #21768', () => {
+  const Component = () => <>Foo</>;
+  const withDecorator: Decorator = (Story) => (
+    <>
+      <Story />
+    </>
+  );
+
+  const meta = {
+    component: Component,
+    decorators: [withDecorator],
+  } satisfies Meta<typeof Component>;
+
+  const Basic: StoryObj<typeof meta> = {};
+
+  type Expected = ReactStory<{}, {}>;
+  expectTypeOf(Basic).toEqualTypeOf<Expected>();
+});

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6166,6 +6166,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@storybook/csf@npm:0.0.2--canary.65.ef100c4.0":
+  version: 0.0.2--canary.65.ef100c4.0
+  resolution: "@storybook/csf@npm:0.0.2--canary.65.ef100c4.0"
+  dependencies:
+    type-fest: ^2.19.0
+  checksum: cb275451d548286937b56cac48696784e17676d3ef00d4051e94cd26110537181094e872f80ca82ecdcd334f8292513663df924361f1936dc944fed43cebabc8
+  languageName: node
+  linkType: hard
+
 "@storybook/csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/csf@npm:0.0.1"
@@ -7404,7 +7413,7 @@ __metadata:
   resolution: "@storybook/types@workspace:lib/types"
   dependencies:
     "@storybook/channels": 7.0.0-rc.10
-    "@storybook/csf": next
+    "@storybook/csf": 0.0.2--canary.65.ef100c4.0
     "@types/babel__core": ^7.0.0
     "@types/express": ^4.7.0
     "@types/node": ^16.0.0

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6166,15 +6166,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/csf@npm:0.0.2--canary.65.ef100c4.0":
-  version: 0.0.2--canary.65.ef100c4.0
-  resolution: "@storybook/csf@npm:0.0.2--canary.65.ef100c4.0"
-  dependencies:
-    type-fest: ^2.19.0
-  checksum: cb275451d548286937b56cac48696784e17676d3ef00d4051e94cd26110537181094e872f80ca82ecdcd334f8292513663df924361f1936dc944fed43cebabc8
-  languageName: node
-  linkType: hard
-
 "@storybook/csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/csf@npm:0.0.1"
@@ -6185,11 +6176,11 @@ __metadata:
   linkType: hard
 
 "@storybook/csf@npm:next":
-  version: 0.0.2-next.10
-  resolution: "@storybook/csf@npm:0.0.2-next.10"
+  version: 0.0.2-next.11
+  resolution: "@storybook/csf@npm:0.0.2-next.11"
   dependencies:
     type-fest: ^2.19.0
-  checksum: a46deb02d9899b1d85e8fed3bfcdde4368fb8220fd8d78e090046e891241cfa0f294c91687d0ac592c7d8036f1294be8874fab14f11ecabe255659272047c961
+  checksum: fa4025ff520fcfc6eaf9bb9cabbf11d5c06d6ae7ec91bd8102f8f32505ca9149b305e55cd151789a18c1ddee69fe6997293aeff20dcc8c28b6f09833c98a8831
   languageName: node
   linkType: hard
 
@@ -7413,7 +7404,7 @@ __metadata:
   resolution: "@storybook/types@workspace:lib/types"
   dependencies:
     "@storybook/channels": 7.0.0-rc.10
-    "@storybook/csf": 0.0.2--canary.65.ef100c4.0
+    "@storybook/csf": next
     "@types/babel__core": ^7.0.0
     "@types/express": ^4.7.0
     "@types/node": ^16.0.0


### PR DESCRIPTION
Closes #21768

## What I did

When using interfaces as Props for a component, decorators give TS issues when it is not used inline (so as a seperate function).

I now convert Args defined as an interface into a type, to make sure we don't get those kind of assignability issues.

The Simplify type-fest utlity seems to well-suited for this purpose:

https://github.com/sindresorhus/type-fest/blob/2e498662b7cdb8e70fbaa9864d7d860e48983a40/source/simplify.d.ts#L1-L3

The actual change is in a package outside of the monorepo, see this PR:

https://github.com/ComponentDriven/csf/pull/65

## How to test

See the added unit tests.

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
