### PR TITLE
CLI: Fix pnp paths logic in storybook metadata

### DIFF
--- a/code/lib/telemetry/src/get-framework-info.test.ts
+++ b/code/lib/telemetry/src/get-framework-info.test.ts
@@ -1,0 +1,55 @@
+import type { StorybookConfig } from '@storybook/types';
+import { getFrameworkInfo } from './get-framework-info';
+import { getActualPackageJson } from './package-json';
+
+jest.mock('./package-json', () => ({
+  getActualPackageJson: jest.fn(),
+}));
+
+describe('getFrameworkInfo', () => {
+  it('should return an empty object if mainConfig.framework is undefined', async () => {
+    const result = await getFrameworkInfo({} as StorybookConfig);
+    expect(result).toEqual({});
+  });
+
+  it('should return an empty object if mainConfig.framework name is undefined', async () => {
+    const result = await getFrameworkInfo({ framework: {} } as StorybookConfig);
+    expect(result).toEqual({});
+  });
+
+  it('should call getActualPackageJson with the correct package name', async () => {
+    const packageName = '@storybook/react';
+    const framework = { name: packageName };
+    await getFrameworkInfo({ framework } as StorybookConfig);
+    expect(getActualPackageJson).toHaveBeenCalledWith(packageName);
+  });
+
+  it('should resolve the framework package json correctly and strip project paths in the metadata', async () => {
+    const packageName = '/path/to/project/@storybook/react';
+    const framework = { name: packageName };
+    const frameworkPackageJson = {
+      name: packageName,
+      dependencies: {
+        '@storybook/react': '7.0.0',
+        '@storybook/builder-vite': '7.0.0',
+      },
+    };
+
+    jest.spyOn(process, 'cwd').mockReturnValue('/path/to/project');
+
+    (getActualPackageJson as jest.Mock).mockResolvedValueOnce(frameworkPackageJson);
+
+    const result = await getFrameworkInfo({ framework } as StorybookConfig);
+
+    expect(getActualPackageJson).toHaveBeenCalledWith(packageName);
+
+    expect(result).toEqual({
+      framework: {
+        name: '$SNIP/@storybook/react',
+        options: undefined,
+      },
+      builder: '@storybook/builder-vite',
+      renderer: '@storybook/react',
+    });
+  });
+});

--- a/code/lib/telemetry/src/get-framework-info.ts
+++ b/code/lib/telemetry/src/get-framework-info.ts
@@ -49,21 +49,26 @@ export const getFrameworkPackageName = (mainConfig?: StorybookConfig) => {
 };
 
 export async function getFrameworkInfo(mainConfig: StorybookConfig) {
-  if (!mainConfig.framework) return {};
+  if (!mainConfig?.framework) return {};
 
-  const frameworkName = getFrameworkPackageName(mainConfig);
-  if (!frameworkName) return {};
-  const frameworkOptions =
-    typeof mainConfig.framework === 'object' ? mainConfig.framework.options : {};
+  const rawName =
+    typeof mainConfig.framework === 'string' ? mainConfig.framework : mainConfig.framework?.name;
+  if (!rawName) return {};
 
-  const frameworkPackageJson = await getActualPackageJson(frameworkName);
+  const frameworkPackageJson = await getActualPackageJson(rawName);
 
   const builder = findMatchingPackage(frameworkPackageJson, knownBuilders);
   const renderer = findMatchingPackage(frameworkPackageJson, knownRenderers);
 
+  // parse framework name and strip off pnp paths etc.
+  const sanitizedFrameworkName = getFrameworkPackageName(mainConfig);
+
+  const frameworkOptions =
+    typeof mainConfig.framework === 'object' ? mainConfig.framework.options : {};
+
   return {
     framework: {
-      name: frameworkName,
+      name: sanitizedFrameworkName,
       options: frameworkOptions,
     },
     builder,

--- a/code/lib/telemetry/src/get-framework-info.ts
+++ b/code/lib/telemetry/src/get-framework-info.ts
@@ -54,12 +54,15 @@ export async function getFrameworkInfo(mainConfig: StorybookConfig) {
 
   const frameworkPackageJson = await getActualPackageJson(rawName);
 
+  if (!frameworkPackageJson) {
+    return {};
+  }
+
   const builder = findMatchingPackage(frameworkPackageJson, knownBuilders);
   const renderer = findMatchingPackage(frameworkPackageJson, knownRenderers);
 
   // parse framework name and strip off pnp paths etc.
   const sanitizedFrameworkName = getFrameworkPackageName(rawName);
-
   const frameworkOptions =
     typeof mainConfig.framework === 'object' ? mainConfig.framework.options : {};
 

--- a/code/lib/telemetry/src/get-framework-info.ts
+++ b/code/lib/telemetry/src/get-framework-info.ts
@@ -33,14 +33,7 @@ function findMatchingPackage(packageJson: PackageJson, suffixes: string[]) {
   return suffixes.map((suffix) => `@storybook/${suffix}`).find((pkg) => allDependencies[pkg]);
 }
 
-export const getFrameworkPackageName = (mainConfig?: StorybookConfig) => {
-  const packageNameOrPath =
-    typeof mainConfig?.framework === 'string' ? mainConfig.framework : mainConfig?.framework?.name;
-
-  if (!packageNameOrPath) {
-    return null;
-  }
-
+export const getFrameworkPackageName = (packageNameOrPath: string) => {
   const normalizedPath = path.normalize(packageNameOrPath).replace(new RegExp(/\\/, 'g'), '/');
 
   const knownFramework = Object.keys(frameworkPackages).find((pkg) => normalizedPath.endsWith(pkg));
@@ -49,11 +42,15 @@ export const getFrameworkPackageName = (mainConfig?: StorybookConfig) => {
 };
 
 export async function getFrameworkInfo(mainConfig: StorybookConfig) {
-  if (!mainConfig?.framework) return {};
+  if (!mainConfig?.framework) {
+    return {};
+  }
 
   const rawName =
     typeof mainConfig.framework === 'string' ? mainConfig.framework : mainConfig.framework?.name;
-  if (!rawName) return {};
+  if (!rawName) {
+    return {};
+  }
 
   const frameworkPackageJson = await getActualPackageJson(rawName);
 
@@ -61,7 +58,7 @@ export async function getFrameworkInfo(mainConfig: StorybookConfig) {
   const renderer = findMatchingPackage(frameworkPackageJson, knownRenderers);
 
   // parse framework name and strip off pnp paths etc.
-  const sanitizedFrameworkName = getFrameworkPackageName(mainConfig);
+  const sanitizedFrameworkName = getFrameworkPackageName(rawName);
 
   const frameworkOptions =
     typeof mainConfig.framework === 'object' ? mainConfig.framework.options : {};


### PR DESCRIPTION
Closes #23252

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

The logic from #23199 was slightly wrong, making the code try to require a package json with a wrong path and therefore break. This PR switches the logic to only parse and remove pnp paths after retrieving the package json for a given storybook framework

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
