### PR TITLE
Core: Restore `useParameter` behaviour for Docs entries

### DIFF
--- a/code/e2e-tests/addon-backgrounds.spec.ts
+++ b/code/e2e-tests/addon-backgrounds.spec.ts
@@ -10,11 +10,14 @@ test.describe('addon-backgrounds', () => {
     await new SbPage(page).waitUntilLoaded();
   });
 
+  const backgroundToolbarSelector = '[title="Change the background of the preview"]';
+  const gridToolbarSelector = '[title="Apply a grid to the preview"]';
+
   test('should have a dark background', async ({ page }) => {
     const sbPage = new SbPage(page);
 
     await sbPage.navigateToStory('example/button', 'primary');
-    await sbPage.selectToolbar('[title="Change the background of the preview"]', '#list-item-dark');
+    await sbPage.selectToolbar(backgroundToolbarSelector, '#list-item-dark');
 
     await expect(sbPage.getCanvasBodyElement()).toHaveCSS('background-color', 'rgb(51, 51, 51)');
   });
@@ -23,8 +26,33 @@ test.describe('addon-backgrounds', () => {
     const sbPage = new SbPage(page);
 
     await sbPage.navigateToStory('example/button', 'primary');
-    await sbPage.selectToolbar('[title="Apply a grid to the preview"]');
+    await sbPage.selectToolbar(gridToolbarSelector);
 
     await expect(sbPage.getCanvasBodyElement()).toHaveCSS('background-image', /linear-gradient/);
+  });
+
+  test('button should appear for story pages', async ({ page }) => {
+    const sbPage = new SbPage(page);
+
+    await sbPage.navigateToStory('example/button', 'primary');
+    await expect(sbPage.page.locator(backgroundToolbarSelector)).toBeVisible();
+  });
+
+  test('button should appear for attached docs pages', async ({ page }) => {
+    const sbPage = new SbPage(page);
+
+    await sbPage.navigateToStory('example/button', 'docs');
+    await expect(sbPage.page.locator(backgroundToolbarSelector)).toBeVisible();
+  });
+
+  test('button should appear for unattached docs pages', async ({ page }) => {
+    const sbPage = new SbPage(page);
+
+    // We start on the introduction page by default.
+    await sbPage.page.waitForURL((url) =>
+      url.search.includes(`path=/docs/example-introduction--docs`)
+    );
+
+    await expect(sbPage.page.locator(backgroundToolbarSelector)).toBeVisible();
   });
 });

--- a/code/lib/core-events/src/index.ts
+++ b/code/lib/core-events/src/index.ts
@@ -23,7 +23,11 @@ enum events {
   FORCE_REMOUNT = 'forceRemount',
   // Request the story has been loaded into the store, ahead of time, before it's actually
   PRELOAD_ENTRIES = 'preloadStories',
-  // The story has been loaded into the store, we have parameters/args/etc
+  // The project has been loaded into the store, we have dynamic annotations (parameters, argTypes)
+  PROJECT_PREPARED = 'projectPrepared',
+  // The component has been loaded into the store, we have dynamic annotations (parameters, argTypes)
+  COMPONENT_PREPARED = 'componentPrepared',
+  // The story has been loaded into the store, we have dynamic annotations (parameters, argTypes, args)
   STORY_PREPARED = 'storyPrepared',
   // The next 6 events are emitted by the StoryRenderer when rendering the current story
   STORY_CHANGED = 'storyChanged',
@@ -42,7 +46,7 @@ enum events {
   STORY_ARGS_UPDATED = 'storyArgsUpdated',
   // Reset either a single arg of a story all args of a story
   RESET_STORY_ARGS = 'resetStoryArgs',
-  // Emitted by the preview at startup once it knows the initial set of globals+globalTypes
+  // Emitted by the preview at startup (and on HMR) once it knows the initial set of globals+globalTypes
   SET_GLOBALS = 'setGlobals',
   // Tell the preview to update the value of a global
   UPDATE_GLOBALS = 'updateGlobals',
@@ -99,6 +103,8 @@ export const {
   STORY_ERRORED,
   STORY_INDEX_INVALIDATED,
   STORY_MISSING,
+  PROJECT_PREPARED,
+  COMPONENT_PREPARED,
   STORY_PREPARED,
   STORY_RENDER_PHASE_CHANGED,
   STORY_RENDERED,

--- a/code/lib/manager-api/src/index.tsx
+++ b/code/lib/manager-api/src/index.tsx
@@ -64,6 +64,7 @@ import * as shortcuts from './modules/shortcuts';
 import * as url from './modules/url';
 import * as version from './modules/versions';
 
+import * as projectAnnotations from './modules/projectAnnotations';
 import * as globals from './modules/globals';
 
 export * from './lib/shortcut';
@@ -93,6 +94,7 @@ export type State = layout.SubState &
   shortcuts.SubState &
   releaseNotes.SubState &
   settings.SubState &
+  projectAnnotations.SubState &
   globals.SubState &
   RouterData &
   API_OptionsData &
@@ -104,6 +106,7 @@ export type API = addons.SubAPI &
   provider.SubAPI &
   stories.SubAPI &
   refs.SubAPI &
+  projectAnnotations.SubAPI &
   globals.SubAPI &
   layout.SubAPI &
   notifications.SubAPI &
@@ -217,6 +220,7 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
       shortcuts,
       stories,
       refs,
+      projectAnnotations,
       globals,
       url,
       version,

--- a/code/lib/manager-api/src/modules/projectAnnotations.ts
+++ b/code/lib/manager-api/src/modules/projectAnnotations.ts
@@ -1,0 +1,46 @@
+import { PROJECT_PREPARED } from '@storybook/core-events';
+import type { API_ProjectAnnotations, ProjectPreparedPayload } from '@storybook/types';
+
+import type { ModuleFn } from '../index';
+
+// eslint-disable-next-line import/no-cycle
+import { getEventMetadata } from '../lib/events';
+
+export interface SubState {
+  projectAnnotations?: API_ProjectAnnotations;
+}
+
+export interface SubAPI {
+  getProjectAnnotations: () => API_ProjectAnnotations | null;
+}
+
+export const init: ModuleFn<SubAPI, SubState, true> = ({ store, fullAPI }) => {
+  const api: SubAPI = {
+    getProjectAnnotations() {
+      return store.getState().projectAnnotations;
+    },
+  };
+
+  const state: SubState = {};
+  const initModule = () => {
+    fullAPI.on(
+      PROJECT_PREPARED,
+      async function handleProjectPrepared({ argTypes, parameters }: ProjectPreparedPayload) {
+        const { ref } = getEventMetadata(this, fullAPI);
+
+        const projectAnnotations = { argTypes, parameters };
+        if (!ref) {
+          await store.setState({ projectAnnotations });
+        } else {
+          await fullAPI.updateRef(ref.id, { projectAnnotations });
+        }
+      }
+    );
+  };
+
+  return {
+    api,
+    state,
+    init: initModule,
+  };
+};

--- a/code/lib/manager-api/src/modules/stories.ts
+++ b/code/lib/manager-api/src/modules/stories.ts
@@ -2,6 +2,7 @@ import { global } from '@storybook/global';
 import { toId, sanitize } from '@storybook/csf';
 import type {
   StoryKind,
+  ComponentId,
   ComponentTitle,
   StoryName,
   StoryId,
@@ -15,10 +16,13 @@ import type {
   StoryIndex,
   API_LoadedRefData,
   API_IndexHash,
+  ComponentPreparedPayload,
+  StoryPreparedPayload,
 } from '@storybook/types';
 import {
   PRELOAD_ENTRIES,
   STORY_PREPARED,
+  COMPONENT_PREPARED,
   UPDATE_STORY_ARGS,
   RESET_STORY_ARGS,
   STORY_ARGS_UPDATED,
@@ -54,7 +58,9 @@ type Direction = -1 | 1;
 type ParameterName = string;
 
 type ViewMode = 'story' | 'info' | 'settings' | string | undefined;
-type StoryUpdate = Pick<API_StoryEntry, 'parameters' | 'initialArgs' | 'argTypes' | 'args'>;
+type StoryUpdate = Partial<
+  Pick<API_StoryEntry, 'prepared' | 'parameters' | 'initialArgs' | 'argTypes' | 'args'>
+>;
 
 export interface SubState extends API_LoadedRefData {
   storyId: StoryId;
@@ -428,7 +434,12 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
       }
     });
 
-    fullAPI.on(STORY_PREPARED, function handler({ id, ...update }) {
+    fullAPI.on(COMPONENT_PREPARED, function handler({ id, ...update }: ComponentPreparedPayload) {
+      const { ref } = getEventMetadata(this, fullAPI);
+      fullAPI.updateStory(id, { ...update, prepared: true }, ref);
+    });
+
+    fullAPI.on(STORY_PREPARED, function handler({ id, ...update }: StoryPreparedPayload) {
       const { ref, sourceType } = getEventMetadata(this, fullAPI);
       fullAPI.updateStory(id, { ...update, prepared: true }, ref);
 

--- a/code/lib/manager-api/src/tests/projectAnnotations.test.ts
+++ b/code/lib/manager-api/src/tests/projectAnnotations.test.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from 'events';
+import { PROJECT_PREPARED } from '@storybook/core-events';
+
+import type { ModuleArgs } from '../index';
+import { init as initModule } from '../modules/projectAnnotations';
+
+const { getEventMetadata } = require('../lib/events');
+
+jest.mock('@storybook/client-logger');
+jest.mock('../lib/events');
+beforeEach(() => {
+  getEventMetadata.mockReset().mockReturnValue({ sourceType: 'local' });
+});
+
+function createMockStore() {
+  let state = {};
+  return {
+    getState: jest.fn().mockImplementation(() => state),
+    setState: jest.fn().mockImplementation((s) => {
+      state = { ...state, ...s };
+    }),
+  };
+}
+
+describe('projectAnnotations API', () => {
+  it('set annotations on PROJECT_PREPARED, local', () => {
+    const api = Object.assign(new EventEmitter(), {});
+    const store = createMockStore();
+    const {
+      state,
+      init,
+      api: newApi,
+    } = initModule({ store, fullAPI: api } as unknown as ModuleArgs);
+    store.setState(state);
+    init();
+
+    api.emit(PROJECT_PREPARED, {
+      parameters: { a: 'b' },
+      argTypes: { a: { type: { name: 'string' } } },
+    });
+    expect(store.getState()).toEqual({
+      projectAnnotations: {
+        parameters: { a: 'b' },
+        argTypes: { a: { type: { name: 'string' } } },
+      },
+    });
+    expect(newApi.getProjectAnnotations()).toEqual({
+      parameters: { a: 'b' },
+      argTypes: { a: { type: { name: 'string' } } },
+    });
+  });
+
+  it('set annotations on PROJECT_PREPARED, ref', () => {
+    const api = Object.assign(new EventEmitter(), { updateRef: jest.fn() });
+    const store = createMockStore();
+    const { state, init } = initModule({ store, fullAPI: api } as unknown as ModuleArgs);
+    store.setState(state);
+    init();
+
+    getEventMetadata.mockReturnValueOnce({ sourceType: 'external', ref: { id: 'ref' } });
+    api.emit(PROJECT_PREPARED, {
+      parameters: { a: 'b' },
+      argTypes: { a: { type: { name: 'string' } } },
+    });
+
+    expect(api.updateRef).toHaveBeenCalledWith('ref', {
+      projectAnnotations: {
+        parameters: { a: 'b' },
+        argTypes: { a: { type: { name: 'string' } } },
+      },
+    });
+  });
+});

--- a/code/lib/preview-api/src/modules/preview-web/Preview.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/Preview.tsx
@@ -6,6 +6,7 @@ import {
   FORCE_REMOUNT,
   FORCE_RE_RENDER,
   GLOBALS_UPDATED,
+  PROJECT_PREPARED,
   RESET_STORY_ARGS,
   SET_GLOBALS,
   STORY_ARGS_UPDATED,
@@ -136,8 +137,9 @@ export class Preview<TRenderer extends Renderer> {
 
   // If initialization gets as far as project annotations, this function runs.
   initializeWithProjectAnnotations(projectAnnotations: ProjectAnnotations<TRenderer>) {
-    this.storyStore.setProjectAnnotations(projectAnnotations);
+    this.setProjectAnnotations(projectAnnotations);
 
+    // Set initial
     this.setInitialGlobals();
 
     let storyIndexPromise: Promise<StoryIndex>;
@@ -156,6 +158,12 @@ export class Preview<TRenderer extends Renderer> {
         this.renderPreviewEntryError('Error loading story index:', err);
         throw err;
       });
+  }
+
+  setProjectAnnotations(projectAnnotations: ProjectAnnotations<TRenderer>) {
+    this.storyStore.setProjectAnnotations(projectAnnotations);
+    const { parameters, argTypes } = projectAnnotations;
+    this.channel.emit(PROJECT_PREPARED, { parameters, argTypes });
   }
 
   async setInitialGlobals() {
@@ -210,7 +218,7 @@ export class Preview<TRenderer extends Renderer> {
       return;
     }
 
-    await this.storyStore.setProjectAnnotations(projectAnnotations);
+    this.setProjectAnnotations(projectAnnotations);
     this.emitGlobals();
   }
 

--- a/code/lib/preview-api/src/modules/preview-web/Preview.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/Preview.tsx
@@ -162,7 +162,7 @@ export class Preview<TRenderer extends Renderer> {
 
   setProjectAnnotations(projectAnnotations: ProjectAnnotations<TRenderer>) {
     this.storyStore.setProjectAnnotations(projectAnnotations);
-    const { parameters, argTypes } = projectAnnotations;
+    const { parameters = {}, argTypes = {} } = projectAnnotations;
     this.channel.emit(PROJECT_PREPARED, { parameters, argTypes });
   }
 

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -28,6 +28,7 @@ import {
   STORY_UNCHANGED,
   UPDATE_GLOBALS,
   UPDATE_STORY_ARGS,
+  PROJECT_PREPARED,
 } from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
 import type { Renderer, ModuleImportFn, ProjectAnnotations } from '@storybook/types';
@@ -178,6 +179,15 @@ describe('PreviewWeb', () => {
       const preview = await createAndRenderPreview();
 
       expect(preview.storyStore.globals!.get()).toEqual({ a: 'c' });
+    });
+
+    it('emits the PROJECT_PREPARED event', async () => {
+      await createAndRenderPreview();
+
+      expect(mockChannel.emit).toHaveBeenCalledWith(PROJECT_PREPARED, {
+        argTypes: {},
+        parameters: { docs: expect.any(Object) },
+      });
     });
 
     it('emits the SET_GLOBALS event', async () => {
@@ -3304,6 +3314,21 @@ describe('PreviewWeb', () => {
       await waitForRender();
 
       expect(preview.storyStore.globals!.get()).toEqual({ a: 'edited' });
+    });
+
+    it('emits PROJECT_PREPARED with new values', async () => {
+      document.location.search = '?id=component-one--a';
+      const preview = await createAndRenderPreview();
+
+      mockChannel.emit.mockClear();
+      preview.onGetProjectAnnotationsChanged({ getProjectAnnotations: newGetProjectAnnotations });
+      await waitForRender();
+
+      await waitForEvents([PROJECT_PREPARED]);
+      expect(mockChannel.emit).toHaveBeenCalledWith(PROJECT_PREPARED, {
+        argTypes: {},
+        parameters: { docs: expect.any(Object) },
+      });
     });
 
     it('emits SET_GLOBALS with new values', async () => {

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -29,6 +29,7 @@ import {
   UPDATE_GLOBALS,
   UPDATE_STORY_ARGS,
   PROJECT_PREPARED,
+  COMPONENT_PREPARED,
 } from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
 import type { Renderer, ModuleImportFn, ProjectAnnotations } from '@storybook/types';
@@ -432,6 +433,23 @@ describe('PreviewWeb', () => {
         );
       });
 
+      it('emits COMPONENT_PREPARED', async () => {
+        document.location.search = '?id=component-one--a';
+        await createAndRenderPreview();
+
+        expect(mockChannel.emit).toHaveBeenCalledWith(COMPONENT_PREPARED, {
+          id: 'component-one',
+          parameters: {
+            docs: expect.any(Object),
+            fileName: './src/ComponentOne.stories.js',
+          },
+          argTypes: {
+            foo: { name: 'foo', type: { name: 'string' } },
+            one: { name: 'one', type: { name: 'string' }, mapping: { 1: 'mapped-1' } },
+          },
+        });
+      });
+
       it('emits STORY_PREPARED', async () => {
         document.location.search = '?id=component-one--a';
         await createAndRenderPreview();
@@ -710,6 +728,23 @@ describe('PreviewWeb', () => {
         ]);
       });
 
+      it('emits COMPONENT_PREPARED', async () => {
+        document.location.search = '?id=component-one--docs&viewMode=docs';
+        await createAndRenderPreview();
+
+        expect(mockChannel.emit).toHaveBeenCalledWith(COMPONENT_PREPARED, {
+          id: 'component-one',
+          parameters: {
+            docs: expect.any(Object),
+            fileName: './src/ComponentOne.stories.js',
+          },
+          argTypes: {
+            foo: { name: 'foo', type: { name: 'string' } },
+            one: { name: 'one', type: { name: 'string' }, mapping: { 1: 'mapped-1' } },
+          },
+        });
+      });
+
       it('emits DOCS_RENDERED', async () => {
         document.location.search = '?id=component-one--docs&viewMode=docs';
 
@@ -753,6 +788,13 @@ describe('PreviewWeb', () => {
         await createAndRenderPreview();
 
         expect(importFn).toHaveBeenCalledWith('./src/ComponentTwo.stories.js');
+      });
+
+      it('DOES NOT emit COMPONENT_PREPARED', async () => {
+        document.location.search = '?id=introduction--docs&viewMode=docs';
+        await createAndRenderPreview();
+
+        expect(mockChannel.emit).not.toHaveBeenCalledWith(COMPONENT_PREPARED, expect.any(Object));
       });
 
       it('emits DOCS_RENDERED', async () => {
@@ -1866,6 +1908,31 @@ describe('PreviewWeb', () => {
         expect(mockChannel.emit).toHaveBeenCalledWith(STORY_CHANGED, 'component-one--b');
       });
 
+      it('emits COMPONENT_PREPARED', async () => {
+        document.location.search = '?id=component-one--a';
+        await createAndRenderPreview();
+
+        mockChannel.emit.mockClear();
+        emitter.emit(SET_CURRENT_STORY, {
+          storyId: 'component-one--b',
+          viewMode: 'story',
+        });
+        await waitForSetCurrentStory();
+
+        await waitForEvents([COMPONENT_PREPARED]);
+        expect(mockChannel.emit).toHaveBeenCalledWith(COMPONENT_PREPARED, {
+          id: 'component-one',
+          parameters: {
+            docs: expect.any(Object),
+            fileName: './src/ComponentOne.stories.js',
+          },
+          argTypes: {
+            foo: { name: 'foo', type: { name: 'string' } },
+            one: { name: 'one', type: { name: 'string' }, mapping: { 1: 'mapped-1' } },
+          },
+        });
+      });
+
       it('emits STORY_PREPARED', async () => {
         document.location.search = '?id=component-one--a';
         await createAndRenderPreview();
@@ -2362,6 +2429,31 @@ describe('PreviewWeb', () => {
         });
       });
 
+      it('emits COMPONENT_PREPARED', async () => {
+        document.location.search = '?id=component-one--a';
+        await createAndRenderPreview();
+
+        mockChannel.emit.mockClear();
+        emitter.emit(SET_CURRENT_STORY, {
+          storyId: 'component-one--docs',
+          viewMode: 'docs',
+        });
+        await waitForSetCurrentStory();
+        await waitForRender();
+
+        expect(mockChannel.emit).toHaveBeenCalledWith(COMPONENT_PREPARED, {
+          id: 'component-one',
+          parameters: {
+            docs: expect.any(Object),
+            fileName: './src/ComponentOne.stories.js',
+          },
+          argTypes: {
+            foo: { name: 'foo', type: { name: 'string' } },
+            one: { name: 'one', type: { name: 'string' }, mapping: { 1: 'mapped-1' } },
+          },
+        });
+      });
+
       it('emits DOCS_RENDERED', async () => {
         document.location.search = '?id=component-one--a';
         await createAndRenderPreview();
@@ -2444,6 +2536,31 @@ describe('PreviewWeb', () => {
             id: 'component-one--a',
           })
         );
+      });
+
+      it('emits COMPONENT_PREPARED', async () => {
+        document.location.search = '?id=component-one--docs&viewMode=docs';
+        await createAndRenderPreview();
+
+        mockChannel.emit.mockClear();
+        emitter.emit(SET_CURRENT_STORY, {
+          storyId: 'component-one--a',
+          viewMode: 'story',
+        });
+        await waitForSetCurrentStory();
+
+        await waitForEvents([COMPONENT_PREPARED]);
+        expect(mockChannel.emit).toHaveBeenCalledWith(COMPONENT_PREPARED, {
+          id: 'component-one',
+          parameters: {
+            docs: expect.any(Object),
+            fileName: './src/ComponentOne.stories.js',
+          },
+          argTypes: {
+            foo: { name: 'foo', type: { name: 'string' } },
+            one: { name: 'one', type: { name: 'string' }, mapping: { 1: 'mapped-1' } },
+          },
+        });
       });
 
       it('emits STORY_PREPARED', async () => {
@@ -2692,7 +2809,7 @@ describe('PreviewWeb', () => {
           : componentTwoExports;
       });
 
-      it('calls renderToCanvass teardown', async () => {
+      it('calls renderToCanvas teardown', async () => {
         document.location.search = '?id=component-one--a';
         const preview = await createAndRenderPreview();
         mockChannel.emit.mockClear();
@@ -2723,6 +2840,27 @@ describe('PreviewWeb', () => {
         await waitForRender();
 
         expect(mockChannel.emit).not.toHaveBeenCalledWith(STORY_CHANGED, 'component-one--a');
+      });
+
+      it('emits COMPONENT_PREPARED', async () => {
+        document.location.search = '?id=component-one--a';
+        const preview = await createAndRenderPreview();
+        mockChannel.emit.mockClear();
+
+        preview.onStoriesChanged({ importFn: newImportFn });
+        await waitForRender();
+
+        expect(mockChannel.emit).toHaveBeenCalledWith(COMPONENT_PREPARED, {
+          id: 'component-one',
+          parameters: {
+            docs: expect.any(Object),
+            fileName: './src/ComponentOne.stories.js',
+          },
+          argTypes: {
+            foo: { name: 'foo', type: { name: 'string' } },
+            one: { name: 'one', type: { name: 'string' }, mapping: { 1: 'mapped-1' } },
+          },
+        });
       });
 
       it('emits STORY_PREPARED with new annotations', async () => {

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWithSelection.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWithSelection.tsx
@@ -89,12 +89,6 @@ export class PreviewWithSelection<TFramework extends Renderer> extends Preview<T
     this.channel.on(PRELOAD_ENTRIES, this.onPreloadStories.bind(this));
   }
 
-  initializeWithProjectAnnotations(projectAnnotations: ProjectAnnotations<TFramework>) {
-    return super
-      .initializeWithProjectAnnotations(projectAnnotations)
-      .then(() => this.setInitialGlobals());
-  }
-
   async setInitialGlobals() {
     if (!this.storyStore.globals)
       throw new Error(`Cannot call setInitialGlobals before initialization`);

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWithSelection.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWithSelection.tsx
@@ -82,7 +82,7 @@ function isCsfDocsRender<TFramework extends Renderer>(
   return isDocsRender(r) && r.subtype === 'csf';
 }
 
-function componentId(storyId: StoryId): ComponentId {
+function toComponentId(storyId: StoryId): ComponentId {
   return storyId.split('--')[0];
 }
 
@@ -395,7 +395,7 @@ export class PreviewWithSelection<TFramework extends Renderer> extends Preview<T
 
       const { parameters, argTypes } = this.storyStore.preparedMetaFromCSFFile({ csfFile });
       this.channel.emit(COMPONENT_PREPARED, {
-        id: componentId(storyId),
+        id: toComponentId(storyId),
         parameters,
         argTypes,
       });

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.test.ts
@@ -39,6 +39,7 @@ describe('resolveOf', () => {
     const projectAnnotations = { render: jest.fn() };
     const store = {
       componentStoriesFromCSFFile: () => [story],
+      preparedMetaFromCSFFile: () => ({ prepareMeta: 'preparedMeta' }),
       projectAnnotations,
     } as unknown as StoryStore<Renderer>;
     const context = new DocsContext(channel, store, renderStoryToElement, [csfFile]);
@@ -179,6 +180,7 @@ describe('resolveOf', () => {
     const projectAnnotations = { render: jest.fn() };
     const store = {
       componentStoriesFromCSFFile: () => [story],
+      preparedMetaFromCSFFile: () => ({ prepareMeta: 'preparedMeta' }),
       projectAnnotations,
     } as unknown as StoryStore<Renderer>;
     const context = new DocsContext(channel, store, renderStoryToElement, [csfFile]);

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
@@ -14,7 +14,6 @@ import type { Channel } from '@storybook/channels';
 
 import dedent from 'ts-dedent';
 import type { StoryStore } from '../../store';
-import { prepareMeta } from '../../store';
 import type { DocsContextProps } from './DocsContextProps';
 
 export class DocsContext<TRenderer extends Renderer> implements DocsContextProps<TRenderer> {
@@ -181,11 +180,7 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
       case 'meta': {
         return {
           ...resolved,
-          preparedMeta: prepareMeta(
-            resolved.csfFile.meta,
-            this.projectAnnotations,
-            resolved.csfFile.moduleExports.default
-          ),
+          preparedMeta: this.store.preparedMetaFromCSFFile({ csfFile: resolved.csfFile }),
         };
       }
       case 'story':

--- a/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts
@@ -31,6 +31,8 @@ import { DocsContext } from '../docs-context/DocsContext';
 export class CsfDocsRender<TRenderer extends Renderer> implements Render<TRenderer> {
   public readonly type: RenderType = 'docs';
 
+  public readonly subtype = 'csf';
+
   public readonly id: StoryId;
 
   public story?: PreparedStory<TRenderer>;
@@ -45,7 +47,7 @@ export class CsfDocsRender<TRenderer extends Renderer> implements Render<TRender
 
   public preparing = false;
 
-  private csfFiles?: CSFFile<TRenderer>[];
+  public csfFiles?: CSFFile<TRenderer>[];
 
   constructor(
     protected channel: Channel,

--- a/code/lib/preview-api/src/modules/preview-web/render/MdxDocsRender.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/MdxDocsRender.ts
@@ -29,6 +29,8 @@ import { DocsContext } from '../docs-context/DocsContext';
 export class MdxDocsRender<TRenderer extends Renderer> implements Render<TRenderer> {
   public readonly type: RenderType = 'docs';
 
+  public readonly subtype = 'mdx';
+
   public readonly id: StoryId;
 
   private exports?: ModuleExports;

--- a/code/lib/preview-api/src/modules/preview-web/render/StoryRender.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/StoryRender.test.ts
@@ -25,10 +25,11 @@ describe('StoryRender', () => {
   it('throws PREPARE_ABORTED if torndown during prepare', async () => {
     const [importGate, openImportGate] = createGate();
     const mockStore = {
-      loadStory: jest.fn(async () => {
+      loadCSFFileByStoryId: jest.fn(async () => {
         await importGate;
         return {};
       }),
+      storyFromCSFFile: () => ({}),
       cleanupStory: jest.fn(),
     };
 

--- a/code/lib/preview-api/src/modules/store/csf/prepareStory.test.ts
+++ b/code/lib/preview-api/src/modules/store/csf/prepareStory.test.ts
@@ -724,10 +724,12 @@ describe('prepareMeta', () => {
       undecoratedStoryFn,
       playFunction,
       prepareContext,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      parameters: { __isArgsStory, ...parameters },
       ...expectedPreparedMeta
     } = preparedStory;
 
-    expect(preparedMeta).toMatchObject(expectedPreparedMeta);
-    expect(Object.keys(preparedMeta)).toHaveLength(Object.keys(expectedPreparedMeta).length);
+    expect(preparedMeta).toMatchObject({ ...expectedPreparedMeta, parameters });
+    expect(Object.keys(preparedMeta)).toHaveLength(Object.keys(expectedPreparedMeta).length + 1);
   });
 });

--- a/code/lib/preview-api/src/modules/store/csf/prepareStory.ts
+++ b/code/lib/preview-api/src/modules/store/csf/prepareStory.ts
@@ -190,7 +190,6 @@ function preparePartialAnnotations<TRenderer extends Renderer>(
     componentAnnotations.render ||
     projectAnnotations.render;
 
-  if (!render) throw new Error(`No render function available for id '${id}'`);
   const passedArgTypes: StrictArgTypes = combineParameters(
     projectAnnotations.argTypes,
     componentAnnotations.argTypes,
@@ -199,7 +198,7 @@ function preparePartialAnnotations<TRenderer extends Renderer>(
 
   const { passArgsFirst = true } = parameters;
   // eslint-disable-next-line no-underscore-dangle
-  parameters.__isArgsStory = passArgsFirst && render.length > 0;
+  parameters.__isArgsStory = passArgsFirst && render && render.length > 0;
 
   // Pull out args[X] into initialArgs for argTypes enhancers
   const passedArgs: Args = {

--- a/code/lib/preview-api/src/modules/store/csf/prepareStory.ts
+++ b/code/lib/preview-api/src/modules/store/csf/prepareStory.ts
@@ -169,8 +169,6 @@ function preparePartialAnnotations<TRenderer extends Renderer>(
   // anything at render time. The assumption is that as we don't load all the stories at once, this
   // will have a limited cost. If this proves misguided, we can refactor it.
 
-  const id = storyAnnotations?.id || componentAnnotations.id;
-
   const tags = [...(storyAnnotations?.tags || componentAnnotations.tags || []), 'story'];
 
   const parameters: Parameters = combineParameters(
@@ -182,23 +180,25 @@ function preparePartialAnnotations<TRenderer extends Renderer>(
   // Currently it is only possible to set these globally
   const { argTypesEnhancers = [], argsEnhancers = [] } = projectAnnotations;
 
-  // The render function on annotations *has* to be an `ArgsStoryFn`, so when we normalize
-  // CSFv1/2, we use a new field called `userStoryFn` so we know that it can be a LegacyStoryFn
-  const render =
-    storyAnnotations?.userStoryFn ||
-    storyAnnotations?.render ||
-    componentAnnotations.render ||
-    projectAnnotations.render;
-
   const passedArgTypes: StrictArgTypes = combineParameters(
     projectAnnotations.argTypes,
     componentAnnotations.argTypes,
     storyAnnotations?.argTypes
   ) as StrictArgTypes;
 
-  const { passArgsFirst = true } = parameters;
-  // eslint-disable-next-line no-underscore-dangle
-  parameters.__isArgsStory = passArgsFirst && render && render.length > 0;
+  if (storyAnnotations) {
+    // The render function on annotations *has* to be an `ArgsStoryFn`, so when we normalize
+    // CSFv1/2, we use a new field called `userStoryFn` so we know that it can be a LegacyStoryFn
+    const render =
+      storyAnnotations?.userStoryFn ||
+      storyAnnotations?.render ||
+      componentAnnotations.render ||
+      projectAnnotations.render;
+    const { passArgsFirst = true } = parameters;
+
+    // eslint-disable-next-line no-underscore-dangle
+    parameters.__isArgsStory = passArgsFirst && render && render.length > 0;
+  }
 
   // Pull out args[X] into initialArgs for argTypes enhancers
   const passedArgs: Args = {

--- a/code/lib/types/src/modules/api-stories.ts
+++ b/code/lib/types/src/modules/api-stories.ts
@@ -49,6 +49,9 @@ export interface API_ComponentEntry extends API_BaseEntry {
   parent?: StoryId;
   children: StoryId[];
 
+  prepared: boolean;
+  parameters?: Parameters;
+
   /** @deprecated */
   isRoot: false;
   /** @deprecated */
@@ -82,9 +85,7 @@ export interface API_StoryEntry extends API_BaseEntry {
   importPath: Path;
   tags: Tag[];
   prepared: boolean;
-  parameters?: {
-    [parameterName: string]: any;
-  };
+  parameters?: Parameters;
   args?: Args;
   argTypes?: ArgTypes;
   initialArgs?: Args;

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -3,7 +3,7 @@
 import type { RenderData } from '../../../router/src/types';
 import type { Channel } from '../../../channels/src';
 import type { ThemeVars } from '../../../theming/src/types';
-import type { ViewMode } from './csf';
+import type { ArgTypes, Parameters, ViewMode } from './csf';
 import type { DocsOptions } from './core-common';
 import type { API_HashEntry, API_IndexHash } from './api-stories';
 import type { SetStoriesStory, SetStoriesStoryData } from './channelApi';
@@ -134,10 +134,16 @@ export type API_SetRefData = Partial<
 
 export type API_StoryMapper = (ref: API_ComposedRef, story: SetStoriesStory) => SetStoriesStory;
 
+export type API_ProjectAnnotations = {
+  argTypes: ArgTypes;
+  parameters: Parameters;
+};
+
 export interface API_LoadedRefData {
   index?: API_IndexHash;
   indexError?: Error;
   previewInitialized: boolean;
+  projectAnnotations?: API_ProjectAnnotations;
 }
 
 export interface API_ComposedRef extends API_LoadedRefData {
@@ -163,6 +169,7 @@ export type API_ComposedRefUpdate = Partial<
     | 'version'
     | 'indexError'
     | 'previewInitialized'
+    | 'projectAnnotations'
   >
 >;
 

--- a/code/lib/types/src/modules/channelApi.ts
+++ b/code/lib/types/src/modules/channelApi.ts
@@ -55,3 +55,22 @@ export interface SetGlobalsPayload {
   globals: Globals;
   globalTypes: GlobalTypes;
 }
+
+export interface ProjectPreparedPayload {
+  argTypes: ArgTypes;
+  parameters: Parameters;
+}
+
+export interface ComponentPreparedPayload {
+  id: ComponentId;
+  argTypes: ArgTypes;
+  parameters: Parameters;
+}
+
+export interface StoryPreparedPayload {
+  id: StoryId;
+  args: Args;
+  initialArgs: Args;
+  argTypes: ArgTypes;
+  parameters: Parameters;
+}

--- a/code/ui/manager/src/globals/exports.ts
+++ b/code/ui/manager/src/globals/exports.ts
@@ -116,6 +116,7 @@ export default {
   '@storybook/channels': ['Channel'],
   '@storybook/core-events': [
     'CHANNEL_CREATED',
+    'COMPONENT_PREPARED',
     'CONFIG_ERROR',
     'CURRENT_STORY_WAS_SET',
     'DOCS_RENDERED',
@@ -128,6 +129,7 @@ export default {
     'PRELOAD_ENTRIES',
     'PREVIEW_BUILDER_PROGRESS',
     'PREVIEW_KEYDOWN',
+    'PROJECT_PREPARED',
     'REGISTER_SUBSCRIPTION',
     'RESET_STORY_ARGS',
     'SELECT_STORY',

--- a/code/ui/manager/src/index.tsx
+++ b/code/ui/manager/src/index.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { Location, LocationProvider, useNavigate } from '@storybook/router';
-import { Provider as ManagerProvider } from '@storybook/manager-api';
+import { Provider as ManagerProvider, useParameter } from '@storybook/manager-api';
 import type { Combo } from '@storybook/manager-api';
 import { ThemeProvider, ensure as ensureTheme } from '@storybook/theming';
 
@@ -45,6 +45,7 @@ const Main: FC<{ provider: Provider }> = ({ provider }) => {
           docsOptions={global?.DOCS_OPTIONS || {}}
         >
           {({ state, api }: Combo) => {
+            console.log(useParameter('backgrounds'));
             const panelCount = Object.keys(api.getPanels()).length;
             const story = api.getData(state.storyId, state.refId);
             const isLoading = story


### PR DESCRIPTION
Closes #21798 

## What I did

- Added two new events `PROJECT_PREPARED` and `COMPONENT_PREPARED`, analogous to `STORY_PREPARED`.
- They transmit annotations (specifically `argTypes` and `parameters`) at appropriate times for components and the project.
- Collect this information on the manager side:
  - Component annotations get stored in the `index` (both for local + refs), similar to the story annotations
  - Project annotations get stored at the top-level (both for local + ref)
- Update `getParameter` (`useParameter`) to fall back to the component then the project if parameters are not available.

This means attached docs use the component's parameters -- in particular it means certain toolbars (backgrounds in essentials) appear again:

<img width="349" alt="image" src="https://user-images.githubusercontent.com/132554/231749740-cb020bc6-8984-4628-8b0a-c1be4d81a772.png">

And unattached docs use the project's:

<img width="478" alt="image" src="https://user-images.githubusercontent.com/132554/231749708-524b3878-78a6-4fb2-bf5a-e28cb2957db7.png">

## What I didn't do, but could in future:

1. Also store globals+globalTypes in the `state.projectAnnotations` and `ref.projectAnnotations`. This, plus an update to `getGlobals[Types]` would address https://github.com/storybookjs/storybook/issues/17759.
  A. Additional to this we should probably refactor the `SET_GLOBALS` event to just be part of `PROJECT_PREPARED`.
3. Send over (initial) args (or other annotations) at the component or project level (I'm not sure if we should?). Then again, are `argTypes` useful without initial args?
4. Refactor this code to read options from the project parameter rather than the first story, which seems like a good move!: https://github.com/storybookjs/storybook/blob/be000bb1ccc4febd160fc53cc2a73d53f97faf2c/code/lib/manager-api/src/modules/stories.ts#L435-L442

## How to test

 - Run a sandbox, check toolbar behaviour
 - Check the same for composition!
 - See tests

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
