### PR TITLE
Web-components: Fix source decorator to handle document fragments

### DIFF
--- a/code/renderers/web-components/src/docs/sourceDecorator.test.ts
+++ b/code/renderers/web-components/src/docs/sourceDecorator.test.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, render } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 import { addons, useEffect } from '@storybook/preview-api';
 import { SNIPPET_RENDERED } from '@storybook/docs-tools';
@@ -84,5 +84,35 @@ describe('sourceDecorator', () => {
       args: {},
       source: '<div>args story</div>',
     });
+  });
+
+  it('should handle document fragment without removing its child nodes', async () => {
+    const storyFn = () =>
+      html`my
+        <div>args story</div>`;
+    const decoratedStoryFn = () => {
+      const fragment = document.createDocumentFragment();
+      render(storyFn(), fragment);
+      return fragment;
+    };
+    const context = makeContext('args', { __isArgsStory: true }, {});
+    const story = sourceDecorator(decoratedStoryFn, context);
+    await tick();
+    expect(mockChannel.emit).toHaveBeenCalledWith(SNIPPET_RENDERED, {
+      id: 'lit-test--args',
+      args: {},
+      source: `my
+        <div>args story</div>`,
+    });
+    expect(story).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <!---->
+        my
+              
+        <div>
+          args story
+        </div>
+      </DocumentFragment>
+    `);
   });
 });

--- a/code/renderers/web-components/src/docs/sourceDecorator.ts
+++ b/code/renderers/web-components/src/docs/sourceDecorator.ts
@@ -40,7 +40,11 @@ export function sourceDecorator(
   });
   if (!skipSourceRender(context)) {
     const container = window.document.createElement('div');
-    render(renderedForSource, container);
+    if (renderedForSource instanceof DocumentFragment) {
+      render(renderedForSource.cloneNode(true), container);
+    } else {
+      render(renderedForSource, container);
+    }
     source = container.innerHTML.replace(LIT_EXPRESSION_COMMENTS, '');
   }
 

--- a/code/renderers/web-components/src/types.ts
+++ b/code/renderers/web-components/src/types.ts
@@ -1,7 +1,12 @@
 import type { StoryContext as StoryContextBase, WebRenderer } from '@storybook/types';
 import type { TemplateResult, SVGTemplateResult } from 'lit';
 
-export type StoryFnHtmlReturnType = string | Node | TemplateResult | SVGTemplateResult;
+export type StoryFnHtmlReturnType =
+  | string
+  | Node
+  | DocumentFragment
+  | TemplateResult
+  | SVGTemplateResult;
 
 export type StoryContext = StoryContextBase<WebComponentsRenderer>;
 


### PR DESCRIPTION
## What I did

I'm migrating our company's setup from Storybook 6 to Storybook 7 and ran into the issue with one of our decorators. Let me explain what it does first.

We have a custom decorator to allow rendering stories explicitly with Lit 1 and Lit 2 to help in migration for Lit 1 -> 2.

```js
export const withLitCompat = render =>
  makeDecorator({
    name: 'withLitCompat',
    parameterName: 'litCompat',
    wrapper: (getStory, context) => {
      const fragment = document.createDocumentFragment();
      render(getStory(context), fragment);
      return fragment;
    },
  });
```

Then you can configure what lit version you want your stories to be rendered with, e.g.:

```js
// preview.js
import { render } from 'my-design-system/lit-1.js';
import { withLitCompat } from 'path/to/with-lit-compat.js';

export const decorators = [
  withLitCompat(render),
];
```

Storybook 7 [changed the order of decorators](https://github.com/storybookjs/storybook/blob/v7.0.0/MIGRATION.md#changed-decorator-order-between-previewjs-and-addonsframeworks), so the `sourceDecorator` is executed after our custom decorators, which results in the following bug:
- document fragment with child nodes containing the story is passed from `withLitCompat` to `sourceDecorator`
- document fragment gets rendered in `sourceDecorator` by Lit which moves its child nodes to the new div, leaving it empty
- document fragment (now empty) is passed further to the `renderToCanvas` which renders empty document fragment

This fix makes sure to clone the document fragment to prevent moving of the child nodes which fixes this bug.

## How to test

Unit test is provided to verify correct document fragment handling.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
