### PR TITLE
NextJS: Fix fonts not loading with 3+ words in name

### DIFF
--- a/code/frameworks/nextjs/src/font/webpack/loader/utils/get-css-meta.ts
+++ b/code/frameworks/nextjs/src/font/webpack/loader/utils/get-css-meta.ts
@@ -37,7 +37,7 @@ export function getCSSMeta(options: Options) {
 }
 
 function getClassName({ styles, weights, fontFamily }: Options) {
-  const font = fontFamily.replace(' ', '-').toLowerCase();
+  const font = fontFamily.replaceAll(' ', '-').toLowerCase();
   const style = isNextCSSPropertyValid(styles) ? styles[0] : null;
   const weight = isNextCSSPropertyValid(weights) ? weights[0] : null;
 


### PR DESCRIPTION
Closes #22248

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

<!-- Briefly describe what your PR does -->

This PR fixes a bug not loading fonts has 3 (or more) words name.

It caused by using `replace` instead of `replaceAll` when get `className` from font family name. 

Before:
![image](https://github.com/storybookjs/storybook/assets/14973783/d5928c8b-4298-4c19-8e99-9cc8dd2a5d1f)

After:
![image](https://github.com/storybookjs/storybook/assets/14973783/5f05a17a-b9e2-402a-933a-d2c1c3c2cde6)


## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Run a sandbox for `nextjs/default-ts` template.
2. Create `NextFont.tsx` and `NextFontTest.stories.tsx` as below in same any directory.
3. Access story created.



```tsx
// NextFont.tsx
import { Petit_Formal_Script } from 'next/font/google';
import React from 'react';

const font = Petit_Formal_Script({
  weight: '400',
  variable: '--font-script',
  subsets: ['latin'],
});

export const NextFontTest: React.FC = () => {
  return (
    <div>
      <section>
        <h2>
          Apply font styles with{' '}
          <a
            target="_blank"
            href="https://nextjs.org/docs/pages/api-reference/components/font#classname"
            rel="noreferrer noopener"
          >
            <code>className</code> method
          </a>
        </h2>
        <p className={font.className}>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
          ut labore et dolore magna aliqua.
        </p>
      </section>
      <section>
        <h2>
          Apply font styles with{' '}
          <a
            target="_blank"
            href="https://nextjs.org/docs/pages/api-reference/components/font#css-variables"
            rel="noreferrer noopener"
          >
            CSS variable method
          </a>
        </h2>
        <p className={font.variable} style={{ fontFamily: 'var(--font-script)' }}>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
          ut labore et dolore magna aliqua.
        </p>
      </section>
    </div>
  );
};

```

```tsx
// NextFontTest.stories.tsx
import { Meta, StoryObj } from '@storybook/react';
import { NextFontTest } from './NextFontTest';

export default { component: NextFontTest } satisfies Meta<typeof NextFontTest>;

type Story = StoryObj<typeof NextFontTest>;

export const Default: Story = {};

```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
