### PR TITLE
UI: Fix upgrade command in about page

### DIFF
--- a/code/ui/manager/src/settings/about.tsx
+++ b/code/ui/manager/src/settings/about.tsx
@@ -160,7 +160,7 @@ const AboutScreen: FC<{
               <b>Upgrade all Storybook packages to latest:</b>
             </p>
             <SyntaxHighlighter language="bash" copyable padded bordered>
-              npx sb upgrade
+              npx storybook@latest upgrade
             </SyntaxHighlighter>
           </DocumentWrapper>
         </Upgrade>


### PR DESCRIPTION
Closes N/A

## What I did

Users should always upgrade using the latest/next upgrade command, not the one that is currently installed.

<img width="743" alt="image" src="https://user-images.githubusercontent.com/488689/231490475-68ffba58-03ad-4ae1-9797-da8e9914ae54.png">
