### PR TITLE
Chore: Fix SvelteKit migration notice

### DIFF
--- a/code/frameworks/svelte-vite/src/utils.ts
+++ b/code/frameworks/svelte-vite/src/utils.ts
@@ -31,7 +31,7 @@ export async function handleSvelteKit(plugins: PluginOption[], options: Options)
       Please use the @storybook/sveltekit framework instead.
       You can migrate automatically by running
       
-      npx sb@next automigrate
+      npx storybook@latest automigrate
 
       See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#sveltekit-needs-the-storybooksveltekit-framework
       `


### PR DESCRIPTION
With this small pull request, the command used to migrate is updated to include the new binaries' way of migrating to Storybook 7.0.

What was changed:
- Updated the command featured in the error message to a more accurate one.

@JReinhold, I assigned this to you so that you could take a look and let me know of any feedback so that we can continue to work on this or merge it and make it available to our users.

Thanks in advance.