### PR TITLE
Vue3: Use latest release of vue-component-type-helpers

### DIFF
--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -55,7 +55,7 @@
     "@storybook/types": "7.1.0-alpha.30",
     "ts-dedent": "^2.0.0",
     "type-fest": "^3.11.0",
-    "vue-component-type-helpers": "^1.6.5"
+    "vue-component-type-helpers": "latest"
   },
   "devDependencies": {
     "@digitak/esrun": "^3.2.2",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7650,7 +7650,7 @@ __metadata:
     type-fest: ^3.11.0
     typescript: ~4.9.3
     vue: ^3.2.47
-    vue-component-type-helpers: ^1.6.5
+    vue-component-type-helpers: latest
     vue-tsc: latest
   peerDependencies:
     vue: ^3.0.0
@@ -30525,10 +30525,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-component-type-helpers@npm:^1.6.5":
-  version: 1.7.11
-  resolution: "vue-component-type-helpers@npm:1.7.11"
-  checksum: 91437b05d7b475e1e33686b561674134616d353c77fb87949ca99ead59272557eb3de4628d39512694880ab6e7cdf15045cf9a204bf6203d0b35b5b4b8a540b5
+"vue-component-type-helpers@npm:latest":
+  version: 1.6.5
+  resolution: "vue-component-type-helpers@npm:1.6.5"
+  checksum: 205d520c05e53d1cc6f53fe920c64b4c6883249cbfe15026fcda250980bf4ddfc004292e0c9ecaa7fcf983bd143482ffbc4191e0b84f6d3f996a0a07ca3396c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #22853 

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Using the latest release of vue-component-type-helpers so that it is in sync with the latest vscode plugin.

My feeling is that this really should be a peer dep instead. So that the user can specify self with version of the volar tools they are using.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
