### PR TITLE
CLI: Fix error parsing on NPM proxy

### DIFF
--- a/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
@@ -439,7 +439,8 @@ describe('NPM Proxy', () => {
 
   describe('parseErrors', () => {
     it('should parse npm errors', () => {
-      const NPM_ERROR_SAMPLE = `
+      const NPM_RESOLVE_ERROR_SAMPLE = `
+        npm ERR!
         npm ERR! code ERESOLVE
         npm ERR! ERESOLVE unable to resolve dependency tree
         npm ERR! 
@@ -447,26 +448,25 @@ describe('NPM Proxy', () => {
         npm ERR! Found: react@undefined
         npm ERR! node_modules/react
         npm ERR!   react@"30" from the root project
-        npm ERR! 
-        npm ERR! Could not resolve dependency:
-        npm ERR! peer react@"^16.8.0 || ^17.0.0 || ^18.0.0" from @storybook/react@7.1.0-alpha.17
-        npm ERR! node_modules/@storybook/react
-        npm ERR!   dev @storybook/react@"^7.1.0-alpha.17" from the root project
-        npm ERR! 
-        npm ERR! Fix the upstream dependency conflict, or retry
-        npm ERR! this command with --force or --legacy-peer-deps
-        npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
-        npm ERR! 
-        npm ERR! 
-        npm ERR! For a full report see:
-        npm ERR! /Users/yannbraga/.npm/_logs/2023-05-12T08_38_18_464Z-eresolve-report.txt
-
-        npm ERR! A complete log of this run can be found in:
-        npm ERR!     /Users/yannbraga/.npm/_logs/2023-05-12T08_38_18_464Z-debug-0.log
         `;
 
-      expect(npmProxy.parseErrorFromLogs(NPM_ERROR_SAMPLE)).toEqual(
+      const NPM_TIMEOUT_ERROR_SAMPLE = `
+          npm notice 
+          npm notice New major version of npm available! 8.5.0 -> 9.6.7
+          npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.6.7>
+          npm notice Run \`npm install -g npm@9.6.7\` to update!
+          npm notice 
+          npm ERR! code ERR_SOCKET_TIMEOUT
+          npm ERR! errno ERR_SOCKET_TIMEOUT
+          npm ERR! network Invalid response body while trying to fetch https://registry.npmjs.org/@storybook%2ftypes: Socket timeout
+          npm ERR! network This is a problem related to network connectivity.
+      `;
+
+      expect(npmProxy.parseErrorFromLogs(NPM_RESOLVE_ERROR_SAMPLE)).toEqual(
         'NPM error ERESOLVE - Dependency resolution error.'
+      );
+      expect(npmProxy.parseErrorFromLogs(NPM_TIMEOUT_ERROR_SAMPLE)).toEqual(
+        'NPM error ERR_SOCKET_TIMEOUT - Socket timed out.'
       );
     });
 

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -21,7 +21,7 @@ export type NpmListOutput = {
   dependencies: NpmDependencies;
 };
 
-const NPM_ERROR_REGEX = /\bERR! code\s+([A-Z]+)\b/;
+const NPM_ERROR_REGEX = /npm ERR! code (\w+)/;
 const NPM_ERROR_CODES = {
   E401: 'Authentication failed or is required.',
   E403: 'Access to the resource is forbidden.',
@@ -248,7 +248,6 @@ export class NPMProxy extends JsPackageManager {
 
   public parseErrorFromLogs(logs: string): string {
     let finalMessage = 'NPM error';
-    console.log({ logs });
     const match = logs.match(NPM_ERROR_REGEX);
 
     if (match) {


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

The regex was wrong and not accounting for all error formats. Should be fixed now.

## How to test

Check the tests

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
