### PR TITLE
Release tooling: Give the full commit hash to the github API

### DIFF
--- a/scripts/release/utils/get-github-info.ts
+++ b/scripts/release/utils/get-github-info.ts
@@ -74,7 +74,7 @@ function makeQuery(repos: ReposWithCommitsAndPRsToFetch) {
                     }    
                     mergeCommit {
                       commitUrl
-                      abbreviatedOid
+                      oid
                     }
                   }`
               )
@@ -285,11 +285,11 @@ export async function getPullInfoFromPullRequest(request: {
     user: user ? user.login : null,
     id: null,
     pull: request.pull,
-    commit: commit ? commit.abbreviatedOid : null,
+    commit: commit ? commit.oid : null,
     title: title || null,
     labels: data ? (data.labels.nodes || []).map((label: { name: string }) => label.name) : null,
     links: {
-      commit: commit ? `[\`${commit.abbreviatedOid}\`](${commit.commitUrl})` : null,
+      commit: commit ? `[\`${commit.oid}\`](${commit.commitUrl})` : null,
       pull: `[#${request.pull}](https://github.com/${request.repo}/pull/${request.pull})`,
       user: user ? `[@${user.login}](${user.url})` : null,
     },

--- a/scripts/release/utils/get-unpicked-prs.ts
+++ b/scripts/release/utils/get-unpicked-prs.ts
@@ -23,7 +23,7 @@ export async function getUnpickedPRs(baseBranch: string, verbose?: boolean): Pro
               title
               baseRefName
               mergeCommit { 
-                abbreviatedOid
+                oid
               }
               labels(first: 20) {
                 nodes {
@@ -55,7 +55,7 @@ export async function getUnpickedPRs(baseBranch: string, verbose?: boolean): Pro
     id: node.id,
     branch: node.baseRefName,
     title: node.title,
-    mergeCommit: node.mergeCommit.abbreviatedOid,
+    mergeCommit: node.mergeCommit.oid,
     labels: node.labels.nodes.map((l: any) => l.name),
   }));
 


### PR DESCRIPTION
## What I did

Use the full commit hash for the github API, as it returns null with the short one sometimes (might be a clash??) 
## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
