### PR TITLE
Build: bump the node version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
         default: 'small'
     working_directory: /tmp/storybook
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.0
         environment:
           NODE_OPTIONS: --max_old_space_size=6144
     resource_class: <<parameters.class>>
@@ -30,7 +30,7 @@ executors:
         default: 'small'
     working_directory: /tmp/storybook
     docker:
-      - image: cimg/node:16.17.1-browsers
+      - image: cimg/node:16.20.0-browsers
         environment:
           NODE_OPTIONS: --max_old_space_size=6144
     resource_class: <<parameters.class>>


### PR DESCRIPTION
bump the node version in CI,
I'm hoping this will fix: https://app.circleci.com/pipelines/github/storybookjs/storybook/45951/workflows/ca70f6d2-3c54-4d55-986b-a683a6007983/jobs/507096