### PR TITLE
CLI: Fix storybook dev after storybook init via subprocess

### DIFF
--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -344,34 +344,19 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
     if (shouldRunDev) {
       logger.log('\nRunning Storybook');
 
-      switch (projectType) {
-        case ProjectType.ANGULAR: {
-          try {
-            // for angular specifically, we have to run the `ng` command, and to stream the output
-            // it has to be a sync command.
-            packageManager.runPackageCommandSync(
-              `ng run ${installResult.projectName}:storybook`,
-              ['--quiet'],
-              undefined,
-              'inherit'
-            );
-          } catch (e) {
-            if (e.message.includes('Command failed with exit code 129')) {
-              // catch ctrl + c error
-            } else {
-              throw e;
-            }
-          }
-          break;
-        }
-
-        default: {
-          await dev({
-            ...options,
-            port: 6006,
-            open: true,
-            quiet: true,
-          });
+      try {
+        // instead of calling 'dev' automatically, we spawn a subprocess so that it gets
+        // executed directly in the user's project directory. This avoid potential issues
+        // with packages running in npxs' node_modules
+        packageManager.runPackageCommandSync(storybookCommand, ['--quiet'], undefined, 'inherit');
+      } catch (e) {
+        const isCtrlC =
+          e.message.includes('Command failed with exit code 129') &&
+          e.message.includes('CTRL+C') &&
+          e.message.includes('SIGINT');
+        if (!isCtrlC) {
+          // only throw if it's not ctrl + c
+          throw e;
         }
       }
     }

--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -38,7 +38,6 @@ import { JsPackageManagerFactory, useNpmWarning } from './js-package-manager';
 import type { NpmOptions } from './NpmOptions';
 import type { CommandOptions } from './generators/types';
 import { HandledError } from './HandledError';
-import { dev } from './dev';
 
 const logger = console;
 


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

When executing `dev` directly in Storybook `init`, there is a possibility of having the following issue:

```
WARN   Failed to load preset: "@storybook/react-vite/preset"
ERR! Error: Cannot find module '@storybook/react-vite/preset'
ERR! Require stack:
ERR! - /Users/xyz/.npm/_npx/eb8bf615e50a412a/node_modules/@storybook/core-common/dist/index.js
ERR! - /Users/xyz/.npm/_npx/eb8bf615e50a412a/node_modules/@storybook/telemetry/dist/index.js
ERR! - /Users/xyz/.npm/_npx/eb8bf615e50a412a/node_modules/@storybook/cli/dist/generate.js
```

This happens because of the location of the packages in node_modules. By spawning a subprocess, this problem goes away as the process executes in the current working directory instead, where the node_modules should be present and correctly resolved.


## How to test


1. Build packages and start local registry
2. Set your global registry to: `npm config set registry http://localhost:6001`
3. Run init e.g. `src/lib/cli/bin/index.js init` in a react-vite project
4. Things should work


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
