### PR TITLE
doc: link 'Image, fonts, and assets' to static `preview-head.html`; enhance code snippet to demonstrate relative pathing

### DIFF
--- a/docs/configure/images-and-assets.md
+++ b/docs/configure/images-and-assets.md
@@ -140,7 +140,7 @@ Suppose you are serving assets in a [static directory](#serving-static-files-via
 
 ### Referencing Fonts in Stories
 
-After configuring Storybook to server assets from your static folder, you can reference those assets in Storybook. For example, you can reference and apply a custom font in your stories.
+After configuring Storybook to serve assets from your static folder, you can reference those assets in Storybook. For example, you can reference and apply a custom font in your stories.
 
 Inside the `.storybook/` configuration folder, create `preview-head.html`, then use `<link />` to reference your font.
 

--- a/docs/configure/images-and-assets.md
+++ b/docs/configure/images-and-assets.md
@@ -137,3 +137,16 @@ In this case, you need to have all your images and media files with relative pat
 If you load static content via importing, this is automatic, and you do not have to do anything.
 
 Suppose you are serving assets in a [static directory](#serving-static-files-via-storybook-configuration) along with your Storybook. In that case, you need to use relative paths to load images or use the base element.
+
+### Referencing Fonts in Stories
+
+After configuring Storybook to server assets from your static folder, you can reference those assets in Storybook. For example, you can reference and apply a custom font in your stories.
+
+Inside the `.storybook/` configuration folder, create `preview-head.html`, then use `<link />` to reference your font.
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={['common/storybook-preview-head-example.html.mdx']} />
+
+<!-- prettier-ignore-end -->

--- a/docs/snippets/common/storybook-preview-head-example.html.mdx
+++ b/docs/snippets/common/storybook-preview-head-example.html.mdx
@@ -2,8 +2,9 @@
 <!-- .storybook/preview-head.html -->
 
 <!-- Pull in static files served from your Static directory or the internet -->
+<!-- Example: `main.js|ts` is configured with staticDirs: ['../public'] and your font is located in the `fonts` directory inside your `public` directory -->
+<link rel="preload" href="/fonts/my-font.woff2" /> 
 
-<link rel=”preload” href=”your/font” />
 
 <!-- Or you can load custom head-tag JavaScript: -->
 

--- a/docs/snippets/common/storybook-preview-head-example.html.mdx
+++ b/docs/snippets/common/storybook-preview-head-example.html.mdx
@@ -3,8 +3,7 @@
 
 <!-- Pull in static files served from your Static directory or the internet -->
 <!-- Example: `main.js|ts` is configured with staticDirs: ['../public'] and your font is located in the `fonts` directory inside your `public` directory -->
-<link rel="preload" href="/fonts/my-font.woff2" /> 
-
+<link rel="preload" href="/fonts/my-font.woff2" />
 
 <!-- Or you can load custom head-tag JavaScript: -->
 


### PR DESCRIPTION
It seems like there's frequent enough questions about how to load fonts in stories, and devs aren't entirely connecting the existing doc to the use of `preview-head.html` to serve their own static fonts.

Discord issues:
https://discord.com/channels/486522875931656193/1110070593056952351/1110070593056952351
https://discord.com/channels/486522875931656193/1097070271040589865/1097070271040589865
https://discord.com/channels/486522875931656193/1100050706196598964/1100050706196598964
https://discord.com/channels/486522875931656193/1083367049021104188/1083367049021104188
https://discord.com/channels/486522875931656193/1089727645685645342/1089727645685645342


Related:

https://github.com/storybookjs/storybook/issues/15507
https://github.com/storybookjs/storybook/issues/15826
https://github.com/storybookjs/storybook/issues/14644

(Not sure it "Closes" any of those but I think the gap here is making the connection to the resource and how `preview-head.html` acts like it's already referencing assets bundled in `storybook-static` imo)

## What I did

doc: 'Images, fonts, and assets' (`images-and-assets.md`) now reference code snippet for importing and referencing static fonts in `preview-head.html` (`common/storybook-preview-head-example.html.mdx`)

improve code snippet commentary about relative path referencing of static files.

## How to test

`yarn lint`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`
