### PR TITLE
improve sandboxes commit message

### DIFF
--- a/.github/workflows/generate-sandboxes-next.yml
+++ b/.github/workflows/generate-sandboxes-next.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
   # To test fixes on push rather than wait for the scheduling, do the following:
   # 1. Uncomment the lines below and add your branch.
-  # push:
-  #   branches:
-  #     - <your-branch-name>
+  push:
+    branches:
+      - feat/improve-sandboxes-commit-message
   # 2. change the "ref" value to <your-branch-name> in the actions/checkout step below.
   # 3. don't forget to undo the values back to `next` before you merge your changes.
 
@@ -24,7 +24,7 @@ jobs:
           node-version: 16
       - uses: actions/checkout@v3
         with:
-          ref: next
+          ref: feat/improve-sandboxes-commit-message
       - name: Setup git user
         run: |
           git config --global user.name "Storybook Bot"

--- a/.github/workflows/generate-sandboxes-next.yml
+++ b/.github/workflows/generate-sandboxes-next.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
   # To test fixes on push rather than wait for the scheduling, do the following:
   # 1. Uncomment the lines below and add your branch.
-  push:
-    branches:
-      - feat/improve-sandboxes-commit-message
+  # push:
+  #   branches:
+  #     - <your-branch-name>
   # 2. change the "ref" value to <your-branch-name> in the actions/checkout step below.
   # 3. don't forget to undo the values back to `next` before you merge your changes.
 
@@ -24,7 +24,7 @@ jobs:
           node-version: 16
       - uses: actions/checkout@v3
         with:
-          ref: feat/improve-sandboxes-commit-message
+          ref: next
       - name: Setup git user
         run: |
           git config --global user.name "Storybook Bot"

--- a/scripts/sandbox/publish.ts
+++ b/scripts/sandbox/publish.ts
@@ -54,7 +54,7 @@ const publish = async (options: PublishOptions & { tmpFolder: string }) => {
   logger.log(`🚛 Moving all the repros into the repository`);
   await copy(REPROS_DIRECTORY, tmpFolder);
 
-  await commitAllToGit(tmpFolder);
+  await commitAllToGit({ cwd: tmpFolder, branch });
 
   logger.info(`
      🙌 All the examples were bootstrapped:

--- a/scripts/sandbox/templates/item.ejs
+++ b/scripts/sandbox/templates/item.ejs
@@ -1,8 +1,12 @@
-<h1><%= name %></h1>
+<h1>
+  <%= name %>
+</h1>
 
 <p>This is project generated to serve as a reproduction starter for Storybook.</p>
 
-<a href="<%= stackblitzUrl %>">View it in Stackblitz</a>
+<a href="<%= stackblitzUrl %>">
+  View it in Stackblitz
+</a>
 
 <h3>Testing instructions</h3>
 
@@ -15,4 +19,3 @@
 <pre>
   yarn storybook
 </pre>
-

--- a/scripts/sandbox/utils/git.ts
+++ b/scripts/sandbox/utils/git.ts
@@ -1,23 +1,82 @@
+import fetch from 'node-fetch';
 import { execaCommand } from '../../utils/exec';
 // eslint-disable-next-line import/no-cycle
 import { logger } from '../publish';
 
-export async function commitAllToGit(cwd: string) {
+const getTheLastCommitHashThatUpdatedTheSandboxRepo = async (branch: string) => {
+  const owner = 'storybookjs';
+  const repo = 'sandboxes';
+
+  try {
+    const branchData = await (
+      await fetch(`https://api.github.com/repos/${owner}/${repo}/branches/${branch}`)
+    ).json();
+    const latestCommitSha = branchData.commit.sha;
+    const commitData = await (
+      await fetch(`https://api.github.com/repos/${owner}/${repo}/commits/${latestCommitSha}`)
+    ).json();
+    const latestCommitMessage = commitData.commit.message;
+    logger.log(
+      `Latest commit message of ${owner}/${repo} on branch ${branch}: ${latestCommitMessage}`
+    );
+    // The commit message will look like this: Update examples - Thu Apr 13 2023 - 97dbc82537c3
+    // the hash at the end relates to the monorepo commit that updated the sandboxes
+    return latestCommitMessage.split('\n')[0].split(' - ')[2];
+  } catch (error) {
+    logger.error(
+      `Error getting latest commit message of ${owner}/${repo} on branch ${branch}: ${error.message}`
+    );
+
+    throw error;
+  }
+};
+
+/**
+ * When commiting the changes to the sandboxes repo, we want to include the PRs that were merged since the last commit that updated the sandboxes.
+ * This might help us debug issues or changes that affected the sandboxes at some point in time.
+ */
+export async function commitAllToGit({ cwd, branch }: { cwd: string; branch: string }) {
   try {
     logger.log(`💪 Committing everything to the repository`);
 
     await execaCommand('git add .', { cwd });
 
-    const currentCommitSHA = await execaCommand('git rev-parse HEAD');
-    await execaCommand(
-      `git commit -m "Update examples - ${new Date().toDateString()} - ${currentCommitSHA.stdout
+    const currentCommitHash = (await execaCommand('git rev-parse HEAD')).stdout
+      .toString()
+      .slice(0, 12);
+
+    let gitCommitCommand;
+
+    try {
+      const previousCommitHash = await getTheLastCommitHashThatUpdatedTheSandboxRepo(branch);
+      const mergeCommits = (
+        await execaCommand(
+          `git log ${previousCommitHash}..${currentCommitHash} --merges --pretty=%s`
+        )
+      ).stdout
         .toString()
-        .slice(0, 12)}"`,
-      {
-        shell: true,
-        cwd,
-      }
-    );
+        .split('\n')
+        .filter((s: string) => s.includes('pull request'));
+
+      const prLinks = mergeCommits.map((mergeCommit) => {
+        const prNumber = mergeCommit.match(/Merge pull request #(\d+)/)[1];
+        const branchName = mergeCommit.match(/from (.+)/)[1].replace('storybookjs/', '');
+        return `- https://github.com/storybookjs/storybook/pull/${prNumber} (${branchName})`;
+      });
+
+      const diffLink = `https://github.com/storybookjs/storybook/compare/${previousCommitHash}...${currentCommitHash}`;
+
+      const commitTitle = `Update sandboxes - ${new Date().toDateString()} - ${previousCommitHash}`;
+      const commitBody = [...prLinks, `\nCheck the diff here: ${diffLink}`].join('\n');
+      gitCommitCommand = `git commit -m "${commitTitle}" -m "${commitBody}"`;
+    } catch (err) {
+      gitCommitCommand = `git commit -m "Update sandboxes - ${new Date().toDateString()} - ${currentCommitHash}`;
+    }
+
+    await execaCommand(gitCommitCommand, {
+      shell: true,
+      cwd,
+    });
   } catch (e) {
     logger.log(
       `🤷 Git found no changes between previous versions so there is nothing to commit. Skipping publish!`

--- a/scripts/sandbox/utils/template.ts
+++ b/scripts/sandbox/utils/template.ts
@@ -9,7 +9,12 @@ export async function renderTemplate(templatePath: string, templateData: Record<
 
   const output = format(render(template, templateData), {
     parser: 'html',
-  }).replace(new RegExp('</li>\\n\\n', 'g'), '</li>\n');
+  })
+    // overly complicated regex replacements to fix prettier's bad formatting
+    .replace(new RegExp('</li>\\n\\n', 'g'), '</li>\n')
+    .replace(new RegExp('<a\\n', 'g'), '<a')
+    .replace(new RegExp('node"\\n>', 'g'), 'node=">')
+    .replace(new RegExp('/\\n</a>/', 'g'), '</a>');
   return output;
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR provides an improved commit message whenever we generate sandboxes, so it's easier to debug or investigate what happened at the moment of a sandbox being updated.

- display merged PRs between sandbox updates
- display a link to the diff in the monorepo


## How to test

We can only properly test this after merged or if we force an update to the sandboxes after there are actual sandbox changes. Tricky!

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
