### PR TITLE
CLI: Fix storybook upgrade precheckfailure object

### DIFF
--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -60,7 +60,10 @@ export const automigrate = async ({
   renderer: rendererPackage,
   skipInstall,
   hideMigrationSummary = false,
-}: FixOptions = {}) => {
+}: FixOptions = {}): Promise<{
+  fixResults: Record<string, FixStatus>;
+  preCheckFailure: PreCheckFailure;
+}> => {
   if (list) {
     logAvailableMigrations();
     return null;
@@ -79,7 +82,7 @@ export const automigrate = async ({
 
   logger.info('🔎 checking possible migrations..');
 
-  const { fixResults, fixSummary } = await runFixes({
+  const { fixResults, fixSummary, preCheckFailure } = await runFixes({
     fixes,
     useNpm,
     pkgMgr,
@@ -117,7 +120,7 @@ export const automigrate = async ({
 
   cleanup();
 
-  return fixResults;
+  return { fixResults, preCheckFailure };
 };
 
 export async function runFixes({
@@ -138,7 +141,11 @@ export async function runFixes({
   userSpecifiedConfigDir?: string;
   rendererPackage?: string;
   skipInstall?: boolean;
-}) {
+}): Promise<{
+  preCheckFailure?: PreCheckFailure;
+  fixResults: Record<FixId, FixStatus>;
+  fixSummary: FixSummary;
+}> {
   if (useNpm) {
     useNpmWarning();
     // eslint-disable-next-line no-param-reassign
@@ -146,6 +153,9 @@ export async function runFixes({
   }
 
   const packageManager = JsPackageManagerFactory.getPackageManager({ force: pkgMgr });
+
+  const fixResults = {} as Record<FixId, FixStatus>;
+  const fixSummary: FixSummary = { succeeded: [], failed: {}, manual: [], skipped: [] };
 
   const {
     configDir: inferredConfigDir,
@@ -160,6 +170,8 @@ export async function runFixes({
         🤔 Are you running automigrate from your project directory? Please specify your Storybook config directory with the --config-dir flag.
       `);
     return {
+      fixResults,
+      fixSummary,
       preCheckFailure: PreCheckFailure.UNDETECTED_SB_VERSION,
     };
   }
@@ -175,6 +187,8 @@ export async function runFixes({
         )} so the automigrations will be skipped. You might be running this command in a monorepo or a non-standard project structure. If that is the case, please rerun this command by specifying the path to your Storybook config directory via the --config-dir option.`
       );
       return {
+        fixResults,
+        fixSummary,
         preCheckFailure: PreCheckFailure.MAINJS_NOT_FOUND,
       };
     }
@@ -186,12 +200,11 @@ export async function runFixes({
     logger.info('Please fix the error and try again.');
 
     return {
+      fixResults,
+      fixSummary,
       preCheckFailure: PreCheckFailure.MAINJS_EVALUATION,
     };
   }
-
-  const fixResults = {} as Record<FixId, FixStatus>;
-  const fixSummary: FixSummary = { succeeded: [], failed: {}, manual: [], skipped: [] };
 
   for (let i = 0; i < fixes.length; i += 1) {
     const f = fixes[i] as Fix;

--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -212,12 +212,11 @@ export const doUpgrade = async ({
     checkVersionConsistency();
     automigrationResults = await automigrate({ dryRun, yes, packageManager: pkgMgr, configDir });
   }
-
   if (!options.disableTelemetry) {
     const afterVersion = await getStorybookCoreVersion();
-    const { preCheckFailure, ...results } = automigrationResults || {};
+    const { preCheckFailure, fixResults } = automigrationResults || {};
     const automigrationTelemetry = {
-      automigrationResults: preCheckFailure ? null : results,
+      automigrationResults: preCheckFailure ? null : fixResults,
       automigrationPreCheckFailure: preCheckFailure || null,
     };
     telemetry('upgrade', {


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR fixes two distinct issues, one regarding destructuring a property that was supposed to exist but didn't, the other one is about precheck failures that we supposedly sent to telemetry but actually didn't!

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
