### PR TITLE
Chore: (Docs) Adds video callouts for parameters and naming components and stories

### DIFF
--- a/docs/writing-stories/naming-components-and-hierarchy.md
+++ b/docs/writing-stories/naming-components-and-hierarchy.md
@@ -2,6 +2,8 @@
 title: 'Naming components and hierarchy'
 ---
 
+<YouTubeCallout id="VPfjrhDlkVc" title="How to Name Stories and Components" />
+
 The title of the component you export in the `default` export controls the name shown in the sidebar.
 
 <!-- prettier-ignore-start -->

--- a/docs/writing-stories/parameters.md
+++ b/docs/writing-stories/parameters.md
@@ -2,6 +2,8 @@
 title: 'Parameters'
 ---
 
+<YouTubeCallout id="u32vmGVJY2U" title="Build Better Storybooks with Parameters" />
+
 Parameters are a set of static, named metadata about a story, typically used to control the behavior of Storybook features and addons.
 
 For example, let’s customize the backgrounds addon via a parameter. We’ll use `parameters.backgrounds` to define which backgrounds appear in the backgrounds toolbar when a story is selected.


### PR DESCRIPTION
With this small pull request, the documentation was updated to feature the videos showcasing both Storybook's features.

What was done:
- Updated the documentation to feature the video links