### PR TITLE
Bug: simplify the export type of addon actions decorator so it doesn't get generated incorrectly

### DIFF
--- a/code/addons/actions/src/decorator.ts
+++ b/code/addons/actions/src/decorator.ts
@@ -1,5 +1,6 @@
 import { global } from '@storybook/global';
 import { useEffect, makeDecorator } from '@storybook/preview-api';
+import type { Addon_DecoratorFunction } from '@storybook/types';
 import { actions } from './runtime/actions';
 
 import { PARAM_KEY } from './constants';
@@ -51,7 +52,7 @@ const applyEventHandlers = (actionsFn: any, ...handles: any[]) => {
   }, [root, actionsFn, handles]);
 };
 
-export const withActions = makeDecorator({
+export const withActions: Addon_DecoratorFunction = makeDecorator({
   name: 'withActions',
   parameterName: PARAM_KEY,
   skipIfNoParametersOrOptions: true,


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21820

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did


Looks like tsup is generating the typings wrong for this file, referencing a path that only exists in the monorepo.

I traced the output code, it's trying to reference, and it's just a function type of any to any, pretty useless.

So trying to fix the actual issue inside tsup can wait; I fixed the issue by making the type better by referencing @storybook/types instead.
I verified the output typings file is correct that way.
