### PR TITLE
Fix eslintrc json migration if extends not defined in .eslintrc.json

### DIFF
--- a/code/lib/cli/src/automigrate/helpers/eslintPlugin.ts
+++ b/code/lib/cli/src/automigrate/helpers/eslintPlugin.ts
@@ -52,6 +52,7 @@ export async function configureEslintPlugin(eslintFile: string, packageManager: 
     paddedLog(`Configuring Storybook ESLint plugin at ${eslintFile}`);
     if (eslintFile.endsWith('json')) {
       const eslintConfig = (await readJson(eslintFile)) as { extends?: string[] };
+      eslintConfig.extends = eslintConfig.extends || [];
       const existingConfigValue = Array.isArray(eslintConfig.extends)
         ? eslintConfig.extends
         : [eslintConfig.extends].filter(Boolean);


### PR DESCRIPTION
Fixes: #23178

Closes #23178

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

During migration, if .eslintrc.json does not have `extends` defined, then set it to an empty array.

## Checklist

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`