### PR TITLE
Build: Don't auto-trigger CI on release PRs

### DIFF
--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - next
       - main
-      - version-prerelease-from-**
-      - version-patch-from-**
 
 jobs:
   get-branch:
@@ -56,7 +54,7 @@ jobs:
   trigger-pr-tests:
     runs-on: ubuntu-latest
     needs: get-branch
-    if: github.event_name == 'pull_request_target' && ((github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ci:pr')) && !contains(github.event.pull_request.labels.*.name, 'ci:merged') && !contains(github.event.pull_request.labels.*.name, 'ci:daily'))
+    if: github.event_name == 'pull_request_target' && (((github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'release')) || contains(github.event.pull_request.labels.*.name, 'ci:pr')) && !contains(github.event.pull_request.labels.*.name, 'ci:merged') && !contains(github.event.pull_request.labels.*.name, 'ci:daily'))
     steps:
       - name: Trigger PR tests
         run: >

--- a/scripts/release/__tests__/generate-pr-description.test.ts
+++ b/scripts/release/__tests__/generate-pr-description.test.ts
@@ -174,6 +174,7 @@ For each pull request below, you need to either manually cherry pick it, or disc
         Before merging the PR, there are a few QA steps to go through:
 
         - [ ] Add the \\"freeze\\" label to this PR, to ensure it doesn\\'t get automatically forced pushed by new changes.
+        - [ ] Add the \\"ci:daily\\" label to this PR, to trigger the full test suite to run on this PR.
 
         And for each change below:
 
@@ -235,6 +236,13 @@ For each pull request below, you need to either manually cherry pick it, or disc
         "This is an automated pull request. None of the changes requires a version bump, they are only internal or documentation related. Merging this PR will not trigger a new release, but documentation will be updated.
         If you\\'re not a core maintainer with permissions to release you can ignore this pull request.
 
+        ## To do
+
+        Before merging the PR:
+
+        - [ ] Add the \\"freeze\\" label to this PR, to ensure it doesn\\'t get automatically forced pushed by new changes.
+        - [ ] Add the \\"ci:daily\\" label to this PR, to trigger the full test suite to run on this PR.
+
         This is a list of all the PRs merged and commits pushed directly to \\\`next\\\` since the last release:
 
         - **🐛 Bug**: Some PR title for a bug [#42](https://github.com/storybookjs/storybook/pull/42)
@@ -263,7 +271,7 @@ For each pull request below, you need to either manually cherry pick it, or disc
 
         - [ ] [#42](https://github.com/storybookjs/storybook/pull/42): \\\`git cherry-pick -m1 -x abc123\\\`
 
-        If you\\'ve made any changes (change PR titles, revert PRs), manually trigger a re-generation of this PR with [this workflow](https://github.com/storybookjs/storybook/actions/workflows/prepare-prerelease.yml) and wait for it to finish.
+        If you\\'ve made any changes (change PR titles, revert PRs), manually trigger a re-generation of this PR with [this workflow](https://github.com/storybookjs/storybook/actions/workflows/prepare-patch-release.yml) and wait for it to finish.
 
         When everything above is done:
         - Merge this PR
@@ -294,6 +302,7 @@ For each pull request below, you need to either manually cherry pick it, or disc
         Before merging the PR, there are a few QA steps to go through:
 
         - [ ] Add the \\"freeze\\" label to this PR, to ensure it doesn\\'t get automatically forced pushed by new changes.
+        - [ ] Add the \\"ci:daily\\" label to this PR, to trigger the full test suite to run on this PR.
 
         And for each change below:
 
@@ -350,6 +359,13 @@ For each pull request below, you need to either manually cherry pick it, or disc
         "This is an automated pull request. None of the changes requires a version bump, they are only internal or documentation related. Merging this PR will not trigger a new release, but documentation will be updated.
         If you\\'re not a core maintainer with permissions to release you can ignore this pull request.
 
+        ## To do
+
+        Before merging the PR:
+
+        - [ ] Add the \\"freeze\\" label to this PR, to ensure it doesn\\'t get automatically forced pushed by new changes.
+        - [ ] Add the \\"ci:daily\\" label to this PR, to trigger the full test suite to run on this PR.
+
         This is a list of all the PRs merged and commits pushed directly to \\\`next\\\` since the last release:
 
         - **🐛 Bug**: Some PR title for a bug [#42](https://github.com/storybookjs/storybook/pull/42)
@@ -373,7 +389,7 @@ For each pull request below, you need to either manually cherry pick it, or disc
 
 
 
-        If you\\'ve made any changes (change PR titles, revert PRs), manually trigger a re-generation of this PR with [this workflow](https://github.com/storybookjs/storybook/actions/workflows/prepare-prerelease.yml) and wait for it to finish.
+        If you\\'ve made any changes (change PR titles, revert PRs), manually trigger a re-generation of this PR with [this workflow](https://github.com/storybookjs/storybook/actions/workflows/prepare-patch-release.yml) and wait for it to finish.
 
         When everything above is done:
         - Merge this PR

--- a/scripts/release/generate-pr-description.ts
+++ b/scripts/release/generate-pr-description.ts
@@ -150,6 +150,7 @@ export const generateReleaseDescription = ({
   Before merging the PR, there are a few QA steps to go through:
 
   - [ ] Add the "freeze" label to this PR, to ensure it doesn't get automatically forced pushed by new changes.
+  - [ ] Add the "ci:daily" label to this PR, to trigger the full test suite to run on this PR.
   
   And for each change below:
   
@@ -201,7 +202,7 @@ export const generateNonReleaseDescription = (
 
   ${manualCherryPicks || ''}
 
-  If you've made any changes (change PR titles, revert PRs), manually trigger a re-generation of this PR with [this workflow](https://github.com/storybookjs/storybook/actions/workflows/prepare-prerelease.yml) and wait for it to finish.
+  If you've made any changes (change PR titles, revert PRs), manually trigger a re-generation of this PR with [this workflow](https://github.com/storybookjs/storybook/actions/workflows/prepare-patch-release.yml) and wait for it to finish.
   
   When everything above is done:
   - Merge this PR

--- a/scripts/release/generate-pr-description.ts
+++ b/scripts/release/generate-pr-description.ts
@@ -200,6 +200,13 @@ export const generateNonReleaseDescription = (
     dedent`This is an automated pull request. None of the changes requires a version bump, they are only internal or documentation related. Merging this PR will not trigger a new release, but documentation will be updated.
   If you're not a core maintainer with permissions to release you can ignore this pull request.
   
+  ## To do
+
+  Before merging the PR:
+
+  - [ ] Add the "freeze" label to this PR, to ensure it doesn't get automatically forced pushed by new changes.
+  - [ ] Add the "ci:daily" label to this PR, to trigger the full test suite to run on this PR.
+
   This is a list of all the PRs merged and commits pushed directly to \`next\` since the last release:
   
   ${changeList}


### PR DESCRIPTION
<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

We don't want to trigger CI on any updates to release PRs because they update frequently and it's a waste to run CI before we actually are ready for the release process.

Now the Releaser have to manually add the <kbd>ci:daily</kbd> label to trigger CI on changes.

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
