### PR TITLE
Telemetry: Add CLI version to context

### DIFF
--- a/code/frameworks/angular/package.json
+++ b/code/frameworks/angular/package.json
@@ -49,6 +49,7 @@
     "@storybook/manager-api": "7.1.0-alpha.0",
     "@storybook/node-logger": "7.1.0-alpha.0",
     "@storybook/preview-api": "7.1.0-alpha.0",
+    "@storybook/telemetry": "7.1.0-alpha.0",
     "@storybook/types": "7.1.0-alpha.0",
     "@types/node": "^16.0.0",
     "@types/react": "^16.14.34",

--- a/code/frameworks/angular/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.ts
@@ -13,7 +13,8 @@ import { sync as readUpSync } from 'read-pkg-up';
 import { BrowserBuilderOptions, StylePreprocessorOptions } from '@angular-devkit/build-angular';
 
 import { CLIOptions } from '@storybook/types';
-import { getEnvConfig } from '@storybook/cli';
+import { getEnvConfig, versions } from '@storybook/cli';
+import { addToGlobalContext } from '@storybook/telemetry';
 
 import { buildStaticStandalone, withTelemetry } from '@storybook/core-server';
 import {
@@ -23,6 +24,8 @@ import {
 import { StandaloneOptions } from '../utils/standalone-options';
 import { runCompodoc } from '../utils/run-compodoc';
 import { errorSummary, printErrorDetails } from '../utils/error-handler';
+
+addToGlobalContext('cliVersion', versions.storybook);
 
 export type StorybookBuilderOptions = JsonObject & {
   browserTarget?: string | null;

--- a/code/frameworks/angular/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.ts
@@ -13,8 +13,8 @@ import { sync as findUpSync } from 'find-up';
 import { sync as readUpSync } from 'read-pkg-up';
 
 import { CLIOptions } from '@storybook/types';
-import { getEnvConfig } from '@storybook/cli';
-
+import { getEnvConfig, versions } from '@storybook/cli';
+import { addToGlobalContext } from '@storybook/telemetry';
 import { buildDevStandalone, withTelemetry } from '@storybook/core-server';
 import {
   AssetPattern,
@@ -23,6 +23,8 @@ import {
 import { StandaloneOptions } from '../utils/standalone-options';
 import { runCompodoc } from '../utils/run-compodoc';
 import { printErrorDetails, errorSummary } from '../utils/error-handler';
+
+addToGlobalContext('cliVersion', versions.storybook);
 
 export type StorybookBuilderOptions = JsonObject & {
   browserTarget?: string | null;

--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -6,7 +6,7 @@ import leven from 'leven';
 import { sync as readUpSync } from 'read-pkg-up';
 
 import { logger } from '@storybook/node-logger';
-import { globalContext } from '@storybook/telemetry';
+import { addToGlobalContext } from '@storybook/telemetry';
 
 import type { CommandOptions } from './generators/types';
 import { initiate } from './initiate';
@@ -23,7 +23,7 @@ import { build } from './build';
 import { parseList, getEnvConfig } from './utils';
 import versions from './versions';
 
-globalContext.cliVersion = versions.storybook;
+addToGlobalContext('cliVersion', versions.storybook);
 
 const pkg = readUpSync({ cwd: __dirname }).packageJson;
 const consoleLogger = console;

--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -6,6 +6,7 @@ import leven from 'leven';
 import { sync as readUpSync } from 'read-pkg-up';
 
 import { logger } from '@storybook/node-logger';
+import { globalContext } from '@storybook/telemetry';
 
 import type { CommandOptions } from './generators/types';
 import { initiate } from './initiate';
@@ -20,6 +21,9 @@ import { generateStorybookBabelConfigInCWD } from './babel-config';
 import { dev } from './dev';
 import { build } from './build';
 import { parseList, getEnvConfig } from './utils';
+import versions from './versions';
+
+globalContext.cliVersion = versions.storybook;
 
 const pkg = readUpSync({ cwd: __dirname }).packageJson;
 const consoleLogger = console;

--- a/code/lib/cli/src/index.ts
+++ b/code/lib/cli/src/index.ts
@@ -1,2 +1,6 @@
+import versions from './versions';
+
+export { versions };
+
 export * from './js-package-manager';
 export * from './utils';

--- a/code/lib/telemetry/src/index.ts
+++ b/code/lib/telemetry/src/index.ts
@@ -15,6 +15,8 @@ export { getStorybookCoreVersion } from './package-json';
 
 export { getPrecedingUpgrade } from './event-cache';
 
+export { globalContext } from './telemetry';
+
 export const telemetry = async (
   eventType: EventType,
   payload: Payload = {},

--- a/code/lib/telemetry/src/index.ts
+++ b/code/lib/telemetry/src/index.ts
@@ -15,7 +15,7 @@ export { getStorybookCoreVersion } from './package-json';
 
 export { getPrecedingUpgrade } from './event-cache';
 
-export { globalContext } from './telemetry';
+export { addToGlobalContext } from './telemetry';
 
 export const telemetry = async (
   eventType: EventType,

--- a/code/lib/telemetry/src/telemetry.ts
+++ b/code/lib/telemetry/src/telemetry.ts
@@ -16,10 +16,14 @@ let tasks: Promise<any>[] = [];
 // send telemetry
 const sessionId = nanoid();
 
+export const addToGlobalContext = (key: string, value: any) => {
+  globalContext[key] = value;
+};
+
 // context info sent with all events, provided
 // by the app. currently:
 // - cliVersion
-export const globalContext = {
+const globalContext = {
   inCI: Boolean(process.env.CI),
   isTTY: process.stdout.isTTY,
 } as Record<string, any>;

--- a/code/lib/telemetry/src/telemetry.ts
+++ b/code/lib/telemetry/src/telemetry.ts
@@ -19,7 +19,10 @@ const sessionId = nanoid();
 // context info sent with all events, provided
 // by the app. currently:
 // - cliVersion
-export const globalContext = {} as Record<string, any>;
+export const globalContext = {
+  inCI: Boolean(process.env.CI),
+  isTTY: process.stdout.isTTY,
+} as Record<string, any>;
 
 export async function sendTelemetry(
   data: TelemetryData,
@@ -36,8 +39,6 @@ export async function sendTelemetry(
     : {
         ...globalContext,
         anonymousId: getAnonymousProjectId(),
-        inCI: Boolean(process.env.CI),
-        isTTY: process.stdout.isTTY,
       };
   const eventId = nanoid();
   const body = { ...rest, eventType, eventId, sessionId, metadata, payload, context };

--- a/code/lib/telemetry/src/telemetry.ts
+++ b/code/lib/telemetry/src/telemetry.ts
@@ -16,6 +16,11 @@ let tasks: Promise<any>[] = [];
 // send telemetry
 const sessionId = nanoid();
 
+// context info sent with all events, provided
+// by the app. currently:
+// - cliVersion
+export const globalContext = {} as Record<string, any>;
+
 export async function sendTelemetry(
   data: TelemetryData,
   options: Partial<Options> = { retryDelay: 1000, immediate: false }
@@ -27,8 +32,9 @@ export async function sendTelemetry(
   // flatten the data before we send it
   const { eventType, payload, metadata, ...rest } = data;
   const context = options.stripMetadata
-    ? {}
+    ? globalContext
     : {
+        ...globalContext,
         anonymousId: getAnonymousProjectId(),
         inCI: Boolean(process.env.CI),
         isTTY: process.stdout.isTTY,

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5636,6 +5636,7 @@ __metadata:
     "@storybook/manager-api": 7.1.0-alpha.0
     "@storybook/node-logger": 7.1.0-alpha.0
     "@storybook/preview-api": 7.1.0-alpha.0
+    "@storybook/telemetry": 7.1.0-alpha.0
     "@storybook/types": 7.1.0-alpha.0
     "@types/node": ^16.0.0
     "@types/react": ^16.14.34

--- a/scripts/event-log-checker.ts
+++ b/scripts/event-log-checker.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import assert from 'assert';
 import fetch from 'node-fetch';
 import { allTemplates } from '../code/lib/cli/src/sandbox-templates';
+import versions from '../code/lib/cli/src/versions';
 import { oneWayHash } from '../code/lib/telemetry/src/one-way-hash';
 
 const PORT = process.env.PORT || 6007;
@@ -47,6 +48,12 @@ async function run() {
     });
 
     const [bootEvent, mainEvent] = events;
+
+    test(`both events should have cliVersion in context`, () => {
+      const cliVersion = versions.storybook;
+      assert.equal(bootEvent.context.cliVersion, cliVersion);
+      assert.equal(mainEvent.context.cliVersion, cliVersion);
+    });
 
     test(`Should log a boot event with a payload of type ${eventType}`, () => {
       assert.equal(bootEvent.eventType, 'boot');


### PR DESCRIPTION
## What I did

We don't enrich boot events with metadata so that it doesn't affect perf, but we can include the CLI version without additional overhead, and it is useful for understanding whether we've fixed bugs across versions.

## How to test

In a sandbox:

```
STORYBOOK_TELEMETRY_DEBUG=1 yarn storybook 
```
