### PR TITLE
CLI: Catch errors thrown on sanity check of SB installs

### DIFF
--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -416,7 +416,8 @@ export abstract class JsPackageManager {
     command: string,
     args: string[],
     stdio?: 'pipe' | 'inherit',
-    cwd?: string
+    cwd?: string,
+    ignoreError?: boolean
   ): string {
     const commandResult = spawnSync(command, args, {
       cwd: cwd ?? this.cwd,
@@ -425,7 +426,7 @@ export abstract class JsPackageManager {
       shell: true,
     });
 
-    if (commandResult.status !== 0) {
+    if (commandResult.status !== 0 && ignoreError !== true) {
       throw new Error(commandResult.stderr ?? '');
     }
 

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -48,12 +48,19 @@ export class NPMProxy extends JsPackageManager {
   }
 
   public runPackageCommand(command: string, args: string[], cwd?: string): string {
-    return this.executeCommand(`npm`, ['exec', '--', command, ...args], undefined, cwd);
+    return this.executeCommand('npm', ['exec', '--', command, ...args], undefined, cwd);
   }
 
   public findInstallations() {
     const pipeToNull = platform() === 'win32' ? '2>NUL' : '2>/dev/null';
-    const commandResult = this.executeCommand('npm', ['ls', '--json', '--depth=99', pipeToNull]);
+    const commandResult = this.executeCommand(
+      'npm',
+      ['ls', '--json', '--depth=99', pipeToNull],
+      undefined,
+      undefined,
+      // ignore errors, because npm ls will exit with code 1 if there are e.g. unmet peer dependencies
+      true
+    );
 
     try {
       const parsedOutput = JSON.parse(commandResult);


### PR DESCRIPTION

Closes https://github.com/storybookjs/storybook/issues/21872

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Add ignoreError flag to executeCommand method in JsPackageManager and use it in findInstallations method of NPMProxy to ignore errors returned by npm ls command

## How to test

1. Run `upgrade` command in a repro where `npm ls --json --depth=99` returns some errors, like unmeet peer-dep errors
2. The upgrade shouldn't exit with an error


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
