### PR TITLE
Release tooling: Keep redundant commits when cherry-picking

### DIFF
--- a/scripts/release/pick-patches.ts
+++ b/scripts/release/pick-patches.ts
@@ -118,7 +118,7 @@ export const run = async (_: unknown) => {
     const prSpinner = ora(`Cherry picking #${pr.number}`).start();
 
     try {
-      await git.raw(['cherry-pick', '-m', '1', '-x', pr.mergeCommit]);
+      await git.raw(['cherry-pick', '-m', '1', '--keep-redundant-commits', '-x', pr.mergeCommit]);
       prSpinner.succeed(`Picked: ${formatPR(pr)}`);
     } catch (pickError) {
       prSpinner.fail(`Failed to automatically pick: ${formatPR(pr)}`);


### PR DESCRIPTION
<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Adds the [`--keep-redundant-commits`](https://git-scm.com/docs/git-cherry-pick/2.22.0#Documentation/git-cherry-pick.txt---keep-redundant-commits) flag to cherry picking when picking patch PRs.

This ensures that it doesn't bail when trying to pick already picked PRs, such as those that have been manually picked previously, or where the "picked" label was not originally on for some reason.

We want to still cherry-pick and commit these commits so they get into the git history, and thus gets correctly labeled when publishing the version. If we instead chose to skip the commits, the labeler would not label such PRs as "picked".

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
