### PR TITLE
Chore: (Docs) Removes references to outdated APIs and packages

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1187,8 +1187,8 @@ This can result in errors if you are using experimental JS features in your addo
 or using babel dependent features such as Component selectors in Emotion.
 
 ESbuild also places some constraints on things you can import into your addon's manager code: only woff2 files are supported, and not all image file types are supported.
-Here's the list of supported file types:
-https://github.com/storybookjs/storybook/blob/4a37372f649e85e7a0c35b0493da016dbb5dee17/code/lib/builder-manager/src/index.ts#L54-L64
+Here's the [list](https://github.com/storybookjs/storybook/blob/next/code/builders/builder-manager/src/index.ts#L53-L70) of supported file types.
+
 This is not configurable.
 
 If this is a problem for your addon, you need to pre-compile your addon's manager code to ensure it works.

--- a/docs/essentials/toolbars-and-globals.md
+++ b/docs/essentials/toolbars-and-globals.md
@@ -166,8 +166,6 @@ Using the ThemeProvider example above, you could expand it to display which them
 
 If you're working on a Storybook addon that needs to update the global and refreshes the UI, you can do so. As mentioned previously, the `@storybook/manager-api` package provides the necessary hook for this scenario. You can use the `updateGlobals` function to update any global values you need.
 
-Also, you can use both `@storybook/addons` and `@storybook/core-events` packages together to trigger the refresh.
-
 For example, if you were working on a [toolbar addon](../addons/addon-types.md#toolbars), and you want to refresh the UI and update the global once the user clicks on a button:
 
 <!-- prettier-ignore-start -->

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -191,7 +191,7 @@ A common error is that an addon tries to access the "channel", but the channel i
 1.  You're trying to access addon channel (e.g., by calling `setOptions`) in a non-browser environment like Jest. You may need to add a channel mock:
 
     ```js
-    import { addons, mockChannel } from '@storybook/addons';
+    import { addons, mockChannel } from '@storybook/preview-api';
 
     addons.setChannel(mockChannel());
     ```

--- a/docs/snippets/common/storybook-client-preview.ts.mdx
+++ b/docs/snippets/common/storybook-client-preview.ts.mdx
@@ -1,7 +1,7 @@
 ```ts
 // your-framework/src/client/preview/index.ts
 
-import { start } from '@storybook/core-client';
+import { start } from '@storybook/preview-api';
 
 import './globals';
 


### PR DESCRIPTION
With this pull request some outdated API references were updated to factor in the recent changes to the monorepo