### PR TITLE
Update snippet storybook-vite-builder-register.js.mdx

### DIFF
--- a/docs/snippets/common/storybook-vite-builder-register.js.mdx
+++ b/docs/snippets/common/storybook-vite-builder-register.js.mdx
@@ -4,8 +4,9 @@
 export default {
   stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
-  core: {
-    builder: '@storybook/builder-vite', // 👈 The builder enabled here.
+  framework: {
+    name: '@storybook/builder-vite', // 👈 The builder enabled here.
+    options: {}
   },
 };
 ```


### PR DESCRIPTION
The actual snippet contains old configuration. As said in the [MIGRATION.md](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#builderoptions-renamed): "`core.builder` are now removed, in favor of the new frameworks api.".

## What I did

Removes the `core.builder` option and replace it for `framework` config.

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
