### PR TITLE
Docs: Addon designs updates for 7.0

### DIFF
--- a/docs/sharing/design-integrations.md
+++ b/docs/sharing/design-integrations.md
@@ -75,12 +75,6 @@ Run the following command to install the addon.
 
 <!-- prettier-ignore-end -->
 
-<div class="aside">
-
-ℹ️ This addon is still being converted to fully support Storybook 7.0. If you're adding this addon to a Storybook 7.0 instance or migrating from a previous version, you must install the `beta` version.
-
-</div>
-
 Update your Storybook configuration (in `.storybook/main.js|ts`) to include the addon.
 
 <!-- prettier-ignore-start -->
@@ -88,6 +82,7 @@ Update your Storybook configuration (in `.storybook/main.js|ts`) to include the 
 <CodeSnippets
   paths={[
     'common/storybook-main-figma-addon-register.js.mdx',
+    'common/storybook-main-figma-addon-register.ts.mdx',
   ]}
 />
 

--- a/docs/snippets/common/storybook-figma-addon-install.npm.js.mdx
+++ b/docs/snippets/common/storybook-figma-addon-install.npm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-npm install --save-dev storybook-addon-designs@beta
+npm install --save-dev @storybook/addon-designs
 ```

--- a/docs/snippets/common/storybook-figma-addon-install.pnpm.js.mdx
+++ b/docs/snippets/common/storybook-figma-addon-install.pnpm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-pnpm add --save-dev storybook-addon-designs@beta
+pnpm add --save-dev @storybook/addon-designs
 ```

--- a/docs/snippets/common/storybook-figma-addon-install.yarn.js.mdx
+++ b/docs/snippets/common/storybook-figma-addon-install.yarn.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-yarn add --dev storybook-addon-designs@beta
+yarn add --dev @storybook/addon-designs
 ```

--- a/docs/snippets/common/storybook-main-figma-addon-register.js.mdx
+++ b/docs/snippets/common/storybook-main-figma-addon-register.js.mdx
@@ -1,11 +1,11 @@
 ```js
-// .storybook/main.js|ts
+// .storybook/main.js
 
 export default {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
     // Other Storybook addons
-    'storybook-addon-designs', // 👈 Addon is registered here
+    '@storybook/addon-designs', // 👈 Addon is registered here
   ],
 };
 ```

--- a/docs/snippets/common/storybook-main-figma-addon-register.ts.mdx
+++ b/docs/snippets/common/storybook-main-figma-addon-register.ts.mdx
@@ -1,0 +1,17 @@
+```ts
+// .storybook/main.ts
+
+// Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-vite)
+import type { StorybookConfig } from '@storybook/your-framework';
+
+const config: StorybookConfig = {
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: [
+    // Other Storybook addons
+    '@storybook/addon-designs', // 👈 Addon is registered here
+  ],
+};
+
+export default config;
+```


### PR DESCRIPTION
With this pull request the information regarding the `addon-designs` is updated to remove any references for the beta that was underway for supporting Storybook 7.0.

What was done:
- Updated the snippets 
- Removed the beta aside