### PR TITLE
UI: Add toolbar "text" input type

### DIFF
--- a/code/addons/toolbars/src/components/ToolbarManager.tsx
+++ b/code/addons/toolbars/src/components/ToolbarManager.tsx
@@ -30,11 +30,11 @@ export const ToolbarManager: FC = () => {
         const normalizedArgType = normalizeArgType(id, globalTypes[id] as ToolbarArgType);
 
         if (isNormalizedToolbarArgTypeItems(normalizedArgType)) {
-          return <ToolbarTextInput key={id} id={id} {...normalizeArgType} />;
+          return <ToolbarMenuList key={id} id={id} {...normalizedArgType} />;
         }
 
         if (isNormalizedToolbarArgTypeText(normalizedArgType)) {
-          return <ToolbarMenuList key={id} id={id} {...normalizedArgType} />;
+          return <ToolbarTextInput key={id} id={id} {...normalizedArgType} />;
         }
 
         return null;

--- a/code/addons/toolbars/src/components/ToolbarManager.tsx
+++ b/code/addons/toolbars/src/components/ToolbarManager.tsx
@@ -45,8 +45,8 @@ export const ToolbarManager: FC = () => {
 
 const isNormalizedToolbarArgTypeItems = (
   arg: NormalizedToolbarArgType
-): arg is NormalizedToolbarArgTypeItems => arg.toolbar.items != null;
+): arg is NormalizedToolbarArgTypeItems => 'items' in arg.toolbar;
 
 const isNormalizedToolbarArgTypeText = (
   arg: NormalizedToolbarArgType
-): arg is NormalizedToolbarArgTypeText => arg.toolbar.items == null;
+): arg is NormalizedToolbarArgTypeText => !('items' in arg.toolbar);

--- a/code/addons/toolbars/src/components/ToolbarManager.tsx
+++ b/code/addons/toolbars/src/components/ToolbarManager.tsx
@@ -4,7 +4,13 @@ import { useGlobalTypes } from '@storybook/manager-api';
 import { Separator } from '@storybook/components';
 import { ToolbarMenuList } from './ToolbarMenuList';
 import { normalizeArgType } from '../utils/normalize-toolbar-arg-type';
-import type { ToolbarArgType } from '../types';
+import type {
+  NormalizedToolbarArgType,
+  NormalizedToolbarArgTypeItems,
+  NormalizedToolbarArgTypeText,
+  ToolbarArgType,
+} from '../types';
+import { ToolbarTextInput } from './ToolbarTextInput';
 
 /**
  * A smart component for handling manager-preview interactions.
@@ -23,8 +29,24 @@ export const ToolbarManager: FC = () => {
       {globalIds.map((id) => {
         const normalizedArgType = normalizeArgType(id, globalTypes[id] as ToolbarArgType);
 
-        return <ToolbarMenuList key={id} id={id} {...normalizedArgType} />;
+        if (isNormalizedToolbarArgTypeItems(normalizedArgType)) {
+          return <ToolbarTextInput key={id} id={id} {...normalizeArgType} />;
+        }
+
+        if (isNormalizedToolbarArgTypeText(normalizedArgType)) {
+          return <ToolbarMenuList key={id} id={id} {...normalizedArgType} />;
+        }
+
+        return null;
       })}
     </>
   );
 };
+
+const isNormalizedToolbarArgTypeItems = (
+  arg: NormalizedToolbarArgType
+): arg is NormalizedToolbarArgTypeItems => arg.items != null;
+
+const isNormalizedToolbarArgTypeText = (
+  arg: NormalizedToolbarArgType
+): arg is NormalizedToolbarArgTypeText => arg.items == null;

--- a/code/addons/toolbars/src/components/ToolbarManager.tsx
+++ b/code/addons/toolbars/src/components/ToolbarManager.tsx
@@ -45,8 +45,8 @@ export const ToolbarManager: FC = () => {
 
 const isNormalizedToolbarArgTypeItems = (
   arg: NormalizedToolbarArgType
-): arg is NormalizedToolbarArgTypeItems => arg.items != null;
+): arg is NormalizedToolbarArgTypeItems => arg.toolbar.items != null;
 
 const isNormalizedToolbarArgTypeText = (
   arg: NormalizedToolbarArgType
-): arg is NormalizedToolbarArgTypeText => arg.items == null;
+): arg is NormalizedToolbarArgTypeText => arg.toolbar.items == null;

--- a/code/addons/toolbars/src/components/ToolbarMenuList.tsx
+++ b/code/addons/toolbars/src/components/ToolbarMenuList.tsx
@@ -7,10 +7,10 @@ import { ToolbarMenuButton } from './ToolbarMenuButton';
 import type { WithKeyboardCycleProps } from '../hoc/withKeyboardCycle';
 import { withKeyboardCycle } from '../hoc/withKeyboardCycle';
 import { getSelectedIcon, getSelectedTitle } from '../utils/get-selected';
-import type { ToolbarMenuProps } from '../types';
+import type { ToolbarMenuListPropsBase, ToolbarItem } from '../types';
 import { ToolbarMenuListItem } from './ToolbarMenuListItem';
 
-type ToolbarMenuListProps = ToolbarMenuProps & WithKeyboardCycleProps;
+type ToolbarMenuListProps = ToolbarMenuListPropsBase & WithKeyboardCycleProps;
 
 export const ToolbarMenuList: FC<ToolbarMenuListProps> = withKeyboardCycle(
   ({
@@ -61,7 +61,7 @@ export const ToolbarMenuList: FC<ToolbarMenuListProps> = withKeyboardCycle(
         tooltip={({ onHide }) => {
           const links = items
             // Special case handling for various "type" variants
-            .filter(({ type }) => {
+            .filter(({ type }: ToolbarItem) => {
               let shouldReturn = true;
 
               if (type === 'reset' && !currentValue) {
@@ -70,7 +70,7 @@ export const ToolbarMenuList: FC<ToolbarMenuListProps> = withKeyboardCycle(
 
               return shouldReturn;
             })
-            .map((item) => {
+            .map((item: ToolbarItem) => {
               const listItem = ToolbarMenuListItem({
                 ...item,
                 currentValue,

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -9,11 +9,12 @@ type ToolbarTextInputProps = NormalizedToolbarArgTypeText;
 export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
   id,
   description,
+  defaultValue,
   toolbar: { icon, title, isSecret },
 }) => {
   const [globals, updateGlobals] = useGlobals();
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
-  const currentValue = globals[id];
+  const currentValue = globals[id] ?? defaultValue;
   const hasGlobalValue = Boolean(currentValue);
 
   const handleInputChange = useCallback(

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useEffect, useCallback, type ChangeEventHandler, useState } from 'react';
+import React, { type FC, useCallback, type ChangeEventHandler, useState } from 'react';
 import { useGlobals } from '@storybook/manager-api';
 import { TooltipMessage, WithTooltip } from '@storybook/components';
 import { ToolbarMenuButton } from './ToolbarMenuButton';

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -1,18 +1,20 @@
-import React, { type FC, useEffect, useCallback, type ChangeEventHandler } from 'react';
+import React, { type FC, useEffect, useCallback, type ChangeEventHandler, useState } from 'react';
 import { useGlobals } from '@storybook/manager-api';
-import { Icons, TooltipMessage, WithTooltip } from '@storybook/components';
+import { TooltipMessage, WithTooltip } from '@storybook/components';
+import { ToolbarMenuButton } from './ToolbarMenuButton';
 import type { NormalizedToolbarArgTypeText } from '../types';
 
 type ToolbarTextInputProps = NormalizedToolbarArgTypeText;
 
 export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
   id,
-  name,
   description,
   toolbar: { icon, title, defaultValue, isSecret },
 }) => {
   const [globals, updateGlobals] = useGlobals();
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const currentValue = globals[id];
+  const hasGlobalValue = Boolean(currentValue);
   useEffect(() => {
     if (currentValue == null) updateGlobals({ [id]: defaultValue });
   });
@@ -22,13 +24,21 @@ export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
       const value = e?.target?.value;
       if (value != null) updateGlobals({ [id]: value });
     },
-    [updateGlobals]
+    [updateGlobals, id]
   ) as ChangeEventHandler<HTMLInputElement>;
 
   return (
-    <WithTooltip tooltip={<TooltipMessage title={title} desc={description} />}>
-      {icon && <Icons icon={icon} />}
-      {title ? `\xa0${title}` : `\xa0${name}`}
+    <WithTooltip
+      closeOnOutsideClick
+      onVisibleChange={setIsTooltipVisible}
+      tooltip={<TooltipMessage title={title} desc={description} />}
+    >
+      <ToolbarMenuButton
+        active={isTooltipVisible || hasGlobalValue}
+        description={description ?? ''}
+        icon={icon}
+        title={title ?? ''}
+      />
       <input
         type={isSecret ? 'password' : 'text'}
         value={currentValue}

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -9,15 +9,12 @@ type ToolbarTextInputProps = NormalizedToolbarArgTypeText;
 export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
   id,
   description,
-  toolbar: { icon, title, defaultValue, isSecret },
+  toolbar: { icon, title, isSecret },
 }) => {
   const [globals, updateGlobals] = useGlobals();
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const currentValue = globals[id];
   const hasGlobalValue = Boolean(currentValue);
-  useEffect(() => {
-    if (currentValue == null) updateGlobals({ [id]: defaultValue });
-  });
 
   const handleInputChange = useCallback(
     (e) => {

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -9,17 +9,12 @@ type ToolbarTextInputProps = NormalizedToolbarArgTypeText;
 export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
   id,
   description,
-  defaultValue,
   toolbar: { icon, title, isSecret },
 }) => {
   const [globals, updateGlobals] = useGlobals();
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const currentValue = globals[id];
   const hasGlobalValue = Boolean(currentValue);
-
-  useEffect(() => {
-    if (currentValue == null) updateGlobals({ [id]: defaultValue });
-  });
 
   const handleInputChange = useCallback(
     (e) => {

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -1,5 +1,6 @@
-import type { FC } from 'react';
-import React from 'react';
+import React, { type FC, useEffect, useCallback, type ChangeEventHandler } from 'react';
+import { useGlobals } from '@storybook/manager-api';
+import { Icons, TooltipMessage, WithTooltip } from '@storybook/components';
 import type { NormalizedToolbarArgTypeText } from '../types';
 
 type ToolbarTextInputProps = NormalizedToolbarArgTypeText;
@@ -8,11 +9,31 @@ export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
   id,
   name,
   description,
-  toolbar: { title },
+  toolbar: { icon, title, defaultValue, isSecret },
 }) => {
+  const [globals, updateGlobals] = useGlobals();
+  const currentValue = globals[id];
+  useEffect(() => {
+    if (currentValue == null) updateGlobals({ [id]: defaultValue });
+  });
+
+  const handleInputChange = useCallback(
+    (e) => {
+      const value = e?.target?.value;
+      if (value != null) updateGlobals({ [id]: value });
+    },
+    [updateGlobals]
+  ) as ChangeEventHandler<HTMLInputElement>;
+
   return (
-    <p>
-      {name} {title}
-    </p>
+    <WithTooltip tooltip={<TooltipMessage title={title} desc={description} />}>
+      {icon && <Icons icon={icon} />}
+      {title ? `\xa0${title}` : `\xa0${name}`}
+      <input
+        type={isSecret ? 'password' : 'text'}
+        value={currentValue}
+        onChange={handleInputChange}
+      />
+    </WithTooltip>
   );
 };

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -9,12 +9,17 @@ type ToolbarTextInputProps = NormalizedToolbarArgTypeText;
 export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
   id,
   description,
+  defaultValue,
   toolbar: { icon, title, isSecret },
 }) => {
   const [globals, updateGlobals] = useGlobals();
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const currentValue = globals[id];
   const hasGlobalValue = Boolean(currentValue);
+
+  useEffect(() => {
+    if (currentValue == null) updateGlobals({ [id]: defaultValue });
+  });
 
   const handleInputChange = useCallback(
     (e) => {

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -39,6 +39,7 @@ export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
       <input
         type={isSecret ? 'password' : 'text'}
         value={currentValue}
+        autocomplete={isSecret ? 'off' : 'on'}
         onChange={handleInputChange}
       />
     </WithTooltip>

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -21,7 +21,7 @@ export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
       const value = e?.target?.value;
       if (value != null) updateGlobals({ [id]: value });
     },
-    [updateGlobals, id]
+    [currentValue, updateGlobals]
   ) as ChangeEventHandler<HTMLInputElement>;
 
   return (

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -44,7 +44,6 @@ export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
       <input
         type={isSecret ? 'password' : 'text'}
         value={currentValue}
-        autocomplete={isSecret ? 'off' : 'on'}
         onChange={handleInputChange}
       />
     </WithTooltip>

--- a/code/addons/toolbars/src/components/ToolbarTextInput.tsx
+++ b/code/addons/toolbars/src/components/ToolbarTextInput.tsx
@@ -1,0 +1,18 @@
+import type { FC } from 'react';
+import React from 'react';
+import type { NormalizedToolbarArgTypeText } from '../types';
+
+type ToolbarTextInputProps = NormalizedToolbarArgTypeText;
+
+export const ToolbarTextInput: FC<ToolbarTextInputProps> = ({
+  id,
+  name,
+  description,
+  toolbar: { title },
+}) => {
+  return (
+    <p>
+      {name} {title}
+    </p>
+  );
+};

--- a/code/addons/toolbars/src/hoc/withKeyboardCycle.tsx
+++ b/code/addons/toolbars/src/hoc/withKeyboardCycle.tsx
@@ -2,14 +2,14 @@ import React, { useRef, useEffect, useCallback } from 'react';
 import { useGlobals, useStorybookApi } from '@storybook/manager-api';
 import { createCycleValueArray } from '../utils/create-cycle-value-array';
 import { registerShortcuts } from '../utils/register-shortcuts';
-import type { ToolbarMenuProps } from '../types';
+import type { ToolbarMenuListPropsBase } from '../types';
 
 export type WithKeyboardCycleProps = {
   cycleValues?: string[];
 };
 
-export const withKeyboardCycle = (Component: React.ComponentType<ToolbarMenuProps>) => {
-  const WithKeyboardCycle = (props: ToolbarMenuProps) => {
+export const withKeyboardCycle = (Component: React.ComponentType<ToolbarMenuListPropsBase>) => {
+  const WithKeyboardCycle = (props: ToolbarMenuListPropsBase) => {
     const {
       id,
       toolbar: { items, shortcuts },

--- a/code/addons/toolbars/src/types.ts
+++ b/code/addons/toolbars/src/types.ts
@@ -27,18 +27,20 @@ interface NormalizedToolbarConfigBase {
   title?: string;
   /** Choose an icon to show for this toolbar item */
   icon: IconsProps['icon'];
+}
+
+interface NormalizedToolbarConfigItems extends NormalizedToolbarConfigBase {
+  items: ToolbarItem[];
+  /** Bind keyboard shortcuts to navigate items */
+  shortcuts?: ToolbarShortcuts;
   /** Set to true to prevent default update of icon to match any present selected items icon */
   preventDynamicIcon?: boolean;
   /** Change title based on selected value */
   dynamicTitle?: boolean;
 }
 
-interface NormalizedToolbarConfigItems extends NormalizedToolbarConfigBase {
-  items: ToolbarItem[];
-  shortcuts?: ToolbarShortcuts;
-}
-
 interface NormalizedToolbarConfigText extends NormalizedToolbarConfigBase {
+  /** Mask the value of the input like a password */
   isSecret?: boolean;
 }
 

--- a/code/addons/toolbars/src/types.ts
+++ b/code/addons/toolbars/src/types.ts
@@ -62,19 +62,18 @@ type ToolbarConfigItems = NormalizedToolbarConfigItems & {
 
 type ToolbarConfigText = NormalizedToolbarConfigText & {
   isSecret?: boolean;
-  defaultValue?: null | undefined | string;
 };
 
 export type ToolbarConfig = ToolbarConfigItems | ToolbarConfigText;
 
 export type ToolbarArgTypeItems = InputType & {
-  toolbar: ToolbarConfigText;
-};
-
-export type ToolbarArgTypeText = InputType & {
   toolbar: ToolbarConfigItems;
 };
 
-export type ToolbarArgType = ToolbarConfigItems | ToolbarConfigText;
+export type ToolbarArgTypeText = InputType & {
+  toolbar: ToolbarConfigText;
+};
 
-export type ToolbarMenuProps = NormalizedToolbarConfigItems & { id: string };
+export type ToolbarArgType = ToolbarArgTypeItems | ToolbarArgTypeText;
+
+export type ToolbarMenuListPropsBase = NormalizedToolbarArgTypeItems & { id: string };

--- a/code/addons/toolbars/src/types.ts
+++ b/code/addons/toolbars/src/types.ts
@@ -22,29 +22,48 @@ export interface ToolbarItem {
   type?: ToolbarItemType;
 }
 
-export interface NormalizedToolbarConfig {
+interface NormalizedToolbarConfigBase {
   /** The label to show for this toolbar item */
   title?: string;
   /** Choose an icon to show for this toolbar item */
   icon: IconsProps['icon'];
   /** Set to true to prevent default update of icon to match any present selected items icon */
   preventDynamicIcon?: boolean;
-  items: ToolbarItem[];
-  shortcuts?: ToolbarShortcuts;
   /** Change title based on selected value */
   dynamicTitle?: boolean;
 }
+
+interface NormalizedToolbarConfigItems extends NormalizedToolbarConfigBase {
+  items: ToolbarItem[];
+  shortcuts?: ToolbarShortcuts;
+}
+
+interface NormalizedToolbarConfigText extends NormalizedToolbarConfigBase {
+  isSecret?: boolean;
+}
+
+export type NormalizedToolbarConfig = NormalizedToolbarConfigItems | NormalizedToolbarConfigText;
 
 export type NormalizedToolbarArgType = InputType & {
   toolbar: NormalizedToolbarConfig;
 };
 
-export type ToolbarConfig = NormalizedToolbarConfig & {
+type ToolbarConfigItems = NormalizedToolbarConfigItems & {
   items: string[] | ToolbarItem[];
 };
 
-export type ToolbarArgType = InputType & {
-  toolbar: ToolbarConfig;
+type ToolbarConfigText = NormalizedToolbarConfigText;
+
+export type ToolbarConfig = ToolbarConfigItems | ToolbarConfigText;
+
+export type ToolbarArgTypeItems = InputType & {
+  toolbar: ToolbarConfigText;
 };
 
-export type ToolbarMenuProps = NormalizedToolbarArgType & { id: string };
+export type ToolbarArgTypeText = InputType & {
+  toolbar: ToolbarConfigItems;
+};
+
+export type ToolbarArgType = ToolbarConfigItems | ToolbarConfigText;
+
+export type ToolbarMenuProps = NormalizedToolbarConfigItems & { id: string };

--- a/code/addons/toolbars/src/types.ts
+++ b/code/addons/toolbars/src/types.ts
@@ -40,8 +40,6 @@ interface NormalizedToolbarConfigItems extends NormalizedToolbarConfigBase {
 }
 
 interface NormalizedToolbarConfigText extends NormalizedToolbarConfigBase {
-  /** Default value */
-  defaultValue: string;
   /** Mask the value of the input like a password */
   isSecret: boolean;
 }

--- a/code/addons/toolbars/src/types.ts
+++ b/code/addons/toolbars/src/types.ts
@@ -40,8 +40,10 @@ interface NormalizedToolbarConfigItems extends NormalizedToolbarConfigBase {
 }
 
 interface NormalizedToolbarConfigText extends NormalizedToolbarConfigBase {
+  /** Default value */
+  defaultValue: string;
   /** Mask the value of the input like a password */
-  isSecret?: boolean;
+  isSecret: boolean;
 }
 
 export type NormalizedToolbarConfig = NormalizedToolbarConfigItems | NormalizedToolbarConfigText;
@@ -60,7 +62,10 @@ type ToolbarConfigItems = NormalizedToolbarConfigItems & {
   items: string[] | ToolbarItem[];
 };
 
-type ToolbarConfigText = NormalizedToolbarConfigText;
+type ToolbarConfigText = NormalizedToolbarConfigText & {
+  isSecret?: boolean;
+  defaultValue?: null | undefined | string;
+};
 
 export type ToolbarConfig = ToolbarConfigItems | ToolbarConfigText;
 

--- a/code/addons/toolbars/src/types.ts
+++ b/code/addons/toolbars/src/types.ts
@@ -44,9 +44,15 @@ interface NormalizedToolbarConfigText extends NormalizedToolbarConfigBase {
 
 export type NormalizedToolbarConfig = NormalizedToolbarConfigItems | NormalizedToolbarConfigText;
 
-export type NormalizedToolbarArgType = InputType & {
-  toolbar: NormalizedToolbarConfig;
+export type NormalizedToolbarArgTypeItems = InputType & {
+  toolbar: NormalizedToolbarConfigItems;
 };
+
+export type NormalizedToolbarArgTypeText = InputType & {
+  toolbar: NormalizedToolbarConfigText;
+};
+
+export type NormalizedToolbarArgType = NormalizedToolbarArgTypeItems | NormalizedToolbarArgTypeText;
 
 type ToolbarConfigItems = NormalizedToolbarConfigItems & {
   items: string[] | ToolbarItem[];

--- a/code/addons/toolbars/src/utils/normalize-toolbar-arg-type.ts
+++ b/code/addons/toolbars/src/utils/normalize-toolbar-arg-type.ts
@@ -1,4 +1,10 @@
-import type { NormalizedToolbarArgType, ToolbarArgType, ToolbarItem } from '../types';
+import type {
+  NormalizedToolbarArgType,
+  ToolbarArgType,
+  ToolbarArgTypeItems,
+  ToolbarArgTypeText,
+  ToolbarItem,
+} from '../types';
 
 const defaultItemValues: ToolbarItem = {
   type: 'item',
@@ -18,32 +24,42 @@ export const normalizeArgType = (
     },
   };
 
-  if (base.items == null)
+  if (isToolbarArgTypeText(argType)) {
     return {
       ...base,
       toolbar: {
         ...base.toolbar,
-        isSecret: base.toolbar.isSecret ?? false,
-        defaultValue: base.toolbar.defaultValue ?? '',
+        isSecret: argType.toolbar.isSecret ?? false,
       },
     };
+  }
 
-  return {
-    ...base,
-    toolbar: {
-      ...base.toolbar,
-      items: argType.toolbar.items.map((_item) => {
-        const item = typeof _item === 'string' ? { value: _item, title: _item } : _item;
+  if (isToolbarArgTypeItems(argType)) {
+    return {
+      ...base,
+      toolbar: {
+        ...base.toolbar,
+        items: argType.toolbar.items.map((_item) => {
+          const item = typeof _item === 'string' ? { value: _item, title: _item } : _item;
 
-        // Cater for the special type "reset" which will reset value and also icon
-        // of toolbar button if any icon was present on toolbar to begin with
-        if (item.type === 'reset' && argType.toolbar.icon) {
-          item.icon = argType.toolbar.icon;
-          item.hideIcon = true;
-        }
+          // Cater for the special type "reset" which will reset value and also icon
+          // of toolbar button if any icon was present on toolbar to begin with
+          if (item.type === 'reset' && argType.toolbar.icon) {
+            item.icon = argType.toolbar.icon;
+            item.hideIcon = true;
+          }
 
-        return { ...defaultItemValues, ...item };
-      }),
-    },
-  };
+          return { ...defaultItemValues, ...item };
+        }),
+      },
+    };
+  }
+
+  throw new Error('Invalid toolbar config');
 };
+
+const isToolbarArgTypeItems = (arg: ToolbarArgType): arg is ToolbarArgTypeItems =>
+  'items' in arg.toolbar;
+
+const isToolbarArgTypeText = (arg: ToolbarArgType): arg is ToolbarArgTypeText =>
+  !('items' in arg.toolbar);

--- a/code/addons/toolbars/src/utils/normalize-toolbar-arg-type.ts
+++ b/code/addons/toolbars/src/utils/normalize-toolbar-arg-type.ts
@@ -15,7 +15,6 @@ export const normalizeArgType = (
     description: argType.description || key,
     toolbar: {
       ...argType.toolbar,
-      items,
     },
   };
 
@@ -23,17 +22,20 @@ export const normalizeArgType = (
 
   return {
     ...base,
-    items: argType.toolbar.items.map((_item) => {
-      const item = typeof _item === 'string' ? { value: _item, title: _item } : _item;
+    toolbar: {
+      ...base.toolbar,
+      items: argType.toolbar.items.map((_item) => {
+        const item = typeof _item === 'string' ? { value: _item, title: _item } : _item;
 
-      // Cater for the special type "reset" which will reset value and also icon
-      // of toolbar button if any icon was present on toolbar to begin with
-      if (item.type === 'reset' && argType.toolbar.icon) {
-        item.icon = argType.toolbar.icon;
-        item.hideIcon = true;
-      }
+        // Cater for the special type "reset" which will reset value and also icon
+        // of toolbar button if any icon was present on toolbar to begin with
+        if (item.type === 'reset' && argType.toolbar.icon) {
+          item.icon = argType.toolbar.icon;
+          item.hideIcon = true;
+        }
 
-      return { ...defaultItemValues, ...item };
-    }),
+        return { ...defaultItemValues, ...item };
+      }),
+    },
   };
 };

--- a/code/addons/toolbars/src/utils/normalize-toolbar-arg-type.ts
+++ b/code/addons/toolbars/src/utils/normalize-toolbar-arg-type.ts
@@ -8,12 +8,21 @@ const defaultItemValues: ToolbarItem = {
 export const normalizeArgType = (
   key: string,
   argType: ToolbarArgType
-): NormalizedToolbarArgType => ({
-  ...argType,
-  name: argType.name || key,
-  description: argType.description || key,
-  toolbar: {
-    ...argType.toolbar,
+): NormalizedToolbarArgType => {
+  const base = {
+    ...argType,
+    name: argType.name || key,
+    description: argType.description || key,
+    toolbar: {
+      ...argType.toolbar,
+      items,
+    },
+  };
+
+  if (base.items == null) return base;
+
+  return {
+    ...base,
     items: argType.toolbar.items.map((_item) => {
       const item = typeof _item === 'string' ? { value: _item, title: _item } : _item;
 
@@ -26,5 +35,5 @@ export const normalizeArgType = (
 
       return { ...defaultItemValues, ...item };
     }),
-  },
-});
+  };
+};

--- a/code/addons/toolbars/src/utils/normalize-toolbar-arg-type.ts
+++ b/code/addons/toolbars/src/utils/normalize-toolbar-arg-type.ts
@@ -18,7 +18,15 @@ export const normalizeArgType = (
     },
   };
 
-  if (base.items == null) return base;
+  if (base.items == null)
+    return {
+      ...base,
+      toolbar: {
+        ...base.toolbar,
+        isSecret: base.toolbar.isSecret ?? false,
+        defaultValue: base.toolbar.defaultValue ?? '',
+      },
+    };
 
   return {
     ...base,

--- a/code/addons/toolbars/template/stories/globals.stories.ts
+++ b/code/addons/toolbars/template/stories/globals.stories.ts
@@ -23,7 +23,9 @@ export default {
     (storyFn: PartialStoryFn, { globals }: StoryContext) => {
       const object = {
         ...globals,
-        caption: `Locale is '${globals.locale}', so I say: ${greetingForLocale(globals.locale)}`,
+        caption: `Locale is '${globals.locale}', so I say: ${greetingForLocale(globals.locale)} ${
+          globals.userName
+        }`,
       };
       return storyFn({ args: { object } });
     },

--- a/code/addons/toolbars/template/stories/globals.stories.ts
+++ b/code/addons/toolbars/template/stories/globals.stories.ts
@@ -23,8 +23,8 @@ export default {
     (storyFn: PartialStoryFn, { globals }: StoryContext) => {
       const object = {
         ...globals,
-        caption: `Locale is '${globals.locale}', so I say: ${greetingForLocale(globals.locale)} ${
-          globals.userName
+        caption: `Locale is '${globals.locale}', so I say: ${greetingForLocale(globals.locale)}${
+          globals.userName !== '' ? ` ${globals.userName}` : ''
         }`,
       };
       return storyFn({ args: { object } });

--- a/code/addons/toolbars/template/stories/preview.ts
+++ b/code/addons/toolbars/template/stories/preview.ts
@@ -14,12 +14,12 @@ export const globalTypes = {
     },
   },
   userName: {
-    name: 'Your name',
+    name: 'User name',
     description: 'What is your name?',
-    defaultValue: '',
-    isSecret: false,
     toolbar: {
+      title: 'Name',
       icon: 'user',
+      isSecret: false,
     },
   },
   locale: {

--- a/code/addons/toolbars/template/stories/preview.ts
+++ b/code/addons/toolbars/template/stories/preview.ts
@@ -13,9 +13,11 @@ export const globalTypes = {
       ],
     },
   },
-  name: {
+  userName: {
     name: 'Your name',
     description: 'What is your name?',
+    defaultValue: '',
+    isSecret: false,
     toolbar: {
       icon: 'user',
     },

--- a/code/addons/toolbars/template/stories/preview.ts
+++ b/code/addons/toolbars/template/stories/preview.ts
@@ -13,6 +13,13 @@ export const globalTypes = {
       ],
     },
   },
+  name: {
+    name: 'Your name',
+    description: 'What is your name?',
+    toolbar: {
+      icon: 'user',
+    },
+  },
   locale: {
     name: 'Locale',
     description: 'Internationalization locale',

--- a/docs/snippets/common/storybook-preview-configure-globaltypes.js.mdx
+++ b/docs/snippets/common/storybook-preview-configure-globaltypes.js.mdx
@@ -17,6 +17,16 @@ export default {
         dynamicTitle: true,
       },
     },
+    endpoint: {
+      name: 'API Endpoint',
+      description: 'Backend API endpoint',
+      defaultValue: 'https://example.com',
+      toolbar: {
+        title: 'API Endpoint',
+        icon: 'key',
+        isSecret: false,
+      },
+    },
   },
 };
 ```

--- a/docs/snippets/common/storybook-preview-configure-globaltypes.ts.mdx
+++ b/docs/snippets/common/storybook-preview-configure-globaltypes.ts.mdx
@@ -20,6 +20,16 @@ const preview: Preview = {
         dynamicTitle: true,
       },
     },
+    endpoint: {
+      name: 'API Endpoint',
+      description: 'Backend API endpoint',
+      defaultValue: 'https://example.com',
+      toolbar: {
+        title: 'API Endpoint',
+        icon: 'key',
+        isSecret: false,
+      },
+    },
   },
 };
 


### PR DESCRIPTION
Closes #18738

## What I did

Implemented a new toolbar type: text input. Works like this

```
userName: {
  name: 'User name',
  description: 'What is your name?',
  toolbar: {
    title: 'Name',
    icon: 'user',
    isSecret: false,
  },
},
```

<img width="802" alt="image" src="https://user-images.githubusercontent.com/721372/230286846-a1bd8658-345a-44b1-be7f-49e1adc9a4d1.png">

https://user-images.githubusercontent.com/721372/230291847-43988b19-69f5-4b61-bcaf-d2c7a40edd99.mp4

## How to test

1. yarn start
2. Open Storybook in your browser
3. Access story: http://localhost:6006/?path=/story/addons-toolbars-globals--basic
4. Type text into input box, watch greeting change.
5. Edit `template/stories/preview.ts` and update the `userName` value.
6. Refresh the page to see change.

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
