### PR TITLE
Export applicationConfig decorator and adjust documentation for usage

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -31,7 +31,7 @@
     - [Addon-a11y: Removed deprecated withA11y decorator](#addon-a11y-removed-deprecated-witha11y-decorator)
   - [7.0 Vite changes](#70-vite-changes)
     - [Vite builder uses Vite config automatically](#vite-builder-uses-vite-config-automatically)
-    - [Vite cache moved to node\_modules/.cache/.vite-storybook](#vite-cache-moved-to-node_modulescachevite-storybook)
+    - [Vite cache moved to node_modules/.cache/.vite-storybook](#vite-cache-moved-to-node_modulescachevite-storybook)
   - [7.0 Webpack changes](#70-webpack-changes)
     - [Webpack4 support discontinued](#webpack4-support-discontinued)
     - [Babel mode v7 exclusively](#babel-mode-v7-exclusively)
@@ -77,7 +77,7 @@
     - [Dropped addon-docs manual babel configuration](#dropped-addon-docs-manual-babel-configuration)
     - [Dropped addon-docs manual configuration](#dropped-addon-docs-manual-configuration)
     - [Autoplay in docs](#autoplay-in-docs)
-    - [Removed STORYBOOK\_REACT\_CLASSES global](#removed-storybook_react_classes-global)
+    - [Removed STORYBOOK_REACT_CLASSES global](#removed-storybook_react_classes-global)
     - [parameters.docs.source.excludeDecorators defaults to true](#parametersdocssourceexcludedecorators-defaults-to-true)
   - [7.0 Deprecations and default changes](#70-deprecations-and-default-changes)
     - [storyStoreV7 enabled by default](#storystorev7-enabled-by-default)
@@ -940,15 +940,35 @@ For example, if you want to configure BrowserAnimationModule in your stories, pl
 ```js
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { importProvidersFrom } from '@angular/core';
-import { applicationConfig } from '@storybook/angular';
+import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
+import {ExampleComponent} from './example.component';
 
-export default {
+const meta: Meta = {
   title: 'Example',
+  component: ExampleComponent,
   decorators: [
+    // Define application-wide providers with the applicationConfig decorator
     applicationConfig({
-      providers: [importProvidersFrom(BrowserAnimationsModule)],
+      providers: [
+        importProvidersFrom(BrowserAnimationsModule),
+        // Extract all providers (and nested ones) from a ModuleWithProviders
+        importProvidersFrom(SomeOtherModule.forRoot()),
+      ],
     }
   ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ExampleComponent>
+
+export const Default: Story = {
+  render: () => ({
+    // Define application-wide providers directly in the render function
+    applicationConfig: {
+      providers: [importProvidersFrom(BrowserAnimationsModule)],
+    }
+  }),
 };
 ```
 

--- a/code/frameworks/angular/README.md
+++ b/code/frameworks/angular/README.md
@@ -209,16 +209,16 @@ WithCustomProvider.decorators = [
 
 ## applicationConfig decorator
 
-If your component relies on application-wide providers, like the ones defined by BrowserAnimationsModule or any other modules which use the forRoot pattern to provide a ModuleWithProviders, you can use the applicationConfig decorator to provide them to the [bootstrapApplication function](https://angular.io/guide/standalone-components#configuring-dependency-injection), which we use to bootstrap the component in Storybook.
+If your component relies on application-wide providers, like the ones defined by BrowserAnimationsModule or any other modules which use the forRoot pattern to provide a ModuleWithProviders, you can use the applicationConfig decorator on the meta default export to provide them to the [bootstrapApplication function](https://angular.io/guide/standalone-components#configuring-dependency-injection), which we use to bootstrap the component in Storybook.
 
 ```js
 
-import { StoryFn, Meta, applicationConfig } from '@storybook/angular';
+import { StoryObj, Meta, applicationConfig } from '@storybook/angular';
 import { BrowserAnimationsModule, provideAnimations } from '@angular/platform-browser/animations';
 import { importProvidersFrom } from '@angular/core';
 import { ChipsModule } from './angular-src/chips.module';
 
-export default {
+const meta: Meta = {
   component: ChipsGroupComponent,
   decorators: [
     // Apply application config to all stories
@@ -233,23 +233,21 @@ export default {
       ],
     }),
   ],
-} as Meta;
+};
 
-const Template = (): StoryFn => (args) => ({
-  props: args,
-});
+export default meta;
 
-export const Base = Template();
+type Story = StoryObj<typeof ChipsGroupComponent>;
 
-export const WithCustomApplicationProvider = Template();
-
-WithCustomApplicationProvider.decorators = [
-  // Apply application config to a specific story
-  // The configuration will not be merged with the global configuration defined in the export default block
-  applicationConfig({
-    providers: [...]
-  }),
-];
+export const WithCustomApplicationProvider: Story = {
+  render: () => ({
+    // Apply application config to a specific story
+    applicationConfig: {
+      // The providers will be merged with the ones defined in the applicationConfig decorators providers array of the global meta object
+      providers: [...]
+    }
+  })
+}
 ```
 
 ## FAQ

--- a/code/frameworks/angular/src/client/index.ts
+++ b/code/frameworks/angular/src/client/index.ts
@@ -9,7 +9,7 @@ export * from './public-types';
 
 export type { StoryFnAngularReturnType as IStory } from './types';
 
-export { moduleMetadata, componentWrapperDecorator } from './decorators';
+export { moduleMetadata, componentWrapperDecorator, applicationConfig } from './decorators';
 
 // optimization: stop HMR propagation in webpack
 module?.hot?.decline();

--- a/code/frameworks/angular/template/stories/core/applicationConfig/with-browser-animations.stories.ts
+++ b/code/frameworks/angular/template/stories/core/applicationConfig/with-browser-animations.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/angular';
+import { Meta, StoryObj, applicationConfig } from '@storybook/angular';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { within, userEvent } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
@@ -7,6 +7,11 @@ import { OpenCloseComponent } from '../moduleMetadata/angular-src/open-close-com
 
 const meta: Meta = {
   component: OpenCloseComponent,
+  decorators: [
+    applicationConfig({
+      providers: [importProvidersFrom(BrowserAnimationsModule)],
+    }),
+  ],
   parameters: {
     chromatic: { delay: 100 },
   },
@@ -19,9 +24,6 @@ type Story = StoryObj<typeof OpenCloseComponent>;
 export const WithBrowserAnimations: Story = {
   render: () => ({
     template: `<app-open-close></app-open-close>`,
-    applicationConfig: {
-      providers: [importProvidersFrom(BrowserAnimationsModule)],
-    },
     moduleMetadata: {
       declarations: [OpenCloseComponent],
     },


### PR DESCRIPTION
Relates to https://github.com/storybookjs/storybook/issues/21284

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Exported `applicationConfig` provider

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
