### PR TITLE
Sandboxes: Pin @vitejs/plugin-react to avoid conflict

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -16,7 +16,12 @@ import { join, resolve, sep } from 'path';
 import slash from 'slash';
 import type { Task } from '../task';
 import { executeCLIStep, steps } from '../utils/cli-step';
-import { installYarn2, configureYarn2ForVerdaccio, addPackageResolutions } from '../utils/yarn';
+import {
+  installYarn2,
+  configureYarn2ForVerdaccio,
+  addPackageResolutions,
+  addWorkaroundResolutions,
+} from '../utils/yarn';
 import { exec } from '../utils/exec';
 import type { ConfigFile } from '../../code/lib/csf-tools';
 import { writeConfig } from '../../code/lib/csf-tools';
@@ -81,6 +86,7 @@ export const install: Task['run'] = async (
       dryRun,
       debug,
     });
+    await addWorkaroundResolutions({ cwd, dryRun, debug });
   } else {
     // We need to add package resolutions to ensure that we only ever install the latest version
     // of any storybook packages as verdaccio is not able to both proxy to npm and publish over

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -58,6 +58,19 @@ export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
   );
 };
 
+export const addWorkaroundResolutions = async ({ cwd, dryRun }: YarnOptions) => {
+  logger.info(`🔢 Adding resolutions for workarounds`);
+  if (dryRun) return;
+
+  const packageJsonPath = path.join(cwd, 'package.json');
+  const packageJson = await readJSON(packageJsonPath);
+  packageJson.resolutions = {
+    ...packageJson.resolutions,
+    '@vitejs/plugin-react': '^4.0.0', // due to conflicting version in @storybook/vite-react
+  };
+  await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
+};
+
 export const configureYarn2ForVerdaccio = async ({ cwd, dryRun, debug }: YarnOptions) => {
   const command = [
     // We don't want to use the cache or we might get older copies of our built packages


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/pull/22454
Closes https://github.com/storybookjs/storybook/pull/22294

## What I did

This fixes the issue that is currently preventing contributors from being able to create vite-react sandboxes without `--no-link`.  The problem is that we use `@vitejs/plugin-react@3` in `@storybook/react-vite`, but new vite projects are created in the sandboxes using the latest version 4.  

This addresses the problem by adding a `resolutions` in the sandbox that pins the version to `^4.0.0`.  We don't use the backup version supplied in react-vite, so this does not have any impact on how we use the sandbox, and it doesn't impact everyday Storybook users either.

## How to test

Run `yarn task --task sandbox --template react-vite/default-ts --start-from install`, it should succeed.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
