### PR TITLE
CLI: Fix storybook package manager command in init

### DIFF
--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -352,7 +352,7 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
         // executed directly in the user's project directory. This avoid potential issues
         // with packages running in npxs' node_modules
         packageManager.runPackageCommandSync(
-          storybookCommand.replace(/yarn|pnpm|npm/, ''),
+          storybookCommand.replace(/^(yarn|pnpm|npm) /, ''),
           ['--quiet'],
           undefined,
           'inherit'

--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -351,7 +351,12 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
         // instead of calling 'dev' automatically, we spawn a subprocess so that it gets
         // executed directly in the user's project directory. This avoid potential issues
         // with packages running in npxs' node_modules
-        packageManager.runPackageCommandSync(storybookCommand, ['--quiet'], undefined, 'inherit');
+        packageManager.runPackageCommandSync(
+          storybookCommand.replace(/yarn|pnpm|npm/, ''),
+          ['--quiet'],
+          undefined,
+          'inherit'
+        );
       } catch (e) {
         const isCtrlC =
           e.message.includes('Command failed with exit code 129') &&

--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -352,7 +352,7 @@ async function doInitiate(options: CommandOptions, pkg: PackageJson): Promise<vo
         // executed directly in the user's project directory. This avoid potential issues
         // with packages running in npxs' node_modules
         packageManager.runPackageCommandSync(
-          storybookCommand.replace(/^(yarn|pnpm|npm) /, ''),
+          storybookCommand.replace(/^yarn /, ''),
           ['--quiet'],
           undefined,
           'inherit'


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR fixes a small oversight from a previous PR:

<img width="494" alt="image" src="https://github.com/storybookjs/storybook/assets/1671563/aecf9644-d149-4f1c-ac73-75d7b87122f1">


## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
