### PR TITLE
fix: Storybook 7 viewport menu not working

### DIFF
--- a/code/addons/viewport/src/Tool.tsx
+++ b/code/addons/viewport/src/Tool.tsx
@@ -106,11 +106,25 @@ const getStyles = (
   styles: Styles,
   isRotated: boolean
 ): ViewportStyles | undefined => {
-  if (!styles || !prevStyles) {
+  if (styles === null) {
     return undefined;
   }
-  const result = typeof styles === 'function' ? styles(prevStyles) : styles;
-  return isRotated ? flip(result) : result;
+
+  let result: ViewportStyles | undefined;
+
+  if (typeof styles === 'function') {
+    if (prevStyles) {
+      result = styles(prevStyles);
+    }
+  } else {
+    result = styles;
+  }
+
+  if (result && isRotated) {
+    return flip(result);
+  }
+
+  return result;
 };
 
 export const ViewportTool: FC = memo(

--- a/code/addons/viewport/src/Tool.tsx
+++ b/code/addons/viewport/src/Tool.tsx
@@ -110,21 +110,8 @@ const getStyles = (
     return undefined;
   }
 
-  let result: ViewportStyles | undefined;
-
-  if (typeof styles === 'function') {
-    if (prevStyles) {
-      result = styles(prevStyles);
-    }
-  } else {
-    result = styles;
-  }
-
-  if (result && isRotated) {
-    return flip(result);
-  }
-
-  return result;
+  const result = typeof styles === 'function' ? styles(prevStyles) : styles;
+  return isRotated ? flip(result) : result;
 };
 
 export const ViewportTool: FC = memo(

--- a/code/addons/viewport/src/models/Viewport.ts
+++ b/code/addons/viewport/src/models/Viewport.ts
@@ -1,4 +1,4 @@
-export type Styles = ViewportStyles | ((s: ViewportStyles) => ViewportStyles) | null;
+export type Styles = ViewportStyles | ((s: ViewportStyles | undefined) => ViewportStyles) | null;
 
 export interface Viewport {
   name: string;

--- a/code/e2e-tests/addon-viewport.spec.ts
+++ b/code/e2e-tests/addon-viewport.spec.ts
@@ -20,4 +20,24 @@ test.describe('addon-viewport', () => {
     // Check that Button story is still displayed
     await expect(sbPage.previewRoot()).toContainText('Button');
   });
+
+  test('iframe width should be changed when a mobile viewport is selected', async ({ page }) => {
+    const sbPage = new SbPage(page);
+
+    // Click on viewport button and select small mobile
+    await sbPage.navigateToStory('example/button', 'primary');
+
+    // Measure the original dimensions of previewRoot
+    const originalDimensions = await sbPage.previewRoot().boundingBox();
+    await expect(originalDimensions?.width).toBeDefined();
+
+    await sbPage.selectToolbar('[title="Change the size of the preview"]', '#list-item-mobile1');
+
+    // Measure the adjusted dimensions of previewRoot after clicking the mobile item.
+    const adjustedDimensions = await sbPage.previewRoot().boundingBox();
+    await expect(adjustedDimensions?.width).toBeDefined();
+
+    // Compare the two widths
+    await expect(adjustedDimensions?.width).not.toBe(originalDimensions?.width);
+  });
 });


### PR DESCRIPTION
Closes #22718

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Modified `getStyles` function in `code/addons/viewport/src/Tool.tsx` so that it works correctly even when `prevStyles` is `undefined`.

I did a little bit of digging, and it seems like the bug was introduced by https://github.com/storybookjs/storybook/commit/fe02579b4ca5f162044ab5ca28293228458fc28f. The main problem introduced by this commit is that `getStyles` now always returns `undefined` if `prevStyles` is `undefined` which is initialized as such and never gets updated, so subsequent calls to `getStyles` in `ViewportTool` component's body always yield `undefined`, resulting in no style being applied to the iframe.

## How to test

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access any story, click the viewport resize button in the preview toolbar, and choose any viewport item in the popover menu, and check if the iframe is resized accordingly.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
