### PR TITLE
React: Fix default export docgen for React.FC and forwardRef

### DIFF
--- a/code/presets/create-react-app/package.json
+++ b/code/presets/create-react-app/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
-    "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.630821.0",
+    "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
     "@storybook/types": "7.1.0-alpha.0",
     "@types/babel__core": "^7.1.7",
     "babel-plugin-react-docgen": "^4.1.0",
@@ -59,7 +59,6 @@
   "devDependencies": {
     "@storybook/node-logger": "7.1.0-alpha.0",
     "@types/node": "^16.0.0",
-    "@types/semver": "^7.3.6",
     "typescript": "~4.9.3"
   },
   "peerDependencies": {

--- a/code/presets/react-webpack/package.json
+++ b/code/presets/react-webpack/package.json
@@ -70,7 +70,7 @@
     "@storybook/docs-tools": "7.1.0-alpha.0",
     "@storybook/node-logger": "7.1.0-alpha.0",
     "@storybook/react": "7.1.0-alpha.0",
-    "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.630821.0",
+    "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
     "@types/node": "^16.0.0",
     "@types/semver": "^7.3.4",
     "babel-plugin-add-react-displayname": "^0.0.5",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6713,11 +6713,10 @@ __metadata:
   dependencies:
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.1
     "@storybook/node-logger": 7.1.0-alpha.0
-    "@storybook/react-docgen-typescript-plugin": 1.0.6--canary.9.630821.0
+    "@storybook/react-docgen-typescript-plugin": 1.0.6--canary.9.0c3f3b7.0
     "@storybook/types": 7.1.0-alpha.0
     "@types/babel__core": ^7.1.7
     "@types/node": ^16.0.0
-    "@types/semver": ^7.3.6
     babel-plugin-react-docgen: ^4.1.0
     pnp-webpack-plugin: ^1.7.0
     semver: ^7.3.5
@@ -6769,7 +6768,7 @@ __metadata:
     "@storybook/docs-tools": 7.1.0-alpha.0
     "@storybook/node-logger": 7.1.0-alpha.0
     "@storybook/react": 7.1.0-alpha.0
-    "@storybook/react-docgen-typescript-plugin": 1.0.6--canary.9.630821.0
+    "@storybook/react-docgen-typescript-plugin": 1.0.6--canary.9.0c3f3b7.0
     "@types/node": ^16.0.0
     "@types/semver": ^7.3.4
     babel-plugin-add-react-displayname: ^0.0.5
@@ -6967,9 +6966,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/react-docgen-typescript-plugin@npm:1.0.6--canary.9.630821.0":
-  version: 1.0.6--canary.9.630821.0
-  resolution: "@storybook/react-docgen-typescript-plugin@npm:1.0.6--canary.9.630821.0"
+"@storybook/react-docgen-typescript-plugin@npm:1.0.6--canary.9.0c3f3b7.0":
+  version: 1.0.6--canary.9.0c3f3b7.0
+  resolution: "@storybook/react-docgen-typescript-plugin@npm:1.0.6--canary.9.0c3f3b7.0"
   dependencies:
     debug: ^4.1.1
     endent: ^2.0.1
@@ -6981,7 +6980,7 @@ __metadata:
   peerDependencies:
     typescript: ">= 4.x"
     webpack: ">= 4"
-  checksum: e444a6f2ef67a631ebd35f78a1637c2adbb964d5063a4a088ccf3027c65ca2430826906c70e4972049ef1603aa01ce9c38393704fc2d6de293a627cc40ddc3b2
+  checksum: 505a728f36df3f519f4985bdf18f2078ea18a1a8f7f837fc831f971363fb7643a182f01a6857a9729ac5a1246d370526fca5a19017f82e7493af4ca945cb7235
   languageName: node
   linkType: hard
 
@@ -8774,7 +8773,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.3.12, @types/semver@npm:^7.3.4, @types/semver@npm:^7.3.6":
+"@types/semver@npm:^7.3.12, @types/semver@npm:^7.3.4":
   version: 7.3.13
   resolution: "@types/semver@npm:7.3.13"
   checksum: 73295bb1fee46f8c76c7a759feeae5a3022f5bedfdc17d16982092e4b33af17560234fb94861560c20992a702a1e1b9a173bb623a96f95f80892105f5e7d25e3


### PR DESCRIPTION
Closes #21898, closes #21801

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Bumped the version, so we get the fixes from this PR:
https://github.com/storybookjs/react-docgen-typescript-plugin/pull/10

## How to test

See this repo:
https://github.com/kyletsang/storybook-ts-docs-repro

Copy the non working example to a webpack react repo, and see that it works now!

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
