### PR TITLE
TypeScript: Downgrade to the last version of type-fest that doesn't need typescript 5.0

### DIFF
--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -71,7 +71,7 @@
     "@types/picomatch": "^2.3.0",
     "mock-fs": "^5.2.0",
     "slash": "^5.0.0",
-    "type-fest": "~3.6.0",
+    "type-fest": "~2.19",
     "typescript": "~4.9.3"
   },
   "publishConfig": {

--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -71,7 +71,7 @@
     "@types/picomatch": "^2.3.0",
     "mock-fs": "^5.2.0",
     "slash": "^5.0.0",
-    "type-fest": "^3.11.0",
+    "type-fest": "~3.6.0",
     "typescript": "~4.9.3"
   },
   "publishConfig": {

--- a/code/package.json
+++ b/code/package.json
@@ -88,7 +88,7 @@
     "playwright": "1.36.0",
     "playwright-core": "1.36.0",
     "serialize-javascript": "^3.1.0",
-    "type-fest": "~3.6.0"
+    "type-fest": "~2.19"
   },
   "dependencies": {
     "@babel/core": "^7.22.9",

--- a/code/package.json
+++ b/code/package.json
@@ -88,7 +88,7 @@
     "playwright": "1.36.0",
     "playwright-core": "1.36.0",
     "serialize-javascript": "^3.1.0",
-    "type-fest": "^3.11.0"
+    "type-fest": "~3.6.0"
   },
   "dependencies": {
     "@babel/core": "^7.22.9",

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -71,7 +71,7 @@
     "prop-types": "^15.7.2",
     "react-element-to-jsx-string": "^15.0.0",
     "ts-dedent": "^2.0.0",
-    "type-fest": "~3.6.0",
+    "type-fest": "~2.19",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -71,7 +71,7 @@
     "prop-types": "^15.7.2",
     "react-element-to-jsx-string": "^15.0.0",
     "ts-dedent": "^2.0.0",
-    "type-fest": "^3.11.0",
+    "type-fest": "~3.6.0",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {

--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -60,7 +60,7 @@
     "@storybook/preview-api": "7.2.0-alpha.0",
     "@storybook/types": "7.2.0-alpha.0",
     "sveltedoc-parser": "^4.2.1",
-    "type-fest": "^3.11.0"
+    "type-fest": "~3.6.0"
   },
   "devDependencies": {
     "expect-type": "^0.15.0",

--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -60,7 +60,7 @@
     "@storybook/preview-api": "7.2.0-alpha.0",
     "@storybook/types": "7.2.0-alpha.0",
     "sveltedoc-parser": "^4.2.1",
-    "type-fest": "~3.6.0"
+    "type-fest": "~2.19"
   },
   "devDependencies": {
     "expect-type": "^0.15.0",

--- a/code/renderers/vue/package.json
+++ b/code/renderers/vue/package.json
@@ -55,7 +55,7 @@
     "@storybook/preview-api": "7.2.0-alpha.0",
     "@storybook/types": "7.2.0-alpha.0",
     "ts-dedent": "^2.0.0",
-    "type-fest": "^3.11.0"
+    "type-fest": "~3.6.0"
   },
   "devDependencies": {
     "typescript": "~4.9.3",

--- a/code/renderers/vue/package.json
+++ b/code/renderers/vue/package.json
@@ -55,7 +55,7 @@
     "@storybook/preview-api": "7.2.0-alpha.0",
     "@storybook/types": "7.2.0-alpha.0",
     "ts-dedent": "^2.0.0",
-    "type-fest": "~3.6.0"
+    "type-fest": "~2.19"
   },
   "devDependencies": {
     "typescript": "~4.9.3",

--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -55,7 +55,7 @@
     "@storybook/types": "7.2.0-alpha.0",
     "lodash": "^4.17.21",
     "ts-dedent": "^2.0.0",
-    "type-fest": "~3.6.0",
+    "type-fest": "~2.19",
     "vue-component-type-helpers": "latest"
   },
   "devDependencies": {

--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -55,7 +55,7 @@
     "@storybook/types": "7.2.0-alpha.0",
     "lodash": "^4.17.21",
     "ts-dedent": "^2.0.0",
-    "type-fest": "^3.11.0",
+    "type-fest": "~3.6.0",
     "vue-component-type-helpers": "latest"
   },
   "devDependencies": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6597,7 +6597,7 @@ __metadata:
     resolve-from: ^5.0.0
     slash: ^5.0.0
     ts-dedent: ^2.0.0
-    type-fest: ~3.6.0
+    type-fest: ~2.19
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft
@@ -7465,7 +7465,7 @@ __metadata:
     react-element-to-jsx-string: ^15.0.0
     require-from-string: ^2.0.2
     ts-dedent: ^2.0.0
-    type-fest: ~3.6.0
+    type-fest: ~2.19
     util-deprecate: ^1.0.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -7803,7 +7803,7 @@ __metadata:
     svelte: ^4.0.0
     svelte-check: ^3.4.3
     sveltedoc-parser: ^4.2.1
-    type-fest: ~3.6.0
+    type-fest: ~2.19
     typescript: ^5.0.4
   peerDependencies:
     svelte: ^3.1.0 || ^4.0.0
@@ -7997,7 +7997,7 @@ __metadata:
     "@vue/vue3-jest": 29
     lodash: ^4.17.21
     ts-dedent: ^2.0.0
-    type-fest: ~3.6.0
+    type-fest: ~2.19
     typescript: ~4.9.3
     vue: ^3.2.47
     vue-component-type-helpers: latest
@@ -8019,7 +8019,7 @@ __metadata:
     "@storybook/preview-api": 7.2.0-alpha.0
     "@storybook/types": 7.2.0-alpha.0
     ts-dedent: ^2.0.0
-    type-fest: ~3.6.0
+    type-fest: ~2.19
     typescript: ~4.9.3
     vue: 2.6.14
     vue-tsc: latest
@@ -30008,10 +30008,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:~3.6.0":
-  version: 3.6.1
-  resolution: "type-fest@npm:3.6.1"
-  checksum: ec3a9076d90ee2928588d7f337672567bd853d4b5c56cf813128c7396caf69a375ace8e778f5f90a457d25b7cb732fee6b030a8d943bab751139312f22bba804
+"type-fest@npm:~2.19":
+  version: 2.19.0
+  resolution: "type-fest@npm:2.19.0"
+  checksum: a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6597,7 +6597,7 @@ __metadata:
     resolve-from: ^5.0.0
     slash: ^5.0.0
     ts-dedent: ^2.0.0
-    type-fest: ^3.11.0
+    type-fest: ~3.6.0
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft
@@ -7465,7 +7465,7 @@ __metadata:
     react-element-to-jsx-string: ^15.0.0
     require-from-string: ^2.0.2
     ts-dedent: ^2.0.0
-    type-fest: ^3.11.0
+    type-fest: ~3.6.0
     util-deprecate: ^1.0.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -7803,7 +7803,7 @@ __metadata:
     svelte: ^4.0.0
     svelte-check: ^3.4.3
     sveltedoc-parser: ^4.2.1
-    type-fest: ^3.11.0
+    type-fest: ~3.6.0
     typescript: ^5.0.4
   peerDependencies:
     svelte: ^3.1.0 || ^4.0.0
@@ -7997,7 +7997,7 @@ __metadata:
     "@vue/vue3-jest": 29
     lodash: ^4.17.21
     ts-dedent: ^2.0.0
-    type-fest: ^3.11.0
+    type-fest: ~3.6.0
     typescript: ~4.9.3
     vue: ^3.2.47
     vue-component-type-helpers: latest
@@ -8019,7 +8019,7 @@ __metadata:
     "@storybook/preview-api": 7.2.0-alpha.0
     "@storybook/types": 7.2.0-alpha.0
     ts-dedent: ^2.0.0
-    type-fest: ^3.11.0
+    type-fest: ~3.6.0
     typescript: ~4.9.3
     vue: 2.6.14
     vue-tsc: latest
@@ -30008,10 +30008,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^3.11.0":
-  version: 3.13.1
-  resolution: "type-fest@npm:3.13.1"
-  checksum: 547d22186f73a8c04590b70dcf63baff390078c75ea8acd366bbd510fd0646e348bd1970e47ecf795b7cff0b41d26e9c475c1fedd6ef5c45c82075fbf916b629
+"type-fest@npm:~3.6.0":
+  version: 3.6.1
+  resolution: "type-fest@npm:3.6.1"
+  checksum: ec3a9076d90ee2928588d7f337672567bd853d4b5c56cf813128c7396caf69a375ace8e778f5f90a457d25b7cb732fee6b030a8d943bab751139312f22bba804
   languageName: node
   linkType: hard
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -51,7 +51,7 @@
     "esbuild": "^0.18.0",
     "eslint": "^8.28.0",
     "serialize-javascript": "^3.1.0",
-    "type-fest": "~3.6.0"
+    "type-fest": "~2.19"
   },
   "dependencies": {
     "@actions/core": "^1.10.0",
@@ -179,7 +179,7 @@
     "ts-dedent": "^2.0.0",
     "ts-node": "^10.9.1",
     "tsup": "^6.7.0",
-    "type-fest": "~3.6.0",
+    "type-fest": "~2.19",
     "typescript": "5.0.4",
     "util": "^0.12.4",
     "uuid": "^9.0.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -51,7 +51,7 @@
     "esbuild": "^0.18.0",
     "eslint": "^8.28.0",
     "serialize-javascript": "^3.1.0",
-    "type-fest": "^3.11.0"
+    "type-fest": "~3.6.0"
   },
   "dependencies": {
     "@actions/core": "^1.10.0",
@@ -179,7 +179,7 @@
     "ts-dedent": "^2.0.0",
     "ts-node": "^10.9.1",
     "tsup": "^6.7.0",
-    "type-fest": "^3.11.0",
+    "type-fest": "~3.6.0",
     "typescript": "5.0.4",
     "util": "^0.12.4",
     "uuid": "^9.0.0",

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -3038,7 +3038,7 @@ __metadata:
     ts-loader: ^9.4.2
     ts-node: ^10.9.1
     tsup: ^6.7.0
-    type-fest: ^3.11.0
+    type-fest: ~3.6.0
     typescript: 5.0.4
     util: ^0.12.4
     uuid: ^9.0.0
@@ -15996,10 +15996,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^3.11.0":
-  version: 3.13.1
-  resolution: "type-fest@npm:3.13.1"
-  checksum: 547d22186f73a8c04590b70dcf63baff390078c75ea8acd366bbd510fd0646e348bd1970e47ecf795b7cff0b41d26e9c475c1fedd6ef5c45c82075fbf916b629
+"type-fest@npm:~3.6.0":
+  version: 3.6.1
+  resolution: "type-fest@npm:3.6.1"
+  checksum: ec3a9076d90ee2928588d7f337672567bd853d4b5c56cf813128c7396caf69a375ace8e778f5f90a457d25b7cb732fee6b030a8d943bab751139312f22bba804
   languageName: node
   linkType: hard
 

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -3038,7 +3038,7 @@ __metadata:
     ts-loader: ^9.4.2
     ts-node: ^10.9.1
     tsup: ^6.7.0
-    type-fest: ~3.6.0
+    type-fest: ~2.19
     typescript: 5.0.4
     util: ^0.12.4
     uuid: ^9.0.0
@@ -15996,10 +15996,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:~3.6.0":
-  version: 3.6.1
-  resolution: "type-fest@npm:3.6.1"
-  checksum: ec3a9076d90ee2928588d7f337672567bd853d4b5c56cf813128c7396caf69a375ace8e778f5f90a457d25b7cb732fee6b030a8d943bab751139312f22bba804
+"type-fest@npm:~2.19":
+  version: 2.19.0
+  resolution: "type-fest@npm:2.19.0"
+  checksum: a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/23554

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I looked up which version of `type-fest` started depending on `typescript` 5.0, and downgraded to the last available version that doesn't.

## How to test

@j-m It'd be great if you could help us verify this change will solve your issue.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
