### PR TITLE
Fix e2e tests failing in Firefox

### DIFF
--- a/code/e2e-tests/util.ts
+++ b/code/e2e-tests/util.ts
@@ -37,8 +37,9 @@ export class SbPage {
     // assert url changes
     const viewMode = name === 'docs' ? 'docs' : 'story';
 
-    const url = this.page.url();
-    await expect(url).toContain(`path=/${viewMode}/${titleId}--${storyId}`);
+    await this.page.waitForURL((url) =>
+      url.search.includes(`path=/${viewMode}/${titleId}--${storyId}`)
+    );
 
     const selected = await storyLink.getAttribute('data-selected');
     await expect(selected).toBe('true');


### PR DESCRIPTION
e2e tests are consistently failing in StoryStore v6 sandboxes because Firefox is slower to update the URL than expected. This changes the logic to wait for the URL to change, instead of asserting it's state immediately.

This might not fix all the CI fails, but it fixes some of them at least.

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
