### PR TITLE
CLI: Mark qwik as using addon-interactions

### DIFF
--- a/code/lib/cli/src/generators/baseGenerator.ts
+++ b/code/lib/cli/src/generators/baseGenerator.ts
@@ -132,7 +132,9 @@ const getFrameworkDetails = (
 const stripVersions = (addons: string[]) => addons.map((addon) => getPackageDetails(addon)[0]);
 
 const hasInteractiveStories = (rendererId: SupportedRenderers) =>
-  ['react', 'angular', 'preact', 'svelte', 'vue', 'vue3', 'html', 'solid'].includes(rendererId);
+  ['react', 'angular', 'preact', 'svelte', 'vue', 'vue3', 'html', 'solid', 'qwik'].includes(
+    rendererId
+  );
 
 const hasFrameworkTemplates = (framework?: SupportedFrameworks) =>
   ['angular', 'nextjs'].includes(framework);


### PR DESCRIPTION
## What I did

Add Qwik to the list of frameworks that supports interactive stories.

See [this PR](https://github.com/literalpie/storybook-framework-qwik/pull/47/files) in the storybook-framework-qwik project where I update the templates to match other frameworks. If I release that before this PR, the storybook addon-interactions dependency will be missing for people who use npm init with Qwik.

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
