### PR TITLE
Angular: Fix initialization of Storybook in Angular 16.1

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/angular-builders-multiproject.ts
+++ b/code/lib/cli/src/automigrate/fixes/angular-builders-multiproject.ts
@@ -19,7 +19,7 @@ export const angularBuildersMultiproject: Fix<AngularBuildersMultiprojectRunOpti
     const frameworkPackageName = getFrameworkPackageName(mainConfig);
 
     if (
-      (await isNxProject(packageManager)) ||
+      (await isNxProject()) ||
       frameworkPackageName !== '@storybook/angular' ||
       !angularVersion ||
       semver.lt(angularVersion, '14.0.0')

--- a/code/lib/cli/src/automigrate/fixes/angular-builders.ts
+++ b/code/lib/cli/src/automigrate/fixes/angular-builders.ts
@@ -25,7 +25,7 @@ export const angularBuilders: Fix<AngularBuildersRunOptions> = {
     // Skip in case of NX
     if (
       !angularVersion ||
-      (await isNxProject(packageManager)) ||
+      (await isNxProject()) ||
       framewworkPackageName !== '@storybook/angular'
     ) {
       return null;

--- a/code/lib/cli/src/detect.ts
+++ b/code/lib/cli/src/detect.ts
@@ -212,7 +212,7 @@ export async function detect(
     return ProjectType.UNDETECTED;
   }
 
-  if (await isNxProject(packageManager)) {
+  if (await isNxProject()) {
     return ProjectType.NX;
   }
 

--- a/code/lib/cli/src/helpers.ts
+++ b/code/lib/cli/src/helpers.ts
@@ -300,7 +300,6 @@ export function getStorybookVersionSpecifier(packageJson: PackageJsonWithDepsAnd
   return allDeps[storybookPackage];
 }
 
-export async function isNxProject(packageManager: JsPackageManager) {
-  const nxVersion = await packageManager.getPackageVersion('nx');
-  return !!nxVersion ?? findUp.sync('nx.json');
+export async function isNxProject() {
+  return findUp.sync('nx.json');
 }


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/23568

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed initialization of Storybook in Angular 16.1. An nx project was wrongly recognized, because `@angular-eslint/schematics` introduced a dependency on `nx`. I have removed the logic to identify a workspace being a nx workspace by evaluating `nx` as a dependency. Instead, we only rely on the existent of a `nx.json` file, since that should be enough to identify a workspace using nx or not in most of the cases.

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
