### PR TITLE
Vite: downgrade remark related dependencies

### DIFF
--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -59,8 +59,8 @@
     "glob": "^8.1.0",
     "glob-promise": "^6.0.2",
     "magic-string": "^0.27.0",
-    "remark-external-links": "^9.0.1",
-    "remark-slug": "^7.0.1",
+    "remark-external-links": "^8.0.0",
+    "remark-slug": "^6.0.0",
     "rollup": "^2.25.0 || ^3.3.0"
   },
   "devDependencies": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5718,8 +5718,8 @@ __metadata:
     glob: ^8.1.0
     glob-promise: ^6.0.2
     magic-string: ^0.27.0
-    remark-external-links: ^9.0.1
-    remark-slug: ^7.0.1
+    remark-external-links: ^8.0.0
+    remark-slug: ^6.0.0
     rollup: ^3.20.1
     slash: ^5.0.0
     typescript: ~4.9.3
@@ -8224,7 +8224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/hast@npm:^2.0.0, @types/hast@npm:^2.3.2":
+"@types/hast@npm:^2.0.0":
   version: 2.3.4
   resolution: "@types/hast@npm:2.3.4"
   dependencies:
@@ -17962,13 +17962,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-absolute-url@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "is-absolute-url@npm:4.0.1"
-  checksum: 6f8f603945bd9f2c6031758bbc12352fc647bd5d807cad10d96cc6300fd0e15240cc091521a61db767e4ec0bacff257b4f1015fd5249c147bbb4a4497356c72e
-  languageName: node
-  linkType: hard
-
 "is-accessor-descriptor@npm:^0.1.6":
   version: 0.1.6
   resolution: "is-accessor-descriptor@npm:0.1.6"
@@ -21137,17 +21130,6 @@ __metadata:
   dependencies:
     unist-util-visit: ^2.0.0
   checksum: d81bb0b702f99878c8e8e4f66dd7f6f673ab341f061b3d9487ba47dad28b584e02f16b4c42df23714eaac8a7dd8544ba7d77308fad8d4a9fd0ac92e2a7f56be9
-  languageName: node
-  linkType: hard
-
-"mdast-util-definitions@npm:^5.0.0":
-  version: 5.1.2
-  resolution: "mdast-util-definitions@npm:5.1.2"
-  dependencies:
-    "@types/mdast": ^3.0.0
-    "@types/unist": ^2.0.0
-    unist-util-visit: ^4.0.0
-  checksum: da9049c15562e44ee4ea4a36113d98c6c9eaa3d8a17d6da2aef6a0626376dcd01d9ec007d77a8dfcad6d0cbd5c32a4abbad72a3f48c3172a55934c7d9a916480
   languageName: node
   linkType: hard
 
@@ -26050,22 +26032,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remark-external-links@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "remark-external-links@npm:9.0.1"
-  dependencies:
-    "@types/hast": ^2.3.2
-    "@types/mdast": ^3.0.0
-    extend: ^3.0.0
-    is-absolute-url: ^4.0.0
-    mdast-util-definitions: ^5.0.0
-    space-separated-tokens: ^2.0.0
-    unified: ^10.0.0
-    unist-util-visit: ^4.0.0
-  checksum: 6d8c0eef3119e60330a6963655db8b07525dc5578b1162ec7a18dadb0c58931ae56b15521652e1bd5653957e6a284d488743edeb44faf3a0cd9643105d0c4a81
-  languageName: node
-  linkType: hard
-
 "remark-footnotes@npm:2.0.0":
   version: 2.0.0
   resolution: "remark-footnotes@npm:2.0.0"
@@ -26389,20 +26355,6 @@ __metadata:
     mdast-util-to-string: ^1.0.0
     unist-util-visit: ^2.0.0
   checksum: 7cc2857936fce9c9c00b9c7d70de46d594cedf93bd8560fd006164dee7aacccdf472654ee35b33f4fb4bd0af882d89998c6d0c9088c2e95702a9fc15ebae002a
-  languageName: node
-  linkType: hard
-
-"remark-slug@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "remark-slug@npm:7.0.1"
-  dependencies:
-    "@types/hast": ^2.3.2
-    "@types/mdast": ^3.0.0
-    github-slugger: ^1.0.0
-    mdast-util-to-string: ^3.0.0
-    unified: ^10.0.0
-    unist-util-visit: ^4.0.0
-  checksum: a5bb0e06e410a49ac6185ef0aee01fdc5a7d3808ff4f3b0300386bba32825f705cfc8c3512e2bf27301956c4b0d7311ba1dc937db3a4280b76f895d69f1112f1
   languageName: node
   linkType: hard
 
@@ -27712,13 +27664,6 @@ __metadata:
   version: 1.1.5
   resolution: "space-separated-tokens@npm:1.1.5"
   checksum: 3ee0a6905f89e1ffdfe474124b1ade9fe97276a377a0b01350bc079b6ec566eb5b219e26064cc5b7f3899c05bde51ffbc9154290b96eaf82916a1e2c2c13ead9
-  languageName: node
-  linkType: hard
-
-"space-separated-tokens@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "space-separated-tokens@npm:2.0.2"
-  checksum: 6173e1d903dca41dcab6a2deed8b4caf61bd13b6d7af8374713500570aa929ff9414ae09a0519f4f8772df993300305a395d4871f35bc4ca72b6db57e1f30af8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did

#21796 included remark plugins but unfortunately they mismatch with the dependencies of addon-docs, which causes issues when running yarn link:

```
Error: Assertion failed: Writing attempt prevented to /Users/yannbraga/open-source/storybook/code/frameworks/react-vite/node_modules/@storybook/builder-vite which is outside project root: /Users/yannbraga/open-source/storybook/sandbox/react-vite-default-ts
    at nb (/Users/yannbraga/open-source/storybook/sandbox/react-vite-default-ts/.yarn/releases/yarn-3.5.0.cjs:709:1786)
    at Nle (/Users/yannbraga/open-source/storybook/sandbox/react-vite-default-ts/.yarn/releases/yarn-3.5.0.cjs:709:2357)
```

and here's a little more explanation:
```
builder-vite::locator=before-storybook%40workspace%3A. - previously hoisted dependency mismatch, needed: remark-external-links@9.0.1, available: remark-external-links@8.0.0
│ ├─is-absolute-url@4.0.1 - filled by: is-absolute-url@3.0.3 at .
│ ├─mdast-util-definitions@5.1.2 - filled by: mdast-util-definitions@4.0.0 at .
│ ├─mdast-util-to-string@3.1.1 - filled by: mdast-util-to-string@1.1.0 at .
│ ├─remark-external-links@9.0.1 - filled by: remark-external-links@8.0.0 at .
│ ├─remark-slug@7.0.1 - filled by: remark-slug@6.1.0 at .
│ ├─space-separated-tokens@2.0.2 - filled by: space-separated-tokens@1.1.5 at .
│ ├─unist-util-is@5.2.1 - filled by: unist-util-is@4.1.0 at .
│ ├─unist-util-visit@4.1.2 - filled by: unist-util-visit@2.0.3 at .
│ ├─unist-util-visit-parents@5.1.3 - filled by: unist-util-visit-parents@3.1.1 at .
```

This issue blocks the creation of Vite sandboxes locally. In this PR I downgraded the remark versions, however I do not know the effects of it @JReinhold please check this out!

The alternative solution would be to upgrade the dependency in addon-docs, however I don't know the effects of that either.

## How to test

1. Run a sandbox for a vite template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. It should work

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
