### PR TITLE
Adjust child process I/O for compodoc command

### DIFF
--- a/code/frameworks/angular/src/builders/utils/run-compodoc.spec.ts
+++ b/code/frameworks/angular/src/builders/utils/run-compodoc.spec.ts
@@ -45,7 +45,8 @@ describe('runCompodoc', () => {
     expect(mockRunScript).toHaveBeenCalledWith(
       'compodoc',
       ['-p', 'path/to/tsconfig.json', '-d', 'path/to/project'],
-      'path/to/project'
+      'path/to/project',
+      'inherit'
     );
   });
 
@@ -66,7 +67,8 @@ describe('runCompodoc', () => {
     expect(mockRunScript).toHaveBeenCalledWith(
       'compodoc',
       ['-d', 'path/to/project', '-p', 'path/to/tsconfig.stories.json'],
-      'path/to/project'
+      'path/to/project',
+      'inherit'
     );
   });
 
@@ -87,7 +89,8 @@ describe('runCompodoc', () => {
     expect(mockRunScript).toHaveBeenCalledWith(
       'compodoc',
       ['-p', 'path/to/tsconfig.json', '-d', 'path/to/project'],
-      'path/to/project'
+      'path/to/project',
+      'inherit'
     );
   });
 
@@ -108,7 +111,8 @@ describe('runCompodoc', () => {
     expect(mockRunScript).toHaveBeenCalledWith(
       'compodoc',
       ['-p', 'path/to/tsconfig.json', '--output', 'path/to/customFolder'],
-      'path/to/project'
+      'path/to/project',
+      'inherit'
     );
   });
 
@@ -129,7 +133,8 @@ describe('runCompodoc', () => {
     expect(mockRunScript).toHaveBeenCalledWith(
       'compodoc',
       ['-p', 'path/to/tsconfig.json', '-d', 'path/to/customFolder'],
-      'path/to/project'
+      'path/to/project',
+      'inherit'
     );
   });
 });

--- a/code/frameworks/angular/src/builders/utils/run-compodoc.ts
+++ b/code/frameworks/angular/src/builders/utils/run-compodoc.ts
@@ -31,7 +31,8 @@ export const runCompodoc = (
       const stdout = packageManager.runPackageCommandSync(
         'compodoc',
         finalCompodocArgs,
-        context.workspaceRoot
+        context.workspaceRoot,
+        'inherit'
       );
 
       context.logger.info(stdout);

--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -427,8 +427,18 @@ export abstract class JsPackageManager {
   ): // Use generic and conditional type to force `string[]` if fetchAllVersions is true and `string` if false
   Promise<T extends true ? string[] : string>;
 
-  public abstract runPackageCommand(command: string, args: string[], cwd?: string): Promise<string>;
-  public abstract runPackageCommandSync(command: string, args: string[], cwd?: string): string;
+  public abstract runPackageCommand(
+    command: string,
+    args: string[],
+    cwd?: string,
+    stdio?: string
+  ): Promise<string>;
+  public abstract runPackageCommandSync(
+    command: string,
+    args: string[],
+    cwd?: string,
+    stdio?: 'inherit' | 'pipe'
+  ): string;
   public abstract findInstallations(pattern?: string[]): Promise<InstallationMetadata | undefined>;
 
   public executeCommandSync({

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -47,11 +47,17 @@ export class NPMProxy extends JsPackageManager {
     return this.installArgs;
   }
 
-  public runPackageCommandSync(command: string, args: string[], cwd?: string): string {
+  public runPackageCommandSync(
+    command: string,
+    args: string[],
+    cwd?: string,
+    stdio?: 'pipe' | 'inherit'
+  ): string {
     return this.executeCommandSync({
       command: 'npm',
       args: ['exec', '--', command, ...args],
       cwd,
+      stdio,
     });
   }
 

--- a/code/lib/cli/src/js-package-manager/PNPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/PNPMProxy.ts
@@ -67,11 +67,17 @@ export class PNPMProxy extends JsPackageManager {
     return this.installArgs;
   }
 
-  public runPackageCommandSync(command: string, args: string[], cwd?: string): string {
+  public runPackageCommandSync(
+    command: string,
+    args: string[],
+    cwd?: string,
+    stdio?: 'pipe' | 'inherit'
+  ): string {
     return this.executeCommandSync({
       command: 'pnpm',
       args: ['exec', command, ...args],
       cwd,
+      stdio,
     });
   }
 

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
@@ -42,8 +42,13 @@ export class Yarn1Proxy extends JsPackageManager {
     return `yarn ${command}`;
   }
 
-  public runPackageCommandSync(command: string, args: string[], cwd?: string): string {
-    return this.executeCommandSync({ command: `yarn`, args: [command, ...args], cwd });
+  public runPackageCommandSync(
+    command: string,
+    args: string[],
+    cwd?: string,
+    stdio?: 'pipe' | 'inherit'
+  ): string {
+    return this.executeCommandSync({ command: `yarn`, args: [command, ...args], cwd, stdio });
   }
 
   async runPackageCommand(command: string, args: string[], cwd?: string): Promise<string> {

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -28,8 +28,13 @@ export class Yarn2Proxy extends JsPackageManager {
     return `yarn ${command}`;
   }
 
-  public runPackageCommandSync(command: string, args: string[], cwd?: string) {
-    return this.executeCommandSync({ command: 'yarn', args: [command, ...args], cwd });
+  public runPackageCommandSync(
+    command: string,
+    args: string[],
+    cwd?: string,
+    stdio?: 'pipe' | 'inherit'
+  ) {
+    return this.executeCommandSync({ command: 'yarn', args: [command, ...args], cwd, stdio });
   }
 
   async runPackageCommand(command: string, args: string[], cwd?: string) {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/22400

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Refactor package manager's runPackageCommand method to include an optional stdio parameter for better control over child process I/O

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
