### PR TITLE
add legacy font formats

### DIFF
--- a/code/lib/builder-manager/src/index.ts
+++ b/code/lib/builder-manager/src/index.ts
@@ -60,6 +60,10 @@ export const getConfig: ManagerBuilder['getConfig'] = async (options) => {
       '.webp': 'dataurl',
       '.webm': 'dataurl',
       '.woff2': 'dataurl',
+      // legacy font formats
+      '.woff': 'dataurl',
+      '.eot': 'dataurl',
+      '.ttf': 'dataurl',
     },
     target: ['chrome100'],
     platform: 'browser',


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/22104

## What I did

I added a bunch of extra font file extentions to the manager builder's content type mappings for esbuild.