### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Any change inside the `/code` and `/scripts` directories will require approval from @storybookjs/core team.
+
+/code/ @storybookjs/core
+/scripts/ @storybookjs/core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,8 @@
 # Any change inside the `/code` and `/scripts` directories will require approval from @storybookjs/core team.
 
+/.github/ @storybookjs/core
+/.circleci/ @storybookjs/core
+/.yarn/ @storybookjs/core
 /code/ @storybookjs/core
 /scripts/ @storybookjs/core
+/package.json @storybookjs/core


### PR DESCRIPTION
## What I did

This PR adds a [`CODEOWNERS`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file that specifies that all changes in the `code` and `scripts` directories will now require approval from @storybookjs/core team. After this PR is merged, I will turn on branch protection rule that makes this a requirement for merging PRs going forward.

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
