### PR TITLE
Vite: Fix pnpm support by replacing @storybook/global with `window`

### DIFF
--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -47,7 +47,6 @@
     "@storybook/client-logger": "7.1.0-alpha.21",
     "@storybook/core-common": "7.1.0-alpha.21",
     "@storybook/csf-plugin": "7.1.0-alpha.21",
-    "@storybook/global": "^5.0.0",
     "@storybook/mdx2-csf": "^1.0.0",
     "@storybook/node-logger": "7.1.0-alpha.21",
     "@storybook/preview": "7.1.0-alpha.21",

--- a/code/lib/builder-vite/src/codegen-set-addon-channel.ts
+++ b/code/lib/builder-vite/src/codegen-set-addon-channel.ts
@@ -1,6 +1,5 @@
 export async function generateAddonSetupCode() {
   return `
-    import { global } from '@storybook/global';
     import { createChannel as createPostMessageChannel } from '@storybook/channel-postmessage';
     import { createChannel as createWebSocketChannel } from '@storybook/channel-websocket';
     import { addons } from '@storybook/preview-api';
@@ -9,7 +8,7 @@ export async function generateAddonSetupCode() {
     addons.setChannel(channel);
     window.__STORYBOOK_ADDONS_CHANNEL__ = channel;
     
-    if (global.CONFIG_TYPE === 'DEVELOPMENT'){
+    if (window.CONFIG_TYPE === 'DEVELOPMENT'){
       const serverChannel = createWebSocketChannel({});
       addons.setServerChannel(serverChannel);
       window.__STORYBOOK_SERVER_CHANNEL__ = serverChannel;

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5550,7 +5550,6 @@ __metadata:
     "@storybook/client-logger": 7.1.0-alpha.21
     "@storybook/core-common": 7.1.0-alpha.21
     "@storybook/csf-plugin": 7.1.0-alpha.21
-    "@storybook/global": ^5.0.0
     "@storybook/mdx2-csf": ^1.0.0
     "@storybook/node-logger": 7.1.0-alpha.21
     "@storybook/preview": 7.1.0-alpha.21


### PR DESCRIPTION
Closes #22695

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

If we want to use `@storybook/global` in a virtual module in the vite builder, we'd need to add it to the runtime bundle in order to support pnpm users.  Since this is purely preview code, though, we can just use `window` and avoid the dep entirely.

## How to test

Create a pnpm project, add storybook, swap in this change, confirm that stories load.  I did that in my own pnpm project and it works well now on 7.0.15.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
