### PR TITLE
CLI: Fix duplicated dependency warning for major version differences

### DIFF
--- a/code/lib/cli/src/automigrate/helpers/getMigrationSummary.test.ts
+++ b/code/lib/cli/src/automigrate/helpers/getMigrationSummary.test.ts
@@ -26,7 +26,7 @@ describe('getMigrationSummary', () => {
   const installationMetadata: InstallationMetadata = {
     duplicatedDependencies: {
       '@storybook/core-client': ['7.0.0', '7.1.0'],
-      '@storybook/instrumenter': ['7.0.0', '7.1.0'],
+      '@storybook/instrumenter': ['6.0.0', '7.1.0'],
       '@storybook/core-common': ['6.0.0', '7.1.0'],
       '@storybook/addon-essentials': ['7.0.0', '7.1.0'],
     },
@@ -136,12 +136,12 @@ describe('getMigrationSummary', () => {
       Critical: The following dependencies are duplicated and WILL cause unexpected behavior:
 
       @storybook/instrumenter:
-      7.0.0, 7.1.0
-
-      @storybook/core-common:
       6.0.0, 7.1.0
 
       Attention: The following dependencies are duplicated which might cause unexpected behavior:
+
+      @storybook/core-common:
+      6.0.0, 7.1.0
 
       @storybook/addon-essentials:
       7.0.0, 7.1.0

--- a/code/lib/cli/src/automigrate/helpers/getMigrationSummary.ts
+++ b/code/lib/cli/src/automigrate/helpers/getMigrationSummary.ts
@@ -147,7 +147,7 @@ function getWarnings(installationMetadata: InstallationMetadata) {
 
       const hasMultipleMajorVersions = hasMultipleVersions(versions);
 
-      if (hasMultipleMajorVersions || disallowList.includes(dep)) {
+      if (disallowList.includes(dep) && hasMultipleMajorVersions) {
         acc.critical.push(`${chalk.redBright(dep)}:\n${versions.join(', ')}`);
       } else {
         acc.trivial.push(`${chalk.hex('#ff9800')(dep)}:\n${versions.join(', ')}`);

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -153,7 +153,7 @@ export async function runFixes({
   const sbVersionCoerced = storybookVersion && semver.coerce(storybookVersion)?.version;
   if (!sbVersionCoerced) {
     logger.info(dedent`
-      [Storybook automigrate] ❌ Unable to determine storybook version  so the automigrations will be skipped.
+      [Storybook automigrate] ❌ Unable to determine storybook version so the automigrations will be skipped.
         🤔 Are you running automigrate from your project directory? Please specify your Storybook config directory with the --config-dir flag.
       `);
     return {


### PR DESCRIPTION
Closes #21849

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

The automigration will now only promote duplicated dependencies to "critical" if they differ in major and are part of the disallowlist.

## How to test

1. See the tests

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
