### PR TITLE
Core: Support `parameters.__id` and `metaId` in indexers

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.deprecated.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.deprecated.test.ts
@@ -1164,14 +1164,15 @@ describe('StoryIndexGenerator with deprecated indexer API', () => {
                 const csf = loadCsf(code, { ...options, fileName }).parse();
 
                 // eslint-disable-next-line no-underscore-dangle
-                return Object.entries(csf._stories).map(([key, story]) => ({
-                  key,
-                  id: story.id,
+                return Object.entries(csf._stories).map(([exportName, story]) => ({
+                  type: 'story',
+                  importPath: fileName,
+                  exportName,
                   name: story.name,
                   title: csf.meta.title,
-                  importPath: fileName,
-                  type: 'story',
+                  metaId: csf.meta.id,
                   tags: story.tags ?? csf.meta.tags,
+                  __id: story.id,
                 }));
               },
             },

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -42,14 +42,15 @@ const storiesMdxIndexer: Indexer = {
     const csf = loadCsf(code, { ...opts, fileName }).parse();
 
     // eslint-disable-next-line no-underscore-dangle
-    return Object.entries(csf._stories).map(([key, story]) => ({
-      key,
-      id: story.id,
+    return Object.entries(csf._stories).map(([exportName, story]) => ({
+      type: 'story',
+      importPath: fileName,
+      exportName,
       name: story.name,
       title: csf.meta.title,
-      importPath: fileName,
-      type: 'story',
+      metaId: csf.meta.id,
       tags: story.tags ?? csf.meta.tags,
+      __id: story.id,
     }));
   },
 };
@@ -61,14 +62,15 @@ const csfIndexer: Indexer = {
     const csf = loadCsf(code, { ...options, fileName }).parse();
 
     // eslint-disable-next-line no-underscore-dangle
-    return Object.entries(csf._stories).map(([key, story]) => ({
-      key,
-      id: story.id,
+    return Object.entries(csf._stories).map(([exportName, story]) => ({
+      type: 'story',
+      importPath: fileName,
+      exportName,
       name: story.name,
       title: csf.meta.title,
-      importPath: fileName,
-      type: 'story',
+      metaId: csf.meta.id,
       tags: story.tags ?? csf.meta.tags,
+      __id: story.id,
     }));
   },
 };

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -302,9 +302,10 @@ export class StoryIndexGenerator {
 
     const entries: ((StoryIndexEntry | DocsCacheEntry) & { tags: Tag[] })[] = indexInputs.map(
       (input) => {
-        const name = input.name ?? storyNameFromExport(input.key);
+        const name = input.name ?? storyNameFromExport(input.exportName);
         const title = input.title ?? defaultMakeTitle();
-        const id = input.id ?? toId(title, name);
+        // eslint-disable-next-line no-underscore-dangle
+        const id = input.__id ?? toId(input.metaId ?? title, storyNameFromExport(input.exportName));
         const tags = (input.tags || []).concat('story');
 
         return {

--- a/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
@@ -229,7 +229,7 @@ describe('story extraction', () => {
     `);
   });
 
-  it('auto-generates id from name, title and/or metaId inputs', async () => {
+  it('auto-generates id', async () => {
     const relativePath = './src/A.stories.js';
     const absolutePath = path.join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
@@ -240,6 +240,7 @@ describe('story extraction', () => {
         {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
+            // exportName + title -> id
             {
               exportName: 'StoryOne',
               name: 'Story One',
@@ -248,6 +249,7 @@ describe('story extraction', () => {
               importPath: fileName,
               type: 'story',
             },
+            // exportName + custom title (ignoring custom name) -> id
             {
               exportName: 'StoryTwo',
               name: 'Custom Name For Second Story',
@@ -256,6 +258,7 @@ describe('story extraction', () => {
               importPath: fileName,
               type: 'story',
             },
+            // exportName + custom metaId (ignoring custom title and name) -> id
             {
               exportName: 'StoryThree',
               metaId: 'custom-meta-id',

--- a/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
@@ -35,14 +35,27 @@ describe('story extraction', () => {
         {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
+            // properties identical to the auto-generated ones, eg. 'StoryOne' -> 'Story One'
             {
-              key: 'StoryOne',
-              id: 'a--story-one',
+              type: 'story',
+              importPath: fileName,
+              exportName: 'StoryOne',
               name: 'Story One',
               title: 'A',
+              metaId: 'a',
               tags: ['story-tag-from-indexer'],
-              importPath: fileName,
+              __id: 'a--story-one',
+            },
+            // properties different from the auto-generated ones, eg. 'StoryOne' -> 'Another Story Name'
+            {
               type: 'story',
+              importPath: fileName,
+              exportName: 'StoryOne',
+              name: 'Another Story Name',
+              title: 'Custom Title',
+              metaId: 'custom-id',
+              tags: ['story-tag-from-indexer'],
+              __id: 'some-custom-id--the-first-story',
             },
           ],
         },
@@ -65,6 +78,17 @@ describe('story extraction', () => {
             "title": "A",
             "type": "story",
           },
+          Object {
+            "id": "some-custom-id--the-first-story",
+            "importPath": "./src/A.stories.js",
+            "name": "Another Story Name",
+            "tags": Array [
+              "story-tag-from-indexer",
+              "story",
+            ],
+            "title": "Custom Title",
+            "type": "story",
+          },
         ],
         "type": "stories",
       }
@@ -83,7 +107,7 @@ describe('story extraction', () => {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
             {
-              key: 'StoryOne',
+              exportName: 'StoryOne',
               importPath: fileName,
               type: 'story',
             },
@@ -125,8 +149,8 @@ describe('story extraction', () => {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
             {
-              key: 'StoryOne',
-              id: 'a--story-one',
+              exportName: 'StoryOne',
+              __id: 'a--story-one',
               name: 'Story One',
               tags: ['story-tag-from-indexer'],
               importPath: fileName,
@@ -171,8 +195,8 @@ describe('story extraction', () => {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
             {
-              key: 'StoryOne',
-              id: 'a--story-one',
+              exportName: 'StoryOne',
+              __id: 'a--story-one',
               title: 'A',
               tags: ['story-tag-from-indexer'],
               importPath: fileName,
@@ -205,7 +229,7 @@ describe('story extraction', () => {
     `);
   });
 
-  it('auto-generates id from name and title inputs', async () => {
+  it('auto-generates id from name, title and/or metaId inputs', async () => {
     const relativePath = './src/A.stories.js';
     const absolutePath = path.join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
@@ -217,13 +241,29 @@ describe('story extraction', () => {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
             {
-              key: 'StoryOne',
+              exportName: 'StoryOne',
               name: 'Story One',
               title: 'A',
               tags: ['story-tag-from-indexer'],
               importPath: fileName,
               type: 'story',
             },
+            {
+              exportName: 'StoryTwo',
+              name: 'Custom Name For Second Story',
+              title: 'Custom Title',
+              tags: ['story-tag-from-indexer'],
+              importPath: fileName,
+              type: 'story',
+            },
+            {
+              exportName: 'StoryThree',
+              metaId: 'custom-meta-id',
+              title: 'Custom Title',
+              tags: ['story-tag-from-indexer'],
+              importPath: fileName,
+              type: 'story',
+            },
           ],
         },
       ],
@@ -245,13 +285,35 @@ describe('story extraction', () => {
             "title": "A",
             "type": "story",
           },
+          Object {
+            "id": "custom-title--story-two",
+            "importPath": "./src/A.stories.js",
+            "name": "Custom Name For Second Story",
+            "tags": Array [
+              "story-tag-from-indexer",
+              "story",
+            ],
+            "title": "Custom Title",
+            "type": "story",
+          },
+          Object {
+            "id": "custom-meta-id--story-three",
+            "importPath": "./src/A.stories.js",
+            "name": "Story Three",
+            "tags": Array [
+              "story-tag-from-indexer",
+              "story",
+            ],
+            "title": "Custom Title",
+            "type": "story",
+          },
         ],
         "type": "stories",
       }
     `);
   });
 
-  it('auto-generates id, title and name from key input', async () => {
+  it('auto-generates id, title and name from exportName input', async () => {
     const relativePath = './src/A.stories.js';
     const absolutePath = path.join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
@@ -263,7 +325,7 @@ describe('story extraction', () => {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
             {
-              key: 'StoryOne',
+              exportName: 'StoryOne',
               tags: ['story-tag-from-indexer'],
               importPath: fileName,
               type: 'story',
@@ -309,8 +371,8 @@ describe('docs entries from story extraction', () => {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
             {
-              key: 'StoryOne',
-              id: 'a--story-one',
+              exportName: 'StoryOne',
+              __id: 'a--story-one',
               name: 'Story One',
               title: 'A',
               tags: ['story-tag-from-indexer'],
@@ -369,8 +431,8 @@ describe('docs entries from story extraction', () => {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
             {
-              key: 'StoryOne',
-              id: 'a--story-one',
+              exportName: 'StoryOne',
+              __id: 'a--story-one',
               name: 'Story One',
               title: 'A',
               tags: [AUTODOCS_TAG, 'story-tag-from-indexer'],
@@ -430,8 +492,8 @@ describe('docs entries from story extraction', () => {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
             {
-              key: 'StoryOne',
-              id: 'a--story-one',
+              exportName: 'StoryOne',
+              __id: 'a--story-one',
               name: 'Story One',
               title: 'A',
               tags: [AUTODOCS_TAG, 'story-tag-from-indexer'],
@@ -478,8 +540,8 @@ describe('docs entries from story extraction', () => {
           test: /\.stories\.(m?js|ts)x?$/,
           index: async (fileName) => [
             {
-              key: 'StoryOne',
-              id: 'a--story-one',
+              exportName: 'StoryOne',
+              __id: 'a--story-one',
               name: 'Story One',
               title: 'A',
               tags: [STORIES_MDX_TAG, 'story-tag-from-indexer'],

--- a/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
@@ -55,7 +55,7 @@ describe('story extraction', () => {
               title: 'Custom Title',
               metaId: 'custom-id',
               tags: ['story-tag-from-indexer'],
-              __id: 'some-custom-id--the-first-story',
+              __id: 'some-fully-custom-id',
             },
           ],
         },
@@ -79,7 +79,7 @@ describe('story extraction', () => {
             "type": "story",
           },
           Object {
-            "id": "some-custom-id--the-first-story",
+            "id": "some-fully-custom-id",
             "importPath": "./src/A.stories.js",
             "name": "Another Story Name",
             "tags": Array [

--- a/code/lib/core-server/src/utils/stories-json.test.ts
+++ b/code/lib/core-server/src/utils/stories-json.test.ts
@@ -48,9 +48,10 @@ const storiesMdxIndexer: Indexer = {
     const csf = loadCsf(code, { ...opts, fileName }).parse();
 
     // eslint-disable-next-line no-underscore-dangle
-    return Object.entries(csf._stories).map(([key, story]) => ({
-      key,
-      id: story.id,
+    return Object.entries(csf._stories).map(([exportName, story]) => ({
+      exportName,
+      __id: story.id,
+      metaId: csf.meta.id,
       name: story.name,
       title: csf.meta.title,
       importPath: fileName,
@@ -67,10 +68,11 @@ const csfIndexer: Indexer = {
     const csf = loadCsf(code, { ...options, fileName }).parse();
 
     // eslint-disable-next-line no-underscore-dangle
-    return Object.entries(csf._stories).map(([key, story]) => ({
-      key,
-      id: story.id,
+    return Object.entries(csf._stories).map(([exportName, story]) => ({
+      exportName,
+      __id: story.id,
       name: story.name,
+      metaId: csf.meta.id,
       title: csf.meta.title,
       importPath: fileName,
       type: 'story',

--- a/code/lib/csf-tools/src/CsfFile.test.ts
+++ b/code/lib/csf-tools/src/CsfFile.test.ts
@@ -202,6 +202,27 @@ describe('CsfFile', () => {
       `);
     });
 
+    it('custom parameters.__id', () => {
+      expect(
+        parse(
+          dedent`
+          export default { title: 'foo/bar', id: 'custom-meta-id' };
+          export const JustCustomMetaId = {};
+          export const CustomParemetersId = { parameters: { __id: 'custom-id' } };
+      `
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+          id: custom-meta-id
+        stories:
+          - id: custom-meta-id--just-custom-meta-id
+            name: Just Custom Meta Id
+          - id: custom-id
+            name: Custom Paremeters Id
+      `);
+    });
+
     it('typescript', () => {
       expect(
         parse(

--- a/code/lib/preview-api/template/stories/indexer.stories.ts
+++ b/code/lib/preview-api/template/stories/indexer.stories.ts
@@ -1,0 +1,26 @@
+import { expect } from '@storybook/jest';
+import { global as globalThis } from '@storybook/global';
+import type { PlayFunctionContext } from '@storybook/types';
+
+export default {
+  component: globalThis.Components.Pre,
+  args: { text: 'Check that id assertions in interaction tests are passing' },
+  id: 'indexer-custom-meta-id',
+};
+
+// FIXME: fails with "Didn't find 'lib-preview-api-indexer--default' in CSF file, this is unexpected"
+export const Default = {
+  play: async ({ id }: PlayFunctionContext<any>) => {
+    await expect(id).toBe('indexer-custom-meta-id--default');
+  },
+};
+
+// FIXME: fails with Didn't find 'lib-preview-api-indexer--custom-parameters-id' in CSF file, this is unexpected
+export const CustomParametersId = {
+  parameters: {
+    __id: 'custom-id',
+  },
+  play: async ({ id }: PlayFunctionContext<any>) => {
+    await expect(id).toBe('indexer-custom-meta-id--custom-id');
+  },
+};

--- a/code/lib/preview-api/template/stories/indexer.stories.ts
+++ b/code/lib/preview-api/template/stories/indexer.stories.ts
@@ -8,19 +8,17 @@ export default {
   id: 'indexer-custom-meta-id',
 };
 
-// FIXME: fails with "Didn't find 'lib-preview-api-indexer--default' in CSF file, this is unexpected"
 export const Default = {
   play: async ({ id }: PlayFunctionContext<any>) => {
     await expect(id).toBe('indexer-custom-meta-id--default');
   },
 };
 
-// FIXME: fails with Didn't find 'lib-preview-api-indexer--custom-parameters-id' in CSF file, this is unexpected
 export const CustomParametersId = {
   parameters: {
     __id: 'custom-id',
   },
   play: async ({ id }: PlayFunctionContext<any>) => {
-    await expect(id).toBe('indexer-custom-meta-id--custom-id');
+    await expect(id).toBe('custom-id');
   },
 };

--- a/code/lib/types/src/modules/indexer.ts
+++ b/code/lib/types/src/modules/indexer.ts
@@ -1,6 +1,7 @@
 import type { StoryId, ComponentTitle, StoryName, Parameters, Tag, Path } from './csf';
 
-type ExportKey = string;
+type ExportName = string;
+type MetaId = string;
 
 interface StoriesSpecifier {
   /**
@@ -100,27 +101,47 @@ export type DocsIndexEntry = BaseIndexEntry & {
 
 export type IndexEntry = StoryIndexEntry | DocsIndexEntry;
 
-export interface BaseIndexInput {
-  /** the file to import from e.g. the story file */
+/**
+ * The base input for indexing a story or docs entry.
+ */
+export type BaseIndexInput = {
+  /** The file to import from e.g. the story file. */
   importPath: Path;
-  /** the key to import from the file e.g. the story export for this entry */
-  key: ExportKey;
-  /** the location in the sidebar, auto-generated from {@link importPath} if unspecified */
-  title?: ComponentTitle;
-  /** the name of the story, auto-generated from {@link key} if unspecified */
+  /** The name of the export to import. */
+  exportName: ExportName;
+  /** The name of the entry, auto-generated from {@link exportName} if unspecified. */
   name?: StoryName;
-  /** the unique story ID, auto-generated from {@link title} and {@link name} if unspecified */
-  id?: StoryId;
-  /** tags for filtering entries in Storybook and its tools */
+  /** The location in the sidebar, auto-generated from {@link importPath} if unspecified. */
+  title?: ComponentTitle;
+  /**
+   * The custom id optionally set at `meta.id` if it needs to differ from the id generated via {@link title}.
+   * If unspecified, the meta id will be auto-generated from {@link title}.
+   * If specified, the meta in the CSF file _must_ have a matching id set at `meta.id`, to be correctly matched.
+   */
+  metaId?: MetaId;
+  /** Tags for filtering entries in Storybook and its tools. */
   tags?: Tag[];
-}
+  /**
+   * The id of the entry, auto-generated from {@link title}/{@link metaId} and {@link exportName} if unspecified.
+   * If specified, the story in the CSF file _must_ have a matching id set at `parameters.__id`, to be correctly matched.
+   * Only use this if you need to override the auto-generated id.
+   */
+  __id?: StoryId;
+};
+
+/**
+ * The input for indexing a story entry.
+ */
 export type StoryIndexInput = BaseIndexInput & {
   type: 'story';
 };
 
+/**
+ * The input for indexing a docs entry.
+ */
 export type DocsIndexInput = BaseIndexInput & {
   type: 'docs';
-  /** paths to story files that must be pre-loaded for this docs entry */
+  /** Paths to story files that must be pre-loaded for this docs entry. */
   storiesImports?: Path[];
 };
 


### PR DESCRIPTION
Works on #23457 

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

1. This PR changes the `IndexInput`:
	1. rename `key` to `exportName`
	2. Add support for `metaId`, to optionally overwrite the automatic generation of meta id based on title. If this is passed by the indexer, it _must_ also be set at `meta.id` to be picked up by the preview too. `CsfFile.parse()` already does all of this.
	3. Add support for `__id`, to optionally overwrite the automatic generation of the whole story id. If this is passed by the indexer, it _must_ also be set at `story.parameters.__id` to be picked up by the preview too.
1. Adds support for `story.parameters.__id` in `CsfFile.parse()`. If this is set now, the story will pick that up as the its id, disregarding anything else.

<!-- Briefly describe what your PR does -->

## How to test

See new unit tests for `CsfFIle`, as well as the updated ones with the `IndexInput` changes. I've also added some stories that tests the custom id, that should show up in Chromatic. 

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
5. Open Storybook in your browser
6. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
