### PR TITLE
Telemetry: Add globals usage to project.json

### DIFF
--- a/code/lib/telemetry/package.json
+++ b/code/lib/telemetry/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@storybook/client-logger": "7.1.0-rc.1",
     "@storybook/core-common": "7.1.0-rc.1",
+    "@storybook/csf-tools": "7.1.0-rc.1",
     "chalk": "^4.1.0",
     "detect-package-manager": "^2.0.1",
     "fetch-retry": "^5.0.2",

--- a/code/lib/telemetry/src/storybook-metadata.ts
+++ b/code/lib/telemetry/src/storybook-metadata.ts
@@ -7,6 +7,7 @@ import {
   getProjectRoot,
 } from '@storybook/core-common';
 import type { StorybookConfig, PackageJson } from '@storybook/types';
+import { readConfig } from '@storybook/csf-tools';
 
 import type { StorybookMetadata, Dependency, StorybookAddon } from './types';
 import { getActualPackageVersion, getActualPackageVersions } from './package-json';
@@ -160,6 +161,16 @@ export const computeStorybookMetadata = async ({
   const hasStorybookEslint = !!allDependencies['eslint-plugin-storybook'];
 
   const storybookInfo = getStorybookInfo(packageJson);
+
+  const { previewConfig } = storybookInfo;
+  if (previewConfig) {
+    const config = await readConfig(previewConfig);
+    const usesGlobals = !!(
+      config.getFieldNode(['globals']) || config.getFieldNode(['globalTypes'])
+    );
+    metadata.preview = { ...metadata.preview, usesGlobals };
+  }
+
   const storybookVersion = storybookPackages[storybookInfo.frameworkPackage]?.version;
 
   return {

--- a/code/lib/telemetry/src/types.ts
+++ b/code/lib/telemetry/src/types.ts
@@ -54,6 +54,9 @@ export type StorybookMetadata = {
   hasCustomBabel?: boolean;
   features?: StorybookConfig['features'];
   refCount?: number;
+  preview?: {
+    usesGlobals?: boolean;
+  };
 };
 
 export interface Payload {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7452,6 +7452,7 @@ __metadata:
   dependencies:
     "@storybook/client-logger": 7.1.0-rc.1
     "@storybook/core-common": 7.1.0-rc.1
+    "@storybook/csf-tools": 7.1.0-rc.1
     chalk: ^4.1.0
     detect-package-manager: ^2.0.1
     fetch-retry: ^5.0.2


### PR DESCRIPTION
Closes N/A

## What I did

Record whether users are setting `globals` or `globalTypes` in their projects, to help figure out whether to invest more in this area.

## How to test

Run a project and check its `/project.json` and/or `STORYBOOK_TELEMETRY_DEBUG=1`. I've tested:
- [ ] There is no `preview.js/ts`  => no `preview` metadata
- [ ] There is a `preview.js/ts` 
  - [ ] it doesn't set `globals` or `globalTypes` => `preview: { usesGlobals: false }`
  - [ ] it sets `globals` or `globalTypes` => `preview: { usesGlobals: false }`
