### PR TITLE
Docs: State that `yarn` is not required at root for install when contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 - Ensure you have node version 16 installed (suggestion: v16.5).
 - Ensure if you are using Windows to use the Windows Subsystem for Linux (WSL).
-- Run `yarn start` directory to run a basic test Storybook "sandbox".
+- Run `yarn start` in the root directory to run a basic test Storybook "sandbox".
 
 The `yarn start` script will generate a React Vite TypeScript sandbox with a set of test stories inside it, as well as taking all steps required to get it running (building the various packages we need etc). There is no need to run `yarn` or `yarn install` as `yarn start` will do this for you.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 - Ensure if you are using Windows to use the Windows Subsystem for Linux (WSL).
 - Run `yarn start` directory to run a basic test Storybook "sandbox".
 
-The `yarn start` script will generate a React Vite TypeScript sandbox with a set of test stories inside it, as well as taking all steps required to get it running (building the various packages we need etc).
+The `yarn start` script will generate a React Vite TypeScript sandbox with a set of test stories inside it, as well as taking all steps required to get it running (building the various packages we need etc). There is no need to run `yarn` or `yarn install` as `yarn start` will do this for you.
 
 # Running against different sandbox templates
 


### PR DESCRIPTION
This PR updates contributing docs to state that `yarn`/`yarn install` in not required when contributing to StorybookJS. I think not having this in the docs leads to a lot of confusion when attempting to install and contribute for the first time. 

### What I changed
* It's typical to want to clone a repo and immediately `npm i` or `yarn`, so I made the language a bit clearer to NOT do that  as it will lead to issues.

## How to test

* View CONTRIBUTING docs

## Checklist

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
