### PR TITLE
Build: Dedupe dependencies when linking a sandbox

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -16,7 +16,12 @@ import { join, resolve, sep } from 'path';
 import slash from 'slash';
 import type { Task } from '../task';
 import { executeCLIStep, steps } from '../utils/cli-step';
-import { installYarn2, configureYarn2ForVerdaccio, addPackageResolutions } from '../utils/yarn';
+import {
+  installYarn2,
+  configureYarn2ForVerdaccio,
+  addPackageResolutions,
+  dedupeDependencies,
+} from '../utils/yarn';
 import { exec } from '../utils/exec';
 import type { ConfigFile } from '../../code/lib/csf-tools';
 import { writeConfig } from '../../code/lib/csf-tools';
@@ -74,6 +79,9 @@ export const install: Task['run'] = async (
   await installYarn2({ cwd, dryRun, debug });
 
   if (link) {
+    // try to dedupe dependencies to avoid conflicts with yarn link
+    await dedupeDependencies({ cwd, dryRun, debug });
+
     await executeCLIStep(steps.link, {
       argument: sandboxDir,
       cwd: CODE_DIRECTORY,

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -30,6 +30,19 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
   await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
 };
 
+export const dedupeDependencies = async ({ cwd, dryRun, debug }: YarnOptions) => {
+  await exec(
+    `yarn dedupe`,
+    { cwd },
+    {
+      dryRun,
+      debug,
+      startMessage: `➰ Deduplicating dependencies`,
+      errorMessage: `🚨 Deduplicating dependencies failed`,
+    }
+  );
+};
+
 export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
   const pnpApiExists = await pathExists(path.join(cwd, '.pnp.cjs'));
 


### PR DESCRIPTION
Closes #22294

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Attempt to fix the linking issue by running `yarn dedupe` right before linking

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
