### PR TITLE
Chore: (Docs) Adds documentation on legacy framework deprecation and next steps

### DIFF
--- a/docs/configure/frameworks.md
+++ b/docs/configure/frameworks.md
@@ -62,6 +62,10 @@ Out of the box, most frameworks work seamlessly with Storybook. However, some fr
 
 Storybook is a framework-agnostic tool. It can be used with any framework. However, to make it easier for you to get started, we provide instructions that you can use to build your framework. To learn more, read our [frameworks guide](../contribute/framework.md).
 
+### Legacy framework support
+
+We're deprecating support for several frameworks, including [Aurelia](https://github.com/aurelia/framework), [Marionette](https://github.com/marionettejs/backbone.marionette), [Mithril](https://github.com/MithrilJS/mithril.js), [Rax](https://github.com/alibaba/rax), and [Riot](https://github.com/riot/riot). Nevertheless, we're always looking for help maintaining these frameworks. If you're working with one of them and you want to continue supporting them, visit the dedicated [Storybook End-of-Life repository](https://github.com/storybook-eol) to learn more about the sunsetting process and for instructions on how to contribute our visit our [Discord server](https://discord.gg/storybook).
+
 ### Learn about configuring Storybook
 
 - [Theming](./theming.md) to customize the look and feel of Storybook's UI


### PR DESCRIPTION
With this pull request, the documentation is updated to feature a note on the Frameworks page regarding the deprecation of the Aurelia, Marionette, Mithril, Rax, and Riot frameworks.

Follows up on #22492