### PR TITLE
Vue3:add support for multi setup functions call 

### DIFF
--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import type { ConcreteComponent } from 'vue';
+import type { App, ConcreteComponent } from 'vue';
 import { createApp, h, isReactive, isVNode, reactive } from 'vue';
 import type { RenderContext, ArgsStoryFn } from '@storybook/types';
 import type { Args, StoryContext } from '@storybook/csf';
@@ -25,9 +25,18 @@ export const render: ArgsStoryFn<VueRenderer> = (props, context) => {
   return h(Component, props, createOrUpdateSlots(context));
 };
 
-let setupFunction = (_app: any) => {};
-export const setup = (fn: (app: any) => void) => {
-  setupFunction = fn;
+// set of setup functions that will be called when story is created
+const setupFunctions = new Set<(app: App, storyContext?: StoryContext<VueRenderer>) => void>();
+/** add a setup function to set that will be call when story is created a d
+ *
+ * @param fn
+ */
+export const setup = (fn: (app: App, storyContext?: StoryContext<VueRenderer>) => void) => {
+  setupFunctions.add(fn);
+};
+
+const runSetupFunctions = (app: App, storyContext: StoryContext<VueRenderer>) => {
+  setupFunctions.forEach((fn) => fn(app, storyContext));
 };
 
 const map = new Map<
@@ -77,8 +86,9 @@ export function renderToCanvas(
       };
     },
   });
+
   vueApp.config.errorHandler = (e: unknown) => showException(e as Error);
-  setupFunction(vueApp);
+  runSetupFunctions(vueApp, storyContext);
   vueApp.mount(canvasElement);
 
   showMain();

--- a/code/renderers/vue3/src/typings.d.ts
+++ b/code/renderers/vue3/src/typings.d.ts
@@ -1,1 +1,5 @@
 declare var STORYBOOK_ENV: 'vue3';
+
+declare interface ComponentCustomProperties {
+  $translate: (key: string) => string;
+}

--- a/code/renderers/vue3/template/components/index.ts
+++ b/code/renderers/vue3/template/components/index.ts
@@ -1,0 +1,14 @@
+/* eslint-disable no-param-reassign */
+import { global as globalThis } from '@storybook/global';
+
+import Button from './Button.vue';
+import Pre from './Pre.vue';
+import Form from './Form.vue';
+import Html from './Html.vue';
+
+const setGlobal = (global: any) => {
+  global.Components = { Button, Pre, Form, Html };
+  global.storybookRenderer = 'vue3';
+};
+
+setGlobal(globalThis);

--- a/code/renderers/vue3/template/stories/GlobalSetup.stories.js
+++ b/code/renderers/vue3/template/stories/GlobalSetup.stories.js
@@ -1,0 +1,32 @@
+import { inject } from 'vue';
+import GlobalSetup from './GlobalSetup.vue';
+
+export default {
+  component: GlobalSetup,
+  argTypes: {},
+  render: (args) => ({
+    // Components used in your story `template` are defined in the `components` object
+    components: {  GlobalSetup },
+    // The story's `args` need to be mapped into the template through the `setup()` method
+    setup() {
+      const themeColor = inject('themeColor','blue');
+      return { args , themeColor };
+    },
+    // And then the `args` are bound to your component with `v-bind="args"`
+    template: '<global-setup v-bind="args" :backgroundColor="themeColor"  />',
+  }),
+};
+
+export const Primary = {
+  args: {
+    primary: true,
+    label: 'Theme Color Globally Defined',
+  },
+};
+
+export const Secondary = {
+  args: {
+    backgroundColor: 'red',
+    label: 'Theme Color Globally Defined',
+  },
+};

--- a/code/renderers/vue3/template/stories/GlobalSetup.vue
+++ b/code/renderers/vue3/template/stories/GlobalSetup.vue
@@ -1,0 +1,4 @@
+<template>
+  <global-button v-bind="$attrs" />
+  <!-- <div> {{ $translate('greetings.hello') }}</div> -->
+</template>

--- a/code/renderers/vue3/template/stories/preview.js
+++ b/code/renderers/vue3/template/stories/preview.js
@@ -2,12 +2,38 @@ import { global as globalThis } from '@storybook/global';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { setup } from '@storybook/vue3';
 
-// TODO: I'd like to be able to export rather than imperatively calling an imported function
-// export const setup = (app) => {
-//   app.component('GlobalButton', Button);
-// };
+const i18nPlugin = {
+  install: (app, options) => {
+    // inject a globally available $translate() method
+    // eslint-disable-next-line no-param-reassign
+    app.config.globalProperties.$translate = (key) => {
+      // retrieve a nested property in `options`
+      // using `key` as the path
+      // eslint-disable-next-line array-callback-return, consistent-return
+      return key.split('.').reduce((o, i) => {
+        if (o) return o[i];
+      }, options);
+    };
+  },
+};
+const themeColor = 'themeColor';
 
+// add components to global scope
 setup((app) => {
   // This adds a component that can be used globally in stories
   app.component('GlobalButton', globalThis.Components.Button);
+});
+
+// this adds a plugin to vue app
+setup((app, context) => {
+  app.use(i18nPlugin, {
+    greetings: {
+      hello: `Bonjour! from plugin your name is ${context?.name}!`,
+    },
+  });
+});
+
+// additonal setup to provide selected language to the app
+setup((app) => {
+  app.provide(themeColor, 'green');
 });


### PR DESCRIPTION
Closes

vue 3 single use of setup() which is causing issue for add-on authors https://github.com/NickMcBurney/storybook-vue3-router/issues/38

## What I did

change the implementation of setup function most called in preview.js or plugins , now you can use as many as you want and it won't be overridden by any plugin use

this PR should be merged after merging https://github.com/storybookjs/storybook/pull/21956

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
