### PR TITLE
Fix tsconfig resolution in Nextjs projects

### DIFF
--- a/code/frameworks/nextjs/src/imports/webpack.ts
+++ b/code/frameworks/nextjs/src/imports/webpack.ts
@@ -2,8 +2,14 @@ import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 import { loadConfig } from 'tsconfig-paths';
 import type { Configuration as WebpackConfig } from 'webpack';
 
-export const configureImports = (baseConfig: WebpackConfig): void => {
-  const configLoadResult = loadConfig();
+export const configureImports = ({
+  baseConfig,
+  configDir,
+}: {
+  baseConfig: WebpackConfig;
+  configDir: string;
+}): void => {
+  const configLoadResult = loadConfig(configDir);
 
   if (configLoadResult.resultType === 'failed' || !configLoadResult.baseUrl) {
     // either not a typescript project or tsconfig contains no baseUrl

--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -145,7 +145,7 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (baseConfig, 
   configureNextFont(baseConfig);
   configureNextImport(baseConfig);
   configureRuntimeNextjsVersionResolution(baseConfig);
-  configureImports(baseConfig);
+  configureImports({ baseConfig, configDir: options.configDir });
   configureCss(baseConfig, nextConfig);
   configureImages(baseConfig);
   configureRouting(baseConfig);


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I have fixed the way how we try to resolve the app's `tsconfig.json`. In monorepositories very likely each app/lib has its own tsconfig file, which extends the base root config. In this case, we DON'T want to load the root tsconfig file, but the app/lib config file instead. The resolution algorithm now searches for the following paths in the mentioned order:

- `<cwd>/<project>/.storybook/tsconfig.json`
- `<cwd>/<project>/tsconfig.json`
- `<cwd>/tsconfig.json`

## How to test

1. Checkout https://github.com/mandarini/nx-next-storybook-paths
2. Copy/Paste `@storybook/nextjs` dist folder into project.
3. `npx nx build-storybook next-app` shouldn't fail

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
