### PR TITLE
Server: Fix .stories.yml support

### DIFF
--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -486,7 +486,6 @@ const internalTemplates = {
       builder: '@storybook/builder-webpack5',
     },
     isInternal: true,
-    inDevelopment: true,
   },
   // 'internal/pnp': {
   //   ...baseTemplates['cra/default-ts'],

--- a/code/presets/server-webpack/src/index.ts
+++ b/code/presets/server-webpack/src/index.ts
@@ -16,7 +16,10 @@ export const webpack: StorybookConfig['webpack'] = (config) => {
       test: /\.stories\.ya?ml/,
       use: [
         require.resolve('@storybook/preset-server-webpack/dist/loader'),
-        require.resolve('yaml-loader'),
+        {
+          loader: require.resolve('yaml-loader'),
+          options: { asJSON: true },
+        },
       ],
     },
   ];

--- a/code/presets/server-webpack/src/loader.ts
+++ b/code/presets/server-webpack/src/loader.ts
@@ -5,7 +5,8 @@ export default (content: string) => {
     const after = compileCsfModule(JSON.parse(content));
     return after;
   } catch (e) {
-    //
+    // for debugging
+    console.log(content, e);
   }
   return content;
 };

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -61,7 +61,8 @@
     "@storybook/types": "7.1.0-alpha.26",
     "@types/fs-extra": "^11.0.1",
     "fs-extra": "^11.1.0",
-    "ts-dedent": "^2.0.0"
+    "ts-dedent": "^2.0.0",
+    "yaml": "^2.3.1"
   },
   "devDependencies": {
     "typescript": "~4.9.3"

--- a/code/renderers/server/src/preset.ts
+++ b/code/renderers/server/src/preset.ts
@@ -1,11 +1,14 @@
 import fs from 'fs-extra';
+import yaml from 'yaml';
 import { toId } from '@storybook/csf';
 import type { StaticMeta } from '@storybook/csf-tools';
 import type { IndexerOptions, IndexedStory, StoryIndexer } from '@storybook/types';
 
 export const storyIndexers = (indexers: StoryIndexer[] | null) => {
-  const jsonIndexer = async (fileName: string, opts: IndexerOptions) => {
-    const json = await fs.readJson(fileName, 'utf-8');
+  const serverIndexer = async (fileName: string, opts: IndexerOptions) => {
+    const json = fileName.endsWith('.json')
+      ? await fs.readJson(fileName, 'utf-8')
+      : yaml.parse((await fs.readFile(fileName, 'utf-8')).toString());
     const meta: StaticMeta = {
       title: json.title,
     };
@@ -25,8 +28,8 @@ export const storyIndexers = (indexers: StoryIndexer[] | null) => {
   };
   return [
     {
-      test: /(stories|story)\.json$/,
-      indexer: jsonIndexer,
+      test: /(stories|story)\.(json|ya?ml)$/,
+      indexer: serverIndexer,
     },
     ...(indexers || []),
   ];

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7499,6 +7499,7 @@ __metadata:
     fs-extra: ^11.1.0
     ts-dedent: ^2.0.0
     typescript: ~4.9.3
+    yaml: ^2.3.1
   languageName: unknown
   linkType: soft
 
@@ -32376,7 +32377,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0":
+"yaml@npm:^2.0.0, yaml@npm:^2.3.1":
   version: 2.3.1
   resolution: "yaml@npm:2.3.1"
   checksum: ed4c21a907fb1cd60a25177612fa46d95064a144623d269199817908475fe85bef20fb17406e3bdc175351b6488056a6f84beb7836e8c262646546a0220188e3


### PR DESCRIPTION
Closes #22896 

## What I did

Restore `.yml` support in `@storybook/server`:
- [x] Add .yml to indexer
- [x] Fix yaml-loader behavior for webpack (not sure what changed, but we need `asJSON` option now)
- [x] Remove `inDevelopment` flag from server sandbox to improve DX

Self-merging @ndelangen @tmeasday 

## How to test

In the `internal/server-webpack5` sandbox:
1. Update `main.js` to include `.stories.yml` files:
```js
export default { stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(json|yml)'], ... }
```
2. Add a file `stories/button.stories.yml` with the contents:
```
title: Example/ButtonYML
parameters:
  server:
    url: https://storybook-server-demo.netlify.app/api
    id: button
args:
  label: ButtonYML
stories:
  - { name: Primary, args: { primary: true } }
```
3. View the new story in dev/prod modes