### PR TITLE
React: Don't show decorators in JSX snippets

### DIFF
--- a/code/lib/preview-api/src/modules/addons/hooks.ts
+++ b/code/lib/preview-api/src/modules/addons/hooks.ts
@@ -134,7 +134,7 @@ function hookify<TRenderer extends Renderer>(
   decorator: DecoratorFunction<TRenderer>
 ): DecoratorFunction<TRenderer>;
 function hookify<TRenderer extends Renderer>(fn: AbstractFunction) {
-  return (...args: any[]) => {
+  const hookified = (...args: any[]) => {
     const { hooks }: { hooks: HooksContext<TRenderer> } =
       typeof args[0] === 'function' ? args[1] : args[0];
 
@@ -172,6 +172,9 @@ function hookify<TRenderer extends Renderer>(fn: AbstractFunction) {
     hooks.currentDecoratorName = prevDecoratorName;
     return result;
   };
+
+  hookified.originalFn = fn;
+  return hookified;
 }
 
 // Counter to prevent infinite loops.

--- a/code/renderers/react/src/applyDecorators.ts
+++ b/code/renderers/react/src/applyDecorators.ts
@@ -8,6 +8,7 @@ export const applyDecorators = (
   storyFn: LegacyStoryFn<ReactRenderer>,
   decorators: DecoratorFunction<ReactRenderer>[]
 ): LegacyStoryFn<ReactRenderer> => {
+  // @ts-ignore
   const jsxIndex = decorators.findIndex((d) => d.originalFn === jsxDecorator);
 
   const reorderedDecorators =

--- a/code/renderers/react/src/applyDecorators.ts
+++ b/code/renderers/react/src/applyDecorators.ts
@@ -1,0 +1,17 @@
+import { defaultDecorateStory } from '@storybook/preview-api';
+import type { LegacyStoryFn, DecoratorFunction } from '@storybook/types';
+
+import type { ReactRenderer } from './types';
+import { jsxDecorator } from './docs/jsxDecorator';
+
+export const applyDecorators = (
+  storyFn: LegacyStoryFn<ReactRenderer>,
+  decorators: DecoratorFunction<ReactRenderer>[]
+): LegacyStoryFn<ReactRenderer> => {
+  const jsxIndex = decorators.findIndex((d) => d.originalFn === jsxDecorator);
+
+  const reorderedDecorators =
+    jsxIndex === -1 ? decorators : [...decorators.splice(jsxIndex, 1), ...decorators];
+
+  return defaultDecorateStory(storyFn, reorderedDecorators);
+};

--- a/code/renderers/react/src/applyDecorators.ts
+++ b/code/renderers/react/src/applyDecorators.ts
@@ -8,7 +8,8 @@ export const applyDecorators = (
   storyFn: LegacyStoryFn<ReactRenderer>,
   decorators: DecoratorFunction<ReactRenderer>[]
 ): LegacyStoryFn<ReactRenderer> => {
-  // @ts-ignore
+  // @ts-expect-error originalFn is not defined on the type for decorator. This is a temporary fix
+  // that we will remove soon (likely) in favour of a proper concept of "inner" decorators.
   const jsxIndex = decorators.findIndex((d) => d.originalFn === jsxDecorator);
 
   const reorderedDecorators =

--- a/code/renderers/react/src/config.ts
+++ b/code/renderers/react/src/config.ts
@@ -5,3 +5,5 @@ export const parameters = { renderer: 'react', ...docsParams };
 export { decorators, argTypesEnhancers } from './docs/config';
 
 export { render, renderToCanvas } from './render';
+
+export { applyDecorators } from './applyDecorators';

--- a/code/renderers/react/template/stories/decorators.stories.tsx
+++ b/code/renderers/react/template/stories/decorators.stories.tsx
@@ -1,11 +1,12 @@
 import type { FC } from 'react';
-import React from 'react';
+import React, { useContext, createContext } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 
 const Component: FC = () => <p>Story</p>;
 
 export default {
   component: Component,
+  tags: ['autodocs'],
   decorators: [
     (Story) => (
       <>
@@ -25,4 +26,23 @@ export const All: StoryObj<typeof Component> = {
       </>
     ),
   ],
+};
+
+// This story will error if `parameters.docs.source.excludeDecorators` is true:
+// See https://github.com/storybookjs/storybook/issues/21900
+const TestContext = createContext<boolean>(false);
+export const Context: StoryObj<typeof Component> = {
+  // parameters: { docs: { source: { excludeDecorators: true } } },
+  decorators: [
+    (Story) => (
+      <TestContext.Provider value>
+        <Story />
+      </TestContext.Provider>
+    ),
+  ],
+  render: (args, context) => {
+    const arg = useContext(TestContext);
+    if (!arg) throw new Error('Arg not set');
+    return <p>Story</p>;
+  },
 };

--- a/code/renderers/react/template/stories/decorators.stories.tsx
+++ b/code/renderers/react/template/stories/decorators.stories.tsx
@@ -41,8 +41,8 @@ export const Context: StoryObj<typeof Component> = {
     ),
   ],
   render: function Render(args, context) {
-    const arg = useContext(TestContext);
-    if (!arg) throw new Error('Arg not set');
+    const value = useContext(TestContext);
+    if (!value) throw new Error('TestContext not set, decorator did not run!');
     return <p>Story</p>;
   },
 };

--- a/code/renderers/react/template/stories/decorators.stories.tsx
+++ b/code/renderers/react/template/stories/decorators.stories.tsx
@@ -40,7 +40,7 @@ export const Context: StoryObj<typeof Component> = {
       </TestContext.Provider>
     ),
   ],
-  render: (args, context) => {
+  render: function Render(args, context) {
     const arg = useContext(TestContext);
     if (!arg) throw new Error('Arg not set');
     return <p>Story</p>;


### PR DESCRIPTION
Telescoping on https://github.com/storybookjs/storybook/pull/21902

An alternate solution for https://github.com/storybookjs/storybook/issues/21649

## What I did

Always move the JSX decorator to the end of the list, so it avoids all other decorators, as we can't see "inside" decorators in React. However we still need to actually render all the decorators as the story may depend on them.

TODO: 

- [ ] Figure out type issue with decorated.
- [ ] Add an option to disable this behaviour.

## How to test

See stories in this PR:

<img width="941" alt="image" src="https://user-images.githubusercontent.com/132554/229720352-3cd12c14-6a81-4028-9346-c48404d45096.png">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
