### PR TITLE
Vue3: Fix reactive args updates in decorators

### DIFF
--- a/code/addons/controls/template/stories/basics.stories.ts
+++ b/code/addons/controls/template/stories/basics.stories.ts
@@ -4,7 +4,8 @@ import type { PartialStoryFn, StoryContext } from '@storybook/types';
 export default {
   component: globalThis.Components.Pre,
   decorators: [
-    (storyFn: PartialStoryFn, context: StoryContext) => storyFn({ args: { object: context.args } }),
+    (storyFn: PartialStoryFn, context: StoryContext) =>
+      storyFn({ args: { object: { ...context.args } } }),
   ],
   argTypes: {
     boolean: { control: 'boolean' },

--- a/code/addons/controls/template/stories/conditional.stories.ts
+++ b/code/addons/controls/template/stories/conditional.stories.ts
@@ -4,7 +4,8 @@ import type { PartialStoryFn, StoryContext } from '@storybook/types';
 export default {
   component: globalThis.Components.Pre,
   decorators: [
-    (storyFn: PartialStoryFn, context: StoryContext) => storyFn({ args: { object: context.args } }),
+    (storyFn: PartialStoryFn, context: StoryContext) =>
+      storyFn({ args: { object: { ...context.args } } }),
   ],
 };
 

--- a/code/addons/controls/template/stories/disable.stories.ts
+++ b/code/addons/controls/template/stories/disable.stories.ts
@@ -4,7 +4,8 @@ import type { PartialStoryFn, StoryContext } from '@storybook/types';
 export default {
   component: globalThis.Components.Pre,
   decorators: [
-    (storyFn: PartialStoryFn, context: StoryContext) => storyFn({ args: { object: context.args } }),
+    (storyFn: PartialStoryFn, context: StoryContext) =>
+      storyFn({ args: { object: { ...context.args } } }),
   ],
 };
 

--- a/code/addons/controls/template/stories/filters.stories.ts
+++ b/code/addons/controls/template/stories/filters.stories.ts
@@ -4,7 +4,8 @@ import type { PartialStoryFn, StoryContext } from '@storybook/types';
 export default {
   component: globalThis.Components.Pre,
   decorators: [
-    (storyFn: PartialStoryFn, context: StoryContext) => storyFn({ args: { object: context.args } }),
+    (storyFn: PartialStoryFn, context: StoryContext) =>
+      storyFn({ args: { object: { ...context.args } } }),
   ],
   args: {
     helloWorld: 1,

--- a/code/addons/controls/template/stories/issues.stories.ts
+++ b/code/addons/controls/template/stories/issues.stories.ts
@@ -4,7 +4,8 @@ import type { PartialStoryFn, StoryContext } from '@storybook/types';
 export default {
   component: globalThis.Components.Pre,
   decorators: [
-    (storyFn: PartialStoryFn, context: StoryContext) => storyFn({ args: { object: context.args } }),
+    (storyFn: PartialStoryFn, context: StoryContext) =>
+      storyFn({ args: { object: { ...context.args } } }),
   ],
 };
 

--- a/code/addons/controls/template/stories/matchers.stories.ts
+++ b/code/addons/controls/template/stories/matchers.stories.ts
@@ -4,7 +4,8 @@ import type { PartialStoryFn, StoryContext } from '@storybook/types';
 export default {
   component: globalThis.Components.Pre,
   decorators: [
-    (storyFn: PartialStoryFn, context: StoryContext) => storyFn({ args: { object: context.args } }),
+    (storyFn: PartialStoryFn, context: StoryContext) =>
+      storyFn({ args: { object: { ...context.args } } }),
   ],
 };
 

--- a/code/addons/controls/template/stories/sorting.stories.ts
+++ b/code/addons/controls/template/stories/sorting.stories.ts
@@ -4,7 +4,8 @@ import type { PartialStoryFn, StoryContext } from '@storybook/types';
 export default {
   component: globalThis.Components.Pre,
   decorators: [
-    (storyFn: PartialStoryFn, context: StoryContext) => storyFn({ args: { object: context.args } }),
+    (storyFn: PartialStoryFn, context: StoryContext) =>
+      storyFn({ args: { object: { ...context.args } } }),
   ],
   argTypes: {
     x: { type: { required: true } },

--- a/code/lib/store/template/stories/argMapping.stories.ts
+++ b/code/lib/store/template/stories/argMapping.stories.ts
@@ -22,7 +22,7 @@ export default {
   decorators: [
     (storyFn: PartialStoryFn, context: StoryContext) => {
       return storyFn({
-        args: { object: context.args },
+        args: { object: { ...context.args } },
       });
     },
   ],

--- a/code/lib/store/template/stories/argTypes.stories.ts
+++ b/code/lib/store/template/stories/argTypes.stories.ts
@@ -8,7 +8,7 @@ export default {
   // Compose all the argTypes into `object`, so the pre component only needs a single prop
   decorators: [
     (storyFn: PartialStoryFn, context: StoryContext) =>
-      storyFn({ args: { object: context.argTypes } }),
+      storyFn({ args: { object: { ...context.argTypes } } }),
   ],
   argTypes: {
     componentArg: { type: 'string' },

--- a/code/lib/store/template/stories/args.stories.ts
+++ b/code/lib/store/template/stories/args.stories.ts
@@ -20,7 +20,8 @@ export default {
   decorators: [
     (storyFn: PartialStoryFn, context: StoryContext) => {
       const { argNames } = context.parameters;
-      const object = argNames ? pick(context.args, argNames) : context.args;
+      const args = { ...context.args };
+      const object = argNames ? pick(args, argNames) : args;
       return storyFn({ args: { object } });
     },
   ],

--- a/code/renderers/vue3/src/decorateStory.ts
+++ b/code/renderers/vue3/src/decorateStory.ts
@@ -48,10 +48,10 @@ export function decorateStory(
       let story: VueRenderer['storyResult'] | undefined;
 
       const decoratedStory: VueRenderer['storyResult'] = decorator((update) => {
-        story = decorated({
-          ...context,
-          ...sanitizeStoryContextUpdate(update),
-        });
+        const sanitizedUpdate = sanitizeStoryContextUpdate(update);
+        // update the args in a reactive way
+        if (update) sanitizedUpdate.args = Object.assign(context.args, sanitizedUpdate.args);
+        story = decorated({ ...context, ...sanitizedUpdate });
         return story;
       }, context);
 

--- a/code/renderers/vue3/src/docs/sourceDecorator.ts
+++ b/code/renderers/vue3/src/docs/sourceDecorator.ts
@@ -9,6 +9,7 @@ import parserHTML from 'prettier/parser-html';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { isArray } from '@vue/shared';
+import { toRaw } from 'vue';
 
 type ArgEntries = [string, any][];
 type Attribute = {
@@ -60,7 +61,7 @@ function getComponentNameAndChildren(component: any): {
  */
 function generateAttributesSource(_args: Args, argTypes: ArgTypes, byRef?: boolean): string {
   // create a copy of the args object to avoid modifying the original
-  const args = { ..._args };
+  const args = { ...toRaw(_args) };
   // filter out keys that are children or slots, and convert event keys to the proper format
   const argsKeys = Object.keys(args)
     .filter(


### PR DESCRIPTION
## What I did

When doing a decorator update with args, we used to overwrite the reactive args, that are made reactive in the renderToCanvas function. This PR makes sure we don't overwrite those args, but mutate them instead.

We test those decorator args updates in the hooks chromatic stories. I found out that they are accidentally accepted with a visual bug on next, when back porting a PR to main:
https://github.com/storybookjs/storybook/pull/22692

With this PR, args update should work again in Vue. At least the chromatic test are working again.

## How to test

See the lib/store/hooks stories in chromatic.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
