### PR TITLE
Core: Disable esbuild on files imported from `node_modules`

### DIFF
--- a/code/lib/core-common/src/utils/interpret-require.ts
+++ b/code/lib/core-common/src/utils/interpret-require.ts
@@ -13,7 +13,7 @@ export function interopRequireDefault(filePath: string) {
     register({
       target: `node${process.version.slice(1)}`,
       format: 'cjs',
-      hookIgnoreNodeModules: false,
+      hookIgnoreNodeModules: true,
       tsconfigRaw: `{
       "compilerOptions": {
         "strict": false,


### PR DESCRIPTION
Running `esbuild` over some of our larger imports (e.g. `typescript`, imported by `react-docgen-typescript-plugin`) can *significantly* increase their import time (not totally clear why as they are JS files).

I'm not sure why we changed this setting from the default (to not run `esbuild` over `node_modules`) in the first place.

## What I did

Switched back to the default -- to leave files from `node_modules` untranspiled.

## How to test

Hopefully should be covered by the daily sandboxes. But it would be very interesting to see how this affects our measured timings.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
