### PR TITLE
Angular: Fix components disappearing on docs page on property change

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, enableProdMode, importProvidersFrom, NgModule } from '@angular/core';
+import { ApplicationRef, enableProdMode, NgModule } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 
 import { BehaviorSubject, Subject } from 'rxjs';
@@ -14,16 +14,16 @@ type StoryRenderInfo = {
   moduleMetadataSnapshot: string;
 };
 
-const applicationRefs = new Set<ApplicationRef>();
+const applicationRefs = new Map<HTMLElement, ApplicationRef>();
 
 export abstract class AbstractRenderer {
   /**
    * Wait and destroy the platform
    */
-  public static resetApplications() {
+  public static resetApplications(domNode?: HTMLElement) {
     componentNgModules.clear();
-    applicationRefs.forEach((appRef) => {
-      if (!appRef.destroyed) {
+    applicationRefs.forEach((appRef, appDOMNode) => {
+      if (!appRef.destroyed && (!domNode || appDOMNode === domNode)) {
         appRef.destroy();
       }
     });
@@ -50,7 +50,7 @@ export abstract class AbstractRenderer {
     }
   };
 
-  protected previousStoryRenderInfo: StoryRenderInfo;
+  protected previousStoryRenderInfo = new Map<HTMLElement, StoryRenderInfo>();
 
   // Observable to change the properties dynamically without reloading angular module&component
   protected storyProps$: Subject<ICollection | undefined>;
@@ -67,7 +67,7 @@ export abstract class AbstractRenderer {
     }
   }
 
-  protected abstract beforeFullRender(): Promise<void>;
+  protected abstract beforeFullRender(domNode?: HTMLElement): Promise<void>;
 
   protected abstract afterFullRender(): Promise<void>;
 
@@ -100,6 +100,7 @@ export abstract class AbstractRenderer {
 
     if (
       !this.fullRendererRequired({
+        targetDOMNode,
         storyFnAngular,
         moduleMetadata: {
           ...storyFnAngular.moduleMetadata,
@@ -112,7 +113,7 @@ export abstract class AbstractRenderer {
       return;
     }
 
-    await this.beforeFullRender();
+    await this.beforeFullRender(targetDOMNode);
 
     // Complete last BehaviorSubject and set a new one for the current module
     if (this.storyProps$) {
@@ -140,7 +141,7 @@ export abstract class AbstractRenderer {
       ],
     });
 
-    applicationRefs.add(applicationRef);
+    applicationRefs.set(targetDOMNode, applicationRef);
 
     await this.afterFullRender();
   }
@@ -171,22 +172,24 @@ export abstract class AbstractRenderer {
   }
 
   private fullRendererRequired({
+    targetDOMNode,
     storyFnAngular,
     moduleMetadata,
     forced,
   }: {
+    targetDOMNode: HTMLElement;
     storyFnAngular: StoryFnAngularReturnType;
     moduleMetadata: NgModule;
     forced: boolean;
   }) {
-    const { previousStoryRenderInfo } = this;
+    const previousStoryRenderInfo = this.previousStoryRenderInfo.get(targetDOMNode);
 
     const currentStoryRender = {
       storyFnAngular,
       moduleMetadataSnapshot: stringify(moduleMetadata),
     };
 
-    this.previousStoryRenderInfo = currentStoryRender;
+    this.previousStoryRenderInfo.set(targetDOMNode, currentStoryRender);
 
     if (
       // check `forceRender` of story RenderContext

--- a/code/frameworks/angular/src/client/angular-beta/DocsRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/DocsRenderer.ts
@@ -38,8 +38,8 @@ export class DocsRenderer extends AbstractRenderer {
     await super.render({ ...options, forced: false });
   }
 
-  async beforeFullRender(): Promise<void> {
-    DocsRenderer.resetApplications();
+  async beforeFullRender(domNode?: HTMLElement): Promise<void> {
+    DocsRenderer.resetApplications(domNode);
   }
 
   async afterFullRender(): Promise<void> {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21894

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Refactor AbstractRenderer to use a Map instead of a Set for tracking application references, and add support for resetting applications for a specific DOM node in resetApplications().

## How to test

1. Run an Angular sandbox
2. Open Storybook in your browser
3. Access autogenerated button doc and change some properties. The rendered stories at the bottom shouldn't disappear.


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
