### PR TITLE
Core: Lazy start SSv6 API

### DIFF
--- a/code/renderers/react/src/public-api.tsx
+++ b/code/renderers/react/src/public-api.tsx
@@ -12,28 +12,27 @@ interface ClientApi extends Addon_ClientStoryApi<ReactRenderer['storyResult']> {
 const RENDERER = 'react';
 
 let api: ReturnType<typeof start<ReactRenderer>>;
-const lazyStart = () => {
+const getApi = () => {
   if (!api) api = start<ReactRenderer>(renderToCanvas, { render });
+  return api;
 };
 
 export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
-  lazyStart();
-  return (api.clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({
+  return (
+    getApi().clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>
+  ).addParameters({
     renderer: RENDERER,
   });
 };
 
 export const configure: ClientApi['configure'] = (...args) => {
-  lazyStart();
-  return api.configure(RENDERER, ...args);
+  return getApi().configure(RENDERER, ...args);
 };
 
 export const forceReRender: ClientApi['forceReRender'] = () => {
-  lazyStart();
-  return api.forceReRender();
+  return getApi().forceReRender();
 };
 
 export const raw: ClientApi['raw'] = (...args) => {
-  lazyStart();
-  return api.clientApi.raw(...args);
+  return getApi().clientApi.raw(...args);
 };

--- a/code/renderers/react/src/public-api.tsx
+++ b/code/renderers/react/src/public-api.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable prefer-destructuring */
 import { start } from '@storybook/preview-api';
 import type { Addon_ClientStoryApi, Addon_Loadable } from '@storybook/types';
 
@@ -12,14 +11,29 @@ interface ClientApi extends Addon_ClientStoryApi<ReactRenderer['storyResult']> {
 }
 const RENDERER = 'react';
 
-const api = start<ReactRenderer>(renderToCanvas, { render });
+let api: ReturnType<typeof start<ReactRenderer>>;
+const lazyStart = () => {
+  if (!api) api = start<ReactRenderer>(renderToCanvas, { render });
+};
 
 export const storiesOf: ClientApi['storiesOf'] = (kind, m) => {
+  lazyStart();
   return (api.clientApi.storiesOf(kind, m) as ReturnType<ClientApi['storiesOf']>).addParameters({
     renderer: RENDERER,
   });
 };
 
-export const configure: ClientApi['configure'] = (...args) => api.configure(RENDERER, ...args);
-export const forceReRender: ClientApi['forceReRender'] = api.forceReRender;
-export const raw: ClientApi['raw'] = api.clientApi.raw;
+export const configure: ClientApi['configure'] = (...args) => {
+  lazyStart();
+  return api.configure(RENDERER, ...args);
+};
+
+export const forceReRender: ClientApi['forceReRender'] = () => {
+  lazyStart();
+  return api.forceReRender();
+};
+
+export const raw: ClientApi['raw'] = (...args) => {
+  lazyStart();
+  return api.clientApi.raw(...args);
+};


### PR DESCRIPTION
Closes N/A

## What I did

Currently when you import `composeStories` from `@storybook/react`, it will start the SSv6 API, which expects to be run in a browser (or a polyfilled node environment).

This PR lazily starts SSV6 on the first invocation of an SSV6 API method. It's React-only, but if the team approves I'll implement it for the rest of the renderers.

## How to test

In Node:
```
> const { storiesOf } = require('@storybook/react')
> let x = storiesOf('foo')
Uncaught TypeError: Cannot read properties of undefined (reading 'location')
    at getSelectionSpecifierFromPath (/Users/shilman/projects/storybookjs/server-demo/node_modules/@storybook/preview-api/dist/index.js:70:1115)
    at new UrlStore (/Users/shilman/projects/storybookjs/server-demo/node_modules/@storybook/preview-api/dist/index.js:70:1627)
    at new PreviewWeb (/Users/shilman/projects/storybookjs/server-demo/node_modules/@storybook/preview-api/dist/index.js:73:1158)
    at start (/Users/shilman/projects/storybookjs/server-demo/node_modules/@storybook/preview-api/dist/index.js:94:2133)
    at lazyStart (/Users/shilman/projects/storybookjs/server-demo/node_modules/@storybook/react/dist/index.js:116:40)
    at storiesOf (/Users/shilman/projects/storybookjs/server-demo/node_modules/@storybook/react/dist/index.js:119:3)
```

If you try to run this in 7.0.x you'll get the `reading 'location'` error when you require `@storybook/react`.

Also the SSV6 sandboxes should still work.