### PR TITLE
Release tooling: Push `next` to `main` when stable releasing from `next`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,30 +176,9 @@ jobs:
           git commit -m "Update $VERSION_FILE for v${{ steps.version.outputs.current-version }}"
           git push origin main
 
-      # TODO: this is currently disabled, because we may have a better strategy that we want to try out manually first before comitting to it:
-      #     - create a branch "release-<VERSION>" from HEAD of main
-      #     - git push --force origin ${{ steps.target.outputs.target }}:main
-      #     - ... this will keep the "main" history in the new release branch, and then overwrite main's history with next's
-
-      # Sync next-release to main if it is not a prerelease, and this release is from next-release
-      # This happens when eg. next has been tracking 7.1.0-alpha.X, and now we want to release 7.1.0
-      # This will keep next-release, next and main all tracking v7.1.0
-      # See "Alternative merge strategies" in https://stackoverflow.com/a/36321787
-      # - name: Sync next-release to main
-      #   if: steps.publish-needed.outputs.published == 'false' && steps.target.outputs.target == 'next' && !steps.is-prerelease.outputs.prerelease
-      #   working-directory: .
-      #   run: |
-      #     git fetch origin next-release
-      #     git checkout next-release
-      #     git pull
-      #     git fetch origin main
-      #     git checkout main
-      #     git pull
-      #     git merge --no-commit -s ours next-release
-      #     git rm -rf .
-      #     git checkout next-release -- .
-      #     git commit -m "Sync next-release to main"
-      #     git push origin main
+      - name: Overwrite main with next
+        if: steps.target.outputs.target == 'next' && steps.is-prerelease.outputs.prerelease == 'false'
+        run: git push --force origin next:main
 
       - name: Report job failure to Discord
         if: failure()


### PR DESCRIPTION

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added a final step to publishing, that force pushes `next` onto `main` if:

1. This is a stable release (not prerelease) AND
2. This is a release from `next` (not `main` eg. patch backs)

This ensures `main` has the correct history for the stable release. It will clear the existing history of `main` (if it even has diverged), but any previous release can always be checked out via the tag anyway, eg. `git checkout v7.0.13`.

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
