### PR TITLE
Chore (Documentation) Fix issue template to feature correct command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
     id: system
     attributes:
       label: System
-      description: Please paste the results of `npx sb@next info` here.
+      description: Please paste the results of `npx storybook@latest info` here.
       render: shell
   - type: textarea
     id: context


### PR DESCRIPTION
With this small pull request our issue template is updated to feature the correct command when providing the user's information.

What was done:
- Updated the template to remove outdated `sb` binary usage in favour of the `storybook` one.

@vanessayuenn when you have a chance, can you take a look and follow up with me so we can merge this or continue to work on it to provide the most accurate information to our users? 

Thanks in advance

EDIT: To prevent issues with merging just applied the `patch` label, although for situations as this one, it shouldn't be used