### PR TITLE
CLI: Fix upgrade notification message

### DIFF
--- a/code/lib/core-server/src/utils/update-check.ts
+++ b/code/lib/core-server/src/utils/update-check.ts
@@ -37,8 +37,9 @@ export function createUpdateMessage(updateInfo: VersionCheck, version: string): 
   let updateMessage;
 
   try {
-    const suffix = semver.prerelease(updateInfo.data.latest.version) ? '--prerelease' : '';
-    const upgradeCommand = `npx storybook@latest upgrade ${suffix}`.trim();
+    const isPrerelease = semver.prerelease(updateInfo.data.latest.version);
+    const suffix = isPrerelease ? '@next upgrade --prerelease' : '@latest upgrade';
+    const upgradeCommand = `npx storybook${suffix}`;
     updateMessage =
       updateInfo.success && semver.lt(version, updateInfo.data.latest.version)
         ? dedent`


### PR DESCRIPTION
N/A

## What I did

When the upgrade notification check succeeds, we tell the user to upgrade.

The upgrade message is wrong, however. If the upgrade version is stable, it should be`npx storybook@latest upgrade`. If the upgrade version is a prerelease, it should be `npx storybook@next upgrade --prerelease`.

That's because the `@next` release might contain logic & automigrations that are specific to the next release.

Note that this logic assumes that all prereleases are on the `next` dist tag, which might not be the case in the future. Also this should be updated when we overhaul the CLI @JReinhold 
