### PR TITLE
Add Typescript to vue-cli/default-js because stories are written in Typescript

### DIFF
--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -336,7 +336,9 @@ const baseTemplates = {
   },
   'vue-cli/default-js': {
     name: 'Vue-CLI (Default JS)',
-    script: 'npx -p @vue/cli vue create . --default --packageManager=yarn --force --merge',
+    script:
+      // eslint-disable-next-line prettier/prettier, no-useless-escape
+      'npx -p @vue/cli vue create {{beforeDir}} --default --packageManager=yarn --force --merge && cd {{beforeDir}} && yarn add typescript && echo "{ \"include\": [\"src/**/*.ts\"] }" > tsconfig.json && git add . && git commit --amend --no-edit && cd ..',
     expected: {
       framework: '@storybook/vue3-webpack5',
       renderer: '@storybook/vue3',


### PR DESCRIPTION
Closes N/A

## What I did

Added Typescript to the `vue-cli/default-js` sandbox, because some Stories are written in Typescript

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
