### PR TITLE
Build: Fix E2E and chromatic inconsistencies

### DIFF
--- a/code/e2e-tests/addon-viewport.spec.ts
+++ b/code/e2e-tests/addon-viewport.spec.ts
@@ -28,13 +28,13 @@ test.describe('addon-viewport', () => {
     await sbPage.navigateToStory('example/button', 'primary');
 
     // Measure the original dimensions of previewRoot
-    const originalDimensions = await sbPage.previewRoot().boundingBox();
+    const originalDimensions = await sbPage.getCanvasBodyElement().boundingBox();
     await expect(originalDimensions?.width).toBeDefined();
 
     await sbPage.selectToolbar('[title="Change the size of the preview"]', '#list-item-mobile1');
 
     // Measure the adjusted dimensions of previewRoot after clicking the mobile item.
-    const adjustedDimensions = await sbPage.previewRoot().boundingBox();
+    const adjustedDimensions = await sbPage.getCanvasBodyElement().boundingBox();
     await expect(adjustedDimensions?.width).toBeDefined();
 
     // Compare the two widths

--- a/code/renderers/react/template/stories/ts-argtypes.stories.tsx
+++ b/code/renderers/react/template/stories/ts-argtypes.stories.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import mapValues from 'lodash/mapValues.js';
 import { PureArgsTable as ArgsTable } from '@storybook/blocks';
+import type { StoryObj } from '@storybook/react';
 import type { Args, Parameters, StoryContext } from '@storybook/types';
 import { inferControls } from '@storybook/preview-api';
 import { ThemeProvider, themes, convert } from '@storybook/theming';
 
+import { within } from '@storybook/testing-library';
 import { component as TsFunctionComponentComponent } from './docgen-components/ts-function-component/input';
 import { component as TsFunctionComponentInlineDefaultsComponent } from './docgen-components/ts-function-component-inline-defaults/input';
 import { component as TsReactFcGenericsComponent } from './docgen-components/8143-ts-react-fc-generics/input';
@@ -76,6 +78,19 @@ export const TsComponentProps = { parameters: { component: TsComponentPropsCompo
 
 export const TsJsdoc = { parameters: { component: TsJsdocComponent } };
 
-export const TsTypes = { parameters: { component: TsTypesComponent } };
+export const TsTypes: StoryObj = {
+  parameters: { component: TsTypesComponent },
+  play: async ({ canvasElement }) => {
+    // This play function's sole purpose is to add a "chromatic ignore" region to a flaky row.
+    const canvas = within(canvasElement);
+    const funcCell = await canvas.findByText('funcWithArgsAndReturns');
+    const funcRow = funcCell.parentElement?.parentElement;
+    if (funcRow?.nodeName === 'TR') {
+      funcRow.setAttribute('data-chromatic', 'ignore');
+    } else {
+      throw new Error('the DOM structure changed, please update this test');
+    }
+  },
+};
 
 export const TsHtml = { parameters: { component: TsHtmlComponent } };

--- a/code/renderers/react/template/stories/ts-argtypes.stories.tsx
+++ b/code/renderers/react/template/stories/ts-argtypes.stories.tsx
@@ -78,18 +78,26 @@ export const TsComponentProps = { parameters: { component: TsComponentPropsCompo
 
 export const TsJsdoc = { parameters: { component: TsJsdocComponent } };
 
+const addChromaticIgnore = async (element: HTMLElement) => {
+  const row = element.parentElement?.parentElement;
+  if (row?.nodeName === 'TR') {
+    row.setAttribute('data-chromatic', 'ignore');
+  } else {
+    throw new Error('the DOM structure changed, please update this test');
+  }
+};
+
 export const TsTypes: StoryObj = {
   parameters: { component: TsTypesComponent },
   play: async ({ canvasElement }) => {
-    // This play function's sole purpose is to add a "chromatic ignore" region to a flaky row.
+    // This play function's sole purpose is to add a "chromatic ignore" region to flaky rows.
     const canvas = within(canvasElement);
     const funcCell = await canvas.findByText('funcWithArgsAndReturns');
-    const funcRow = funcCell.parentElement?.parentElement;
-    if (funcRow?.nodeName === 'TR') {
-      funcRow.setAttribute('data-chromatic', 'ignore');
-    } else {
-      throw new Error('the DOM structure changed, please update this test');
-    }
+    addChromaticIgnore(funcCell);
+    const namedNumericCell = await canvas.findByText('namedNumericLiteralUnion');
+    addChromaticIgnore(namedNumericCell);
+    const inlinedNumericCell = await canvas.findByText('inlinedNumericLiteralUnion');
+    addChromaticIgnore(inlinedNumericCell);
   },
 };
 

--- a/code/ui/.storybook/preview.tsx
+++ b/code/ui/.storybook/preview.tsx
@@ -64,18 +64,19 @@ const ThemeStack = styled.div(
 const PlayFnNotice = styled.div(
   {
     position: 'absolute',
-    bottom: '1rem',
-    right: '1rem',
-    border: '1px solid #ccc',
-    borderRadius: '5px',
-    padding: '1rem',
-    fontSize: '12px',
+    top: 0,
+    left: 0,
+    width: '100%',
+    borderBottom: '1px solid #ccc',
+    padding: '3px 8px',
+    fontSize: '10px',
+    fontWeight: 'bold',
     '> *': {
       display: 'block',
     },
   },
   ({ theme }) => ({
-    background: theme.background.content,
+    background: '#fffbd9',
     color: theme.color.defaultText,
   })
 );
@@ -219,10 +220,15 @@ export const decorators = [
             <Global styles={createReset} />
             <ThemedSetRoot />
             {!parameters.theme && isChromatic() && playFunction && (
-              <PlayFnNotice>
-                <span>Detected play function.</span>
-                <span>Rendering in a single theme</span>
-              </PlayFnNotice>
+              <>
+                <PlayFnNotice>
+                  <span>
+                    Detected play function in Chromatic. Rendering only light theme to avoid
+                    multiple play functions in the same story.
+                  </span>
+                </PlayFnNotice>
+                <div style={{ marginBottom: 20 }} />
+              </>
             )}
             <StoryFn />
           </ThemeProvider>

--- a/code/ui/blocks/src/blocks/DocsPage.stories.tsx
+++ b/code/ui/blocks/src/blocks/DocsPage.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { within } from '@storybook/testing-library';
 import { DocsPage } from './DocsPage';
 
 const meta = {
@@ -16,8 +17,20 @@ export const Default: Story = {
   parameters: {
     relativeCsfPaths: ['../examples/Button.stories'],
   },
+  play: async ({ canvasElement }) => {
+    // This play function's sole purpose is to add a "chromatic ignore" region to a flaky row.
+    const canvas = within(canvasElement);
+    const sizeCell = await canvas.findByText('How large should the button be?');
+    const sizeRow = sizeCell.parentElement?.parentElement?.parentElement;
+    if (sizeRow?.nodeName === 'TR') {
+      sizeRow.setAttribute('data-chromatic', 'ignore');
+    } else {
+      throw new Error('the DOM structure changed, please update this test');
+    }
+  },
 };
 export const SingleStory: Story = {
+  ...Default,
   parameters: {
     relativeCsfPaths: ['../examples/DocsPageParameters.stories'],
   },

--- a/code/ui/manager/src/components/layout/app.mockdata.tsx
+++ b/code/ui/manager/src/components/layout/app.mockdata.tsx
@@ -105,6 +105,7 @@ class PlaceholderClock extends Component<{ color: string }, { count: number }> {
     return (
       <PlaceholderBlock color={color}>
         <h2
+          data-chromatic="ignore"
           style={{
             position: 'absolute',
             bottom: 0,


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR solves a few sources of flakiness.

### Viewports E2E test

It seemed to be testing the wrong element, which playwright assumed had the same dimensions either without or with viewports enabled:

![image](https://github.com/storybookjs/storybook/assets/1671563/ae2baa87-586d-46fe-a1d0-20c27540983a)

![image](https://github.com/storybookjs/storybook/assets/1671563/c1993560-85d2-4841-9e62-03bb7d52eb35)

### Chromatic

The "Desktop" component stories had a counter which was causing inconsistencies, and now it has chromatic ignore regions to avoid it:
<img width="960" alt="image" src="https://github.com/storybookjs/storybook/assets/1671563/0a5600a0-75ae-4285-9a85-c7971c6f5c3c">


The "DocsPage" story has a very inconsistent args table row which keeps changing in order, therefore I added a play function which injects a chromatic ignore region to it. I did it in the play function and not in the component so that we don't always ignore snapshots for the argstable component, and we really just ignore in the place we know is inconsistent.

Additionally I made the "play function banner" (we display only when snapshotting stories in Chromatic that have play function) more prominent and explanatory

<img width="1122" alt="image" src="https://github.com/storybookjs/storybook/assets/1671563/8a7db379-65d8-4dbf-b6ac-1589b944512f">

The "TS Argtypes" suffers a similar issue, where a minified function name keeps changing, so I added a similar mechanism using the play function.

## How to test

Tests should work correctly

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
