### PR TITLE
Typescript: Migrate `@storybook/csf-tools` to strict TS

### DIFF
--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -447,7 +447,7 @@ export class ConfigFile {
 
   appendValueToArray(path: string[], value: any) {
     const node = this.valueToNode(value);
-    this.appendNodeToArray(path, node);
+    if (node) this.appendNodeToArray(path, node);
   }
 
   appendNodeToArray(path: string[], node: t.Expression) {

--- a/code/lib/csf-tools/src/babelParse.ts
+++ b/code/lib/csf-tools/src/babelParse.ts
@@ -13,7 +13,7 @@ function parseWithFlowOrTypescript(source: string, parserOptions: babelParser.Pa
   // Merge the provided parserOptions with the custom parser plugins
   const mergedParserOptions = {
     ...parserOptions,
-    plugins: [...parserOptions.plugins, ...parserPlugins],
+    plugins: [...(parserOptions.plugins ?? []), ...parserPlugins],
   };
 
   return babelParser.parse(source, mergedParserOptions);

--- a/code/lib/csf-tools/src/getStorySortParameter.ts
+++ b/code/lib/csf-tools/src/getStorySortParameter.ts
@@ -105,7 +105,7 @@ export const getStorySortParameter = (previewCode: string) => {
           node.declaration.declarations.forEach((decl) => {
             if (t.isVariableDeclarator(decl) && t.isIdentifier(decl.id)) {
               const { name: exportName } = decl.id;
-              if (exportName === 'parameters') {
+              if (exportName === 'parameters' && decl.init) {
                 const paramsObject = stripTSModifiers(decl.init);
                 storySort = parseParameters(paramsObject);
               }

--- a/code/lib/csf-tools/tsconfig.json
+++ b/code/lib/csf-tools/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "strict": false
+    "strict": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Part of #22176

## What I did

1. Ensure I'm using node 16
2. Ran `yarn task --task compile --no-link --start-from=install`
3. Change tsconfig.json `compilerOptions.strict` to `true`
4. Ran `yarn check` inside `code/lib/csf-tools`
5. Fix VSCode linter errors in 640c4a376c7beddfa639226607c5f01b54687aec and af26a45850e69cd35055aee0b23db0ff706ca982
6. Fix yarn check errors

## How to test

1. Ran `yarn check` inside `code/lib/csf-tools`
2. from `storybook/`, ran `yarn run test getStorySortParameter.test.ts` and `yarn run test ConfigFile.test.ts` to ensure tests are passing


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
