### PR TITLE
Read dev-dep react-scripts too when called on CRA projects

### DIFF
--- a/code/lib/cli/src/generators/REACT_SCRIPTS/index.ts
+++ b/code/lib/cli/src/generators/REACT_SCRIPTS/index.ts
@@ -26,7 +26,8 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
     : {};
 
   const packageJson = await packageManager.retrievePackageJson();
-  const craVersion = semver.coerce(packageJson.dependencies['react-scripts'])?.version;
+  const dependencyRaw = packageJson.dependencies['react-scripts'] || packageJson.devDependencies['react-scripts']
+  const craVersion = semver.coerce(dependencyRaw)?.version;
   const isCra5OrHigher = craVersion && semver.gte(craVersion, '5.0.0');
   const updatedOptions = isCra5OrHigher ? { ...options, builder: CoreBuilder.Webpack5 } : options;
 


### PR DESCRIPTION
Closes #22794

## What I did

Added support for readinv devDependencies too

## How to test

1. Create a new CRA project: `npx create-react-app my-app && cd my-app`
2. Init storybook `node /path-to-sb/code/lib/cli/bin/index.js init`
3. Notice nothing crashes

## Checklist

**NOTE: I am unsure if this requires a dedicated test or not.**

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["bug"]`
