### PR TITLE
CLI: Add addon query-params to list of SB7 incompatible addons

### DIFF
--- a/code/lib/cli/src/automigrate/helpers/getIncompatibleAddons.ts
+++ b/code/lib/cli/src/automigrate/helpers/getIncompatibleAddons.ts
@@ -30,6 +30,7 @@ export const getIncompatibleAddons = async (mainConfig: StorybookConfig) => {
     'storybook-addon-mock': '3.2.0',
     '@chakra-ui/storybook-addon': '4.0.16',
     'storybook-mobile-addon': '1.0.2',
+    '@storybook/addon-queryparams': '6.2.9',
   };
 
   const addons = getAddonNames(mainConfig).filter((addon) => addon in incompatibleList);


### PR DESCRIPTION
With this pull request, the `addon-queryparams` addon is added to the list of incompatible addons per this [comment](https://github.com/storybookjs/storybook/issues/20529#issuecomment-1507937040) and also based on a cursory search, the addon itself is no longer being actively maintained since 6.4 and to avoid further issues it would be on our best interest to also add this one as well.

What was done:
- Updated the list of incompatible addons in the CLI to feature the mentioned addon