### PR TITLE
Release tooling: Fix double run of publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,15 @@ jobs:
       run:
         working-directory: scripts
     steps:
+      - name: Cancel if [skip ci]
+        if: contains(github.event.head_commit.message, '[skip ci]')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # From https://stackoverflow.com/a/75809743
+        run: |
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+
       - name: Checkout ${{ github.ref_name }}
         uses: actions/checkout@v3
         with:
@@ -71,7 +80,7 @@ jobs:
           git config --global user.name "storybook-bot"
           git config --global user.email "32066757+storybook-bot@users.noreply.github.com"
           git add .
-          git commit -m "Bump version from $CURRENT_VERSION to $DEFERRED_NEXT_VERSION" || true
+          git commit -m "Bump version from $CURRENT_VERSION to $DEFERRED_NEXT_VERSION [skip ci]" || true
           git push origin ${{ github.ref_name }}
 
       - name: Get current version
@@ -149,7 +158,7 @@ jobs:
           git pull
           git checkout origin/main ./CHANGELOG.md
           git add ./CHANGELOG.md
-          git commit -m "Update CHANGELOG.md for v${{ steps.version.outputs.current-version }}"
+          git commit -m "Update CHANGELOG.md for v${{ steps.version.outputs.current-version }} [skip ci]"
           git push origin next
 
       - name: Sync versions/next.json from `next` to `main`


### PR DESCRIPTION
<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

#23393 introduced an "apply" step to the publishing workflow, that committed the version bump to `next-release`/`latest-release`. This had the unfortunate side-effect that this commit would trigger a secondary run of the publish workflow, running simultaneously with the already running publish workflow (albeit a little behind). The secondary run would be a no-op, but it would fail in the end. The existing workflow would complete without errors.

You can see how this played out in the release of `7.0.27`, with [this](https://github.com/storybookjs/storybook/actions/runs/5533128145) being the real run and [this](https://github.com/storybookjs/storybook/actions/runs/5533139969) being the secondary run triggered.

This PR adds a guard against that, by cancelling the workflow if it's triggered by a commit with `[skip ci]`, and then add that string to the version bump commit.

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
