### PR TITLE
DangerJS: Require either 'patch:no', 'patch:yes' or 'patch:done' label

### DIFF
--- a/scripts/dangerfile.ts
+++ b/scripts/dangerfile.ts
@@ -47,6 +47,13 @@ const checkRequiredLabels = (labels: string[]) => {
   } else if (foundLabels.length > 1) {
     fail(`Please choose only one of these labels: ${JSON.stringify(foundLabels)}`);
   }
+
+  const patchLabels = ['patch:no', 'patch:yes', 'patch:done'];
+  if (isEmpty(intersection(patchLabels, labels))) {
+    fail(`PR is not labeled with one of: ${JSON.stringify(patchLabels)}`);
+  } else if (foundLabels.length > 1) {
+    fail(`Please choose only one of these labels: ${JSON.stringify(foundLabels)}`);
+  }
 };
 
 const checkPrTitle = (title: string) => {

--- a/scripts/dangerfile.ts
+++ b/scripts/dangerfile.ts
@@ -41,18 +41,18 @@ const checkRequiredLabels = (labels: string[]) => {
     );
   }
 
-  const foundLabels = intersection(requiredLabels, labels);
-  if (isEmpty(foundLabels)) {
+  const foundRequiredLabels = intersection(requiredLabels, labels);
+  if (isEmpty(foundRequiredLabels)) {
     fail(`PR is not labeled with one of: ${JSON.stringify(requiredLabels)}`);
-  } else if (foundLabels.length > 1) {
-    fail(`Please choose only one of these labels: ${JSON.stringify(foundLabels)}`);
+  } else if (foundRequiredLabels.length > 1) {
+    fail(`Please choose only one of these labels: ${JSON.stringify(foundRequiredLabels)}`);
   }
 
-  const patchLabels = ['patch:no', 'patch:yes', 'patch:done'];
-  if (isEmpty(intersection(patchLabels, labels))) {
-    fail(`PR is not labeled with one of: ${JSON.stringify(patchLabels)}`);
-  } else if (foundLabels.length > 1) {
-    fail(`Please choose only one of these labels: ${JSON.stringify(foundLabels)}`);
+  const foundPatchLabels = intersection(['patch:no', 'patch:yes'], labels);
+  if (isEmpty(foundPatchLabels)) {
+    fail(`PR is not labeled with one of: ${JSON.stringify(foundPatchLabels)}`);
+  } else if (foundPatchLabels.length > 1) {
+    fail(`Please choose only one of these labels: ${JSON.stringify(foundPatchLabels)}`);
   }
 };
 

--- a/scripts/release/__tests__/generate-pr-description.test.ts
+++ b/scripts/release/__tests__/generate-pr-description.test.ts
@@ -12,7 +12,7 @@ describe('Generate PR Description', () => {
       user: 'JReinhold',
       id: 'pr-id-42',
       title: 'Some PR title for a bug',
-      labels: ['bug', 'build', 'other label', 'patch'],
+      labels: ['bug', 'build', 'other label', 'patch:yes'],
       commit: 'abc123',
       pull: 42,
       links: {
@@ -104,7 +104,7 @@ describe('Generate PR Description', () => {
         "- [ ] **🐛 Bug**: Some PR title for a bug [#42](https://github.com/storybookjs/storybook/pull/42) (will also be patched)
         - [ ] **✨ Feature Request**: Some PR title for a 'new' feature [#48](https://github.com/storybookjs/storybook/pull/48)
         - [ ] **⚠️ Direct commit**: Some title for a "direct commit" [22bb11](https://github.com/storybookjs/storybook/commit/22bb11)
-        - [ ] **📝 Documentation**: Another PR \`title\` for docs [#11](https://github.com/storybookjs/storybook/pull/11) (will also be patched)
+        - [ ] **📝 Documentation**: Another PR \`title\` for docs [#11](https://github.com/storybookjs/storybook/pull/11)
         - [ ] **❔ Missing Label**: Some PR title with a missing label [#77](https://github.com/storybookjs/storybook/pull/77)"
       `);
     });
@@ -116,7 +116,7 @@ describe('Generate PR Description', () => {
         "## 🍒 Manual cherry picking needed!
 
         The following pull requests could not be cherry-picked automatically because it resulted in merge conflicts.
-        For each pull request below, you need to either manually cherry pick it, or discard it by removing the "patch" label from the PR and re-generate this PR.
+        For each pull request below, you need to either manually cherry pick it, or discard it by replacing the "patch:yes" label with "patch:no" on the PR and re-generate this PR.
 
         - [ ] [#42](https://github.com/storybookjs/storybook/pull/42): \`git cherry-pick -m1 -x abc123\`"
       `);

--- a/scripts/release/__tests__/label-patches.test.ts
+++ b/scripts/release/__tests__/label-patches.test.ts
@@ -57,7 +57,7 @@ const pullInfoMock = {
   pull: 55,
   commit: '930b47f011f750c44a1782267d698ccdd3c04da3',
   title: 'Legal: Fix license',
-  labels: ['documentation', 'patch', 'picked'],
+  labels: ['documentation', 'patch:yes', 'patch:done'],
   links: {
     commit:
       '[`930b47f011f750c44a1782267d698ccdd3c04da3`](https://github.com/storybookjs/storybook/commit/930b47f011f750c44a1782267d698ccdd3c04da3)',
@@ -73,7 +73,7 @@ beforeEach(() => {
   gitClient.git.log.mockResolvedValue(gitLogMock);
   gitClient.git.getRemotes.mockResolvedValue(remoteMock);
   githubInfo.getPullInfoFromCommit.mockResolvedValue(pullInfoMock);
-  github.getLabelIds.mockResolvedValue({ picked: 'pick-id' });
+  github.getLabelIds.mockResolvedValue({ 'patch:done': 'pick-id' });
 });
 
 test('it should fail early when no GH_TOKEN is set', async () => {
@@ -130,8 +130,8 @@ test('it should label the PR associated with cheery picks in the current branch'
       "Found latest tag: v7.2.1",
       "Looking at cherry pick commits since v7.2.1",
       "Found the following picks : Commit: 930b47f011f750c44a1782267d698ccdd3c04da3 PR: [#55](https://github.com/storybookjs/storybook/pull/55)",
-      "Labeling the PRs with the picked label...",
-      "Successfully labeled all PRs with the picked label.",
+      "Labeling the PRs with the patch:done label...",
+      "Successfully labeled all PRs with the patch:done label.",
     ]
   `);
 });

--- a/scripts/release/generate-pr-description.ts
+++ b/scripts/release/generate-pr-description.ts
@@ -90,7 +90,7 @@ export const mapToChangelist = ({
         )[0] || 'unknown') as keyof typeof LABELS_BY_IMPORTANCE;
 
       return `- [ ] **${LABELS_BY_IMPORTANCE[label]}**: ${change.title} ${change.links.pull}${
-        !unpickedPatches && change.labels.includes('patch') ? ' (will also be patched)' : ''
+        !unpickedPatches && change.labels.includes('patch:yes') ? ' (will also be patched)' : ''
       }`;
     })
     .join('\n');
@@ -123,7 +123,7 @@ export const mapCherryPicksToTodo = ({
   return dedent`## 🍒 Manual cherry picking needed!
 
   The following pull requests could not be cherry-picked automatically because it resulted in merge conflicts.
-  For each pull request below, you need to either manually cherry pick it, or discard it by removing the "patch" label from the PR and re-generate this PR.
+  For each pull request below, you need to either manually cherry pick it, or discard it by replacing the "patch:yes" label with "patch:no" on the PR and re-generate this PR.
   
   ${list}`;
 };

--- a/scripts/release/label-patches.ts
+++ b/scripts/release/label-patches.ts
@@ -63,11 +63,11 @@ export const run = async (_: unknown) => {
 
   spinner2.succeed(`Found the following picks 🍒:\n ${commitWithPr.join('\n')}`);
 
-  const spinner3 = ora(`Labeling the PRs with the picked label...`).start();
+  const spinner3 = ora(`Labeling the PRs with the patch:done label...`).start();
   try {
-    const labelToId = await getLabelIds({ repo, labelNames: ['picked'] });
-    await Promise.all(pullRequests.map((pr) => labelPR(pr.id, labelToId.picked)));
-    spinner3.succeed(`Successfully labeled all PRs with the picked label.`);
+    const labelToId = await getLabelIds({ repo, labelNames: ['patch:done'] });
+    await Promise.all(pullRequests.map((pr) => labelPR(pr.id, labelToId['patch:done'])));
+    spinner3.succeed(`Successfully labeled all PRs with the patch:done label.`);
   } catch (e) {
     spinner3.fail(`Something went wrong when labelling the PRs.`);
     console.error(e);

--- a/scripts/release/pick-patches.ts
+++ b/scripts/release/pick-patches.ts
@@ -29,8 +29,8 @@ interface PR {
 }
 
 const LABEL = {
-  PATCH: 'patch',
-  PICKED: 'picked',
+  PATCH: 'patch:yes',
+  PICKED: 'patch:done',
   DOCUMENTATION: 'documentation',
 } as const;
 

--- a/scripts/release/unreleased-changes-exists.ts
+++ b/scripts/release/unreleased-changes-exists.ts
@@ -15,7 +15,7 @@ program
     '-F, --from <version>',
     'Which version/tag/commit to go back and check changes from. Defaults to latest release tag'
   )
-  .option('-P, --unpicked-patches', 'Set to only consider PRs labeled with "patch" label')
+  .option('-P, --unpicked-patches', 'Set to only consider PRs labeled with "patch:yes" label')
   .option('-V, --verbose', 'Enable verbose logging', false);
 
 const optionsSchema = z.object({

--- a/scripts/release/utils/get-unpicked-prs.ts
+++ b/scripts/release/utils/get-unpicked-prs.ts
@@ -16,7 +16,7 @@ export async function getUnpickedPRs(baseBranch: string, verbose?: boolean): Pro
     `
       query ($owner: String!, $repo: String!, $state: PullRequestState!, $order: IssueOrder!) {
         repository(owner: $owner, name: $repo) {
-          pullRequests(states: [$state], labels: ["patch"], orderBy: $order, first: 50, baseRefName: "next") {
+          pullRequests(states: [$state], labels: ["patch:yes"], orderBy: $order, first: 50, baseRefName: "next") {
             nodes {
               id
               number
@@ -60,7 +60,7 @@ export async function getUnpickedPRs(baseBranch: string, verbose?: boolean): Pro
   }));
 
   const unpickedPRs = prs
-    .filter((pr: any) => !pr.labels.includes('picked'))
+    .filter((pr: any) => !pr.labels.includes('patch:done'))
     .filter((pr: any) => pr.branch === baseBranch)
     .reverse();
 

--- a/scripts/release/write-changelog.ts
+++ b/scripts/release/write-changelog.ts
@@ -13,7 +13,7 @@ program
     'write changelog based on merged PRs and commits. the <version> argument describes the changelog entry heading, but NOT which commits/PRs to include, must be a semver string'
   )
   .arguments('<version>')
-  .option('-P, --unpicked-patches', 'Set to only consider PRs labeled with "patch" label')
+  .option('-P, --unpicked-patches', 'Set to only consider PRs labeled with "patch:yes" label')
   .option(
     '-F, --from <tag>',
     'Which tag or commit to generate changelog from, eg. "7.0.7". Leave unspecified to select latest released tag in git history'


### PR DESCRIPTION
Closes N/A

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Often the "patch" label is forgotten. This PR changes Danger.js to always enforce setting either a "patch:yes", "patch:no" or "patch:done" label.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
