### PR TITLE
Build: add discord notification when generating sandboxes fails

### DIFF
--- a/.github/workflows/generate-sandboxes-main.yml
+++ b/.github/workflows/generate-sandboxes-main.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     - cron: '2 2 */1 * *'
   workflow_dispatch:
+  # To test fixes on push rather than wait for the scheduling, do the following:
+  # 1. Uncomment the lines below and add your branch.
+  # push:
+  #   branches:
+  #     - <your-branch-name>
+  # 2. change the "ref" value to <your-branch-name> in the actions/checkout step below.
+  # 3. 👉 DON'T FORGET TO UNDO THE VALUES BACK TO `main` BEFORE YOU MERGE YOUR CHANGES!
 
 jobs:
   generate:
@@ -41,3 +48,10 @@ jobs:
       - name: Publish
         run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT}}@github.com/storybookjs/sandboxes.git --push --branch=main
         working-directory: ./code
+      - name: The job has failed
+        if: ${{ failure() || cancelled() }}
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_URL }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: 'The generation of sandboxes in the **main** branch has failed. [View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'

--- a/.github/workflows/generate-sandboxes-next.yml
+++ b/.github/workflows/generate-sandboxes-next.yml
@@ -49,4 +49,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_URL }}
         uses: Ilshidur/action-discord@master
         with:
-          args: 'generate sandboxes norbert/discord-message-generate-sandboxes-fail has failed. [View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+          args: 'generate sandboxes norbert/discord-message-generate-sandboxes-fail has failed. [View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }})'

--- a/.github/workflows/generate-sandboxes-next.yml
+++ b/.github/workflows/generate-sandboxes-next.yml
@@ -4,14 +4,9 @@ on:
   schedule:
     - cron: '2 2 */1 * *'
   workflow_dispatch:
-  # To test fixes on push rather than wait for the scheduling, do the following:
-  # 1. Uncomment the lines below and add your branch.
-  # push:
-  #   branches:
-  #     - <your-branch-name>
-  # 2. change the "ref" value to <your-branch-name> in the actions/checkout step below.
-  # 3. don't forget to undo the values back to `next` before you merge your changes.
-
+  push:
+    branches:
+      - norbert/discord-message-generate-sandboxes-fail
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -24,7 +19,7 @@ jobs:
           node-version: 16
       - uses: actions/checkout@v3
         with:
-          ref: next
+          ref: norbert/discord-message-generate-sandboxes-fail
       - name: Setup git user
         run: |
           git config --global user.name "Storybook Bot"
@@ -46,5 +41,12 @@ jobs:
         run: yarn generate-sandboxes --local-registry
         working-directory: ./code
       - name: Publish
-        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT}}@github.com/storybookjs/sandboxes.git --push --branch=next
+        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT}}@github.com/storybookjs/sandboxes.git --push --branch=norbert/discord-message-generate-sandboxes-fail
         working-directory: ./code
+      - name: The job has failed
+        if: ${{ failure() || cancelled() }}
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_URL }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: 'generate sandboxes norbert/discord-message-generate-sandboxes-fail has failed. [View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_number }})'

--- a/.github/workflows/generate-sandboxes-next.yml
+++ b/.github/workflows/generate-sandboxes-next.yml
@@ -49,4 +49,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_URL }}
         uses: Ilshidur/action-discord@master
         with:
-          args: 'generate sandboxes norbert/discord-message-generate-sandboxes-fail has failed. [View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_number }})'
+          args: 'generate sandboxes norbert/discord-message-generate-sandboxes-fail has failed. [View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'

--- a/.github/workflows/generate-sandboxes-next.yml
+++ b/.github/workflows/generate-sandboxes-next.yml
@@ -4,9 +4,14 @@ on:
   schedule:
     - cron: '2 2 */1 * *'
   workflow_dispatch:
-  push:
-    branches:
-      - norbert/discord-message-generate-sandboxes-fail
+  # To test fixes on push rather than wait for the scheduling, do the following:
+  # 1. Uncomment the lines below and add your branch.
+  # push:
+  #   branches:
+  #     - <your-branch-name>
+  # 2. change the "ref" value to <your-branch-name> in the actions/checkout step below.
+  # 3. 👉 DON'T FORGET TO UNDO THE VALUES BACK TO `next` BEFORE YOU MERGE YOUR CHANGES!
+
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -19,7 +24,7 @@ jobs:
           node-version: 16
       - uses: actions/checkout@v3
         with:
-          ref: norbert/discord-message-generate-sandboxes-fail
+          ref: next
       - name: Setup git user
         run: |
           git config --global user.name "Storybook Bot"
@@ -41,7 +46,7 @@ jobs:
         run: yarn generate-sandboxes --local-registry
         working-directory: ./code
       - name: Publish
-        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT}}@github.com/storybookjs/sandboxes.git --push --branch=norbert/discord-message-generate-sandboxes-fail
+        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT}}@github.com/storybookjs/sandboxes.git --push --branch=next
         working-directory: ./code
       - name: The job has failed
         if: ${{ failure() || cancelled() }}
@@ -49,4 +54,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_URL }}
         uses: Ilshidur/action-discord@master
         with:
-          args: 'generate sandboxes norbert/discord-message-generate-sandboxes-fail has failed. [View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }})'
+          args: 'The generation of sandboxes in the **next** branch has failed. [View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'


### PR DESCRIPTION
Adding discord notifications to the monitoring channel so we are alerted when generating sandboxes fails