### PR TITLE
Build: Remove patch label checking from danger

### DIFF
--- a/scripts/dangerfile.ts
+++ b/scripts/dangerfile.ts
@@ -50,14 +50,6 @@ const checkRequiredLabels = (labels: string[]) => {
     fail(`Please choose only one of these labels: ${JSON.stringify(foundRequiredLabels)}`);
   }
 
-  const labelsForPatchStatus = ['patch:no', 'patch:yes'];
-  const foundPatchLabels = intersection(labelsForPatchStatus, labels);
-  if (isEmpty(foundPatchLabels)) {
-    fail(`PR is not labeled with one of: ${JSON.stringify(labelsForPatchStatus)}`);
-  } else if (foundPatchLabels.length > 1) {
-    fail(`Please choose only one of these labels: ${JSON.stringify(foundPatchLabels)}`);
-  }
-
   const foundCILabels = intersection(ciLabels, labels);
   if (isEmpty(foundCILabels)) {
     fail(`PR is not labeled with one of: ${JSON.stringify(ciLabels)}`);


### PR DESCRIPTION
## What I did

Remove checking for patch labels from danger file

## How to test

Let's check it in this PR

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
