### PR TITLE
Upgrade satellite repos for 7.0

### DIFF
--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -109,7 +109,7 @@
     "@storybook/csf-plugin": "7.0.0",
     "@storybook/csf-tools": "7.0.0",
     "@storybook/global": "^5.0.0",
-    "@storybook/mdx2-csf": "next",
+    "@storybook/mdx2-csf": "^1.0.0",
     "@storybook/node-logger": "7.0.0",
     "@storybook/postinstall": "7.0.0",
     "@storybook/preview-api": "7.0.0",

--- a/code/addons/interactions/package.json
+++ b/code/addons/interactions/package.json
@@ -88,7 +88,7 @@
   },
   "devDependencies": {
     "@devtools-ds/object-inspector": "^1.1.2",
-    "@storybook/jest": "next",
+    "@storybook/jest": "^0.1.0",
     "@storybook/testing-library": "^0.1.0",
     "@types/node": "^16.0.0",
     "formik": "^2.2.9",

--- a/code/addons/interactions/package.json
+++ b/code/addons/interactions/package.json
@@ -89,7 +89,7 @@
   "devDependencies": {
     "@devtools-ds/object-inspector": "^1.1.2",
     "@storybook/jest": "next",
-    "@storybook/testing-library": "next",
+    "@storybook/testing-library": "^0.1.0",
     "@types/node": "^16.0.0",
     "formik": "^2.2.9",
     "typescript": "~4.9.3"

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@storybook/client-logger": "7.0.0",
     "@storybook/core-events": "7.0.0",
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/global": "^5.0.0",
     "@storybook/manager-api": "7.0.0",
     "@storybook/preview-api": "7.0.0",

--- a/code/addons/storyshots-puppeteer/package.json
+++ b/code/addons/storyshots-puppeteer/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@axe-core/puppeteer": "^4.2.0",
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/node-logger": "7.0.0",
     "@storybook/types": "7.0.0",
     "@types/jest-image-snapshot": "^5.1.0",

--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -47,7 +47,7 @@
     "@storybook/client-logger": "7.0.0",
     "@storybook/core-common": "7.0.0",
     "@storybook/csf-plugin": "7.0.0",
-    "@storybook/mdx2-csf": "next",
+    "@storybook/mdx2-csf": "^1.0.0",
     "@storybook/node-logger": "7.0.0",
     "@storybook/preview": "7.0.0",
     "@storybook/preview-api": "7.0.0",

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -48,7 +48,7 @@
     "@babel/core": "~7.21.0",
     "@babel/preset-env": "~7.20.2",
     "@babel/types": "~7.21.2",
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/csf-tools": "7.0.0",
     "@storybook/node-logger": "7.0.0",
     "@storybook/types": "7.0.0",

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -63,7 +63,7 @@
     "@storybook/core-events": "7.0.0",
     "@storybook/csf": "^0.1.0",
     "@storybook/csf-tools": "7.0.0",
-    "@storybook/docs-mdx": "next",
+    "@storybook/docs-mdx": "^0.1.0",
     "@storybook/global": "^5.0.0",
     "@storybook/manager": "7.0.0",
     "@storybook/node-logger": "7.0.0",

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -61,7 +61,7 @@
     "@storybook/builder-manager": "7.0.0",
     "@storybook/core-common": "7.0.0",
     "@storybook/core-events": "7.0.0",
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/csf-tools": "7.0.0",
     "@storybook/docs-mdx": "next",
     "@storybook/global": "^5.0.0",

--- a/code/lib/csf-tools/package.json
+++ b/code/lib/csf-tools/package.json
@@ -45,7 +45,7 @@
     "@babel/parser": "~7.21.2",
     "@babel/traverse": "~7.21.2",
     "@babel/types": "~7.21.2",
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/types": "7.0.0",
     "fs-extra": "^11.1.0",
     "recast": "^0.23.1",

--- a/code/lib/manager-api/package.json
+++ b/code/lib/manager-api/package.json
@@ -45,7 +45,7 @@
     "@storybook/channels": "7.0.0",
     "@storybook/client-logger": "7.0.0",
     "@storybook/core-events": "7.0.0",
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/global": "^5.0.0",
     "@storybook/router": "7.0.0",
     "@storybook/theming": "7.0.0",

--- a/code/lib/preview-api/package.json
+++ b/code/lib/preview-api/package.json
@@ -71,7 +71,7 @@
     "@storybook/channels": "7.0.0",
     "@storybook/client-logger": "7.0.0",
     "@storybook/core-events": "7.0.0",
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/global": "^5.0.0",
     "@storybook/types": "7.0.0",
     "@types/qs": "^6.9.5",

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -44,7 +44,7 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/types": "7.0.0",
     "estraverse": "^5.2.0",
     "lodash": "^4.17.21",

--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -49,7 +49,7 @@
     "file-system-cache": "^2.0.0"
   },
   "devDependencies": {
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@types/node": "^16.0.0",
     "typescript": "~4.9.3"
   },

--- a/code/package.json
+++ b/code/package.json
@@ -150,7 +150,7 @@
     "@storybook/html-vite": "workspace:*",
     "@storybook/html-webpack5": "workspace:*",
     "@storybook/instrumenter": "workspace:*",
-    "@storybook/jest": "next",
+    "@storybook/jest": "^0.1.0",
     "@storybook/linter-config": "^3.1.2",
     "@storybook/manager": "workspace:*",
     "@storybook/manager-api": "workspace:*",

--- a/code/package.json
+++ b/code/package.json
@@ -183,7 +183,7 @@
     "@storybook/svelte": "workspace:*",
     "@storybook/svelte-webpack5": "workspace:*",
     "@storybook/telemetry": "workspace:*",
-    "@storybook/testing-library": "next",
+    "@storybook/testing-library": "^0.1.0",
     "@storybook/theming": "workspace:*",
     "@storybook/types": "workspace:*",
     "@storybook/vue": "workspace:*",

--- a/code/package.json
+++ b/code/package.json
@@ -139,7 +139,7 @@
     "@storybook/core-events": "workspace:*",
     "@storybook/core-server": "workspace:*",
     "@storybook/core-webpack": "workspace:*",
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/csf-plugin": "workspace:*",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/docs-tools": "workspace:*",

--- a/code/ui/blocks/package.json
+++ b/code/ui/blocks/package.json
@@ -47,7 +47,7 @@
     "@storybook/client-logger": "7.0.0",
     "@storybook/components": "7.0.0",
     "@storybook/core-events": "7.0.0",
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/docs-tools": "7.0.0",
     "@storybook/global": "^5.0.0",
     "@storybook/manager-api": "7.0.0",

--- a/code/ui/components/package.json
+++ b/code/ui/components/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@storybook/client-logger": "7.0.0",
-    "@storybook/csf": "next",
+    "@storybook/csf": "^0.1.0",
     "@storybook/global": "^5.0.0",
     "@storybook/theming": "7.0.0",
     "@storybook/types": "7.0.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5103,7 +5103,7 @@ __metadata:
     "@storybook/csf-plugin": 7.0.0
     "@storybook/csf-tools": 7.0.0
     "@storybook/global": ^5.0.0
-    "@storybook/mdx2-csf": next
+    "@storybook/mdx2-csf": ^1.0.0
     "@storybook/node-logger": 7.0.0
     "@storybook/postinstall": 7.0.0
     "@storybook/preview-api": 7.0.0
@@ -5230,7 +5230,7 @@ __metadata:
   dependencies:
     "@storybook/client-logger": 7.0.0
     "@storybook/core-events": 7.0.0
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/global": ^5.0.0
     "@storybook/manager-api": 7.0.0
     "@storybook/preview-api": 7.0.0
@@ -5314,7 +5314,7 @@ __metadata:
   resolution: "@storybook/addon-storyshots-puppeteer@workspace:addons/storyshots-puppeteer"
   dependencies:
     "@axe-core/puppeteer": ^4.2.0
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/node-logger": 7.0.0
     "@storybook/types": 7.0.0
     "@types/jest-image-snapshot": ^5.1.0
@@ -5644,7 +5644,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0
     "@storybook/components": 7.0.0
     "@storybook/core-events": 7.0.0
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/docs-tools": 7.0.0
     "@storybook/global": ^5.0.0
     "@storybook/manager-api": 7.0.0
@@ -5704,7 +5704,7 @@ __metadata:
     "@storybook/core-common": 7.0.0
     "@storybook/csf-plugin": 7.0.0
     "@storybook/mdx1-csf": ">=1.0.0-next.1"
-    "@storybook/mdx2-csf": next
+    "@storybook/mdx2-csf": ^1.0.0
     "@storybook/node-logger": 7.0.0
     "@storybook/preview": 7.0.0
     "@storybook/preview-api": 7.0.0
@@ -5950,7 +5950,7 @@ __metadata:
     "@babel/core": ~7.21.0
     "@babel/preset-env": ~7.20.2
     "@babel/types": ~7.21.2
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/csf-tools": 7.0.0
     "@storybook/node-logger": 7.0.0
     "@storybook/types": 7.0.0
@@ -5984,7 +5984,7 @@ __metadata:
   dependencies:
     "@popperjs/core": ^2.6.0
     "@storybook/client-logger": 7.0.0
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/global": ^5.0.0
     "@storybook/theming": 7.0.0
     "@storybook/types": 7.0.0
@@ -6074,9 +6074,9 @@ __metadata:
     "@storybook/builder-manager": 7.0.0
     "@storybook/core-common": 7.0.0
     "@storybook/core-events": 7.0.0
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/csf-tools": 7.0.0
-    "@storybook/docs-mdx": next
+    "@storybook/docs-mdx": ^0.1.0
     "@storybook/global": ^5.0.0
     "@storybook/manager": 7.0.0
     "@storybook/node-logger": 7.0.0
@@ -6154,7 +6154,7 @@ __metadata:
     "@babel/parser": ~7.21.2
     "@babel/traverse": ~7.21.2
     "@babel/types": ~7.21.2
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/types": 7.0.0
     "@types/fs-extra": ^11.0.1
     "@types/js-yaml": ^3.12.6
@@ -6175,6 +6175,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/csf@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@storybook/csf@npm:0.1.0"
+  dependencies:
+    type-fest: ^2.19.0
+  checksum: 76e284884eacb54bb2130448c45204d64e9ca436d73614d3369d72049b1e786e31e55c0bbb922b8e1069fecbc97a3d68796d401f8e3d93d7ffba0df59b6d8cbe
+  languageName: node
+  linkType: hard
+
 "@storybook/csf@npm:next":
   version: 0.0.2-next.11
   resolution: "@storybook/csf@npm:0.0.2-next.11"
@@ -6184,10 +6193,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/docs-mdx@npm:next":
-  version: 0.0.1-next.6
-  resolution: "@storybook/docs-mdx@npm:0.0.1-next.6"
-  checksum: 432edf135510839a9cca021f175c78869e739a64b32892a9f8b85343d49c27a68f066bf70c1bb4f104e71b20f34e5c95de8dc5ba6d190ba8c19e2b5d4e2d4271
+"@storybook/docs-mdx@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@storybook/docs-mdx@npm:0.1.0"
+  checksum: e4d510f0452a7a3cb09d9617920c18b974f836299dfba38d6b2e62fbfea418d71f340b6c280a87201b1336a7221c7cc16b47794c1f8e81d01dcfa1f599343085
   languageName: node
   linkType: hard
 
@@ -6383,7 +6392,7 @@ __metadata:
     "@storybook/channels": 7.0.0
     "@storybook/client-logger": 7.0.0
     "@storybook/core-events": 7.0.0
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/global": ^5.0.0
     "@storybook/router": 7.0.0
     "@storybook/theming": 7.0.0
@@ -6458,10 +6467,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/mdx2-csf@npm:next":
-  version: 1.0.0-next.6
-  resolution: "@storybook/mdx2-csf@npm:1.0.0-next.6"
-  checksum: 1f67347f159e0eb90fb6183443028854bbfb19738fe90f26019feabd8d43d8f0313bb35c0ff89afcf9b40f3e7b1a1814d2d37b83888d5e6cd3a0605728e5a661
+"@storybook/mdx2-csf@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@storybook/mdx2-csf@npm:1.0.0"
+  checksum: 250ea2d78ba49bc6a1d1035fcc3db834e67bf1ab8df9362799e34ad691872ef90c430e4d68e3ceeb485f9dfbd8720e9a9b4597dc26c835ba0d8a23906bc2564d
   languageName: node
   linkType: hard
 
@@ -6818,7 +6827,7 @@ __metadata:
     "@storybook/client-logger": 7.0.0
     "@storybook/core-common": 7.0.0
     "@storybook/core-events": 7.0.0
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/global": ^5.0.0
     "@storybook/types": 7.0.0
     "@types/qs": ^6.9.5
@@ -7052,7 +7061,7 @@ __metadata:
     "@storybook/core-events": "workspace:*"
     "@storybook/core-server": "workspace:*"
     "@storybook/core-webpack": "workspace:*"
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/csf-plugin": "workspace:*"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/docs-tools": "workspace:*"
@@ -7243,7 +7252,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@workspace:lib/source-loader"
   dependencies:
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@storybook/types": 7.0.0
     estraverse: ^5.2.0
     jest-specific-snapshot: ^7.0.0
@@ -7404,7 +7413,7 @@ __metadata:
   resolution: "@storybook/types@workspace:lib/types"
   dependencies:
     "@storybook/channels": 7.0.0
-    "@storybook/csf": next
+    "@storybook/csf": ^0.1.0
     "@types/babel__core": ^7.0.0
     "@types/express": ^4.7.0
     "@types/node": ^16.0.0

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5176,7 +5176,7 @@ __metadata:
     "@storybook/core-events": 7.0.0
     "@storybook/global": ^5.0.0
     "@storybook/instrumenter": 7.0.0
-    "@storybook/jest": next
+    "@storybook/jest": ^0.1.0
     "@storybook/manager-api": 7.0.0
     "@storybook/preview-api": 7.0.0
     "@storybook/testing-library": ^0.1.0
@@ -5820,20 +5820,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/channel-postmessage@npm:7.0.0-rc.5":
-  version: 7.0.0-rc.5
-  resolution: "@storybook/channel-postmessage@npm:7.0.0-rc.5"
-  dependencies:
-    "@storybook/channels": 7.0.0-rc.5
-    "@storybook/client-logger": 7.0.0-rc.5
-    "@storybook/core-events": 7.0.0-rc.5
-    "@storybook/global": ^5.0.0
-    qs: ^6.10.0
-    telejson: ^7.0.3
-  checksum: acacfd84722dac74f446f6eee1c3f814798e2e52c102d638bc22c2977feb5936cd4a65994e67da68fc7e88a97ccabefca4a625699df286f751b95a26e16306ad
-  languageName: node
-  linkType: hard
-
 "@storybook/channel-websocket@7.0.0, @storybook/channel-websocket@workspace:*, @storybook/channel-websocket@workspace:lib/channel-websocket":
   version: 0.0.0-use.local
   resolution: "@storybook/channel-websocket@workspace:lib/channel-websocket"
@@ -5853,13 +5839,6 @@ __metadata:
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft
-
-"@storybook/channels@npm:7.0.0-rc.5":
-  version: 7.0.0-rc.5
-  resolution: "@storybook/channels@npm:7.0.0-rc.5"
-  checksum: 046f7fead115ab8a46137a2219ecefc55a66fef640bb536c6cddd7c561e891e615bdbb00a5dce7c96efcc20be7c19a4c56e018d0aae05018438bc821790b5875
-  languageName: node
-  linkType: hard
 
 "@storybook/cli@7.0.0, @storybook/cli@workspace:*, @storybook/cli@workspace:lib/cli":
   version: 0.0.0-use.local
@@ -5933,15 +5912,6 @@ __metadata:
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft
-
-"@storybook/client-logger@npm:7.0.0-rc.5":
-  version: 7.0.0-rc.5
-  resolution: "@storybook/client-logger@npm:7.0.0-rc.5"
-  dependencies:
-    "@storybook/global": ^5.0.0
-  checksum: 63c24ea67fa1a46d784d55032cd52a04d0bd9a1c8b1a0ca655bb6ee41ff428c131519f5bb129a5e732e01fcca151a111e868aeb2ebe5ad9db64898a51943d6f6
-  languageName: node
-  linkType: hard
 
 "@storybook/codemod@7.0.0, @storybook/codemod@workspace:*, @storybook/codemod@workspace:lib/codemod":
   version: 0.0.0-use.local
@@ -6057,13 +6027,6 @@ __metadata:
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft
-
-"@storybook/core-events@npm:7.0.0-rc.5":
-  version: 7.0.0-rc.5
-  resolution: "@storybook/core-events@npm:7.0.0-rc.5"
-  checksum: 80dc7cc59ad1411f6c504d5ab3d88befc441807190432aaea3e60e343ab5fe501895569fd3f889be514d7fcf4911590411814db68794b364466256cbf780ec77
-  languageName: node
-  linkType: hard
 
 "@storybook/core-server@7.0.0, @storybook/core-server@workspace:*, @storybook/core-server@workspace:lib/core-server":
   version: 0.0.0-use.local
@@ -6181,15 +6144,6 @@ __metadata:
   dependencies:
     type-fest: ^2.19.0
   checksum: 76e284884eacb54bb2130448c45204d64e9ca436d73614d3369d72049b1e786e31e55c0bbb922b8e1069fecbc97a3d68796d401f8e3d93d7ffba0df59b6d8cbe
-  languageName: node
-  linkType: hard
-
-"@storybook/csf@npm:next":
-  version: 0.0.2-next.11
-  resolution: "@storybook/csf@npm:0.0.2-next.11"
-  dependencies:
-    type-fest: ^2.19.0
-  checksum: fa4025ff520fcfc6eaf9bb9cabbf11d5c06d6ae7ec91bd8102f8f32505ca9149b305e55cd151789a18c1ddee69fe6997293aeff20dcc8c28b6f09833c98a8831
   languageName: node
   linkType: hard
 
@@ -6332,28 +6286,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/instrumenter@npm:next":
-  version: 7.0.0-rc.5
-  resolution: "@storybook/instrumenter@npm:7.0.0-rc.5"
-  dependencies:
-    "@storybook/channels": 7.0.0-rc.5
-    "@storybook/client-logger": 7.0.0-rc.5
-    "@storybook/core-events": 7.0.0-rc.5
-    "@storybook/global": ^5.0.0
-    "@storybook/preview-api": 7.0.0-rc.5
-  checksum: 60f7f42d2705a0aa2aeaebd2cb5b96c1f33504ec94d86c3a19446d12f44f852ee6f645804c3e6e1222e8adf6cbee14cc0effd0eba118ece1154df08b3462aee6
-  languageName: node
-  linkType: hard
-
-"@storybook/jest@npm:next":
-  version: 0.0.11-next.0
-  resolution: "@storybook/jest@npm:0.0.11-next.0"
+"@storybook/jest@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@storybook/jest@npm:0.1.0"
   dependencies:
     "@storybook/expect": storybook-jest
-    "@storybook/instrumenter": next
+    "@storybook/instrumenter": ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
     "@testing-library/jest-dom": ^5.16.2
     jest-mock: ^27.3.0
-  checksum: 36699b8ce63b2cd288f2c5af1bbea1773513da5bb97e05c58ed2194de0a4d7dffaeb699057701e51fab21fb09d5f79635565c182c082233efa8fa1e0bfa16253
+  checksum: 0385f189d283468b980512d972b6223cf4848b304746f750ac501fb9d2eb7d99ad911d26f2fb072e639de0084b197de729f652a327caff8705c9d3d8c7043943
   languageName: node
   linkType: hard
 
@@ -6844,30 +6785,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/preview-api@npm:7.0.0-rc.5":
-  version: 7.0.0-rc.5
-  resolution: "@storybook/preview-api@npm:7.0.0-rc.5"
-  dependencies:
-    "@storybook/channel-postmessage": 7.0.0-rc.5
-    "@storybook/channels": 7.0.0-rc.5
-    "@storybook/client-logger": 7.0.0-rc.5
-    "@storybook/core-events": 7.0.0-rc.5
-    "@storybook/csf": next
-    "@storybook/global": ^5.0.0
-    "@storybook/types": 7.0.0-rc.5
-    "@types/qs": ^6.9.5
-    dequal: ^2.0.2
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-    qs: ^6.10.0
-    slash: ^3.0.0
-    synchronous-promise: ^2.0.15
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  checksum: d1cee85bed84bb78f235b3631b95f2e717ad22f9341665e798552ed517ab20ec9226e8b8e7649d403f9847ae66edfb0302ad37ce223b33da466ca96fdc074eff
-  languageName: node
-  linkType: hard
-
 "@storybook/preview-web@7.0.0, @storybook/preview-web@workspace:*, @storybook/preview-web@workspace:lib/preview-web":
   version: 0.0.0-use.local
   resolution: "@storybook/preview-web@workspace:lib/preview-web"
@@ -7072,7 +6989,7 @@ __metadata:
     "@storybook/html-vite": "workspace:*"
     "@storybook/html-webpack5": "workspace:*"
     "@storybook/instrumenter": "workspace:*"
-    "@storybook/jest": next
+    "@storybook/jest": ^0.1.0
     "@storybook/linter-config": ^3.1.2
     "@storybook/manager": "workspace:*"
     "@storybook/manager-api": "workspace:*"
@@ -7421,18 +7338,6 @@ __metadata:
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft
-
-"@storybook/types@npm:7.0.0-rc.5":
-  version: 7.0.0-rc.5
-  resolution: "@storybook/types@npm:7.0.0-rc.5"
-  dependencies:
-    "@storybook/channels": 7.0.0-rc.5
-    "@types/babel__core": ^7.0.0
-    "@types/express": ^4.7.0
-    file-system-cache: ^2.0.0
-  checksum: 854c232a1ce24316a3d01f9838c938d4d698749b70f915bedfd6f611a7fb4e5bb7c3e5057a3034217c4cd43e779a4a02c39957f8c8661a6ac270e45d24491895
-  languageName: node
-  linkType: hard
 
 "@storybook/vue-vite@workspace:frameworks/vue-vite":
   version: 0.0.0-use.local

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5179,7 +5179,7 @@ __metadata:
     "@storybook/jest": next
     "@storybook/manager-api": 7.0.0
     "@storybook/preview-api": 7.0.0
-    "@storybook/testing-library": next
+    "@storybook/testing-library": ^0.1.0
     "@storybook/theming": 7.0.0
     "@storybook/types": 7.0.0
     "@types/node": ^16.0.0
@@ -5925,7 +5925,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/client-logger@7.0.0, @storybook/client-logger@workspace:*, @storybook/client-logger@workspace:lib/client-logger":
+"@storybook/client-logger@7.0.0, @storybook/client-logger@^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0, @storybook/client-logger@workspace:*, @storybook/client-logger@workspace:lib/client-logger":
   version: 0.0.0-use.local
   resolution: "@storybook/client-logger@workspace:lib/client-logger"
   dependencies:
@@ -5934,7 +5934,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/client-logger@npm:7.0.0-rc.5, @storybook/client-logger@npm:next":
+"@storybook/client-logger@npm:7.0.0-rc.5":
   version: 7.0.0-rc.5
   resolution: "@storybook/client-logger@npm:7.0.0-rc.5"
   dependencies:
@@ -6319,7 +6319,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/instrumenter@7.0.0, @storybook/instrumenter@workspace:*, @storybook/instrumenter@workspace:lib/instrumenter":
+"@storybook/instrumenter@7.0.0, @storybook/instrumenter@^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0, @storybook/instrumenter@workspace:*, @storybook/instrumenter@workspace:lib/instrumenter":
   version: 0.0.0-use.local
   resolution: "@storybook/instrumenter@workspace:lib/instrumenter"
   dependencies:
@@ -7105,7 +7105,7 @@ __metadata:
     "@storybook/svelte": "workspace:*"
     "@storybook/svelte-webpack5": "workspace:*"
     "@storybook/telemetry": "workspace:*"
-    "@storybook/testing-library": next
+    "@storybook/testing-library": ^0.1.0
     "@storybook/theming": "workspace:*"
     "@storybook/types": "workspace:*"
     "@storybook/vue": "workspace:*"
@@ -7370,16 +7370,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/testing-library@npm:next":
-  version: 0.0.14-next.1
-  resolution: "@storybook/testing-library@npm:0.0.14-next.1"
+"@storybook/testing-library@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@storybook/testing-library@npm:0.1.0"
   dependencies:
-    "@storybook/client-logger": next
-    "@storybook/instrumenter": next
+    "@storybook/client-logger": ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
+    "@storybook/instrumenter": ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
     "@testing-library/dom": ^8.3.0
     "@testing-library/user-event": ^13.2.1
     ts-dedent: ^2.2.0
-  checksum: 0d386dd136c5f6a5e695247eb7c7fa10182cb73150aae9744d6b7197c6cd049dfeffbbe192c06131858a346726b80e6fa28e8ac7a0f0012759f6f092b219cd61
+  checksum: 182c5ed9f79b9108f79fb668b780530c85a1515830efb3b156cb4802ae9dd5aca357f28a472ebf9e513b1f3996335a21f7e1646cece1110bac9adf7f6b6a4770
   languageName: node
   linkType: hard
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -56,7 +56,7 @@
     "@nrwl/nx-cloud": "^15.0.2",
     "@nrwl/workspace": "^15.4.5",
     "@storybook/eslint-config-storybook": "^3.1.2",
-    "@storybook/jest": "next",
+    "@storybook/jest": "^0.1.0",
     "@storybook/linter-config": "^3.1.2",
     "@storybook/testing-library": "^0.1.0",
     "@swc/core": "^1.3.23",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -58,7 +58,7 @@
     "@storybook/eslint-config-storybook": "^3.1.2",
     "@storybook/jest": "next",
     "@storybook/linter-config": "^3.1.2",
-    "@storybook/testing-library": "next",
+    "@storybook/testing-library": "^0.1.0",
     "@swc/core": "^1.3.23",
     "@testing-library/dom": "^7.29.4",
     "@testing-library/jest-dom": "^5.11.9",

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -2731,40 +2731,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/channel-postmessage@npm:7.0.0-rc.2":
-  version: 7.0.0-rc.2
-  resolution: "@storybook/channel-postmessage@npm:7.0.0-rc.2"
+"@storybook/channel-postmessage@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/channel-postmessage@npm:7.0.0"
   dependencies:
-    "@storybook/channels": 7.0.0-rc.2
-    "@storybook/client-logger": 7.0.0-rc.2
-    "@storybook/core-events": 7.0.0-rc.2
+    "@storybook/channels": 7.0.0
+    "@storybook/client-logger": 7.0.0
+    "@storybook/core-events": 7.0.0
     "@storybook/global": ^5.0.0
     qs: ^6.10.0
     telejson: ^7.0.3
-  checksum: cccbf8edc13be1b8fe7b0584f666c2e61bcbfdd7ff065b11f877950da90469e8abbce05733f62e2892d193057a39777c2bfae093fa0841a58f4c4db73b13f4ea
+  checksum: 655f99da0306b4e5a86f17a90ec144e93ce62f4a92fc015375c381f4e6b3f8b7871527952fb659c2bfc6509df3fcbe42237ea42b1d595d6d133b1807e82c3016
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:7.0.0-rc.2":
-  version: 7.0.0-rc.2
-  resolution: "@storybook/channels@npm:7.0.0-rc.2"
-  checksum: 54597c1db52059c435b38c6edf6f1f5d2d75362fc4b7420f6fe571e4ece6a2615d6edab50a0b52b4235512eced8c663f2ac2ca3c2fbf890db9d5f3f224a1b441
+"@storybook/channels@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/channels@npm:7.0.0"
+  checksum: 92d423d88f11714fa2f3a916461af35047620c8c99e74a6865259f304d222d2009d805be94ea78ce7142cddcff5d06150f55010bd64d13bac3ed156a7189b50a
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@npm:7.0.0-rc.2, @storybook/client-logger@npm:next":
-  version: 7.0.0-rc.2
-  resolution: "@storybook/client-logger@npm:7.0.0-rc.2"
+"@storybook/client-logger@npm:7.0.0, @storybook/client-logger@npm:^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/client-logger@npm:7.0.0"
   dependencies:
     "@storybook/global": ^5.0.0
-  checksum: 33fd8781c11d6fd53502654b204b4d0164663abac1c3847861f9f307a3318ff25c560ec77912d0d84d767ea61dac0ff8d488a8bc61977b57cd25f3485b5a9d61
+  checksum: 046a35050fdb1ee63c7e16655cc9706125d48c4d74b7ab25b932f2099be71f850d575d582944a12c7565fc871110ff69cd567feea5c23f63ebd7592cbd57d95e
   languageName: node
   linkType: hard
 
-"@storybook/core-events@npm:7.0.0-rc.2":
-  version: 7.0.0-rc.2
-  resolution: "@storybook/core-events@npm:7.0.0-rc.2"
-  checksum: a2f487321be3b03a3bc45e27e66c5bb3a75e1bb85673a610d2b6a0fb2c391f2b493b229494681440da486a5f71b5be45a9f072391a807824778f4dbd0a35f9f3
+"@storybook/core-events@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/core-events@npm:7.0.0"
+  checksum: c389262a0dce02ad4b914d9c1a438490c72f609613c046a17e30791061509eb7b8b88350df77758f85140d144ecaa9760144a8eabe918252b6648e6e94706377
   languageName: node
   linkType: hard
 
@@ -2811,28 +2811,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/instrumenter@npm:next":
-  version: 7.0.0-rc.2
-  resolution: "@storybook/instrumenter@npm:7.0.0-rc.2"
+"@storybook/instrumenter@npm:^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/instrumenter@npm:7.0.0"
   dependencies:
-    "@storybook/channels": 7.0.0-rc.2
-    "@storybook/client-logger": 7.0.0-rc.2
-    "@storybook/core-events": 7.0.0-rc.2
+    "@storybook/channels": 7.0.0
+    "@storybook/client-logger": 7.0.0
+    "@storybook/core-events": 7.0.0
     "@storybook/global": ^5.0.0
-    "@storybook/preview-api": 7.0.0-rc.2
-  checksum: 0cde313ac97a64b27d6de3da77da7e4681c357bd7a484b9a4ddd27ca3494d01cfd41fa5fd668e39df6036e561961f9e45f3449e85fbec1dd563e2c2f0e23a18a
+    "@storybook/preview-api": 7.0.0
+  checksum: 9a0a5a74b9b899bf68633cb28867f9a92d8c24b67194830b441669b0fcbda8cf17a296142e0525871a185ab392c2ff460a980c9e2d9bcbe27e9795674208eb32
   languageName: node
   linkType: hard
 
-"@storybook/jest@npm:next":
-  version: 0.0.11-next.0
-  resolution: "@storybook/jest@npm:0.0.11-next.0"
+"@storybook/jest@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@storybook/jest@npm:0.1.0"
   dependencies:
     "@storybook/expect": storybook-jest
-    "@storybook/instrumenter": next
+    "@storybook/instrumenter": ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
     "@testing-library/jest-dom": ^5.16.2
     jest-mock: ^27.3.0
-  checksum: 36699b8ce63b2cd288f2c5af1bbea1773513da5bb97e05c58ed2194de0a4d7dffaeb699057701e51fab21fb09d5f79635565c182c082233efa8fa1e0bfa16253
+  checksum: 0385f189d283468b980512d972b6223cf4848b304746f750ac501fb9d2eb7d99ad911d26f2fb072e639de0084b197de729f652a327caff8705c9d3d8c7043943
   languageName: node
   linkType: hard
 
@@ -2863,27 +2863,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/preview-api@npm:7.0.0-rc.2":
-  version: 7.0.0-rc.2
-  resolution: "@storybook/preview-api@npm:7.0.0-rc.2"
+"@storybook/preview-api@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/preview-api@npm:7.0.0"
   dependencies:
-    "@storybook/channel-postmessage": 7.0.0-rc.2
-    "@storybook/channels": 7.0.0-rc.2
-    "@storybook/client-logger": 7.0.0-rc.2
-    "@storybook/core-events": 7.0.0-rc.2
+    "@storybook/channel-postmessage": 7.0.0
+    "@storybook/channels": 7.0.0
+    "@storybook/client-logger": 7.0.0
+    "@storybook/core-events": 7.0.0
     "@storybook/csf": next
     "@storybook/global": ^5.0.0
-    "@storybook/types": 7.0.0-rc.2
+    "@storybook/types": 7.0.0
     "@types/qs": ^6.9.5
     dequal: ^2.0.2
     lodash: ^4.17.21
     memoizerific: ^1.11.3
     qs: ^6.10.0
-    slash: ^3.0.0
     synchronous-promise: ^2.0.15
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
-  checksum: 24a465dff1243b68fa14d5e1930257a24f30715598d2280e7783a71222b2f5aeb6891e0df16929702beff0e7369b03f3fa5d39ccdc3e2e82ae58c1dbfb73747a
+  checksum: b323e8f153b936dae672fa1c55d26dc1261e94f216ebb76ab1ff80d2c13e960eb1b7a034f1a6f71ecf963a43135298da761c5a0463c0d5f71768ca48976b605f
   languageName: node
   linkType: hard
 
@@ -2909,9 +2908,9 @@ __metadata:
     "@nrwl/nx-cloud": ^15.0.2
     "@nrwl/workspace": ^15.4.5
     "@storybook/eslint-config-storybook": ^3.1.2
-    "@storybook/jest": next
+    "@storybook/jest": ^0.1.0
     "@storybook/linter-config": ^3.1.2
-    "@storybook/testing-library": next
+    "@storybook/testing-library": ^0.1.0
     "@swc/core": ^1.3.23
     "@testing-library/dom": ^7.29.4
     "@testing-library/jest-dom": ^5.11.9
@@ -3022,28 +3021,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/testing-library@npm:next":
-  version: 0.0.14-next.1
-  resolution: "@storybook/testing-library@npm:0.0.14-next.1"
+"@storybook/testing-library@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@storybook/testing-library@npm:0.1.0"
   dependencies:
-    "@storybook/client-logger": next
-    "@storybook/instrumenter": next
+    "@storybook/client-logger": ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
+    "@storybook/instrumenter": ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
     "@testing-library/dom": ^8.3.0
     "@testing-library/user-event": ^13.2.1
     ts-dedent: ^2.2.0
-  checksum: 0d386dd136c5f6a5e695247eb7c7fa10182cb73150aae9744d6b7197c6cd049dfeffbbe192c06131858a346726b80e6fa28e8ac7a0f0012759f6f092b219cd61
+  checksum: 182c5ed9f79b9108f79fb668b780530c85a1515830efb3b156cb4802ae9dd5aca357f28a472ebf9e513b1f3996335a21f7e1646cece1110bac9adf7f6b6a4770
   languageName: node
   linkType: hard
 
-"@storybook/types@npm:7.0.0-rc.2":
-  version: 7.0.0-rc.2
-  resolution: "@storybook/types@npm:7.0.0-rc.2"
+"@storybook/types@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/types@npm:7.0.0"
   dependencies:
-    "@storybook/channels": 7.0.0-rc.2
+    "@storybook/channels": 7.0.0
     "@types/babel__core": ^7.0.0
     "@types/express": ^4.7.0
     file-system-cache: ^2.0.0
-  checksum: 38a3eb5aabf506ad46e9318f010e18ee40af25fa98709b556849808a2687fc4fc2b246e157dc22b1c6eea0fff10cda8d811fda76250be9e5fa00fd706fc99472
+  checksum: dd78825e60e59771b11ebd87b8799ed90069c946e1289c7ce00dd688f25079fbe2aaf919c747bf5b8b388ae4ee13ebb07b366213170b2ce2cc327ee62ceffec6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Upgrade satellite projects in the `@storybook` namespace from `next` to their 7.0-compatible numbered equivalents

## How to test

- [ ] CI passes

