### PR TITLE
Core: Pass parameters in `SET_INDEX` for docs entries

### DIFF
--- a/code/e2e-tests/addon-backgrounds.spec.ts
+++ b/code/e2e-tests/addon-backgrounds.spec.ts
@@ -40,13 +40,6 @@ test.describe('addon-backgrounds', () => {
   });
 
   test.describe('docs pages', () => {
-    // eslint-disable-next-line jest/no-disabled-tests
-    test.skip(
-      // eslint-disable-next-line jest/valid-title
-      templateName.includes('ssv6'),
-      'Only run this test for Sandboxes with StoryStoreV7 enabled'
-    );
-
     test('button should appear for attached docs pages', async ({ page }) => {
       const sbPage = new SbPage(page);
 
@@ -54,7 +47,18 @@ test.describe('addon-backgrounds', () => {
       await expect(sbPage.page.locator(backgroundToolbarSelector)).toBeVisible();
     });
 
-    test('button should appear for unattached docs pages', async ({ page }) => {
+    test('button should appear for unattached .mdx files', async ({ page }) => {
+      // SSv6 does not support .mdx files. There is a unattached stories.mdx file
+      // at /docs/addons-docs-stories-mdx-unattached--docs, but these are functionally
+      // really attached
+
+      // eslint-disable-next-line jest/no-disabled-tests
+      test.skip(
+        // eslint-disable-next-line jest/valid-title
+        templateName.includes('ssv6'),
+        'Only run this test for Sandboxes with StoryStoreV7 enabled'
+      );
+
       const sbPage = new SbPage(page);
 
       // We start on the introduction page by default.

--- a/code/lib/preview-api/src/modules/core-client/start.test.ts
+++ b/code/lib/preview-api/src/modules/core-client/start.test.ts
@@ -986,6 +986,10 @@ describe('start', () => {
                 "id": "introduction",
                 "importPath": "./Introduction.stories.mdx",
                 "name": undefined,
+                "parameters": Object {
+                  "fileName": "./Introduction.stories.mdx",
+                  "renderer": "test",
+                },
                 "storiesImports": Array [],
                 "tags": Array [
                   "stories-mdx",
@@ -1244,6 +1248,10 @@ describe('start', () => {
                 "id": "component-b--docs",
                 "importPath": "file2",
                 "name": "Docs",
+                "parameters": Object {
+                  "fileName": "file2",
+                  "renderer": "test",
+                },
                 "storiesImports": Array [],
                 "tags": Array [
                   "autodocs",
@@ -1277,6 +1285,10 @@ describe('start', () => {
                 "id": "component-c--docs",
                 "importPath": "exports-map-0",
                 "name": "Docs",
+                "parameters": Object {
+                  "fileName": "exports-map-0",
+                  "renderer": "test",
+                },
                 "storiesImports": Array [],
                 "tags": Array [
                   "component-tag",

--- a/code/lib/preview-api/src/modules/store/StoryStore.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.ts
@@ -388,6 +388,9 @@ export class StoryStore<TRenderer extends Renderer> {
 
   getSetIndexPayload(): API_PreparedStoryIndex {
     if (!this.storyIndex) throw new Error('getSetIndexPayload called before initialization');
+    if (!this.cachedCSFFiles)
+      throw new Error('Cannot call getSetIndexPayload() unless you call cacheAllCSFFiles() first');
+    const { cachedCSFFiles } = this;
 
     const stories = this.extract({ includeDocsOnly: true });
 
@@ -404,7 +407,12 @@ export class StoryStore<TRenderer extends Renderer> {
                 argTypes: stories[id].argTypes,
                 parameters: stories[id].parameters,
               }
-            : entry,
+            : {
+                ...entry,
+                parameters: this.preparedMetaFromCSFFile({
+                  csfFile: cachedCSFFiles[entry.importPath],
+                }).parameters,
+              },
         ])
       ),
     };


### PR DESCRIPTION
Closes #21798 for SSv6

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Include parameters in the (v6) `SET_STORIES` event.

## How to test

See E2E spec.

In a ssv6 sandbox, visit:
- http://localhost:6006/?path=/docs/addons-docs-stories-mdx-unattached--docs
- http://localhost:6006/?path=/docs/example-button--docs

And check the backgrounds toolbar item.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
