### PR TITLE
Add regex to ignore outdated Browserslist in Jest initialization base file

### DIFF
--- a/code/jest.init.base.ts
+++ b/code/jest.init.base.ts
@@ -28,6 +28,7 @@ Object.defineProperty(global, 'localStorage', { value: localStorageMock, writabl
 const ignoreList = [
   (error: any) => error.message.includes('":nth-child" is potentially unsafe'),
   (error: any) => error.message.includes('":first-child" is potentially unsafe'),
+  (error: any) => error.message.match(/Browserslist: .* is outdated. Please run:/),
   (error: any) => error.message.includes('Failed prop type') && error.stack.includes('storyshots'),
   (error: any) =>
     error.message.includes('react-async-component-lifecycle-hooks') &&


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added regex to ignore outdated Browserslist in Jest initialization base file

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
