### PR TITLE
UI: Fix ArgsTable empty state on docs

### DIFF
--- a/code/ui/blocks/src/blocks/DocsPage.stories.tsx
+++ b/code/ui/blocks/src/blocks/DocsPage.stories.tsx
@@ -6,6 +6,9 @@ const meta = {
   component: DocsPage,
   parameters: {
     docsStyles: true,
+    chromatic: {
+      disableSnapshot: true
+    },
   },
 } satisfies Meta<typeof DocsPage>;
 
@@ -17,20 +20,8 @@ export const Default: Story = {
   parameters: {
     relativeCsfPaths: ['../examples/Button.stories'],
   },
-  play: async ({ canvasElement }) => {
-    // This play function's sole purpose is to add a "chromatic ignore" region to a flaky row.
-    const canvas = within(canvasElement);
-    const sizeCell = await canvas.findByText('How large should the button be?');
-    const sizeRow = sizeCell.parentElement?.parentElement?.parentElement;
-    if (sizeRow?.nodeName === 'TR') {
-      sizeRow.setAttribute('data-chromatic', 'ignore');
-    } else {
-      throw new Error('the DOM structure changed, please update this test');
-    }
-  },
 };
 export const SingleStory: Story = {
-  ...Default,
   parameters: {
     relativeCsfPaths: ['../examples/DocsPageParameters.stories'],
   },

--- a/code/ui/blocks/src/blocks/DocsPage.stories.tsx
+++ b/code/ui/blocks/src/blocks/DocsPage.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { within } from '@storybook/testing-library';
 import { DocsPage } from './DocsPage';
 
 const meta = {
@@ -16,17 +15,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   parameters: {
     relativeCsfPaths: ['../examples/Button.stories'],
-  },
-  play: async ({ canvasElement }) => {
-    // This play function's sole purpose is to add a "chromatic ignore" region to a flaky row.
-    const canvas = within(canvasElement);
-    const sizeCell = await canvas.findByText('How large should the button be?');
-    const sizeRow = sizeCell.parentElement?.parentElement?.parentElement;
-    if (sizeRow?.nodeName === 'TR') {
-      sizeRow.setAttribute('data-chromatic', 'ignore');
-    } else {
-      throw new Error('the DOM structure changed, please update this test');
-    }
   },
 };
 export const SingleStory: Story = {

--- a/code/ui/blocks/src/blocks/DocsPage.stories.tsx
+++ b/code/ui/blocks/src/blocks/DocsPage.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { within } from '@storybook/testing-library';
 import { DocsPage } from './DocsPage';
 
 const meta = {
@@ -15,6 +16,17 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   parameters: {
     relativeCsfPaths: ['../examples/Button.stories'],
+  },
+  play: async ({ canvasElement }) => {
+    // This play function's sole purpose is to add a "chromatic ignore" region to a flaky row.
+    const canvas = within(canvasElement);
+    const sizeCell = await canvas.findByText('How large should the button be?');
+    const sizeRow = sizeCell.parentElement?.parentElement?.parentElement;
+    if (sizeRow?.nodeName === 'TR') {
+      sizeRow.setAttribute('data-chromatic', 'ignore');
+    } else {
+      throw new Error('the DOM structure changed, please update this test');
+    }
   },
 };
 export const SingleStory: Story = {

--- a/code/ui/blocks/src/blocks/DocsPage.stories.tsx
+++ b/code/ui/blocks/src/blocks/DocsPage.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { within } from '@storybook/testing-library';
 import { DocsPage } from './DocsPage';
 
 const meta = {
@@ -7,7 +6,7 @@ const meta = {
   parameters: {
     docsStyles: true,
     chromatic: {
-      disableSnapshot: true
+      disableSnapshot: true,
     },
   },
 } satisfies Meta<typeof DocsPage>;

--- a/code/ui/blocks/src/components/ArgsTable/ArgsTable.tsx
+++ b/code/ui/blocks/src/components/ArgsTable/ArgsTable.tsx
@@ -346,7 +346,8 @@ export const ArgsTable: FC<ArgsTableProps> = (props) => {
   const hasNoUngrouped = groups.ungrouped.length === 0;
   const hasNoSections = Object.entries(groups.sections).length === 0;
   const hasNoUngroupedSubsections = Object.entries(groups.ungroupedSubsections).length === 0;
-  if (hasNoUngrouped && hasNoSections && hasNoUngroupedSubsections) return <Empty />;
+  if (hasNoUngrouped && hasNoSections && hasNoUngroupedSubsections)
+    return <Empty inAddonPanel={inAddonPanel} />;
 
   let colSpan = 1;
   if (updateArgs) colSpan += 1;

--- a/code/ui/blocks/src/components/ArgsTable/Empty.tsx
+++ b/code/ui/blocks/src/components/ArgsTable/Empty.tsx
@@ -3,14 +3,23 @@ import React, { useEffect, useState } from 'react';
 import { styled } from '@storybook/theming';
 import { Icon, Link } from '@storybook/components/experimental';
 
-const Wrapper = styled.div({
-  height: '100%',
+interface EmptyProps {
+  inAddonPanel?: boolean;
+}
+
+const Wrapper = styled.div<{ inAddonPanel?: boolean }>(({ inAddonPanel, theme }) => ({
+  height: inAddonPanel ? '100%' : 'auto',
   display: 'flex',
+  border: inAddonPanel ? 'none' : `1px solid ${theme.appBorderColor}`,
+  borderRadius: inAddonPanel ? 0 : theme.appBorderRadius,
+  padding: inAddonPanel ? 0 : 40,
   alignItems: 'center',
   justifyContent: 'center',
   flexDirection: 'column',
   gap: 15,
-});
+  background: theme.background.content,
+  boxShadow: 'rgba(0, 0, 0, 0.10) 0 1px 3px 0',
+}));
 
 const Content = styled.div({
   display: 'flex',
@@ -45,8 +54,8 @@ const Divider = styled.div(({ theme }) => ({
 }));
 
 const VideoIcon = styled.div(({ theme }) => ({
-  width: 24,
-  height: 18,
+  width: 22,
+  height: 16,
   borderRadius: theme.appBorderRadius,
   border: `1px solid ${theme.color.secondary}`,
   display: 'flex',
@@ -54,7 +63,7 @@ const VideoIcon = styled.div(({ theme }) => ({
   justifyContent: 'center',
 }));
 
-export const Empty: FC = () => {
+export const Empty: FC<EmptyProps> = ({ inAddonPanel }) => {
   const [isLoading, setIsLoading] = useState(true);
 
   // We are adding a small delay to avoid flickering when the story is loading.
@@ -71,7 +80,7 @@ export const Empty: FC = () => {
   if (isLoading) return null;
 
   return (
-    <Wrapper>
+    <Wrapper inAddonPanel={inAddonPanel}>
       <Content>
         <Title>Interactive story playground</Title>
         <Description>
@@ -85,7 +94,7 @@ export const Empty: FC = () => {
           target="_blank"
           icon={
             <VideoIcon>
-              <Icon.Play size={10} />
+              <Icon.Play size={8} />
             </VideoIcon>
           }
           withArrow

--- a/code/ui/blocks/src/components/ArgsTable/Empty.tsx
+++ b/code/ui/blocks/src/components/ArgsTable/Empty.tsx
@@ -82,33 +82,50 @@ export const Empty: FC<EmptyProps> = ({ inAddonPanel }) => {
   return (
     <Wrapper inAddonPanel={inAddonPanel}>
       <Content>
-        <Title>Interactive story playground</Title>
+        <Title>
+          {inAddonPanel
+            ? 'Interactive story playground'
+            : "Args table with interactive controls couldn't be auto-generated"}
+        </Title>
         <Description>
           Controls give you an easy to use interface to test your components. Set your story args
           and you&apos;ll see controls appearing here automatically.
         </Description>
       </Content>
       <Links>
-        <Link
-          href="https://youtu.be/0gOfS6K0x0E"
-          target="_blank"
-          icon={
-            <VideoIcon>
-              <Icon.Play size={8} />
-            </VideoIcon>
-          }
-          withArrow
-        >
-          Watch 5m video
-        </Link>
-        <Divider />
-        <Link
-          href="https://storybook.js.org/docs/react/essentials/controls"
-          target="_blank"
-          withArrow
-        >
-          Read docs
-        </Link>
+        {inAddonPanel && (
+          <>
+            <Link
+              href="https://youtu.be/0gOfS6K0x0E"
+              target="_blank"
+              icon={
+                <VideoIcon>
+                  <Icon.Play size={8} />
+                </VideoIcon>
+              }
+              withArrow
+            >
+              Watch 5m video
+            </Link>
+            <Divider />
+            <Link
+              href="https://storybook.js.org/docs/react/essentials/controls"
+              target="_blank"
+              withArrow
+            >
+              Read docs
+            </Link>
+          </>
+        )}
+        {!inAddonPanel && (
+          <Link
+            href="https://storybook.js.org/docs/react/essentials/controls"
+            target="_blank"
+            withArrow
+          >
+            Learn how to set that up
+          </Link>
+        )}
       </Links>
     </Wrapper>
   );

--- a/code/ui/components/src/new/Link/Link.tsx
+++ b/code/ui/components/src/new/Link/Link.tsx
@@ -39,7 +39,6 @@ const StyledLink = styled.a<Omit<LinkProps, 'children'>>(({ theme, variant = 'pr
   display: 'inline-flex',
   gap: 4,
   alignItems: 'center',
-  fontSize: theme.typography.size.s2 - 1,
   transition: 'all 150ms ease-out',
   textDecoration: 'none',
   lineHeight: 1,
@@ -70,8 +69,9 @@ const StyledLink = styled.a<Omit<LinkProps, 'children'>>(({ theme, variant = 'pr
   },
 }));
 
-const StyledLeft = styled.span({
+const StyledLeft = styled.span(({ theme }) => ({
   display: 'inline-flex',
   gap: 6,
   alignItems: 'center',
-});
+  fontSize: theme.typography.size.s2 - 1,
+}));


### PR DESCRIPTION
## What I did

After updating the ArgsTable to have a better loading state and empty state, we forgot that the empty state was also used in docs. This PR address that.

This is how it looks right now 👇

![CleanShot 2023-08-02 at 16 31 23@2x](https://github.com/storybookjs/storybook/assets/1540635/8f6aa079-de20-47a3-87cc-93ce8ed8e3ad)

This is how it look with this PR 👇

![CleanShot 2023-08-03 at 08 00 52@2x](https://github.com/storybookjs/storybook/assets/1540635/2513b386-5a85-401b-8270-1cf6666b37ae)

## How to test

1. Run Storybook UI locally with `yarn storybook:ui` on this branch
2. Open this story -> http://localhost:6006/?path=/story/blocks-blocks-docspage--single-story
3. Look at the empty state in docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
