### PR TITLE
Add version prompt for compodoc installation

### DIFF
--- a/code/lib/cli/src/generators/ANGULAR/helpers.ts
+++ b/code/lib/cli/src/generators/ANGULAR/helpers.ts
@@ -10,14 +10,19 @@ export const compoDocPreviewPrefix = dedent`
   setCompodocJson(docJson);
 `.trimStart();
 
-export const promptForCompoDocs = async (): Promise<boolean> => {
-  const { useCompoDoc } = await prompts({
-    type: 'confirm',
-    name: 'useCompoDoc',
+export const promptForCompoDocs = async (): Promise<'1.1.19' | '1.1.20' | false> => {
+  const { compodocVersion } = await prompts({
+    type: 'select',
+    name: 'compodocVersion',
     message: 'Do you want to use Compodoc for documentation?',
+    choices: [
+      { title: 'Yes (v1.1.19) - (Node v16 support)', value: '1.1.19' },
+      { title: 'Yes (v1.1.20) - (Node >= v18 required)', value: '1.1.20' },
+      { title: 'No', value: null },
+    ],
   });
 
-  return useCompoDoc;
+  return compodocVersion;
 };
 
 export class AngularJSON {

--- a/code/lib/cli/src/generators/ANGULAR/index.ts
+++ b/code/lib/cli/src/generators/ANGULAR/index.ts
@@ -55,13 +55,13 @@ const generator: Generator<{ projectName: string }> = async (
 
   const { root, projectType } = angularProject;
   const { projects } = angularJSON;
-  const useCompodoc = commandOptions.yes ? true : await promptForCompoDocs();
+  const compodocVersion = commandOptions.yes ? '1.1.19' : await promptForCompoDocs();
   const storybookFolder = root ? `${root}/.storybook` : '.storybook';
 
   angularJSON.addStorybookEntries({
     angularProjectName,
     storybookFolder,
-    useCompodoc,
+    useCompodoc: compodocVersion !== null,
     root,
   });
   angularJSON.write();
@@ -71,7 +71,7 @@ const generator: Generator<{ projectName: string }> = async (
     npmOptions,
     {
       ...updatedOptions,
-      ...(useCompodoc && {
+      ...(compodocVersion && {
         frameworkPreviewParts: {
           prefix: compoDocPreviewPrefix,
         },
@@ -79,7 +79,7 @@ const generator: Generator<{ projectName: string }> = async (
     },
     'angular',
     {
-      ...(useCompodoc && { extraPackages: ['@compodoc/compodoc'] }),
+      ...(compodocVersion && { extraPackages: [`@compodoc/compodoc@${compodocVersion}`] }),
       addScripts: false,
       componentsDestinationPath: root ? `${root}/src/stories` : undefined,
       storybookConfigFolder: storybookFolder,


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I have adjusted the prompt for installing a specific version of compodoc, since compodoc v.1.1.20 only works in Node >= v18 environments.

## How to test

1. Setup an Angular project
2. sb init
3. A prompt should show up to select a specific compodoc version

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
