### PR TITLE
fix: make sure shift + 7 shortcut to focus search field works

### DIFF
--- a/code/lib/manager-api/src/lib/shortcut.ts
+++ b/code/lib/manager-api/src/lib/shortcut.ts
@@ -80,7 +80,7 @@ export const shortcutMatchesShortcut = (
   shortcut: API_KeyCollection
 ): boolean => {
   if (!inputShortcut || !shortcut) return false;
-  if (inputShortcut.join('') === 'shift/') inputShortcut.shift(); // shift is optional for `/`
+  if (inputShortcut.join('').startsWith('shift/')) inputShortcut.shift(); // shift is optional for `/`
   if (inputShortcut.length !== shortcut.length) return false;
   return !inputShortcut.find((input, i) =>
     Array.isArray(input) ? !input.includes(shortcut[i]) : input !== shortcut[i]


### PR DESCRIPTION
Closes #22072

## What I did

Due to problem described in issue, shortcut doesn't match. With `startsWith` it does match, which makes the shortcut work again.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Click [shift] + [7] (`/`)

The search field should now be focused!

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
