### PR TITLE
Tech: do not generate ESM dist for preset files

### DIFF
--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -24,6 +24,7 @@
     "url": "https://opencollective.com/storybook"
   },
   "license": "MIT",
+  "sideEffects": false,
   "exports": {
     ".": {
       "node": "./dist/index.js",
@@ -38,7 +39,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./blocks": {
@@ -53,7 +53,6 @@
     },
     "./dist/preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./dist/shims/mdx-react-shim": {

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -24,7 +24,6 @@
     "url": "https://opencollective.com/storybook"
   },
   "license": "MIT",
-  "sideEffects": false,
   "exports": {
     ".": {
       "node": "./dist/index.js",

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -30,7 +30,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./manager": {

--- a/code/frameworks/html-vite/package.json
+++ b/code/frameworks/html-vite/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/html-webpack5/package.json
+++ b/code/frameworks/html-webpack5/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -29,7 +29,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./preview.js": {

--- a/code/frameworks/preact-vite/package.json
+++ b/code/frameworks/preact-vite/package.json
@@ -27,7 +27,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/preact-webpack5/package.json
+++ b/code/frameworks/preact-webpack5/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/react-webpack5/package.json
+++ b/code/frameworks/react-webpack5/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/server-webpack5/package.json
+++ b/code/frameworks/server-webpack5/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/svelte-vite/package.json
+++ b/code/frameworks/svelte-vite/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/svelte-webpack5/package.json
+++ b/code/frameworks/svelte-webpack5/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/sveltekit/package.json
+++ b/code/frameworks/sveltekit/package.json
@@ -31,7 +31,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/vue-vite/package.json
+++ b/code/frameworks/vue-vite/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/vue-webpack5/package.json
+++ b/code/frameworks/vue-webpack5/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/vue3-vite/package.json
+++ b/code/frameworks/vue3-vite/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/vue3-webpack5/package.json
+++ b/code/frameworks/vue3-webpack5/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/web-components-vite/package.json
+++ b/code/frameworks/web-components-vite/package.json
@@ -28,7 +28,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/frameworks/web-components-webpack5/package.json
+++ b/code/frameworks/web-components-webpack5/package.json
@@ -31,7 +31,6 @@
     },
     "./preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/lib/builder-webpack5/package.json
+++ b/code/lib/builder-webpack5/package.json
@@ -29,13 +29,11 @@
     "./presets/custom-webpack-preset": {
       "node": "./dist/presets/custom-webpack-preset.js",
       "require": "./dist/presets/custom-webpack-preset.js",
-      "import": "./dist/presets/custom-webpack-preset.mjs",
       "types": "./dist/presets/custom-webpack-preset.d.ts"
     },
     "./presets/preview-preset": {
       "node": "./dist/presets/preview-preset.js",
       "require": "./dist/presets/preview-preset.js",
-      "import": "./dist/presets/preview-preset.mjs",
       "types": "./dist/presets/preview-preset.d.ts"
     },
     "./templates/virtualModuleModernEntry.js.handlebars": "./templates/virtualModuleModernEntry.js.handlebars",

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -29,13 +29,11 @@
     "./dist/presets/babel-cache-preset": {
       "node": "./dist/presets/babel-cache-preset.js",
       "require": "./dist/presets/babel-cache-preset.js",
-      "import": "./dist/presets/babel-cache-preset.mjs",
       "types": "./dist/presets/babel-cache-preset.d.ts"
     },
     "./dist/presets/common-preset": {
       "node": "./dist/presets/common-preset.js",
       "require": "./dist/presets/common-preset.js",
-      "import": "./dist/presets/common-preset.mjs",
       "types": "./dist/presets/common-preset.d.ts"
     },
     "./public/favicon.svg": "./public/favicon.svg",

--- a/code/lib/react-dom-shim/package.json
+++ b/code/lib/react-dom-shim/package.json
@@ -35,7 +35,6 @@
     },
     "./dist/preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -33,7 +33,6 @@
     },
     "./dist/preset": {
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
     "./package.json": "./package.json"

--- a/scripts/prepare/bundle.ts
+++ b/scripts/prepare/bundle.ts
@@ -73,11 +73,15 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
     optimized,
   });
 
+  const nonPresetEntries = allEntries.filter((f) => !path.parse(f).name.includes('preset'));
+
   if (formats.includes('esm')) {
     tasks.push(
       build({
         silent: true,
-        entry: allEntries,
+        treeshake: true,
+        entry: nonPresetEntries,
+        shims: false,
         watch,
         outDir,
         format: ['esm'],

--- a/scripts/prepare/bundle.ts
+++ b/scripts/prepare/bundle.ts
@@ -73,6 +73,10 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
     optimized,
   });
 
+  /* preset files are always CJS only.
+   * Generating an ESM file for them anyway is problematic because they often have a reference to `require`.
+   * TSUP generated code will then have a `require` polyfill/guard in the ESM files, which causes issues for webpack.
+   */
   const nonPresetEntries = allEntries.filter((f) => !path.parse(f).name.includes('preset'));
 
   if (formats.includes('esm')) {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21316

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

When TSup is bundling code, it will add a bit of require polyfill code to the output, when it encounters code referencing `require` in 1 of the entrypoints.

It will add the polyfill code to all entrypoints, and will refuse to treeshake it out.

So I made en excemption for preset entries, to never get a mjs file generated, because those often have references to `require` in them.

## How to test

Run the build process and check for existence of this type of code in dist:
```
var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
  get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
}) : x)(function(x) {
  if (typeof require !== "undefined")
    return require.apply(this, arguments);
  throw new Error('Dynamic require of "' + x + '" is not supported');
});

export {
  __require
};
```

At least within the docs addon this no longer happens.

This code does impact all monorepo packages though, but I think that's fine. AFAIK we never use mjs exports of presets, always the cjs files.

Some day we'll convert everything over to ONLY ESM, and have all packages be type=module, but that's a project for future me.