### PR TITLE
Update core-common typescript type `StorybookConfig["stories"]`

### DIFF
--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -317,7 +317,7 @@ export interface StorybookConfig {
    *
    * @example `['./src/*.stories.@(j|t)sx?']`
    */
-  stories: StoriesEntry[];
+  stories: StoriesEntry[] | ((list: StoriesEntry[]) => Promise<StoriesEntry[]>);
 
   /**
    * Framework, e.g. '@storybook/react-vite', required in v7


### PR DESCRIPTION
update the StorybookConfig["stories"] type to include a function that returns a Promise of StoriesEntry[]

## What I did

I updated the type of `stories` to include an async function that takes a StoriesEntry[] parameter and returns a Promise of  StoriesEntry[]

This is in direct reference to the documentation showing how to use an async function for stories located here: https://storybook.js.org/docs/react/configure/overview#with-a-custom-implementation

Here is the typescript error I see with the existing type. After consuming my change, the typescript error goes away.
![Screenshot 2023-08-03 at 3 00 38 PM](https://github.com/storybookjs/storybook/assets/3885959/7ed0a8e4-0b5c-4be8-9777-0e8f41f2d8bf)


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`
