### PR TITLE
Optimize webpack-builder: minify using swc

### DIFF
--- a/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -327,16 +327,27 @@ export default async (
       ...(isProd
         ? {
             minimize: true,
-            minimizer: [
-              new TerserWebpackPlugin({
-                minify: TerserWebpackPlugin.swcMinify,
-                terserOptions: {
-                  sourceMap: true,
-                  mangle: false,
-                  keep_fnames: true,
-                },
-              }),
-            ],
+            minimizer: builderOptions.useSWC
+              ? [
+                  new TerserWebpackPlugin({
+                    minify: TerserWebpackPlugin.swcMinify,
+                    terserOptions: {
+                      sourceMap: true,
+                      mangle: false,
+                      keep_fnames: true,
+                    },
+                  }),
+                ]
+              : [
+                  new TerserWebpackPlugin({
+                    parallel: true,
+                    terserOptions: {
+                      sourceMap: true,
+                      mangle: false,
+                      keep_fnames: true,
+                    },
+                  }),
+                ],
           }
         : {}),
     },

--- a/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -324,18 +324,21 @@ export default async (
       sideEffects: true,
       usedExports: isProd,
       moduleIds: 'named',
-      minimizer: isProd
-        ? [
-            new TerserWebpackPlugin({
-              parallel: true,
-              terserOptions: {
-                sourceMap: true,
-                mangle: false,
-                keep_fnames: true,
-              },
-            }),
-          ]
-        : [],
+      ...(isProd
+        ? {
+            minimize: true,
+            minimizer: [
+              new TerserWebpackPlugin({
+                minify: TerserWebpackPlugin.swcMinify,
+                terserOptions: {
+                  sourceMap: true,
+                  mangle: false,
+                  keep_fnames: true,
+                },
+              }),
+            ],
+          }
+        : {}),
     },
     performance: {
       hints: isProd ? 'warning' : false,


### PR DESCRIPTION
I found that terserPlugin support swc, and considering what we use to optimize storybook with isn't really a public API anyway... I figured I could just sneak this in and replace terser with swc.

see: https://webpack.js.org/plugins/terser-webpack-plugin/#swc

Related: https://github.com/storybookjs/storybook/issues/18329
Related: https://github.com/storybookjs/storybook/issues/19994
Related: https://github.com/storybookjs/storybook/issues/15548