### PR TITLE
Chore: (Docs) Remove 7.0 refs

### DIFF
--- a/code/addons/docs/docs/multiframework.md
+++ b/code/addons/docs/docs/multiframework.md
@@ -106,7 +106,7 @@ The input is the story function and the story context (id, parameters, args, etc
 
 ## Dynamic source rendering
 
-With the release of Storybook 6.0, we've improved how stories are rendered in the [`Source` doc block](https://storybook.js.org/docs/7.0/react/api/doc-block-source). One of such improvements is the `dynamic` source type, which renders a snippet based on the output the story function.
+With the release of Storybook 6.0, we've improved how stories are rendered in the [`Source` doc block](https://storybook.js.org/docs/react/api/doc-block-source). One of such improvements is the `dynamic` source type, which renders a snippet based on the output the story function.
 
 This dynamic rendering is framework-specific, meaning it needs a custom implementation for each framework.
 

--- a/code/addons/gfm/README.md
+++ b/code/addons/gfm/README.md
@@ -6,6 +6,6 @@ The "@storybook/addon-mdx-gfm" addon is meant as a migration assistant for Story
 > This addon will likely be removed in a future version.
 
 It's recommended you read this document and follow its instructions instead:
-https://storybook.js.org/docs/7.0/react/writing-docs/mdx#lack-of-github-flavored-markdown-gfm
+https://storybook.js.org/docs/react/writing-docs/mdx#lack-of-github-flavored-markdown-gfm
 
 Once you've made the necessary changes, you can remove the addon from your package.json and storybook config.

--- a/code/frameworks/sveltekit/README.md
+++ b/code/frameworks/sveltekit/README.md
@@ -38,7 +38,7 @@ However SvelteKit has some [Kit-specific modules](https://kit.svelte.dev/docs/mo
 | [`$service-worker`](https://kit.svelte.dev/docs/modules#$service-worker)           | ⛔ Not supported       | They are only meant to be used in service workers                                                                                   |
 | [`@sveltejs/kit/*`](https://kit.svelte.dev/docs/modules#sveltejs-kit)              | ✅ Supported           |                                                                                                                                     |
 
-This is just the beginning. We're close to adding basic support for many of the SvelteKit features. Longer term we're planning on making it an even better experience to [build](https://storybook.js.org/docs/7.0/react/writing-stories/introduction), [test](https://storybook.js.org/docs/7.0/react/writing-tests/introduction) and [document](https://storybook.js.org/docs/7.0/react/writing-docs/introduction) all the SvelteKit goodies like [pages](https://kit.svelte.dev/docs/routing), [forms](https://kit.svelte.dev/docs/form-actions) and [layouts](https://kit.svelte.dev/docs/routing#layout) in Storybook, while still integrating with all the addons and workflows you know and love.
+This is just the beginning. We're close to adding basic support for many of the SvelteKit features. Longer term we're planning on making it an even better experience to [build](https://storybook.js.org/docs/svelte/writing-stories/introduction), [test](https://storybook.js.org/docs/svelte/writing-tests/introduction) and [document](https://storybook.js.org/docs/svelte/writing-docs/introduction) all the SvelteKit goodies like [pages](https://kit.svelte.dev/docs/routing), [forms](https://kit.svelte.dev/docs/form-actions) and [layouts](https://kit.svelte.dev/docs/routing#layout) in Storybook, while still integrating with all the addons and workflows you know and love.
 
 ## Requirements
 
@@ -55,7 +55,7 @@ Run the following command in your SvelteKit project's root directory, and follow
 npx storybook@next init
 ```
 
-[More on getting started with Storybook](https://storybook.js.org/docs/7.0/svelte/get-started/install)
+[More on getting started with Storybook](https://storybook.js.org/docs/svelte/get-started/install)
 
 ### In a project with Storybook
 

--- a/docs/snippets/angular/build-storybook-production-mode.with-builder.js.mdx
+++ b/docs/snippets/angular/build-storybook-production-mode.with-builder.js.mdx
@@ -1,6 +1,6 @@
 ```shell
 # Builds Storybook with Angular's custom builder
-# See https://storybook.js.org/docs/7.0/angular/get-started/install
+# See https://storybook.js.org/docs/angular/get-started/install
 # to learn how to create the custom builder
 ng run my-project:build-storybook
 ```

--- a/docs/snippets/angular/button-group-story.ts.mdx
+++ b/docs/snippets/angular/button-group-story.ts.mdx
@@ -15,7 +15,7 @@ import * as ButtonStories from './Button.stories';
 
 const meta: Meta<ButtonGroup> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',
@@ -33,7 +33,7 @@ type Story = StoryObj<ButtonGroup>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const Pair: Story = {

--- a/docs/snippets/angular/button-story-action-event-handle.ts.mdx
+++ b/docs/snippets/angular/button-story-action-event-handle.ts.mdx
@@ -9,7 +9,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-argtypes-with-categories.ts.mdx
+++ b/docs/snippets/angular/button-story-argtypes-with-categories.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-argtypes-with-subcategories.ts.mdx
+++ b/docs/snippets/angular/button-story-argtypes-with-subcategories.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-baseline.ts.mdx
+++ b/docs/snippets/angular/button-story-baseline.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-click-handler-args.ts.mdx
+++ b/docs/snippets/angular/button-story-click-handler-args.ts.mdx
@@ -9,7 +9,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-click-handler-simplificated.ts.mdx
+++ b/docs/snippets/angular/button-story-click-handler-simplificated.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-click-handler.ts.mdx
+++ b/docs/snippets/angular/button-story-click-handler.ts.mdx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-component-args-primary.ts.mdx
+++ b/docs/snippets/angular/button-story-component-args-primary.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-component-decorator.ts.mdx
+++ b/docs/snippets/angular/button-story-component-decorator.ts.mdx
@@ -11,7 +11,7 @@ import { Parent } from './parent.component'; // Parent contains ng-content
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-controls-primary-variant.ts.mdx
+++ b/docs/snippets/angular/button-story-controls-primary-variant.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-controls-radio-group.ts.mdx
+++ b/docs/snippets/angular/button-story-controls-radio-group.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-decorator.ts.mdx
+++ b/docs/snippets/angular/button-story-decorator.ts.mdx
@@ -11,7 +11,7 @@ import { Parent } from './parent.component'; // Parent contains ng-content
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-default-export-with-component.ts.mdx
+++ b/docs/snippets/angular/button-story-default-export-with-component.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-default-export.ts.mdx
+++ b/docs/snippets/angular/button-story-default-export.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-disable-addon.ts.mdx
+++ b/docs/snippets/angular/button-story-disable-addon.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-grouped.ts.mdx
+++ b/docs/snippets/angular/button-story-grouped.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Button',

--- a/docs/snippets/angular/button-story-hide-nocontrols-warning.ts.mdx
+++ b/docs/snippets/angular/button-story-hide-nocontrols-warning.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-hoisted.ts.mdx
+++ b/docs/snippets/angular/button-story-hoisted.ts.mdx
@@ -7,7 +7,7 @@ import { Button as ButtonComponent } from './button.component';
 
 const meta: Meta<ButtonComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Button',

--- a/docs/snippets/angular/button-story-matching-argtypes.ts.mdx
+++ b/docs/snippets/angular/button-story-matching-argtypes.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-onclick-action-argtype.ts.mdx
+++ b/docs/snippets/angular/button-story-onclick-action-argtype.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-primary-composition.ts.mdx
+++ b/docs/snippets/angular/button-story-primary-composition.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-primary-long-name.ts.mdx
+++ b/docs/snippets/angular/button-story-primary-long-name.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-rename-story.ts.mdx
+++ b/docs/snippets/angular/button-story-rename-story.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/angular/button-story-using-args.ts.mdx
+++ b/docs/snippets/angular/button-story-using-args.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/angular/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/angular/button-story-with-addon-example.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -25,7 +25,7 @@ type Story = StoryObj<Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const Basic: Story = {

--- a/docs/snippets/angular/button-story-with-args.ts.mdx
+++ b/docs/snippets/angular/button-story-with-args.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/angular/button-story-with-blue-args.ts.mdx
+++ b/docs/snippets/angular/button-story-with-blue-args.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story-with-emojis.ts.mdx
+++ b/docs/snippets/angular/button-story-with-emojis.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/angular/button-story-with-parameters.ts.mdx
+++ b/docs/snippets/angular/button-story-with-parameters.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/button-story.ts.mdx
+++ b/docs/snippets/angular/button-story.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/angular/checkbox-story-csf.ts.mdx
+++ b/docs/snippets/angular/checkbox-story-csf.ts.mdx
@@ -7,7 +7,7 @@ import { Checkbox } from './checkbox.component';
 
 const meta: Meta<Checkbox> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Checkbox',

--- a/docs/snippets/angular/checkbox-story-grouped.ts.mdx
+++ b/docs/snippets/angular/checkbox-story-grouped.ts.mdx
@@ -7,7 +7,7 @@ import { Checkbox } from './checkbox.component';
 
 const meta: Meta<Checkbox> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Checkbox',

--- a/docs/snippets/angular/component-story-auto-title.csf3-story-ts.ts.mdx
+++ b/docs/snippets/angular/component-story-auto-title.csf3-story-ts.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 /**
  * Story written in CSF 3.0 with auto title generation
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn more about it.
  */
 const meta: Meta<MyComponent> = {

--- a/docs/snippets/angular/component-story-conditional-controls-mutual-exclusion.ts.mdx
+++ b/docs/snippets/angular/component-story-conditional-controls-mutual-exclusion.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/component-story-conditional-controls-toggle.ts.mdx
+++ b/docs/snippets/angular/component-story-conditional-controls-toggle.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/component-story-conditional-controls-toggle.ts.mdx
+++ b/docs/snippets/angular/component-story-conditional-controls-toggle.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/component-story-custom-args-complex.ts.mdx
+++ b/docs/snippets/angular/component-story-custom-args-complex.ts.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './your-component.component';
 
 const meta: Meta<YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -34,7 +34,7 @@ const someFunction = (valuePropertyA: String, valuePropertyB: String) => {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const ExampleStory: Story = {

--- a/docs/snippets/angular/component-story-custom-args-mapping.ts.mdx
+++ b/docs/snippets/angular/component-story-custom-args-mapping.ts.mdx
@@ -11,7 +11,7 @@ const arrows = { ArrowUp, ArrowDown, ArrowLeft, ArrowRight };
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/component-story-custom-params.ts.mdx
+++ b/docs/snippets/angular/component-story-custom-params.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/component-story-disable-controls-alt.ts.mdx
+++ b/docs/snippets/angular/component-story-disable-controls-alt.ts.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './YourComponent.component';
 
 const meta: Meta<YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/angular/component-story-disable-controls-regex.ts.mdx
+++ b/docs/snippets/angular/component-story-disable-controls-regex.ts.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './YourComponent.component';
 
 const meta: Meta<YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/angular/component-story-disable-controls.ts.mdx
+++ b/docs/snippets/angular/component-story-disable-controls.ts.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './YourComponent.component';
 
 const meta: Meta<YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/angular/component-story-figma-integration.ts.mdx
+++ b/docs/snippets/angular/component-story-figma-integration.ts.mdx
@@ -7,7 +7,7 @@ import { withDesign } from 'storybook-addon-designs';
 
 import { MyComponent } from './MyComponent.component';
 
-// More on default export: https://storybook.js.org/docs/7.0/angular/writing-stories/introduction#default-export
+// More on default export: https://storybook.js.org/docs/angular/writing-stories/introduction#default-export
 const meta: Meta<MyComponent> = {
   title: 'FigmaExample',
   component: MyComponent,

--- a/docs/snippets/angular/component-story-sort-controls.ts.mdx
+++ b/docs/snippets/angular/component-story-sort-controls.ts.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './YourComponent.component';
 
 const meta: Meta<YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/angular/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-cdn.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/angular/component-story-static-asset-with-import.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-with-import.ts.mdx
@@ -9,7 +9,7 @@ import imageFile from './static/image.png';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -26,7 +26,7 @@ const image = {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/angular/component-story-static-asset-without-import.ts.mdx
+++ b/docs/snippets/angular/component-story-static-asset-without-import.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',

--- a/docs/snippets/angular/component-story-with-accessibility.ts.mdx
+++ b/docs/snippets/angular/component-story-with-accessibility.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading to learn how to generate automatic titles
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading to learn how to generate automatic titles
    */
   title: 'Accessibility testing',
   component: Button,

--- a/docs/snippets/angular/component-story-with-custom-render-function.ts.mdx
+++ b/docs/snippets/angular/component-story-with-custom-render-function.ts.mdx
@@ -13,7 +13,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/angular/documentscreen-story-msw-graphql-query.ts.mdx
+++ b/docs/snippets/angular/documentscreen-story-msw-graphql-query.ts.mdx
@@ -19,7 +19,7 @@ import { MockGraphQLModule } from './mock-graphql.module';
 
 const meta: Meta<DocumentScreen> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'DocumentScreen',

--- a/docs/snippets/angular/foo-bar-baz-story.ts.mdx
+++ b/docs/snippets/angular/foo-bar-baz-story.ts.mdx
@@ -7,7 +7,7 @@ import { Foo } from './Foo.component';
 
 const meta: Meta<Foo> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Foo/Bar',

--- a/docs/snippets/angular/gizmo-story-controls-customization.ts.mdx
+++ b/docs/snippets/angular/gizmo-story-controls-customization.ts.mdx
@@ -8,7 +8,7 @@ import { Gizmo } from './Gizmo.component';
 
 const meta: Meta<Gizmo> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Gizmo',

--- a/docs/snippets/angular/histogram-story.ts.mdx
+++ b/docs/snippets/angular/histogram-story.ts.mdx
@@ -7,7 +7,7 @@ import { HistogramComponent } from './histogram.component';
 
 const meta: Meta<HistogramComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',

--- a/docs/snippets/angular/list-story-expanded.ts.mdx
+++ b/docs/snippets/angular/list-story-expanded.ts.mdx
@@ -12,7 +12,7 @@ import { ListItem } from './list-item.component';
 
 const meta: Meta<List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/angular/list-story-reuse-data.ts.mdx
+++ b/docs/snippets/angular/list-story-reuse-data.ts.mdx
@@ -15,7 +15,7 @@ import { Selected, Unselected } from './ListItem.stories';
 
 const meta: Meta<List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -33,7 +33,7 @@ type Story = StoryObj<List>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems: Story = {

--- a/docs/snippets/angular/list-story-starter.ts.mdx
+++ b/docs/snippets/angular/list-story-starter.ts.mdx
@@ -11,7 +11,7 @@ import { List } from './list.component';
 
 const meta: Meta<List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   component: List,

--- a/docs/snippets/angular/list-story-template.ts.mdx
+++ b/docs/snippets/angular/list-story-template.ts.mdx
@@ -15,7 +15,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta: Meta<List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -33,7 +33,7 @@ type Story = StoryObj<List>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 const ListTemplate: Story = {

--- a/docs/snippets/angular/list-story-unchecked.ts.mdx
+++ b/docs/snippets/angular/list-story-unchecked.ts.mdx
@@ -15,7 +15,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta: Meta<List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -33,7 +33,7 @@ type Story = StoryObj<List>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const OneItem: Story = {

--- a/docs/snippets/angular/loader-story.ts.mdx
+++ b/docs/snippets/angular/loader-story.ts.mdx
@@ -13,7 +13,7 @@ import { TodoItem } from './TodoItem';
 
 const meta: Meta<TodoItem> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Examples/Loader',
@@ -31,7 +31,7 @@ type Story = StoryObj<TodoItem>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/angular/login-form-with-play-function.ts.mdx
+++ b/docs/snippets/angular/login-form-with-play-function.ts.mdx
@@ -11,7 +11,7 @@ import { LoginForm } from './LoginForm.component';
 
 const meta: Meta<LoginForm> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Form',
@@ -24,7 +24,7 @@ type Story = StoryObj<LoginForm>;
 export const EmptyForm: Story = {};
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
@@ -36,7 +36,7 @@ export const FilledForm: Story = {
 
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 
     // 👇 Assert DOM structure

--- a/docs/snippets/angular/my-component-argtypes-with-mapping.ts.mdx
+++ b/docs/snippets/angular/my-component-argtypes-with-mapping.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/angular/my-component-env-var-config.ts.mdx
+++ b/docs/snippets/angular/my-component-env-var-config.ts.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 // To apply a set of backgrounds to all stories of Button:
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/angular/my-component-play-function-alt-queries.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-alt-queries.ts.mdx
@@ -16,14 +16,14 @@ export default meta;
 type Story = StoryObj<MyComponent>;
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleWithRole: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };

--- a/docs/snippets/angular/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-composition.ts.mdx
@@ -16,7 +16,7 @@ export default meta;
 type Story = StoryObj<MyComponent>;
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FirstStory: Story = {

--- a/docs/snippets/angular/my-component-play-function-query-findby.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-query-findby.ts.mdx
@@ -16,7 +16,7 @@ export default meta;
 type Story = StoryObj<MyComponent>;
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const AsyncExample: Story = {

--- a/docs/snippets/angular/my-component-play-function-waitfor.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-waitfor.ts.mdx
@@ -16,7 +16,7 @@ export default meta;
 type Story = StoryObj<MyComponent>;
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleAsyncStory: Story = {
@@ -31,7 +31,7 @@ export const ExampleAsyncStory: Story = {
       delay: 100,
     });
 
-    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 

--- a/docs/snippets/angular/my-component-play-function-with-clickevent.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-with-clickevent.ts.mdx
@@ -16,14 +16,14 @@ export default meta;
 type Story = StoryObj<MyComponent>;
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ClickExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
   },
 };
@@ -32,7 +32,7 @@ export const FireEventExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };

--- a/docs/snippets/angular/my-component-play-function-with-delay.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-with-delay.ts.mdx
@@ -16,7 +16,7 @@ export default meta;
 type Story = StoryObj<MyComponent>;
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const DelayedStory: Story = {

--- a/docs/snippets/angular/my-component-play-function-with-selectevent.ts.mdx
+++ b/docs/snippets/angular/my-component-play-function-with-selectevent.ts.mdx
@@ -21,7 +21,7 @@ function sleep(ms: number) {
 }
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleChangeEvent: Story = {

--- a/docs/snippets/angular/my-component-story-basic-and-props.ts.mdx
+++ b/docs/snippets/angular/my-component-story-basic-and-props.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/angular/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/angular/my-component-story-configure-viewports.ts.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -31,7 +31,7 @@ type Story = StoryObj<MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const MyStory: Story = {

--- a/docs/snippets/angular/my-component-story-mandatory-export.ts.mdx
+++ b/docs/snippets/angular/my-component-story-mandatory-export.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/angular/my-component-story-use-globaltype.ts.mdx
+++ b/docs/snippets/angular/my-component-story-use-globaltype.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/angular/my-component-story-with-nonstory.ts.mdx
+++ b/docs/snippets/angular/my-component-story-with-nonstory.ts.mdx
@@ -9,7 +9,7 @@ import someData from './data.json';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/angular/my-component-story-with-storyname.ts.mdx
+++ b/docs/snippets/angular/my-component-story-with-storyname.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/angular/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/angular/my-component-with-env-variables.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/angular/other-foo-bar-story.ts.mdx
+++ b/docs/snippets/angular/other-foo-bar-story.ts.mdx
@@ -7,7 +7,7 @@ import { Foo } from './Foo.component';
 
 const meta: Meta<Foo> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'OtherFoo/Bar',

--- a/docs/snippets/angular/page-story-slots.ts.mdx
+++ b/docs/snippets/angular/page-story-slots.ts.mdx
@@ -7,7 +7,7 @@ import { Page } from './page.component';
 
 const meta: Meta<Page> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -19,7 +19,7 @@ type Story = StoryObj<Page>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const CustomFooter: Story = {

--- a/docs/snippets/angular/page-story.ts.mdx
+++ b/docs/snippets/angular/page-story.ts.mdx
@@ -16,7 +16,7 @@ import * as HeaderStories from './Header.stories';
 
 const meta: Meta<Page> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',

--- a/docs/snippets/angular/register-component-with-play-function.ts.mdx
+++ b/docs/snippets/angular/register-component-with-play-function.ts.mdx
@@ -16,7 +16,7 @@ export default meta;
 type Story = StoryObj<RegistrationForm>;
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
@@ -38,7 +38,7 @@ export const FilledForm: Story = {
     await userEvent.type(passwordInput, 'ExamplePassword', {
       delay: 100,
     });
-    // See https://storybook.js.org/docs/7.0/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/angular/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);

--- a/docs/snippets/angular/storybook-addon-a11y-component-config.ts.mdx
+++ b/docs/snippets/angular/storybook-addon-a11y-component-config.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',

--- a/docs/snippets/angular/storybook-addon-a11y-disable.ts.mdx
+++ b/docs/snippets/angular/storybook-addon-a11y-disable.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Disable a11y addon',

--- a/docs/snippets/angular/storybook-addon-a11y-story-config.ts.mdx
+++ b/docs/snippets/angular/storybook-addon-a11y-story-config.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',

--- a/docs/snippets/angular/storybook-addon-backgrounds-configure-backgrounds.ts.mdx
+++ b/docs/snippets/angular/storybook-addon-backgrounds-configure-backgrounds.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './button.component';
 // To apply a set of backgrounds to all stories of Button:
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/storybook-addon-backgrounds-configure-grid.ts.mdx
+++ b/docs/snippets/angular/storybook-addon-backgrounds-configure-grid.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './button.component';
 // To apply a set of backgrounds to all stories of Button:
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/storybook-addon-backgrounds-disable-backgrounds.ts.mdx
+++ b/docs/snippets/angular/storybook-addon-backgrounds-disable-backgrounds.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/storybook-addon-backgrounds-disable-grid.ts.mdx
+++ b/docs/snippets/angular/storybook-addon-backgrounds-disable-grid.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/storybook-addon-backgrounds-override-background-color.ts.mdx
+++ b/docs/snippets/angular/storybook-addon-backgrounds-override-background-color.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/storybook-component-layout-param.ts.mdx
+++ b/docs/snippets/angular/storybook-component-layout-param.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/storybook-csf-3-auto-title-redundant.ts.mdx
+++ b/docs/snippets/angular/storybook-csf-3-auto-title-redundant.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent.component';
 
 const meta: Meta<MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   component: MyComponent,

--- a/docs/snippets/angular/storybook-customize-argtypes.ts.mdx
+++ b/docs/snippets/angular/storybook-customize-argtypes.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/storybook-interactions-play-function.ts.mdx
+++ b/docs/snippets/angular/storybook-interactions-play-function.ts.mdx
@@ -11,7 +11,7 @@ import { Form } from './Form.component';
 
 const meta: Meta<Form> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -25,7 +25,7 @@ export default meta;
 type Story = StoryObj<Form>;
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted: Story = {

--- a/docs/snippets/angular/storybook-interactions-step-function.ts.mdx
+++ b/docs/snippets/angular/storybook-interactions-step-function.ts.mdx
@@ -16,7 +16,7 @@ export default meta;
 type Story = StoryObj<MyComponent>;
 
 /*
- * See https://storybook.js.org/docs/7.0/angular/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/angular/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted: Story = {

--- a/docs/snippets/angular/storybook-story-layout-param.ts.mdx
+++ b/docs/snippets/angular/storybook-story-layout-param.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/angular/table-story-fully-customize-controls.ts.mdx
+++ b/docs/snippets/angular/table-story-fully-customize-controls.ts.mdx
@@ -7,7 +7,7 @@ import { Table } from './Table.component';
 
 const meta: Meta<Table> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Custom Table',
@@ -19,7 +19,7 @@ type Story = StoryObj<Table>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/angular/api/csf
+ * See https://storybook.js.org/docs/angular/api/csf
  * to learn how to use render functions.
  */
 export const Numeric: Story = {

--- a/docs/snippets/angular/your-component-with-decorator.ts.mdx
+++ b/docs/snippets/angular/your-component-with-decorator.ts.mdx
@@ -9,7 +9,7 @@ import { YourComponent } from './your.component';
 
 const meta: Meta<YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/angular/your-component.ts.mdx
+++ b/docs/snippets/angular/your-component.ts.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './your.component';
 //👇 This default export determines where your story goes in the story list
 const meta: Meta<YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/angular/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/angular/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/button-story-action-event-handle.js.mdx
+++ b/docs/snippets/common/button-story-action-event-handle.js.mdx
@@ -7,7 +7,7 @@ import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-action-event-handle.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-action-event-handle.ts-4-9.mdx
@@ -10,7 +10,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-action-event-handle.ts.mdx
+++ b/docs/snippets/common/button-story-action-event-handle.ts.mdx
@@ -10,7 +10,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-argtypes-with-categories.js.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-categories.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-argtypes-with-categories.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-categories.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-argtypes-with-categories.ts.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-categories.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-argtypes-with-subcategories.js.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-subcategories.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-argtypes-with-subcategories.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-subcategories.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-argtypes-with-subcategories.ts.mdx
+++ b/docs/snippets/common/button-story-argtypes-with-subcategories.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-baseline-with-satisfies-story-level.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-baseline-with-satisfies-story-level.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-baseline.ts.mdx
+++ b/docs/snippets/common/button-story-baseline.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-controls-primary-variant.js.mdx
+++ b/docs/snippets/common/button-story-controls-primary-variant.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-controls-primary-variant.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-controls-primary-variant.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-controls-primary-variant.ts.mdx
+++ b/docs/snippets/common/button-story-controls-primary-variant.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-controls-radio-group.js.mdx
+++ b/docs/snippets/common/button-story-controls-radio-group.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-controls-radio-group.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-controls-radio-group.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-controls-radio-group.ts.mdx
+++ b/docs/snippets/common/button-story-controls-radio-group.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-default-export.js.mdx
+++ b/docs/snippets/common/button-story-default-export.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-default-export.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-default-export.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-default-export.ts.mdx
+++ b/docs/snippets/common/button-story-default-export.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-disable-addon.js.mdx
+++ b/docs/snippets/common/button-story-disable-addon.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-disable-addon.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-disable-addon.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-disable-addon.ts.mdx
+++ b/docs/snippets/common/button-story-disable-addon.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-grouped.js.mdx
+++ b/docs/snippets/common/button-story-grouped.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Button',

--- a/docs/snippets/common/button-story-grouped.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-grouped.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Button',

--- a/docs/snippets/common/button-story-grouped.ts.mdx
+++ b/docs/snippets/common/button-story-grouped.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Button',

--- a/docs/snippets/common/button-story-hide-nocontrols-warning.js.mdx
+++ b/docs/snippets/common/button-story-hide-nocontrols-warning.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-hide-nocontrols-warning.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-hide-nocontrols-warning.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-hide-nocontrols-warning.ts.mdx
+++ b/docs/snippets/common/button-story-hide-nocontrols-warning.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-hoisted.js.mdx
+++ b/docs/snippets/common/button-story-hoisted.js.mdx
@@ -5,7 +5,7 @@ import { Button as ButtonComponent } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Button',

--- a/docs/snippets/common/button-story-hoisted.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-hoisted.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button as ButtonComponent } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Button',

--- a/docs/snippets/common/button-story-hoisted.ts.mdx
+++ b/docs/snippets/common/button-story-hoisted.ts.mdx
@@ -8,7 +8,7 @@ import { Button as ButtonComponent } from './Button';
 
 const meta: Meta<typeof ButtonComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Button',

--- a/docs/snippets/common/button-story-hypothetical-example.js.mdx
+++ b/docs/snippets/common/button-story-hypothetical-example.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Sample = {

--- a/docs/snippets/common/button-story-hypothetical-example.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-hypothetical-example.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Sample: Story = {

--- a/docs/snippets/common/button-story-hypothetical-example.ts.mdx
+++ b/docs/snippets/common/button-story-hypothetical-example.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Sample: Story = {

--- a/docs/snippets/common/button-story-matching-argtypes.js.mdx
+++ b/docs/snippets/common/button-story-matching-argtypes.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-matching-argtypes.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-matching-argtypes.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-matching-argtypes.ts.mdx
+++ b/docs/snippets/common/button-story-matching-argtypes.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-onclick-action-argtype.js.mdx
+++ b/docs/snippets/common/button-story-onclick-action-argtype.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-onclick-action-argtype.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-onclick-action-argtype.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-onclick-action-argtype.ts.mdx
+++ b/docs/snippets/common/button-story-onclick-action-argtype.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-primary-composition.js.mdx
+++ b/docs/snippets/common/button-story-primary-composition.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-primary-composition.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-primary-composition.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-primary-composition.ts.mdx
+++ b/docs/snippets/common/button-story-primary-composition.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-primary-long-name.js.mdx
+++ b/docs/snippets/common/button-story-primary-long-name.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-primary-long-name.ts-4-9.mdx
+++ b/docs/snippets/common/button-story-primary-long-name.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-primary-long-name.ts.mdx
+++ b/docs/snippets/common/button-story-primary-long-name.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/button-story-with-parameters.js.mdx
+++ b/docs/snippets/common/button-story-with-parameters.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/checkbox-story-csf.js.mdx
+++ b/docs/snippets/common/checkbox-story-csf.js.mdx
@@ -5,7 +5,7 @@ import { Checkbox } from './Checkbox';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Checkbox',

--- a/docs/snippets/common/checkbox-story-csf.ts-4-9.mdx
+++ b/docs/snippets/common/checkbox-story-csf.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Checkbox } from './Checkbox';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Checkbox',

--- a/docs/snippets/common/checkbox-story-csf.ts.mdx
+++ b/docs/snippets/common/checkbox-story-csf.ts.mdx
@@ -8,7 +8,7 @@ import { Checkbox } from './Checkbox';
 
 const meta: Meta<typeof Checkbox> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Checkbox',

--- a/docs/snippets/common/checkbox-story-grouped.js.mdx
+++ b/docs/snippets/common/checkbox-story-grouped.js.mdx
@@ -5,7 +5,7 @@ import { CheckBox } from './Checkbox';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Checkbox',

--- a/docs/snippets/common/checkbox-story-grouped.ts-4-9.mdx
+++ b/docs/snippets/common/checkbox-story-grouped.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { CheckBox } from './Checkbox';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Checkbox',

--- a/docs/snippets/common/checkbox-story-grouped.ts.mdx
+++ b/docs/snippets/common/checkbox-story-grouped.ts.mdx
@@ -8,7 +8,7 @@ import { CheckBox } from './Checkbox';
 
 const meta: Meta<typeof CheckBox> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Design System/Atoms/Checkbox',

--- a/docs/snippets/common/component-story-auto-title.csf3-story-ts.ts-4-9.mdx
+++ b/docs/snippets/common/component-story-auto-title.csf3-story-ts.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 /**
  * Story written in CSF 3.0 with auto title generation
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn more about it.
  */
 const meta = {

--- a/docs/snippets/common/component-story-auto-title.csf3-story-ts.ts.mdx
+++ b/docs/snippets/common/component-story-auto-title.csf3-story-ts.ts.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 /**
  * Story written in CSF 3.0 with auto title generation
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn more about it.
  */
 const meta: Meta<typeof MyComponent> = {

--- a/docs/snippets/common/component-story-auto-title.csf3-story.js.mdx
+++ b/docs/snippets/common/component-story-auto-title.csf3-story.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 /**
  * Story written in CSF 3.0 with auto title generation
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn more about it.
  */
 export default { component: MyComponent };

--- a/docs/snippets/common/component-story-conditional-controls-mutual-exclusion.js.mdx
+++ b/docs/snippets/common/component-story-conditional-controls-mutual-exclusion.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-conditional-controls-mutual-exclusion.ts-4-9.mdx
+++ b/docs/snippets/common/component-story-conditional-controls-mutual-exclusion.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-conditional-controls-mutual-exclusion.ts.mdx
+++ b/docs/snippets/common/component-story-conditional-controls-mutual-exclusion.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-conditional-controls-toggle.js.mdx
+++ b/docs/snippets/common/component-story-conditional-controls-toggle.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-conditional-controls-toggle.ts-4-9.mdx
+++ b/docs/snippets/common/component-story-conditional-controls-toggle.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-conditional-controls-toggle.ts.mdx
+++ b/docs/snippets/common/component-story-conditional-controls-toggle.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-custom-args-mapping.js.mdx
+++ b/docs/snippets/common/component-story-custom-args-mapping.js.mdx
@@ -9,7 +9,7 @@ const arrows = { ArrowUp, ArrowDown, ArrowLeft, ArrowRight };
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-custom-args-mapping.ts-4-9.mdx
+++ b/docs/snippets/common/component-story-custom-args-mapping.ts-4-9.mdx
@@ -12,7 +12,7 @@ const arrows = { ArrowUp, ArrowDown, ArrowLeft, ArrowRight };
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-custom-args-mapping.ts.mdx
+++ b/docs/snippets/common/component-story-custom-args-mapping.ts.mdx
@@ -12,7 +12,7 @@ const arrows = { ArrowUp, ArrowDown, ArrowLeft, ArrowRight };
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-custom-params.js.mdx
+++ b/docs/snippets/common/component-story-custom-params.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-custom-params.ts-4-9.mdx
+++ b/docs/snippets/common/component-story-custom-params.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-custom-params.ts.mdx
+++ b/docs/snippets/common/component-story-custom-params.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/component-story-disable-controls-alt.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls-alt.js.mdx
@@ -5,7 +5,7 @@ import { YourComponent } from './YourComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-disable-controls-alt.ts-4-9.mdx
+++ b/docs/snippets/common/component-story-disable-controls-alt.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './YourComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-disable-controls-alt.ts.mdx
+++ b/docs/snippets/common/component-story-disable-controls-alt.ts.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './YourComponent';
 
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-disable-controls-regex.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls-regex.js.mdx
@@ -5,7 +5,7 @@ import { YourComponent } from './YourComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-disable-controls-regex.ts-4-9.mdx
+++ b/docs/snippets/common/component-story-disable-controls-regex.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './YourComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-disable-controls-regex.ts.mdx
+++ b/docs/snippets/common/component-story-disable-controls-regex.ts.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './YourComponent';
 
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-disable-controls.js.mdx
+++ b/docs/snippets/common/component-story-disable-controls.js.mdx
@@ -5,7 +5,7 @@ import { YourComponent } from './YourComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-disable-controls.ts-4-9.mdx
+++ b/docs/snippets/common/component-story-disable-controls.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './YourComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-disable-controls.ts.mdx
+++ b/docs/snippets/common/component-story-disable-controls.ts.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './YourComponent';
 
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-sort-controls.js.mdx
+++ b/docs/snippets/common/component-story-sort-controls.js.mdx
@@ -5,7 +5,7 @@ import { YourComponent } from './your-component';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-sort-controls.ts-4-9.mdx
+++ b/docs/snippets/common/component-story-sort-controls.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './YourComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/component-story-sort-controls.ts.mdx
+++ b/docs/snippets/common/component-story-sort-controls.ts.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './YourComponent';
 
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/common/custom-docs-page.mdx.mdx
+++ b/docs/snippets/common/custom-docs-page.mdx.mdx
@@ -3,7 +3,7 @@
 
 # Replacing DocsPage with custom `MDX` content
 
-This file is a documentation-only `MDX`file to customize Storybook's [DocsPage](https://storybook.js.org/docs/7.0/react/writing-docs/docs-page#replacing-docspage).
+This file is a documentation-only `MDX`file to customize Storybook's [DocsPage](https://storybook.js.org/docs/react/writing-docs/docs-page#replacing-docspage).
 
 It can be further expanded with your own code snippets and include specific information related to your stories.
 

--- a/docs/snippets/common/foo-bar-baz-story.js.mdx
+++ b/docs/snippets/common/foo-bar-baz-story.js.mdx
@@ -5,7 +5,7 @@ import { Foo } from './Foo';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Foo/Bar',

--- a/docs/snippets/common/foo-bar-baz-story.ts-4-9.mdx
+++ b/docs/snippets/common/foo-bar-baz-story.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Foo } from './Foo';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Foo/Bar',

--- a/docs/snippets/common/foo-bar-baz-story.ts.mdx
+++ b/docs/snippets/common/foo-bar-baz-story.ts.mdx
@@ -8,7 +8,7 @@ import { Foo } from './Foo';
 
 const meta: Meta<typeof Foo> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Foo/Bar',

--- a/docs/snippets/common/gizmo-story-controls-customization.js.mdx
+++ b/docs/snippets/common/gizmo-story-controls-customization.js.mdx
@@ -5,7 +5,7 @@ import { Gizmo } from './Gizmo';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Gizmo',

--- a/docs/snippets/common/gizmo-story-controls-customization.ts-4-9.mdx
+++ b/docs/snippets/common/gizmo-story-controls-customization.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Gizmo } from './Gizmo';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Gizmo',

--- a/docs/snippets/common/gizmo-story-controls-customization.ts.mdx
+++ b/docs/snippets/common/gizmo-story-controls-customization.ts.mdx
@@ -8,7 +8,7 @@ import { Gizmo } from './Gizmo';
 
 const meta: Meta<typeof Gizmo> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Gizmo',

--- a/docs/snippets/common/my-component-argtypes-with-mapping.js.mdx
+++ b/docs/snippets/common/my-component-argtypes-with-mapping.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/common/my-component-argtypes-with-mapping.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-argtypes-with-mapping.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/common/my-component-argtypes-with-mapping.ts.mdx
+++ b/docs/snippets/common/my-component-argtypes-with-mapping.ts.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/common/my-component-env-var-config.js.mdx
+++ b/docs/snippets/common/my-component-env-var-config.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/common/my-component-env-var-config.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-env-var-config.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/common/my-component-env-var-config.ts.mdx
+++ b/docs/snippets/common/my-component-env-var-config.ts.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/common/my-component-play-function-alt-queries.js.mdx
+++ b/docs/snippets/common/my-component-play-function-alt-queries.js.mdx
@@ -10,14 +10,14 @@ export default {
   component: MyComponent,
 };
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleWithRole = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };

--- a/docs/snippets/common/my-component-play-function-alt-queries.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-play-function-alt-queries.ts-4-9.mdx
@@ -16,14 +16,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleWithRole: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };

--- a/docs/snippets/common/my-component-play-function-alt-queries.ts.mdx
+++ b/docs/snippets/common/my-component-play-function-alt-queries.ts.mdx
@@ -16,14 +16,14 @@ const meta: Meta<typeof MyComponent> = {
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleWithRole: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };

--- a/docs/snippets/common/my-component-play-function-composition.js.mdx
+++ b/docs/snippets/common/my-component-play-function-composition.js.mdx
@@ -11,7 +11,7 @@ export default {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FirstStory = {

--- a/docs/snippets/common/my-component-play-function-composition.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-play-function-composition.ts-4-9.mdx
@@ -17,7 +17,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FirstStory: Story = {

--- a/docs/snippets/common/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/common/my-component-play-function-composition.ts.mdx
@@ -17,7 +17,7 @@ export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FirstStory: Story = {

--- a/docs/snippets/common/my-component-play-function-query-findby.js.mdx
+++ b/docs/snippets/common/my-component-play-function-query-findby.js.mdx
@@ -10,7 +10,7 @@ export default {
   component: MyComponent,
 };
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const AsyncExample = {

--- a/docs/snippets/common/my-component-play-function-query-findby.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-play-function-query-findby.ts-4-9.mdx
@@ -16,7 +16,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const AsyncExample: Story = {

--- a/docs/snippets/common/my-component-play-function-query-findby.ts.mdx
+++ b/docs/snippets/common/my-component-play-function-query-findby.ts.mdx
@@ -16,7 +16,7 @@ const meta: Meta<typeof MyComponent> = {
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const AsyncExample: Story = {

--- a/docs/snippets/common/my-component-play-function-waitfor.js.mdx
+++ b/docs/snippets/common/my-component-play-function-waitfor.js.mdx
@@ -10,7 +10,7 @@ export default {
   component: MyComponent,
 };
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleAsyncStory = {
@@ -25,7 +25,7 @@ export const ExampleAsyncStory = {
       delay: 100,
     });
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 

--- a/docs/snippets/common/my-component-play-function-waitfor.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-play-function-waitfor.ts-4-9.mdx
@@ -16,7 +16,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleAsyncStory: Story = {
@@ -31,7 +31,7 @@ export const ExampleAsyncStory: Story = {
       delay: 100,
     });
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 

--- a/docs/snippets/common/my-component-play-function-waitfor.ts.mdx
+++ b/docs/snippets/common/my-component-play-function-waitfor.ts.mdx
@@ -16,7 +16,7 @@ const meta: Meta<typeof MyComponent> = {
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleAsyncStory: Story = {
@@ -31,7 +31,7 @@ export const ExampleAsyncStory: Story = {
       delay: 100,
     });
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 

--- a/docs/snippets/common/my-component-play-function-with-clickevent.js.mdx
+++ b/docs/snippets/common/my-component-play-function-with-clickevent.js.mdx
@@ -17,7 +17,7 @@ export const ClickExample = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
   },
 };
@@ -26,7 +26,7 @@ export const FireEventExample = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };

--- a/docs/snippets/common/my-component-play-function-with-clickevent.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-play-function-with-clickevent.ts-4-9.mdx
@@ -23,7 +23,7 @@ export const ClickExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
   },
 };
@@ -32,7 +32,7 @@ export const FireEventExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };

--- a/docs/snippets/common/my-component-play-function-with-clickevent.ts.mdx
+++ b/docs/snippets/common/my-component-play-function-with-clickevent.ts.mdx
@@ -23,7 +23,7 @@ export const ClickExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
   },
 };
@@ -32,7 +32,7 @@ export const FireEventExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };

--- a/docs/snippets/common/my-component-play-function-with-delay.js.mdx
+++ b/docs/snippets/common/my-component-play-function-with-delay.js.mdx
@@ -10,7 +10,7 @@ export default {
   component: MyComponent,
 };
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const DelayedStory = {

--- a/docs/snippets/common/my-component-play-function-with-delay.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-play-function-with-delay.ts-4-9.mdx
@@ -16,7 +16,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const DelayedStory: Story = {

--- a/docs/snippets/common/my-component-play-function-with-delay.ts.mdx
+++ b/docs/snippets/common/my-component-play-function-with-delay.ts.mdx
@@ -16,7 +16,7 @@ const meta: Meta<typeof MyComponent> = {
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const DelayedStory: Story = {

--- a/docs/snippets/common/my-component-play-function-with-selectevent.js.mdx
+++ b/docs/snippets/common/my-component-play-function-with-selectevent.js.mdx
@@ -15,7 +15,7 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleChangeEvent = {

--- a/docs/snippets/common/my-component-play-function-with-selectevent.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-play-function-with-selectevent.ts-4-9.mdx
@@ -21,7 +21,7 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleChangeEvent: Story = {

--- a/docs/snippets/common/my-component-play-function-with-selectevent.ts.mdx
+++ b/docs/snippets/common/my-component-play-function-with-selectevent.ts.mdx
@@ -21,7 +21,7 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/* See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleChangeEvent: Story = {

--- a/docs/snippets/common/my-component-story-mandatory-export.js.mdx
+++ b/docs/snippets/common/my-component-story-mandatory-export.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-  * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+  * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/common/my-component-story-mandatory-export.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-story-mandatory-export.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/common/my-component-story-mandatory-export.ts.mdx
+++ b/docs/snippets/common/my-component-story-mandatory-export.ts.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/common/my-component-story-with-storyname.js.mdx
+++ b/docs/snippets/common/my-component-story-with-storyname.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-  * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+  * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/common/my-component-story-with-storyname.ts-4-9.mdx
+++ b/docs/snippets/common/my-component-story-with-storyname.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/common/my-component-story-with-storyname.ts.mdx
+++ b/docs/snippets/common/my-component-story-with-storyname.ts.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/common/my-component-story.js.mdx
+++ b/docs/snippets/common/my-component-story.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/common/other-foo-bar-story.js.mdx
+++ b/docs/snippets/common/other-foo-bar-story.js.mdx
@@ -5,7 +5,7 @@ import { Foo } from './Foo';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'OtherFoo/Bar',

--- a/docs/snippets/common/other-foo-bar-story.ts-4-9.mdx
+++ b/docs/snippets/common/other-foo-bar-story.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Foo } from './Foo';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'OtherFoo/Bar',

--- a/docs/snippets/common/other-foo-bar-story.ts.mdx
+++ b/docs/snippets/common/other-foo-bar-story.ts.mdx
@@ -8,7 +8,7 @@ import { Foo } from './Foo';
 
 const meta: Meta<typeof Foo> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'OtherFoo/Bar',

--- a/docs/snippets/common/register-component-with-play-function.js.mdx
+++ b/docs/snippets/common/register-component-with-play-function.js.mdx
@@ -11,7 +11,7 @@ export default {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm = {
@@ -33,7 +33,7 @@ export const FilledForm = {
     await userEvent.type(passwordInput, 'ExamplePassword', {
       delay: 100,
     });
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);

--- a/docs/snippets/common/register-component-with-play-function.ts-4-9.mdx
+++ b/docs/snippets/common/register-component-with-play-function.ts-4-9.mdx
@@ -17,7 +17,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
@@ -39,7 +39,7 @@ export const FilledForm: Story = {
     await userEvent.type(passwordInput, 'ExamplePassword', {
       delay: 100,
     });
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);

--- a/docs/snippets/common/register-component-with-play-function.ts.mdx
+++ b/docs/snippets/common/register-component-with-play-function.ts.mdx
@@ -17,7 +17,7 @@ export default meta;
 type Story = StoryObj<typeof RegistrationForm>;
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
@@ -39,7 +39,7 @@ export const FilledForm: Story = {
     await userEvent.type(passwordInput, 'ExamplePassword', {
       delay: 100,
     });
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);

--- a/docs/snippets/common/storybook-addon-a11y-component-config.js.mdx
+++ b/docs/snippets/common/storybook-addon-a11y-component-config.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',

--- a/docs/snippets/common/storybook-addon-a11y-component-config.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-addon-a11y-component-config.ts-4-9.mdx
@@ -10,7 +10,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',

--- a/docs/snippets/common/storybook-addon-a11y-component-config.ts.mdx
+++ b/docs/snippets/common/storybook-addon-a11y-component-config.ts.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.js.mdx
@@ -6,7 +6,7 @@ import { Button } from './Button';
 // To apply a set of backgrounds to all stories of Button:
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 // To apply a set of backgrounds to all stories of Button:
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.ts.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-backgrounds.ts.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 // To apply a set of backgrounds to all stories of Button:
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-grid.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-grid.js.mdx
@@ -6,7 +6,7 @@ import { Button } from './Button';
 // To apply a grid to all stories of Button:
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-grid.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-grid.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 // To apply a set of backgrounds to all stories of Button:
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-configure-grid.ts.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-configure-grid.ts.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 // To apply a set of backgrounds to all stories of Button:
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.ts.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-backgrounds.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-grid.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-grid.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-grid.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-grid.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-disable-grid.ts.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-disable-grid.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-override-background-color.js.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-override-background-color.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-override-background-color.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-override-background-color.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-addon-backgrounds-override-background-color.ts.mdx
+++ b/docs/snippets/common/storybook-addon-backgrounds-override-background-color.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-component-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-component-layout-param.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-component-layout-param.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-component-layout-param.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-component-layout-param.ts.mdx
+++ b/docs/snippets/common/storybook-component-layout-param.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-csf-3-auto-title-redundant.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-csf-3-auto-title-redundant.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   component: MyComponent,

--- a/docs/snippets/common/storybook-csf-3-auto-title-redundant.ts.mdx
+++ b/docs/snippets/common/storybook-csf-3-auto-title-redundant.ts.mdx
@@ -8,7 +8,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   component: MyComponent,

--- a/docs/snippets/common/storybook-customize-argtypes.js.mdx
+++ b/docs/snippets/common/storybook-customize-argtypes.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-customize-argtypes.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-customize-argtypes.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-customize-argtypes.ts.mdx
+++ b/docs/snippets/common/storybook-customize-argtypes.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-fix-imports-autodocs-monorepo.js.mdx
+++ b/docs/snippets/common/storybook-fix-imports-autodocs-monorepo.js.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from '@component-package/src/MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/common/storybook-fix-imports-autodocs-monorepo.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-fix-imports-autodocs-monorepo.ts-4-9.mdx
@@ -12,7 +12,7 @@ import { MyComponent } from '@component-package/src/MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/common/storybook-fix-imports-autodocs-monorepo.ts.mdx
+++ b/docs/snippets/common/storybook-fix-imports-autodocs-monorepo.ts.mdx
@@ -12,7 +12,7 @@ import { MyComponent } from '@component-package/src/MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/common/storybook-interactions-play-function.js.mdx
+++ b/docs/snippets/common/storybook-interactions-play-function.js.mdx
@@ -9,7 +9,7 @@ import { Form } from './Form';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Form',
@@ -20,7 +20,7 @@ export default {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted = {

--- a/docs/snippets/common/storybook-interactions-play-function.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-interactions-play-function.ts-4-9.mdx
@@ -12,7 +12,7 @@ import { Form } from './Form';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Form',
@@ -26,7 +26,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted: Story = {

--- a/docs/snippets/common/storybook-interactions-play-function.ts.mdx
+++ b/docs/snippets/common/storybook-interactions-play-function.ts.mdx
@@ -12,7 +12,7 @@ import { Form } from './Form';
 
 const meta: Meta<typeof Form> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -26,7 +26,7 @@ export default meta;
 type Story = StoryObj<typeof Form>;
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted: Story = {

--- a/docs/snippets/common/storybook-interactions-step-function.js.mdx
+++ b/docs/snippets/common/storybook-interactions-step-function.js.mdx
@@ -11,7 +11,7 @@ export default {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted = {

--- a/docs/snippets/common/storybook-interactions-step-function.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-interactions-step-function.ts-4-9.mdx
@@ -17,7 +17,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted: Story = {

--- a/docs/snippets/common/storybook-interactions-step-function.ts.mdx
+++ b/docs/snippets/common/storybook-interactions-step-function.ts.mdx
@@ -17,7 +17,7 @@ export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted: Story = {

--- a/docs/snippets/common/storybook-mdx-template-with-prop.mdx.mdx
+++ b/docs/snippets/common/storybook-mdx-template-with-prop.mdx.mdx
@@ -5,7 +5,7 @@ import { Meta, Title, Subtitle, Description, Primary, Controls, Stories } from '
 
 {/* 
   * 👇 The isTemplate property is required to tell Storybook that this is a template
-  * See https://storybook.js.org/docs/7.0/react/api/doc-block-meta
+  * See https://storybook.js.org/docs/react/api/doc-block-meta
   * to learn how to use
 */}
 

--- a/docs/snippets/common/storybook-story-layout-param.js.mdx
+++ b/docs/snippets/common/storybook-story-layout-param.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button':
 
 export default {
   /* 👇 The title prop is optional.
-  * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+  * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',

--- a/docs/snippets/common/storybook-story-layout-param.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-story-layout-param.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-story-layout-param.ts.mdx
+++ b/docs/snippets/common/storybook-story-layout-param.ts.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/common/storybook-test-runner-a11y-config.js.mdx
+++ b/docs/snippets/common/storybook-test-runner-a11y-config.js.mdx
@@ -4,7 +4,7 @@
 const { injectAxe, checkA11y } = require('axe-playwright');
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-tests/test-runner#test-hook-api-experimental
+ * See https://storybook.js.org/docs/react/writing-tests/test-runner#test-hook-api-experimental
  * to learn more about the test-runner hooks API.
  */
 module.exports = {

--- a/docs/snippets/common/storybook-test-runner-a11y-config.ts.mdx
+++ b/docs/snippets/common/storybook-test-runner-a11y-config.ts.mdx
@@ -6,7 +6,7 @@ import { injectAxe, checkA11y } from 'axe-playwright';
 import type { TestRunnerConfig } from '@storybook/test-runner';
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-tests/test-runner#test-hook-api-experimental
+ * See https://storybook.js.org/docs/react/writing-tests/test-runner#test-hook-api-experimental
  * to learn more about the test-runner hooks API.
  */
 const a11yConfig: TestRunnerConfig = {

--- a/docs/snippets/common/storybook-test-runner-a11y-configure.js.mdx
+++ b/docs/snippets/common/storybook-test-runner-a11y-configure.js.mdx
@@ -6,7 +6,7 @@ const { injectAxe, checkA11y, configureAxe } = require('axe-playwright');
 const { getStoryContext } = require('@storybook/test-runner');
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-tests/test-runner#test-hook-api-experimental
+ * See https://storybook.js.org/docs/react/writing-tests/test-runner#test-hook-api-experimental
  * to learn more about the test-runner hooks API.
  */
 module.exports = {

--- a/docs/snippets/common/storybook-test-runner-a11y-configure.ts.mdx
+++ b/docs/snippets/common/storybook-test-runner-a11y-configure.ts.mdx
@@ -8,7 +8,7 @@ import { getStoryContext } from '@storybook/test-runner';
 import type { TestRunnerConfig } from '@storybook/test-runner';
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-tests/test-runner#test-hook-api-experimental
+ * See https://storybook.js.org/docs/react/writing-tests/test-runner#test-hook-api-experimental
  * to learn more about the test-runner hooks API.
  */
 const a11yConfig: TestRunnerConfig = {

--- a/docs/snippets/common/storybook-test-runner-a11y-disable.js.mdx
+++ b/docs/snippets/common/storybook-test-runner-a11y-disable.js.mdx
@@ -6,7 +6,7 @@ const { injectAxe, checkA11y } = require('axe-playwright');
 const { getStoryContext } = require('@storybook/test-runner');
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-tests/test-runner#test-hook-api-experimental
+ * See https://storybook.js.org/docs/react/writing-tests/test-runner#test-hook-api-experimental
  * to learn more about the test-runner hooks API.
  */
 module.exports = {

--- a/docs/snippets/common/storybook-test-runner-a11y-disable.ts.mdx
+++ b/docs/snippets/common/storybook-test-runner-a11y-disable.ts.mdx
@@ -8,7 +8,7 @@ import { getStoryContext } from '@storybook/test-runner';
 import type { TestRunnerConfig } from '@storybook/test-runner';
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-tests/test-runner#test-hook-api-experimental
+ * See https://storybook.js.org/docs/react/writing-tests/test-runner#test-hook-api-experimental
  * to learn more about the test-runner hooks API.
  */
 const a11yConfig: TestRunnerConfig = {

--- a/docs/snippets/html/button-story-component-decorator.js.mdx
+++ b/docs/snippets/html/button-story-component-decorator.js.mdx
@@ -21,7 +21,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/html/button-story-rename-story.js.mdx
+++ b/docs/snippets/html/button-story-rename-story.js.mdx
@@ -13,7 +13,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/html/button-story-rename-story.ts.mdx
+++ b/docs/snippets/html/button-story-rename-story.ts.mdx
@@ -18,7 +18,7 @@ type Story = StoryObj<ButtonArgs>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/html/button-story-using-args.js.mdx
+++ b/docs/snippets/html/button-story-using-args.js.mdx
@@ -13,7 +13,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/html/button-story-using-args.ts.mdx
+++ b/docs/snippets/html/button-story-using-args.ts.mdx
@@ -17,7 +17,7 @@ type Story = StoryObj<ButtonArgs>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/html/button-story-with-args.js.mdx
+++ b/docs/snippets/html/button-story-with-args.js.mdx
@@ -11,7 +11,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/html/button-story-with-args.ts.mdx
+++ b/docs/snippets/html/button-story-with-args.ts.mdx
@@ -21,7 +21,7 @@ type Story = StoryObj<ButtonArgs>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/html/button-story-with-emojis.js.mdx
+++ b/docs/snippets/html/button-story-with-emojis.js.mdx
@@ -13,7 +13,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/html/button-story-with-emojis.ts.mdx
+++ b/docs/snippets/html/button-story-with-emojis.ts.mdx
@@ -17,7 +17,7 @@ type Story = StoryObj<ButtonArgs>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/html/button-story.js.mdx
+++ b/docs/snippets/html/button-story.js.mdx
@@ -11,7 +11,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/html/button-story.ts.mdx
+++ b/docs/snippets/html/button-story.ts.mdx
@@ -15,7 +15,7 @@ export default meta;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/html/histogram-story.js.mdx
+++ b/docs/snippets/html/histogram-story.js.mdx
@@ -5,7 +5,7 @@ import { createHistogram } from './Histogram';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/html/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/html/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
@@ -13,7 +13,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Default = {

--- a/docs/snippets/html/histogram-story.ts.mdx
+++ b/docs/snippets/html/histogram-story.ts.mdx
@@ -7,7 +7,7 @@ import { createHistogram, HistogramProps } from './Histogram';
 
 const meta: Meta<HistogramProps> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/html/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/html/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
@@ -18,7 +18,7 @@ type Story = StoryObj<HistogramProps>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Default: Story = {

--- a/docs/snippets/html/list-story-expanded.js.mdx
+++ b/docs/snippets/html/list-story-expanded.js.mdx
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Empty = {

--- a/docs/snippets/html/list-story-expanded.ts.mdx
+++ b/docs/snippets/html/list-story-expanded.ts.mdx
@@ -15,7 +15,7 @@ type Story = StoryObj<ListArgs>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const Empty: Story = {

--- a/docs/snippets/html/list-story-reuse-data.js.mdx
+++ b/docs/snippets/html/list-story-reuse-data.js.mdx
@@ -17,7 +17,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems = {

--- a/docs/snippets/html/list-story-reuse-data.ts.mdx
+++ b/docs/snippets/html/list-story-reuse-data.ts.mdx
@@ -22,7 +22,7 @@ type Story = StoryObj<ListArgs>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems: Story = {

--- a/docs/snippets/html/list-story-starter.ts.mdx
+++ b/docs/snippets/html/list-story-starter.ts.mdx
@@ -7,7 +7,7 @@ import { createList, ListArgs } from './List';
 
 const meta: Meta<ListArgs> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/html/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/html/your-component.js.mdx
+++ b/docs/snippets/html/your-component.js.mdx
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const FirstStory = {

--- a/docs/snippets/html/your-component.ts.mdx
+++ b/docs/snippets/html/your-component.ts.mdx
@@ -19,7 +19,7 @@ type Story = StoryObj<ComponentProps>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/html/api/csf
+ * See https://storybook.js.org/docs/html/api/csf
  * to learn how to use render functions.
  */
 export const FirstStory: Story = {

--- a/docs/snippets/preact/button-story-with-args.js.mdx
+++ b/docs/snippets/preact/button-story-with-args.js.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/preact/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/preact/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -17,7 +17,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/preact/api/csf
+ * See https://storybook.js.org/docs/preact/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/preact/button-story.js.mdx
+++ b/docs/snippets/preact/button-story.js.mdx
@@ -8,7 +8,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/preact/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/preact/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -17,7 +17,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/preact/api/csf
+ * See https://storybook.js.org/docs/preact/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/preact/component-story-with-custom-render-function.js.mdx
+++ b/docs/snippets/preact/component-story-with-custom-render-function.js.mdx
@@ -10,7 +10,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/preact/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/preact/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/preact/histogram-story.js.mdx
+++ b/docs/snippets/preact/histogram-story.js.mdx
@@ -8,7 +8,7 @@ import { Histogram } from './Histogram';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/preact/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/preact/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
@@ -17,7 +17,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/preact/api/csf
+ * See https://storybook.js.org/docs/preact/api/csf
  * to learn how to use render functions.
  */
 export const Default = {

--- a/docs/snippets/preact/histogram-story.mdx.mdx
+++ b/docs/snippets/preact/histogram-story.mdx.mdx
@@ -9,7 +9,7 @@ import { Histogram } from './Histogram';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/preact/api/csf
+  See https://storybook.js.org/docs/preact/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/preact/your-component.js.mdx
+++ b/docs/snippets/preact/your-component.js.mdx
@@ -9,7 +9,7 @@ import { YourComponent } from './YourComponent';
 //👇 This default export determines where your story goes in the story list
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/preact/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/preact/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -18,7 +18,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/preact/api/csf
+ * See https://storybook.js.org/docs/preact/api/csf
  * to learn how to use render functions.
  */
 export const FirstStory = {

--- a/docs/snippets/react/button-group-story.js.mdx
+++ b/docs/snippets/react/button-group-story.js.mdx
@@ -10,7 +10,7 @@ import * as ButtonStories from './Button.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',

--- a/docs/snippets/react/button-group-story.ts-4-9.mdx
+++ b/docs/snippets/react/button-group-story.ts-4-9.mdx
@@ -10,7 +10,7 @@ import * as ButtonStories from './Button.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',

--- a/docs/snippets/react/button-group-story.ts.mdx
+++ b/docs/snippets/react/button-group-story.ts.mdx
@@ -10,7 +10,7 @@ import * as ButtonStories from './Button.stories';
 
 const meta: Meta<typeof ButtonGroup> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',

--- a/docs/snippets/react/button-story-click-handler-args.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-args.js.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-click-handler-args.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-click-handler-args.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-click-handler-args.ts.mdx
+++ b/docs/snippets/react/button-story-click-handler-args.ts.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-click-handler-simple-docs.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-simple-docs.js.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-click-handler-simplificated.js.mdx
+++ b/docs/snippets/react/button-story-click-handler-simplificated.js.mdx
@@ -5,7 +5,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-  * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+  * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',

--- a/docs/snippets/react/button-story-click-handler-simplificated.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-click-handler-simplificated.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-click-handler-simplificated.ts.mdx
+++ b/docs/snippets/react/button-story-click-handler-simplificated.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-click-handler.js.mdx
+++ b/docs/snippets/react/button-story-click-handler.js.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-click-handler.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-click-handler.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-click-handler.ts.mdx
+++ b/docs/snippets/react/button-story-click-handler.ts.mdx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-component-args-primary.js.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-component-args-primary.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-component-args-primary.ts.mdx
+++ b/docs/snippets/react/button-story-component-args-primary.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-component-decorator.js.mdx
+++ b/docs/snippets/react/button-story-component-decorator.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-component-decorator.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-component-decorator.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-component-decorator.ts.mdx
+++ b/docs/snippets/react/button-story-component-decorator.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-decorator.js.mdx
+++ b/docs/snippets/react/button-story-decorator.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-decorator.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-decorator.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-decorator.ts.mdx
+++ b/docs/snippets/react/button-story-decorator.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-default-export-with-component.js.mdx
+++ b/docs/snippets/react/button-story-default-export-with-component.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-default-export-with-component.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-default-export-with-component.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-default-export-with-component.ts.mdx
+++ b/docs/snippets/react/button-story-default-export-with-component.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-rename-story.js.mdx
+++ b/docs/snippets/react/button-story-rename-story.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-rename-story.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-rename-story.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/react/button-story-rename-story.ts.mdx
+++ b/docs/snippets/react/button-story-rename-story.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/react/button-story-using-args.js.mdx
+++ b/docs/snippets/react/button-story-using-args.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-using-args.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-using-args.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-using-args.ts.mdx
+++ b/docs/snippets/react/button-story-using-args.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/react/button-story-with-addon-example.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-addon-example.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-with-addon-example.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Basic: Story = {

--- a/docs/snippets/react/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/react/button-story-with-addon-example.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Basic: Story = {

--- a/docs/snippets/react/button-story-with-args.js.mdx
+++ b/docs/snippets/react/button-story-with-args.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-args.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-with-args.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button, ButtonProps } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-args.ts.mdx
+++ b/docs/snippets/react/button-story-with-args.ts.mdx
@@ -7,7 +7,7 @@ import { Button, ButtonProps } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-blue-args.js.mdx
+++ b/docs/snippets/react/button-story-with-blue-args.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-blue-args.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-with-blue-args.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-blue-args.ts.mdx
+++ b/docs/snippets/react/button-story-with-blue-args.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-emojis.js.mdx
+++ b/docs/snippets/react/button-story-with-emojis.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -16,7 +16,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/react/button-story-with-emojis.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-with-emojis.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/react/button-story-with-emojis.ts.mdx
+++ b/docs/snippets/react/button-story-with-emojis.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/react/button-story-with-parameters.js.mdx
+++ b/docs/snippets/react/button-story-with-parameters.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-parameters.ts-4-9.mdx
+++ b/docs/snippets/react/button-story-with-parameters.ts-4-9.mdx
@@ -7,7 +7,7 @@ import type { Meta } from '@storybook/react';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-parameters.ts.mdx
+++ b/docs/snippets/react/button-story-with-parameters.ts.mdx
@@ -7,7 +7,7 @@ import type { Meta } from '@storybook/react';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/button-story-with-sample.js.mdx
+++ b/docs/snippets/react/button-story-with-sample.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -16,7 +16,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Sample = {

--- a/docs/snippets/react/button-story.js.mdx
+++ b/docs/snippets/react/button-story.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -16,7 +16,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/react/button-story.ts-4-9.mdx
+++ b/docs/snippets/react/button-story.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/react/button-story.ts.mdx
+++ b/docs/snippets/react/button-story.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/react/button-story.with-hooks.js.mdx
+++ b/docs/snippets/react/button-story.with-hooks.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/react/component-story-custom-args-complex.js.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.js.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './your-component';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/react/component-story-custom-args-complex.ts-4-9.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './your-component';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/react/component-story-custom-args-complex.ts.mdx
+++ b/docs/snippets/react/component-story-custom-args-complex.ts.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './your-component';
 
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/react/component-story-figma-integration.js.mdx
+++ b/docs/snippets/react/component-story-figma-integration.js.mdx
@@ -7,7 +7,7 @@ import { withDesign } from 'storybook-addon-designs';
 
 import { MyComponent } from './MyComponent';
 
-// More on default export: https://storybook.js.org/docs/7.0/react/writing-stories/introduction#default-export
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
   title: 'FigmaExample',
   component: MyComponent,

--- a/docs/snippets/react/component-story-figma-integration.ts-4-9.mdx
+++ b/docs/snippets/react/component-story-figma-integration.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { withDesign } from 'storybook-addon-designs';
 
 import { MyComponent } from './MyComponent';
 
-// More on default export: https://storybook.js.org/docs/7.0/react/writing-stories/introduction#default-export
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
   title: 'FigmaExample',
   component: MyComponent,

--- a/docs/snippets/react/component-story-figma-integration.ts.mdx
+++ b/docs/snippets/react/component-story-figma-integration.ts.mdx
@@ -7,7 +7,7 @@ import { withDesign } from 'storybook-addon-designs';
 
 import { MyComponent } from './MyComponent';
 
-// More on default export: https://storybook.js.org/docs/7.0/react/writing-stories/introduction#default-export
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<typeof MyComponent> = {
   title: 'FigmaExample',
   component: MyComponent,

--- a/docs/snippets/react/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-cdn.js.mdx
@@ -5,7 +5,7 @@ import React from 'react';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -13,7 +13,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage = {

--- a/docs/snippets/react/component-story-static-asset-cdn.ts-4-9.mdx
+++ b/docs/snippets/react/component-story-static-asset-cdn.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',

--- a/docs/snippets/react/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/react/component-story-static-asset-cdn.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',

--- a/docs/snippets/react/component-story-static-asset-with-import.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-with-import.js.mdx
@@ -7,7 +7,7 @@ import imageFile from './static/image.png';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -20,7 +20,7 @@ const image = {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docsct/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage = {

--- a/docs/snippets/react/component-story-static-asset-with-import.ts-4-9.mdx
+++ b/docs/snippets/react/component-story-static-asset-with-import.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -25,7 +25,7 @@ const image = {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/react/component-story-static-asset-with-import.ts.mdx
+++ b/docs/snippets/react/component-story-static-asset-with-import.ts.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -25,7 +25,7 @@ const image = {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/react/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/react/component-story-static-asset-without-import.js.mdx
@@ -5,7 +5,7 @@ import React from 'react';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',

--- a/docs/snippets/react/component-story-static-asset-without-import.ts-4-9.mdx
+++ b/docs/snippets/react/component-story-static-asset-without-import.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',

--- a/docs/snippets/react/component-story-static-asset-without-import.ts.mdx
+++ b/docs/snippets/react/component-story-static-asset-without-import.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',

--- a/docs/snippets/react/component-story-with-accessibility.js.mdx
+++ b/docs/snippets/react/component-story-with-accessibility.js.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading to learn how to generate automatic titles
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading to learn how to generate automatic titles
    */
   title: 'Accessibility testing',
   component: Button,

--- a/docs/snippets/react/component-story-with-accessibility.ts-4-9.mdx
+++ b/docs/snippets/react/component-story-with-accessibility.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading to learn how to generate automatic titles
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading to learn how to generate automatic titles
    */
   title: 'Accessibility testing',
   component: Button,

--- a/docs/snippets/react/component-story-with-accessibility.ts.mdx
+++ b/docs/snippets/react/component-story-with-accessibility.ts.mdx
@@ -7,7 +7,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading to learn how to generate automatic titles
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading to learn how to generate automatic titles
    */
   title: 'Accessibility testing',
   component: Button,

--- a/docs/snippets/react/component-story-with-custom-render-function.js.mdx
+++ b/docs/snippets/react/component-story-with-custom-render-function.js.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/component-story-with-custom-render-function.ts-4-9.mdx
+++ b/docs/snippets/react/component-story-with-custom-render-function.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/component-story-with-custom-render-function.ts.mdx
+++ b/docs/snippets/react/component-story-with-custom-render-function.ts.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/documentscreen-story-msw-graphql-query.js.mdx
+++ b/docs/snippets/react/documentscreen-story-msw-graphql-query.js.mdx
@@ -73,7 +73,7 @@ const TestData = {
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'DocumentScreen',

--- a/docs/snippets/react/documentscreen-story-msw-graphql-query.ts-4-9.mdx
+++ b/docs/snippets/react/documentscreen-story-msw-graphql-query.ts-4-9.mdx
@@ -74,7 +74,7 @@ const TestData = {
 };
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'DocumentScreen',

--- a/docs/snippets/react/documentscreen-story-msw-graphql-query.ts.mdx
+++ b/docs/snippets/react/documentscreen-story-msw-graphql-query.ts.mdx
@@ -74,7 +74,7 @@ const TestData = {
 };
 const meta: Meta<typeof DocumentScreen> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'DocumentScreen',

--- a/docs/snippets/react/histogram-story.js.mdx
+++ b/docs/snippets/react/histogram-story.js.mdx
@@ -5,7 +5,7 @@ import { Histogram } from './Histogram';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',

--- a/docs/snippets/react/histogram-story.ts-4-9.mdx
+++ b/docs/snippets/react/histogram-story.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Histogram } from './Histogram';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',

--- a/docs/snippets/react/histogram-story.ts.mdx
+++ b/docs/snippets/react/histogram-story.ts.mdx
@@ -7,7 +7,7 @@ import { Histogram } from './Histogram';
 
 const meta: Meta<typeof Histogram> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',

--- a/docs/snippets/react/list-story-expanded.js.mdx
+++ b/docs/snippets/react/list-story-expanded.js.mdx
@@ -8,7 +8,7 @@ import { ListItem } from './ListItem';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -19,7 +19,7 @@ export const Empty = {};
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const OneItem = {

--- a/docs/snippets/react/list-story-expanded.ts-4-9.mdx
+++ b/docs/snippets/react/list-story-expanded.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { ListItem } from './ListItem';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -22,7 +22,7 @@ export const Empty: Story = {};
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const OneItem: Story = {

--- a/docs/snippets/react/list-story-expanded.ts.mdx
+++ b/docs/snippets/react/list-story-expanded.ts.mdx
@@ -8,7 +8,7 @@ import { ListItem } from './ListItem';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -22,7 +22,7 @@ export const Empty: Story = {};
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const OneItem: Story = {

--- a/docs/snippets/react/list-story-reuse-data.js.mdx
+++ b/docs/snippets/react/list-story-reuse-data.js.mdx
@@ -11,7 +11,7 @@ import { Selected, Unselected } from './ListItem.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -20,7 +20,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 

--- a/docs/snippets/react/list-story-reuse-data.ts-4-9.mdx
+++ b/docs/snippets/react/list-story-reuse-data.ts-4-9.mdx
@@ -11,7 +11,7 @@ import { Selected, Unselected } from './ListItem.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems: Story = {

--- a/docs/snippets/react/list-story-reuse-data.ts.mdx
+++ b/docs/snippets/react/list-story-reuse-data.ts.mdx
@@ -11,7 +11,7 @@ import { Selected, Unselected } from './ListItem.stories';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof List>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems: Story = {

--- a/docs/snippets/react/list-story-starter.js.mdx
+++ b/docs/snippets/react/list-story-starter.js.mdx
@@ -7,7 +7,7 @@ import { List } from './List';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-starter.ts-4-9.mdx
+++ b/docs/snippets/react/list-story-starter.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { List } from './List';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-starter.ts.mdx
+++ b/docs/snippets/react/list-story-starter.ts.mdx
@@ -7,7 +7,7 @@ import { List } from './List';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-template.js.mdx
+++ b/docs/snippets/react/list-story-template.js.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-template.ts-4-9.mdx
+++ b/docs/snippets/react/list-story-template.ts-4-9.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * Seehttps://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * Seehttps://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-template.ts.mdx
+++ b/docs/snippets/react/list-story-template.ts.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * Seehttps://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * Seehttps://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-unchecked.js.mdx
+++ b/docs/snippets/react/list-story-unchecked.js.mdx
@@ -10,7 +10,7 @@ import { Unchecked } from './ListItem.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-unchecked.ts-4-9.mdx
+++ b/docs/snippets/react/list-story-unchecked.ts-4-9.mdx
@@ -10,7 +10,7 @@ import { Unchecked } from './ListItem.stories';
 
 export const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-unchecked.ts.mdx
+++ b/docs/snippets/react/list-story-unchecked.ts.mdx
@@ -10,7 +10,7 @@ import { Unchecked } from './ListItem.stories';
 
 export const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-with-unchecked-children.js.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.js.mdx
@@ -10,7 +10,7 @@ import { Unchecked } from './ListItem.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-with-unchecked-children.ts-4-9.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.ts-4-9.mdx
@@ -10,7 +10,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
+++ b/docs/snippets/react/list-story-with-unchecked-children.ts.mdx
@@ -10,7 +10,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/react/loader-story.js.mdx
+++ b/docs/snippets/react/loader-story.js.mdx
@@ -9,7 +9,7 @@ import { TodoItem } from './TodoItem';
 
 export default {
   /* 👇 The title prop is optional.
-  * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+  * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Examples/Loader'

--- a/docs/snippets/react/loader-story.ts-4-9.mdx
+++ b/docs/snippets/react/loader-story.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { TodoItem } from './TodoItem';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Examples/Loader',

--- a/docs/snippets/react/loader-story.ts.mdx
+++ b/docs/snippets/react/loader-story.ts.mdx
@@ -9,7 +9,7 @@ import { TodoItem } from './TodoItem';
 
 const meta: Meta<typeof TodoItem> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Examples/Loader',

--- a/docs/snippets/react/login-form-with-play-function.js.mdx
+++ b/docs/snippets/react/login-form-with-play-function.js.mdx
@@ -9,7 +9,7 @@ import { LoginForm } from './LoginForm';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Form',
@@ -19,7 +19,7 @@ export default {
 export const EmptyForm = {};
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm = {
@@ -31,7 +31,7 @@ export const FilledForm = {
 
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 
     // 👇 Assert DOM structure

--- a/docs/snippets/react/login-form-with-play-function.ts-4-9.mdx
+++ b/docs/snippets/react/login-form-with-play-function.ts-4-9.mdx
@@ -11,7 +11,7 @@ import { LoginForm } from './LoginForm';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Form',
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof meta>;
 export const EmptyForm: Story = {};
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
@@ -36,7 +36,7 @@ export const FilledForm: Story = {
 
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 
     // 👇 Assert DOM structure

--- a/docs/snippets/react/login-form-with-play-function.ts.mdx
+++ b/docs/snippets/react/login-form-with-play-function.ts.mdx
@@ -11,7 +11,7 @@ import { LoginForm } from './LoginForm';
 
 const meta: Meta<typeof LoginForm> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Form',
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof LoginForm>;
 export const EmptyForm: Story = {};
 
 /*
- * See https://storybook.js.org/docs/7.0/react/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
@@ -36,7 +36,7 @@ export const FilledForm: Story = {
 
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-    // See https://storybook.js.org/docs/7.0/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 
     // 👇 Assert DOM structure

--- a/docs/snippets/react/mock-context-container.js.mdx
+++ b/docs/snippets/react/mock-context-container.js.mdx
@@ -11,7 +11,7 @@ import { Normal as UserFriendsNormal } from './UserFriends.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ProfilePage',

--- a/docs/snippets/react/my-component-story-basic-and-props.js.mdx
+++ b/docs/snippets/react/my-component-story-basic-and-props.js.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/react/my-component-story-basic-and-props.ts-4-9.mdx
+++ b/docs/snippets/react/my-component-story-basic-and-props.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/react/my-component-story-basic-and-props.ts.mdx
+++ b/docs/snippets/react/my-component-story-basic-and-props.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/react/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/react/my-component-story-configure-viewports.js.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/my-component-story-configure-viewports.ts-4-9.mdx
+++ b/docs/snippets/react/my-component-story-configure-viewports.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/react/my-component-story-configure-viewports.ts.mdx
@@ -9,7 +9,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/react/my-component-story-use-globaltype.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -29,7 +29,7 @@ const getCaptionForLocale = (locale) => {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const StoryWithLocale = {

--- a/docs/snippets/react/my-component-story-use-globaltype.ts-4-9.mdx
+++ b/docs/snippets/react/my-component-story-use-globaltype.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -34,7 +34,7 @@ const getCaptionForLocale = (locale) => {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const StoryWithLocale = {

--- a/docs/snippets/react/my-component-story-use-globaltype.ts.mdx
+++ b/docs/snippets/react/my-component-story-use-globaltype.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -34,7 +34,7 @@ const getCaptionForLocale = (locale) => {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const StoryWithLocale = {

--- a/docs/snippets/react/my-component-story-with-nonstory.js.mdx
+++ b/docs/snippets/react/my-component-story-with-nonstory.js.mdx
@@ -7,7 +7,7 @@ import someData from './data.json';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/my-component-story-with-nonstory.ts-4-9.mdx
+++ b/docs/snippets/react/my-component-story-with-nonstory.ts-4-9.mdx
@@ -9,7 +9,7 @@ import someData from './data.json';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/my-component-story-with-nonstory.ts.mdx
+++ b/docs/snippets/react/my-component-story-with-nonstory.ts.mdx
@@ -9,7 +9,7 @@ import someData from './data.json';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/react/my-component-with-env-variables.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/my-component-with-env-variables.ts-4-9.mdx
+++ b/docs/snippets/react/my-component-with-env-variables.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/react/my-component-with-env-variables.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/react/page-story-slots.js.mdx
+++ b/docs/snippets/react/page-story-slots.js.mdx
@@ -7,7 +7,7 @@ import { Page } from './Page';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -16,7 +16,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const CustomFooter = {

--- a/docs/snippets/react/page-story-slots.ts-4-9.mdx
+++ b/docs/snippets/react/page-story-slots.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { Page } from './Page';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',

--- a/docs/snippets/react/page-story-slots.ts.mdx
+++ b/docs/snippets/react/page-story-slots.ts.mdx
@@ -7,7 +7,7 @@ import { Page } from './Page';
 
 const meta: Meta<typeof Page> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',

--- a/docs/snippets/react/page-story.js.mdx
+++ b/docs/snippets/react/page-story.js.mdx
@@ -8,7 +8,7 @@ import * as HeaderStories from './Header.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',

--- a/docs/snippets/react/page-story.ts-4-9.mdx
+++ b/docs/snippets/react/page-story.ts-4-9.mdx
@@ -10,7 +10,7 @@ import * as HeaderStories from './Header.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',

--- a/docs/snippets/react/page-story.ts.mdx
+++ b/docs/snippets/react/page-story.ts.mdx
@@ -10,7 +10,7 @@ import * as HeaderStories from './Header.stories';
 
 const meta: Meta<typeof Page> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',

--- a/docs/snippets/react/storybook-addon-a11y-disable.js.mdx
+++ b/docs/snippets/react/storybook-addon-a11y-disable.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Disable a11y addon',

--- a/docs/snippets/react/storybook-addon-a11y-disable.ts-4-9.mdx
+++ b/docs/snippets/react/storybook-addon-a11y-disable.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Disable a11y addon',

--- a/docs/snippets/react/storybook-addon-a11y-disable.ts.mdx
+++ b/docs/snippets/react/storybook-addon-a11y-disable.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Disable a11y addon',

--- a/docs/snippets/react/storybook-addon-a11y-story-config.js.mdx
+++ b/docs/snippets/react/storybook-addon-a11y-story-config.js.mdx
@@ -5,7 +5,7 @@ import { MyComponent } from './MyComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',

--- a/docs/snippets/react/storybook-addon-a11y-story-config.ts-4-9.mdx
+++ b/docs/snippets/react/storybook-addon-a11y-story-config.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',

--- a/docs/snippets/react/storybook-addon-a11y-story-config.ts.mdx
+++ b/docs/snippets/react/storybook-addon-a11y-story-config.ts.mdx
@@ -7,7 +7,7 @@ import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',

--- a/docs/snippets/react/table-story-fully-customize-controls.js.mdx
+++ b/docs/snippets/react/table-story-fully-customize-controls.js.mdx
@@ -9,7 +9,7 @@ import { TR } from './TableRow';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Custom Table',
@@ -18,7 +18,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/react/api/csf
+ * See https://storybook.js.org/docs/react/api/csf
  * to learn how to use render functions.
  */
 export const TableStory = {

--- a/docs/snippets/react/table-story-fully-customize-controls.ts-4-9.mdx
+++ b/docs/snippets/react/table-story-fully-customize-controls.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { TR } from './TableRow';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Custom Table',

--- a/docs/snippets/react/table-story-fully-customize-controls.ts.mdx
+++ b/docs/snippets/react/table-story-fully-customize-controls.ts.mdx
@@ -9,7 +9,7 @@ import { TR } from './TableRow';
 
 const meta: Meta<typeof Table> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Custom Table',

--- a/docs/snippets/react/your-component-with-decorator.js.mdx
+++ b/docs/snippets/react/your-component-with-decorator.js.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './YourComponent';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/react/your-component-with-decorator.ts-4-9.mdx
+++ b/docs/snippets/react/your-component-with-decorator.ts-4-9.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './YourComponent';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/react/your-component-with-decorator.ts.mdx
+++ b/docs/snippets/react/your-component-with-decorator.ts.mdx
@@ -7,7 +7,7 @@ import { YourComponent } from './YourComponent';
 
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/react/your-component.js.mdx
+++ b/docs/snippets/react/your-component.js.mdx
@@ -6,7 +6,7 @@ import { YourComponent } from './YourComponent';
 //👇 This default export determines where your story goes in the story list
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/react/your-component.ts-4-9.mdx
+++ b/docs/snippets/react/your-component.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './YourComponent';
 //👇 This default export determines where your story goes in the story list
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/react/your-component.ts.mdx
+++ b/docs/snippets/react/your-component.ts.mdx
@@ -8,7 +8,7 @@ import { YourComponent } from './YourComponent';
 //👇 This default export determines where your story goes in the story list
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/svelte/button-group-story.js.mdx
+++ b/docs/snippets/svelte/button-group-story.js.mdx
@@ -8,7 +8,7 @@ import * as ButtonStories from './Button.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',
@@ -17,7 +17,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Pair = {

--- a/docs/snippets/svelte/button-story-auto-docs.js.mdx
+++ b/docs/snippets/svelte/button-story-auto-docs.js.mdx
@@ -15,7 +15,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/svelte/button-story-click-handler-args.js.mdx
+++ b/docs/snippets/svelte/button-story-click-handler-args.js.mdx
@@ -7,7 +7,7 @@ import { action } from '@storybook/addon-actions';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/svelte/button-story-click-handler-simplificated.native-format.mdx
+++ b/docs/snippets/svelte/button-story-click-handler-simplificated.native-format.mdx
@@ -7,7 +7,7 @@
 </script>
 
 <!-- 
-  See https://storybook.js.org/docs/7.0/svelte/essentials/actions#action-argtype-annotation
+  See https://storybook.js.org/docs/svelte/essentials/actions#action-argtype-annotation
   to learn how to set up argTypes for actions
 -->
 

--- a/docs/snippets/svelte/button-story-click-handler.js.mdx
+++ b/docs/snippets/svelte/button-story-click-handler.js.mdx
@@ -7,7 +7,7 @@ import { action } from '@storybook/addon-actions';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/svelte/button-story-component-args-primary.js.mdx
+++ b/docs/snippets/svelte/button-story-component-args-primary.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/svelte/button-story-component-decorator.js.mdx
+++ b/docs/snippets/svelte/button-story-component-decorator.js.mdx
@@ -6,7 +6,7 @@ import MarginDecorator from './MarginDecorator.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/svelte/button-story-decorator.js.mdx
+++ b/docs/snippets/svelte/button-story-decorator.js.mdx
@@ -6,7 +6,7 @@ import MarginDecorator from './MarginDecorator.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -15,7 +15,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/svelte/button-story-decorator.mdx.mdx
+++ b/docs/snippets/svelte/button-story-decorator.mdx.mdx
@@ -10,7 +10,7 @@ import MarginDecorator from './MarginDecorator.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/button-story-default-docs-code.js.mdx
+++ b/docs/snippets/svelte/button-story-default-docs-code.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/svelte/button-story-default-export-with-component.js.mdx
+++ b/docs/snippets/svelte/button-story-default-export-with-component.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/svelte/button-story-rename-story.js.mdx
+++ b/docs/snippets/svelte/button-story-rename-story.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-  * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+  * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Primary = ({

--- a/docs/snippets/svelte/button-story-using-args.js.mdx
+++ b/docs/snippets/svelte/button-story-using-args.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/svelte/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/svelte/button-story-with-addon-example.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Basic = {

--- a/docs/snippets/svelte/button-story-with-args.js.mdx
+++ b/docs/snippets/svelte/button-story-with-args.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/svelte/button-story-with-args.mdx.mdx
+++ b/docs/snippets/svelte/button-story-with-args.mdx.mdx
@@ -9,7 +9,7 @@ import Button from './Button.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/button-story-with-blue-args.js.mdx
+++ b/docs/snippets/svelte/button-story-with-blue-args.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/svelte/button-story-with-emojis.js.mdx
+++ b/docs/snippets/svelte/button-story-with-emojis.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/svelte/button-story-with-emojis.mdx.mdx
+++ b/docs/snippets/svelte/button-story-with-emojis.mdx.mdx
@@ -9,7 +9,7 @@ import Button from './Button.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/button-story.js.mdx
+++ b/docs/snippets/svelte/button-story.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/svelte/button-story.mdx.mdx
+++ b/docs/snippets/svelte/button-story.mdx.mdx
@@ -11,7 +11,7 @@ import Button from './Button.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/checkbox-story.mdx.mdx
+++ b/docs/snippets/svelte/checkbox-story.mdx.mdx
@@ -9,7 +9,7 @@ import Checkbox from './Checkbox.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/component-story-custom-args-complex.js.mdx
+++ b/docs/snippets/svelte/component-story-custom-args-complex.js.mdx
@@ -5,7 +5,7 @@ import YourComponent from './YourComponent.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -29,7 +29,7 @@ const someFunction = (valuePropertyA, valuePropertyB) => {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const ExampleStory = {

--- a/docs/snippets/svelte/component-story-figma-integration.js.mdx
+++ b/docs/snippets/svelte/component-story-figma-integration.js.mdx
@@ -5,7 +5,7 @@ import { withDesign } from 'storybook-addon-designs';
 
 import MyComponent from './MyComponent.svelte';
 
-// More on default export: https://storybook.js.org/docs/7.0/svelte/writing-stories/introduction#default-export
+// More on default export: https://storybook.js.org/docs/svelte/writing-stories/introduction#default-export
 export default {
   title: 'FigmaExample',
   component: { MyComponent },
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Example = {

--- a/docs/snippets/svelte/component-story-figma-integration.mdx.mdx
+++ b/docs/snippets/svelte/component-story-figma-integration.mdx.mdx
@@ -15,7 +15,7 @@ import MyComponent from './MyComponent.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/component-story-mdx-story-by-name.mdx.mdx
+++ b/docs/snippets/svelte/component-story-mdx-story-by-name.mdx.mdx
@@ -9,7 +9,7 @@ import Button from './Button.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-cdn.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage = {

--- a/docs/snippets/svelte/component-story-static-asset-cdn.mdx.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-cdn.mdx.mdx
@@ -9,7 +9,7 @@ import MyComponent from './MyComponent.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/component-story-static-asset-with-import.js.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-with-import.js.mdx
@@ -7,7 +7,7 @@ import imageFile from './static/image.png';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -21,7 +21,7 @@ const image = {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage = {

--- a/docs/snippets/svelte/component-story-static-asset-with-import.mdx.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-with-import.mdx.mdx
@@ -11,7 +11,7 @@ import imageFile from './static/image.png';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/svelte/component-story-static-asset-without-import.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage = {

--- a/docs/snippets/svelte/component-story-with-accessibility.js.mdx
+++ b/docs/snippets/svelte/component-story-with-accessibility.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Accessibility testing',

--- a/docs/snippets/svelte/component-story-with-accessibility.mdx.mdx
+++ b/docs/snippets/svelte/component-story-with-accessibility.mdx.mdx
@@ -18,7 +18,7 @@ import Button from './Button.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/documentscreen-story-msw-graphql-query.js.mdx
+++ b/docs/snippets/svelte/documentscreen-story-msw-graphql-query.js.mdx
@@ -8,7 +8,7 @@ import MockApolloWrapperClient from './MockApolloWrapperClient.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'DocumentScreen',

--- a/docs/snippets/svelte/histogram-story.js.mdx
+++ b/docs/snippets/svelte/histogram-story.js.mdx
@@ -5,7 +5,7 @@ import Histogram from './Histogram.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Default = {

--- a/docs/snippets/svelte/histogram-story.mdx.mdx
+++ b/docs/snippets/svelte/histogram-story.mdx.mdx
@@ -9,7 +9,7 @@ import Histogram from './Histogram.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/loader-story.js.mdx
+++ b/docs/snippets/svelte/loader-story.js.mdx
@@ -7,7 +7,7 @@ import TodoItem from './TodoItem.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Examples/Loader',
@@ -16,7 +16,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/svelte/loader-story.mdx.mdx
+++ b/docs/snippets/svelte/loader-story.mdx.mdx
@@ -11,7 +11,7 @@ import fetch from 'node-fetch';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/login-form-with-play-function.js.mdx
+++ b/docs/snippets/svelte/login-form-with-play-function.js.mdx
@@ -9,7 +9,7 @@ import LoginForm from './LoginForm.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Form',
@@ -18,7 +18,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const EmptyForm = {
@@ -29,7 +29,7 @@ export const EmptyForm = {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/svelte/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/svelte/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm = {
@@ -45,7 +45,7 @@ export const FilledForm = {
 
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-    // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 
     // 👇 Assert DOM structure

--- a/docs/snippets/svelte/login-form-with-play-function.mdx.mdx
+++ b/docs/snippets/svelte/login-form-with-play-function.mdx.mdx
@@ -13,7 +13,7 @@ import LoginForm from './LoginForm.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 
@@ -39,7 +39,7 @@ import LoginForm from './LoginForm.svelte';
       
       await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-      // See https://storybook.js.org/docs/7.0/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+      // See https://storybook.js.org/docs/svelte/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
       await userEvent.click(canvas.getByRole('button'));
 
       // 👇 Assert DOM structure

--- a/docs/snippets/svelte/mdx-canvas-multiple-stories.mdx.mdx
+++ b/docs/snippets/svelte/mdx-canvas-multiple-stories.mdx.mdx
@@ -9,7 +9,7 @@ import Badge from './Badge.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/my-component-story-basic-and-props.js.mdx
+++ b/docs/snippets/svelte/my-component-story-basic-and-props.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',

--- a/docs/snippets/svelte/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/svelte/my-component-story-configure-viewports.js.mdx
@@ -7,7 +7,7 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -25,7 +25,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const MyStory = {

--- a/docs/snippets/svelte/my-component-story-configure-viewports.mdx.mdx
+++ b/docs/snippets/svelte/my-component-story-configure-viewports.mdx.mdx
@@ -19,7 +19,7 @@ import MyComponent from './MyComponent.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/svelte/my-component-story-use-globaltype.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -29,7 +29,7 @@ const getCaptionForLocale = (locale) => {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const StoryWithLocale = {

--- a/docs/snippets/svelte/my-component-story-use-globaltype.mdx.mdx
+++ b/docs/snippets/svelte/my-component-story-use-globaltype.mdx.mdx
@@ -20,7 +20,7 @@ export const getCaptionForLocale = (locale) => {
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/my-component-story-with-nonstory.js.mdx
+++ b/docs/snippets/svelte/my-component-story-with-nonstory.js.mdx
@@ -7,7 +7,7 @@ import someData from './data.json';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -21,7 +21,7 @@ export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const SimpleStory = {

--- a/docs/snippets/svelte/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/svelte/my-component-with-env-variables.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const ExampleStory = {

--- a/docs/snippets/svelte/my-component-with-env-variables.mdx.mdx
+++ b/docs/snippets/svelte/my-component-with-env-variables.mdx.mdx
@@ -9,7 +9,7 @@ import MyComponent from './MyComponent.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/page-story.js.mdx
+++ b/docs/snippets/svelte/page-story.js.mdx
@@ -8,7 +8,7 @@ import * as HeaderStories from './Header.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -17,7 +17,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const LoggedIn = {

--- a/docs/snippets/svelte/storybook-addon-a11y-disable.js.mdx
+++ b/docs/snippets/svelte/storybook-addon-a11y-disable.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Disable a11y addon',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 

--- a/docs/snippets/svelte/storybook-addon-a11y-disable.mdx.mdx
+++ b/docs/snippets/svelte/storybook-addon-a11y-disable.mdx.mdx
@@ -11,7 +11,7 @@ import MyComponent from './MyComponent.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/storybook-addon-a11y-story-config.js.mdx
+++ b/docs/snippets/svelte/storybook-addon-a11y-story-config.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const ExampleStory = {

--- a/docs/snippets/svelte/storybook-addon-a11y-story-config.mdx.mdx
+++ b/docs/snippets/svelte/storybook-addon-a11y-story-config.mdx.mdx
@@ -11,7 +11,7 @@ import MyComponent from './MyComponent.svelte';
 
 <!--
  👇 Render functions are a framework specific feature to allow you control on how the component renders.
-  See https://storybook.js.org/docs/7.0/svelte/api/csf
+  See https://storybook.js.org/docs/svelte/api/csf
   to learn how to use render functions.
 -->
 

--- a/docs/snippets/svelte/your-component-with-decorator.js.mdx
+++ b/docs/snippets/svelte/your-component-with-decorator.js.mdx
@@ -7,7 +7,7 @@ import MarginDecorator from './MarginDecorator.svelte';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/svelte/your-component.js.mdx
+++ b/docs/snippets/svelte/your-component.js.mdx
@@ -6,7 +6,7 @@ import YourComponent from './YourComponent.svelte';
 //👇This default export determines where your story goes in the story list
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/svelte/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/svelte/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -15,7 +15,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/svelte/api/csf
+ * See https://storybook.js.org/docs/svelte/api/csf
  * to learn how to use render functions.
  */
 export const FirstStory = {

--- a/docs/snippets/vue/button-group-story.2.js.mdx
+++ b/docs/snippets/vue/button-group-story.2.js.mdx
@@ -8,7 +8,7 @@ import * as ButtonStories from './Button.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',
@@ -17,7 +17,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Pair = {

--- a/docs/snippets/vue/button-group-story.2.ts-4-9.mdx
+++ b/docs/snippets/vue/button-group-story.2.ts-4-9.mdx
@@ -10,7 +10,7 @@ import * as ButtonStories from './Button.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',

--- a/docs/snippets/vue/button-group-story.2.ts.mdx
+++ b/docs/snippets/vue/button-group-story.2.ts.mdx
@@ -10,7 +10,7 @@ import * as ButtonStories from './Button.stories';
 
 const meta: Meta<typeof ButtonGroup> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',

--- a/docs/snippets/vue/button-group-story.3.js.mdx
+++ b/docs/snippets/vue/button-group-story.3.js.mdx
@@ -8,7 +8,7 @@ import * as ButtonStories from './Button.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',
@@ -17,7 +17,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Pair = {

--- a/docs/snippets/vue/button-group-story.3.ts-4-9.mdx
+++ b/docs/snippets/vue/button-group-story.3.ts-4-9.mdx
@@ -10,7 +10,7 @@ import * as ButtonStories from './Button.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',

--- a/docs/snippets/vue/button-group-story.3.ts.mdx
+++ b/docs/snippets/vue/button-group-story.3.ts.mdx
@@ -10,7 +10,7 @@ import * as ButtonStories from './Button.stories';
 
 const meta: Meta<typeof ButtonGroup> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'ButtonGroup',

--- a/docs/snippets/vue/button-story-click-handler-args.2.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler-args.2.js.mdx
@@ -7,7 +7,7 @@ import { action } from '@storybook/addon-actions';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-click-handler-args.2.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-click-handler-args.2.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Text: Story = {

--- a/docs/snippets/vue/button-story-click-handler-args.2.ts.mdx
+++ b/docs/snippets/vue/button-story-click-handler-args.2.ts.mdx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Text: Story = {

--- a/docs/snippets/vue/button-story-click-handler-args.3.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler-args.3.js.mdx
@@ -7,7 +7,7 @@ import { action } from '@storybook/addon-actions';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-click-handler-args.3.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-click-handler-args.3.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-click-handler-args.3.ts.mdx
+++ b/docs/snippets/vue/button-story-click-handler-args.3.ts.mdx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-click-handler-simplificated.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler-simplificated.js.mdx
@@ -5,13 +5,13 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
   component: Button,
   /*
-   * See https://storybook.js.org/docs/7.0/vue/essentials/actions#action-argtype-annotation
+   * See https://storybook.js.org/docs/vue/essentials/actions#action-argtype-annotation
    * to learn how to set up argTypes for actions
    */
   argTypes: {

--- a/docs/snippets/vue/button-story-click-handler-simplificated.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-click-handler-simplificated.ts-4-9.mdx
@@ -7,13 +7,13 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
   component: Button,
   /*
-   * See https://storybook.js.org/docs/7.0/vue/essentials/actions#action-argtype-annotation
+   * See https://storybook.js.org/docs/vue/essentials/actions#action-argtype-annotation
    * to learn how to set up argTypes for actions
    */
   argTypes: {
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Text: Story = {

--- a/docs/snippets/vue/button-story-click-handler-simplificated.ts.mdx
+++ b/docs/snippets/vue/button-story-click-handler-simplificated.ts.mdx
@@ -7,13 +7,13 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
   component: Button,
   /*
-   * See https://storybook.js.org/docs/7.0/vue/essentials/actions#action-argtype-annotation
+   * See https://storybook.js.org/docs/vue/essentials/actions#action-argtype-annotation
    * to learn how to set up argTypes for actions
    */
   argTypes: {
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Text: Story = {

--- a/docs/snippets/vue/button-story-click-handler.2.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler.2.js.mdx
@@ -7,7 +7,7 @@ import { action } from '@storybook/addon-actions';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-click-handler.2.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-click-handler.2.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Text: Story = {

--- a/docs/snippets/vue/button-story-click-handler.2.ts.mdx
+++ b/docs/snippets/vue/button-story-click-handler.2.ts.mdx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Text: Story = {

--- a/docs/snippets/vue/button-story-click-handler.3.js.mdx
+++ b/docs/snippets/vue/button-story-click-handler.3.js.mdx
@@ -7,7 +7,7 @@ import { action } from '@storybook/addon-actions';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-click-handler.3.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-click-handler.3.ts-4-9.mdx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Text: Story = {

--- a/docs/snippets/vue/button-story-click-handler.3.ts.mdx
+++ b/docs/snippets/vue/button-story-click-handler.3.ts.mdx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Text: Story = {

--- a/docs/snippets/vue/button-story-component-args-primary.js.mdx
+++ b/docs/snippets/vue/button-story-component-args-primary.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-component-args-primary.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-component-args-primary.ts-4-9.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-component-args-primary.ts.mdx
+++ b/docs/snippets/vue/button-story-component-args-primary.ts.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-component-decorator.js.mdx
+++ b/docs/snippets/vue/button-story-component-decorator.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-component-decorator.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-component-decorator.ts-4-9.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-component-decorator.ts.mdx
+++ b/docs/snippets/vue/button-story-component-decorator.ts.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-decorator.js.mdx
+++ b/docs/snippets/vue/button-story-decorator.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/vue/button-story-decorator.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-decorator.ts-4-9.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-decorator.ts.mdx
+++ b/docs/snippets/vue/button-story-decorator.ts.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-default-export-with-component.js.mdx
+++ b/docs/snippets/vue/button-story-default-export-with-component.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-default-export-with-component.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-default-export-with-component.ts-4-9.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-default-export-with-component.ts.mdx
+++ b/docs/snippets/vue/button-story-default-export-with-component.ts.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-rename-story.js.mdx
+++ b/docs/snippets/vue/button-story-rename-story.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/vue/button-story-rename-story.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-rename-story.ts-4-9.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-rename-story.ts.mdx
+++ b/docs/snippets/vue/button-story-rename-story.ts.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-using-args.2.js.mdx
+++ b/docs/snippets/vue/button-story-using-args.2.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/vue/button-story-using-args.2.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-using-args.2.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-using-args.2.ts.mdx
+++ b/docs/snippets/vue/button-story-using-args.2.ts.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-using-args.3.js.mdx
+++ b/docs/snippets/vue/button-story-using-args.3.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/vue/button-story-using-args.3.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-using-args.3.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-using-args.3.ts.mdx
+++ b/docs/snippets/vue/button-story-using-args.3.ts.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/vue/button-story-with-addon-example.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-with-addon-example.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-with-addon-example.ts-4-9.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Basic: Story = {

--- a/docs/snippets/vue/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/vue/button-story-with-addon-example.ts.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Basic: Story = {

--- a/docs/snippets/vue/button-story-with-args.2.js.mdx
+++ b/docs/snippets/vue/button-story-with-args.2.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/vue/button-story-with-args.2.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-with-args.2.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-with-args.2.ts.mdx
+++ b/docs/snippets/vue/button-story-with-args.2.ts.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-with-args.3.js.mdx
+++ b/docs/snippets/vue/button-story-with-args.3.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/vue/button-story-with-args.3.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-with-args.3.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-with-args.3.ts.mdx
+++ b/docs/snippets/vue/button-story-with-args.3.ts.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-with-blue-args.js.mdx
+++ b/docs/snippets/vue/button-story-with-blue-args.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-with-blue-args.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-with-blue-args.ts-4-9.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-with-blue-args.ts.mdx
+++ b/docs/snippets/vue/button-story-with-blue-args.ts.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/vue/button-story-with-emojis.js.mdx
+++ b/docs/snippets/vue/button-story-with-emojis.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-  * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+  * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
   * to learn how to generate automatic titles
   */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/vue/button-story-with-emojis.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story-with-emojis.ts-4-9.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story-with-emojis.ts.mdx
+++ b/docs/snippets/vue/button-story-with-emojis.ts.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story.js.mdx
+++ b/docs/snippets/vue/button-story.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary = {

--- a/docs/snippets/vue/button-story.ts-4-9.mdx
+++ b/docs/snippets/vue/button-story.ts-4-9.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/button-story.ts.mdx
+++ b/docs/snippets/vue/button-story.ts.mdx
@@ -8,7 +8,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof Button>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/component-story-custom-args-complex.js.mdx
+++ b/docs/snippets/vue/component-story-custom-args-complex.js.mdx
@@ -5,7 +5,7 @@ import YourComponent from './YourComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/vue/component-story-custom-args-complex.ts-4-9.mdx
+++ b/docs/snippets/vue/component-story-custom-args-complex.ts-4-9.mdx
@@ -7,7 +7,7 @@ import YourComponent from './YourComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ExampleStory: Story = {

--- a/docs/snippets/vue/component-story-custom-args-complex.ts.mdx
+++ b/docs/snippets/vue/component-story-custom-args-complex.ts.mdx
@@ -7,7 +7,7 @@ import YourComponent from './YourComponent.vue';
 
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof YourComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ExampleStory: Story = {

--- a/docs/snippets/vue/component-story-figma-integration.js.mdx
+++ b/docs/snippets/vue/component-story-figma-integration.js.mdx
@@ -5,7 +5,7 @@ import { withDesign } from 'storybook-addon-designs';
 
 import MyComponent from './MyComponent.vue';
 
-// More on default export: https://storybook.js.org/docs/7.0/vue/writing-stories/introduction#default-export
+// More on default export: https://storybook.js.org/docs/vue/writing-stories/introduction#default-export
 export default {
   title: 'FigmaExample',
   component: MyComponent,
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Example = {

--- a/docs/snippets/vue/component-story-figma-integration.ts-4-9.mdx
+++ b/docs/snippets/vue/component-story-figma-integration.ts-4-9.mdx
@@ -8,7 +8,7 @@ import { withDesign } from 'storybook-addon-designs';
 
 import MyComponent from './MyComponent.vue';
 
-// More on default export: https://storybook.js.org/docs/7.0/vue/writing-stories/introduction#default-export
+// More on default export: https://storybook.js.org/docs/vue/writing-stories/introduction#default-export
 const meta = {
   title: 'FigmaExample',
   component: MyComponent,
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Example: Story = {

--- a/docs/snippets/vue/component-story-figma-integration.ts.mdx
+++ b/docs/snippets/vue/component-story-figma-integration.ts.mdx
@@ -8,7 +8,7 @@ import { withDesign } from 'storybook-addon-designs';
 
 import MyComponent from './MyComponent.vue';
 
-// More on default export: https://storybook.js.org/docs/7.0/vue/writing-stories/introduction#default-export
+// More on default export: https://storybook.js.org/docs/vue/writing-stories/introduction#default-export
 const meta: Meta<typeof MyComponent> = {
   title: 'FigmaExample',
   component: MyComponent,
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Example: Story = {

--- a/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-cdn.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -13,7 +13,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage = {

--- a/docs/snippets/vue/component-story-static-asset-cdn.ts-4-9.mdx
+++ b/docs/snippets/vue/component-story-static-asset-cdn.ts-4-9.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/vue/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/vue/component-story-static-asset-cdn.ts.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/vue/component-story-static-asset-with-import.2.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-with-import.2.js.mdx
@@ -7,7 +7,7 @@ import imageFile from './static/image.png';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -21,7 +21,7 @@ const image = {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage = {

--- a/docs/snippets/vue/component-story-static-asset-with-import.2.ts-4-9.mdx
+++ b/docs/snippets/vue/component-story-static-asset-with-import.2.ts-4-9.mdx
@@ -9,7 +9,7 @@ import imageFile from './static/image.png';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/vue/component-story-static-asset-with-import.2.ts.mdx
+++ b/docs/snippets/vue/component-story-static-asset-with-import.2.ts.mdx
@@ -9,7 +9,7 @@ import imageFile from './static/image.png';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/vue/component-story-static-asset-with-import.3.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-with-import.3.js.mdx
@@ -7,7 +7,7 @@ import imageFile from './static/image.png';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -21,7 +21,7 @@ const image = {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage = {

--- a/docs/snippets/vue/component-story-static-asset-with-import.3.ts-4-9.mdx
+++ b/docs/snippets/vue/component-story-static-asset-with-import.3.ts-4-9.mdx
@@ -9,7 +9,7 @@ import imageFile from './static/image.png';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/vue/component-story-static-asset-with-import.3.ts.mdx
+++ b/docs/snippets/vue/component-story-static-asset-with-import.3.ts.mdx
@@ -9,7 +9,7 @@ import imageFile from './static/image.png';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/vue/component-story-static-asset-without-import.js.mdx
+++ b/docs/snippets/vue/component-story-static-asset-without-import.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',

--- a/docs/snippets/vue/component-story-static-asset-without-import.ts-4-9.mdx
+++ b/docs/snippets/vue/component-story-static-asset-without-import.ts-4-9.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/vue/component-story-static-asset-without-import.ts.mdx
+++ b/docs/snippets/vue/component-story-static-asset-without-import.ts.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'img',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/vue/component-story-with-accessibility.2.js.mdx
+++ b/docs/snippets/vue/component-story-with-accessibility.2.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Accessibility testing',

--- a/docs/snippets/vue/component-story-with-accessibility.2.ts-4-9.mdx
+++ b/docs/snippets/vue/component-story-with-accessibility.2.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Accessibility testing',

--- a/docs/snippets/vue/component-story-with-accessibility.2.ts.mdx
+++ b/docs/snippets/vue/component-story-with-accessibility.2.ts.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Accessibility testing',

--- a/docs/snippets/vue/component-story-with-accessibility.3.js.mdx
+++ b/docs/snippets/vue/component-story-with-accessibility.3.js.mdx
@@ -5,7 +5,7 @@ import Button from './Button.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Accessibility testing',

--- a/docs/snippets/vue/component-story-with-accessibility.3.ts-4-9.mdx
+++ b/docs/snippets/vue/component-story-with-accessibility.3.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Accessibility testing',

--- a/docs/snippets/vue/component-story-with-accessibility.3.ts.mdx
+++ b/docs/snippets/vue/component-story-with-accessibility.3.ts.mdx
@@ -7,7 +7,7 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Accessibility testing',

--- a/docs/snippets/vue/component-story-with-custom-render-function.js.mdx
+++ b/docs/snippets/vue/component-story-with-custom-render-function.js.mdx
@@ -7,7 +7,7 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/vue/component-story-with-custom-render-function.ts-4-9.mdx
+++ b/docs/snippets/vue/component-story-with-custom-render-function.ts-4-9.mdx
@@ -10,7 +10,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/vue/component-story-with-custom-render-function.ts.mdx
+++ b/docs/snippets/vue/component-story-with-custom-render-function.ts.mdx
@@ -10,7 +10,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/vue/documentscreen-story-msw-graphql-query.js.mdx
+++ b/docs/snippets/vue/documentscreen-story-msw-graphql-query.js.mdx
@@ -9,7 +9,7 @@ import { graphql } from 'msw';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'DocumentScreen',
@@ -67,7 +67,7 @@ const TestData = {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const MockedSuccess = {

--- a/docs/snippets/vue/documentscreen-story-msw-graphql-query.ts-4-9.mdx
+++ b/docs/snippets/vue/documentscreen-story-msw-graphql-query.ts-4-9.mdx
@@ -11,7 +11,7 @@ import WrapperComponent from './ApolloWrapperClient.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'DocumentScreen',
@@ -72,7 +72,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const MockedSuccess: Story = {

--- a/docs/snippets/vue/documentscreen-story-msw-graphql-query.ts.mdx
+++ b/docs/snippets/vue/documentscreen-story-msw-graphql-query.ts.mdx
@@ -11,7 +11,7 @@ import WrapperComponent from './ApolloWrapperClient.vue';
 
 const meta: Meta<typeof DocumentScreen> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'DocumentScreen',
@@ -72,7 +72,7 @@ type Story = StoryObj<typeof DocumentScreen>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const MockedSuccess: Story = {

--- a/docs/snippets/vue/histogram-story.2.js.mdx
+++ b/docs/snippets/vue/histogram-story.2.js.mdx
@@ -5,7 +5,7 @@ import Histogram from './Histogram.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Default = {

--- a/docs/snippets/vue/histogram-story.2.ts-4-9.mdx
+++ b/docs/snippets/vue/histogram-story.2.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Histogram from './Histogram.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Default: Story = {

--- a/docs/snippets/vue/histogram-story.2.ts.mdx
+++ b/docs/snippets/vue/histogram-story.2.ts.mdx
@@ -7,7 +7,7 @@ import Histogram from './Histogram.vue';
 
 const meta: Meta<typeof Histogram> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Histogram>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Default: Story = {

--- a/docs/snippets/vue/histogram-story.3.js.mdx
+++ b/docs/snippets/vue/histogram-story.3.js.mdx
@@ -5,7 +5,7 @@ import Histogram from './Histogram.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Default = {

--- a/docs/snippets/vue/histogram-story.3.ts-4-9.mdx
+++ b/docs/snippets/vue/histogram-story.3.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Histogram from './Histogram.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Default: Story = {

--- a/docs/snippets/vue/histogram-story.3.ts.mdx
+++ b/docs/snippets/vue/histogram-story.3.ts.mdx
@@ -7,7 +7,7 @@ import Histogram from './Histogram.vue';
 
 const meta: Meta<typeof Histogram> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Histogram',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Histogram>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Default: Story = {

--- a/docs/snippets/vue/list-story-expanded.js.mdx
+++ b/docs/snippets/vue/list-story-expanded.js.mdx
@@ -6,7 +6,7 @@ import ListItem from './ListItem.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -15,7 +15,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Empty = {

--- a/docs/snippets/vue/list-story-expanded.ts-4-9.mdx
+++ b/docs/snippets/vue/list-story-expanded.ts-4-9.mdx
@@ -9,7 +9,7 @@ import ListItem from './ListItem.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Empty: Story = {

--- a/docs/snippets/vue/list-story-expanded.ts.mdx
+++ b/docs/snippets/vue/list-story-expanded.ts.mdx
@@ -9,7 +9,7 @@ import ListItem from './ListItem.vue';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof List>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Empty: Story = {

--- a/docs/snippets/vue/list-story-reuse-data.2.js.mdx
+++ b/docs/snippets/vue/list-story-reuse-data.2.js.mdx
@@ -9,7 +9,7 @@ import { Selected, Unselected } from './ListItem.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -18,7 +18,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems = {

--- a/docs/snippets/vue/list-story-reuse-data.2.ts-4-9.mdx
+++ b/docs/snippets/vue/list-story-reuse-data.2.ts-4-9.mdx
@@ -11,7 +11,7 @@ import { Selected, Unselected } from './ListItem.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems: Story = {

--- a/docs/snippets/vue/list-story-reuse-data.2.ts.mdx
+++ b/docs/snippets/vue/list-story-reuse-data.2.ts.mdx
@@ -11,7 +11,7 @@ import { Selected, Unselected } from './ListItem.stories';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof List>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems: Story = {

--- a/docs/snippets/vue/list-story-reuse-data.3.js.mdx
+++ b/docs/snippets/vue/list-story-reuse-data.3.js.mdx
@@ -9,7 +9,7 @@ import { Selected, Unselected } from './ListItem.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -18,7 +18,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems = {

--- a/docs/snippets/vue/list-story-reuse-data.3.ts-4-9.mdx
+++ b/docs/snippets/vue/list-story-reuse-data.3.ts-4-9.mdx
@@ -11,7 +11,7 @@ import { Selected, Unselected } from './ListItem.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems: Story = {

--- a/docs/snippets/vue/list-story-reuse-data.3.ts.mdx
+++ b/docs/snippets/vue/list-story-reuse-data.3.ts.mdx
@@ -11,7 +11,7 @@ import { Selected, Unselected } from './ListItem.stories';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof List>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ManyItems: Story = {

--- a/docs/snippets/vue/list-story-starter.js.mdx
+++ b/docs/snippets/vue/list-story-starter.js.mdx
@@ -5,7 +5,7 @@ import List from './ListComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/vue/list-story-starter.ts-4-9.mdx
+++ b/docs/snippets/vue/list-story-starter.ts-4-9.mdx
@@ -8,7 +8,7 @@ import List from './ListComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/vue/list-story-starter.ts.mdx
+++ b/docs/snippets/vue/list-story-starter.ts.mdx
@@ -8,7 +8,7 @@ import List from './ListComponent.vue';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/vue/list-story-template.2.js.mdx
+++ b/docs/snippets/vue/list-story-template.2.js.mdx
@@ -9,7 +9,7 @@ import { Unchecked } from './ListItem.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/vue/list-story-template.2.ts-4-9.mdx
+++ b/docs/snippets/vue/list-story-template.2.ts-4-9.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/vue/list-story-template.2.ts.mdx
+++ b/docs/snippets/vue/list-story-template.2.ts.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/vue/list-story-template.3.js.mdx
+++ b/docs/snippets/vue/list-story-template.3.js.mdx
@@ -9,7 +9,7 @@ import { Unchecked } from './ListItem.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/vue/list-story-template.3.ts-4-9.mdx
+++ b/docs/snippets/vue/list-story-template.3.ts-4-9.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/vue/list-story-template.3.ts.mdx
+++ b/docs/snippets/vue/list-story-template.3.ts.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',

--- a/docs/snippets/vue/list-story-unchecked.2.js.mdx
+++ b/docs/snippets/vue/list-story-unchecked.2.js.mdx
@@ -9,7 +9,7 @@ import { Unchecked } from './ListItem.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -17,7 +17,7 @@ export default {
 };
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const OneItem = {

--- a/docs/snippets/vue/list-story-unchecked.2.ts-4-9.mdx
+++ b/docs/snippets/vue/list-story-unchecked.2.ts-4-9.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const OneItem: Story = {

--- a/docs/snippets/vue/list-story-unchecked.2.ts.mdx
+++ b/docs/snippets/vue/list-story-unchecked.2.ts.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof List>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const OneItem: Story = {

--- a/docs/snippets/vue/list-story-unchecked.3.js.mdx
+++ b/docs/snippets/vue/list-story-unchecked.3.js.mdx
@@ -9,7 +9,7 @@ import { Unchecked } from './ListItem.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -18,7 +18,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const OneItem = {

--- a/docs/snippets/vue/list-story-unchecked.3.ts-4-9.mdx
+++ b/docs/snippets/vue/list-story-unchecked.3.ts-4-9.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const OneItem: Story = {

--- a/docs/snippets/vue/list-story-unchecked.3.ts.mdx
+++ b/docs/snippets/vue/list-story-unchecked.3.ts.mdx
@@ -11,7 +11,7 @@ import { Unchecked } from './ListItem.stories';
 
 const meta: Meta<typeof List> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'List',
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof List>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const OneItem: Story = {

--- a/docs/snippets/vue/loader-story.js.mdx
+++ b/docs/snippets/vue/loader-story.js.mdx
@@ -7,7 +7,7 @@ import fetch from 'node-fetch';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Examples/Loader',

--- a/docs/snippets/vue/loader-story.ts-4-9.mdx
+++ b/docs/snippets/vue/loader-story.ts-4-9.mdx
@@ -9,7 +9,7 @@ import fetch from 'node-fetch';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Examples/Loader',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/loader-story.ts.mdx
+++ b/docs/snippets/vue/loader-story.ts.mdx
@@ -9,7 +9,7 @@ import fetch from 'node-fetch';
 
 const meta: Meta<typeof TodoItem> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Examples/Loader',
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof TodoItem>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/login-form-with-play-function.js.mdx
+++ b/docs/snippets/vue/login-form-with-play-function.js.mdx
@@ -9,7 +9,7 @@ import LoginForm from './LoginForm.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Form',
@@ -18,7 +18,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const EmptyForm = {
@@ -29,7 +29,7 @@ export const EmptyForm = {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/vue/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm = {
@@ -45,7 +45,7 @@ export const FilledForm = {
 
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 
     // 👇 Assert DOM structure

--- a/docs/snippets/vue/login-form-with-play-function.ts-4-9.mdx
+++ b/docs/snippets/vue/login-form-with-play-function.ts-4-9.mdx
@@ -12,7 +12,7 @@ import LoginForm from './LoginForm.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Form',
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const EmptyForm: Story = {
@@ -35,7 +35,7 @@ export const EmptyForm: Story = {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/vue/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
@@ -51,7 +51,7 @@ export const FilledForm: Story = {
 
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 
     // 👇 Assert DOM structure

--- a/docs/snippets/vue/login-form-with-play-function.ts.mdx
+++ b/docs/snippets/vue/login-form-with-play-function.ts.mdx
@@ -12,7 +12,7 @@ import LoginForm from './LoginForm.vue';
 
 const meta: Meta<typeof LoginForm> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Form',
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof LoginForm>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const EmptyForm: Story = {
@@ -35,7 +35,7 @@ export const EmptyForm: Story = {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/vue/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/vue/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
@@ -51,7 +51,7 @@ export const FilledForm: Story = {
 
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-    // See https://storybook.js.org/docs/7.0/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/vue/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 
     // 👇 Assert DOM structure

--- a/docs/snippets/vue/my-component-story-basic-and-props.js.mdx
+++ b/docs/snippets/vue/my-component-story-basic-and-props.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Basic = {

--- a/docs/snippets/vue/my-component-story-basic-and-props.ts-4-9.mdx
+++ b/docs/snippets/vue/my-component-story-basic-and-props.ts-4-9.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Basic: Story = {

--- a/docs/snippets/vue/my-component-story-basic-and-props.ts.mdx
+++ b/docs/snippets/vue/my-component-story-basic-and-props.ts.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Path/To/MyComponent',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Basic: Story = {

--- a/docs/snippets/vue/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/vue/my-component-story-configure-viewports.js.mdx
@@ -7,7 +7,7 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -26,7 +26,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const MyStory = {

--- a/docs/snippets/vue/my-component-story-configure-viewports.ts-4-9.mdx
+++ b/docs/snippets/vue/my-component-story-configure-viewports.ts-4-9.mdx
@@ -10,7 +10,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const MyStory: Story = {

--- a/docs/snippets/vue/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/vue/my-component-story-configure-viewports.ts.mdx
@@ -10,7 +10,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const MyStory: Story = {

--- a/docs/snippets/vue/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/vue/my-component-story-use-globaltype.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -29,7 +29,7 @@ const getCaptionForLocale = (locale) => {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const StoryWithLocale = {

--- a/docs/snippets/vue/my-component-story-use-globaltype.ts-4-9.mdx
+++ b/docs/snippets/vue/my-component-story-use-globaltype.ts-4-9.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -38,7 +38,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const MyStory: Story = {

--- a/docs/snippets/vue/my-component-story-use-globaltype.ts.mdx
+++ b/docs/snippets/vue/my-component-story-use-globaltype.ts.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',
@@ -35,7 +35,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const MyStory: Story = {

--- a/docs/snippets/vue/my-component-story-with-nonstory.js.mdx
+++ b/docs/snippets/vue/my-component-story-with-nonstory.js.mdx
@@ -7,7 +7,7 @@ import someData from './data.json';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/vue/my-component-story-with-nonstory.ts-4-9.mdx
+++ b/docs/snippets/vue/my-component-story-with-nonstory.ts-4-9.mdx
@@ -10,7 +10,7 @@ import someData from './data.json';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/vue/my-component-story-with-nonstory.ts.mdx
+++ b/docs/snippets/vue/my-component-story-with-nonstory.ts.mdx
@@ -10,7 +10,7 @@ import someData from './data.json';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/vue/my-component-with-env-variables.js.mdx
+++ b/docs/snippets/vue/my-component-with-env-variables.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/vue/my-component-with-env-variables.ts-4-9.mdx
+++ b/docs/snippets/vue/my-component-with-env-variables.ts-4-9.mdx
@@ -8,7 +8,7 @@ import MyComponent from './YourPage.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/vue/my-component-with-env-variables.ts.mdx
+++ b/docs/snippets/vue/my-component-with-env-variables.ts.mdx
@@ -8,7 +8,7 @@ import MyComponent from './YourPage.vue';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'MyComponent',

--- a/docs/snippets/vue/page-story-slots.2.js.mdx
+++ b/docs/snippets/vue/page-story-slots.2.js.mdx
@@ -5,7 +5,7 @@ import Page from './Page.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const CustomFooter = {

--- a/docs/snippets/vue/page-story-slots.2.ts-4-9.mdx
+++ b/docs/snippets/vue/page-story-slots.2.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Page from './Page.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/page-story-slots.2.ts.mdx
+++ b/docs/snippets/vue/page-story-slots.2.ts.mdx
@@ -7,7 +7,7 @@ import Page from './Page.vue';
 
 const meta: Meta<typeof Page> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Page>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/page-story-slots.3.js.mdx
+++ b/docs/snippets/vue/page-story-slots.3.js.mdx
@@ -5,7 +5,7 @@ import Page from './Page.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const CustomFooter = {

--- a/docs/snippets/vue/page-story-slots.3.ts-4-9.mdx
+++ b/docs/snippets/vue/page-story-slots.3.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Page from './Page.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/page-story-slots.3.ts.mdx
+++ b/docs/snippets/vue/page-story-slots.3.ts.mdx
@@ -7,7 +7,7 @@ import Page from './Page.vue';
 
 const meta: Meta<typeof Page> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Page>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/page-story.2.-ts-4-9.mdx
+++ b/docs/snippets/vue/page-story.2.-ts-4-9.mdx
@@ -10,7 +10,7 @@ import * as HeaderStories from './Header.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/page-story.2.js.mdx
+++ b/docs/snippets/vue/page-story.2.js.mdx
@@ -8,7 +8,7 @@ import * as HeaderStories from './Header.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -17,7 +17,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const LoggedIn = {

--- a/docs/snippets/vue/page-story.2.ts.mdx
+++ b/docs/snippets/vue/page-story.2.ts.mdx
@@ -10,7 +10,7 @@ import * as HeaderStories from './Header.stories';
 
 const meta: Meta<typeof Page> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof Page>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/page-story.3.js.mdx
+++ b/docs/snippets/vue/page-story.3.js.mdx
@@ -8,7 +8,7 @@ import * as HeaderStories from './Header.stories';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -17,7 +17,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const LoggedIn = {

--- a/docs/snippets/vue/page-story.3.ts-4-9.mdx
+++ b/docs/snippets/vue/page-story.3.ts-4-9.mdx
@@ -10,7 +10,7 @@ import * as HeaderStories from './Header.stories';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/page-story.3.ts.mdx
+++ b/docs/snippets/vue/page-story.3.ts.mdx
@@ -10,7 +10,7 @@ import * as HeaderStories from './Header.stories';
 
 const meta: Meta<typeof Page> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Page',
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof Page>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/storybook-addon-a11y-disable.js.mdx
+++ b/docs/snippets/vue/storybook-addon-a11y-disable.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Disable a11y addon',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const NonA11yStory = {

--- a/docs/snippets/vue/storybook-addon-a11y-disable.ts-4-9.mdx
+++ b/docs/snippets/vue/storybook-addon-a11y-disable.ts-4-9.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Disable a11y addon',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const NonA11yStory: Story = {

--- a/docs/snippets/vue/storybook-addon-a11y-disable.ts.mdx
+++ b/docs/snippets/vue/storybook-addon-a11y-disable.ts.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Disable a11y addon',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const NonA11yStory: Story = {

--- a/docs/snippets/vue/storybook-addon-a11y-story-config.js.mdx
+++ b/docs/snippets/vue/storybook-addon-a11y-story-config.js.mdx
@@ -5,7 +5,7 @@ import MyComponent from './MyComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ExampleStory = {

--- a/docs/snippets/vue/storybook-addon-a11y-story-config.ts-4-9.mdx
+++ b/docs/snippets/vue/storybook-addon-a11y-story-config.ts-4-9.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ExampleStory = {

--- a/docs/snippets/vue/storybook-addon-a11y-story-config.ts.mdx
+++ b/docs/snippets/vue/storybook-addon-a11y-story-config.ts.mdx
@@ -8,7 +8,7 @@ import MyComponent from './MyComponent.vue';
 
 const meta: Meta<typeof MyComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Configure a11y addon',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof MyComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const ExampleStory = {

--- a/docs/snippets/vue/table-story-fully-customize-controls.2.js.mdx
+++ b/docs/snippets/vue/table-story-fully-customize-controls.2.js.mdx
@@ -5,7 +5,7 @@ import Table from './Table.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Custom Table',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const TableStory = {

--- a/docs/snippets/vue/table-story-fully-customize-controls.2.ts-4-9.mdx
+++ b/docs/snippets/vue/table-story-fully-customize-controls.2.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Table from './Table.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Custom Table',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const TableStory: Story = {

--- a/docs/snippets/vue/table-story-fully-customize-controls.2.ts.mdx
+++ b/docs/snippets/vue/table-story-fully-customize-controls.2.ts.mdx
@@ -7,7 +7,7 @@ import Table from './Table.vue';
 
 const meta: Meta<typeof Table> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Custom Table',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Table>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const TableStory: Story = {

--- a/docs/snippets/vue/table-story-fully-customize-controls.3.js.mdx
+++ b/docs/snippets/vue/table-story-fully-customize-controls.3.js.mdx
@@ -5,7 +5,7 @@ import Table from './Table.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Custom Table',
@@ -14,7 +14,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const TableStory = {

--- a/docs/snippets/vue/table-story-fully-customize-controls.3.ts-4-9.mdx
+++ b/docs/snippets/vue/table-story-fully-customize-controls.3.ts-4-9.mdx
@@ -7,7 +7,7 @@ import Table from './Table.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Custom Table',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const TableStory: Story = {

--- a/docs/snippets/vue/table-story-fully-customize-controls.3.ts.mdx
+++ b/docs/snippets/vue/table-story-fully-customize-controls.3.ts.mdx
@@ -7,7 +7,7 @@ import Table from './Table.vue';
 
 const meta: Meta<typeof Table> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Custom Table',
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Table>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const TableStory: Story = {

--- a/docs/snippets/vue/your-component-with-decorator.js.mdx
+++ b/docs/snippets/vue/your-component-with-decorator.js.mdx
@@ -5,7 +5,7 @@ import YourComponent from './YourComponent.vue';
 
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/vue/your-component-with-decorator.ts-4-9.mdx
+++ b/docs/snippets/vue/your-component-with-decorator.ts-4-9.mdx
@@ -8,7 +8,7 @@ import YourComponent from './YourComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/vue/your-component-with-decorator.ts.mdx
+++ b/docs/snippets/vue/your-component-with-decorator.ts.mdx
@@ -8,7 +8,7 @@ import YourComponent from './YourComponent.vue';
 
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',

--- a/docs/snippets/vue/your-component.2.js.mdx
+++ b/docs/snippets/vue/your-component.2.js.mdx
@@ -6,7 +6,7 @@ import YourComponent from './YourComponent.vue';
 //👇 This default export determines where your story goes in the story list
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -15,7 +15,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/api/csf
  * to learn how to use render functions.
  */
 export const FirstStory = {

--- a/docs/snippets/vue/your-component.2.ts-4-9.mdx
+++ b/docs/snippets/vue/your-component.2.ts-4-9.mdx
@@ -7,7 +7,7 @@ import YourComponent from './YourComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const FirstStory: Story = {

--- a/docs/snippets/vue/your-component.2.ts.mdx
+++ b/docs/snippets/vue/your-component.2.ts.mdx
@@ -7,7 +7,7 @@ import YourComponent from './YourComponent.vue';
 
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof YourComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const FirstStory: Story = {

--- a/docs/snippets/vue/your-component.3.js.mdx
+++ b/docs/snippets/vue/your-component.3.js.mdx
@@ -6,7 +6,7 @@ import YourComponent from './YourComponent.vue';
 //👇 This default export determines where your story goes in the story list
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -15,7 +15,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const FirstStory = {

--- a/docs/snippets/vue/your-component.3.ts-4-9.mdx
+++ b/docs/snippets/vue/your-component.3.ts-4-9.mdx
@@ -7,7 +7,7 @@ import YourComponent from './YourComponent.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/vue/your-component.3.ts.mdx
+++ b/docs/snippets/vue/your-component.3.ts.mdx
@@ -7,7 +7,7 @@ import YourComponent from './YourComponent.vue';
 
 const meta: Meta<typeof YourComponent> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'YourComponent',
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof YourComponent>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/docs/snippets/web-components/button-story-with-addon-example.js.mdx
+++ b/docs/snippets/web-components/button-story-with-addon-example.js.mdx
@@ -16,7 +16,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const Basic = {

--- a/docs/snippets/web-components/button-story-with-addon-example.ts.mdx
+++ b/docs/snippets/web-components/button-story-with-addon-example.ts.mdx
@@ -21,7 +21,7 @@ type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const Basic: Story = {

--- a/docs/snippets/web-components/component-story-static-asset-cdn.js.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-cdn.js.mdx
@@ -10,7 +10,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage = {

--- a/docs/snippets/web-components/component-story-static-asset-cdn.ts.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-cdn.ts.mdx
@@ -15,7 +15,7 @@ type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/web-components/component-story-static-asset-with-import.js.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-with-import.js.mdx
@@ -17,7 +17,7 @@ const image = {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage = {

--- a/docs/snippets/web-components/component-story-static-asset-with-import.ts.mdx
+++ b/docs/snippets/web-components/component-story-static-asset-with-import.ts.mdx
@@ -22,7 +22,7 @@ type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const WithAnImage: Story = {

--- a/docs/snippets/web-components/login-form-with-play-function.js.mdx
+++ b/docs/snippets/web-components/login-form-with-play-function.js.mdx
@@ -12,7 +12,7 @@ export default {
 export const EmptyForm = {};
 
 /*
- * See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm = {
@@ -24,7 +24,7 @@ export const FilledForm = {
 
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 
     // 👇 Assert DOM structure

--- a/docs/snippets/web-components/login-form-with-play-function.ts.mdx
+++ b/docs/snippets/web-components/login-form-with-play-function.ts.mdx
@@ -16,7 +16,7 @@ type Story = StoryObj;
 export const EmptyForm: Story = {};
 
 /*
- * See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
@@ -28,7 +28,7 @@ export const FilledForm: Story = {
 
     await userEvent.type(canvas.getByTestId('password'), 'a-random-password');
 
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
 
     // 👇 Assert DOM structure

--- a/docs/snippets/web-components/my-component-play-function-alt-queries.js.mdx
+++ b/docs/snippets/web-components/my-component-play-function-alt-queries.js.mdx
@@ -8,14 +8,14 @@ export default {
   component: 'demo-my-component',
 };
 
-/* See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleWithRole = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };

--- a/docs/snippets/web-components/my-component-play-function-alt-queries.ts.mdx
+++ b/docs/snippets/web-components/my-component-play-function-alt-queries.ts.mdx
@@ -13,14 +13,14 @@ export default meta;
 
 type Story = StoryObj;
 
-/* See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleWithRole: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button', { name: / button label/i }));
   },
 };

--- a/docs/snippets/web-components/my-component-play-function-composition.js.mdx
+++ b/docs/snippets/web-components/my-component-play-function-composition.js.mdx
@@ -9,7 +9,7 @@ export default {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FirstStory = {

--- a/docs/snippets/web-components/my-component-play-function-composition.ts.mdx
+++ b/docs/snippets/web-components/my-component-play-function-composition.ts.mdx
@@ -14,7 +14,7 @@ export default meta;
 type Story = StoryObj;
 
 /*
- * See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FirstStory: Story = {

--- a/docs/snippets/web-components/my-component-play-function-query-findby.js.mdx
+++ b/docs/snippets/web-components/my-component-play-function-query-findby.js.mdx
@@ -8,7 +8,7 @@ export default {
   component: 'demo-my-component',
 };
 
-/* See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const AsyncExample = {

--- a/docs/snippets/web-components/my-component-play-function-query-findby.ts.mdx
+++ b/docs/snippets/web-components/my-component-play-function-query-findby.ts.mdx
@@ -13,7 +13,7 @@ export default meta;
 
 type Story = StoryObj;
 
-/* See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const AsyncExample: Story = {

--- a/docs/snippets/web-components/my-component-play-function-waitfor.js.mdx
+++ b/docs/snippets/web-components/my-component-play-function-waitfor.js.mdx
@@ -8,7 +8,7 @@ export default {
   component: 'demo-my-component',
 };
 
-/* See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleAsyncStory = {
@@ -23,7 +23,7 @@ export const ExampleAsyncStory = {
       delay: 100,
     });
 
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 

--- a/docs/snippets/web-components/my-component-play-function-waitfor.ts.mdx
+++ b/docs/snippets/web-components/my-component-play-function-waitfor.ts.mdx
@@ -13,7 +13,7 @@ export default meta;
 
 type Story = StoryObj;
 
-/* See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleAsyncStory: Story = {
@@ -28,7 +28,7 @@ export const ExampleAsyncStory: Story = {
       delay: 100,
     });
 
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const Submit = canvas.getByRole('button');
     await userEvent.click(Submit);
 

--- a/docs/snippets/web-components/my-component-play-function-with-clickevent.js.mdx
+++ b/docs/snippets/web-components/my-component-play-function-with-clickevent.js.mdx
@@ -15,7 +15,7 @@ export const ClickExample = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
   },
 };
@@ -24,7 +24,7 @@ export const FireEventExample = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };

--- a/docs/snippets/web-components/my-component-play-function-with-clickevent.js.mdx
+++ b/docs/snippets/web-components/my-component-play-function-with-clickevent.js.mdx
@@ -8,7 +8,7 @@ export default {
   component: 'demo-my-component',
 };
 
-/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ClickExample = {

--- a/docs/snippets/web-components/my-component-play-function-with-clickevent.ts.mdx
+++ b/docs/snippets/web-components/my-component-play-function-with-clickevent.ts.mdx
@@ -20,7 +20,7 @@ export const ClickExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await userEvent.click(canvas.getByRole('button'));
   },
 };
@@ -29,7 +29,7 @@ export const FireEventExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     await fireEvent.click(canvas.getByTestId('data-testid'));
   },
 };

--- a/docs/snippets/web-components/my-component-play-function-with-clickevent.ts.mdx
+++ b/docs/snippets/web-components/my-component-play-function-with-clickevent.ts.mdx
@@ -13,7 +13,7 @@ export default meta;
 
 type Story = StoryObj;
 
-/* See https://storybook.js.org/docs/react/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ClickExample: Story = {

--- a/docs/snippets/web-components/my-component-play-function-with-delay.js.mdx
+++ b/docs/snippets/web-components/my-component-play-function-with-delay.js.mdx
@@ -8,7 +8,7 @@ export default {
   component: 'demo-my-component',
 };
 
-/* See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const DelayedStory = {

--- a/docs/snippets/web-components/my-component-play-function-with-delay.ts.mdx
+++ b/docs/snippets/web-components/my-component-play-function-with-delay.ts.mdx
@@ -13,7 +13,7 @@ export default meta;
 
 type Story = StoryObj;
 
-/* See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const DelayedStory: Story = {

--- a/docs/snippets/web-components/my-component-play-function-with-selectevent.js.mdx
+++ b/docs/snippets/web-components/my-component-play-function-with-selectevent.js.mdx
@@ -13,7 +13,7 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/* See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleChangeEvent = {

--- a/docs/snippets/web-components/my-component-play-function-with-selectevent.ts.mdx
+++ b/docs/snippets/web-components/my-component-play-function-with-selectevent.ts.mdx
@@ -18,7 +18,7 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/* See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+/* See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const ExampleChangeEvent: Story = {

--- a/docs/snippets/web-components/my-component-story-configure-viewports.js.mdx
+++ b/docs/snippets/web-components/my-component-story-configure-viewports.js.mdx
@@ -19,7 +19,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const MyStory = {

--- a/docs/snippets/web-components/my-component-story-configure-viewports.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-configure-viewports.ts.mdx
@@ -24,7 +24,7 @@ type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const MyStory: Story = {

--- a/docs/snippets/web-components/my-component-story-use-globaltype-backwards-compat.js.mdx
+++ b/docs/snippets/web-components/my-component-story-use-globaltype-backwards-compat.js.mdx
@@ -5,7 +5,7 @@ import { html } from 'lit';
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const StoryWithLocale = {

--- a/docs/snippets/web-components/my-component-story-use-globaltype-backwards-compat.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-use-globaltype-backwards-compat.ts.mdx
@@ -7,7 +7,7 @@ import { StoryObj } from '@storybook/web-components';
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const StoryWithLocale: StoryObj = {

--- a/docs/snippets/web-components/my-component-story-use-globaltype.js.mdx
+++ b/docs/snippets/web-components/my-component-story-use-globaltype.js.mdx
@@ -25,7 +25,7 @@ const getCaptionForLocale = (locale) => {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const StoryWithLocale = {

--- a/docs/snippets/web-components/my-component-story-use-globaltype.ts.mdx
+++ b/docs/snippets/web-components/my-component-story-use-globaltype.ts.mdx
@@ -30,7 +30,7 @@ type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const StoryWithLocale: Story = {

--- a/docs/snippets/web-components/page-story-slots.js.mdx
+++ b/docs/snippets/web-components/page-story-slots.js.mdx
@@ -10,7 +10,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const CustomFooter = {

--- a/docs/snippets/web-components/register-component-with-play-function.js.mdx
+++ b/docs/snippets/web-components/register-component-with-play-function.js.mdx
@@ -9,7 +9,7 @@ export default {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm = {
@@ -31,7 +31,7 @@ export const FilledForm = {
     await userEvent.type(passwordInput, 'ExamplePassword', {
       delay: 100,
     });
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);

--- a/docs/snippets/web-components/register-component-with-play-function.ts.mdx
+++ b/docs/snippets/web-components/register-component-with-play-function.ts.mdx
@@ -14,7 +14,7 @@ export default meta;
 type Story = StoryObj;
 
 /*
- * See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const FilledForm: Story = {
@@ -36,7 +36,7 @@ export const FilledForm: Story = {
     await userEvent.type(passwordInput, 'ExamplePassword', {
       delay: 100,
     });
-    // See https://storybook.js.org/docs/7.0/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
+    // See https://storybook.js.org/docs/web-components/essentials/actions#automatically-matching-args to learn how to setup logging in the Actions panel
     const submitButton = canvas.getByRole('button');
 
     await userEvent.click(submitButton);

--- a/docs/snippets/web-components/storybook-addon-backgrounds-configure-grid.js.mdx
+++ b/docs/snippets/web-components/storybook-addon-backgrounds-configure-grid.js.mdx
@@ -4,7 +4,7 @@
 // To apply a set of backgrounds to all stories of Button:
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/web-components/storybook-addon-backgrounds-configure-grid.js.mdx
+++ b/docs/snippets/web-components/storybook-addon-backgrounds-configure-grid.js.mdx
@@ -4,7 +4,7 @@
 // To apply a set of backgrounds to all stories of Button:
 export default {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/web-components/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/web-components/storybook-addon-backgrounds-configure-grid.ts.mdx
+++ b/docs/snippets/web-components/storybook-addon-backgrounds-configure-grid.ts.mdx
@@ -6,7 +6,7 @@ import type { Meta } from '@storybook/web-components';
 // To apply a set of backgrounds to all stories of Button:
 const meta: Meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/web-components/storybook-addon-backgrounds-configure-grid.ts.mdx
+++ b/docs/snippets/web-components/storybook-addon-backgrounds-configure-grid.ts.mdx
@@ -6,7 +6,7 @@ import type { Meta } from '@storybook/web-components';
 // To apply a set of backgrounds to all stories of Button:
 const meta: Meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/web-components/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Button',

--- a/docs/snippets/web-components/storybook-interactions-play-function.js.mdx
+++ b/docs/snippets/web-components/storybook-interactions-play-function.js.mdx
@@ -14,7 +14,7 @@ export default {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted = {

--- a/docs/snippets/web-components/storybook-interactions-play-function.ts.mdx
+++ b/docs/snippets/web-components/storybook-interactions-play-function.ts.mdx
@@ -19,7 +19,7 @@ export default meta;
 type Story = StoryObj;
 
 /*
- * See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted: Story = {

--- a/docs/snippets/web-components/storybook-interactions-step-function.js.mdx
+++ b/docs/snippets/web-components/storybook-interactions-step-function.js.mdx
@@ -9,7 +9,7 @@ const meta: Meta = {
 };
 
 /*
- * See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted = {

--- a/docs/snippets/web-components/storybook-interactions-step-function.ts.mdx
+++ b/docs/snippets/web-components/storybook-interactions-step-function.ts.mdx
@@ -14,7 +14,7 @@ export default meta;
 type Story = StoryObj;
 
 /*
- * See https://storybook.js.org/docs/7.0/web-components/writing-stories/play-function#working-with-the-canvas
+ * See https://storybook.js.org/docs/web-components/writing-stories/play-function#working-with-the-canvas
  * to learn more about using the canvasElement to query the DOM
  */
 export const Submitted: Story = {

--- a/docs/snippets/web-components/table-story-fully-customize-controls.js.mdx
+++ b/docs/snippets/web-components/table-story-fully-customize-controls.js.mdx
@@ -11,7 +11,7 @@ export default {
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const TableStory = {

--- a/docs/snippets/web-components/table-story-fully-customize-controls.ts.mdx
+++ b/docs/snippets/web-components/table-story-fully-customize-controls.ts.mdx
@@ -16,7 +16,7 @@ type Story = StoryObj;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/web-components/api/csf
+ * See https://storybook.js.org/docs/web-components/api/csf
  * to learn how to use render functions.
  */
 export const TableStory: Story = {


### PR DESCRIPTION
With this pull request, the links used in our documentation are updated to reference the correct place once 7.0 comes online. This will prevent misconceptions/ broken links in the documentation.

@shilman , @yannbf if you could merge this before the transition I'd appreciate.