### PR TITLE
Fix: remove the alias for `global`

### DIFF
--- a/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/lib/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -30,7 +30,6 @@ import { createBabelLoader } from './babel-loader-preview';
 const wrapForPnP = (input: string) => dirname(require.resolve(join(input, 'package.json')));
 
 const storybookPaths: Record<string, string> = {
-  global: wrapForPnP('@storybook/global'),
   ...[
     // these packages are not pre-bundled because of react dependencies
     'api',


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/21242

## What I did

Remove the alias for `global` for webpack