### PR TITLE
Normalize paths exposed to vite-builder's `storybook-stories.js` file

### DIFF
--- a/code/lib/builder-vite/src/codegen-importfn-script.ts
+++ b/code/lib/builder-vite/src/codegen-importfn-script.ts
@@ -33,7 +33,7 @@ async function toImportFn(stories: string[]) {
       logger.warn(`Cannot process ${ext} file with storyStoreV7: ${relativePath}`);
     }
 
-    return `  '${toImportPath(relativePath)}': async () => import('/@fs/${file}')`;
+    return `  '${toImportPath(relativePath)}': async () => import('/@fs/${normalizePath(file)}')`;
   });
 
   return `

--- a/code/lib/builder-vite/src/codegen-importfn-script.ts
+++ b/code/lib/builder-vite/src/codegen-importfn-script.ts
@@ -33,7 +33,7 @@ async function toImportFn(stories: string[]) {
       logger.warn(`Cannot process ${ext} file with storyStoreV7: ${relativePath}`);
     }
 
-    return `  '${toImportPath(relativePath)}': async () => import('/@fs/${normalizePath(file)}')`;
+    return `  '${toImportPath(relativePath)}': async () => import('/@fs/${file}')`;
   });
 
   return `

--- a/code/lib/builder-vite/src/list-stories.ts
+++ b/code/lib/builder-vite/src/list-stories.ts
@@ -4,6 +4,7 @@ import { glob } from 'glob';
 import { normalizeStories } from '@storybook/core-common';
 
 import type { Options } from '@storybook/types';
+import { normalizePath } from 'vite';
 
 export async function listStories(options: Options) {
   return (
@@ -20,5 +21,5 @@ export async function listStories(options: Options) {
         return glob(slash(absolutePattern), { follow: true });
       })
     )
-  ).reduce((carry, stories) => carry.concat(stories), []);
+  ).reduce((carry, stories) => carry.concat(stories.map(normalizePath)), []);
 }


### PR DESCRIPTION
## What I did

> **Note** The issue this PR addresses was reproduced on a Windows environment.

### Context

I've finally found some time to upgrade from the 7.0 alpha. Because I am ~~ahead of my time~~ an impatient and curious lad, I did not target the latest stable release, but instead went directly for the latest pre-release. 

### The issue 

Starting from `7.1.0-alpha.11`, one of my Storybooks stopped working and raised the following errors:

#### Browser:
```log
Uncaught SyntaxError: Invalid Unicode escape sequence
```

#### Vite server:
```log
22:11:42 [vite] warning: 
/virtual:/@storybook/builder-vite/storybook-stories.js
1  |  const importers = {
2  |          './.storybook/docs/useAnything.docs.mdx': async () => import('/@fs/H:\Tests\vite-storybook-windows\.storybook\docs\useAnything.docs.mdx'),
   |                                                                       ^
3  |    './src/stories/Button.stories.ts': async () => import('/@fs/H:\Tests\vite-storybook-windows\src\stories\Button.stories.ts')
4  |      };
The above dynamic import cannot be analyzed by Vite.
See https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.

  Plugin: vite:import-analysis
  File: /virtual:/@storybook/builder-vite/storybook-stories.js
```

### Where does it come from?

Notice how the above error displays non-normalized paths (`path\to\file`): this eventually causes errors since those single backslashes are interpreted as escaping characters.

* This probaby comes from #22171 which upgraded [glob](https://github.com/isaacs/node-glob) from version 8.x to 10.x
* Quite a jump forwards, since [version 9 is a complete rewrite](https://github.com/isaacs/node-glob/blob/main/changelog.md#90).
* Looking at the changelog, it looks like they introduced a lot of changes regarding Windows and escaping.

[Basically, here's where the breaking difference seems to be coming from:](https://github.com/storybookjs/storybook/blob/next/code/lib/builder-vite/src/list-stories.ts#L20)
* `7.1.0-alpha.10` (`glob@8.x`) returns `['H:/Tests/vite-storybook-windows/.storybook/docs/useAnything.docs.mdx']`
* `7.1.0-alpha.11` (`glob@10.x`) returns `['H:\\Tests\\vite-storybook-windows\\.storybook\\docs\\useAnything.docs.mdx']`

I've came up with this quickfix, but:
* There might be a better way of fixing this (e.g. by passing options to `glob`)
* I only looked into the case I was facing, we might need to keep an eye on other use cases of `glob` within Storybook's codebase because there might still remain undetected related issues?

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [X] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [X] Make sure to add/update documentation regarding your changes
- [X] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)
