### PR TITLE
Angular: Make enableProdMode optional

### DIFF
--- a/code/frameworks/angular/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.ts
@@ -35,6 +35,7 @@ export type StorybookBuilderOptions = JsonObject & {
   docs: boolean;
   compodoc: boolean;
   compodocArgs: string[];
+  enableProdMode?: boolean;
   styles?: StyleElement[];
   stylePreprocessorOptions?: StylePreprocessorOptions;
   assets?: AssetPattern[];
@@ -78,6 +79,7 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (
         loglevel,
         outputDir,
         quiet,
+        enableProdMode = true,
         webpackStatsJson,
         disableTelemetry,
         assets,
@@ -90,6 +92,7 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (
         loglevel,
         outputDir,
         quiet,
+        enableProdMode,
         disableTelemetry,
         angularBrowserTarget: browserTarget,
         angularBuilderContext: context,

--- a/code/frameworks/angular/src/builders/build-storybook/schema.json
+++ b/code/frameworks/angular/src/builders/build-storybook/schema.json
@@ -29,6 +29,11 @@
       "description": "Controls level of logging during build. Can be one of: [silly, verbose, info (default), warn, error, silent].",
       "pattern": "(silly|verbose|info|warn|silent)"
     },
+    "enableProdMode": {
+      "type": "boolean",
+      "description": "Disable Angular's development mode, which turns off assertions and other checks within the framework.",
+      "default": true
+    },
     "quiet": {
       "type": "boolean",
       "description": "Suppress verbose build output.",

--- a/code/frameworks/angular/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.ts
@@ -32,6 +32,7 @@ export type StorybookBuilderOptions = JsonObject & {
   tsConfig?: string;
   compodoc: boolean;
   compodocArgs: string[];
+  enableProdMode?: boolean;
   styles?: StyleElement[];
   stylePreprocessorOptions?: StylePreprocessorOptions;
   assets?: AssetPattern[];
@@ -93,6 +94,7 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (options, cont
         https,
         port,
         quiet,
+        enableProdMode = false,
         smokeTest,
         sslCa,
         sslCert,
@@ -112,6 +114,7 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (options, cont
         https,
         port,
         quiet,
+        enableProdMode,
         smokeTest,
         sslCa,
         sslCert,

--- a/code/frameworks/angular/src/builders/start-storybook/schema.json
+++ b/code/frameworks/angular/src/builders/start-storybook/schema.json
@@ -66,6 +66,11 @@
       "description": "Suppress verbose build output.",
       "default": false
     },
+    "enableProdMode": {
+      "type": "boolean",
+      "description": "Disable Angular's development mode, which turns off assertions and other checks within the framework.",
+      "default": false
+    },
     "docs": {
       "type": "boolean",
       "description": "Starts Storybook in documentation mode. Learn more about it : https://storybook.js.org/docs/react/writing-docs/build-documentation#preview-storybooks-documentation.",

--- a/code/frameworks/angular/src/builders/utils/standalone-options.ts
+++ b/code/frameworks/angular/src/builders/utils/standalone-options.ts
@@ -10,6 +10,7 @@ export type StandaloneOptions = CLIOptions &
   LoadOptions &
   BuilderOptions & {
     mode?: 'static' | 'dev';
+    enableProdMode: boolean;
     angularBrowserTarget?: string | null;
     angularBuilderOptions?: Record<string, any> & {
       styles?: StyleElement[];

--- a/code/frameworks/angular/src/preset.ts
+++ b/code/frameworks/angular/src/preset.ts
@@ -1,6 +1,7 @@
 import { dirname, join } from 'path';
 import { PresetProperty } from '@storybook/types';
 import { StorybookConfig } from './types';
+import { StandaloneOptions } from './builders/utils/standalone-options';
 
 const wrapForPnP = (input: string) => dirname(require.resolve(join(input, 'package.json')));
 
@@ -16,7 +17,7 @@ export const previewAnnotations: StorybookConfig['previewAnnotations'] = (
 ) => {
   const annotations = [...entries, require.resolve('./client/config')];
 
-  if (options.configType === 'PRODUCTION') {
+  if ((options as any as StandaloneOptions).enableProdMode) {
     annotations.unshift(require.resolve('./client/preview-prod'));
   }
 


### PR DESCRIPTION
Relates https://github.com/storybookjs/storybook/issues/23272
Addresses the following comment: https://github.com/storybookjs/storybook/pull/23404#issuecomment-1638648750

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

The [enableProdMode](https://angular.io/api/core/enableProdMode) is now configurable. It defaults in `dev` mode to `false` and in `build` mode to `true`. The defaults can be overwritten by the options, which are passed to the `storybook` and `build-storybook` executor in the `angular.json`

## How to test

- not necessary

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
