### PR TITLE
CLI: Fix installing user's project before init

### DIFF
--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -300,6 +300,10 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
     }
   }
 
+  if (!options.skipInstall) {
+    await packageManager.installDependencies();
+  }
+
   const installResult = await installStorybook(projectType as ProjectType, packageManager, options);
 
   if (!options.skipInstall) {

--- a/code/lib/cli/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/cli/src/js-package-manager/JsPackageManager.ts
@@ -82,18 +82,19 @@ export abstract class JsPackageManager {
   public async installDependencies() {
     let done = commandLog('Preparing to install dependencies');
     done();
-    logger.log();
 
     logger.log();
+    logger.log();
+
     done = commandLog('Installing dependencies');
 
     try {
       await this.runInstall();
+      done();
     } catch (e) {
       done('An error occurred while installing dependencies.');
       throw new HandledError(e);
     }
-    done();
   }
 
   packageJsonPath(): string {


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
