### PR TITLE
CLI: Suppress dev-server info table when `--quiet` is true

### DIFF
--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -159,6 +159,7 @@ export async function buildDevStandalone(
       frameworkName.split('@storybook/').length > 1
         ? frameworkName.split('@storybook/')[1]
         : frameworkName;
+
     if (!options.quiet) {
       outputStartupInformation({
         updateInfo: versionCheck,

--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -159,16 +159,17 @@ export async function buildDevStandalone(
       frameworkName.split('@storybook/').length > 1
         ? frameworkName.split('@storybook/')[1]
         : frameworkName;
-
-    outputStartupInformation({
-      updateInfo: versionCheck,
-      version,
-      name,
-      address,
-      networkAddress,
-      managerTotalTime,
-      previewTotalTime,
-    });
+    if (!options.quiet) {
+      outputStartupInformation({
+        updateInfo: versionCheck,
+        version,
+        name,
+        address,
+        networkAddress,
+        managerTotalTime,
+        previewTotalTime,
+      });
+    }
   }
   return { port, address, networkAddress };
 }


### PR DESCRIPTION
Closes #23127

## What I did

Disabled verbose table on dev start when `--quiet` provided

## How to test

1. Add `--quiet` to `devCommand` in `scripts/tasks/dev.ts`
2. run `yarn  start`

## Checklist


- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

