### PR TITLE
React: Use correct default annotations for composeStories

### DIFF
--- a/code/lib/preview-api/src/modules/store/csf/testing-utils/index.ts
+++ b/code/lib/preview-api/src/modules/store/csf/testing-utils/index.ts
@@ -21,7 +21,7 @@ import { normalizeComponentAnnotations } from '../normalizeComponentAnnotations'
 import { getValuesFromArgTypes } from '../getValuesFromArgTypes';
 import { normalizeProjectAnnotations } from '../normalizeProjectAnnotations';
 
-let GLOBAL_STORYBOOK_PROJECT_ANNOTATIONS = {};
+let GLOBAL_STORYBOOK_PROJECT_ANNOTATIONS = composeConfigs([]);
 
 export function setProjectAnnotations<TRenderer extends Renderer = Renderer>(
   projectAnnotations: ProjectAnnotations<TRenderer> | ProjectAnnotations<TRenderer>[]
@@ -33,7 +33,7 @@ export function setProjectAnnotations<TRenderer extends Renderer = Renderer>(
 export function composeStory<TRenderer extends Renderer = Renderer, TArgs extends Args = Args>(
   storyAnnotations: LegacyStoryAnnotationsOrFn<TRenderer>,
   componentAnnotations: ComponentAnnotations<TRenderer, TArgs>,
-  projectAnnotations: ProjectAnnotations<TRenderer> = GLOBAL_STORYBOOK_PROJECT_ANNOTATIONS,
+  projectAnnotations: ProjectAnnotations<TRenderer> = GLOBAL_STORYBOOK_PROJECT_ANNOTATIONS as ProjectAnnotations<TRenderer>,
   defaultConfig: ProjectAnnotations<TRenderer> = {},
   exportsName?: string
 ): PreparedStoryFn<TRenderer, Partial<TArgs>> {
@@ -60,7 +60,7 @@ export function composeStory<TRenderer extends Renderer = Renderer, TArgs extend
     normalizedComponentAnnotations
   );
 
-  const normalizedProjectAnnotations = normalizeProjectAnnotations({
+  const normalizedProjectAnnotations = normalizeProjectAnnotations<TRenderer>({
     ...projectAnnotations,
     ...defaultConfig,
   });

--- a/code/renderers/react/src/__test__/composeStories.test.tsx
+++ b/code/renderers/react/src/__test__/composeStories.test.tsx
@@ -9,8 +9,6 @@ import { setProjectAnnotations, composeStories, composeStory } from '..';
 import type { Button } from './Button';
 import * as stories from './Button.stories';
 
-setProjectAnnotations([]);
-
 // example with composeStories, returns an object with all stories composed with args/decorators
 const { CSF3Primary } = composeStories(stories);
 
@@ -43,21 +41,27 @@ test('reuses args from composeStories', () => {
   expect(buttonElement).not.toBeNull();
 });
 
-describe('GlobalConfig', () => {
-  test('renders with default globalConfig', () => {
+describe('projectAnnotations', () => {
+  test('renders with default projectAnnotations', () => {
     const WithEnglishText = composeStory(stories.CSF2StoryWithLocale, stories.default);
     const { getByText } = render(<WithEnglishText />);
     const buttonElement = getByText('Hello!');
     expect(buttonElement).not.toBeNull();
   });
 
-  test('renders with custom globalConfig', () => {
+  test('renders with custom projectAnnotations via composeStory params', () => {
     const WithPortugueseText = composeStory(stories.CSF2StoryWithLocale, stories.default, {
       globalTypes: { locale: { defaultValue: 'pt' } } as any,
     });
     const { getByText } = render(<WithPortugueseText />);
     const buttonElement = getByText('Olá!');
     expect(buttonElement).not.toBeNull();
+  });
+
+  test('renders with custom projectAnnotations via setProjectAnnotations', () => {
+    setProjectAnnotations([{ parameters: { injected: true } }]);
+    const Story = composeStory(stories.CSF2StoryWithLocale, stories.default);
+    expect(Story.parameters?.injected).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #21562

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

The default project annotations when using `composeStories` in a project that did not call `setProjectAnnotations` could break with errors such as `[TypeError: runStep is not a function]`. This PR fixes that by calling `composeConfigs` for the default annotations.

## How to test

See the tests!

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
