### PR TITLE
Addon-Docs: Change URL hash when TOC item is clicked and when scrolling

### DIFF
--- a/code/lib/router/src/router.tsx
+++ b/code/lib/router/src/router.tsx
@@ -48,7 +48,12 @@ export const useNavigate = () => {
 
   return useCallback((to: R.To | number, { plain, ...options } = {} as NavigateOptions) => {
     if (typeof to === 'string' && to.startsWith('#')) {
-      document.location.hash = to;
+      if (!to.substring(1)) {
+        // if only '#' symbol is found, remove the hash entirely.
+        navigate(document.location.search);
+      } else {
+        document.location.hash = to;
+      }
       return undefined;
     }
     if (typeof to === 'string') {

--- a/code/lib/router/src/router.tsx
+++ b/code/lib/router/src/router.tsx
@@ -48,8 +48,7 @@ export const useNavigate = () => {
 
   return useCallback((to: R.To | number, { plain, ...options } = {} as NavigateOptions) => {
     if (typeof to === 'string' && to.startsWith('#')) {
-      if (!to.substring(1)) {
-        // if only '#' symbol is found, remove the hash entirely.
+      if (to === '#') {
         navigate(document.location.search);
       } else {
         document.location.hash = to;

--- a/code/ui/blocks/src/blocks/DocsContainer.tsx
+++ b/code/ui/blocks/src/blocks/DocsContainer.tsx
@@ -56,7 +56,15 @@ export const DocsContainer: FC<PropsWithChildren<DocsContainerProps>> = ({
       <SourceContainer channel={context.channel}>
         <ThemeProvider theme={ensureTheme(theme)}>
           <DocsPageWrapper
-            toc={toc ? <TableOfContents className="sbdocs sbdocs-toc--custom" {...toc} /> : null}
+            toc={
+              toc ? (
+                <TableOfContents
+                  className="sbdocs sbdocs-toc--custom"
+                  channel={context.channel}
+                  {...toc}
+                />
+              ) : null
+            }
           >
             {children}
           </DocsPageWrapper>


### PR DESCRIPTION
## What I did

Hello, I've noticed nothing actually happens to the url when the item of the table of contents for a docs page (if enabled) is clicked. 

I thought it would be better for user experience if the current url actually changes to include the corresponding hash when a toc item is clicked. This PR includes that behavior.

While I was on it, I also added a behavior where the url hash changes reactively to the current scroll position and the current active link.

I've recorded short videos demonstrating the behaviors described above.

### Url hash change on click

https://github.com/storybookjs/storybook/assets/71210554/a5c10ddc-6a95-4350-ae08-ac2e95e08743

### Url hash change on scroll

https://github.com/storybookjs/storybook/assets/71210554/62a5dfe5-0a23-4671-b8dd-30731dba5432


## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
