### PR TITLE
Angular: Enable prod mode when Storybook is built

### DIFF
--- a/code/frameworks/angular/src/client/preview-prod.ts
+++ b/code/frameworks/angular/src/client/preview-prod.ts
@@ -1,0 +1,3 @@
+import { enableProdMode } from '@angular/core';
+
+enableProdMode();

--- a/code/frameworks/angular/src/preset.ts
+++ b/code/frameworks/angular/src/preset.ts
@@ -10,10 +10,18 @@ export const addons: PresetProperty<'addons', StorybookConfig> = [
   require.resolve('./server/framework-preset-angular-docs'),
 ];
 
-export const previewAnnotations: StorybookConfig['previewAnnotations'] = (entries = []) => [
-  ...entries,
-  require.resolve('./client/config'),
-];
+export const previewAnnotations: StorybookConfig['previewAnnotations'] = (
+  entries = [],
+  options
+) => {
+  const annotations = [...entries, require.resolve('./client/config')];
+
+  if (options.configType === 'PRODUCTION') {
+    annotations.unshift(require.resolve('./client/preview-prod'));
+  }
+
+  return annotations;
+};
 
 export const core: PresetProperty<'core', StorybookConfig> = async (config, options) => {
   const framework = await options.presets.apply<StorybookConfig['framework']>('framework');


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/23272

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Use Angular prod mode when Storybook is built

## How to test

- not necessary. I did it already.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
