### PR TITLE
Add explicit require.resolve calls to nextjs webpack loader config

### DIFF
--- a/code/frameworks/nextjs/src/css/webpack.ts
+++ b/code/frameworks/nextjs/src/css/webpack.ts
@@ -15,9 +15,9 @@ export const configureCss = (baseConfig: WebpackConfig, nextConfig: NextConfig):
       rules[i] = {
         test: /\.css$/,
         use: [
-          'style-loader',
+          require.resolve('style-loader'),
           {
-            loader: 'css-loader',
+            loader: require.resolve('css-loader'),
             options: {
               importLoaders: 1,
               ...getImportAndUrlCssLoaderOptions(nextConfig),
@@ -27,7 +27,7 @@ export const configureCss = (baseConfig: WebpackConfig, nextConfig: NextConfig):
               },
             },
           },
-          'postcss-loader',
+          require.resolve('postcss-loader'),
         ],
       };
     }
@@ -35,19 +35,19 @@ export const configureCss = (baseConfig: WebpackConfig, nextConfig: NextConfig):
   rules?.push({
     test: /\.(scss|sass)$/,
     use: [
-      'style-loader',
+      require.resolve('style-loader'),
       {
-        loader: 'css-loader',
+        loader: require.resolve('css-loader'),
         options: {
           importLoaders: 3,
           ...getImportAndUrlCssLoaderOptions(nextConfig),
           modules: { auto: true, getLocalIdent: getCssModuleLocalIdent },
         },
       },
-      'postcss-loader',
-      'resolve-url-loader',
+      require.resolve('postcss-loader'),
+      require.resolve('resolve-url-loader'),
       {
-        loader: 'sass-loader',
+        loader: require.resolve('sass-loader'),
         options: {
           sourceMap: true,
           sassOptions: nextConfig.sassOptions,


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21605, https://github.com/storybookjs/storybook/issues/20468

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Add explicit require.resolve calls to webpack configurations of Next.js framework to pass absolute loader paths to webpack to make it properly work with pnpm
## How to test

```
pnpm --version
# 7.29.1
pnpm create next-app my-app --ts --eslint --src-dir --no-experimental-app --import-alias '@/*'
cd my-app
pnpm dev # just to check that everything works
pnpx storybook@next init
pnpm storybook # boom, you get the error
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
