### PR TITLE
React-vite: Fix perf regression by pinning vite-plugin-react-docgen-ts

### DIFF
--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -48,7 +48,7 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@joshwooding/vite-plugin-react-docgen-typescript": "^0.2.1",
+    "@joshwooding/vite-plugin-react-docgen-typescript": "0.2.1",
     "@rollup/pluginutils": "^4.2.0",
     "@storybook/builder-vite": "7.1.0-alpha.0",
     "@storybook/react": "7.1.0-alpha.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -3559,7 +3559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@joshwooding/vite-plugin-react-docgen-typescript@npm:^0.2.1":
+"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.2.1":
   version: 0.2.1
   resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.2.1"
   dependencies:
@@ -7001,7 +7001,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/react-vite@workspace:frameworks/react-vite"
   dependencies:
-    "@joshwooding/vite-plugin-react-docgen-typescript": ^0.2.1
+    "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@rollup/pluginutils": ^4.2.0
     "@storybook/builder-vite": 7.1.0-alpha.0
     "@storybook/react": 7.1.0-alpha.0


### PR DESCRIPTION
Closes #22011

## What I did

It seems as if https://github.com/joshwooding/vite-plugin-react-docgen-typescript/pull/17 might have caused a huge performance regression. This is likely causing problems for end users and might also be what has broken CI for the storybook repo.

## How to test

- [ ] CI passes
