### PR TITLE
Bug: Fix incorrect type-file for addon-actions

### DIFF
--- a/code/addons/actions/package.json
+++ b/code/addons/actions/package.json
@@ -61,6 +61,9 @@
       "manager": [
         "dist/manager.d.ts"
       ],
+      "decorator": [
+        "dist/decorator.d.ts"
+      ],
       "preview": [
         "dist/preview.d.ts"
       ]


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21887

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixes a small issue where types for decorators file from addon-actions was pointing to the wrong .d.ts file in package.json

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
