### PR TITLE
(#21325) Fix search bar not reflecting custom shortcut when set

### DIFF
--- a/code/ui/manager/src/components/sidebar/Search.tsx
+++ b/code/ui/manager/src/components/sidebar/Search.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-cycle */
-import { useStorybookApi } from '@storybook/manager-api';
+import { shortcutToHumanString, useStorybookApi } from '@storybook/manager-api';
 import { styled } from '@storybook/theming';
 import { Icons } from '@storybook/components';
 import type { DownshiftState, StateChangeOptions } from 'downshift';
@@ -115,7 +115,8 @@ const FocusKey = styled.code(({ theme }) => ({
   position: 'absolute',
   top: 8,
   right: 16,
-  width: 16,
+  paddingInline: 4,
+  maxWidth: 30,
   height: 16,
   zIndex: 1,
   lineHeight: '16px',
@@ -354,7 +355,9 @@ export const Search = React.memo<{
               <SearchIcon icon="search" />
               {/* @ts-expect-error (TODO) */}
               <Input {...inputProps} />
-              {enableShortcuts && <FocusKey>/</FocusKey>}
+              {enableShortcuts && (
+                <FocusKey>{shortcutToHumanString(api.getShortcutKeys().search)}</FocusKey>
+              )}
               <ClearIcon icon="cross" onClick={() => clearSelection()} />
             </SearchField>
             <FocusContainer tabIndex={0} id="storybook-explorer-menu">


### PR DESCRIPTION

Closes #21325

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

**Description:**

Fixed the bug by retrieving the latest changes from the context using` api.getShortcutKeys().search`. 
Additionally, there was a  text overflow issue which was also addressed by updating the styling.

**Changes Made:**

Retrieved latest changes from context using api.getShortcutKeys().search
Updated styling to prevent text overflow

**Screenshots:**

- Upon testing found the text was overflowing 

<img width="1162" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/101552310/229590961-9000a9af-e02c-45e8-895e-057c0b439aea.png">

- Here is the screenshot with the text overflowing fix as well

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/101552310/229591300-d91b8487-35c3-4dab-bd4b-d79b73cd5aa2.png">




## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
