### PR TITLE
Update CONTRIBUTING.md - fix link to storybook website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,4 @@ yarn task --task dev --template <your template> --start-from=publish
 
 # Contributing to Storybook
 
-For further advice on how to contribute, please refer to our [NEW contributing guide on the Storybook website](https://storybook.js.org/docs/next/react/contribute/how-to-contribute).
+For further advice on how to contribute, please refer to our [NEW contributing guide on the Storybook website](https://storybook.js.org/docs/react/contribute/how-to-contribute).


### PR DESCRIPTION
The link to the Contributing guide on the storybook website included the string `next/` in the path which doesn't exist. Removed that to fix the link.