### PR TITLE
CLI: Fix link to new framework API migrations

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
+++ b/code/lib/cli/src/automigrate/fixes/new-frameworks.ts
@@ -424,7 +424,7 @@ export const newFrameworks: Fix<NewFrameworkRunOptions> = {
       ${migrationSteps}
 
       To learn more about the new framework format, see: ${chalk.yellow(
-        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md##new-framework-api'
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#new-framework-api'
       )}${disclaimer}
     `;
   },


### PR DESCRIPTION
With this pull request, the link pointing at the migration guide is fixed, allowing it to correctly display the relevant entry.

@ndelangen or @yannbf if any of you could take a look and let me know of any feedback I'd appreciate it.
Closes #21874

