### PR TITLE
Docs: Clarify APIs of Controls doc block/addon/argTypes

### DIFF
--- a/docs/api/doc-block-controls.md
+++ b/docs/api/doc-block-controls.md
@@ -10,6 +10,12 @@ The `Controls` block can be used to show a dynamic table of args for a given sto
 
 </div>
 
+<div class="aside">
+
+⚠️ The Controls doc block will only have functioning UI controls if you have also installed and registered [`@storybook/addon-controls`](../essentials/controls.md) (included in [`@storybook/addon-essentials`](../essentials/introduction.md)).
+
+</div>
+
 ![Screenshot of Controls block](./doc-block-controls.png)
 
 <!-- prettier-ignore-start -->
@@ -65,6 +71,12 @@ The following `exclude` configurations are equivalent:
 The example above applied the parameter at the [component](../writing-stories/parameters.md#component-parameters) (or meta) level, but it could also be applied at the [project](../writing-stories/parameters.md#global-parameters) or [story](../writing-stories/parameters.md#story-parameters) level.
 
 </details>
+
+<div class="aside">
+
+💡 This API configures Controls blocks used within docs pages. To configure the Controls addon panel, see the [Controls addon docs](../essentials/controls.md). To configure individual controls, you can specify [argTypes](./arg-types.md#control) for each.
+
+</div>
 
 ### `exclude`
 


### PR DESCRIPTION
Closes #22600

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Add callouts to Controls doc block API reference
    - `@storybook/addon-controls` must be registered
    - How to configure what
        - Controls blocks in docs pages: this API
        - Controls in addons panel: Controls addon
        - Individual controls: argTypes

## How to test

1. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `api-ref-doc-block-controls-install-addon`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
