### PR TITLE
feat(autodocs): allow opt-out of autodocs when globally set to true

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -184,7 +184,7 @@ describe('StoryIndexGenerator', () => {
                 "importPath": "./src/D.stories.jsx",
                 "name": "Story One",
                 "tags": Array [
-                  "autodocs",
+                  "no-autodocs",
                   "story",
                 ],
                 "title": "D",
@@ -324,24 +324,12 @@ describe('StoryIndexGenerator', () => {
                 "title": "B",
                 "type": "story",
               },
-              "d--docs": Object {
-                "id": "d--docs",
-                "importPath": "./src/D.stories.jsx",
-                "name": "docs",
-                "storiesImports": Array [],
-                "tags": Array [
-                  "autodocs",
-                  "docs",
-                ],
-                "title": "D",
-                "type": "docs",
-              },
               "d--story-one": Object {
                 "id": "d--story-one",
                 "importPath": "./src/D.stories.jsx",
                 "name": "Story One",
                 "tags": Array [
-                  "autodocs",
+                  "no-autodocs",
                   "story",
                 ],
                 "title": "D",
@@ -406,7 +394,6 @@ describe('StoryIndexGenerator', () => {
             "a--story-one",
             "b--docs",
             "b--story-one",
-            "d--docs",
             "d--story-one",
             "first-nested-deeply-f--docs",
             "first-nested-deeply-f--story-one",
@@ -432,7 +419,6 @@ describe('StoryIndexGenerator', () => {
           expect.arrayContaining(['autodocs'])
         );
       });
-
       it('throws an error if you attach a named MetaOf entry which clashes with a tagged autodocs entry', async () => {
         const csfSpecifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
           './src/B.stories.ts',

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -45,6 +45,7 @@ type CacheEntry = false | StoriesCacheEntry | DocsCacheEntry | ErrorEntry;
 type SpecifierStoriesCache = Record<Path, CacheEntry>;
 
 export const AUTODOCS_TAG = 'autodocs';
+export const NO_AUTODOCS_TAG = 'no-autodocs';
 export const STORIES_MDX_TAG = 'stories-mdx';
 export const PLAY_FN_TAG = 'play-fn';
 
@@ -266,7 +267,9 @@ export class StoryIndexGenerator {
     if (csf.stories.length) {
       const { autodocs } = this.options.docs;
       const componentAutodocs = componentTags.includes(AUTODOCS_TAG);
-      const autodocsOptedIn = autodocs === true || (autodocs === 'tag' && componentAutodocs);
+      const autodocsOptedIn =
+        !componentTags.includes(NO_AUTODOCS_TAG) &&
+        (autodocs === true || (autodocs === 'tag' && componentAutodocs));
       // We need a docs entry attached to the CSF file if either:
       //  a) it is a stories.mdx transpiled to CSF, OR
       //  b) we have docs page enabled for this file

--- a/code/lib/core-server/src/utils/__mockdata__/src/D.stories.jsx
+++ b/code/lib/core-server/src/utils/__mockdata__/src/D.stories.jsx
@@ -1,7 +1,7 @@
 const component = {};
 export default {
   component,
-  tags: ['autodocs'],
+  tags: ['no-autodocs'],
 };
 
 export const StoryOne = {};

--- a/code/lib/core-server/src/utils/stories-json.test.ts
+++ b/code/lib/core-server/src/utils/stories-json.test.ts
@@ -171,7 +171,7 @@ describe('useStoriesJson', () => {
               "importPath": "./src/D.stories.jsx",
               "name": "Story One",
               "tags": Array [
-                "autodocs",
+                "no-autodocs",
                 "story",
               ],
               "title": "D",
@@ -373,7 +373,7 @@ describe('useStoriesJson', () => {
               },
               "story": "Story One",
               "tags": Array [
-                "autodocs",
+                "no-autodocs",
                 "story",
               ],
               "title": "D",
@@ -586,7 +586,7 @@ describe('useStoriesJson', () => {
               },
               "story": "Story One",
               "tags": Array [
-                "autodocs",
+                "no-autodocs",
                 "story",
               ],
               "title": "D",
@@ -760,7 +760,7 @@ describe('useStoriesJson', () => {
               },
               "story": "Story One",
               "tags": Array [
-                "autodocs",
+                "no-autodocs",
                 "story",
               ],
               "title": "D",

--- a/code/lib/preview-api/src/modules/client-api/StoryStoreFacade.ts
+++ b/code/lib/preview-api/src/modules/client-api/StoryStoreFacade.ts
@@ -22,6 +22,7 @@ import type { StoryStore } from '../../store';
 import { userOrAutoTitle, sortStoriesV6 } from '../../store';
 
 export const AUTODOCS_TAG = 'autodocs';
+export const NO_AUTODOCS_TAG = 'no-autodocs';
 export const STORIES_MDX_TAG = 'stories-mdx';
 
 export class StoryStoreFacade<TRenderer extends Renderer> {
@@ -210,7 +211,9 @@ export class StoryStoreFacade<TRenderer extends Renderer> {
     const docsOptions = (global.DOCS_OPTIONS || {}) as DocsOptions;
     const { autodocs } = docsOptions;
     const componentAutodocs = componentTags.includes(AUTODOCS_TAG);
-    const autodocsOptedIn = autodocs === true || (autodocs === 'tag' && componentAutodocs);
+    const autodocsOptedIn =
+      !componentTags.includes(NO_AUTODOCS_TAG) &&
+      (autodocs === true || (autodocs === 'tag' && componentAutodocs));
     if (storyExports.length) {
       if (componentTags.includes(STORIES_MDX_TAG) || autodocsOptedIn) {
         const name = docsOptions.defaultName;

--- a/code/lib/preview-api/src/modules/core-client/start.test.ts
+++ b/code/lib/preview-api/src/modules/core-client/start.test.ts
@@ -1336,7 +1336,7 @@ describe('start', () => {
         global.DOCS_OPTIONS = { autodocs: true, defaultName: 'Docs' };
       });
 
-      it('adds stories for each component with autodocs tag', async () => {
+      it('adds stories for each component with autodocs tag & not no-autodocs tag', async () => {
         const renderToDOM = jest.fn();
 
         const { configure, clientApi } = start(renderToDOM);
@@ -1354,6 +1354,11 @@ describe('start', () => {
             .addParameters({ tags: ['autodocs'] })
             .add('Story Three', jest.fn());
 
+          clientApi
+            .storiesOf('Component D', { id: 'file2' } as NodeModule)
+            .addParameters({ tags: ['no-autodocs'] })
+            .add('Story Three', jest.fn());
+
           return [componentCExports];
         });
 
@@ -1366,6 +1371,7 @@ describe('start', () => {
             "component-a--story-two",
             "component-b--docs",
             "component-b--story-three",
+            "component-d--story-three",
             "component-c--docs",
             "component-c--story-one",
             "component-c--story-two",

--- a/code/renderers/react/template/stories/errors.stories.tsx
+++ b/code/renderers/react/template/stories/errors.stories.tsx
@@ -9,6 +9,7 @@ export default {
     storyshots: { disable: true },
     chromatic: { disable: true },
   },
+  tags: ['no-autodocs'],
   decorators: [
     // Skip errors if we are running in the test runner
     (storyFn: any) => window?.navigator?.userAgent?.match(/StorybookTestRunner/) || storyFn(),

--- a/docs/snippets/common/storybook-autodocs-true-disable-per-story.js.mdx
+++ b/docs/snippets/common/storybook-autodocs-true-disable-per-story.js.mdx
@@ -1,0 +1,11 @@
+```js
+// Button.stories.js|jsx
+
+import { Button } from './Button':
+
+export default {
+  title: 'Button',
+  tags: ['no-autodocs'],
+  component: Button,
+}
+```

--- a/docs/snippets/common/storybook-autodocs-true-disable-per-story.ts.mdx
+++ b/docs/snippets/common/storybook-autodocs-true-disable-per-story.ts.mdx
@@ -1,0 +1,16 @@
+```ts
+// Button.stories.ts|tsx
+
+// Replace your-framework with the name of your framework
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { Button } from './Button';
+
+const meta = {
+  title: 'Button',
+  component: Button,
+  tags: ['no-autodocs'],
+} satisfies Meta<typeof Button>;
+
+export default meta;
+```

--- a/docs/writing-docs/autodocs.md
+++ b/docs/writing-docs/autodocs.md
@@ -50,6 +50,18 @@ By default, Storybook offers zero-config support for documentation and automatic
 | `autodocs`    | Configures auto-generated documentation pages. Available options: `true`, `false`,`tag` (default) <br/> `docs: { autodocs: false }` |
 | `defaultName` | Renames the auto-generated documentation page<br/> `docs: { defaultName: 'Documentation' }`                                         |
 
+#### Disabling autodocs when `docs.autodocs = true`
+
+When setting `docs.autodocs: true`, you can disable the autodocs generation on a per story basis by adding a`no-autodocs` to your story. For example:
+
+<CodeSnippets
+  paths={[
+    'common/sstorybook-autodocs-true-disable-per-story.js.mdx',
+    'common/sstorybook-autodocs-true-disable-per-story.ts.mdx',
+  ]}
+/>
+
+
 ### Write a custom template
 
 To replace the default documentation template used by Storybook, you can extend your UI configuration file (i.e., `.storybook/preview.js`) and introduce a `docs` [parameter](./doc-blocks.md#customizing-the-automatic-docs-page). This parameter accepts a `page` function that returns a React component, which you can use to generate the required template. For example:


### PR DESCRIPTION
Closes #21085

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added the ability to pass `tags: ['no-autodocs']` in your stories file to avoid auto-generating docs while autodocs is globally set to true

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Set `autodocs: true` within `main.ts`
3. set `tags: ['no-autodocs']` within `Button.stories.tsx`
4. Open Storybook in your browser
5. Access Button stories and verify there is no auto-generated docs page

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
