### PR TITLE
Build: Enable strict TS by default

### DIFF
--- a/Issue.md
+++ b/Issue.md
@@ -1,0 +1,67 @@
+*What:*
+We want to step our TS game in the monorepo and enable strict typescript in all packages!
+
+*Why:*
+Having TS track for you if a variable might be null or not, enables us to code with much more confidence, 
+and also gives us quick in editor feedback, when you make assumptions that are not actually true! 
+
+*How:*
+We would like to change as little as possible of the actual runtime behavior in this migration.
+However, we also don't want to simply silence the compiler everywhere with `!`, `as` or `ts-ignore` to get this migration in.
+As a rule of thumb, if the logic is easy enough, prefer improving the code (e.g. add a null check) over silencing the compiler.
+If the change needed to do the right thing, is too risky, and not in your expertise, it is okay to silence the compiler.
+It is not ideal, but we still gain the benefit that new code written will have extra typesafety.
+
+Feel free to contribute too any of packages in the list below!
+
+- [ ] @storybook/addon-backgrounds
+- [ ] @storybook/addon-docs
+- [ ] @storybook/addon-highlight
+- [ ] @storybook/addon-interactions
+- [ ] @storybook/addon-jest
+- [ ] @storybook/addon-mdx-gfm
+- [ ] @storybook/addon-measure
+- [ ] @storybook/addon-outline
+- [ ] @storybook/addon-storyshots
+- [ ] @storybook/addon-storyshots-puppeteer
+- [ ] @storybook/addon-storysource
+- [ ] @storybook/addon-viewport
+- [ ] @storybook/addons
+- [ ] @storybook/angular
+- [ ] @storybook/api
+- [ ] @storybook/blocks
+- [ ] @storybook/channel-postmessage
+- [ ] @storybook/channel-websocket
+- [ ] @storybook/channels
+- [ ] @storybook/cli
+- [ ] @storybook/client-api
+- [ ] @storybook/codemod
+- [ ] @storybook/components
+- [ ] @storybook/core-client
+- [ ] @storybook/core-events
+- [ ] @storybook/core-server
+- [ ] @storybook/csf-tools
+- [ ] @storybook/docs-tools
+- [ ] @storybook/external-docs
+- [ ] @storybook/html-vite
+- [ ] @storybook/instrumenter
+- [ ] @storybook/manager
+- [ ] @storybook/manager-api
+- [ ] @storybook/postinstall
+- [ ] @storybook/preact-vite
+- [ ] @storybook/preset-create-react-app
+- [ ] @storybook/preset-vue-webpack
+- [ ] @storybook/preset-vue3-webpack
+- [ ] @storybook/react-vite
+- [ ] @storybook/router
+- [ ] @storybook/scripts
+- [ ] @storybook/server
+- [ ] @storybook/source-loader
+- [ ] @storybook/svelte-vite
+- [ ] @storybook/sveltekit
+- [ ] @storybook/theming
+- [ ] @storybook/types
+- [ ] @storybook/vue3-vite
+- [ ] @storybook/vue3-webpack5
+- [ ] @storybook/web-components
+- [ ] @storybook/web-components-vite

--- a/code/addons/backgrounds/tsconfig.json
+++ b/code/addons/backgrounds/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/addons/docs/tsconfig.json
+++ b/code/addons/docs/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/addons/gfm/tsconfig.json
+++ b/code/addons/gfm/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/addons/highlight/tsconfig.json
+++ b/code/addons/highlight/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "types": ["webpack-env"]
+    "types": ["webpack-env"],
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/addons/interactions/tsconfig.json
+++ b/code/addons/interactions/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["testing-library__jest-dom"]
+    "types": ["testing-library__jest-dom"],
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/addons/jest/tsconfig.json
+++ b/code/addons/jest/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "strict": false
+  },
   "include": ["src/**/*"]
 }

--- a/code/addons/measure/tsconfig.json
+++ b/code/addons/measure/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/addons/outline/tsconfig.json
+++ b/code/addons/outline/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/addons/storyshots-core/tsconfig.json
+++ b/code/addons/storyshots-core/tsconfig.json
@@ -4,7 +4,8 @@
     "declaration": true,
     "jsx": "preserve",
     "skipLibCheck": true,
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "strict": false
   },
   "include": ["src/**/*.ts"]
 }

--- a/code/addons/storyshots-puppeteer/tsconfig.json
+++ b/code/addons/storyshots-puppeteer/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "skipLibCheck": true,
     "types": ["node"],
-    "declaration": true
+    "declaration": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/addons/storysource/tsconfig.json
+++ b/code/addons/storysource/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/addons/viewport/tsconfig.json
+++ b/code/addons/viewport/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/frameworks/angular/tsconfig.json
+++ b/code/frameworks/angular/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "strict": false
   },
   "include": ["src/**/*", "src/**/*.json", "template/**/*"]
 }

--- a/code/frameworks/html-vite/tsconfig.json
+++ b/code/frameworks/html-vite/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "types": ["node"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": false
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.*", "src/**/__testfixtures__/**"]

--- a/code/frameworks/preact-vite/tsconfig.json
+++ b/code/frameworks/preact-vite/tsconfig.json
@@ -5,7 +5,8 @@
     "types": ["node"],
     "resolveJsonModule": true,
     "jsx": "react-jsx",
-    "jsxImportSource": "preact"
+    "jsxImportSource": "preact",
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/frameworks/react-vite/tsconfig.json
+++ b/code/frameworks/react-vite/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "types": ["node"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/frameworks/svelte-vite/tsconfig.json
+++ b/code/frameworks/svelte-vite/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "types": ["node"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/frameworks/sveltekit/tsconfig.json
+++ b/code/frameworks/sveltekit/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "types": ["node"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/frameworks/vue3-vite/tsconfig.json
+++ b/code/frameworks/vue3-vite/tsconfig.json
@@ -4,7 +4,8 @@
     "rootDir": "./src",
     "types": ["node"],
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/frameworks/vue3-webpack5/tsconfig.json
+++ b/code/frameworks/vue3-webpack5/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/frameworks/web-components-vite/tsconfig.json
+++ b/code/frameworks/web-components-vite/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "types": ["node"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/lib/addons/tsconfig.json
+++ b/code/lib/addons/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/channel-postmessage/tsconfig.json
+++ b/code/lib/channel-postmessage/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/channel-websocket/tsconfig.json
+++ b/code/lib/channel-websocket/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/channels/tsconfig.json
+++ b/code/lib/channels/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/client-api/tsconfig.json
+++ b/code/lib/client-api/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/codemod/tsconfig.json
+++ b/code/lib/codemod/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "skipLibCheck": true,
-    "allowJs": true
+    "allowJs": true,
+    "strict": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "__testfixtures__", "__tests__"]

--- a/code/lib/core-client/tsconfig.json
+++ b/code/lib/core-client/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*", "typings.d.ts"]
+  "include": ["src/**/*", "typings.d.ts"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/core-events/tsconfig.json
+++ b/code/lib/core-events/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -94,6 +94,7 @@
     "semver": "^7.3.7",
     "serve-favicon": "^2.5.0",
     "telejson": "^7.0.3",
+    "tiny-invariant": "^1.3.1",
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2",
     "watchpack": "^2.2.0",

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -553,7 +553,7 @@ export class StoryIndexGenerator {
     } catch (err) {
       this.lastError = err;
       logger.warn(`🚨 ${this.lastError.toString()}`);
-      invariant(this.lastError != null);
+      invariant(this.lastError);
       throw this.lastError;
     }
   }

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import glob from 'globby';
 import slash from 'slash';
+import invariant from 'tiny-invariant';
 
 import type {
   IndexEntry,
@@ -552,6 +553,7 @@ export class StoryIndexGenerator {
     } catch (err) {
       this.lastError = err;
       logger.warn(`🚨 ${this.lastError.toString()}`);
+      invariant(this.lastError != null);
       throw this.lastError;
     }
   }

--- a/code/lib/core-server/tsconfig.json
+++ b/code/lib/core-server/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/lib/csf-tools/tsconfig.json
+++ b/code/lib/csf-tools/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "strict": false
+  },
   "include": ["src/**/*"]
 }

--- a/code/lib/docs-tools/tsconfig.json
+++ b/code/lib/docs-tools/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "strict": false
+  },
   "include": ["src/**/*"]
 }

--- a/code/lib/instrumenter/tsconfig.json
+++ b/code/lib/instrumenter/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/manager-api-shim/tsconfig.json
+++ b/code/lib/manager-api-shim/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/manager-api/tsconfig.json
+++ b/code/lib/manager-api/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/lib/postinstall/tsconfig.json
+++ b/code/lib/postinstall/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/lib/router/tsconfig.json
+++ b/code/lib/router/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/source-loader/tsconfig.json
+++ b/code/lib/source-loader/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/theming/tsconfig.json
+++ b/code/lib/theming/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/lib/types/tsconfig.json
+++ b/code/lib/types/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/presets/vue-webpack/tsconfig.json
+++ b/code/presets/vue-webpack/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/presets/vue3-webpack/tsconfig.json
+++ b/code/presets/vue3-webpack/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/renderers/server/tsconfig.json
+++ b/code/renderers/server/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*", "template/**/*"]
+  "include": ["src/**/*", "template/**/*"],
+  "compilerOptions": {
+    "strict": false
+  }
 }

--- a/code/renderers/web-components/tsconfig.json
+++ b/code/renderers/web-components/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": false
   },
   "include": ["src/**/*", "template/**/*"]
 }

--- a/code/tsconfig.json
+++ b/code/tsconfig.json
@@ -17,7 +17,8 @@
     "strictBindCallApply": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "noUnusedLocals": true,
-    "types": ["jest"]
+    "types": ["jest"],
+    "strict": true
   },
   "exclude": ["dist", "**/dist", "node_modules", "**/node_modules", "**/setup-jest.ts"],
   "ts-node": {

--- a/code/ui/blocks/src/blocks/Canvas.tsx
+++ b/code/ui/blocks/src/blocks/Canvas.tsx
@@ -189,6 +189,7 @@ export const Canvas: FC<CanvasProps & DeprecatedCanvasProps> = (props) => {
     }
   }
   if (hookError) {
+    // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw hookError;
   }
 

--- a/code/ui/blocks/tsconfig.json
+++ b/code/ui/blocks/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "esnext",
     "rootDir": "./src",
-    "types": ["jest"]
+    "types": ["jest"],
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/ui/components/tsconfig.json
+++ b/code/ui/components/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["react-syntax-highlighter", "jest", "testing-library__jest-dom"]
+    "types": ["react-syntax-highlighter", "jest", "testing-library__jest-dom"],
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/ui/manager/tsconfig.json
+++ b/code/ui/manager/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["testing-library__jest-dom"]
+    "types": ["testing-library__jest-dom"],
+    "strict": false
   },
   "include": ["src/**/*"]
 }

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6105,6 +6105,7 @@ __metadata:
     serve-favicon: ^2.5.0
     slash: ^5.0.0
     telejson: ^7.0.3
+    tiny-invariant: ^1.3.1
     ts-dedent: ^2.0.0
     typescript: ~4.9.3
     util-deprecate: ^1.0.2
@@ -28464,6 +28465,13 @@ __metadata:
     globalyzer: 0.1.0
     globrex: ^0.1.2
   checksum: cbe072f0d213a1395d30aa94845a051d4af18fe8ffb79c8e99ac1787cd25df69083f17791a53997cb65f469f48950cb61426ccc0683cc9df170ac2430e883702
+  languageName: node
+  linkType: hard
+
+"tiny-invariant@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "tiny-invariant@npm:1.3.1"
+  checksum: 5b87c1d52847d9452b60d0dcb77011b459044e0361ca8253bfe7b43d6288106e12af926adb709a6fc28900e3864349b91dad9a4ac93c39aa15f360b26c2ff4db
   languageName: node
   linkType: hard
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,7 +14,8 @@
     "migrate-docs": "node --require esbuild-register ./ts-to-ts49.ts",
     "task": "ts-node --swc ./task.ts",
     "test": "jest --config ./jest.config.js",
-    "upgrade": "ts-node --swc ./task.ts"
+    "upgrade": "ts-node --swc ./task.ts",
+    "strict-ts": "node --require esbuild-register ./strict-ts.ts"
   },
   "husky": {
     "hooks": {

--- a/scripts/strict-ts.ts
+++ b/scripts/strict-ts.ts
@@ -1,0 +1,41 @@
+import glob from 'fast-glob';
+import path from 'path';
+import fsSync from 'node:fs';
+import JSON5 from 'json5';
+
+const files = glob.sync('**/*/tsconfig.json', {
+  absolute: true,
+  cwd: '..',
+});
+
+(async function main() {
+  const packages = files
+    .filter((file) => !file.includes('node_modules') && !file.includes('dist'))
+    .map((file) => {
+      const packageJson = path.join(path.dirname(file), 'package.json');
+      let packageName;
+      if (fsSync.existsSync(packageJson)) {
+        const json = fsSync.readFileSync(packageJson, { encoding: 'utf-8' });
+        packageName = JSON5.parse(json).name;
+      }
+
+      let strict;
+      if (fsSync.existsSync(file)) {
+        const tsconfig = fsSync.readFileSync(file, { encoding: 'utf-8' });
+        const tsconfigJson = JSON5.parse(tsconfig);
+        strict = tsconfigJson?.compilerOptions?.strict ?? false;
+      }
+
+      if (packageName && strict === false) {
+        return packageName;
+      }
+      return null;
+    })
+    .filter(Boolean)
+    .sort();
+
+  console.log(packages.join('\n'));
+  console.log(packages.length);
+
+  // console.log(files.filter((file) => !file.includes('node_modules') && !file.includes('dist')));
+})();

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -13,14 +13,8 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "strictBindCallApply": true,
-    "lib": [
-      "dom",
-      "esnext"
-    ],
-    "types": [
-      "node",
-      "jest"
-    ],
+    "lib": ["dom", "esnext"],
+    "types": ["node", "jest"],
     "strict": false,
     "strictNullChecks": false,
     "forceConsistentCasingInFileNames": true,
@@ -28,25 +22,15 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true,
+    "resolveJsonModule": true
   },
-  "exclude": [
-    "dist",
-    "**/dist",
-    "node_modules",
-    "**/node_modules"
-  ],
-  "include": [
-    "./**/*",
-    "./.eslintrc.js"
-  ],
+  "exclude": ["dist", "**/dist", "node_modules", "**/node_modules"],
+  "include": ["./**/*", "./.eslintrc.js"],
   "ts-node": {
     "transpileOnly": true,
     "files": true,
     "compilerOptions": {
-      "types": [
-        "node"
-      ]
+      "types": ["node"]
     }
   }
 }


### PR DESCRIPTION
## What I did

Enable strict TS by default, so that new projects by default use it.

I see quite a lot of new packages such as sveltekit, html-vite not using strict TS. Probably just because you manually have to turn it on. 

So it is inversed now, you have to manually disable it.

Will work the rest of the week to get as much as possible tsconfig using stict: true! 