### PR TITLE
Build: fix the theme output during development

### DIFF
--- a/code/lib/theming/scripts/fix-theme-type-export.ts
+++ b/code/lib/theming/scripts/fix-theme-type-export.ts
@@ -7,7 +7,7 @@ const run = async () => {
   const target = join(process.cwd(), 'dist', 'index.d.ts');
   const contents = await readFile(target, 'utf8');
 
-  const footer = contents.includes('// devmode')
+  const footer = contents.includes('// dev-mode')
     ? `export { StorybookTheme as Theme } from '../src/index';`
     : dedent`
         interface Theme extends StorybookTheme {}


### PR DESCRIPTION
Found an problem with the type definitions creation script we created for development.