### PR TITLE
Chore: (UI) Updates sidebar composition links

### DIFF
--- a/code/ui/manager/src/components/sidebar/RefIndicator.tsx
+++ b/code/ui/manager/src/components/sidebar/RefIndicator.tsx
@@ -282,7 +282,7 @@ const LoginRequiredMessage: FC<RefType> = ({ loginUrl, id }) => {
 };
 
 const ReadDocsMessage: FC = () => (
-  <Message href="https://storybook.js.org" target="_blank">
+  <Message href="https://storybook.js.org/docs/react/sharing/storybook-composition" target="_blank">
     <GreenIcon icon="document" />
     <div>
       <MessageTitle>Read Composition docs</MessageTitle>
@@ -312,7 +312,7 @@ const LoadingMessage: FC<{ url: string }> = ({ url }) => (
 );
 
 const PerformanceDegradedMessage: FC = () => (
-  <Message href="https://storybook.js.org/docs" target="_blank">
+  <Message href="https://storybook.js.org/docs/react/sharing/storybook-composition#improve-your-storybook-composition" target="_blank">
     <YellowIcon icon="lightning" />
     <div>
       <MessageTitle>Reduce lag</MessageTitle>

--- a/code/ui/manager/src/components/sidebar/RefIndicator.tsx
+++ b/code/ui/manager/src/components/sidebar/RefIndicator.tsx
@@ -312,7 +312,10 @@ const LoadingMessage: FC<{ url: string }> = ({ url }) => (
 );
 
 const PerformanceDegradedMessage: FC = () => (
-  <Message href="https://storybook.js.org/docs/react/sharing/storybook-composition#improve-your-storybook-composition" target="_blank">
+  <Message
+    href="https://storybook.js.org/docs/react/sharing/storybook-composition#improve-your-storybook-composition"
+    target="_blank"
+  >
     <YellowIcon icon="lightning" />
     <div>
       <MessageTitle>Reduce lag</MessageTitle>


### PR DESCRIPTION
With this pull request, the URLs provided for the composition documentation in our UI were updated to point at the right place, as they were only pointing users to the website instead of the actual place where the documentation lives.

Closes #21507

What was done:
- Update both links featured in the info dropdown to point at the right location in our documentation

@ndelangen, when you have a moment, can you take a look and let me know of any feedback you may have so that we can continue to work on this or merge it? Thanks in advance.