### PR TITLE
Telemetry: Always send error events if init doesn't succeed

### DIFF
--- a/code/lib/cli/src/HandledError.ts
+++ b/code/lib/cli/src/HandledError.ts
@@ -1,0 +1,9 @@
+export class HandledError extends Error {
+  public handled = true;
+
+  constructor(messageOrError: string | Error) {
+    super(typeof messageOrError === 'string' ? messageOrError : messageOrError.message);
+
+    if (typeof messageOrError !== 'string') this.cause = messageOrError;
+  }
+}

--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -8,6 +8,7 @@ import { commandLog } from '../helpers';
 import type { PackageJson, PackageJsonWithDepsAndDevDeps } from './PackageJson';
 import storybookPackagesVersions from '../versions';
 import type { InstallationMetadata } from './types';
+import { HandledError } from '../HandledError';
 
 const logger = console;
 
@@ -79,7 +80,7 @@ export abstract class JsPackageManager {
       this.runInstall();
     } catch (e) {
       done('An error occurred while installing dependencies.');
-      process.exit(1);
+      throw new HandledError(e);
     }
     done();
   }
@@ -204,7 +205,7 @@ export abstract class JsPackageManager {
       } catch (e) {
         logger.error('An error occurred while installing dependencies.');
         logger.log(e.message);
-        process.exit(1);
+        throw new HandledError(e);
       }
     }
   }
@@ -248,7 +249,7 @@ export abstract class JsPackageManager {
       } catch (e) {
         logger.error('An error occurred while removing dependencies.');
         logger.log(e.message);
-        process.exit(1);
+        throw new HandledError(e);
       }
     }
   }
@@ -308,7 +309,7 @@ export abstract class JsPackageManager {
       }
 
       logger.error(`\n     ${chalk.red(e.message)}`);
-      process.exit(1);
+      throw new HandledError(e);
     }
 
     const versionToUse =


### PR DESCRIPTION
Closes #21878

## What I did

We should never exit early from init via `process.exit()` or a return inside the `doInitiate()` function

## How to test

The only one I was able to reproduce was an incorrect project type:

```
STORYBOOK_TELEMETRY_DEBUG=1 ~/GitHub/storybookjs/storybook/code/lib/cli/bin/index.js init  -t madeup
```

I think the other changes only happen if you somehow crash yarn etc.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
