### PR TITLE
Angular: Fix 16.1 compatibility

### DIFF
--- a/code/frameworks/angular/src/server/angular-cli-webpack.js
+++ b/code/frameworks/angular/src/server/angular-cli-webpack.js
@@ -11,6 +11,7 @@ const {
 
 const getAngularWebpackUtils = () => {
   try {
+    // Angular < 16.1.0
     const {
       getCommonConfig,
       getStylesConfig,
@@ -25,6 +26,7 @@ const getAngularWebpackUtils = () => {
       getTypeScriptConfig,
     };
   } catch (e) {
+    // Angular > 16.1.0
     const {
       getCommonConfig,
       getStylesConfig,

--- a/code/frameworks/angular/src/server/angular-cli-webpack.js
+++ b/code/frameworks/angular/src/server/angular-cli-webpack.js
@@ -1,18 +1,45 @@
+/* eslint-disable global-require */
 // Private angular devkit stuff
 const {
   generateI18nBrowserWebpackConfigFromContext,
 } = require('@angular-devkit/build-angular/src/utils/webpack-browser-config');
-const {
-  getCommonConfig,
-  getStylesConfig,
-  getDevServerConfig,
-  getTypeScriptConfig,
-} = require('@angular-devkit/build-angular/src/webpack/configs');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const { filterOutStylingRules } = require('./utils/filter-out-styling-rules');
 const {
   default: StorybookNormalizeAngularEntryPlugin,
 } = require('./plugins/storybook-normalize-angular-entry-plugin');
+
+const getAngularWebpackUtils = () => {
+  try {
+    const {
+      getCommonConfig,
+      getStylesConfig,
+      getDevServerConfig,
+      getTypeScriptConfig,
+    } = require('@angular-devkit/build-angular/src/webpack/configs');
+
+    return {
+      getCommonConfig,
+      getStylesConfig,
+      getDevServerConfig,
+      getTypeScriptConfig,
+    };
+  } catch (e) {
+    const {
+      getCommonConfig,
+      getStylesConfig,
+      getDevServerConfig,
+      getTypeScriptConfig,
+    } = require('@angular-devkit/build-angular/src/tools/webpack/configs');
+
+    return {
+      getCommonConfig,
+      getStylesConfig,
+      getDevServerConfig,
+      getTypeScriptConfig,
+    };
+  }
+};
 
 /**
  * Extract webpack config from angular-cli 13.x.x
@@ -26,6 +53,8 @@ exports.getWebpackConfig = async (baseConfig, { builderOptions, builderContext }
   /**
    * Get angular-cli Webpack config
    */
+  const { getCommonConfig, getStylesConfig, getDevServerConfig, getTypeScriptConfig } =
+    getAngularWebpackUtils();
   const { config: cliConfig } = await generateI18nBrowserWebpackConfigFromContext(
     {
       // Default options


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/23057

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I found out that angular moved the code internall that we used to replicate their webpack config.
I made it future & backwards compatible with a `try-catch` trying both places.

## How to test

Sandboxes should pass