### PR TITLE
Chore: (Docs) - Removes reference to the Storybook deployer

### DIFF
--- a/docs/sharing/publish-storybook.md
+++ b/docs/sharing/publish-storybook.md
@@ -50,7 +50,7 @@ Storybook will create a static web application capable of being served by any we
 
 ## Publish Storybook with Chromatic
 
-Once you've built your Storybook as a static web app, you can publish it to your web host. We recommend [Chromatic](https://www.chromatic.com/?utm_source=storybook_website&utm_medium=link&utm_campaign=storybook), a free publishing service made for Storybook that documents, versions, and indexes your UI components securely in the cloud.
+Once you've built your Storybook as a static web application, you can publish it to your web host. We recommend [Chromatic](https://www.chromatic.com/?utm_source=storybook_website&utm_medium=link&utm_campaign=storybook), a free publishing service made for Storybook that documents, versions, and indexes your UI components securely in the cloud.
 
 ![Storybook publishing workflow](./workflow-publish.png)
 
@@ -129,13 +129,12 @@ When you publish Storybook, you also get component history and versioning down t
 
 ## Publish Storybook to other services
 
-You can publish the static Storybook web app to many hosts. We maintain [`storybook-deployer`](https://github.com/storybookjs/storybook-deployer), a handy tool to help you publish to AWS or GitHub pages.
-
-But features like [Composition](./storybook-composition.md), [embed](./embed.md), history, and versioning require tighter integration with Storybook APIs and secure authentication. Your hosting provider may not be capable of supporting these features. Learn about the Component Publishing Protocol (CPP) to see what.
+Since Storybook is built as a static web application, you can also publish it to any web host, including [GitHub Pages](https://docs.github.com/en/pages), [Netlify](https://www.netlify.com/), [AWS S3](https://aws.amazon.com/s3/), and more. However, features such as [Composition](./storybook-composition.md),
+[embedding stories](./embed.md), history, and versioning require tighter integration with Storybook APIs and secure authentication. Your hosting provider may not be capable of supporting these features. Learn about the Component Publishing Protocol (CPP) to see what.
 
 <div class="aside">
 
-ℹ️ Additional header configuration may be required to serve Storybook's static files correctly on your host. See the [Migration guide](../../MIGRATION.md#deploying-build-artifacts) for more information on the required headers.
+ℹ️ Additional header configuration may be required to serve Storybook's static files correctly on your host. For more information on the required headers, see the [Migration guide](https://github.com/storybookjs/storybook/blob/main/MIGRATION.md#deploying-build-artifacts).
 
 </div>
 

--- a/docs/sharing/publish-storybook.md
+++ b/docs/sharing/publish-storybook.md
@@ -133,6 +133,12 @@ You can publish the static Storybook web app to many hosts. We maintain [`storyb
 
 But features like [Composition](./storybook-composition.md), [embed](./embed.md), history, and versioning require tighter integration with Storybook APIs and secure authentication. Your hosting provider may not be capable of supporting these features. Learn about the Component Publishing Protocol (CPP) to see what.
 
+<div class="aside">
+
+ℹ️ Additional header configuration may be required to serve Storybook's static files correctly on your host. See the [Migration guide](../../MIGRATION.md#deploying-build-artifacts) for more information on the required headers.
+
+</div>
+
 <details>
 
 <summary><h2>Component Publishing Protocol (CPP)</h2></summary>


### PR DESCRIPTION
With this small pull request, the documentation was updated to remove any references to the now deprecated storybook deployer package.

Addresses and closes #22505
