### PR TITLE
Release: Fix release and changelog generation

### DIFF
--- a/scripts/release/__tests__/generate-pr-description.test.ts
+++ b/scripts/release/__tests__/generate-pr-description.test.ts
@@ -185,7 +185,7 @@ For each pull request below, you need to either manually cherry pick it, or disc
         And for each change below:
 
         1. Ensure the change is appropriate for the version bump. E.g. patch release should only contain patches, not new or de-stabilizing features. If a change is not appropriate, revert the PR.
-        2. Ensure the PR is labeled correctly with \\"BREAKING CHANGE\\", \\"feature request\\", \\"maintainance\\", \\"bug\\", \\"build\\" or \\"documentation\\".
+        2. Ensure the PR is labeled correctly with one of: \\"BREAKING CHANGE\\", \\"feature request\\", \\"bug\\", \\"maintenance\\", \\"dependencies\\", \\"documentation\\", \\"build\\", \\"unknown\\".
         3. Ensure the PR title is correct, and follows the format \\"[Area]: [Summary]\\", e.g. *\\"React: Fix hooks in CSF3 render functions\\"*. If it is not correct, change the title in the PR.
             - Areas include: React, Vue, Core, Docs, Controls, etc.
             - First word of summary indicates the type: “Add”, “Fix”, “Upgrade”, etc.
@@ -305,7 +305,7 @@ For each pull request below, you need to either manually cherry pick it, or disc
         And for each change below:
 
         1. Ensure the change is appropriate for the version bump. E.g. patch release should only contain patches, not new or de-stabilizing features. If a change is not appropriate, revert the PR.
-        2. Ensure the PR is labeled correctly with \\"BREAKING CHANGE\\", \\"feature request\\", \\"maintainance\\", \\"bug\\", \\"build\\" or \\"documentation\\".
+        2. Ensure the PR is labeled correctly with one of: \\"BREAKING CHANGE\\", \\"feature request\\", \\"bug\\", \\"maintenance\\", \\"dependencies\\", \\"documentation\\", \\"build\\", \\"unknown\\".
         3. Ensure the PR title is correct, and follows the format \\"[Area]: [Summary]\\", e.g. *\\"React: Fix hooks in CSF3 render functions\\"*. If it is not correct, change the title in the PR.
             - Areas include: React, Vue, Core, Docs, Controls, etc.
             - First word of summary indicates the type: “Add”, “Fix”, “Upgrade”, etc.

--- a/scripts/release/generate-pr-description.ts
+++ b/scripts/release/generate-pr-description.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import dedent from 'ts-dedent';
 import { setOutput } from '@actions/core';
 import type { Change } from './utils/get-changes';
-import { getChanges } from './utils/get-changes';
+import { getChanges, LABELS_BY_IMPORTANCE } from './utils/get-changes';
 import { getCurrentVersion } from './get-current-version';
 
 program
@@ -42,17 +42,6 @@ type Options = {
   manualCherryPicks?: string[];
   verbose: boolean;
 };
-
-const LABELS_BY_IMPORTANCE = {
-  'BREAKING CHANGE': '❗ Breaking Change',
-  'feature request': '✨ Feature Request',
-  bug: '🐛 Bug',
-  maintenance: '🔧 Maintenance',
-  dependencies: '📦 Dependencies',
-  documentation: '📝 Documentation',
-  build: '🏗️ Build',
-  unknown: '❔ Missing Label',
-} as const;
 
 const CHANGE_TITLES_TO_IGNORE = [
   /^bump version.*/i,
@@ -167,7 +156,9 @@ export const generateReleaseDescription = ({
   And for each change below:
   
   1. Ensure the change is appropriate for the version bump. E.g. patch release should only contain patches, not new or de-stabilizing features. If a change is not appropriate, revert the PR.
-  2. Ensure the PR is labeled correctly with "BREAKING CHANGE", "feature request", "maintainance", "bug", "build" or "documentation".
+  2. Ensure the PR is labeled correctly with one of: ${Object.keys(LABELS_BY_IMPORTANCE)
+    .map((label) => `"${label}"`)
+    .join(', ')}.
   3. Ensure the PR title is correct, and follows the format "[Area]: [Summary]", e.g. *"React: Fix hooks in CSF3 render functions"*. If it is not correct, change the title in the PR.
       - Areas include: React, Vue, Core, Docs, Controls, etc.
       - First word of summary indicates the type: “Add”, “Fix”, “Upgrade”, etc.

--- a/scripts/release/unreleased-changes-exists.ts
+++ b/scripts/release/unreleased-changes-exists.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { setOutput } from '@actions/core';
 import { intersection } from 'lodash';
 import type { Change } from './utils/get-changes';
-import { getChanges } from './utils/get-changes';
+import { RELEASED_LABELS, getChanges } from './utils/get-changes';
 import { getCurrentVersion } from './get-current-version';
 
 program
@@ -35,8 +35,6 @@ const validateOptions = (options: { [key: string]: any }): options is Options =>
   return true;
 };
 
-const LABELS_TO_RELEASE = ['BREAKING CHANGE', 'feature request', 'bug', 'maintenance'] as const;
-
 export const run = async (
   options: unknown
 ): Promise<{ changesToRelease: Change[]; hasChangesToRelease: boolean }> => {
@@ -59,7 +57,7 @@ export const run = async (
   });
 
   const changesToRelease = changes.filter(
-    ({ labels }) => intersection(LABELS_TO_RELEASE, labels).length > 0
+    ({ labels }) => intersection(Object.keys(RELEASED_LABELS), labels).length > 0
   );
 
   const hasChangesToRelease = changesToRelease.length > 0;

--- a/scripts/release/utils/get-changes.ts
+++ b/scripts/release/utils/get-changes.ts
@@ -212,7 +212,8 @@ export const getChangelogText = ({
       return pull
         ? `- ${title} - ${pull}, thanks ${user}!`
         : `- ⚠️ _Direct commit_ ${title} - ${commit} by ${user}`;
-    });
+    })
+    .sort();
   const text = [heading, '', ...formattedEntries].join('\n');
 
   console.log(`✅ Generated Changelog:`);

--- a/scripts/release/utils/get-changes.ts
+++ b/scripts/release/utils/get-changes.ts
@@ -6,7 +6,24 @@ import { getPullInfoFromCommit } from './get-github-info';
 import { getUnpickedPRs } from './get-unpicked-prs';
 import { git } from './git-client';
 
-const LABELS_FOR_CHANGELOG = ['BREAKING CHANGE', 'feature request', 'bug', 'maintenance'];
+export const RELEASED_LABELS = {
+  'BREAKING CHANGE': '❗ Breaking Change',
+  'feature request': '✨ Feature Request',
+  bug: '🐛 Bug',
+  maintenance: '🔧 Maintenance',
+  dependencies: '📦 Dependencies',
+} as const;
+
+export const UNRELEASED_LABELS = {
+  documentation: '📝 Documentation',
+  build: '🏗️ Build',
+  unknown: '❔ Missing Label',
+} as const;
+
+export const LABELS_BY_IMPORTANCE = {
+  ...RELEASED_LABELS,
+  ...UNRELEASED_LABELS,
+} as const;
 
 const getCommitAt = async (id: string, verbose?: boolean) => {
   if (!semver.valid(id)) {
@@ -187,7 +204,7 @@ export const getChangelogText = ({
         return false;
       }
       // only include PRs that with labels listed in LABELS_FOR_CHANGELOG
-      return entry.labels?.some((label) => LABELS_FOR_CHANGELOG.includes(label));
+      return entry.labels?.some((label) => Object.keys(RELEASED_LABELS).includes(label));
     })
     .map((entry) => {
       const { title, links } = entry;


### PR DESCRIPTION
<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR includes a few minor fixes to release tooling:

- The "dependencies" label is now correctly considered a "release" label, meaning it is part of a changelog, and it triggers a release PR creation.
- Sort changelog entries alphabetically to make them easier to scan.

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
