### PR TITLE
Chore: (Templates) Updates code references to 7.0

### DIFF
--- a/code/addons/gfm/src/index.ts
+++ b/code/addons/gfm/src/index.ts
@@ -13,7 +13,7 @@ export const mdxLoaderOptions = async (config: any) => {
 deprecate(dedent`
   The "@storybook/addon-mdx-gfm" addon is meant as a migration assistant for Storybook 7.0; and will likely be removed in a future version.
   It's recommended you read this document:
-  https://storybook.js.org/docs/7.0/react/writing-docs/mdx#lack-of-github-flavored-markdown-gfm
+  https://storybook.js.org/docs/react/writing-docs/mdx#lack-of-github-flavored-markdown-gfm
 
   Once you've made the necessary changes, you can remove the addon from your package.json and storybook config.
 `);

--- a/code/frameworks/angular/template/cli/Button.stories.ts
+++ b/code/frameworks/angular/template/cli/Button.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import Button from './button.component';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/angular/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/angular/writing-stories/introduction
 const meta: Meta<Button> = {
   title: 'Example/Button',
   component: Button,
@@ -22,7 +22,7 @@ const meta: Meta<Button> = {
 export default meta;
 type Story = StoryObj<Button>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/angular/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/angular/writing-stories/args
 export const Primary: Story = {
   args: {
     primary: true,

--- a/code/frameworks/angular/template/cli/Header.stories.ts
+++ b/code/frameworks/angular/template/cli/Header.stories.ts
@@ -8,7 +8,7 @@ import Header from './header.component';
 const meta: Meta<Header> = {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/angular/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/angular/writing-docs/autodocs
   tags: ['autodocs'],
   render: (args) => ({ props: args }),
   decorators: [
@@ -18,7 +18,7 @@ const meta: Meta<Header> = {
     }),
   ],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/angular/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/angular/configure/story-layout
     layout: 'fullscreen',
   },
 };

--- a/code/frameworks/angular/template/cli/Page.stories.ts
+++ b/code/frameworks/angular/template/cli/Page.stories.ts
@@ -11,7 +11,7 @@ const meta: Meta<Page> = {
   title: 'Example/Page',
   component: Page,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/angular/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/angular/configure/story-layout
     layout: 'fullscreen',
   },
   decorators: [
@@ -31,7 +31,7 @@ export const LoggedOut: Story = {
   }),
 };
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/angular/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/angular/writing-tests/interaction-testing
 export const LoggedIn: Story = {
   render: (args: Page) => ({
     props: args,

--- a/code/frameworks/ember/template/cli/Button.stories.js
+++ b/code/frameworks/ember/template/cli/Button.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/ember/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/ember/writing-stories/introduction
 export default {
   title: 'Example/Button',
   render: (args) => ({
@@ -12,11 +12,11 @@ export default {
   argTypes: {
     label: { control: 'text' },
   },
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
 };
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/ember/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/ember/writing-stories/args
 export const Text = {
   args: {
     label: 'Button',

--- a/code/frameworks/nextjs/template/cli/js/Button.stories.js
+++ b/code/frameworks/nextjs/template/cli/js/Button.stories.js
@@ -1,6 +1,6 @@
 import { Button } from './Button';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 export default {
   title: 'Example/Button',
   component: Button,
@@ -12,7 +12,7 @@ export default {
   },
 };
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Primary = {
   args: {
     primary: true,

--- a/code/frameworks/nextjs/template/cli/js/Header.stories.js
+++ b/code/frameworks/nextjs/template/cli/js/Header.stories.js
@@ -3,10 +3,10 @@ import { Header } from './Header';
 export default {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
 };

--- a/code/frameworks/nextjs/template/cli/js/Page.stories.js
+++ b/code/frameworks/nextjs/template/cli/js/Page.stories.js
@@ -5,14 +5,14 @@ export default {
   title: 'Example/Page',
   component: Page,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
 };
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/react/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/react/writing-tests/interaction-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/frameworks/nextjs/template/cli/ts-3-8/Button.stories.ts
+++ b/code/frameworks/nextjs/template/cli/ts-3-8/Button.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from './Button';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 const meta: Meta<typeof Button> = {
   title: 'Example/Button',
   component: Button,
@@ -17,7 +17,7 @@ const meta: Meta<typeof Button> = {
 export default meta;
 type Story = StoryObj<typeof Button>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Primary: Story = {
   args: {
     primary: true,

--- a/code/frameworks/nextjs/template/cli/ts-3-8/Header.stories.ts
+++ b/code/frameworks/nextjs/template/cli/ts-3-8/Header.stories.ts
@@ -4,10 +4,10 @@ import { Header } from './Header';
 const meta: Meta<typeof Header> = {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
 };

--- a/code/frameworks/nextjs/template/cli/ts-3-8/Page.stories.ts
+++ b/code/frameworks/nextjs/template/cli/ts-3-8/Page.stories.ts
@@ -7,7 +7,7 @@ const meta: Meta<typeof Page> = {
   title: 'Example/Page',
   component: Page,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
 };
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof Page>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/react/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/react/writing-tests/interaction-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/frameworks/nextjs/template/cli/ts/Button.stories.ts
+++ b/code/frameworks/nextjs/template/cli/ts/Button.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from './Button';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 const meta: Meta<typeof Button> = {
   title: 'Example/Button',
   component: Button,
@@ -17,7 +17,7 @@ const meta: Meta<typeof Button> = {
 export default meta;
 type Story = StoryObj<typeof Button>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Primary: Story = {
   args: {
     primary: true,

--- a/code/frameworks/nextjs/template/cli/ts/Header.stories.ts
+++ b/code/frameworks/nextjs/template/cli/ts/Header.stories.ts
@@ -4,10 +4,10 @@ import { Header } from './Header';
 const meta: Meta<typeof Header> = {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
 };

--- a/code/frameworks/nextjs/template/cli/ts/Page.stories.ts
+++ b/code/frameworks/nextjs/template/cli/ts/Page.stories.ts
@@ -7,7 +7,7 @@ const meta: Meta<typeof Page> = {
   title: 'Example/Page',
   component: Page,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
 };
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof Page>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/react/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/react/writing-tests/interaction-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/lib/cli/src/automigrate/fixes/mdx-gfm.ts
+++ b/code/lib/cli/src/automigrate/fixes/mdx-gfm.ts
@@ -51,7 +51,7 @@ export const mdxgfm: Fix<Options> = {
 
       Storybook 7.0 uses MDX2 for compiling MDX, and thus no longer supports GFM out of the box.
       Because of this you need to explicitly add the GFM plugin in the addon-docs options:
-      https://storybook.js.org/docs/7.0/react/writing-docs/mdx#lack-of-github-flavored-markdown-gfm
+      https://storybook.js.org/docs/react/writing-docs/mdx#lack-of-github-flavored-markdown-gfm
 
       We recommend you follow the guide on the link above, however we can add a temporary storybook addon that helps make this migration easier.
       We'll install the addon and add it to your storybook config.

--- a/code/renderers/html/template/cli/js/Button.stories.js
+++ b/code/renderers/html/template/cli/js/Button.stories.js
@@ -1,6 +1,6 @@
 import { createButton } from './Button';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/html/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/html/writing-stories/introduction
 export default {
   title: 'Example/Button',
   tags: ['autodocs'],
@@ -21,7 +21,7 @@ export default {
   },
 };
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/html/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/html/writing-stories/args
 export const Primary = {
   args: {
     primary: true,

--- a/code/renderers/html/template/cli/js/Header.stories.js
+++ b/code/renderers/html/template/cli/js/Header.stories.js
@@ -2,14 +2,14 @@ import { createHeader } from './Header';
 
 export default {
   title: 'Example/Header',
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/html/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/html/writing-docs/autodocs
   tags: ['autodocs'],
   render: (args) => createHeader(args),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/html/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/html/configure/story-layout
     layout: 'fullscreen',
   },
-  // More on argTypes: https://storybook.js.org/docs/7.0/html/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/html/api/argtypes
   argTypes: {
     onLogin: { action: 'onLogin' },
     onLogout: { action: 'onLogout' },

--- a/code/renderers/html/template/cli/js/Page.stories.js
+++ b/code/renderers/html/template/cli/js/Page.stories.js
@@ -5,14 +5,14 @@ export default {
   title: 'Example/Page',
   render: () => createPage(),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/html/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/html/configure/story-layout
     layout: 'fullscreen',
   },
 };
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/html/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/html/writing-tests/interaction-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/html/template/cli/ts-3-8/Button.stories.ts
+++ b/code/renderers/html/template/cli/ts-3-8/Button.stories.ts
@@ -26,7 +26,7 @@ const meta: Meta<ButtonProps> = {
 export default meta;
 type Story = StoryObj<ButtonProps>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/html/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/html/writing-stories/args
 export const Primary: Story = {
   args: {
     primary: true,

--- a/code/renderers/html/template/cli/ts-3-8/Header.stories.ts
+++ b/code/renderers/html/template/cli/ts-3-8/Header.stories.ts
@@ -4,14 +4,14 @@ import { createHeader } from './Header';
 
 const meta: Meta<HeaderProps> = {
   title: 'Example/Header',
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/html/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/html/writing-docs/autodocs
   tags: ['autodocs'],
   render: (args) => createHeader(args),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/html/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/html/configure/story-layout
     layout: 'fullscreen',
   },
-  // More on argTypes: https://storybook.js.org/docs/7.0/html/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/html/api/argtypes
   argTypes: {
     onLogin: { action: 'onLogin' },
     onLogout: { action: 'onLogout' },

--- a/code/renderers/html/template/cli/ts-3-8/Page.stories.ts
+++ b/code/renderers/html/template/cli/ts-3-8/Page.stories.ts
@@ -6,7 +6,7 @@ const meta: Meta = {
   title: 'Example/Page',
   render: () => createPage(),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/html/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/html/configure/story-layout
     layout: 'fullscreen',
   },
 };
@@ -15,7 +15,7 @@ export default meta;
 
 export const LoggedOut: StoryObj = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/html/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/html/writing-tests/interaction-testing
 export const LoggedIn: StoryObj = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/html/template/cli/ts-4-9/Button.stories.ts
+++ b/code/renderers/html/template/cli/ts-4-9/Button.stories.ts
@@ -26,7 +26,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<ButtonProps>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/html/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/html/writing-stories/args
 export const Primary: Story = {
   args: {
     primary: true,

--- a/code/renderers/html/template/cli/ts-4-9/Header.stories.ts
+++ b/code/renderers/html/template/cli/ts-4-9/Header.stories.ts
@@ -4,14 +4,14 @@ import { createHeader } from './Header';
 
 const meta = {
   title: 'Example/Header',
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/html/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/html/writing-docs/autodocs
   tags: ['autodocs'],
   render: (args) => createHeader(args),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/html/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/html/configure/story-layout
     layout: 'fullscreen',
   },
-  // More on argTypes: https://storybook.js.org/docs/7.0/html/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/html/api/argtypes
   argTypes: {
     onLogin: { action: 'onLogin' },
     onLogout: { action: 'onLogout' },

--- a/code/renderers/html/template/cli/ts-4-9/Page.stories.ts
+++ b/code/renderers/html/template/cli/ts-4-9/Page.stories.ts
@@ -6,7 +6,7 @@ const meta = {
   title: 'Example/Page',
   render: () => createPage(),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/html/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/html/configure/story-layout
     layout: 'fullscreen',
   },
 } satisfies Meta;
@@ -15,7 +15,7 @@ export default meta;
 
 export const LoggedOut: StoryObj = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/html/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/html/writing-tests/interaction-testing
 export const LoggedIn: StoryObj = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/preact/template/cli/Button.stories.jsx
+++ b/code/renderers/preact/template/cli/Button.stories.jsx
@@ -1,6 +1,6 @@
 import { Button } from './Button';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/preact/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/preact/writing-stories/introduction
 export default {
   title: 'Example/Button',
   component: Button,
@@ -11,7 +11,7 @@ export default {
   },
 };
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/preact/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/preact/writing-stories/args
 export const Primary = {
   args: {
     primary: true,

--- a/code/renderers/preact/template/cli/Header.stories.jsx
+++ b/code/renderers/preact/template/cli/Header.stories.jsx
@@ -3,10 +3,10 @@ import { Header } from './Header';
 export default {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/preact/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/preact/writing-docs/autodocs
   tags: ['autodocs'],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/preact/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/preact/configure/story-layout
     layout: 'fullscreen',
   },
   argTypes: {

--- a/code/renderers/preact/template/cli/Page.stories.jsx
+++ b/code/renderers/preact/template/cli/Page.stories.jsx
@@ -6,14 +6,14 @@ export default {
   title: 'Example/Page',
   component: Page,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/preact/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/preact/configure/story-layout
     layout: 'fullscreen',
   },
 };
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/preact/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/preact/writing-tests/interaction-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/react/template/cli/js/Button.stories.js
+++ b/code/renderers/react/template/cli/js/Button.stories.js
@@ -1,6 +1,6 @@
 import { Button } from './Button';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 export default {
   title: 'Example/Button',
   component: Button,
@@ -10,7 +10,7 @@ export default {
   },
 };
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Primary = {
   args: {
     primary: true,

--- a/code/renderers/react/template/cli/js/Header.stories.js
+++ b/code/renderers/react/template/cli/js/Header.stories.js
@@ -3,10 +3,10 @@ import { Header } from './Header';
 export default {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
 };

--- a/code/renderers/react/template/cli/js/Page.stories.js
+++ b/code/renderers/react/template/cli/js/Page.stories.js
@@ -6,14 +6,14 @@ export default {
   title: 'Example/Page',
   component: Page,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
 };
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/react/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/react/writing-tests/interaction-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/react/template/cli/ts-3-8/Button.stories.ts
+++ b/code/renderers/react/template/cli/ts-3-8/Button.stories.ts
@@ -6,7 +6,7 @@ import { Button } from './Button';
 const meta: Meta<typeof Button> = {
   title: 'Example/Button',
   component: Button,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   argTypes: {

--- a/code/renderers/react/template/cli/ts-3-8/Header.stories.ts
+++ b/code/renderers/react/template/cli/ts-3-8/Header.stories.ts
@@ -4,7 +4,7 @@ import { Header } from './Header';
 const meta: Meta<typeof Header> = {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
   parameters: {
     // More on Story layout: https://storybook.js.org/docs/react/configure/story-layout

--- a/code/renderers/react/template/cli/ts-4-9/Button.stories.ts
+++ b/code/renderers/react/template/cli/ts-4-9/Button.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from './Button';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 const meta = {
   title: 'Example/Button',
   component: Button,
@@ -15,7 +15,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Primary: Story = {
   args: {
     primary: true,

--- a/code/renderers/react/template/cli/ts-4-9/Header.stories.ts
+++ b/code/renderers/react/template/cli/ts-4-9/Header.stories.ts
@@ -4,10 +4,10 @@ import { Header } from './Header';
 const meta = {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
 } satisfies Meta<typeof Header>;

--- a/code/renderers/react/template/cli/ts-4-9/Page.stories.ts
+++ b/code/renderers/react/template/cli/ts-4-9/Page.stories.ts
@@ -7,7 +7,7 @@ const meta = {
   title: 'Example/Page',
   component: Page,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
 } satisfies Meta<typeof Page>;
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/react/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/react/writing-tests/interaction-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/svelte/template/cli/js/Button.stories.js
+++ b/code/renderers/svelte/template/cli/js/Button.stories.js
@@ -1,6 +1,6 @@
 import Button from './Button.svelte';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/svelte/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/svelte/writing-stories/introduction
 export default {
   title: 'Example/Button',
   component: Button,
@@ -14,7 +14,7 @@ export default {
   },
 };
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/svelte/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/svelte/writing-stories/args
 export const Primary = {
   args: {
     primary: true,

--- a/code/renderers/svelte/template/cli/js/Header.stories.js
+++ b/code/renderers/svelte/template/cli/js/Header.stories.js
@@ -3,10 +3,10 @@ import Header from './Header.svelte';
 export default {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/svelte/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/svelte/writing-docs/autodocs
   tags: ['autodocs'],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/svelte/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/svelte/configure/story-layout
     layout: 'fullscreen',
   },
 };

--- a/code/renderers/svelte/template/cli/js/Page.stories.js
+++ b/code/renderers/svelte/template/cli/js/Page.stories.js
@@ -6,14 +6,14 @@ export default {
   title: 'Example/Page',
   component: Page,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/svelte/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/svelte/configure/story-layout
     layout: 'fullscreen',
   },
 };
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/svelte/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/svelte/writing-tests/interaction-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/svelte/template/cli/ts-3-8/Button.stories.ts
+++ b/code/renderers/svelte/template/cli/ts-3-8/Button.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/svelte';
 
 import Button from './Button.svelte';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/svelte/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/svelte/writing-stories/introduction
 const meta: Meta<Button> = {
   title: 'Example/Button',
   component: Button,
@@ -19,7 +19,7 @@ const meta: Meta<Button> = {
 export default meta;
 type Story = StoryObj<Button>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/svelte/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/svelte/writing-stories/args
 export const Primary: Story = {
   args: {
     primary: true,

--- a/code/renderers/svelte/template/cli/ts-3-8/Header.stories.ts
+++ b/code/renderers/svelte/template/cli/ts-3-8/Header.stories.ts
@@ -4,10 +4,10 @@ import Header from './Header.svelte';
 const meta: Meta<Header> = {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/svelte/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/svelte/configure/story-layout
     layout: 'fullscreen',
   },
 };

--- a/code/renderers/svelte/template/cli/ts-3-8/Page.stories.ts
+++ b/code/renderers/svelte/template/cli/ts-3-8/Page.stories.ts
@@ -7,7 +7,7 @@ const meta: Meta<Page> = {
   title: 'Example/Page',
   component: Page,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/svelte/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/svelte/configure/story-layout
     layout: 'fullscreen',
   },
 };
@@ -17,7 +17,7 @@ type Story = StoryObj<Page>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/svelte/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/svelte/writing-tests/interaction-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/svelte/template/cli/ts-4-9/Button.stories.ts
+++ b/code/renderers/svelte/template/cli/ts-4-9/Button.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/svelte';
 
 import Button from './Button.svelte';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/svelte/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/svelte/writing-stories/introduction
 const meta = {
   title: 'Example/Button',
   component: Button,
@@ -19,7 +19,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/svelte/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/svelte/writing-stories/args
 export const Primary: Story = {
   args: {
     primary: true,

--- a/code/renderers/svelte/template/cli/ts-4-9/Header.stories.ts
+++ b/code/renderers/svelte/template/cli/ts-4-9/Header.stories.ts
@@ -4,10 +4,10 @@ import Header from './Header.svelte';
 const meta = {
   title: 'Example/Header',
   component: Header,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/svelte/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/svelte/configure/story-layout
     layout: 'fullscreen',
   },
 } satisfies Meta<Header>;

--- a/code/renderers/svelte/template/cli/ts-4-9/Page.stories.ts
+++ b/code/renderers/svelte/template/cli/ts-4-9/Page.stories.ts
@@ -7,7 +7,7 @@ const meta = {
   title: 'Example/Page',
   component: Page,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/svelte/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/svelte/configure/story-layout
     layout: 'fullscreen',
   },
 } satisfies Meta<Page>;
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/svelte/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/svelte/writing-tests/interaction-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/vue/template/cli/Button.stories.js
+++ b/code/renderers/vue/template/cli/Button.stories.js
@@ -1,6 +1,6 @@
 import MyButton from './Button.vue';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/vue/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/vue/writing-stories/introduction
 export default {
   title: 'Example/Button',
   component: MyButton,
@@ -19,7 +19,7 @@ export default {
   },
 };
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/vue/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/vue/writing-stories/args
 export const Primary = {
   args: {
     primary: true,

--- a/code/renderers/vue/template/cli/Header.stories.js
+++ b/code/renderers/vue/template/cli/Header.stories.js
@@ -3,7 +3,7 @@ import MyHeader from './Header.vue';
 export default {
   title: 'Example/Header',
   component: MyHeader,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/vue/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/vue/writing-docs/autodocs
   tags: ['autodocs'],
   render: (args, { argTypes }) => ({
     props: Object.keys(argTypes),
@@ -14,7 +14,7 @@ export default {
       '<my-header :user="user" @onLogin="onLogin" @onLogout="onLogout" @onCreateAccount="onCreateAccount" />',
   }),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/vue/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/vue/configure/story-layout
     layout: 'fullscreen',
   },
 };

--- a/code/renderers/vue/template/cli/Page.stories.js
+++ b/code/renderers/vue/template/cli/Page.stories.js
@@ -9,13 +9,13 @@ export default {
     template: '<my-page />',
   }),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/vue/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/vue/configure/story-layout
     layout: 'fullscreen',
   },
 };
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/vue/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/vue/writing-tests/interaction-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/vue3/template/cli/js/Button.stories.js
+++ b/code/renderers/vue3/template/cli/js/Button.stories.js
@@ -1,6 +1,6 @@
 import MyButton from './Button.vue';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/vue/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/vue/writing-stories/introduction
 export default {
   title: 'Example/Button',
   component: MyButton,
@@ -19,7 +19,7 @@ export default {
   },
 };
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/vue/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/vue/writing-stories/args
 export const Primary = {
   args: {
     primary: true,

--- a/code/renderers/vue3/template/cli/js/Header.stories.js
+++ b/code/renderers/vue3/template/cli/js/Header.stories.js
@@ -3,7 +3,7 @@ import MyHeader from './Header.vue';
 export default {
   title: 'Example/Header',
   component: MyHeader,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/vue/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/vue/writing-docs/autodocs
   tags: ['autodocs'],
   render: (args) => ({
     // Components used in your story `template` are defined in the `components` object
@@ -21,7 +21,7 @@ export default {
     template: '<my-header :user="user" />',
   }),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/vue/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/vue/configure/story-layout
     layout: 'fullscreen',
   },
 };

--- a/code/renderers/vue3/template/cli/js/Page.stories.js
+++ b/code/renderers/vue3/template/cli/js/Page.stories.js
@@ -5,14 +5,14 @@ export default {
   title: 'Example/Page',
   component: MyPage,
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/vue/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/vue/configure/story-layout
     layout: 'fullscreen',
   },
 };
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/vue/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/vue/writing-tests/interaction-testing
 export const LoggedIn = {
   render: () => ({
     components: {

--- a/code/renderers/vue3/template/cli/ts-3-8/Button.stories.ts
+++ b/code/renderers/vue3/template/cli/ts-3-8/Button.stories.ts
@@ -2,11 +2,11 @@ import type { Meta, StoryObj } from '@storybook/vue3';
 
 import Button from './Button.vue';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/vue/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/vue/writing-stories/introduction
 const meta: Meta<typeof Button> = {
   title: 'Example/Button',
   component: Button,
-  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/7.0/vue/writing-docs/docs-page
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/vue/writing-docs/autodocs
   tags: ['autodocs'],
   argTypes: {
     size: { control: 'select', options: ['small', 'medium', 'large'] },
@@ -20,7 +20,7 @@ export default meta;
 type Story = StoryObj<typeof Button>;
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/code/renderers/vue3/template/cli/ts-3-8/Header.stories.ts
+++ b/code/renderers/vue3/template/cli/ts-3-8/Header.stories.ts
@@ -4,7 +4,7 @@ import MyHeader from './Header.vue';
 
 const meta: Meta<typeof MyHeader> = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Example/Header',
@@ -17,10 +17,10 @@ const meta: Meta<typeof MyHeader> = {
     template: '<my-header :user="args.user" />',
   }),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
-  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/7.0/vue/writing-docs/docs-page
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/vue/writing-docs/autodocs
   tags: ['autodocs'],
 };
 

--- a/code/renderers/vue3/template/cli/ts-3-8/Page.stories.ts
+++ b/code/renderers/vue3/template/cli/ts-3-8/Page.stories.ts
@@ -10,17 +10,17 @@ const meta: Meta<typeof MyPage> = {
     template: '<my-page />',
   }),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/vue/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/vue/configure/story-layout
     layout: 'fullscreen',
   },
-  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/7.0/vue/writing-docs/docs-page
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/vue/writing-docs/autodocs
   tags: ['autodocs'],
 };
 
 export default meta;
 type Story = StoryObj<typeof MyPage>;
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/vue/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/vue/writing-tests/interaction-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }: any) => {
     const canvas = within(canvasElement);

--- a/code/renderers/vue3/template/cli/ts-4-9/Button.stories.ts
+++ b/code/renderers/vue3/template/cli/ts-4-9/Button.stories.ts
@@ -2,11 +2,11 @@ import type { Meta, StoryObj } from '@storybook/vue3';
 
 import Button from './Button.vue';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/vue/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/vue/writing-stories/introduction
 const meta = {
   title: 'Example/Button',
   component: Button,
-  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/7.0/vue/writing-docs/docs-page
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/vue/writing-docs/autodocs
   tags: ['autodocs'],
   argTypes: {
     size: { control: 'select', options: ['small', 'medium', 'large'] },
@@ -20,7 +20,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/7.0/vue/api/csf
+ * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
 export const Primary: Story = {

--- a/code/renderers/vue3/template/cli/ts-4-9/Header.stories.ts
+++ b/code/renderers/vue3/template/cli/ts-4-9/Header.stories.ts
@@ -4,7 +4,7 @@ import MyHeader from './Header.vue';
 
 const meta = {
   /* 👇 The title prop is optional.
-   * See https://storybook.js.org/docs/7.0/vue/configure/overview#configure-story-loading
+   * See https://storybook.js.org/docs/vue/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: 'Example/Header',
@@ -17,10 +17,10 @@ const meta = {
     template: '<my-header :user="args.user" />',
   }),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/react/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'fullscreen',
   },
-  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/7.0/vue/writing-docs/docs-page
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/vue/writing-docs/autodocs
   tags: ['autodocs'],
 } satisfies Meta<typeof MyHeader>;
 

--- a/code/renderers/vue3/template/cli/ts-4-9/Page.stories.ts
+++ b/code/renderers/vue3/template/cli/ts-4-9/Page.stories.ts
@@ -10,17 +10,17 @@ const meta = {
     template: '<my-page />',
   }),
   parameters: {
-    // More on how to position stories at: https://storybook.js.org/docs/7.0/vue/configure/story-layout
+    // More on how to position stories at: https://storybook.js.org/docs/vue/configure/story-layout
     layout: 'fullscreen',
   },
-  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/7.0/vue/writing-docs/docs-page
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/vue/writing-docs/autodocs
   tags: ['autodocs'],
 } satisfies Meta<typeof MyPage>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on interaction testing: https://storybook.js.org/docs/7.0/vue/writing-tests/interaction-testing
+// More on interaction testing: https://storybook.js.org/docs/vue/writing-tests/interaction-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }: any) => {
     const canvas = within(canvasElement);

--- a/code/renderers/web-components/template/cli/js/Button.stories.js
+++ b/code/renderers/web-components/template/cli/js/Button.stories.js
@@ -1,6 +1,6 @@
 import { Button } from './Button';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/web-components/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 export default {
   title: 'Example/Button',
   tags: ['autodocs'],
@@ -15,7 +15,7 @@ export default {
   },
 };
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/web-components/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/web-components/writing-stories/args
 export const Primary = {
   args: {
     primary: true,

--- a/code/renderers/web-components/template/cli/js/Header.stories.js
+++ b/code/renderers/web-components/template/cli/js/Header.stories.js
@@ -2,7 +2,7 @@ import { Header } from './Header';
 
 export default {
   title: 'Example/Header',
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/web-components/vue/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/web-components/vue/writing-docs/autodocs
   tags: ['autodocs'],
   render: (args) => Header(args),
 };

--- a/code/renderers/web-components/template/cli/js/Page.stories.js
+++ b/code/renderers/web-components/template/cli/js/Page.stories.js
@@ -8,7 +8,7 @@ export default {
 
 export const LoggedIn = {
   args: {
-    // More on composing args: https://storybook.js.org/docs/7.0/web-components/writing-stories/args#args-composition
+    // More on composing args: https://storybook.js.org/docs/web-components/writing-stories/args#args-composition
     ...HeaderStories.LoggedIn.args,
   },
 };

--- a/code/renderers/web-components/template/cli/ts-3-8/Button.stories.ts
+++ b/code/renderers/web-components/template/cli/ts-3-8/Button.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 import type { ButtonProps } from './Button';
 import { Button } from './Button';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/web-components/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 const meta: Meta<ButtonProps> = {
   title: 'Example/Button',
   tags: ['autodocs'],
@@ -20,7 +20,7 @@ const meta: Meta<ButtonProps> = {
 export default meta;
 type Story = StoryObj<ButtonProps>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/web-components/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/web-components/writing-stories/args
 export const Primary: Story = {
   args: {
     primary: true,

--- a/code/renderers/web-components/template/cli/ts-3-8/Header.stories.ts
+++ b/code/renderers/web-components/template/cli/ts-3-8/Header.stories.ts
@@ -4,7 +4,7 @@ import { Header } from './Header';
 
 const meta: Meta<HeaderProps> = {
   title: 'Example/Header',
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/web-components/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/web-components/writing-docs/autodocs
   tags: ['autodocs'],
   render: (args: HeaderProps) => Header(args),
 };

--- a/code/renderers/web-components/template/cli/ts-3-8/Page.stories.ts
+++ b/code/renderers/web-components/template/cli/ts-3-8/Page.stories.ts
@@ -14,7 +14,7 @@ type Story = StoryObj<PageProps>;
 
 export const LoggedIn: Story = {
   args: {
-    // More on composing args: https://storybook.js.org/docs/7.0/web-components/writing-stories/args#args-composition
+    // More on composing args: https://storybook.js.org/docs/web-components/writing-stories/args#args-composition
     ...HeaderStories.LoggedIn.args,
   },
 };

--- a/code/renderers/web-components/template/cli/ts-4-9/Button.stories.ts
+++ b/code/renderers/web-components/template/cli/ts-4-9/Button.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 import type { ButtonProps } from './Button';
 import { Button } from './Button';
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/web-components/writing-stories/introduction
+// More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 const meta = {
   title: 'Example/Button',
   tags: ['autodocs'],
@@ -20,7 +20,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<ButtonProps>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/web-components/writing-stories/args
+// More on writing stories with args: https://storybook.js.org/docs/web-components/writing-stories/args
 export const Primary: Story = {
   args: {
     primary: true,

--- a/code/renderers/web-components/template/cli/ts-4-9/Header.stories.ts
+++ b/code/renderers/web-components/template/cli/ts-4-9/Header.stories.ts
@@ -4,7 +4,7 @@ import { Header } from './Header';
 
 const meta = {
   title: 'Example/Header',
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/web-components/writing-docs/docs-page
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/web-components/writing-docs/autodocs
   tags: ['autodocs'],
   render: (args: HeaderProps) => Header(args),
 } satisfies Meta<HeaderProps>;

--- a/code/renderers/web-components/template/cli/ts-4-9/Page.stories.ts
+++ b/code/renderers/web-components/template/cli/ts-4-9/Page.stories.ts
@@ -14,7 +14,7 @@ type Story = StoryObj<PageProps>;
 
 export const LoggedIn: Story = {
   args: {
-    // More on composing args: https://storybook.js.org/docs/7.0/web-components/writing-stories/args#args-composition
+    // More on composing args: https://storybook.js.org/docs/web-components/writing-stories/args#args-composition
     ...HeaderStories.LoggedIn.args,
   },
 };


### PR DESCRIPTION
With pull request, the references used in the templates are updated to reflect the changes for 7.0, including dropping the `7.0` reference from the URLs provided and accurately reference autodocs location.

@shilman , @yannbf , @JReinhold if you could merge this before the transition I'd appreciate it.