### PR TITLE
Release tooling: Fix pick patches script

### DIFF
--- a/scripts/release/utils/get-unpicked-prs.ts
+++ b/scripts/release/utils/get-unpicked-prs.ts
@@ -16,7 +16,7 @@ export async function getUnpickedPRs(baseBranch: string, verbose?: boolean): Pro
     `
       query ($owner: String!, $repo: String!, $state: PullRequestState!, $order: IssueOrder!) {
         repository(owner: $owner, name: $repo) {
-          pullRequests(states: [$state], labels: ["patch"], orderBy: $order, first: 50) {
+          pullRequests(states: [$state], labels: ["patch"], orderBy: $order, first: 50, baseRefName: "next") {
             nodes {
               id
               number
@@ -40,7 +40,7 @@ export async function getUnpickedPRs(baseBranch: string, verbose?: boolean): Pro
       repo: 'storybook',
       order: {
         field: 'UPDATED_AT',
-        direction: 'ASC',
+        direction: 'DESC',
       },
       state: 'MERGED',
     }
@@ -61,7 +61,9 @@ export async function getUnpickedPRs(baseBranch: string, verbose?: boolean): Pro
 
   const unpickedPRs = prs
     .filter((pr: any) => !pr.labels.includes('picked'))
-    .filter((pr: any) => pr.branch === baseBranch);
+    .filter((pr: any) => pr.branch === baseBranch)
+    .reverse();
+
   if (verbose) {
     console.log(`🔍 Found unpicked patch pull requests:
   ${JSON.stringify(unpickedPRs, null, 2)}`);


### PR DESCRIPTION
## What I did

Revert to Michael implementation that get's the latest 50 patch PRs instead of the oldest 50!

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
