### PR TITLE
Error on YN0060 - INCOMPATIBLE_PEER_DEPENDENCY 

### DIFF
--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -48,7 +48,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "check": "svelte-check",
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
@@ -66,7 +66,7 @@
     "expect-type": "^0.14.2",
     "svelte": "^3.59.1",
     "svelte-check": "^3.4.3",
-    "typescript": "~4.9.3"
+    "typescript": "^5.0.4"
   },
   "peerDependencies": {
     "svelte": "^3.1.0"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7586,7 +7586,7 @@ __metadata:
     svelte-check: ^3.4.3
     sveltedoc-parser: ^4.2.1
     type-fest: 2.19.0
-    typescript: ~4.9.3
+    typescript: ^5.0.4
   peerDependencies:
     svelte: ^3.1.0
   languageName: unknown
@@ -29235,8 +29235,8 @@ __metadata:
   linkType: hard
 
 "svelte-preprocess@npm:^5.0.3":
-  version: 5.0.4
-  resolution: "svelte-preprocess@npm:5.0.4"
+  version: 5.0.3
+  resolution: "svelte-preprocess@npm:5.0.3"
   dependencies:
     "@types/pug": ^2.0.6
     detect-indent: ^6.1.0
@@ -29253,7 +29253,7 @@ __metadata:
     sass: ^1.26.8
     stylus: ^0.55.0
     sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-    svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0
+    svelte: ^3.23.0
     typescript: ">=3.9.5 || ^4.0.0 || ^5.0.0"
   peerDependenciesMeta:
     "@babel/core":
@@ -29276,7 +29276,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 1ed64b96a91327a47992df0b82df708b5cda92e1da211edbedaf411e633a0be5a8425d19f996abc8dcef52dadd26b5474924dd9eeb30a7b409bf60c33b689d6c
+  checksum: ec4fd22320eba631d7abc2641f542ec7e10f8a1862eb522fb5e12651c1f541d048c64191d770841a48793b8051b5bf6b09307505d66d6bb9786ba6807918057d
   languageName: node
   linkType: hard
 

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -85,7 +85,8 @@ export const configureYarn2ForVerdaccio = async ({ cwd, dryRun, debug }: YarnOpt
     // We need to be able to update lockfile when bootstrapping the examples
     `yarn config set enableImmutableInstalls false`,
     // Discard all YN0013 - FETCH_NOT_CACHED messages
-    `yarn config set logFilters --json '[ { "code": "YN0013", "level": "discard" } ]'`,
+    // Error on YN0060 - INCOMPATIBLE_PEER_DEPENDENCY
+    `yarn config set logFilters --json '[ { "code": "YN0013", "level": "discard" }, { "code": "YN0060", "level": "error" } ]'`,
   ];
 
   await exec(


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Some package managers throw an error if peer dependencies are not met properly. Yarn, though, just logs a warning. It would be nice if our sandboxes fail if peer dependencies are not met. Therefore, yarn now fails for YN0060 - INCOMPATIBLE_PEER_DEPENDENCY instead of just returning back a warning.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
