### PR TITLE
CLI: Remove automigrate reference from init command

### DIFF
--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -35,9 +35,7 @@ import serverGenerator from './generators/SERVER';
 import type { JsPackageManager } from './js-package-manager';
 import { JsPackageManagerFactory, useNpmWarning } from './js-package-manager';
 import type { NpmOptions } from './NpmOptions';
-import { automigrate } from './automigrate';
 import type { CommandOptions } from './generators/types';
-import { initFixes } from './automigrate/fixes';
 import { HandledError } from './HandledError';
 
 const logger = console;
@@ -316,16 +314,6 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
 
   if (!options.disableTelemetry) {
     telemetry('init', { projectType });
-  }
-
-  if (projectType !== ProjectType.REACT_NATIVE) {
-    await automigrate({
-      yes: options.yes || process.env.CI === 'true',
-      packageManager: pkgMgr,
-      fixes: initFixes,
-      configDir: installResult?.configDir,
-      hideMigrationSummary: true,
-    });
   }
 
   logger.log('\nFor more information visit:', chalk.cyan('https://storybook.js.org'));


### PR DESCRIPTION
## What I did

This should have been part of #22523, no clue how I forgot to do this 😮‍💨 

## How to test

1. Run storybook init in a project
2. Automigrate should not be triggered

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
