### PR TITLE
CLI: Fix error logging being swallowed from dev/build failures

### DIFF
--- a/code/lib/core-server/src/withTelemetry.ts
+++ b/code/lib/core-server/src/withTelemetry.ts
@@ -132,7 +132,9 @@ export async function withTelemetry<T>(
     }
 
     const { printError = logger.error } = options;
-    printError(error instanceof Error ? error.message : String(error));
+
+    // the type of error can be Error, string, or a Webpack/Vite Object, potentially other things. Therefore we cast to any
+    printError(error as any);
     if (error instanceof Error) await sendTelemetryError(error, eventType, options);
 
     throw error;


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR fixes a bug that was introduced in #23182 where error logs would be swallowed:

<img width="471" alt="image" src="https://github.com/storybookjs/storybook/assets/1671563/3fcf0b4e-bbf1-47a4-b0fe-951c98d82011">

## How to test

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-webpack/18-ts`
2. Ovewrite webpackFinal with an error, e.g.:
```
  webpackFinal: async (config) => {
    config.module.rules = []
    return config;
  },
```
3. Run Storybook, check the error message

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
