### PR TITLE
Migrate @storybook/react-vite and @storybook/preact-vite to strict TS

### DIFF
--- a/code/frameworks/preact-vite/tsconfig.json
+++ b/code/frameworks/preact-vite/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
-    "strict": false
+    "strict": true
   },
   "include": ["src/**/*"]
 }

--- a/code/frameworks/react-vite/tsconfig.json
+++ b/code/frameworks/react-vite/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "./src",
     "types": ["node"],
     "resolveJsonModule": true,
-    "strict": false
+    "strict": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Closes Part of https://github.com/storybookjs/storybook/issues/22176

## What I did

Migrate @storybook/react-vite and @storybook/preact-vite to strict TS

1. Change in tsconfig.json "strict": false -> "strict": true
2. Run yarn check in the directory of the package (no type errors found)

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
