### PR TITLE
Release: Don't pick patches when prereleasing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,11 +87,11 @@ jobs:
 
       # tags are needed to get list of patches to label as picked
       - name: Fetch git tags
-        if: steps.is-prerelease.outputs.prerelease == 'false'
+        if: github.ref_name == 'main-release'
         run: git fetch --tags origin
 
       - name: Label patch PRs as picked
-        if: steps.is-prerelease.outputs.prerelease == 'false'
+        if: github.ref_name == 'main-release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn release:label-patches

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,9 +87,11 @@ jobs:
 
       # tags are needed to get list of patches to label as picked
       - name: Fetch git tags
+        if: steps.is-prerelease.outputs.prerelease == 'false'
         run: git fetch --tags origin
 
       - name: Label patch PRs as picked
+        if: steps.is-prerelease.outputs.prerelease == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn release:label-patches


### PR DESCRIPTION
We shouldn't add the "picked" label to patches when prereleasing, only when patching.

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
