### PR TITLE
Toolbars: Fix title behavior in UI

### DIFF
--- a/code/addons/toolbars/src/components/ToolbarMenuList.tsx
+++ b/code/addons/toolbars/src/components/ToolbarMenuList.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react';
 import React, { useState, useCallback } from 'react';
 import { useGlobals } from '@storybook/manager-api';
-import { deprecate } from '@storybook/client-logger';
 import { WithTooltip, TooltipLinkList } from '@storybook/components';
 import { ToolbarMenuButton } from './ToolbarMenuButton';
 import type { WithKeyboardCycleProps } from '../hoc/withKeyboardCycle';
@@ -15,7 +14,6 @@ type ToolbarMenuListProps = ToolbarMenuProps & WithKeyboardCycleProps;
 export const ToolbarMenuList: FC<ToolbarMenuListProps> = withKeyboardCycle(
   ({
     id,
-    name,
     description,
     toolbar: { icon: _icon, items, title: _title, preventDynamicIcon, dynamicTitle },
   }) => {
@@ -29,14 +27,6 @@ export const ToolbarMenuList: FC<ToolbarMenuListProps> = withKeyboardCycle(
 
     if (!preventDynamicIcon) {
       icon = getSelectedIcon({ currentValue, items }) || icon;
-    }
-
-    // Deprecation support for old "name of global arg used as title"
-    if (!title) {
-      title = name;
-      deprecate(
-        '`showName` is deprecated as `name` will stop having dual purposes in the future. Please specify a `title` in `globalTypes` instead.'
-      );
     }
 
     if (dynamicTitle) {

--- a/code/addons/toolbars/src/components/ToolbarMenuList.tsx
+++ b/code/addons/toolbars/src/components/ToolbarMenuList.tsx
@@ -14,6 +14,7 @@ type ToolbarMenuListProps = ToolbarMenuProps & WithKeyboardCycleProps;
 export const ToolbarMenuList: FC<ToolbarMenuListProps> = withKeyboardCycle(
   ({
     id,
+    name,
     description,
     toolbar: { icon: _icon, items, title: _title, preventDynamicIcon, dynamicTitle },
   }) => {
@@ -31,6 +32,10 @@ export const ToolbarMenuList: FC<ToolbarMenuListProps> = withKeyboardCycle(
 
     if (dynamicTitle) {
       title = getSelectedTitle({ currentValue, items }) || title;
+    }
+
+    if (!title && !icon) {
+      console.warn(`Toolbar '${name}' has no title or icon`);
     }
 
     const handleItemClick = useCallback(

--- a/code/addons/toolbars/src/components/ToolbarMenuListItem.tsx
+++ b/code/addons/toolbars/src/components/ToolbarMenuListItem.tsx
@@ -21,7 +21,7 @@ export const ToolbarMenuListItem = ({
   const Icon = icon && <Icons style={{ opacity: 1 }} icon={icon} />;
 
   const Item: TooltipLinkListLink = {
-    id: value || currentValue,
+    id: value ?? '_reset',
     active: currentValue === value,
     right,
     title,

--- a/code/addons/toolbars/src/utils/get-selected.ts
+++ b/code/addons/toolbars/src/utils/get-selected.ts
@@ -6,7 +6,9 @@ interface GetSelectedItemProps {
 }
 
 export const getSelectedItem = ({ currentValue, items }: GetSelectedItemProps) => {
-  const selectedItem = currentValue != null && items.find((item) => item.value === currentValue);
+  const selectedItem =
+    currentValue != null &&
+    items.find((item) => item.value === currentValue && item.type !== 'reset');
   return selectedItem;
 };
 


### PR DESCRIPTION
Closes N/A

Reported here https://discord.com/channels/486522875931656193/1105749672489918506

## What I did

There's a bug in Storybook 7 where the toolbar button automatically shows a text label even if no `title` is specified in the toolbar configuration. It also makes a deprecation warning in the console. This PR fixes that. Now if the user doesn't specify a `title` attribute for the toolbar, no label is shown, and no deprecation warning is shown.

It also fixes a few other minor bugs in the same code:
- [x] If no `title` or `icon` is specified, it will warn in the browser console
- [x] If the user uses a `reset` toolbar item
  - [x] it won't show the reset label when `dynamicTitles` is set
  - [x] it won't show a react duplicate key warning in the browser console

Self-merging @valentinpalkovic

## How to test

Run a sandbox and check out the toolbar. In the current code both `Theme` and `Locale` will show up as labels. With this PR, the `Locale` label goes away since it's not configured in the project.
