### PR TITLE
CLI: Do not show a migration summary on sb init

### DIFF
--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -59,6 +59,7 @@ export const automigrate = async ({
   configDir: userSpecifiedConfigDir,
   renderer: rendererPackage,
   skipInstall,
+  hideMigrationSummary = false,
 }: FixOptions = {}) => {
   if (list) {
     logAvailableMigrations();
@@ -100,17 +101,19 @@ export const automigrate = async ({
     await remove(TEMP_LOG_FILE_PATH);
   }
 
-  const packageManager = JsPackageManagerFactory.getPackageManager({ force: pkgMgr });
-  const installationMetadata = await packageManager.findInstallations([
-    '@storybook/*',
-    'storybook',
-  ]);
+  if (!hideMigrationSummary) {
+    const packageManager = JsPackageManagerFactory.getPackageManager({ force: pkgMgr });
+    const installationMetadata = await packageManager.findInstallations([
+      '@storybook/*',
+      'storybook',
+    ]);
 
-  logger.info();
-  logger.info(
-    getMigrationSummary({ fixResults, fixSummary, logFile: LOG_FILE_PATH, installationMetadata })
-  );
-  logger.info();
+    logger.info();
+    logger.info(
+      getMigrationSummary({ fixResults, fixSummary, logFile: LOG_FILE_PATH, installationMetadata })
+    );
+    logger.info();
+  }
 
   cleanup();
 

--- a/code/lib/cli/src/automigrate/types.ts
+++ b/code/lib/cli/src/automigrate/types.ts
@@ -41,6 +41,7 @@ export interface FixOptions {
   configDir?: string;
   renderer?: string;
   skipInstall?: boolean;
+  hideMigrationSummary?: boolean;
 }
 
 export enum FixStatus {

--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -342,6 +342,7 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
       packageManager: pkgMgr,
       fixes: initFixes,
       configDir: installResult?.configDir,
+      hideMigrationSummary: true,
     });
   }
 


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR makes the `sb init` not display the migration summary, as it's quite confusing to see notes about migration when starting a fresh Storybook project.

Before:
<img width="611" alt="image" src="https://user-images.githubusercontent.com/1671563/232229940-faa412b3-f35c-4026-9266-d4239cdfdd7d.png">

After:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/1671563/232229930-ca00e0c7-ff86-45ed-9fbe-a187a0f5034d.png">


## How to test

1. build the cli
2. run `code/lib/cli/bin/index.js init` on a project
3. notice that there's no summary anymore

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
