### PR TITLE
CLI: Fix pnpm init command

### DIFF
--- a/code/lib/cli/src/js-package-manager/PNPMProxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/PNPMProxy.test.ts
@@ -1,24 +1,24 @@
 import { PNPMProxy } from './PNPMProxy';
 
-describe('NPM Proxy', () => {
+describe('PNPM Proxy', () => {
   let pnpmProxy: PNPMProxy;
 
   beforeEach(() => {
     pnpmProxy = new PNPMProxy();
   });
 
-  it('type should be npm', () => {
+  it('type should be pnpm', () => {
     expect(pnpmProxy.type).toEqual('pnpm');
   });
 
   describe('initPackageJson', () => {
-    it('should run `npm init -y`', async () => {
+    it('should run `pnpm init`', async () => {
       const executeCommandSpy = jest.spyOn(pnpmProxy, 'executeCommand').mockResolvedValueOnce('');
 
       await pnpmProxy.initPackageJson();
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ command: 'pnpm', args: ['init', '-y'] })
+        expect.objectContaining({ command: 'pnpm', args: ['init'] })
       );
     });
   });
@@ -53,7 +53,7 @@ describe('NPM Proxy', () => {
   });
 
   describe('runScript', () => {
-    it('should execute script `yarn compodoc -- -e json -d .`', async () => {
+    it('should execute script `pnpm exec compodoc -- -e json -d .`', async () => {
       const executeCommandSpy = jest
         .spyOn(pnpmProxy, 'executeCommand')
         .mockResolvedValueOnce('7.1.0');

--- a/code/lib/cli/src/js-package-manager/PNPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/PNPMProxy.ts
@@ -37,7 +37,7 @@ export class PNPMProxy extends JsPackageManager {
   async initPackageJson() {
     await this.executeCommand({
       command: 'pnpm',
-      args: ['init', '-y'],
+      args: ['init'],
     });
   }
 


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Turns out `-y` is not a known flag to `pnpm init`! It's not an interactive command like in npm, therefore I removed it!

## How to test

1. On an empty dir, run `pnpm init -y`, watch it fail
2. Now run `pnpm init`, watch it succeed!

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
