### PR TITLE
UI: Add new Radix toolbar to the Core UI library

### DIFF
--- a/code/addons/backgrounds/src/containers/BackgroundSelector.tsx
+++ b/code/addons/backgrounds/src/containers/BackgroundSelector.tsx
@@ -4,8 +4,8 @@ import memoize from 'memoizerific';
 
 import { useParameter, useGlobals } from '@storybook/manager-api';
 import { logger } from '@storybook/client-logger';
-import { IconButton, WithTooltip, TooltipLinkList } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { WithTooltip, TooltipLinkList } from '@storybook/components';
+import { IconButton } from '@storybook/components/experimental';
 
 import { PARAM_KEY as BACKGROUNDS_PARAM_KEY } from '../constants';
 import { ColorIcon } from '../components/ColorIcon';
@@ -137,12 +137,13 @@ export const BackgroundSelector: FC = memo(function BackgroundSelector() {
         onVisibleChange={setIsTooltipVisible}
       >
         <IconButton
+          icon="Photo"
           key="background"
           title="Change the background of the preview"
           active={selectedBackgroundColor !== 'transparent' || isTooltipVisible}
-        >
-          <Icon.Photo />
-        </IconButton>
+          size="small"
+          variant="ghost"
+        />
       </WithTooltip>
     </Fragment>
   );

--- a/code/addons/backgrounds/src/containers/GridSelector.tsx
+++ b/code/addons/backgrounds/src/containers/GridSelector.tsx
@@ -2,8 +2,7 @@ import type { FC } from 'react';
 import React, { memo } from 'react';
 
 import { useGlobals, useParameter } from '@storybook/manager-api';
-import { IconButton } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { IconButton } from '@storybook/components/experimental';
 
 import { PARAM_KEY as BACKGROUNDS_PARAM_KEY } from '../constants';
 
@@ -22,6 +21,7 @@ export const GridSelector: FC = memo(function GridSelector() {
 
   return (
     <IconButton
+      icon="Grid"
       key="background"
       active={isActive}
       title="Apply a grid to the preview"
@@ -30,8 +30,8 @@ export const GridSelector: FC = memo(function GridSelector() {
           [BACKGROUNDS_PARAM_KEY]: { ...globals[BACKGROUNDS_PARAM_KEY], grid: !isActive },
         })
       }
-    >
-      <Icon.Grid />
-    </IconButton>
+      size="small"
+      variant="ghost"
+    />
   );
 });

--- a/code/addons/measure/src/Tool.tsx
+++ b/code/addons/measure/src/Tool.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useGlobals, useStorybookApi } from '@storybook/manager-api';
-import { IconButton } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { IconButton } from '@storybook/components/experimental';
 import { TOOL_ID, ADDON_ID } from './constants';
 
 export const Tool = () => {
@@ -29,12 +28,13 @@ export const Tool = () => {
 
   return (
     <IconButton
+      icon="Ruler"
       key={TOOL_ID}
       active={measureEnabled}
       title="Enable measure"
       onClick={toggleMeasure}
-    >
-      <Icon.Ruler />
-    </IconButton>
+      size="small"
+      variant="ghost"
+    />
   );
 };

--- a/code/addons/outline/src/OutlineSelector.tsx
+++ b/code/addons/outline/src/OutlineSelector.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useCallback, useEffect } from 'react';
 import { useGlobals, useStorybookApi } from '@storybook/manager-api';
-import { IconButton } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { IconButton } from '@storybook/components/experimental';
 import { ADDON_ID, PARAM_KEY } from './constants';
 
 export const OutlineSelector = memo(function OutlineSelector() {
@@ -30,12 +29,13 @@ export const OutlineSelector = memo(function OutlineSelector() {
 
   return (
     <IconButton
+      icon="Outline"
+      size="small"
+      variant="ghost"
       key="outline"
       active={isActive}
       title="Apply outlines to the preview"
       onClick={toggleOutline}
-    >
-      <Icon.Outline />
-    </IconButton>
+    />
   );
 });

--- a/code/addons/toolbars/src/components/ToolbarManager.tsx
+++ b/code/addons/toolbars/src/components/ToolbarManager.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React from 'react';
 import { useGlobalTypes } from '@storybook/manager-api';
-import { Separator } from '@storybook/components';
+import { Toolbar } from '@storybook/components/experimental';
 import { ToolbarMenuList } from './ToolbarMenuList';
 import { normalizeArgType } from '../utils/normalize-toolbar-arg-type';
 import type { ToolbarArgType } from '../types';
@@ -19,7 +19,7 @@ export const ToolbarManager: FC = () => {
 
   return (
     <>
-      <Separator />
+      <Toolbar.Separator />
       {globalIds.map((id) => {
         const normalizedArgType = normalizeArgType(id, globalTypes[id] as ToolbarArgType);
 

--- a/code/addons/toolbars/src/components/ToolbarMenuButton.tsx
+++ b/code/addons/toolbars/src/components/ToolbarMenuButton.tsx
@@ -1,11 +1,12 @@
 import type { FC } from 'react';
 import React from 'react';
-import { Icons, IconButton, type IconsProps } from '@storybook/components';
+import type { Icon } from '@storybook/components/experimental';
+import { IconButton, Button } from '@storybook/components/experimental';
 
 interface ToolbarMenuButtonProps {
   active: boolean;
   title: string;
-  icon?: IconsProps['icon'];
+  icon?: Icon.Icons;
   description: string;
   onClick?: () => void;
 }
@@ -18,9 +19,28 @@ export const ToolbarMenuButton: FC<ToolbarMenuButtonProps> = ({
   onClick,
 }) => {
   return (
-    <IconButton active={active} title={description} onClick={onClick}>
-      {icon && <Icons icon={icon} />}
-      {title ? `\xa0${title}` : null}
-    </IconButton>
+    <>
+      {icon && !title && (
+        <IconButton
+          icon={icon}
+          active={active}
+          title={description}
+          onClick={onClick}
+          size="small"
+          variant="ghost"
+        >
+          {title ? `\xa0${title}` : null}
+        </IconButton>
+      )}
+      {icon && title && (
+        <Button
+          active={active}
+          title={description}
+          onClick={onClick}
+          size="small"
+          variant="ghost"
+        >{`\xa0${title}`}</Button>
+      )}
+    </>
   );
 };

--- a/code/addons/toolbars/src/components/ToolbarMenuListItem.tsx
+++ b/code/addons/toolbars/src/components/ToolbarMenuListItem.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import type { TooltipLinkListLink } from '@storybook/components';
-import { Icons } from '@storybook/components';
+import { Icon } from '@storybook/components/experimental';
 import type { ToolbarItem } from '../types';
 
 export type ToolbarMenuListItemProps = {
@@ -18,7 +17,7 @@ export const ToolbarMenuListItem = ({
   onClick,
   currentValue,
 }: ToolbarMenuListItemProps) => {
-  const Icon = icon && <Icons style={{ opacity: 1 }} icon={icon} />;
+  const LocalIcon = icon && Icon[icon];
 
   const Item: TooltipLinkListLink = {
     id: value ?? '_reset',
@@ -30,7 +29,7 @@ export const ToolbarMenuListItem = ({
   };
 
   if (icon && !hideIcon) {
-    Item.left = Icon;
+    Item.left = LocalIcon;
   }
 
   return Item;

--- a/code/addons/toolbars/src/types.ts
+++ b/code/addons/toolbars/src/types.ts
@@ -1,4 +1,4 @@
-import type { IconsProps } from '@storybook/components';
+import type { Icon } from '@storybook/components/experimental';
 import type { InputType } from '@storybook/types';
 
 export type ToolbarShortcutType = 'next' | 'previous' | 'reset';
@@ -14,7 +14,7 @@ export type ToolbarShortcuts = Record<ToolbarShortcutType, ToolbarShortcutConfig
 
 export interface ToolbarItem {
   value?: string;
-  icon?: IconsProps['icon'];
+  icon?: Icon.Icons;
   left?: string;
   right?: string;
   title?: string;
@@ -26,7 +26,7 @@ export interface NormalizedToolbarConfig {
   /** The label to show for this toolbar item */
   title?: string;
   /** Choose an icon to show for this toolbar item */
-  icon: IconsProps['icon'];
+  icon: Icon.Icons;
   /** Set to true to prevent default update of icon to match any present selected items icon */
   preventDynamicIcon?: boolean;
   items: ToolbarItem[];

--- a/code/addons/viewport/src/Tool.tsx
+++ b/code/addons/viewport/src/Tool.tsx
@@ -4,8 +4,8 @@ import memoize from 'memoizerific';
 
 import { styled, Global, type Theme, withTheme } from '@storybook/theming';
 
-import { IconButton, WithTooltip, TooltipLinkList } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { WithTooltip, TooltipLinkList } from '@storybook/components';
+import { IconButton, Button } from '@storybook/components/experimental';
 import { useStorybookApi, useParameter, useAddonState } from '@storybook/manager-api';
 import { registerShortcuts } from './shortcuts';
 import { PARAM_KEY, ADDON_ID } from './constants';
@@ -84,16 +84,6 @@ const ActiveViewportLabel = styled.div(({ theme }) => ({
   borderTop: '3px solid transparent',
   borderBottom: '3px solid transparent',
   background: 'transparent',
-}));
-
-const IconButtonWithLabel = styled(IconButton)(() => ({
-  display: 'inline-flex',
-  alignItems: 'center',
-}));
-
-const IconButtonLabel = styled.div(({ theme }) => ({
-  fontSize: theme.typography.size.s2 - 1,
-  marginLeft: 10,
 }));
 
 interface ViewportToolState {
@@ -180,21 +170,34 @@ export const ViewportTool: FC = memo(
           closeOnOutsideClick
           onVisibleChange={setIsTooltipVisible}
         >
-          <IconButtonWithLabel
-            key="viewport"
-            title="Change the size of the preview"
-            active={isTooltipVisible || !!styles}
-            onDoubleClick={() => {
-              setState({ ...state, selected: responsiveViewport.id });
-            }}
-          >
-            <Icon.Grow />
-            {styles ? (
-              <IconButtonLabel>
-                {isRotated ? `${item.title} (L)` : `${item.title} (P)`}
-              </IconButtonLabel>
-            ) : null}
-          </IconButtonWithLabel>
+          {!styles && (
+            <IconButton
+              icon="Grow"
+              size="small"
+              variant="ghost"
+              key="viewport"
+              title="Change the size of the preview"
+              active={isTooltipVisible || !!styles}
+              onDoubleClick={() => {
+                setState({ ...state, selected: responsiveViewport.id });
+              }}
+            />
+          )}
+          {styles && (
+            <Button
+              icon="Grow"
+              size="small"
+              variant="ghost"
+              key="viewport"
+              title="Change the size of the preview"
+              active={isTooltipVisible || !!styles}
+              onDoubleClick={() => {
+                setState({ ...state, selected: responsiveViewport.id });
+              }}
+            >
+              {isRotated ? `${item.title} (L)` : `${item.title} (P)`}
+            </Button>
+          )}
         </WithTooltip>
 
         {styles ? (
@@ -228,14 +231,15 @@ export const ViewportTool: FC = memo(
               {styles.width.replace('px', '')}
             </ActiveViewportLabel>
             <IconButton
+              icon="Transfer"
               key="viewport-rotate"
               title="Rotate viewport"
               onClick={() => {
                 setState({ ...state, isRotated: !isRotated });
               }}
-            >
-              <Icon.Transfer />
-            </IconButton>
+              size="small"
+              variant="ghost"
+            />
             <ActiveViewportLabel title="Viewport height">
               {styles.height.replace('px', '')}
             </ActiveViewportLabel>

--- a/code/ui/components/package.json
+++ b/code/ui/components/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@radix-ui/react-select": "^1.2.2",
+    "@radix-ui/react-toolbar": "^1.0.4",
     "@storybook/client-logger": "workspace:*",
     "@storybook/csf": "^0.1.0",
     "@storybook/global": "^5.0.0",

--- a/code/ui/components/src/experimental.ts
+++ b/code/ui/components/src/experimental.ts
@@ -13,3 +13,4 @@ export { Select } from './new/Select/Select';
 export { Link } from './new/Link/Link';
 export { Icon } from './new/Icon/Icon';
 export { IconButton } from './new/IconButton/IconButton';
+export { Toolbar } from './new/Toolbar/Toolbar';

--- a/code/ui/components/src/new/IconButton/IconButton.stories.tsx
+++ b/code/ui/components/src/new/IconButton/IconButton.stories.tsx
@@ -52,6 +52,20 @@ export const Disabled: Story = {
   },
 };
 
+export const Animated: Story = {
+  args: {
+    ...Base.args,
+    icon: 'FaceHappy',
+  },
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+      <IconButton icon="FaceHappy" onClickAnimation="glow" />
+      <IconButton icon="FaceHappy" onClickAnimation="rotate360" />
+      <IconButton icon="FaceHappy" onClickAnimation="jiggle" />
+    </div>
+  ),
+};
+
 export const WithHref: Story = {
   render: () => (
     <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>

--- a/code/ui/components/src/new/IconButton/IconButton.tsx
+++ b/code/ui/components/src/new/IconButton/IconButton.tsx
@@ -1,11 +1,11 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { styled } from '@storybook/theming';
 import { darken, lighten, rgba, transparentize } from 'polished';
 import type { Icons } from '@storybook/icons';
 import type { PropsOf } from '../utils/types';
 import { Icon } from '../Icon/Icon';
 
-interface ButtonProps<T extends React.ElementType = React.ElementType> {
+interface IconButtonProps<T extends React.ElementType = React.ElementType> {
   icon: Icons;
   as?: T;
   size?: 'small' | 'medium';
@@ -13,20 +13,40 @@ interface ButtonProps<T extends React.ElementType = React.ElementType> {
   onClick?: () => void;
   disabled?: boolean;
   active?: boolean;
+  onClickAnimation?: 'none' | 'rotate360' | 'glow' | 'jiggle';
 }
 
 export const IconButton: {
   <E extends React.ElementType = 'button'>(
-    props: ButtonProps<E> & Omit<PropsOf<E>, keyof ButtonProps>
+    props: IconButtonProps<E> & Omit<PropsOf<E>, keyof IconButtonProps>
   ): JSX.Element;
   displayName?: string;
 } = forwardRef(
-  ({ as, icon = 'FaceHappy', ...props }: ButtonProps, ref: React.Ref<HTMLButtonElement>) => {
+  (
+    { as, icon = 'FaceHappy', onClickAnimation = 'none', onClick, ...props }: IconButtonProps,
+    ref: React.Ref<HTMLButtonElement>
+  ) => {
     const LocalIcon = Icon[icon];
+    const [isAnimating, setIsAnimating] = useState(false);
+
+    const handleClick = () => {
+      onClick?.();
+      if (onClickAnimation === 'none') return;
+      setIsAnimating(true);
+    };
+
+    useEffect(() => {
+      const timer = setTimeout(() => {
+        if (isAnimating) setIsAnimating(false);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }, [isAnimating]);
 
     return (
-      <StyledButton as={as} ref={ref} {...props}>
-        {icon && <LocalIcon />}
+      <StyledButton as={as} ref={ref} {...props} onClick={handleClick}>
+        <IconWrapper isAnimating={isAnimating} animation={onClickAnimation}>
+          <LocalIcon />
+        </IconWrapper>
       </StyledButton>
     );
   }
@@ -34,7 +54,7 @@ export const IconButton: {
 
 IconButton.displayName = 'IconButton';
 
-const StyledButton = styled.button<Omit<ButtonProps, 'icon'>>(
+const StyledButton = styled.button<Omit<IconButtonProps, 'icon'>>(
   ({ theme, variant = 'solid', size = 'medium', disabled = false, active = false }) => ({
     border: 0,
     cursor: disabled ? 'not-allowed' : 'pointer',
@@ -109,3 +129,12 @@ const StyledButton = styled.button<Omit<ButtonProps, 'icon'>>(
     },
   })
 );
+
+const IconWrapper = styled.div<{
+  isAnimating: boolean;
+  animation: IconButtonProps['onClickAnimation'];
+}>(({ theme, isAnimating, animation }) => ({
+  width: 14,
+  height: 14,
+  animation: isAnimating && animation !== 'none' && `${theme.animation[animation]} 1000ms ease-out`,
+}));

--- a/code/ui/components/src/new/IconButton/IconButton.tsx
+++ b/code/ui/components/src/new/IconButton/IconButton.tsx
@@ -1,3 +1,4 @@
+import type { SyntheticEvent } from 'react';
 import React, { forwardRef, useEffect, useState } from 'react';
 import { styled } from '@storybook/theming';
 import { darken, lighten, rgba, transparentize } from 'polished';
@@ -10,7 +11,7 @@ interface IconButtonProps<T extends React.ElementType = React.ElementType> {
   as?: T;
   size?: 'small' | 'medium';
   variant?: 'solid' | 'outline' | 'ghost';
-  onClick?: () => void;
+  onClick?: (event: SyntheticEvent) => void;
   disabled?: boolean;
   active?: boolean;
   onClickAnimation?: 'none' | 'rotate360' | 'glow' | 'jiggle';
@@ -29,8 +30,8 @@ export const IconButton: {
     const LocalIcon = Icon[icon];
     const [isAnimating, setIsAnimating] = useState(false);
 
-    const handleClick = () => {
-      onClick?.();
+    const handleClick = (event: SyntheticEvent) => {
+      if (onClick) onClick(event);
       if (onClickAnimation === 'none') return;
       setIsAnimating(true);
     };

--- a/code/ui/components/src/new/Toolbar/Toolbar.stories.tsx
+++ b/code/ui/components/src/new/Toolbar/Toolbar.stories.tsx
@@ -25,7 +25,7 @@ export const Base: Story = {
       <Toolbar.Left>
         <Toolbar.ToogleGroup type="single">
           <Toolbar.ToggleItem value="item1">
-            <IconButton icon="Sync" size="small" variant="ghost" />
+            <IconButton icon="Sync" size="small" variant="ghost" onClickAnimation="jiggle" />
           </Toolbar.ToggleItem>
           <Toolbar.ToggleItem value="item2">
             <IconButton icon="Zoom" size="small" variant="ghost" />

--- a/code/ui/components/src/new/Toolbar/Toolbar.stories.tsx
+++ b/code/ui/components/src/new/Toolbar/Toolbar.stories.tsx
@@ -25,7 +25,7 @@ export const Base: Story = {
       <Toolbar.Left>
         <Toolbar.ToogleGroup type="single">
           <Toolbar.ToggleItem value="item1">
-            <IconButton icon="Sync" size="small" variant="ghost" onClickAnimation="jiggle" />
+            <IconButton icon="Sync" size="small" variant="ghost" onClickAnimation="rotate360" />
           </Toolbar.ToggleItem>
           <Toolbar.ToggleItem value="item2">
             <IconButton icon="Zoom" size="small" variant="ghost" />

--- a/code/ui/components/src/new/Toolbar/Toolbar.stories.tsx
+++ b/code/ui/components/src/new/Toolbar/Toolbar.stories.tsx
@@ -9,9 +9,6 @@ const meta: Meta<typeof Toolbar.Root> = {
   title: 'Toolbar',
   component: Toolbar.Root,
   tags: ['autodocs'],
-  parameters: {
-    layout: 'fullscreen',
-  },
 };
 
 export default meta;
@@ -20,6 +17,8 @@ type Story = StoryObj<typeof Toolbar.Root>;
 export const Base: Story = {
   args: {
     hasPadding: true,
+    borderTop: false,
+    borderBottom: false,
   },
   render: (_, { args }) => (
     <Toolbar.Root {...args}>
@@ -80,4 +79,39 @@ export const Base: Story = {
       </Toolbar.Right>
     </Toolbar.Root>
   ),
+};
+
+export const NoMargin: Story = {
+  args: {
+    ...Base.args,
+    hasPadding: false,
+  },
+  render: Base.render,
+};
+
+export const BorderTop: Story = {
+  args: {
+    ...Base.args,
+    borderTop: true,
+    borderBottom: false,
+  },
+  render: Base.render,
+};
+
+export const BorderBottom: Story = {
+  args: {
+    ...Base.args,
+    borderTop: false,
+    borderBottom: true,
+  },
+  render: Base.render,
+};
+
+export const BorderTopBottom: Story = {
+  args: {
+    ...Base.args,
+    borderTop: true,
+    borderBottom: true,
+  },
+  render: Base.render,
 };

--- a/code/ui/components/src/new/Toolbar/Toolbar.stories.tsx
+++ b/code/ui/components/src/new/Toolbar/Toolbar.stories.tsx
@@ -18,14 +18,14 @@ export const Base: Story = {
   args: {
     hasPadding: true,
     borderTop: false,
-    borderBottom: false,
+    borderBottom: true,
   },
   render: (_, { args }) => (
     <Toolbar.Root {...args}>
       <Toolbar.Left>
         <Toolbar.ToogleGroup type="single">
           <Toolbar.ToggleItem value="item1">
-            <IconButton icon="FaceHappy" size="small" variant="ghost" />
+            <IconButton icon="Sync" size="small" variant="ghost" />
           </Toolbar.ToggleItem>
           <Toolbar.ToggleItem value="item2">
             <IconButton icon="Zoom" size="small" variant="ghost" />

--- a/code/ui/components/src/new/Toolbar/Toolbar.stories.tsx
+++ b/code/ui/components/src/new/Toolbar/Toolbar.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { Toolbar } from './Toolbar';
+import { IconButton } from '../IconButton/IconButton';
+import { Button } from '../Button/Button';
+
+const meta: Meta<typeof Toolbar.Root> = {
+  title: 'Toolbar',
+  component: Toolbar.Root,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Toolbar.Root>;
+
+export const Base: Story = {
+  args: {
+    hasPadding: true,
+  },
+  render: (_, { args }) => (
+    <Toolbar.Root {...args}>
+      <Toolbar.Left>
+        <Toolbar.ToogleGroup type="single">
+          <Toolbar.ToggleItem value="item1">
+            <IconButton icon="FaceHappy" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+          <Toolbar.ToggleItem value="item2">
+            <IconButton icon="Zoom" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+          <Toolbar.ToggleItem value="item2">
+            <IconButton icon="ZoomOut" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+          <Toolbar.ToggleItem value="item2">
+            <IconButton icon="ZoomReset" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+        </Toolbar.ToogleGroup>
+        <Toolbar.Separator />
+        <Toolbar.ToogleGroup type="single">
+          <Toolbar.ToggleItem value="item1">
+            <IconButton icon="Photo" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+          <Toolbar.ToggleItem value="item2">
+            <IconButton icon="Grid" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+          <Toolbar.ToggleItem value="item2">
+            <IconButton icon="Grow" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+        </Toolbar.ToogleGroup>
+        <Toolbar.Separator />
+        <Toolbar.ToogleGroup type="single">
+          <Toolbar.ToggleItem value="item1">
+            <Button icon="CircleHollow" size="small" variant="ghost">
+              Theme
+            </Button>
+          </Toolbar.ToggleItem>
+          <Toolbar.ToggleItem value="item2">
+            <IconButton icon="Ruler" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+          <Toolbar.ToggleItem value="item2">
+            <IconButton icon="Outline" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+        </Toolbar.ToogleGroup>
+      </Toolbar.Left>
+      <Toolbar.Right>
+        <Toolbar.ToogleGroup type="single">
+          <Toolbar.ToggleItem value="item2">
+            <IconButton icon="Expand" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+          <Toolbar.ToggleItem value="item2">
+            <IconButton icon="ShareAlt" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+          <Toolbar.ToggleItem value="item2">
+            <IconButton icon="Link" size="small" variant="ghost" />
+          </Toolbar.ToggleItem>
+        </Toolbar.ToogleGroup>
+      </Toolbar.Right>
+    </Toolbar.Root>
+  ),
+};

--- a/code/ui/components/src/new/Toolbar/Toolbar.tsx
+++ b/code/ui/components/src/new/Toolbar/Toolbar.tsx
@@ -45,6 +45,7 @@ const StyledRoot = styled(ToolbarPrimitive.Root)<RootProps>(
     borderBottom: borderBottom ? `1px solid ${theme.appBorderColor}` : 'none',
     borderTop: borderTop ? `1px solid ${theme.appBorderColor}` : 'none',
     boxSizing: 'border-box',
+    backgroundColor: theme.barBg,
   })
 );
 
@@ -69,6 +70,7 @@ const Left = styled.div({
 const Right = styled.div({
   display: 'flex',
   gap: 5,
+  alignItems: 'center',
 });
 
 export const Toolbar = {

--- a/code/ui/components/src/new/Toolbar/Toolbar.tsx
+++ b/code/ui/components/src/new/Toolbar/Toolbar.tsx
@@ -44,6 +44,7 @@ const StyledRoot = styled(ToolbarPrimitive.Root)<RootProps>(
     height: 40,
     borderBottom: borderBottom ? `1px solid ${theme.appBorderColor}` : 'none',
     borderTop: borderTop ? `1px solid ${theme.appBorderColor}` : 'none',
+    boxSizing: 'border-box',
   })
 );
 

--- a/code/ui/components/src/new/Toolbar/Toolbar.tsx
+++ b/code/ui/components/src/new/Toolbar/Toolbar.tsx
@@ -1,0 +1,80 @@
+import type { ComponentPropsWithoutRef, ElementRef } from 'react';
+import React, { forwardRef } from 'react';
+import * as ToolbarPrimitive from '@radix-ui/react-toolbar';
+import { styled } from '@storybook/theming';
+
+interface RootProps extends ComponentPropsWithoutRef<typeof ToolbarPrimitive.Root> {
+  hasPadding?: boolean;
+  borderBottom?: boolean;
+  borderTop?: boolean;
+}
+
+const ToolbarRoot = forwardRef<ElementRef<typeof ToolbarPrimitive.Root>, RootProps>(
+  ({ className, children, ...props }, ref) => (
+    <StyledRoot ref={ref} {...props}>
+      {children}
+    </StyledRoot>
+  )
+);
+ToolbarRoot.displayName = ToolbarPrimitive.Root.displayName;
+
+const ToolbarSeparator = React.forwardRef<
+  ElementRef<typeof ToolbarPrimitive.Separator>,
+  ComponentPropsWithoutRef<typeof ToolbarPrimitive.Separator>
+>(({ className, ...props }, ref) => <StyledSeparator ref={ref} {...props} />);
+ToolbarSeparator.displayName = ToolbarPrimitive.Separator.displayName;
+
+const ToolbarToggleGroup = React.forwardRef<
+  ElementRef<typeof ToolbarPrimitive.ToggleGroup>,
+  ToolbarPrimitive.ToolbarToggleGroupSingleProps | ToolbarPrimitive.ToolbarToggleGroupMultipleProps
+>(({ className, ...props }, ref) => <StyledToggleGroup ref={ref} {...props} />);
+ToolbarToggleGroup.displayName = ToolbarPrimitive.ToggleGroup.displayName;
+
+const ToolbarToggleItem = React.forwardRef<
+  ElementRef<typeof ToolbarPrimitive.ToggleItem>,
+  ComponentPropsWithoutRef<typeof ToolbarPrimitive.ToggleItem>
+>(({ className, ...props }, ref) => <ToolbarPrimitive.ToggleItem ref={ref} {...props} asChild />);
+ToolbarToggleItem.displayName = ToolbarPrimitive.ToggleItem.displayName;
+
+const StyledRoot = styled(ToolbarPrimitive.Root)<RootProps>(
+  ({ theme, hasPadding = true, borderBottom = true, borderTop = false }) => ({
+    display: 'flex',
+    padding: hasPadding ? '0 10px' : 0,
+    justifyContent: 'space-between',
+    height: 40,
+    borderBottom: borderBottom ? `1px solid ${theme.appBorderColor}` : 'none',
+    borderTop: borderTop ? `1px solid ${theme.appBorderColor}` : 'none',
+  })
+);
+
+const StyledSeparator = styled(ToolbarPrimitive.Separator)(({ theme }) => ({
+  width: 1,
+  height: 20,
+  backgroundColor: theme.appBorderColor,
+}));
+
+const StyledToggleGroup = styled(ToolbarPrimitive.ToggleGroup)({
+  display: 'flex',
+  gap: 5,
+  alignItems: 'center',
+});
+
+const Left = styled.div({
+  display: 'flex',
+  gap: 5,
+  alignItems: 'center',
+});
+
+const Right = styled.div({
+  display: 'flex',
+  gap: 5,
+});
+
+export const Toolbar = {
+  Root: ToolbarRoot,
+  Left,
+  Right,
+  ToogleGroup: ToolbarToggleGroup,
+  ToggleItem: ToolbarToggleItem,
+  Separator: ToolbarSeparator,
+};

--- a/code/ui/manager/src/components/preview/toolbar.tsx
+++ b/code/ui/manager/src/components/preview/toolbar.tsx
@@ -108,7 +108,6 @@ export const createTabsTool = (tabs: Addon_BaseType[]): Addon_BaseType => ({
               .filter((p) => !p.hidden)
               .map((t, index) => {
                 const to = t.route(rp);
-                const isActive = rp.path === to;
                 return (
                   <S.UnstyledLink key={t.id || `l${index}`} to={to}>
                     <Toolbar.ToggleItem value={t.id} disabled={t.disabled}>

--- a/code/ui/manager/src/components/preview/toolbar.tsx
+++ b/code/ui/manager/src/components/preview/toolbar.tsx
@@ -1,10 +1,7 @@
 import type { FunctionComponent } from 'react';
 import React, { Fragment, useMemo } from 'react';
-
 import { styled } from '@storybook/theming';
-
-import { FlexBar, IconButton, Separator, TabButton, TabBar } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { IconButton, Toolbar } from '@storybook/components/experimental';
 import {
   shortcutToHumanString,
   Consumer,
@@ -33,11 +30,7 @@ import { remountTool } from './tools/remount';
 export const getTools = (getFn: API['getElements']) => Object.values(getFn(types.TOOL));
 export const getToolsExtra = (getFn: API['getElements']) => Object.values(getFn(types.TOOLEXTRA));
 
-const Bar: FunctionComponent<{ shown: boolean } & Record<string, any>> = ({ shown, ...props }) => (
-  <FlexBar {...props} />
-);
-
-export const Toolbar = styled(Bar)(
+export const ToolbarContainer = styled.div<{ shown: boolean }>(
   {
     position: 'absolute',
     left: 0,
@@ -67,13 +60,27 @@ export const fullScreenTool: Addon_BaseType = {
     <Consumer filter={fullScreenMapper}>
       {({ toggle, value, shortcut, hasPanel, singleStory }) =>
         (!singleStory || (singleStory && hasPanel)) && (
-          <IconButton
-            key="full"
-            onClick={toggle as any}
-            title={`${value ? 'Exit full screen' : 'Go full screen'} [${shortcut}]`}
-          >
-            {value ? <Icon.Close /> : <Icon.Expand />}
-          </IconButton>
+          <>
+            {value ? (
+              <IconButton
+                key="full"
+                icon="Close"
+                onClick={toggle as any}
+                title={`Exit full screen [${shortcut}]`}
+                size="small"
+                variant="ghost"
+              />
+            ) : (
+              <IconButton
+                key="full"
+                icon="Expand"
+                onClick={toggle as any}
+                title={`Go full screen [${shortcut}]`}
+                size="small"
+                variant="ghost"
+              />
+            )}
+          </>
         )
       }
     </Consumer>
@@ -96,7 +103,7 @@ export const createTabsTool = (tabs: Addon_BaseType[]): Addon_BaseType => ({
     <Consumer filter={tabsMapper}>
       {(rp) => (
         <Fragment>
-          <TabBar key="tabs">
+          <Toolbar.ToogleGroup type="single" key="tabs">
             {tabs
               .filter((p) => !p.hidden)
               .map((t, index) => {
@@ -104,14 +111,14 @@ export const createTabsTool = (tabs: Addon_BaseType[]): Addon_BaseType => ({
                 const isActive = rp.path === to;
                 return (
                   <S.UnstyledLink key={t.id || `l${index}`} to={to}>
-                    <TabButton disabled={t.disabled} active={isActive}>
+                    <Toolbar.ToggleItem value={t.id} disabled={t.disabled}>
                       {t.title}
-                    </TabButton>
+                    </Toolbar.ToggleItem>
                   </S.UnstyledLink>
                 );
               })}
-          </TabBar>
-          <Separator />
+          </Toolbar.ToogleGroup>
+          <Toolbar.Separator />
         </Fragment>
       )}
     </Consumer>
@@ -137,13 +144,10 @@ const useTools = (
   const toolsFromConfig = useMemo(() => getTools(getElements), [getElements]);
   const toolsExtraFromConfig = useMemo(() => getToolsExtra(getElements), [getElements]);
 
-  const tools = useMemo(
-    () => [...defaultTools, ...toolsFromConfig],
-    [defaultTools, toolsFromConfig]
-  );
+  const tools = useMemo(() => [...defaultTools, ...toolsFromConfig], [toolsFromConfig]);
   const toolsExtra = useMemo(
     () => [...defaultToolsExtra, ...toolsExtraFromConfig],
-    [defaultToolsExtra, toolsExtraFromConfig]
+    [toolsExtraFromConfig]
   );
 
   return useMemo(() => {
@@ -170,10 +174,16 @@ export const ToolRes: FunctionComponent<ToolData & RenderData> = React.memo<Tool
     const { left, right } = useTools(api.getElements, tabs, viewMode, entry, location, path);
 
     return left || right ? (
-      <Toolbar key="toolbar" shown={isShown} border>
-        <Tools key="left" list={left} />
-        <Tools key="right" list={right} />
-      </Toolbar>
+      <ToolbarContainer key="toolbar" shown={isShown}>
+        <Toolbar.Root>
+          <Toolbar.Left>
+            <Tools key="left" list={left} />
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Tools key="right" list={right} />
+          </Toolbar.Right>
+        </Toolbar.Root>
+      </ToolbarContainer>
     ) : null;
   }
 );

--- a/code/ui/manager/src/components/preview/tools/addons.tsx
+++ b/code/ui/manager/src/components/preview/tools/addons.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { IconButton } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { IconButton } from '@storybook/components/experimental';
 import { Consumer, types } from '@storybook/manager-api';
 import type { Combo } from '@storybook/manager-api';
 import type { Addon_BaseType } from '@storybook/types';
@@ -23,9 +22,27 @@ export const addonsTool: Addon_BaseType = {
         !singleStory &&
         !isVisible && (
           <>
-            <IconButton aria-label="Show addons" key="addons" onClick={toggle} title="Show addons">
-              {panelPosition === 'bottom' ? <Icon.BottomBar /> : <Icon.SidebarAlt />}
-            </IconButton>
+            {panelPosition === 'bottom' ? (
+              <IconButton
+                icon="BottomBar"
+                aria-label="Show addons"
+                key="addons"
+                onClick={toggle}
+                title="Show addons"
+                size="small"
+                variant="ghost"
+              />
+            ) : (
+              <IconButton
+                icon="SidebarAlt"
+                aria-label="Show addons"
+                key="addons"
+                onClick={toggle}
+                title="Show addons"
+                size="small"
+                variant="ghost"
+              />
+            )}
           </>
         )
       }

--- a/code/ui/manager/src/components/preview/tools/copy.tsx
+++ b/code/ui/manager/src/components/preview/tools/copy.tsx
@@ -1,8 +1,8 @@
 import { global } from '@storybook/global';
 import React from 'react';
 import copy from 'copy-to-clipboard';
-import { getStoryHref, IconButton } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { getStoryHref } from '@storybook/components';
+import { IconButton } from '@storybook/components/experimental';
 import { Consumer, types } from '@storybook/manager-api';
 import type { Combo } from '@storybook/manager-api';
 import type { Addon_BaseType } from '@storybook/types';
@@ -34,12 +34,13 @@ export const copyTool: Addon_BaseType = {
       {({ baseUrl, storyId, queryParams }) =>
         storyId ? (
           <IconButton
+            icon="Link"
             key="copy"
             onClick={() => copy(getStoryHref(baseUrl, storyId, queryParams))}
             title="Copy canvas link"
-          >
-            <Icon.Link />
-          </IconButton>
+            size="small"
+            variant="ghost"
+          />
         ) : null
       }
     </Consumer>

--- a/code/ui/manager/src/components/preview/tools/eject.tsx
+++ b/code/ui/manager/src/components/preview/tools/eject.tsx
@@ -1,7 +1,7 @@
 import { global } from '@storybook/global';
 import React from 'react';
-import { getStoryHref, IconButton } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { getStoryHref } from '@storybook/components';
+import { IconButton } from '@storybook/components/experimental';
 import { Consumer, types } from '@storybook/manager-api';
 import type { Combo } from '@storybook/manager-api';
 import type { Addon_BaseType } from '@storybook/types';
@@ -30,13 +30,15 @@ export const ejectTool: Addon_BaseType = {
       {({ baseUrl, storyId, queryParams }) =>
         storyId ? (
           <IconButton
+            as="a"
+            icon="ShareAlt"
             key="opener"
             href={getStoryHref(baseUrl, storyId, queryParams)}
             target="_blank"
             title="Open canvas in new tab"
-          >
-            <Icon.ShareAlt />
-          </IconButton>
+            size="small"
+            variant="ghost"
+          />
         ) : null
       }
     </Consumer>

--- a/code/ui/manager/src/components/preview/tools/menu.tsx
+++ b/code/ui/manager/src/components/preview/tools/menu.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { IconButton, Separator } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { IconButton, Toolbar } from '@storybook/components/experimental';
 import { Consumer, types } from '@storybook/manager-api';
 import type { Combo } from '@storybook/manager-api';
 import type { Addon_BaseType } from '@storybook/types';
@@ -22,10 +21,16 @@ export const menuTool: Addon_BaseType = {
         !singleStory &&
         !isVisible && (
           <>
-            <IconButton aria-label="Show sidebar" key="menu" onClick={toggle} title="Show sidebar">
-              <Icon.Menu />
-            </IconButton>
-            <Separator />
+            <IconButton
+              icon="Menu"
+              aria-label="Show sidebar"
+              key="menu"
+              onClick={toggle}
+              title="Show sidebar"
+              size="small"
+              variant="ghost"
+            />
+            <Toolbar.Separator />
           </>
         )
       }

--- a/code/ui/manager/src/components/preview/tools/remount.tsx
+++ b/code/ui/manager/src/components/preview/tools/remount.tsx
@@ -1,25 +1,9 @@
-import type { ComponentProps } from 'react';
-import React, { useState } from 'react';
-import { IconButton } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import React from 'react';
+import { IconButton } from '@storybook/components/experimental';
 import { Consumer, types } from '@storybook/manager-api';
 import type { Combo } from '@storybook/manager-api';
-import { styled } from '@storybook/theming';
 import { FORCE_REMOUNT } from '@storybook/core-events';
 import type { Addon_BaseType } from '@storybook/types';
-
-interface AnimatedButtonProps {
-  animating?: boolean;
-}
-
-const StyledAnimatedIconButton = styled(IconButton)<
-  AnimatedButtonProps & ComponentProps<typeof IconButton>
->(({ theme, animating, disabled }) => ({
-  opacity: disabled ? 0.5 : 1,
-  svg: {
-    animation: animating && `${theme.animation.rotate360} 1000ms ease-out`,
-  },
-}));
 
 const menuMapper = ({ api, state }: Combo) => {
   const { storyId } = state;
@@ -37,28 +21,23 @@ export const remountTool: Addon_BaseType = {
   match: ({ viewMode }) => viewMode === 'story',
   render: () => (
     <Consumer filter={menuMapper}>
-      {({ remount, storyId, api }) => {
-        const [isAnimating, setIsAnimating] = useState(false);
+      {({ remount, storyId }) => {
         const remountComponent = () => {
           if (!storyId) return;
           remount();
         };
 
-        api.on(FORCE_REMOUNT, () => {
-          setIsAnimating(true);
-        });
-
         return (
-          <StyledAnimatedIconButton
+          <IconButton
             key="remount"
             title="Remount component"
+            icon="Sync"
+            size="small"
+            variant="ghost"
+            onClickAnimation="rotate360"
             onClick={remountComponent}
-            onAnimationEnd={() => setIsAnimating(false)}
-            animating={isAnimating}
             disabled={!storyId}
-          >
-            <Icon.Sync />
-          </StyledAnimatedIconButton>
+          />
         );
       }}
     </Consumer>

--- a/code/ui/manager/src/components/preview/tools/zoom.tsx
+++ b/code/ui/manager/src/components/preview/tools/zoom.tsx
@@ -1,8 +1,7 @@
 import type { SyntheticEvent, MouseEventHandler } from 'react';
 import React, { Component, useCallback } from 'react';
 
-import { IconButton, Separator } from '@storybook/components';
-import { Icon } from '@storybook/components/experimental';
+import { IconButton, Toolbar } from '@storybook/components/experimental';
 import type { Addon_BaseType } from '@storybook/types';
 import { types } from '@storybook/manager-api';
 
@@ -38,15 +37,30 @@ const Zoom = React.memo<{
 }>(function Zoom({ zoomIn, zoomOut, reset }) {
   return (
     <>
-      <IconButton key="zoomin" onClick={zoomIn} title="Zoom in">
-        <Icon.Zoom />
-      </IconButton>
-      <IconButton key="zoomout" onClick={zoomOut} title="Zoom out">
-        <Icon.ZoomOut />
-      </IconButton>
-      <IconButton key="zoomreset" onClick={reset} title="Reset zoom">
-        <Icon.ZoomReset />
-      </IconButton>
+      <IconButton
+        key="zoomin"
+        title="Zoom in"
+        icon="Zoom"
+        size="small"
+        variant="ghost"
+        onClick={zoomIn}
+      />
+      <IconButton
+        key="zoomout"
+        title="Zoom out"
+        icon="ZoomOut"
+        size="small"
+        variant="ghost"
+        onClick={zoomOut}
+      />
+      <IconButton
+        key="zoomreset"
+        title="Reset zoom"
+        icon="ZoomReset"
+        size="small"
+        variant="ghost"
+        onClick={reset}
+      />
     </>
   );
 });
@@ -89,7 +103,7 @@ export const zoomTool: Addon_BaseType = {
     return (
       <>
         <ZoomConsumer>{({ set, value }) => <ZoomWrapper {...{ set, value }} />}</ZoomConsumer>
-        <Separator />
+        <Toolbar.Separator />
       </>
     );
   }),

--- a/code/ui/manager/src/globals/exports.ts
+++ b/code/ui/manager/src/globals/exports.ts
@@ -114,7 +114,15 @@ export default {
     'resetComponents',
     'withReset',
   ],
-  '@storybook/components/experimental': ['Button', 'Icon', 'IconButton', 'Input', 'Link', 'Select'],
+  '@storybook/components/experimental': [
+    'Button',
+    'Icon',
+    'IconButton',
+    'Input',
+    'Link',
+    'Select',
+    'Toolbar',
+  ],
   '@storybook/channels': [
     'Channel',
     'PostMessageTransport',

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5204,6 +5204,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-roving-focus@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@radix-ui/react-roving-focus@npm:1.0.4"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.1
+    "@radix-ui/react-collection": 1.0.3
+    "@radix-ui/react-compose-refs": 1.0.1
+    "@radix-ui/react-context": 1.0.1
+    "@radix-ui/react-direction": 1.0.1
+    "@radix-ui/react-id": 1.0.1
+    "@radix-ui/react-primitive": 1.0.3
+    "@radix-ui/react-use-callback-ref": 1.0.1
+    "@radix-ui/react-use-controllable-state": 1.0.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 61e3ddfd1647e64fba855434ff41e8e7ba707244fe8841f78c450fbdce525383b64259279475615d030dbf1625cbffd8eeebee72d91bf6978794f5dbcf887fc0
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-select@npm:^1.2.2":
   version: 1.2.2
   resolution: "@radix-ui/react-select@npm:1.2.2"
@@ -5244,6 +5272,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-separator@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@radix-ui/react-separator@npm:1.0.3"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-primitive": 1.0.3
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 87bcde47343f2bc4439a0dc34381f557905d9b3c1e8c5a0d32ceea62a8ef84f3abf671c5cb29309fc87759ad41d39af619ba546cf54109d64c8746e3ca683de3
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-slot@npm:1.0.2":
   version: 1.0.2
   resolution: "@radix-ui/react-slot@npm:1.0.2"
@@ -5257,6 +5305,80 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 3af6ea4891e6fa8091e666802adffe7718b3cd390a10fa9229a5f40f8efded9f3918ea01b046103d93923d41cc32119505ebb6bde76cad07a87b6cf4f2119347
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-toggle-group@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@radix-ui/react-toggle-group@npm:1.0.4"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.1
+    "@radix-ui/react-context": 1.0.1
+    "@radix-ui/react-direction": 1.0.1
+    "@radix-ui/react-primitive": 1.0.3
+    "@radix-ui/react-roving-focus": 1.0.4
+    "@radix-ui/react-toggle": 1.0.3
+    "@radix-ui/react-use-controllable-state": 1.0.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 4f4761965022759ac0950ac026029b64049e1f18ef07a01ddde788b7606efcb262c9ae3a418de0c0756bf7285182ed0d268502c6f17ba86d2ff27eee5507bbf7
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-toggle@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@radix-ui/react-toggle@npm:1.0.3"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.1
+    "@radix-ui/react-primitive": 1.0.3
+    "@radix-ui/react-use-controllable-state": 1.0.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 9b487dad213ea7e70b0aa205e7c6f790a6f2bf394c39912e22dbe003403fd0d24a41c2efd31695fc31ab7bac286f28253dbb2fc5202cacd572ebf909f1fdc86c
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-toolbar@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@radix-ui/react-toolbar@npm:1.0.4"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.1
+    "@radix-ui/react-context": 1.0.1
+    "@radix-ui/react-direction": 1.0.1
+    "@radix-ui/react-primitive": 1.0.3
+    "@radix-ui/react-roving-focus": 1.0.4
+    "@radix-ui/react-separator": 1.0.3
+    "@radix-ui/react-toggle-group": 1.0.4
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 3ed7ebe22ef2e8369e08bb59776671a7b8c413628249c338b8db86b4b9ac40127b4201d5bd4a9c23ea1fd21464769b4fa427d3ebcda3a7fcdbd45b256b5a753a
   languageName: node
   linkType: hard
 
@@ -6545,6 +6667,7 @@ __metadata:
   dependencies:
     "@popperjs/core": ^2.6.0
     "@radix-ui/react-select": ^1.2.2
+    "@radix-ui/react-toolbar": ^1.0.4
     "@storybook/client-logger": "workspace:*"
     "@storybook/csf": ^0.1.0
     "@storybook/global": ^5.0.0


### PR DESCRIPTION
## What I did

The toolbar is one of the main piece of the Storybook manager. We would like to improve it to be more accessible and well documented. In this PR we created a new component `Toolbar />` as part on the new Core UI library. It is based on Radix Toolbar and extend all props with our custom styling. This new component will replace `FlexBar` and could be used on the manager as well as addons for multiple use cases.

Older IconButton are still working but as part of this PR, I'm updating most of the old IconButton with the new ones to make it coherent with the rest of the manager.

## How to test

1. Run this branch locally using `yarn storybook:ui`
2. Open Storybook in your browser at this link http://localhost:6006/?path=/story/core-ui-toolbar--base
3. You should now see the new Toolbar component

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [x] Make sure to add/update documentation regarding your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
