### PR TITLE
CLI: Account for windows paths when copying templates

### DIFF
--- a/code/lib/cli/src/dirs.ts
+++ b/code/lib/cli/src/dirs.ts
@@ -38,7 +38,7 @@ export async function getRendererDir(
   const frameworkPackageName =
     externalFramework?.renderer || externalFramework?.packageName || `@storybook/${renderer}`;
 
-  const packageJsonPath = `${frameworkPackageName}/package.json`;
+  const packageJsonPath = join(frameworkPackageName, 'package.json');
 
   const errors: Error[] = [];
 

--- a/code/lib/cli/src/helpers.ts
+++ b/code/lib/cli/src/helpers.ts
@@ -211,7 +211,7 @@ export async function copyTemplateFiles({
   };
   const templatePath = async () => {
     const baseDir = await getRendererDir(packageManager, renderer);
-    const assetsDir = join(baseDir, 'template/cli');
+    const assetsDir = join(baseDir, 'template', 'cli');
 
     const assetsLanguage = join(assetsDir, languageFolderMapping[language]);
     const assetsJS = join(assetsDir, languageFolderMapping[SupportedLanguage.JAVASCRIPT]);
@@ -250,7 +250,7 @@ export async function copyTemplateFiles({
 
   const destinationPath = destination ?? (await targetPath());
   if (includeCommonAssets) {
-    await fse.copy(join(getCliDir(), 'rendererAssets/common'), destinationPath, {
+    await fse.copy(join(getCliDir(), 'rendererAssets', 'common'), destinationPath, {
       overwrite: true,
     });
   }


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

stopped using `/` to account for windows paths!

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
