### PR TITLE
Docs: (Snippets Web Components) Autodocs fix

### DIFF
--- a/docs/snippets/web-components/button-story-auto-docs.js.mdx
+++ b/docs/snippets/web-components/button-story-auto-docs.js.mdx
@@ -4,7 +4,7 @@
 export default {
   component: 'custom-button',
   //👇 Enables auto-generated documentation for the component story
-  tags: ['docsPage'],
+  tags: ['autodocs'],
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/docs/snippets/web-components/button-story-auto-docs.ts.mdx
+++ b/docs/snippets/web-components/button-story-auto-docs.ts.mdx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 const Meta: Meta = {
   component: 'custom-button',
   //👇 Enables auto-generated documentation for the component story
-  tags: ['docsPage'],
+  tags: ['autodocs'],
   argTypes: {
     backgroundColor: { control: 'color' },
   },


### PR DESCRIPTION
Fixed an issue with web component's snippets for autodocs. Up until now they were referencing `docsPage` when actually it should be `autodocs`.

@kylegach to get this patched into the documentation, I'm going to self-merge it once the checklist clears. Sounds good?