### PR TITLE
CLI: Mention how to setup a monorepo manually with babel in missing babelrc automigration

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/missing-babelrc.ts
+++ b/code/lib/cli/src/automigrate/fixes/missing-babelrc.ts
@@ -64,14 +64,20 @@ export const missingBabelRc: Fix<MissingBabelRcOptions> = {
 
       If your project does not have a babel configuration file, we can generate one that's equivalent to the 6.x defaults for you. Keep in mind that this can affect your project if it uses babel, and you may need to make additional changes based on your projects needs.
 
+      ${chalk.bold(
+        'Note:'
+      )} This automatic setup doesn't work in a monorepo, see the babel documentation for how to setup babel manually:
+      ${chalk.yellow('https://babeljs.io/docs')}
+
       We can create a ${chalk.blue(
         '.babelrc.json'
       )} file with some basic configuration and add any necessary package devDependencies.
-
+      
       Please see the migration guide for more information:
       ${chalk.yellow(
         'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#babel-mode-v7-exclusively'
       )}
+     
     `;
   },
   async run() {


### PR DESCRIPTION
Closes #21998

## What I did

Mention how to setup a monorepo manually with babel in missing babelrc automigration.

## How to test

See the note when running npx sb init a plain project without a babel file.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
