### PR TITLE
Docs: Remove "(deprecated)" & "(required)" from headings

### DIFF
--- a/docs/api/arg-types.md
+++ b/docs/api/arg-types.md
@@ -479,7 +479,9 @@ If you only need to specify the documented type, you should use [`table.type`](#
 
 <!-- prettier-ignore-end -->
 
-### `defaultValue` (deprecated)
+### `defaultValue`
+
+(⛔️ **Deprecated**)
 
 Type: `any`
 

--- a/docs/api/doc-block-canvas.md
+++ b/docs/api/doc-block-canvas.md
@@ -202,37 +202,49 @@ Default: `parameters.docs.canvas.withToolbar`
 
 Determines whether to render a toolbar containing tools to interact with the story.
 
-### `children` (deprecated)
+### `children`
+
+(⛔️ **Deprecated**)
 
 Type: `React.ReactNode`
 
 Expects only [Story](./doc-block-story.md) children. Reference the story with the `of` prop instead.
 
-### `columns` (deprecated)
+### `columns`
+
+(⛔️ **Deprecated**)
 
 Type: `number`
 
 Splits the stories based on the number of defined columns. Multiple stories are not supported.
 
-### `isColumn` (deprecated)
+### `isColumn`
+
+(⛔️ **Deprecated**)
 
 Type: `boolean`
 
 Displays the stories one above the other. Multiple stories are not supported.
 
-### `mdxSource` (deprecated)
+### `mdxSource`
+
+(⛔️ **Deprecated**)
 
 Type: `string`
 
 Provides source to display. Use [`source.code`](#source) instead.
 
-### `withSource` (deprecated)
+### `withSource`
+
+(⛔️ **Deprecated**)
 
 Type: `'open' | 'closed' | 'none'`
 
 Controls the source code block visibility. Use [`sourceState`](#sourcestate) instead.
 
-### `withToolbar` (deprecated)
+### `withToolbar`
+
+(⛔️ **Deprecated**)
 
 Type: `boolean`
 

--- a/docs/api/doc-block-colorpalette.md
+++ b/docs/api/doc-block-colorpalette.md
@@ -66,19 +66,25 @@ import { ColorItem } from '@storybook/blocks';
 
 `ColorItem` is configured with the following props:
 
-### `colors` (required)
+### `colors`
+
+(**Required**)
 
 Type: `string[] | { [key: string]: string }`
 
 Provides the list of colors to be displayed. Accepts any valid CSS color format (hex, RGB, HSL, etc.). When an object is provided, the keys will be displayed above the values.
 
-### `subtitle` (required)
+### `subtitle`
+
+(**Required**)
 
 Type: `string`
 
 Provides an additional description of the color.
 
-### `title` (required)
+### `title`
+
+(**Required**)
 
 Type: `string`
 

--- a/docs/api/doc-block-description.md
+++ b/docs/api/doc-block-description.md
@@ -35,19 +35,25 @@ Specifies where to pull the description from. It can either point to a story or 
 
 Descriptions are pulled from the JSDoc comments or parameters, and they are rendered as markdown. See [Writing descriptions](#writing-descriptions) for more details.
 
-### `children` (deprecated)
+### `children`
+
+(⛔️ **Deprecated**)
 
 Type: `string`
 
 See [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#description-block-parametersnotes-and-parametersinfo).
 
-### `markdown` (deprecated)
+### `markdown`
+
+(⛔️ **Deprecated**)
 
 Type: `string`
 
 See [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#description-block-parametersnotes-and-parametersinfo).
 
-### `type` (deprecated)
+### `type`
+
+(⛔️ **Deprecated**)
 
 Type: `'info' | 'notes' | 'docgen' | 'auto'`
 

--- a/docs/api/doc-block-icongallery.md
+++ b/docs/api/doc-block-icongallery.md
@@ -75,7 +75,9 @@ import { IconItem } from '@storybook/blocks';
 
 `IconItem` is configured with the following props:
 
-### `name` (required)
+### `name`
+
+(**Required**)
 
 Type: `string`
 

--- a/docs/api/doc-block-primary.md
+++ b/docs/api/doc-block-primary.md
@@ -27,7 +27,9 @@ import { Primary } from '@storybook/blocks';
 
 `Primary` is configured with the following props:
 
-### `name` (deprecated)
+### `name`
+
+(⛔️ **Deprecated**)
 
 Type: `string`
 

--- a/docs/api/doc-block-source.md
+++ b/docs/api/doc-block-source.md
@@ -151,13 +151,17 @@ Specifies how the source code is rendered.
 
 </div>
 
-### `id` (deprecated)
+### `id`
+
+(⛔️ **Deprecated**)
 
 Type: `string`
 
 Specifies the story id for which to render the source code. Referencing a story this way is no longer supported; use the [`of` prop](#of), instead.
 
-### `ids` (deprecated)
+### `ids`
+
+(⛔️ **Deprecated**)
 
 Type: `string[]`
 

--- a/docs/api/doc-block-story.md
+++ b/docs/api/doc-block-story.md
@@ -124,61 +124,81 @@ Type: Story export
 
 Specifies which story is rendered by the `Story` block. If no `of` is defined and the MDX file is [attached](./doc-block-meta.md#attached-vs-unattached), the primary (first) story will be rendered.
 
-### `args` (deprecated)
+### `args`
+
+(⛔️ **Deprecated**)
 
 Type: `Partial<TArgs>`
 
 Defining and configuring stories in MDX is deprecated. See the [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files) for details.
 
-### `argTypes` (deprecated)
+### `argTypes`
+
+(⛔️ **Deprecated**)
 
 Type: `Partial<ArgTypes<TArgs>>`
 
 Defining and configuring stories in MDX is deprecated. See the [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files) for details.
 
-### `decorators` (deprecated)
+### `decorators`
+
+(⛔️ **Deprecated**)
 
 Type: `DecoratorFunction<TRenderer, TArgs>[]`
 
 Defining and configuring stories in MDX is deprecated. See the [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files) for details.
 
-### `loaders` (deprecated)
+### `loaders`
+
+(⛔️ **Deprecated**)
 
 Type: `LoaderFunction<TRenderer, TArgs>[]`
 
 Defining and configuring stories in MDX is deprecated. See the [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files) for details.
 
-### `name` (deprecated)
+### `name`
+
+(⛔️ **Deprecated**)
 
 Type: `StoryName`
 
 Defining and configuring stories in MDX is deprecated. See the [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files) for details.
 
-### `parameters` (deprecated)
+### `parameters`
+
+(⛔️ **Deprecated**)
 
 Type: `Parameters`
 
 Defining and configuring stories in MDX is deprecated. See the [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files) for details.
 
-### `play` (deprecated)
+### `play`
+
+(⛔️ **Deprecated**)
 
 Type: `PlayFunction<TRenderer, TArgs>`
 
 Defining and configuring stories in MDX is deprecated. See the [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files) for details.
 
-### `render` (deprecated)
+### `render`
+
+(⛔️ **Deprecated**)
 
 Type: `ArgsStoryFn<TRenderer, TArgs>`
 
 Defining and configuring stories in MDX is deprecated. See the [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files) for details.
 
-### `story` (deprecated)
+### `story`
+
+(⛔️ **Deprecated**)
 
 Type: `Omit<StoryAnnotations<TRenderer, TArgs>, 'story'>`
 
 Defining and configuring stories in MDX is deprecated. See the [Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mdx-docs-files) for details.
 
-### `storyName` (deprecated)
+### `storyName`
+
+(⛔️ **Deprecated**)
 
 Type: `StoryName`
 

--- a/docs/api/doc-block-useof.md
+++ b/docs/api/doc-block-useof.md
@@ -67,7 +67,9 @@ useOf = (
 
 ## Parameters
 
-### `moduleExportOrType` (required)
+### `moduleExportOrType`
+
+(**Required**)
 
 Type: `ModuleExport | 'story' | 'meta' | 'component'`
 

--- a/docs/api/main-config-config.md
+++ b/docs/api/main-config-config.md
@@ -2,10 +2,10 @@
 title: 'config'
 ---
 
+(⛔️ **Deprecated**)
+
 Parent: [main.js|ts configuration](./main-config.md)
 
 Type: `string[] | ((config: string[], options: Options) => string[] | Promise<string[]>)`
-
-Deprecated: `true`
 
 Add additional scripts to run in the story preview. Deprecated in favor of [`previewAnnotations`](./main-config-preview-annotations.md).

--- a/docs/api/main-config-framework.md
+++ b/docs/api/main-config-framework.md
@@ -2,11 +2,11 @@
 title: 'framework'
 ---
 
+(**Required**)
+
 Parent: [main.js|ts configuration](./main-config.md)
 
 Type: `FrameworkName | { name: FrameworkName; options?: FrameworkOptions }`
-
-Required: `true`
 
 Configures Storybook based on a set of [framework-specific](../configure/frameworks.md) settings.
 

--- a/docs/api/main-config-stories.md
+++ b/docs/api/main-config-stories.md
@@ -2,6 +2,8 @@
 title: 'stories'
 ---
 
+(**Required**)
+
 Parent: [main.js|ts configuration](./main-config.md)
 
 Type:
@@ -10,8 +12,6 @@ Type:
 | (string | StoriesSpecifier)[]
 | async (list: (string | StoriesSpecifier)[]) => (string | StoriesSpecifier)[]
 ```
-
-Required: `true`
 
 Configures Storybook to load stories from the specified locations. The intention is for you to colocate a story file along with the component it documents:
 
@@ -91,9 +91,9 @@ Type:
 
 #### `StoriesSpecifier.directory`
 
-Type: `string`
+(**Required**)
 
-Required: `true`
+Type: `string`
 
 Where to start looking for story files, relative to the root of your project.
 

--- a/docs/api/main-config.md
+++ b/docs/api/main-config.md
@@ -25,8 +25,8 @@ A typical Storybook configuration file looks like this:
 
 An object to configure Storybook containing the following properties:
 
-- [`framework`](./main-config-framework.md) (required)
-- [`stories`](./main-config-stories.md) (required)
+- [`framework`](./main-config-framework.md) (Required)
+- [`stories`](./main-config-stories.md) (Required)
 - [`addons`](./main-config-addons.md)
 - [`babel`](./main-config-babel.md)
 - [`babelDefault`](./main-config-babel-default.md)

--- a/docs/api/main-config.md
+++ b/docs/api/main-config.md
@@ -44,4 +44,4 @@ An object to configure Storybook containing the following properties:
 - [`typescript`](./main-config-typescript.md)
 - [`viteFinal`](./main-config-vite-final.md)
 - [`webpackFinal`](./main-config-webpack-final.md)
-- [`config`](./main-config-config.md) (deprecated)
+- [`config`](./main-config-config.md) (⛔️ Deprecated)

--- a/docs/snippets/angular/arg-types-default-value.ts.mdx
+++ b/docs/snippets/angular/arg-types-default-value.ts.mdx
@@ -9,7 +9,7 @@ const meta: Meta<Example> = {
   component: Example,
   argTypes: {
     value: {
-      // ❌ Deprecated
+      // ⛔️ Deprecated, do not use
       defaultValue: 0,
     },
   },

--- a/docs/snippets/common/arg-types-default-value.js.mdx
+++ b/docs/snippets/common/arg-types-default-value.js.mdx
@@ -7,7 +7,7 @@ export default {
   component: Example,
   argTypes: {
     value: {
-      // ❌ Deprecated
+      // ⛔️ Deprecated, do not use
       defaultValue: 0,
     },
   },

--- a/docs/snippets/common/arg-types-default-value.ts.mdx
+++ b/docs/snippets/common/arg-types-default-value.ts.mdx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Example> = {
   component: Example,
   argTypes: {
     value: {
-      // ❌ Deprecated
+      // ⛔️ Deprecated, do not use
       defaultValue: 0,
     },
   },

--- a/docs/snippets/web-components/arg-types-default-value.js.mdx
+++ b/docs/snippets/web-components/arg-types-default-value.js.mdx
@@ -5,7 +5,7 @@ export default {
   component: 'demo-example',
   argTypes: {
     value: {
-      // ❌ Deprecated
+      // ⛔️ Deprecated, do not use
       defaultValue: 0,
     },
   },

--- a/docs/snippets/web-components/arg-types-default-value.ts.mdx
+++ b/docs/snippets/web-components/arg-types-default-value.ts.mdx
@@ -7,7 +7,7 @@ const meta: Meta = {
   component: 'demo-example',
   argTypes: {
     value: {
-      // ❌ Deprecated
+      // ⛔️ Deprecated, do not use
       defaultValue: 0,
     },
   },


### PR DESCRIPTION
## What I did

- Removed to ensure heading anchor links are stable over time
- Consistently display deprecated & required properties throughout API references
    - Matches experimental label

<table>
<tr>
<td>

![](https://github.com/storybookjs/storybook/assets/486540/d3f1d9e1-6429-453f-8543-5f25a5936f13)

</td>
<td>

![](https://github.com/storybookjs/storybook/assets/486540/32cefbcd-c2b5-4185-ad08-2560d72437e1)

</td>
</tr>
</table>

## How to test

1. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `no-deprecated-in-headings`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
