### PR TITLE
DangerJS: Fix missing patch label message

### DIFF
--- a/scripts/dangerfile.ts
+++ b/scripts/dangerfile.ts
@@ -48,11 +48,12 @@ const checkRequiredLabels = (labels: string[]) => {
     fail(`Please choose only one of these labels: ${JSON.stringify(foundRequiredLabels)}`);
   }
 
-  const foundPatchLabels = intersection(['patch:no', 'patch:yes'], labels);
+  const patchLabels = ['patch:no', 'patch:yes'];
+  const foundPatchLabels = intersection(patchLabels, labels);
   if (isEmpty(foundPatchLabels)) {
-    fail(`PR is not labeled with one of: ${JSON.stringify(foundPatchLabels)}`);
+    fail(`PR is not labeled with one of: ${JSON.stringify(patchLabels)}`);
   } else if (foundPatchLabels.length > 1) {
-    fail(`Please choose only one of these labels: ${JSON.stringify(foundPatchLabels)}`);
+    fail(`Please choose only one of these labels: ${JSON.stringify(patchLabels)}`);
   }
 };
 


### PR DESCRIPTION

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

If no patch labels was given DangerJS would fail with "PR is not labeled with one of: []".

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
