### PR TITLE
Docs: Video coverage extended

### DIFF
--- a/docs/api/doc-block-argtypes.md
+++ b/docs/api/doc-block-argtypes.md
@@ -2,6 +2,8 @@
 title: 'ArgTypes'
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's ArgTypes Doc Block" params='start=232' />
+
 The `ArgTypes` block can be used to show a static table of [arg types](./argtypes.md) for a given component, as a way to document its interface.
 
 <div class="aside">

--- a/docs/api/doc-block-canvas.md
+++ b/docs/api/doc-block-canvas.md
@@ -2,6 +2,8 @@
 title: 'Canvas'
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's Canvas Doc Block" params='start=148' />
+
 The `Canvas` block is a wrapper around a [`Story`](./doc-block-story.md), featuring a toolbar that allows you to interact with its content while automatically providing the required [`Source`](./doc-block-source.md) snippets.
 
 ![Screenshot of Canvas block](./doc-block-canvas.png)

--- a/docs/api/doc-block-controls.md
+++ b/docs/api/doc-block-controls.md
@@ -2,6 +2,8 @@
 title: 'Controls'
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's Controls Doc Block" params='start=240' />
+
 The `Controls` block can be used to show a dynamic table of args for a given story, as a way to document its interface, and to allow you to change the args for a (separately) rendered story (via the [`Story`](./doc-block-story.md) or [`Canvas`](./doc-block-canvas.md) blocks).
 
 <div class="aside">

--- a/docs/api/doc-block-description.md
+++ b/docs/api/doc-block-description.md
@@ -2,6 +2,8 @@
 title: 'Description'
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's Description Doc Block" params='start=84' />
+
 The `Description` block displays the description for a component, story, or meta, obtained from their respective JSDoc comments.
 
 ![Screenshot of Description block](./doc-block-title-subtitle-description.png)

--- a/docs/api/doc-block-primary.md
+++ b/docs/api/doc-block-primary.md
@@ -2,6 +2,8 @@
 title: 'Primary'
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's Primary Doc Block" params='start=209' />
+
 The `Primary` block displays the primary (first defined in the stories file) story, in a [`Story`](./doc-block-story.md) block. It is typically rendered immediately under the title in a docs entry.
 
 ![Screenshot of Primary block](./doc-block-primary.png)

--- a/docs/api/doc-block-source.md
+++ b/docs/api/doc-block-source.md
@@ -2,6 +2,8 @@
 title: 'Source'
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's Source Doc Block" params='start=136' />
+
 The `Source` block is used to render a snippet of source code directly.
 
 ![Screenshot of Source block](./doc-block-source.png)

--- a/docs/api/doc-block-stories.md
+++ b/docs/api/doc-block-stories.md
@@ -2,6 +2,8 @@
 title: 'Stories'
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's Stories Doc Block" params='start=185' />
+
 The `Stories` block renders the full collection of stories in a stories file.
 
 ![Screenshot of Stories block](./doc-block-stories.png)

--- a/docs/api/doc-block-story.md
+++ b/docs/api/doc-block-story.md
@@ -2,6 +2,8 @@
 title: 'Story'
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's Story Doc Block" params='start=124' />
+
 Stories (component tests) are Storybook's fundamental building blocks.
 
 In Storybook Docs, you can render any of your stories from your CSF files in the context of an MDX file with all annotations (parameters, args, loaders, decorators, play function) applied using the `Story` block.
@@ -123,6 +125,8 @@ import * as HeaderStories from './Header.stories';
 Type: Story export
 
 Specifies which story is rendered by the `Story` block. If no `of` is defined and the MDX file is [attached](./doc-block-meta.md#attached-vs-unattached), the primary (first) story will be rendered.
+
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's Story Doc Block configuration" params='start=160' />
 
 ### `args`
 

--- a/docs/api/doc-block-subtitle.md
+++ b/docs/api/doc-block-subtitle.md
@@ -2,6 +2,8 @@
 title: 'Subtitle'
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's Subtitle Doc Block" params='start=98' />
+
 The `Subtitle` block can serve as a secondary heading for your docs entry.
 
 ![Screenshot of Subtitle block](./doc-block-title-subtitle-description.png)

--- a/docs/api/doc-block-title.md
+++ b/docs/api/doc-block-title.md
@@ -2,6 +2,8 @@
 title: 'Title'
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook's Title Doc Block" params='start=57' />
+
 The `Title` block serves as the primary heading for your docs entry. It is typically used to provide the component or page name.
 
 ![Screenshot of Title block](./doc-block-title-subtitle-description.png)

--- a/docs/sharing/embed.md
+++ b/docs/sharing/embed.md
@@ -2,6 +2,8 @@
 title: 'Embed stories'
 ---
 
+<YouTubeCallout id="2tqRpBcV8ug" title="Your Storybook EVERYWHERE | Embeds with Chromatic" />
+
 Embed stories to showcase your work to teammates and the developer community at large. In order to use embeds, your Storybook must be published and publicly accessible.
 
 Storybook supports `<iframe>` embeds out of the box. If you use Chromatic to [publish Storybook](./publish-storybook.md#publish-storybook-with-chromatic), you can also embed stories in Notion, Medium, and countless other platforms that support the oEmbed standard.

--- a/docs/sharing/publish-storybook.md
+++ b/docs/sharing/publish-storybook.md
@@ -2,6 +2,8 @@
 title: 'Publish Storybook'
 ---
 
+<YouTubeCallout id="zhrboql8UuU" title="How to Test UI AUTOMATICALLY — Storybook and Chromatic" />
+
 Teams publish Storybook online to review and collaborate on works in progress. That allows developers, designers, PMs, and other stakeholders to check if the UI looks right without touching code or requiring a local dev environment.
 
 <video autoPlay muted playsInline loop>

--- a/docs/writing-docs/autodocs.md
+++ b/docs/writing-docs/autodocs.md
@@ -53,7 +53,7 @@ By default, Storybook offers zero-config support for documentation and automatic
 
 ### Write a custom template
 
-To replace the default documentation template used by Storybook, you can extend your UI configuration file (i.e., `.storybook/preview.js`) and introduce a `docs` [parameter](./doc-blocks.md#customizing-the-automatic-docs-page). This parameter accepts a `page` function that returns a React component, which you can use to generate the required template. For example:
+To replace the default documentation template used by Storybook, you can extend your UI configuration file (i.e., `.storybook/preview.js|ts`) and introduce a `docs` [parameter](./doc-blocks.md#customizing-the-automatic-docs-page). This parameter accepts a `page` function that returns a React component, which you can use to generate the required template. For example:
 
 <!-- prettier-ignore-start -->
 
@@ -66,11 +66,7 @@ To replace the default documentation template used by Storybook, you can extend 
 
 <!-- prettier-ignore-end -->
 
-<div class="aside">
-
-💡 Internally, Storybook uses a similar implementation to generate the default template. See the Doc Blocks [API reference](./doc-blocks.md#available-blocks) to learn more about how Doc Blocks work.
-
-</div>
+<YouTubeCallout id="q8SY4yyNE6Q" title="Custom Autodocs with Storybook 7 Docs Page | Quick Tips" />
 
 Going over the code snippet in more detail. When Storybook starts up, it will override the default template with the custom one composed of the following:
 
@@ -78,6 +74,12 @@ Going over the code snippet in more detail. When Storybook starts up, it will ov
 2. The first story defined in the file via the `Primary` Doc Block with a handy set of UI controls to zoom in and out of the component.
 3. An interactive table with all the relevant [`args`](../writing-stories/args.md) and [`argTypes`](../api/argtypes.md) defined in the story via the `Controls` Doc Block.
 4. A overview of the remaining stories via the `Stories` Doc Block.
+
+<div class="aside">
+
+💡 Internally, Storybook uses a similar implementation to generate the default template. See the Doc Blocks [API reference](./doc-blocks.md#available-blocks) to learn more about how Doc Blocks work.
+
+</div>
 
 #### With MDX
 

--- a/docs/writing-docs/autodocs.md
+++ b/docs/writing-docs/autodocs.md
@@ -53,6 +53,8 @@ By default, Storybook offers zero-config support for documentation and automatic
 
 ### Write a custom template
 
+<YouTubeCallout id="q8SY4yyNE6Q" title="Custom Autodocs with Storybook 7 Docs Page | Quick Tips" />
+
 To replace the default documentation template used by Storybook, you can extend your UI configuration file (i.e., `.storybook/preview.js|ts`) and introduce a `docs` [parameter](./doc-blocks.md#customizing-the-automatic-docs-page). This parameter accepts a `page` function that returns a React component, which you can use to generate the required template. For example:
 
 <!-- prettier-ignore-start -->
@@ -66,7 +68,11 @@ To replace the default documentation template used by Storybook, you can extend 
 
 <!-- prettier-ignore-end -->
 
-<YouTubeCallout id="q8SY4yyNE6Q" title="Custom Autodocs with Storybook 7 Docs Page | Quick Tips" />
+<div class="aside">
+
+💡 Internally, Storybook uses a similar implementation to generate the default template. See the Doc Blocks [API reference](./doc-blocks.md#available-blocks) to learn more about how Doc Blocks work.
+
+</div>
 
 Going over the code snippet in more detail. When Storybook starts up, it will override the default template with the custom one composed of the following:
 
@@ -74,12 +80,6 @@ Going over the code snippet in more detail. When Storybook starts up, it will ov
 2. The first story defined in the file via the `Primary` Doc Block with a handy set of UI controls to zoom in and out of the component.
 3. An interactive table with all the relevant [`args`](../writing-stories/args.md) and [`argTypes`](../api/argtypes.md) defined in the story via the `Controls` Doc Block.
 4. A overview of the remaining stories via the `Stories` Doc Block.
-
-<div class="aside">
-
-💡 Internally, Storybook uses a similar implementation to generate the default template. See the Doc Blocks [API reference](./doc-blocks.md#available-blocks) to learn more about how Doc Blocks work.
-
-</div>
 
 #### With MDX
 

--- a/docs/writing-docs/doc-blocks.md
+++ b/docs/writing-docs/doc-blocks.md
@@ -2,6 +2,8 @@
 title: Doc blocks
 ---
 
+<YouTubeCallout id="uAA1JvLcl-w" title="Avoid Documentation Nightmares with Storybook Doc Blocks" />
+
 Storybook offers several doc blocks to help document your components and other aspects of your project.
 
 There are two common ways to use doc blocks in Storybook, within MDX and as part of the docs page template.


### PR DESCRIPTION
## What I did

Introduced some additional videos to complement the documentation further. Featured in this pull request are the following pages:
- Writing stories / AutoDocs (custom template section)
- Writing Docs / Doc Blocks
- Sharing / Embed
- Sharing / Publish
- API / Doc Blocks
   - ArgTypes
   - Canvas
   - Controls
   - Description
   - Primary
   - Source
   - Stories
   - Story
   - Subtitle
   - Title


## How to test

1. Check out the `test_timestamps` branch on the [frontpage](https://github.com/storybookjs/frontpage) repository.  
2. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `chore_docs_adds_videos`.
3. Open the relevant documentation, and the videos should be available, including the timestamped ones.

@chantastic and @kylegach when you have a moment, can you take a look at this and let me know of any feedback? Thanks in advance.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
