### PR TITLE
Release: Fix not escaping content of GH Releases

### DIFF
--- a/scripts/release/get-changelog-from-file.ts
+++ b/scripts/release/get-changelog-from-file.ts
@@ -14,9 +14,14 @@ program
     'get changelog entry for specific version. If not version argument specified it will use the current version in code/package.json'
   )
   .arguments('[version]')
+  .option('-E, --no-escape', 'Escape quote-like characters, so the output is safe in CLIs', true)
   .option('-V, --verbose', 'Enable verbose logging', false);
 
-export const getChangelogFromFile = async (args: { version?: string; verbose?: boolean }) => {
+export const getChangelogFromFile = async (args: {
+  version?: string;
+  escape?: boolean;
+  verbose?: boolean;
+}) => {
   const version = args.version || (await getCurrentVersion());
   const isPrerelease = semver.prerelease(version) !== null;
   const changelogFilename = isPrerelease ? 'CHANGELOG.prerelease.md' : 'CHANGELOG.md';
@@ -33,10 +38,16 @@ export const getChangelogFromFile = async (args: { version?: string; verbose?: b
       )}`
     );
   }
-  const result = `## ${changelogForVersion}`;
+  const result = args.escape
+    ? `## ${changelogForVersion}`
+        .replaceAll('"', '\\"')
+        .replaceAll('`', '\\`')
+        .replaceAll("'", "\\'")
+    : `## ${changelogForVersion}`;
 
   console.log(dedent`📝 Changelog entry found:
       ${result}`);
+
   if (process.env.GITHUB_ACTIONS === 'true') {
     setOutput('changelog', result);
   }
@@ -45,7 +56,11 @@ export const getChangelogFromFile = async (args: { version?: string; verbose?: b
 
 if (require.main === module) {
   const parsed = program.parse();
-  getChangelogFromFile({ version: parsed.args[0], verbose: parsed.opts().verbose }).catch((err) => {
+  getChangelogFromFile({
+    version: parsed.args[0],
+    escape: parsed.opts().escape,
+    verbose: parsed.opts().verbose,
+  }).catch((err) => {
     console.error(err);
     process.exit(1);
   });


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
