### PR TITLE
CI: Add a `ci:docs` workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,6 +459,11 @@ jobs:
           template: $(yarn get-template --cadence << pipeline.parameters.workflow >> --task bench)
 
 workflows:
+  docs:
+    when:
+      equal: [docs, << pipeline.parameters.workflow >>]
+    jobs:
+      - pretty-docs
   normal:
     when:
       equal: [normal, << pipeline.parameters.workflow >>]

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -55,6 +55,25 @@ jobs:
         env:
           CIRCLE_CI_TOKEN: ${{ secrets.CIRCLE_CI_TOKEN }}
           BRANCH: ${{ needs.get-branch.outputs.branch }}
+  trigger-docs-tests:
+    runs-on: ubuntu-latest
+    needs: get-branch
+    if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:docs')
+    steps:
+      - name: Trigger Normal tests
+        run: >
+          curl -X POST --location "https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline" \
+            -H "Content-Type: application/json" \
+            -H "Circle-Token: $CIRCLE_CI_TOKEN" \
+            -d '{
+                  "branch": "'"$BRANCH"'",
+                  "parameters": {
+                    "workflow": "docs"
+                  }
+                }'
+        env:
+          CIRCLE_CI_TOKEN: ${{ secrets.CIRCLE_CI_TOKEN }}
+          BRANCH: ${{ needs.get-branch.outputs.branch }}
   trigger-merged-tests:
     runs-on: ubuntu-latest
     needs: get-branch

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -60,7 +60,7 @@ jobs:
     needs: get-branch
     if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:docs')
     steps:
-      - name: Trigger Normal tests
+      - name: Trigger docs tests
         run: >
           curl -X POST --location "https://circleci.com/api/v2/project/gh/storybookjs/storybook/pipeline" \
             -H "Content-Type: application/json" \

--- a/scripts/dangerfile.ts
+++ b/scripts/dangerfile.ts
@@ -17,7 +17,7 @@ const Versions = {
   MAJOR: 'MAJOR',
 };
 
-const ciLabels = ['ci:normal', 'ci:merged', 'ci:daily'];
+const ciLabels = ['ci:normal', 'ci:merged', 'ci:daily', 'ci:docs'];
 
 const branchVersion = Versions.MINOR;
 


### PR DESCRIPTION
@kylegach Here's what you suggested: a workflow for just docs.

What immediately is obvious is that we have configured a bunch of GitHub checks to be required, which do not run.
I don't really have a solution for this.