### PR TITLE
chore: update zone.js version range package.json

### DIFF
--- a/app/angular/package.json
+++ b/app/angular/package.json
@@ -120,7 +120,7 @@
     "@nrwl/workspace": ">=11.1.0",
     "rxjs": "^6.0.0 || ^7.4.0",
     "typescript": "^3.4.0 || >=4.0.0",
-    "zone.js": "^0.8.29 || ^0.9.0 || ^0.10.0 || ^0.11.0"
+    "zone.js": "^0.8.29 || >= 0.9.0 < 1.0.0"
   },
   "peerDependenciesMeta": {
     "@angular/cli": {


### PR DESCRIPTION
I need this in `6.5.17`
<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I updated the zone.js version scope in package.json to `"^0.8.29 || >=0.9.0 <1.0.0"` to enable the use of Angular 15 and NX version 15. Angular 15 requires `zone.js` version `0.12.0`, which I could not use without this update.

I did the same as: https://github.com/storybookjs/storybook/commit/75e57ad1deacdf5a6cf9c49b05bed591685e0b75

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)


can be labelled `dependencies`