### PR TITLE
Docs: Remove typo in babel documentation

### DIFF
--- a/docs/configure/babel.md
+++ b/docs/configure/babel.md
@@ -135,7 +135,7 @@ For more info, please refer to the [Babel documentation](https://babeljs.io/docs
 
 ### SWC fallback
 
-If you're working with a Webpack-based project and having issues with Babel configuration, you can opt into replacing Babel with the [SWC](https://swc.rs/) compiler. To do so, update your Storybook configuration file (e.g., `.storybook/main.js|ts`) to enable the exp experimental `useSWC` option:
+If you're working with a Webpack-based project and having issues with Babel configuration, you can opt into replacing Babel with the [SWC](https://swc.rs/) compiler. To do so, update your Storybook configuration file (e.g., `.storybook/main.js|ts`) to enable the experimental `useSWC` option:
 
 <!-- prettier-ignore-start -->
 


### PR DESCRIPTION
With this small pull request, the Babel documentation is fixed by removing a small typo introduced with #22861.


What was done:
- Fixed the typo in the documentation

Once again as this experimental feature is not available to 7.0 only for 7.1, I'm only leaving the documentation label to avoid it from being patched back.

Going to self-merge this once the checklist clears cc @kylegach 