### PR TITLE
Documentation: Fix typos in readme in types package

### DIFF
--- a/code/lib/types/README.md
+++ b/code/lib/types/README.md
@@ -3,6 +3,6 @@
 Storybook types exports only typescript types for storybook usage.
 
 It exports typescript enums, which do have a runtime implementation.
-But it should not export any implementation such as classes, method, function or constants.
+But it should not export any implementation such as classes, methods, functions or constants.
 
 It also has no dependencies, all the types it exports are bundled in.


### PR DESCRIPTION
Little typos in types README