### PR TITLE
Skip empty Vue 3 slot generation

### DIFF
--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -102,7 +102,12 @@ function generateSlots(context: StoryContext<VueRenderer, Args>) {
     .filter(([key, value]) => argTypes[key]?.table?.category === 'slots')
     .map(([key, value]) => {
       const slotValue = context.args[key];
-      return [key, typeof slotValue === 'function' ? slotValue : () => slotValue];
+      return [
+        key,
+        typeof slotValue === 'function' || typeof slotValue === 'undefined'
+          ? slotValue
+          : () => slotValue,
+      ];
     });
 
   return reactive(Object.fromEntries(slots));

--- a/code/renderers/vue3/template/cli/js/Button.stories.js
+++ b/code/renderers/vue3/template/cli/js/Button.stories.js
@@ -46,3 +46,10 @@ export const Small = {
     label: 'Button',
   },
 };
+
+export const WithIcon = {
+  args: {
+    label: 'Button',
+    icon: '✅',
+  },
+};

--- a/code/renderers/vue3/template/cli/js/Button.vue
+++ b/code/renderers/vue3/template/cli/js/Button.vue
@@ -1,5 +1,10 @@
 <template>
-  <button type="button" :class="classes" @click="onClick" :style="style">{{ label }}</button>
+  <button type="button" :class="classes" @click="onClick" :style="style">
+    <span v-if="$slots.icon" :style="{ paddingRight: '0.5rem' }">
+      <slot name="icon"></slot>
+    </span>
+    {{ label }}
+  </button>
 </template>
 
 <script>

--- a/code/renderers/vue3/template/cli/ts-3-8/Button.stories.ts
+++ b/code/renderers/vue3/template/cli/ts-3-8/Button.stories.ts
@@ -50,3 +50,10 @@ export const Small: Story = {
     size: 'small',
   },
 };
+
+export const WithIcon: Story = {
+  args: {
+    label: 'Button',
+    icon: '✅',
+  },
+};

--- a/code/renderers/vue3/template/cli/ts-3-8/Button.vue
+++ b/code/renderers/vue3/template/cli/ts-3-8/Button.vue
@@ -1,5 +1,10 @@
 <template>
-  <button type="button" :class="classes" @click="onClick" :style="style">{{ label }} </button>
+  <button type="button" :class="classes" @click="onClick" :style="style">
+    <span v-if="$slots.icon" :style="{ paddingRight: '0.5rem' }">
+      <slot name="icon"></slot>
+    </span>
+    {{ label }}
+  </button>
 </template>
 
 <script lang="ts" setup>

--- a/code/renderers/vue3/template/cli/ts-4-9/Button.stories.ts
+++ b/code/renderers/vue3/template/cli/ts-4-9/Button.stories.ts
@@ -50,3 +50,10 @@ export const Small: Story = {
     size: 'small',
   },
 };
+
+export const WithIcon: Story = {
+  args: {
+    label: 'Button',
+    icon: '✅',
+  },
+};

--- a/code/renderers/vue3/template/cli/ts-4-9/Button.vue
+++ b/code/renderers/vue3/template/cli/ts-4-9/Button.vue
@@ -1,5 +1,10 @@
 <template>
-  <button type="button" :class="classes" @click="onClick" :style="style">{{ label }} </button>
+  <button type="button" :class="classes" @click="onClick" :style="style">
+    <span v-if="$slots.icon" :style="{ paddingRight: '0.5rem' }">
+      <slot name="icon"></slot>
+    </span>
+    {{ label }}
+  </button>
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

<!-- Briefly describe what your PR does -->

We have structures like this in our components:

```
<div v-if="$slots.icon" class="p-4">
    <slot name="icon" />
</div>
```

With Storybook 7.1, these broke due to the Vue 3 renderer's updated slot generation. Previously it used story props to populate Vue component slots, but this was changed to use argTypes in 6c806b6, after which all stories had all slots defined. This would cause such conditions as the example above to always be truthy.

This commit modifies the slot generation a bit to allow slots to be undefined rather than defaulting to an `() => undefined` function value.

## How to test

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template vue3-vite/default-ts`
2. Open Storybook in your browser
3. Access the `Example/Button` story and verify that the icon wrapper `<span>` does not exist on the button stories with no `icon` slot value defined.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
