### PR TITLE
Chore: (Docs) Remove comments from Angular snippets

### DIFF
--- a/docs/snippets/angular/button-story-argtypes-with-subcategories.ts.mdx
+++ b/docs/snippets/angular/button-story-argtypes-with-subcategories.ts.mdx
@@ -1,7 +1,6 @@
 ```ts
 // Button.stories.ts
 
-// Replace your-framework with the name of your framework
 import type { Meta } from '@storybook/angular';
 
 import { Button } from './button.component';

--- a/docs/snippets/angular/gizmo-story-controls-customization.ts.mdx
+++ b/docs/snippets/angular/gizmo-story-controls-customization.ts.mdx
@@ -1,7 +1,6 @@
 ```ts
 // Gizmo.stories.ts
 
-// Replace your-framework with the name of your framework
 import type { Meta } from '@storybook/angular';
 
 import { Gizmo } from './Gizmo.component';


### PR DESCRIPTION
With this small pull request, some of the Angular snippets are updated to remove extraneous comments that shouldn't be mentioned in the example as they are framework-specific, not framework-agnostic