### PR TITLE
Build: Fix release badge on repros

### DIFF
--- a/scripts/sandbox/publish.ts
+++ b/scripts/sandbox/publish.ts
@@ -23,7 +23,7 @@ const publish = async (options: PublishOptions & { tmpFolder: string }) => {
 
   const scriptPath = __dirname;
   const branch = inputBranch || 'next';
-  const templatesData = await getTemplatesData();
+  const templatesData = await getTemplatesData(branch === 'main' ? 'main' : 'next');
 
   logger.log(`👯‍♂️ Cloning the repository ${remote} in branch ${branch}`);
   await execaCommand(`git clone ${remote} .`, { cwd: tmpFolder });
@@ -45,7 +45,7 @@ const publish = async (options: PublishOptions & { tmpFolder: string }) => {
   logger.log(`🚚 Moving template files into the repository`);
 
   const templatePath = join(scriptPath, 'templates', 'root.ejs');
-  const templateData = { data: templatesData, version: branch };
+  const templateData = { data: templatesData, version: branch === 'main' ? 'latest' : 'next' };
 
   const output = await renderTemplate(templatePath, templateData);
 

--- a/scripts/sandbox/utils/template.ts
+++ b/scripts/sandbox/utils/template.ts
@@ -17,7 +17,7 @@ export const getStackblitzUrl = (path: string, branch = 'next') => {
   return `https://stackblitz.com/github/storybookjs/sandboxes/tree/${branch}/${path}/after-storybook?preset=node`;
 };
 
-export async function getTemplatesData() {
+export async function getTemplatesData(branch: string) {
   type TemplatesData = Record<
     string,
     Record<
@@ -37,7 +37,7 @@ export async function getTemplatesData() {
       acc[groupName] = acc[groupName] || {};
       acc[groupName][templateName] = {
         ...generatorData,
-        stackblitzUrl: getStackblitzUrl(curr),
+        stackblitzUrl: getStackblitzUrl(curr, branch),
       };
       return acc;
     },


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

The README of our reproductions contains a badge about its versions, and currently it shows 'main' instead of 'latest' (when applicable):

```html
<img
  alt="Storybook main Badge"
  src="https://img.shields.io/npm/v/@storybook/react/main"
/>
```

I also fixed a similar thing for the stackblitz URL

## How to test

1. The generated README of sandbox repo should be updated

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
