### PR TITLE
CLI: Improve error handling when dealing with angular.json files

### DIFF
--- a/code/lib/cli/src/generators/ANGULAR/index.ts
+++ b/code/lib/cli/src/generators/ANGULAR/index.ts
@@ -27,6 +27,15 @@ const generator: Generator<{ projectName: string }> = async (
 
   const angularJSON = new AngularJSON();
 
+  if (
+    !angularJSON.projects ||
+    (angularJSON.projects && Object.keys(angularJSON.projects).length === 0)
+  ) {
+    throw new Error(
+      'Storybook was not able to find any projects in your angular.json file. Are you sure this is an Angular CLI project?'
+    );
+  }
+
   if (angularJSON.projectsWithoutStorybook.length === 0) {
     throw new Error(
       'Every project in your workspace is already set up with Storybook. There is nothing to do!'
@@ -34,10 +43,17 @@ const generator: Generator<{ projectName: string }> = async (
   }
 
   const angularProjectName = await angularJSON.getProjectName();
-
   paddedLog(`Adding Storybook support to your "${angularProjectName}" project`);
 
-  const { root, projectType } = angularJSON.getProjectSettingsByName(angularProjectName);
+  const angularProject = angularJSON.getProjectSettingsByName(angularProjectName);
+
+  if (!angularProject) {
+    throw new Error(
+      `Somehow we were not able to retrieve the "${angularProjectName}" project in your angular.json file. This is likely a bug in Storybook, please file an issue.`
+    );
+  }
+
+  const { root, projectType } = angularProject;
   const { projects } = angularJSON;
   const useCompodoc = commandOptions.yes ? true : await promptForCompoDocs();
   const storybookFolder = root ? `${root}/.storybook` : '.storybook';


### PR DESCRIPTION
Closes #22350

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

The Storybook CLI now throws different errors and requests the user to file an issue to provide us more information. Regarding #22350 so far we found no way to reproduce the issue, so we rely on the community to bring that up to us.

## How to test

1. Get an angular sandbox with no Storybook
2. Delete all projects on the angular.json file, or make the key contain an empty object, the following error should be thrown:
```
Error: Storybook was not able to find any projects in your angular.json file. Are you sure this is an Angular CLI project?
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
