### PR TITLE
CLI: Make vite the default builder

### DIFF
--- a/code/lib/cli/src/detect.ts
+++ b/code/lib/cli/src/detect.ts
@@ -123,14 +123,12 @@ export function detectBuilder(packageManager: JsPackageManager, projectType: Pro
 
   // Fallback to Vite or Webpack based on project type
   switch (projectType) {
-    case ProjectType.SVELTE:
-    case ProjectType.SVELTEKIT:
-    case ProjectType.VUE:
-    case ProjectType.VUE3:
-    case ProjectType.SFC_VUE:
-      return CoreBuilder.Vite;
-    default:
+    case ProjectType.NEXTJS:
+    case ProjectType.REACT_SCRIPTS:
+    case ProjectType.WEBPACK_REACT:
       return CoreBuilder.Webpack5;
+    default:
+      return CoreBuilder.Vite;
   }
 }
 


### PR DESCRIPTION
## What I did

New projects without a build setup still default to webpack. However, as vite is less prone to config problems (like a missing babelrc file) and in many cases faster, I think that it would makes sense to make vite the default now. 

## How to test

Create a new project, and run npx sb init, and see that it will get a vite builder.

## Checklist

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`


