### PR TITLE
Addon-essentials: Pull addon-themes from essentials

### DIFF
--- a/code/addons/essentials/package.json
+++ b/code/addons/essentials/package.json
@@ -93,16 +93,6 @@
       "require": "./dist/outline/manager.js",
       "import": "./dist/outline/manager.mjs"
     },
-    "./themes/manager": {
-      "types": "./dist/themes/manager.d.ts",
-      "require": "./dist/themes/manager.js",
-      "import": "./dist/themes/manager.mjs"
-    },
-    "./themes/preview": {
-      "types": "./dist/themes/preview.d.ts",
-      "require": "./dist/themes/preview.js",
-      "import": "./dist/themes/preview.mjs"
-    },
     "./toolbars/manager": {
       "types": "./dist/toolbars/manager.d.ts",
       "require": "./dist/toolbars/manager.js",
@@ -136,7 +126,6 @@
     "@storybook/addon-highlight": "workspace:*",
     "@storybook/addon-measure": "workspace:*",
     "@storybook/addon-outline": "workspace:*",
-    "@storybook/addon-themes": "workspace:*",
     "@storybook/addon-toolbars": "workspace:*",
     "@storybook/addon-viewport": "workspace:*",
     "@storybook/core-common": "workspace:*",
@@ -173,9 +162,7 @@
       "./src/outline/preview.ts",
       "./src/outline/manager.ts",
       "./src/toolbars/manager.ts",
-      "./src/viewport/manager.ts",
-      "./src/themes/manager.ts",
-      "./src/themes/preview.ts"
+      "./src/viewport/manager.ts"
     ],
     "platform": "node"
   },

--- a/code/addons/essentials/src/index.ts
+++ b/code/addons/essentials/src/index.ts
@@ -50,7 +50,6 @@ export function addons(options: PresetOptions) {
     'measure',
     'outline',
     'highlight',
-    'themes',
   ]
     .filter((key) => (options as any)[key] !== false)
     .filter((addon) => !checkInstalled(addon, main))

--- a/code/addons/essentials/src/themes/manager.ts
+++ b/code/addons/essentials/src/themes/manager.ts
@@ -1,1 +1,0 @@
-export * from '@storybook/addon-themes/manager';

--- a/code/addons/essentials/src/themes/preview.ts
+++ b/code/addons/essentials/src/themes/preview.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/export
-export * from '@storybook/addon-themes/preview';

--- a/code/addons/themes/README.md
+++ b/code/addons/themes/README.md
@@ -6,7 +6,7 @@ Storybook Addon Themes can be used which between multiple themes for components 
 
 ## Usage
 
-Requires Storybook 7.0 or later. Themes is part of [essentials](https://storybook.js.org/docs/react/essentials/introduction) and so is installed in all new Storybooks by default. If you need to add it to your Storybook, you can run:
+Requires Storybook 7.0 or later. If you need to add it to your Storybook, you can run:
 
 ```sh
 npm i -D @storybook/addon-themes

--- a/code/addons/themes/docs/getting-started/bootstrap.md
+++ b/code/addons/themes/docs/getting-started/bootstrap.md
@@ -2,7 +2,7 @@
 
 ## 📦 Install addon
 
-**NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Import Bootstrap"](#🥾-import-bootstrap).
+<!-- **NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Import Bootstrap"](#🥾-import-bootstrap). -->
 
 To get started, **install the package** as a dev dependency
 

--- a/code/addons/themes/docs/getting-started/emotion.md
+++ b/code/addons/themes/docs/getting-started/emotion.md
@@ -2,7 +2,7 @@
 
 ## 📦 Install addon
 
-**NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Provide your themes"](#🎨-provide-your-themes).
+<!-- **NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Provide your themes"](#🎨-provide-your-themes). -->
 
 To get started, **install the package** as a dev dependency
 

--- a/code/addons/themes/docs/getting-started/material-ui.md
+++ b/code/addons/themes/docs/getting-started/material-ui.md
@@ -2,7 +2,7 @@
 
 ## 📦 Install addon
 
-**NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Import fonts"](#🔤-import-fonts).
+<!-- **NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Import fonts"](#🔤-import-fonts). -->
 
 To get started, **install the package** as a dev dependency
 

--- a/code/addons/themes/docs/getting-started/styled-components.md
+++ b/code/addons/themes/docs/getting-started/styled-components.md
@@ -2,7 +2,7 @@
 
 ## 📦 Install addon
 
-**NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Provide your themes"](#🎨-provide-your-themes).
+<!-- **NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Provide your themes"](#🎨-provide-your-themes). -->
 
 To get started, **install the package** as a dev dependency
 

--- a/code/addons/themes/docs/getting-started/tailwind.md
+++ b/code/addons/themes/docs/getting-started/tailwind.md
@@ -2,7 +2,7 @@
 
 ## 📦 Install addon
 
-**NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Import your css"](#🥾-import-your-css).
+<!-- **NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Import your css"](#🥾-import-your-css). -->
 
 To get started, **install the package** as a dev dependency
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5715,7 +5715,6 @@ __metadata:
     "@storybook/addon-highlight": "workspace:*"
     "@storybook/addon-measure": "workspace:*"
     "@storybook/addon-outline": "workspace:*"
-    "@storybook/addon-themes": "workspace:*"
     "@storybook/addon-toolbars": "workspace:*"
     "@storybook/addon-viewport": "workspace:*"
     "@storybook/core-common": "workspace:*"
@@ -6028,7 +6027,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-themes@workspace:*, @storybook/addon-themes@workspace:addons/themes":
+"@storybook/addon-themes@workspace:addons/themes":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-themes@workspace:addons/themes"
   dependencies:

--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -10,7 +10,6 @@ A major strength of Storybook are [addons](https://storybook.js.org/addons) that
 - [Docs](../writing-docs/introduction.md)
 - [Highlight](./highlight.md)
 - [Measure & outline](./measure-and-outline.md)
-- [Themes](./themes.md)
 - [Toolbars & globals](./toolbars-and-globals.md)
 - [Viewport](./viewport.md)
 
@@ -98,7 +97,6 @@ Below is an abridged configuration and table with all the available options for 
 | `@storybook/addon-backgrounds` | N/A                | N/A                                                                                                                                                      |
 | `@storybook/addon-toolbars`    | N/A                | N/A                                                                                                                                                      |
 | `@storybook/addon-measure`     | N/A                | N/A                                                                                                                                                      |
-| `@storybook/addon-themes`      | N/A                | Provide and switch between multiple themes for components inside the preview in [Storybook](https://storybook.js.org).                                   |
 
 When you start Storybook, your custom configuration will override the default.
 
@@ -121,6 +119,6 @@ For example, if you wanted to disable the [backgrounds addon](./backgrounds.md),
 
 <div class="aside">
 
-💡 You can use the following keys for each individual addon: `actions`, `backgrounds`, `controls`, `docs`, `viewport`, `toolbars`, `measure`, `outline`, `highlight`, `themes`.
+💡 You can use the following keys for each individual addon: `actions`, `backgrounds`, `controls`, `docs`, `viewport`, `toolbars`, `measure`, `outline`, and `highlight`.
 
 </div>

--- a/docs/toc.js
+++ b/docs/toc.js
@@ -247,11 +247,11 @@ module.exports = {
           title: 'Measure & Outline',
           type: 'link',
         },
-        {
-          pathSegment: 'themes',
-          title: 'Themes',
-          type: 'link',
-        },
+        // {
+        //   pathSegment: 'themes',
+        //   title: 'Themes',
+        //   type: 'link',
+        // },
         {
           pathSegment: 'toolbars-and-globals',
           title: 'Toolbars & globals',


### PR DESCRIPTION
## What I did

- Remove addon-themes from essentials until we're ready to migrate users from addon-styling

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
