### PR TITLE
feat(vue3): allow to have multiple Vue 3 setup()

### DIFF
--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -25,9 +25,9 @@ export const render: ArgsStoryFn<VueRenderer> = (props, context) => {
   return h(Component, props, createOrUpdateSlots(context));
 };
 
-let setupFunction = (_app: any) => {};
+const setupFunctions: Array<(app: any) => void> = [];
 export const setup = (fn: (app: any) => void) => {
-  setupFunction = fn;
+  setupFunctions.push(fn);
 };
 
 const map = new Map<
@@ -78,7 +78,7 @@ export function renderToCanvas(
     },
   });
   vueApp.config.errorHandler = (e: unknown) => showException(e as Error);
-  setupFunction(vueApp);
+  setupFunctions.forEach((setupFunction) => setupFunction(vueApp));
   vueApp.mount(canvasElement);
 
   showMain();


### PR DESCRIPTION
## What I did

I'm using [storybook-vue3-router](https://github.com/NickMcBurney/storybook-vue3-router/tree/next) which uses the vue3 renderer [setup call](https://github.com/NickMcBurney/storybook-vue3-router/blob/bd10c17ccc9320687a5cbc15ebc2a95b1227ee5d/src/withVueRouter.ts#L47), and overrides my call to setup() that I use to setup pinia.

This PR allows to have multiple `setup()` functions defined and called during the Vue 3 app setup.

## How to test


<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
