### PR TITLE
Update `@emotion/cache` version

### DIFF
--- a/code/lib/theming/package.json
+++ b/code/lib/theming/package.json
@@ -54,7 +54,7 @@
     "memoizerific": "^1.11.3"
   },
   "devDependencies": {
-    "@emotion/cache": "^11.10.3",
+    "@emotion/cache": "^11.10.7",
     "@emotion/is-prop-valid": "^1.2.0",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2373,16 +2373,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.10.3, @emotion/cache@npm:^11.10.5":
-  version: 11.10.5
-  resolution: "@emotion/cache@npm:11.10.5"
+"@emotion/cache@npm:^11.10.5, @emotion/cache@npm:^11.10.7":
+  version: 11.10.7
+  resolution: "@emotion/cache@npm:11.10.7"
   dependencies:
     "@emotion/memoize": ^0.8.0
     "@emotion/sheet": ^1.2.1
     "@emotion/utils": ^1.2.0
     "@emotion/weak-memoize": ^0.3.0
     stylis: 4.1.3
-  checksum: eeb6891ab04cf17ace0e175742550b97c30df777d6c5b145e91c4c9fbd783c29b4dabe12a8c786b78f37176313a8295c9b90c69d875e6caab5f7e4677a18be91
+  checksum: 0175b8be5117342e76e100fca92932a34c3641160c733a34534153eab7f1c1b2cecafee6d9a7a0646acf7be3c52b0654dc34900439316ae473b59a9eb1a1c8f3
   languageName: node
   linkType: hard
 
@@ -7402,7 +7402,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/theming@workspace:lib/theming"
   dependencies:
-    "@emotion/cache": ^11.10.3
+    "@emotion/cache": ^11.10.7
     "@emotion/is-prop-valid": ^1.2.0
     "@emotion/react": ^11.10.4
     "@emotion/styled": ^11.10.4


### PR DESCRIPTION
## What I did

I hope that this will help with https://github.com/storybookjs/storybook/pull/21213 since I just release a new version of `@emotion/cache` that includes a fix for the problem surfaced [here](https://github.com/storybookjs/storybook/pull/21213#issuecomment-1458027363). The said fix can be seen here: https://github.com/emotion-js/emotion/pull/3019

## How to test

verify is Chromatic baselines are the same

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)
