### PR TITLE
Chore: (Docs) Minor tweaks to the Design addon install instructions

### DIFF
--- a/docs/sharing/design-integrations.md
+++ b/docs/sharing/design-integrations.md
@@ -75,6 +75,12 @@ Run the following command to install the addon.
 
 <!-- prettier-ignore-end -->
 
+<div class="aside">
+
+ℹ️ This addon is still being converted to fully support Storybook 7.0. If you're adding this addon to a Storybook 7.0 instance or migrating from a previous version, you must install the `beta` version.
+
+</div>
+
 Update your Storybook configuration (in `.storybook/main.js|ts`) to include the addon.
 
 <!-- prettier-ignore-start -->

--- a/docs/snippets/common/storybook-figma-addon-install.npm.js.mdx
+++ b/docs/snippets/common/storybook-figma-addon-install.npm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-npm install --save-dev storybook-addon-designs
+npm install --save-dev storybook-addon-designs@beta
 ```

--- a/docs/snippets/common/storybook-figma-addon-install.pnpm.js.mdx
+++ b/docs/snippets/common/storybook-figma-addon-install.pnpm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-pnpm add --save-dev storybook-addon-designs
+pnpm add --save-dev storybook-addon-designs@beta
 ```

--- a/docs/snippets/common/storybook-figma-addon-install.yarn.js.mdx
+++ b/docs/snippets/common/storybook-figma-addon-install.yarn.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-yarn add --dev storybook-addon-designs
+yarn add --dev storybook-addon-designs@beta
 ```


### PR DESCRIPTION
With this pull request, the documentation & snippets on how to install the `storybook-addon-designs` was updated to feature the beta version currently in development and waiting for release.

Addresses this [Discord conversation](https://discord.com/channels/486522875931656193/1097501286338936882/1097506055820419092)
 
What was done:
- Added a temporary aside to mention to users that they need to install the `beta` version of the addon for it to support a Storybook 7.0 instance.
- Updated snippets containing installation instructions for various package managers.


To test for any potential issues, a small reproduction was created [here](https://github.com/jonniebigodes/testing-storybook-7-design-addons-beta) containing examples of to use the addon with 7.0, currently deployed in Chromatic [here](https://643ed2a5977108474f398f03-gxypptuown.chromatic.com/?path=/story/example-button--with-figma).


