### PR TITLE
Documentation: Remove usage of `<LinkWithVersion>`

### DIFF
--- a/docs/configure/babel.md
+++ b/docs/configure/babel.md
@@ -6,7 +6,7 @@ As of version 7.0, Storybook now re-uses your project’s Babel configuration to
 
 <div class="aside">
 
-If you're not using Storybook 7, please reference the <LinkWithVersion version="6.5" href="./babel">previous documentation</LinkWithVersion> for guidance on configuring your Babel setup.
+If you're not using Storybook 7, please reference the [previous documentation](../../../release-6-5/docs/configure/babel.md) for guidance on configuring your Babel setup.
 
 </div>
 

--- a/docs/writing-docs/mdx.md
+++ b/docs/writing-docs/mdx.md
@@ -10,7 +10,7 @@ In addition, you can write pure documentation pages in MDX and add them to Story
 
 <div class="aside">
 
-Writing stories directly in MDX was deprecated in Storybook 7. Please reference the <LinkWithVersion version="6.5" href="./mdx.md">previous documentation</LinkWithVersion> for guidance on that feature.
+Writing stories directly in MDX was deprecated in Storybook 7. Please reference the [previous documentation](../../../release-6-5/docs/writing-docs/mdx.md) for guidance on that feature.
 
 </div>
 


### PR DESCRIPTION
## What I did

- Per https://github.com/storybookjs/frontpage/pull/555, using `<LinkWithVersion>` is no longer necessary. Instead, the links point to the `release-#-#` branch's content directly, which has the benefit of being a functioning link when rendered on GitHub.

## How to test

1. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `versioned-docs-links`
2. Check the "previous documentation" links for the[`writing-docs/mdx`](http://localhost:8000/docs/react/writing-docs/mdx) and [`configure/babel`](http://localhost:8000/docs/react/configure/babel) pages
3. Check those same links when rendered on GitHub

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
