### PR TITLE
Core: Fix race-condition relating to `addons.setConfig`

### DIFF
--- a/code/lib/manager-api/src/index.tsx
+++ b/code/lib/manager-api/src/index.tsx
@@ -65,6 +65,7 @@ import * as version from './modules/versions';
 import * as whatsnew from './modules/whatsnew';
 
 import * as globals from './modules/globals';
+import type { ModuleFn } from './lib/types';
 
 export * from './lib/shortcut';
 
@@ -75,14 +76,6 @@ export type { Options as StoreOptions, Listener as ChannelListener };
 export { ActiveTabs };
 
 export const ManagerContext = createContext({ api: undefined, state: getInitialState({}) });
-
-export type ModuleArgs = RouterData &
-  API_ProviderData<API> & {
-    mode?: 'production' | 'development';
-    state: State;
-    fullAPI: API;
-    store: Store;
-  };
 
 export type State = layout.SubState &
   stories.SubState &
@@ -152,28 +145,10 @@ export const combineParameters = (...parameterSets: Parameters[]) =>
     return undefined;
   });
 
-interface ModuleWithInit<APIType = unknown, StateType = unknown> {
-  init: () => void | Promise<void>;
-  api: APIType;
-  state: StateType;
-}
-
-type ModuleWithoutInit<APIType = unknown, StateType = unknown> = Omit<
-  ModuleWithInit<APIType, StateType>,
-  'init'
->;
-
-export type ModuleFn<APIType = unknown, StateType = unknown, HasInit = false> = (
-  m: ModuleArgs,
-  options?: any
-) => HasInit extends true
-  ? ModuleWithInit<APIType, StateType>
-  : ModuleWithoutInit<APIType, StateType>;
-
 class ManagerProvider extends Component<ManagerProviderProps, State> {
   api: API = {} as API;
 
-  modules: (ModuleWithInit | ModuleWithoutInit)[];
+  modules: ReturnType<ModuleFn>[];
 
   static displayName = 'Manager';
 

--- a/code/lib/manager-api/src/lib/types.tsx
+++ b/code/lib/manager-api/src/lib/types.tsx
@@ -1,0 +1,22 @@
+import type { API_ProviderData } from '@storybook/types';
+import type { RouterData } from '@storybook/router';
+
+import type { API, State } from '../index';
+import type Store from '../store';
+
+export type ModuleFn<APIType = unknown, StateType = unknown> = (
+  m: ModuleArgs,
+  options?: any
+) => {
+  init?: () => void | Promise<void>;
+  api: APIType;
+  state: StateType;
+};
+
+export type ModuleArgs = RouterData &
+  API_ProviderData<API> & {
+    mode?: 'production' | 'development';
+    state: State;
+    fullAPI: API;
+    store: Store;
+  };

--- a/code/lib/manager-api/src/modules/addons.ts
+++ b/code/lib/manager-api/src/modules/addons.ts
@@ -7,7 +7,7 @@ import type {
   API_StateMerger,
 } from '@storybook/types';
 import { Addon_TypesEnum } from '@storybook/types';
-import type { ModuleFn } from '../index';
+import type { ModuleFn } from '../lib/types';
 import type { Options } from '../store';
 
 export interface SubState {

--- a/code/lib/manager-api/src/modules/channel.ts
+++ b/code/lib/manager-api/src/modules/channel.ts
@@ -3,7 +3,8 @@ import { STORIES_COLLAPSE_ALL, STORIES_EXPAND_ALL } from '@storybook/core-events
 import type { Listener } from '@storybook/channels';
 
 import type { API_Provider } from '@storybook/types';
-import type { API, ModuleFn } from '../index';
+import type { API } from '../index';
+import type { ModuleFn } from '../lib/types';
 
 export interface SubAPI {
   /**

--- a/code/lib/manager-api/src/modules/layout.ts
+++ b/code/lib/manager-api/src/modules/layout.ts
@@ -7,7 +7,8 @@ import type { ThemeVars } from '@storybook/theming';
 
 import type { API_Layout, API_PanelPositions, API_UI } from '@storybook/types';
 import merge from '../lib/merge';
-import type { State, ModuleFn } from '../index';
+import type { State } from '../index';
+import type { ModuleFn } from '../lib/types';
 
 const { document } = global;
 
@@ -284,7 +285,7 @@ export const init: ModuleFn = ({ store, provider, singleStory, fullAPI }) => {
     state: merge(api.getInitialOptions(), persisted),
     init: () => {
       api.setOptions(merge(api.getInitialOptions(), persisted));
-      fullAPI.on(SET_CONFIG, () => {
+      provider.channel.on(SET_CONFIG, () => {
         api.setOptions(merge(api.getInitialOptions(), persisted));
       });
     },

--- a/code/lib/manager-api/src/modules/notifications.ts
+++ b/code/lib/manager-api/src/modules/notifications.ts
@@ -1,5 +1,5 @@
 import type { API_Notification } from '@storybook/types';
-import type { ModuleFn } from '../index';
+import type { ModuleFn } from '../lib/types';
 
 export interface SubState {
   notifications: API_Notification[];

--- a/code/lib/manager-api/src/modules/provider.ts
+++ b/code/lib/manager-api/src/modules/provider.ts
@@ -1,11 +1,11 @@
 import type { API_IframeRenderer } from '@storybook/types';
-import type { ModuleFn } from '../index';
+import type { ModuleFn } from '../lib/types';
 
 export interface SubAPI {
   renderPreview?: API_IframeRenderer;
 }
 
-export const init: ModuleFn<SubAPI, {}, true> = ({ provider, fullAPI }) => {
+export const init: ModuleFn<SubAPI, {}> = ({ provider, fullAPI }) => {
   return {
     api: provider.renderPreview ? { renderPreview: provider.renderPreview } : {},
     state: {},

--- a/code/lib/manager-api/src/modules/refs.ts
+++ b/code/lib/manager-api/src/modules/refs.ts
@@ -15,7 +15,7 @@ import {
   transformStoryIndexToStoriesHash,
 } from '../lib/stories';
 
-import type { ModuleFn } from '../index';
+import type { ModuleFn } from '../lib/types';
 
 const { location, fetch } = global;
 
@@ -154,7 +154,7 @@ const map = (
   return input;
 };
 
-export const init: ModuleFn<SubAPI, SubState, void> = (
+export const init: ModuleFn<SubAPI, SubState> = (
   { store, provider, singleStory, docsOptions = {} },
   { runCheck = true } = {}
 ) => {

--- a/code/lib/manager-api/src/modules/settings.ts
+++ b/code/lib/manager-api/src/modules/settings.ts
@@ -1,5 +1,5 @@
 import type { API_Settings, StoryId } from '@storybook/types';
-import type { ModuleFn } from '../index';
+import type { ModuleFn } from '../lib/types';
 
 export interface SubAPI {
   storeSelection: () => void;
@@ -78,5 +78,8 @@ export const init: ModuleFn<SubAPI, SubState> = ({ store, navigate, fullAPI }) =
     },
   };
 
-  return { state: { settings: { lastTrackedStoryId: null } }, api };
+  return {
+    state: { settings: { lastTrackedStoryId: null } },
+    api,
+  };
 };

--- a/code/lib/manager-api/src/modules/shortcuts.ts
+++ b/code/lib/manager-api/src/modules/shortcuts.ts
@@ -2,7 +2,7 @@
 import { global } from '@storybook/global';
 import { FORCE_REMOUNT, PREVIEW_KEYDOWN } from '@storybook/core-events';
 
-import type { ModuleFn } from '../index';
+import type { ModuleFn } from '../lib/types';
 
 import type { KeyboardEventLike } from '../lib/shortcut';
 import { shortcutMatchesShortcut, eventToShortcut } from '../lib/shortcut';
@@ -152,7 +152,7 @@ function focusInInput(event: KeyboardEvent) {
   return /input|textarea/i.test(target.tagName) || target.getAttribute('contenteditable') !== null;
 }
 
-export const init: ModuleFn = ({ store, fullAPI }) => {
+export const init: ModuleFn = ({ store, fullAPI, provider }) => {
   const api: SubAPI = {
     // Getting and setting shortcuts
     getShortcutKeys(): API_Shortcuts {
@@ -397,13 +397,13 @@ export const init: ModuleFn = ({ store, fullAPI }) => {
     // Listen for keydown events in the manager
     document.addEventListener('keydown', (event: KeyboardEvent) => {
       if (!focusInInput(event)) {
-        fullAPI.handleKeydownEvent(event);
+        api.handleKeydownEvent(event);
       }
     });
 
     // Also listen to keydown events sent over the channel
-    fullAPI.on(PREVIEW_KEYDOWN, (data: { event: KeyboardEventLike }) => {
-      fullAPI.handleKeydownEvent(data.event);
+    provider.channel.on(PREVIEW_KEYDOWN, (data: { event: KeyboardEventLike }) => {
+      api.handleKeydownEvent(data.event);
     });
   };
 

--- a/code/lib/manager-api/src/modules/stories.ts
+++ b/code/lib/manager-api/src/modules/stories.ts
@@ -21,7 +21,6 @@ import type {
   API_ViewMode,
   API_StatusState,
   API_StatusUpdate,
-  API_FilterFunction,
 } from '@storybook/types';
 import {
   PRELOAD_ENTRIES,
@@ -40,7 +39,6 @@ import {
   STORY_MISSING,
   DOCS_PREPARED,
   SET_CURRENT_STORY,
-  SET_CONFIG,
 } from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
 

--- a/code/lib/manager-api/src/modules/stories.ts
+++ b/code/lib/manager-api/src/modules/stories.ts
@@ -21,6 +21,7 @@ import type {
   API_ViewMode,
   API_StatusState,
   API_StatusUpdate,
+  API_FilterFunction,
 } from '@storybook/types';
 import {
   PRELOAD_ENTRIES,
@@ -39,6 +40,7 @@ import {
   STORY_MISSING,
   DOCS_PREPARED,
   SET_CURRENT_STORY,
+  SET_CONFIG,
 } from '@storybook/core-events';
 import { logger } from '@storybook/client-logger';
 
@@ -53,7 +55,8 @@ import {
   addPreparedStories,
 } from '../lib/stories';
 
-import type { ComposedRef, ModuleFn } from '../index';
+import type { ComposedRef } from '../index';
+import type { ModuleFn } from '../lib/types';
 
 const { FEATURES, fetch } = global;
 const STORY_INDEX_PATH = './index.json';
@@ -278,7 +281,7 @@ function removeRemovedOptions<T extends Record<string, any> = Record<string, any
   return result;
 }
 
-export const init: ModuleFn<SubAPI, SubState, true> = ({
+export const init: ModuleFn<SubAPI, SubState> = ({
   fullAPI,
   store,
   navigate,
@@ -468,7 +471,7 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
     },
     updateStoryArgs: (story, updatedArgs) => {
       const { id: storyId, refId } = story;
-      fullAPI.emit(UPDATE_STORY_ARGS, {
+      provider.channel.emit(UPDATE_STORY_ARGS, {
         storyId,
         updatedArgs,
         options: { target: refId },
@@ -476,7 +479,7 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
     },
     resetStoryArgs: (story, argNames?: [string]) => {
       const { id: storyId, refId } = story;
-      fullAPI.emit(RESET_STORY_ARGS, {
+      provider.channel.emit(RESET_STORY_ARGS, {
         storyId,
         argNames,
         options: { target: refId },
@@ -495,7 +498,7 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
           return;
         }
 
-        await fullAPI.setIndex(storyIndex);
+        await api.setIndex(storyIndex);
       } catch (err) {
         await store.setState({ indexError: err });
       }
@@ -503,7 +506,7 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
     // The story index we receive on SET_INDEX is "prepared" in that it has parameters
     // The story index we receive on fetchStoryIndex is not, but all the prepared fields are optional
     // so we can cast one to the other easily enough
-    setIndex: async (storyIndex: API_PreparedStoryIndex) => {
+    setIndex: async (storyIndex) => {
       const newHash = transformStoryIndexToStoriesHash(storyIndex, {
         provider,
         docsOptions,
@@ -556,7 +559,7 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
         await fullAPI.updateRef(refId, { index });
       }
     },
-    setPreviewInitialized: async (ref?: ComposedRef): Promise<void> => {
+    setPreviewInitialized: async (ref) => {
       if (!ref) {
         store.setState({ previewInitialized: true });
       } else {
@@ -578,178 +581,174 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
     },
   };
 
-  const initModule = async () => {
-    // On initial load, the local iframe will select the first story (or other "selection specifier")
-    // and emit STORY_SPECIFIED with the id. We need to ensure we respond to this change.
-    fullAPI.on(
-      STORY_SPECIFIED,
-      function handler({
-        storyId,
-        viewMode,
-      }: {
-        storyId: string;
-        viewMode: API_ViewMode;
-        [k: string]: any;
-      }) {
-        const { sourceType } = getEventMetadata(this, fullAPI);
-
-        if (sourceType === 'local') {
-          const state = store.getState();
-          const isCanvasRoute =
-            state.path === '/' || state.viewMode === 'story' || state.viewMode === 'docs';
-          const stateHasSelection = state.viewMode && state.storyId;
-          const stateSelectionDifferent = state.viewMode !== viewMode || state.storyId !== storyId;
-          /**
-           * When storybook starts, we want to navigate to the first story.
-           * But there are a few exceptions:
-           * - If the current storyId and viewMode are already set/correct.
-           * - If the user has navigated away already.
-           * - If the user started storybook with a specific page-URL like "/settings/about"
-           */
-          if (isCanvasRoute) {
-            if (stateHasSelection && stateSelectionDifferent) {
-              // The manager state is correct, the preview state is lagging behind
-              fullAPI.emit(SET_CURRENT_STORY, { storyId: state.storyId, viewMode: state.viewMode });
-            } else if (stateSelectionDifferent) {
-              // The preview state is correct, the manager state is lagging behind
-              navigate(`/${viewMode}/${storyId}`);
-            }
-          }
-        }
-      }
-    );
-
-    // The CURRENT_STORY_WAS_SET event is the best event to use to tell if a ref is ready.
-    // Until the ref has a selection, it will not render anything (e.g. while waiting for
-    // the preview.js file or the index to load). Once it has a selection, it will render its own
-    // preparing spinner.
-    fullAPI.on(CURRENT_STORY_WAS_SET, function handler() {
-      const { ref } = getEventMetadata(this, fullAPI);
-      fullAPI.setPreviewInitialized(ref);
-    });
-
-    fullAPI.on(STORY_CHANGED, function handler() {
+  // On initial load, the local iframe will select the first story (or other "selection specifier")
+  // and emit STORY_SPECIFIED with the id. We need to ensure we respond to this change.
+  provider.channel.on(
+    STORY_SPECIFIED,
+    function handler({
+      storyId,
+      viewMode,
+    }: {
+      storyId: string;
+      viewMode: API_ViewMode;
+      [k: string]: any;
+    }) {
       const { sourceType } = getEventMetadata(this, fullAPI);
 
       if (sourceType === 'local') {
-        const options = fullAPI.getCurrentParameter('options');
-
-        if (options) {
-          fullAPI.setOptions(removeRemovedOptions(options));
+        const state = store.getState();
+        const isCanvasRoute =
+          state.path === '/' || state.viewMode === 'story' || state.viewMode === 'docs';
+        const stateHasSelection = state.viewMode && state.storyId;
+        const stateSelectionDifferent = state.viewMode !== viewMode || state.storyId !== storyId;
+        /**
+         * When storybook starts, we want to navigate to the first story.
+         * But there are a few exceptions:
+         * - If the current storyId and viewMode are already set/correct.
+         * - If the user has navigated away already.
+         * - If the user started storybook with a specific page-URL like "/settings/about"
+         */
+        if (isCanvasRoute) {
+          if (stateHasSelection && stateSelectionDifferent) {
+            // The manager state is correct, the preview state is lagging behind
+            provider.channel.emit(SET_CURRENT_STORY, {
+              storyId: state.storyId,
+              viewMode: state.viewMode,
+            });
+          } else if (stateSelectionDifferent) {
+            // The preview state is correct, the manager state is lagging behind
+            navigate(`/${viewMode}/${storyId}`);
+          }
         }
       }
-    });
-
-    fullAPI.on(STORY_PREPARED, function handler({ id, ...update }: StoryPreparedPayload) {
-      const { ref, sourceType } = getEventMetadata(this, fullAPI);
-      fullAPI.updateStory(id, { ...update, prepared: true }, ref);
-
-      if (!ref) {
-        if (!store.getState().hasCalledSetOptions) {
-          const { options } = update.parameters;
-          fullAPI.setOptions(removeRemovedOptions(options));
-          store.setState({ hasCalledSetOptions: true });
-        }
-      }
-
-      if (sourceType === 'local') {
-        const { storyId, index, refId } = store.getState();
-
-        // create a list of related stories to be preloaded
-        const toBePreloaded = Array.from(
-          new Set([
-            api.findSiblingStoryId(storyId, index, 1, true),
-            api.findSiblingStoryId(storyId, index, -1, true),
-          ])
-        ).filter(Boolean);
-
-        fullAPI.emit(PRELOAD_ENTRIES, {
-          ids: toBePreloaded,
-          options: { target: refId },
-        });
-      }
-    });
-
-    fullAPI.on(DOCS_PREPARED, function handler({ id, ...update }: DocsPreparedPayload) {
-      const { ref } = getEventMetadata(this, fullAPI);
-      fullAPI.updateStory(id, { ...update, prepared: true }, ref);
-    });
-
-    fullAPI.on(SET_INDEX, function handler(index: API_PreparedStoryIndex) {
-      const { ref } = getEventMetadata(this, fullAPI);
-
-      if (!ref) {
-        fullAPI.setIndex(index);
-        const options = fullAPI.getCurrentParameter('options');
-        fullAPI.setOptions(removeRemovedOptions(options));
-      } else {
-        fullAPI.setRef(ref.id, { ...ref, storyIndex: index }, true);
-      }
-    });
-
-    // For composition back-compatibilty
-    fullAPI.on(SET_STORIES, function handler(data: SetStoriesPayload) {
-      const { ref } = getEventMetadata(this, fullAPI);
-      const setStoriesData = data.v ? denormalizeStoryParameters(data) : data.stories;
-
-      if (!ref) {
-        throw new Error('Cannot call SET_STORIES for local frame');
-      } else {
-        fullAPI.setRef(ref.id, { ...ref, setStoriesData }, true);
-      }
-    });
-
-    fullAPI.on(
-      SELECT_STORY,
-      function handler({
-        kind,
-        title = kind,
-        story,
-        name = story,
-        storyId,
-        ...rest
-      }: {
-        kind?: StoryKind;
-        title?: ComponentTitle;
-        story?: StoryName;
-        name?: StoryName;
-        storyId: string;
-        viewMode: API_ViewMode;
-      }) {
-        const { ref } = getEventMetadata(this, fullAPI);
-
-        if (!ref) {
-          fullAPI.selectStory(storyId || title, name, rest);
-        } else {
-          fullAPI.selectStory(storyId || title, name, { ...rest, ref: ref.id });
-        }
-      }
-    );
-
-    fullAPI.on(
-      STORY_ARGS_UPDATED,
-      function handleStoryArgsUpdated({ storyId, args }: { storyId: StoryId; args: Args }) {
-        const { ref } = getEventMetadata(this, fullAPI);
-        fullAPI.updateStory(storyId, { args }, ref);
-      }
-    );
-
-    // When there's a preview error, we don't show it in the manager, but simply
-    fullAPI.on(CONFIG_ERROR, function handleConfigError(err) {
-      const { ref } = getEventMetadata(this, fullAPI);
-      fullAPI.setPreviewInitialized(ref);
-    });
-
-    fullAPI.on(STORY_MISSING, function handleConfigError(err) {
-      const { ref } = getEventMetadata(this, fullAPI);
-      fullAPI.setPreviewInitialized(ref);
-    });
-
-    if (FEATURES?.storyStoreV7) {
-      fullAPI.on(STORY_INDEX_INVALIDATED, () => fullAPI.fetchIndex());
-      await fullAPI.fetchIndex();
     }
-  };
+  );
+
+  // The CURRENT_STORY_WAS_SET event is the best event to use to tell if a ref is ready.
+  // Until the ref has a selection, it will not render anything (e.g. while waiting for
+  // the preview.js file or the index to load). Once it has a selection, it will render its own
+  // preparing spinner.
+  provider.channel.on(CURRENT_STORY_WAS_SET, function handler() {
+    const { ref } = getEventMetadata(this, fullAPI);
+    api.setPreviewInitialized(ref);
+  });
+
+  provider.channel.on(STORY_CHANGED, function handler() {
+    const { sourceType } = getEventMetadata(this, fullAPI);
+
+    if (sourceType === 'local') {
+      const options = api.getCurrentParameter('options');
+
+      if (options) {
+        fullAPI.setOptions(removeRemovedOptions(options));
+      }
+    }
+  });
+
+  provider.channel.on(STORY_PREPARED, function handler({ id, ...update }: StoryPreparedPayload) {
+    const { ref, sourceType } = getEventMetadata(this, fullAPI);
+    api.updateStory(id, { ...update, prepared: true }, ref);
+
+    if (!ref) {
+      if (!store.getState().hasCalledSetOptions) {
+        const { options } = update.parameters;
+        fullAPI.setOptions(removeRemovedOptions(options));
+        store.setState({ hasCalledSetOptions: true });
+      }
+    }
+
+    if (sourceType === 'local') {
+      const { storyId, index, refId } = store.getState();
+
+      // create a list of related stories to be preloaded
+      const toBePreloaded = Array.from(
+        new Set([
+          api.findSiblingStoryId(storyId, index, 1, true),
+          api.findSiblingStoryId(storyId, index, -1, true),
+        ])
+      ).filter(Boolean);
+
+      provider.channel.emit(PRELOAD_ENTRIES, {
+        ids: toBePreloaded,
+        options: { target: refId },
+      });
+    }
+  });
+
+  provider.channel.on(DOCS_PREPARED, function handler({ id, ...update }: DocsPreparedPayload) {
+    const { ref } = getEventMetadata(this, fullAPI);
+    api.updateStory(id, { ...update, prepared: true }, ref);
+  });
+
+  provider.channel.on(SET_INDEX, function handler(index: API_PreparedStoryIndex) {
+    const { ref } = getEventMetadata(this, fullAPI);
+
+    if (!ref) {
+      api.setIndex(index);
+      const options = api.getCurrentParameter('options');
+      fullAPI.setOptions(removeRemovedOptions(options));
+    } else {
+      fullAPI.setRef(ref.id, { ...ref, storyIndex: index }, true);
+    }
+  });
+
+  // For composition back-compatibilty
+  provider.channel.on(SET_STORIES, function handler(data: SetStoriesPayload) {
+    const { ref } = getEventMetadata(this, fullAPI);
+    const setStoriesData = data.v ? denormalizeStoryParameters(data) : data.stories;
+
+    if (!ref) {
+      throw new Error('Cannot call SET_STORIES for local frame');
+    } else {
+      fullAPI.setRef(ref.id, { ...ref, setStoriesData }, true);
+    }
+  });
+
+  provider.channel.on(
+    SELECT_STORY,
+    function handler({
+      kind,
+      title = kind,
+      story,
+      name = story,
+      storyId,
+      ...rest
+    }: {
+      kind?: StoryKind;
+      title?: ComponentTitle;
+      story?: StoryName;
+      name?: StoryName;
+      storyId: string;
+      viewMode: API_ViewMode;
+    }) {
+      const { ref } = getEventMetadata(this, fullAPI);
+
+      if (!ref) {
+        fullAPI.selectStory(storyId || title, name, rest);
+      } else {
+        fullAPI.selectStory(storyId || title, name, { ...rest, ref: ref.id });
+      }
+    }
+  );
+
+  provider.channel.on(
+    STORY_ARGS_UPDATED,
+    function handleStoryArgsUpdated({ storyId, args }: { storyId: StoryId; args: Args }) {
+      const { ref } = getEventMetadata(this, fullAPI);
+      api.updateStory(storyId, { args }, ref);
+    }
+  );
+
+  // When there's a preview error, we don't show it in the manager, but simply
+  provider.channel.on(CONFIG_ERROR, function handleConfigError(err) {
+    const { ref } = getEventMetadata(this, fullAPI);
+    api.setPreviewInitialized(ref);
+  });
+
+  provider.channel.on(STORY_MISSING, function handleConfigError(err) {
+    const { ref } = getEventMetadata(this, fullAPI);
+    api.setPreviewInitialized(ref);
+  });
 
   return {
     api,
@@ -760,6 +759,11 @@ export const init: ModuleFn<SubAPI, SubState, true> = ({
       previewInitialized: false,
       status: {},
     },
-    init: initModule,
+    init: async () => {
+      if (FEATURES?.storyStoreV7) {
+        provider.channel.on(STORY_INDEX_INVALIDATED, () => api.fetchIndex());
+        await api.fetchIndex();
+      }
+    },
   };
 };

--- a/code/lib/manager-api/src/modules/url.ts
+++ b/code/lib/manager-api/src/modules/url.ts
@@ -11,7 +11,7 @@ import { dequal as deepEqual } from 'dequal';
 import { global } from '@storybook/global';
 
 import type { API_Layout, API_UI } from '@storybook/types';
-import type { ModuleArgs, ModuleFn } from '../index';
+import type { ModuleArgs, ModuleFn } from '../lib/types';
 
 const { window: globalWindow } = global;
 
@@ -116,7 +116,9 @@ export interface SubAPI {
   setQueryParams: (input: QueryParams) => void;
 }
 
-export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...rest }) => {
+export const init: ModuleFn<SubAPI, SubState> = (moduleArgs) => {
+  const { store, navigate, provider, fullAPI } = moduleArgs;
+
   const navigateTo = (
     path: string,
     queryParams: Record<string, string> = {},
@@ -153,7 +155,7 @@ export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...r
       };
       if (!deepEqual(customQueryParams, update)) {
         store.setState({ customQueryParams: update });
-        fullAPI.emit(UPDATE_QUERY_PARAMS, update);
+        provider.channel.emit(UPDATE_QUERY_PARAMS, update);
       }
     },
     navigateUrl(url, options) {
@@ -161,49 +163,48 @@ export const init: ModuleFn = ({ store, navigate, state, provider, fullAPI, ...r
     },
   };
 
-  const initModule = () => {
-    // Sets `args` parameter in URL, omitting any args that have their initial value or cannot be unserialized safely.
-    const updateArgsParam = () => {
-      const { path, queryParams, viewMode } = fullAPI.getUrlState();
-      if (viewMode !== 'story') return;
+  /**
+   * Sets `args` parameter in URL, omitting any args that have their initial value or cannot be unserialized safely.
+   */
+  const updateArgsParam = () => {
+    const { path, queryParams, viewMode } = api.getUrlState();
+    if (viewMode !== 'story') return;
 
-      const currentStory = fullAPI.getCurrentStoryData();
-      if (currentStory?.type !== 'story') return;
+    const currentStory = fullAPI.getCurrentStoryData();
+    if (currentStory?.type !== 'story') return;
 
-      const { args, initialArgs } = currentStory;
-      const argsString = buildArgsParam(initialArgs, args);
-      navigateTo(path, { ...queryParams, args: argsString }, { replace: true });
-      api.setQueryParams({ args: argsString });
-    };
-
-    fullAPI.on(SET_CURRENT_STORY, () => updateArgsParam());
-
-    let handleOrId: any;
-    fullAPI.on(STORY_ARGS_UPDATED, () => {
-      if ('requestIdleCallback' in globalWindow) {
-        if (handleOrId) globalWindow.cancelIdleCallback(handleOrId);
-        handleOrId = globalWindow.requestIdleCallback(updateArgsParam, { timeout: 1000 });
-      } else {
-        if (handleOrId) clearTimeout(handleOrId);
-        setTimeout(updateArgsParam, 100);
-      }
-    });
-
-    fullAPI.on(GLOBALS_UPDATED, ({ globals, initialGlobals }) => {
-      const { path, queryParams } = fullAPI.getUrlState();
-      const globalsString = buildArgsParam(initialGlobals, globals);
-      navigateTo(path, { ...queryParams, globals: globalsString }, { replace: true });
-      api.setQueryParams({ globals: globalsString });
-    });
-
-    fullAPI.on(NAVIGATE_URL, (url: string, options: NavigateOptions) => {
-      fullAPI.navigateUrl(url, options);
-    });
+    const { args, initialArgs } = currentStory;
+    const argsString = buildArgsParam(initialArgs, args);
+    navigateTo(path, { ...queryParams, args: argsString }, { replace: true });
+    api.setQueryParams({ args: argsString });
   };
+
+  provider.channel.on(SET_CURRENT_STORY, () => updateArgsParam());
+
+  let handleOrId: any;
+  provider.channel.on(STORY_ARGS_UPDATED, () => {
+    if ('requestIdleCallback' in globalWindow) {
+      if (handleOrId) globalWindow.cancelIdleCallback(handleOrId);
+      handleOrId = globalWindow.requestIdleCallback(updateArgsParam, { timeout: 1000 });
+    } else {
+      if (handleOrId) clearTimeout(handleOrId);
+      setTimeout(updateArgsParam, 100);
+    }
+  });
+
+  provider.channel.on(GLOBALS_UPDATED, ({ globals, initialGlobals }) => {
+    const { path, queryParams } = api.getUrlState();
+    const globalsString = buildArgsParam(initialGlobals, globals);
+    navigateTo(path, { ...queryParams, globals: globalsString }, { replace: true });
+    api.setQueryParams({ globals: globalsString });
+  });
+
+  provider.channel.on(NAVIGATE_URL, (url: string, options: NavigateOptions) => {
+    api.navigateUrl(url, options);
+  });
 
   return {
     api,
-    state: initialUrlSupport({ store, navigate, state, provider, fullAPI, ...rest }),
-    init: initModule,
+    state: initialUrlSupport(moduleArgs),
   };
 };

--- a/code/lib/manager-api/src/modules/versions.ts
+++ b/code/lib/manager-api/src/modules/versions.ts
@@ -5,7 +5,7 @@ import memoize from 'memoizerific';
 import type { API_UnknownEntries, API_Version, API_Versions } from '@storybook/types';
 import { version as currentVersion } from '../version';
 
-import type { ModuleFn } from '../index';
+import type { ModuleFn } from '../lib/types';
 
 const { VERSIONCHECK } = global;
 

--- a/code/lib/manager-api/src/tests/mockStoriesEntries.ts
+++ b/code/lib/manager-api/src/tests/mockStoriesEntries.ts
@@ -1,0 +1,129 @@
+import type { StoryIndex, API_PreparedStoryIndex } from '@storybook/types';
+
+export const mockEntries: StoryIndex['entries'] = {
+  'component-a--docs': {
+    type: 'docs',
+    id: 'component-a--docs',
+    title: 'Component A',
+    name: 'Docs',
+    importPath: './path/to/component-a.ts',
+    storiesImports: [],
+  },
+  'component-a--story-1': {
+    type: 'story',
+    id: 'component-a--story-1',
+    title: 'Component A',
+    name: 'Story 1',
+    importPath: './path/to/component-a.ts',
+  },
+  'component-a--story-2': {
+    type: 'story',
+    id: 'component-a--story-2',
+    title: 'Component A',
+    name: 'Story 2',
+    importPath: './path/to/component-a.ts',
+  },
+  'component-b--story-3': {
+    type: 'story',
+    id: 'component-b--story-3',
+    title: 'Component B',
+    name: 'Story 3',
+    importPath: './path/to/component-b.ts',
+  },
+};
+export const docsEntries: StoryIndex['entries'] = {
+  'component-a--page': {
+    type: 'story',
+    id: 'component-a--page',
+    title: 'Component A',
+    name: 'Page',
+    importPath: './path/to/component-a.ts',
+  },
+  'component-a--story-2': {
+    type: 'story',
+    id: 'component-a--story-2',
+    title: 'Component A',
+    name: 'Story 2',
+    importPath: './path/to/component-a.ts',
+  },
+  'component-b-docs': {
+    type: 'docs',
+    id: 'component-b--docs',
+    title: 'Component B',
+    name: 'Docs',
+    importPath: './path/to/component-b.ts',
+    storiesImports: [],
+    tags: ['stories-mdx'],
+  },
+  'component-c--story-4': {
+    type: 'story',
+    id: 'component-c--story-4',
+    title: 'Component c',
+    name: 'Story 4',
+    importPath: './path/to/component-c.ts',
+  },
+};
+export const navigationEntries: StoryIndex['entries'] = {
+  'a--1': {
+    type: 'story',
+    title: 'a',
+    name: '1',
+    id: 'a--1',
+    importPath: './a.ts',
+  },
+  'a--2': {
+    type: 'story',
+    title: 'a',
+    name: '2',
+    id: 'a--2',
+    importPath: './a.ts',
+  },
+  'b-c--1': {
+    type: 'story',
+    title: 'b/c',
+    name: '1',
+    id: 'b-c--1',
+    importPath: './b/c.ts',
+  },
+  'b-d--1': {
+    type: 'story',
+    title: 'b/d',
+    name: '1',
+    id: 'b-d--1',
+    importPath: './b/d.ts',
+  },
+  'b-d--2': {
+    type: 'story',
+    title: 'b/d',
+    name: '2',
+    id: 'b-d--2',
+    importPath: './b/d.ts',
+  },
+  'custom-id--1': {
+    type: 'story',
+    title: 'b/e',
+    name: '1',
+    id: 'custom-id--1',
+    importPath: './b/.ts',
+  },
+};
+export const preparedEntries: API_PreparedStoryIndex['entries'] = {
+  'a--1': {
+    type: 'story',
+    title: 'a',
+    name: '1',
+    parameters: {},
+    id: 'a--1',
+    args: { a: 'b' },
+    importPath: './a.ts',
+  },
+  'b--1': {
+    type: 'story',
+    title: 'b',
+    name: '1',
+    parameters: {},
+    id: 'b--1',
+    args: { x: 'y' },
+    importPath: './b.ts',
+  },
+};

--- a/code/lib/manager-api/src/tests/stories.test.ts
+++ b/code/lib/manager-api/src/tests/stories.test.ts
@@ -16,28 +16,28 @@ import {
 import { EventEmitter } from 'events';
 import { global } from '@storybook/global';
 
-import { Channel } from '@storybook/channels';
+import type { API_IndexHash, API_StoryEntry } from '@storybook/types';
+import { getEventMetadata as getEventMetadataOriginal } from '../lib/events';
 
-import type { API_StoryEntry, StoryIndex, API_PreparedStoryIndex } from '@storybook/types';
-import { getEventMetadata } from '../lib/events';
-
-import type { SubAPI } from '../modules/stories';
 import { init as initStories } from '../modules/stories';
 import type Store from '../store';
-import type { ModuleArgs } from '..';
+import type { API, State } from '..';
+import { mockEntries, docsEntries, preparedEntries, navigationEntries } from './mockStoriesEntries';
+import type { ModuleArgs } from '../lib/types';
 
-function mockChannel() {
-  const transport = {
-    setHandler: () => {},
-    send: () => {},
-  };
-
-  return new Channel({ transport });
-}
+import { getAncestorIds } from '../../../../ui/manager/src/utils/tree';
 
 const mockGetEntries = jest.fn();
+const fetch = global.fetch as jest.Mock<ReturnType<typeof global.fetch>>;
+const getEventMetadata = getEventMetadataOriginal as unknown as jest.Mock<
+  ReturnType<typeof getEventMetadataOriginal>
+>;
 
-jest.mock('../lib/events');
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+jest.mock('../lib/events', () => ({
+  getEventMetadata: jest.fn(() => ({ sourceType: 'local' })),
+}));
 jest.mock('@storybook/global', () => ({
   global: {
     ...globalThis,
@@ -47,41 +47,7 @@ jest.mock('@storybook/global', () => ({
   },
 }));
 
-const getEventMetadataMock = getEventMetadata as ReturnType<typeof jest.fn>;
-
-const mockEntries: StoryIndex['entries'] = {
-  'component-a--docs': {
-    type: 'docs',
-    id: 'component-a--docs',
-    title: 'Component A',
-    name: 'Docs',
-    importPath: './path/to/component-a.ts',
-    storiesImports: [],
-  },
-  'component-a--story-1': {
-    type: 'story',
-    id: 'component-a--story-1',
-    title: 'Component A',
-    name: 'Story 1',
-    importPath: './path/to/component-a.ts',
-  },
-  'component-a--story-2': {
-    type: 'story',
-    id: 'component-a--story-2',
-    title: 'Component A',
-    name: 'Story 2',
-    importPath: './path/to/component-a.ts',
-  },
-  'component-b--story-3': {
-    type: 'story',
-    id: 'component-b--story-3',
-    title: 'Component B',
-    name: 'Story 3',
-    importPath: './path/to/component-b.ts',
-  },
-};
-
-function createMockStore(initialState = {}) {
+function createMockStore(initialState: Partial<State> = {}) {
   let state = initialState;
   return {
     getState: jest.fn(() => state),
@@ -91,40 +57,34 @@ function createMockStore(initialState = {}) {
     }),
   } as any as Store;
 }
-
-function initStoriesAndSetState({ store, ...options }: any) {
-  const { state, ...result } = initStories({ store, ...options } as any);
-
-  store?.setState(state);
-
-  return { state, ...result };
+function createMockProvider() {
+  return {
+    getConfig: jest.fn().mockReturnValue({}),
+    channel: new EventEmitter(),
+  };
 }
+function createMockModuleArgs({
+  fullAPI = {},
+  initialState = {},
+}: {
+  fullAPI?: Partial<jest.Mocked<API>>;
+  initialState?: Partial<State>;
+}) {
+  const navigate = jest.fn();
+  const store = createMockStore(initialState);
+  const provider = createMockProvider();
 
-const provider = { getConfig: jest.fn().mockReturnValue({}), serverChannel: mockChannel() };
-
-beforeEach(() => {
-  provider.getConfig.mockReset().mockReturnValue({});
-  provider.serverChannel = mockChannel();
-  mockGetEntries.mockReset().mockReturnValue(mockEntries);
-
-  (global.fetch as jest.Mock<ReturnType<typeof global.fetch>>).mockReset().mockReturnValue(
-    Promise.resolve({
-      status: 200,
-      ok: true,
-      json: () => ({ v: 4, entries: mockGetEntries() }),
-    } as any as Response)
-  );
-
-  getEventMetadataMock.mockReturnValue({ sourceType: 'local' } as any);
-  getEventMetadataMock.mockReturnValue({ sourceType: 'local' } as any);
-});
+  return { navigate, store, provider, fullAPI };
+}
 
 describe('stories API', () => {
   it('sets a sensible initialState', () => {
-    const { state } = initStoriesAndSetState({
+    const moduleArgs = createMockModuleArgs({});
+    const { state } = initStories({
+      ...(moduleArgs as unknown as ModuleArgs),
       storyId: 'id',
       viewMode: 'story',
-    } as ModuleArgs);
+    });
 
     expect(state).toEqual(
       expect.objectContaining({
@@ -138,16 +98,11 @@ describe('stories API', () => {
 
   describe('setIndex', () => {
     it('sets the initial set of stories in the stories hash', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter());
-
-      const { api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
-
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
       api.setIndex({ v: 4, entries: mockEntries });
       const { index } = store.getState();
-
       // We need exact key ordering, even if in theory JS doesn't guarantee it
       expect(Object.keys(index)).toEqual([
         'component-a',
@@ -162,7 +117,6 @@ describe('stories API', () => {
         id: 'component-a',
         children: ['component-a--docs', 'component-a--story-1', 'component-a--story-2'],
       });
-
       expect(index['component-a--docs']).toMatchObject({
         type: 'docs',
         id: 'component-a--docs',
@@ -172,7 +126,6 @@ describe('stories API', () => {
         storiesImports: [],
         prepared: false,
       });
-
       expect(index['component-a--story-1']).toMatchObject({
         type: 'story',
         id: 'component-a--story-1',
@@ -185,15 +138,10 @@ describe('stories API', () => {
         (index['component-a--story-1'] as API_StoryEntry as API_StoryEntry).args
       ).toBeUndefined();
     });
-
     it('trims whitespace of group/component names (which originate from the kind)', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter());
-
-      const { api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
-
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
       api.setIndex({
         v: 4,
         entries: {
@@ -207,7 +155,6 @@ describe('stories API', () => {
         },
       });
       const { index } = store.getState();
-
       // We need exact key ordering, even if in theory JS doesn't guarantee it
       expect(Object.keys(index)).toEqual([
         'design-system',
@@ -228,15 +175,10 @@ describe('stories API', () => {
         name: '  My Story  ', // story name is kept as-is, because it's set directly on the story
       });
     });
-
     it('moves rootless stories to the front of the list', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter());
-
-      const { api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
-
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
       api.setIndex({
         v: 4,
         entries: {
@@ -251,7 +193,6 @@ describe('stories API', () => {
         },
       });
       const { index } = store.getState();
-
       // We need exact key ordering, even if in theory JS doesn't guarantee it
       expect(Object.keys(index)).toEqual([
         'component-a',
@@ -270,15 +211,10 @@ describe('stories API', () => {
         children: ['root-first'],
       });
     });
-
     it('sets roots when showRoots = true', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter());
-
-      const { api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
-
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store, provider } = moduleArgs;
       provider.getConfig.mockReturnValue({ sidebar: { showRoots: true } });
       api.setIndex({
         v: 4,
@@ -292,9 +228,7 @@ describe('stories API', () => {
           },
         },
       });
-
       const { index } = store.getState();
-
       // We need exact key ordering, even if in theory JS doens't guarantee it
       expect(Object.keys(index)).toEqual(['a', 'a-b', 'a-b--1']);
       expect(index.a).toMatchObject({
@@ -316,15 +250,10 @@ describe('stories API', () => {
         title: 'a/b',
       });
     });
-
     it('does not put bare stories into a root when showRoots = true', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter());
-
-      const { api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
-
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store, provider } = moduleArgs;
       provider.getConfig.mockReturnValue({ sidebar: { showRoots: true } });
       api.setIndex({
         v: 4,
@@ -338,9 +267,7 @@ describe('stories API', () => {
           },
         },
       });
-
       const { index } = store.getState();
-
       // We need exact key ordering, even if in theory JS doens't guarantee it
       expect(Object.keys(index)).toEqual(['a', 'a--1']);
       expect(index.a).toMatchObject({
@@ -356,17 +283,12 @@ describe('stories API', () => {
         name: '1',
       });
     });
-
     // Stories can get out of order for a few reasons -- see reproductions on
     //   https://github.com/storybookjs/storybook/issues/5518
     it('does the right thing for out of order stories', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter());
-
-      const { api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
-
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store, provider } = moduleArgs;
       provider.getConfig.mockReturnValue({ sidebar: { showRoots: true } });
       api.setIndex({
         v: 4,
@@ -376,9 +298,7 @@ describe('stories API', () => {
           'a--2': { type: 'story', title: 'a', name: '2', id: 'a--2', importPath: './a.ts' },
         },
       });
-
       const { index } = store.getState();
-
       // We need exact key ordering, even if in theory JS doens't guarantee it
       expect(Object.keys(index)).toEqual(['a', 'a--1', 'a--2', 'b', 'b--1']);
       expect(index.a).toMatchObject({
@@ -386,23 +306,17 @@ describe('stories API', () => {
         id: 'a',
         children: ['a--1', 'a--2'],
       });
-
       expect(index.b).toMatchObject({
         type: 'component',
         id: 'b',
         children: ['b--1'],
       });
     });
-
     // Entries on the SET_STORIES event will be prepared
     it('handles properly prepared stories', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter(), {});
-
-      const { api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
-
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
       api.setIndex({
         v: 4,
         entries: {
@@ -417,9 +331,7 @@ describe('stories API', () => {
           },
         },
       });
-
       const { index } = store.getState();
-
       expect(index['prepared--story']).toMatchObject({
         type: 'story',
         id: 'prepared--story',
@@ -431,21 +343,13 @@ describe('stories API', () => {
         args: { arg: 'exists' },
       });
     });
-
     it('retains prepared-ness of stories', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        setOptions: jest.fn(),
-      });
-
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
-      init();
-
+      const fullAPI = { setOptions: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store, provider } = moduleArgs;
       api.setIndex({ v: 4, entries: mockEntries });
-
-      fullAPI.emit(STORY_PREPARED, {
+      provider.channel.emit(STORY_PREPARED, {
         id: 'component-a--story-1',
         parameters: { a: 'b' },
         args: { c: 'd' },
@@ -457,9 +361,7 @@ describe('stories API', () => {
         parameters: { a: 'b' },
         args: { c: 'd' },
       });
-
       api.setIndex({ v: 4, entries: mockEntries });
-
       // Let the promise/await chain resolve
       await new Promise((r) => setTimeout(r, 0));
       expect(store.getState().index['component-a--story-1'] as API_StoryEntry).toMatchObject({
@@ -470,51 +372,13 @@ describe('stories API', () => {
     });
 
     describe('docs entries', () => {
-      const docsEntries: StoryIndex['entries'] = {
-        'component-a--page': {
-          type: 'story',
-          id: 'component-a--page',
-          title: 'Component A',
-          name: 'Page',
-          importPath: './path/to/component-a.ts',
-        },
-        'component-a--story-2': {
-          type: 'story',
-          id: 'component-a--story-2',
-          title: 'Component A',
-          name: 'Story 2',
-          importPath: './path/to/component-a.ts',
-        },
-        'component-b-docs': {
-          type: 'docs',
-          id: 'component-b--docs',
-          title: 'Component B',
-          name: 'Docs',
-          importPath: './path/to/component-b.ts',
-          storiesImports: [],
-          tags: ['stories-mdx'],
-        },
-        'component-c--story-4': {
-          type: 'story',
-          id: 'component-c--story-4',
-          title: 'Component c',
-          name: 'Story 4',
-          importPath: './path/to/component-c.ts',
-        },
-      };
-
       it('handles docs entries', async () => {
-        const navigate = jest.fn();
-        const store = createMockStore();
-        const fullAPI = Object.assign(new EventEmitter());
-
-        const { api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-        Object.assign(fullAPI, api);
+        const moduleArgs = createMockModuleArgs({});
+        const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+        const { store } = moduleArgs;
 
         api.setIndex({ v: 4, entries: docsEntries });
-
         const { index } = store.getState();
-
         // We need exact key ordering, even if in theory JS doesn't guarantee it
         expect(Object.keys(index)).toEqual([
           'component-a',
@@ -530,26 +394,16 @@ describe('stories API', () => {
         expect(index['component-b--docs'].type).toBe('docs');
         expect(index['component-c--story-4'].type).toBe('story');
       });
-
       describe('when DOCS_MODE = true', () => {
         it('strips out story entries', async () => {
-          const navigate = jest.fn();
-          const store = createMockStore();
-          const fullAPI = Object.assign(new EventEmitter());
-
-          const { api } = initStoriesAndSetState({
-            store,
-            navigate,
-            provider,
-            fullAPI,
+          const moduleArgs = createMockModuleArgs({});
+          const { api } = initStories({
+            ...(moduleArgs as unknown as ModuleArgs),
             docsOptions: { docsMode: true },
-          } as any);
-          Object.assign(fullAPI, api);
-
+          });
+          const { store } = moduleArgs;
           api.setIndex({ v: 4, entries: docsEntries });
-
           const { index } = store.getState();
-
           expect(Object.keys(index)).toEqual(['component-b', 'component-b--docs']);
         });
       });
@@ -558,269 +412,197 @@ describe('stories API', () => {
 
   describe('SET_INDEX event', () => {
     it('calls setIndex w/ the data', () => {
-      const fullAPI = Object.assign(new EventEmitter());
-      const navigate = jest.fn();
-      const store = createMockStore();
+      const fullAPI = { setOptions: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { store, provider } = moduleArgs;
 
-      const { init, api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api, {
-        setIndex: jest.fn(),
-        setOptions: jest.fn(),
-      });
-      init();
-
-      fullAPI.emit(SET_INDEX, { v: 4, entries: mockEntries });
-
-      expect(fullAPI.setIndex).toHaveBeenCalled();
+      provider.channel.emit(SET_INDEX, { v: 4, entries: mockEntries });
+      expect(store.getState().index).toEqual(
+        expect.objectContaining({
+          'component-a': expect.any(Object),
+          'component-a--docs': expect.any(Object),
+          'component-a--story-1': expect.any(Object),
+        })
+      );
     });
-
     it('calls setOptions w/ first story parameter', () => {
-      const fullAPI = Object.assign(new EventEmitter());
-      const navigate = jest.fn();
-      const store = createMockStore();
+      const fullAPI = { setOptions: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider } = moduleArgs;
 
-      const { init, api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api, {
-        setIndex: jest.fn(),
-        setOptions: jest.fn(),
+      // HACK api to effectively mock getCurrentParameter
+      Object.assign(api, {
         getCurrentParameter: jest.fn().mockReturnValue('options'),
       });
-      init();
 
-      fullAPI.emit(SET_INDEX, { v: 4, entries: mockEntries });
-
+      provider.channel.emit(SET_INDEX, { v: 4, entries: mockEntries });
       expect(fullAPI.setOptions).toHaveBeenCalledWith('options');
     });
   });
 
   describe('fetchIndex', () => {
     it('deals with 500 errors', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore({});
-      const fullAPI = Object.assign(new EventEmitter(), {}, {});
-
-      (global.fetch as jest.Mock<ReturnType<typeof global.fetch>>).mockReturnValue(
+      fetch.mockReturnValue(
         Promise.resolve({
           status: 500,
           text: async () => new Error('sorting error'),
         } as any as Response)
       );
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
+      const moduleArgs = createMockModuleArgs({});
+      const { init } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
 
       await init();
 
       const { indexError } = store.getState();
       expect(indexError).toBeDefined();
     });
-
     it('watches for the INVALIDATE event and re-fetches -- and resets the hash', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        setIndex: jest.fn(),
-      });
+      fetch.mockReturnValue(
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          json: () => ({
+            v: 4,
+            entries: {
+              'component-a--story-1': {
+                type: 'story',
+                id: 'component-a--story-1',
+                title: 'Component A',
+                name: 'Story 1',
+                importPath: './path/to/component-a.ts',
+              },
+            },
+          }),
+        } as any as Response)
+      );
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
+      const moduleArgs = createMockModuleArgs({});
+      const { init } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store, provider } = moduleArgs;
 
-      (global.fetch as jest.Mock<ReturnType<typeof global.fetch>>).mockClear();
       await init();
-      expect(global.fetch as jest.Mock<ReturnType<typeof global.fetch>>).toHaveBeenCalledTimes(1);
 
-      (global.fetch as jest.Mock<ReturnType<typeof global.fetch>>).mockClear();
-      mockGetEntries.mockReturnValueOnce({
-        'component-a--story-1': {
-          type: 'story',
-          id: 'component-a--story-1',
-          title: 'Component A',
-          name: 'Story 1',
-          importPath: './path/to/component-a.ts',
-        },
-      });
-      fullAPI.emit(STORY_INDEX_INVALIDATED);
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      provider.channel.emit(STORY_INDEX_INVALIDATED);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
 
-      // Let the promise/await chain resolve
-      await new Promise((r) => setTimeout(r, 0));
+      // this side-effect is in an un-awaited promise.
+      await wait(16);
+
       const { index } = store.getState();
-
       expect(Object.keys(index)).toEqual(['component-a', 'component-a--story-1']);
     });
-
     it('clears 500 errors when invalidated', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        setIndex: jest.fn(),
-      });
-
-      (global.fetch as jest.Mock<ReturnType<typeof global.fetch>>).mockReturnValueOnce(
+      fetch.mockReturnValueOnce(
         Promise.resolve({
           status: 500,
           text: async () => new Error('sorting error'),
         } as any as Response)
       );
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
+      const moduleArgs = createMockModuleArgs({});
+      const { init } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store, provider } = moduleArgs;
 
       await init();
 
       const { indexError } = store.getState();
       expect(indexError).toBeDefined();
 
-      (global.fetch as jest.Mock<ReturnType<typeof global.fetch>>).mockClear();
-      mockGetEntries.mockReturnValueOnce({
-        'component-a--story-1': {
-          type: 'story',
-          id: 'component-a--story-1',
-          title: 'Component A',
-          name: 'Story 1',
-          importPath: './path/to/component-a.ts',
-        },
-      });
-      fullAPI.emit(STORY_INDEX_INVALIDATED);
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      fetch.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          json: () => ({
+            v: 4,
+            entries: {
+              'component-a--story-1': {
+                type: 'story',
+                id: 'component-a--story-1',
+                title: 'Component A',
+                name: 'Story 1',
+                importPath: './path/to/component-a.ts',
+              },
+            },
+          }),
+        } as any as Response)
+      );
 
-      // Let the promise/await chain resolve
-      await new Promise((r) => setTimeout(r, 0));
+      provider.channel.emit(STORY_INDEX_INVALIDATED);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      // this side-effect is in an un-awaited promise.
+      await wait(16);
+
       const { index, indexError: newIndexError } = store.getState();
       expect(newIndexError).not.toBeDefined();
-
       expect(Object.keys(index)).toEqual(['component-a', 'component-a--story-1']);
     });
   });
 
   describe('STORY_SPECIFIED event', () => {
     it('navigates to the story', async () => {
-      const navigate = jest.fn();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        isSettingsScreenActive() {
-          return false;
-        },
-      });
-      const store = createMockStore({ viewMode: 'story' });
-      const { init, api } = initStoriesAndSetState({
-        store,
-        navigate,
-        provider,
-        fullAPI,
-        viewMode: 'story',
-      } as any);
+      const moduleArgs = createMockModuleArgs({ initialState: { path: '/' } });
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate, provider } = moduleArgs;
 
-      Object.assign(fullAPI, api);
-      init();
-      fullAPI.emit(STORY_SPECIFIED, { storyId: 'a--1', viewMode: 'story' });
-
+      provider.channel.emit(STORY_SPECIFIED, { storyId: 'a--1', viewMode: 'story' });
       expect(navigate).toHaveBeenCalledWith('/story/a--1');
     });
-
     it('DOES not navigate if the story was already selected', async () => {
-      const navigate = jest.fn();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        isSettingsScreenActive() {
-          return true;
-        },
-      });
-      const store = createMockStore({ viewMode: 'story', storyId: 'a--1' });
-      const { api, init } = initStoriesAndSetState({
-        store,
-        navigate,
-        provider,
-        fullAPI,
-        viewMode: 'story',
-        storyId: 'a--1',
-      } as any);
-      Object.assign(fullAPI, api);
-      init();
+      const moduleArgs = createMockModuleArgs({ initialState: { path: '/story/a--1' } });
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate, provider } = moduleArgs;
 
-      fullAPI.emit(STORY_SPECIFIED, { storyId: 'a--1', viewMode: 'story' });
-
+      provider.channel.emit(STORY_SPECIFIED, { storyId: 'a--1', viewMode: 'story' });
       expect(navigate).not.toHaveBeenCalled();
     });
-
     it('DOES not navigate if a settings page was selected', async () => {
-      const navigate = jest.fn();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        isSettingsScreenActive() {
-          return true;
-        },
-      });
-      const store = createMockStore({ viewMode: 'settings', storyId: 'about' });
-      const { api, init } = initStoriesAndSetState({
-        store,
-        navigate,
-        provider,
-        fullAPI,
-        viewMode: 'settings',
-        storyId: 'about',
-      } as any);
-      Object.assign(fullAPI, api);
-      init();
+      const moduleArgs = createMockModuleArgs({ initialState: { path: '/settings/about' } });
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate, provider } = moduleArgs;
 
-      fullAPI.emit(STORY_SPECIFIED, { storyId: 'a--1', viewMode: 'story' });
-
+      provider.channel.emit(STORY_SPECIFIED, { storyId: 'a--1', viewMode: 'story' });
       expect(navigate).not.toHaveBeenCalled();
     });
-
     it('DOES not navigate if a custom page was selected', async () => {
-      const navigate = jest.fn();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        isSettingsScreenActive() {
-          return true;
-        },
-      });
-      const store = createMockStore({ viewMode: 'custom', storyId: undefined });
-      const { api, init } = initStoriesAndSetState({
-        store,
-        navigate,
-        provider,
-        fullAPI,
-        viewMode: 'custom',
-        storyId: undefined,
-      } as any);
-      Object.assign(fullAPI, api);
-      init();
+      const moduleArgs = createMockModuleArgs({ initialState: { path: '/custom/page' } });
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate, provider } = moduleArgs;
 
-      fullAPI.emit(STORY_SPECIFIED, { storyId: 'a--1', viewMode: 'story' });
-
+      provider.channel.emit(STORY_SPECIFIED, { storyId: 'a--1', viewMode: 'story' });
       expect(navigate).not.toHaveBeenCalled();
     });
   });
 
   describe('CURRENT_STORY_WAS_SET event', () => {
     it('sets previewInitialized', async () => {
-      const navigate = jest.fn();
-      const fullAPI = Object.assign(new EventEmitter(), {});
-      const store = createMockStore({});
-      const { init, api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-
-      Object.assign(fullAPI, api);
-      await init();
-      fullAPI.emit(CURRENT_STORY_WAS_SET, { id: 'a--1' });
+      const moduleArgs = createMockModuleArgs({});
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { store, provider } = moduleArgs;
+      provider.channel.emit(CURRENT_STORY_WAS_SET, { id: 'a--1' });
 
       expect(store.getState().previewInitialized).toBe(true);
     });
-
     it('sets a ref to previewInitialized', async () => {
-      const navigate = jest.fn();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        updateRef: jest.fn(),
-      });
-      const store = createMockStore();
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
+      const fullAPI = { updateRef: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider } = moduleArgs;
+      provider.channel.emit(CURRENT_STORY_WAS_SET, { id: 'a--1' });
 
-      Object.assign(fullAPI, api);
-
-      getEventMetadataMock.mockReturnValueOnce({
+      getEventMetadata.mockReturnValueOnce({
         sourceType: 'external',
-        ref: { id: 'refId', index: { 'a--1': { args: { a: 'b' } } } },
-      } as any);
-      await init();
-      fullAPI.emit(CURRENT_STORY_WAS_SET, { id: 'a--1' });
-
+        refId: 'refId',
+        source: '',
+        sourceLocation: '',
+        type: '',
+        ref: { id: 'refId', index: { 'a--1': { args: { a: 'b' } } } } as any,
+      });
+      provider.channel.emit(CURRENT_STORY_WAS_SET, { id: 'a--1' });
       expect(fullAPI.updateRef.mock.calls.length).toBe(1);
-
       expect(fullAPI.updateRef.mock.calls[0][1]).toEqual({
         previewInitialized: true,
       });
@@ -828,88 +610,53 @@ describe('stories API', () => {
   });
 
   describe('args handling', () => {
-    const parameters = {};
-    const preparedEntries: API_PreparedStoryIndex['entries'] = {
-      'a--1': {
-        type: 'story',
-        title: 'a',
-        name: '1',
-        parameters,
-        id: 'a--1',
-        args: { a: 'b' },
-        importPath: './a.ts',
-      },
-      'b--1': {
-        type: 'story',
-        title: 'b',
-        name: '1',
-        parameters,
-        id: 'b--1',
-        args: { x: 'y' },
-        importPath: './b.ts',
-      },
-    };
-
     it('changes args properly, per story when receiving STORY_ARGS_UPDATED', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        updateRef: jest.fn(),
-      });
+      const fullAPI = { updateRef: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider, store } = moduleArgs;
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-
-      const { setIndex } = Object.assign(fullAPI, api);
-      setIndex({ v: 4, entries: preparedEntries });
-
+      api.setIndex({ v: 4, entries: preparedEntries });
       const { index } = store.getState();
       expect((index['a--1'] as API_StoryEntry).args).toEqual({ a: 'b' });
       expect((index['b--1'] as API_StoryEntry).args).toEqual({ x: 'y' });
-
-      init();
-      fullAPI.emit(STORY_ARGS_UPDATED, { storyId: 'a--1', args: { foo: 'bar' } });
-
+      provider.channel.emit(STORY_ARGS_UPDATED, { storyId: 'a--1', args: { foo: 'bar' } });
       const { index: changedIndex } = store.getState();
       expect((changedIndex['a--1'] as API_StoryEntry).args).toEqual({ foo: 'bar' });
       expect((changedIndex['b--1'] as API_StoryEntry).args).toEqual({ x: 'y' });
     });
-
     it('changes reffed args properly, per story when receiving STORY_ARGS_UPDATED', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = new EventEmitter();
+      const fullAPI = { updateRef: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider } = moduleArgs;
 
-      const { init, api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api, {
-        updateRef: jest.fn(),
-      });
-
-      init();
-      getEventMetadataMock.mockReturnValueOnce({
+      getEventMetadata.mockReturnValueOnce({
         sourceType: 'external',
-        ref: { id: 'refId', index: { 'a--1': { args: { a: 'b' } } } },
-      } as any);
-      fullAPI.emit(STORY_ARGS_UPDATED, { storyId: 'a--1', args: { foo: 'bar' } });
-      expect((fullAPI as any).updateRef).toHaveBeenCalledWith('refId', {
+        refId: 'refId',
+        source: '',
+        sourceLocation: '',
+        type: '',
+        ref: { id: 'refId', index: { 'a--1': { args: { a: 'b' } } } } as any,
+      });
+      provider.channel.emit(STORY_ARGS_UPDATED, { storyId: 'a--1', args: { foo: 'bar' } });
+      expect(fullAPI.updateRef).toHaveBeenCalledWith('refId', {
         index: { 'a--1': { args: { foo: 'bar' } } },
       });
     });
-
     it('updateStoryArgs emits UPDATE_STORY_ARGS to the local frame and does not change anything', () => {
-      const navigate = jest.fn();
-      const emit = jest.fn();
-      const on = jest.fn();
-      const fullAPI = { emit, on };
-      const store = createMockStore();
+      const fullAPI = { updateRef: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider, store } = moduleArgs;
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      const { setIndex } = Object.assign(fullAPI, api);
-      setIndex({ v: 4, entries: preparedEntries });
+      const listener = jest.fn();
+      provider.channel.on(UPDATE_STORY_ARGS, listener);
 
-      init();
-
+      api.setIndex({ v: 4, entries: preparedEntries });
       api.updateStoryArgs({ id: 'a--1' } as API_StoryEntry, { foo: 'bar' });
-      expect(emit).toHaveBeenCalledWith(UPDATE_STORY_ARGS, {
+
+      expect(listener).toHaveBeenCalledWith({
         storyId: 'a--1',
         updatedArgs: { foo: 'bar' },
         options: {
@@ -921,23 +668,18 @@ describe('stories API', () => {
       expect((index['a--1'] as API_StoryEntry).args).toEqual({ a: 'b' });
       expect((index['b--1'] as API_StoryEntry).args).toEqual({ x: 'y' });
     });
-
     it('updateStoryArgs emits UPDATE_STORY_ARGS to the right frame', () => {
-      const navigate = jest.fn();
-      const emit = jest.fn();
-      const on = jest.fn();
-      const fullAPI = { emit, on };
-      const store = createMockStore();
+      const fullAPI = { updateRef: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider } = moduleArgs;
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
+      const listener = jest.fn();
+      provider.channel.on(UPDATE_STORY_ARGS, listener);
 
-      const { setIndex } = Object.assign(fullAPI, api);
-      setIndex({ v: 4, entries: preparedEntries });
-
-      init();
-
+      api.setIndex({ v: 4, entries: preparedEntries });
       api.updateStoryArgs({ id: 'a--1', refId: 'refId' } as API_StoryEntry, { foo: 'bar' });
-      expect(emit).toHaveBeenCalledWith(UPDATE_STORY_ARGS, {
+      expect(listener).toHaveBeenCalledWith({
         storyId: 'a--1',
         updatedArgs: { foo: 'bar' },
         options: {
@@ -945,22 +687,18 @@ describe('stories API', () => {
         },
       });
     });
-
     it('refId to the local frame and does not change anything', () => {
-      const navigate = jest.fn();
-      const emit = jest.fn();
-      const on = jest.fn();
-      const fullAPI = { emit, on };
-      const store = createMockStore();
+      const fullAPI = { updateRef: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider, store } = moduleArgs;
+      const listener = jest.fn();
+      provider.channel.on(RESET_STORY_ARGS, listener);
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-
-      const { setIndex } = Object.assign(fullAPI, api);
-      setIndex({ v: 4, entries: preparedEntries });
-      init();
-
+      api.setIndex({ v: 4, entries: preparedEntries });
       api.resetStoryArgs({ id: 'a--1' } as API_StoryEntry, ['foo']);
-      expect(emit).toHaveBeenCalledWith(RESET_STORY_ARGS, {
+
+      expect(listener).toHaveBeenCalledWith({
         storyId: 'a--1',
         argNames: ['foo'],
         options: {
@@ -972,22 +710,18 @@ describe('stories API', () => {
       expect((index['a--1'] as API_StoryEntry).args).toEqual({ a: 'b' });
       expect((index['b--1'] as API_StoryEntry).args).toEqual({ x: 'y' });
     });
-
     it('resetStoryArgs emits RESET_STORY_ARGS to the right frame', () => {
-      const navigate = jest.fn();
-      const emit = jest.fn();
-      const on = jest.fn();
-      const fullAPI = { emit, on };
-      const store = createMockStore();
+      const fullAPI = { updateRef: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider } = moduleArgs;
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
+      const listener = jest.fn();
+      provider.channel.on(RESET_STORY_ARGS, listener);
 
-      const { setIndex } = Object.assign(fullAPI, api);
-      setIndex({ v: 4, entries: preparedEntries });
-      init();
-
+      api.setIndex({ v: 4, entries: preparedEntries });
       api.resetStoryArgs({ id: 'a--1', refId: 'refId' } as API_StoryEntry, ['foo']);
-      expect(emit).toHaveBeenCalledWith(RESET_STORY_ARGS, {
+      expect(listener).toHaveBeenCalledWith({
         storyId: 'a--1',
         argNames: ['foo'],
         options: {
@@ -997,268 +731,156 @@ describe('stories API', () => {
     });
   });
 
-  const navigationEntries: StoryIndex['entries'] = {
-    'a--1': {
-      type: 'story',
-      title: 'a',
-      name: '1',
-      id: 'a--1',
-      importPath: './a.ts',
-    },
-    'a--2': {
-      type: 'story',
-      title: 'a',
-      name: '2',
-      id: 'a--2',
-      importPath: './a.ts',
-    },
-    'b-c--1': {
-      type: 'story',
-      title: 'b/c',
-      name: '1',
-      id: 'b-c--1',
-      importPath: './b/c.ts',
-    },
-    'b-d--1': {
-      type: 'story',
-      title: 'b/d',
-      name: '1',
-      id: 'b-d--1',
-      importPath: './b/d.ts',
-    },
-    'b-d--2': {
-      type: 'story',
-      title: 'b/d',
-      name: '2',
-      id: 'b-d--2',
-      importPath: './b/d.ts',
-    },
-    'custom-id--1': {
-      type: 'story',
-      title: 'b/e',
-      name: '1',
-      id: 'custom-id--1',
-      importPath: './b/.ts',
-    },
-  };
-
   describe('jumpToStory', () => {
     it('works forward', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      const {
-        api: { setIndex, jumpToStory },
-      } = initStoriesAndSetState({
-        store,
-        storyId: 'a--1',
-        viewMode: 'story',
-        navigate,
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.jumpToStory(1);
 
-      jumpToStory(1);
       expect(navigate).toHaveBeenCalledWith('/story/a--2');
     });
-
     it('works backwards', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
+      const initialState = { path: '/story/a--2', storyId: 'a--2', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      const {
-        api: { setIndex, jumpToStory },
-      } = initStoriesAndSetState({
-        store,
-        storyId: 'a--2',
-        viewMode: 'story',
-        navigate,
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.jumpToStory(-1);
 
-      jumpToStory(-1);
       expect(navigate).toHaveBeenCalledWith('/story/a--1');
     });
-
     it('does nothing if you are at the last story and go forward', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-
-      const {
-        api: { setIndex, jumpToStory },
-      } = initStoriesAndSetState({
-        store,
+      const initialState = {
+        path: '/story/custom-id--1',
         storyId: 'custom-id--1',
         viewMode: 'story',
-        navigate,
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      jumpToStory(1);
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.jumpToStory(1);
       expect(navigate).not.toHaveBeenCalled();
     });
-
     it('does nothing if you are at the first story and go backward', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      const {
-        api: { setIndex, jumpToStory },
-      } = initStoriesAndSetState({
-        store,
-        storyId: 'a--1',
-        viewMode: 'story',
-        navigate,
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
-
-      jumpToStory(-1);
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.jumpToStory(-1);
       expect(navigate).not.toHaveBeenCalled();
     });
-
     it('does nothing if you have not selected a story', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
+      // @ts-expect-error (storyId type is maybe wrong?)
+      const initialState = { path: '/story', storyId: undefined, viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      const {
-        api: { setIndex, jumpToStory },
-      } = initStoriesAndSetState({ store, navigate, provider } as any);
-      setIndex({ v: 4, entries: navigationEntries });
-
-      jumpToStory(1);
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.jumpToStory(1);
       expect(navigate).not.toHaveBeenCalled();
     });
   });
 
   describe('findSiblingStoryId', () => {
     it('works forward', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
 
-      const storyId = 'a--1';
-      const {
-        api: { setIndex, findSiblingStoryId },
-      } = initStoriesAndSetState({ store, navigate, storyId, viewMode: 'story', provider } as any);
-      setIndex({ v: 4, entries: navigationEntries });
-
-      const result = findSiblingStoryId(storyId, store.getState().index, 1, false);
+      api.setIndex({ v: 4, entries: navigationEntries });
+      const result = api.findSiblingStoryId('a--1', store.getState().index, 1, false);
       expect(result).toBe('a--2');
     });
     it('works forward toSiblingGroup', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
 
-      const storyId = 'a--1';
-      const {
-        api: { setIndex, findSiblingStoryId },
-      } = initStoriesAndSetState({ store, navigate, storyId, viewMode: 'story', provider } as any);
-      setIndex({ v: 4, entries: navigationEntries });
-
-      const result = findSiblingStoryId(storyId, store.getState().index, 1, true);
+      api.setIndex({ v: 4, entries: navigationEntries });
+      const result = api.findSiblingStoryId('a--1', store.getState().index, 1, true);
       expect(result).toBe('b-c--1');
     });
   });
   describe('jumpToComponent', () => {
     it('works forward', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      const {
-        api: { setIndex, jumpToComponent },
-      } = initStoriesAndSetState({
-        store,
-        navigate,
-        storyId: 'a--1',
-        viewMode: 'story',
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
-
-      jumpToComponent(1);
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.jumpToComponent(1);
       expect(navigate).toHaveBeenCalledWith('/story/b-c--1');
     });
-
     it('works backwards', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-
-      const {
-        api: { setIndex, jumpToComponent },
-      } = initStoriesAndSetState({
-        store,
-        navigate,
+      const initialState = {
+        path: '/story/b-c--1',
         storyId: 'b-c--1',
         viewMode: 'story',
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      jumpToComponent(-1);
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.jumpToComponent(-1);
       expect(navigate).toHaveBeenCalledWith('/story/a--1');
     });
-
     it('does nothing if you are in the last component and go forward', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-
-      const {
-        api: { setIndex, jumpToComponent },
-      } = initStoriesAndSetState({
-        store,
-        navigate,
+      const initialState = {
+        path: '/story/custom-id--1',
         storyId: 'custom-id--1',
         viewMode: 'story',
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      jumpToComponent(1);
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.jumpToComponent(1);
       expect(navigate).not.toHaveBeenCalled();
     });
-
     it('does nothing if you are at the first component and go backward', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
+      const initialState = { path: '/story/a--2', storyId: 'a--2', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      const {
-        api: { setIndex, jumpToComponent },
-      } = initStoriesAndSetState({
-        store,
-        navigate,
-        storyId: 'a--2',
-        viewMode: 'story',
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
-
-      jumpToComponent(-1);
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.jumpToComponent(-1);
       expect(navigate).not.toHaveBeenCalled();
     });
   });
-
   describe('selectStory', () => {
     it('navigates', () => {
-      const navigate = jest.fn();
-      const store = createMockStore({ storyId: 'a--1', viewMode: 'story' });
-      const {
-        api: { setIndex, selectStory },
-      } = initStoriesAndSetState({ store, navigate, provider } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      selectStory('a--2');
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.selectStory('a--2');
       expect(navigate).toHaveBeenCalledWith('/story/a--2');
     });
-
     it('sets view mode to docs if doc-level component is selected', () => {
-      const navigate = jest.fn();
-      const store = createMockStore({ storyId: 'a--1', viewMode: 'docs' });
-      const {
-        api: { setIndex, selectStory },
-      } = initStoriesAndSetState({ store, navigate, provider } as any);
-      setIndex({
+      const initialState = { path: '/docs/a--1', storyId: 'a--1', viewMode: 'docs' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
+
+      api.setIndex({
         v: 4,
         entries: {
           ...navigationEntries,
@@ -1272,194 +894,129 @@ describe('stories API', () => {
           },
         },
       });
-
-      selectStory('intro');
+      api.selectStory('intro');
       expect(navigate).toHaveBeenCalledWith('/docs/intro--docs');
     });
-
-    describe('legacy api', () => {
+    describe('deprecated api', () => {
       it('allows navigating to a combination of title + name', () => {
-        const navigate = jest.fn();
-        const store = createMockStore();
-        const {
-          api: { setIndex, selectStory },
-        } = initStoriesAndSetState({
-          store,
-          storyId: 'a--1',
-          viewMode: 'story',
-          navigate,
-          provider,
-        } as any);
-        setIndex({ v: 4, entries: navigationEntries });
+        const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+        const moduleArgs = createMockModuleArgs({ initialState });
+        const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+        const { navigate } = moduleArgs;
 
-        selectStory('a', '2');
+        api.setIndex({ v: 4, entries: navigationEntries });
+        api.selectStory('a', '2');
         expect(navigate).toHaveBeenCalledWith('/story/a--2');
       });
-
       it('allows navigating to a given name (in the current component)', () => {
-        const navigate = jest.fn();
-        const store = createMockStore();
-        const {
-          api: { setIndex, selectStory },
-        } = initStoriesAndSetState({
-          store,
-          storyId: 'a--1',
-          viewMode: 'story',
-          navigate,
-          provider,
-        } as any);
-        setIndex({ v: 4, entries: navigationEntries });
+        const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+        const moduleArgs = createMockModuleArgs({ initialState });
+        const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+        const { navigate } = moduleArgs;
 
-        selectStory(undefined, '2');
+        api.setIndex({ v: 4, entries: navigationEntries });
+        api.selectStory(undefined, '2');
         expect(navigate).toHaveBeenCalledWith('/story/a--2');
       });
     });
-
     it('allows navigating away from the settings pages', () => {
-      const navigate = jest.fn();
-      const store = createMockStore({ storyId: 'a--1', viewMode: 'settings' });
-      const {
-        api: { setIndex, selectStory },
-      } = initStoriesAndSetState({ store, navigate, provider } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      const initialState = { path: '/settings/a--1', storyId: 'a--1', viewMode: 'settings' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      selectStory('a--2');
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.selectStory('a--2');
       expect(navigate).toHaveBeenCalledWith('/story/a--2');
     });
-
     it('allows navigating to first story in component on call by component id', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const {
-        api: { setIndex, selectStory },
-      } = initStoriesAndSetState({
-        store,
-        storyId: 'a--1',
-        viewMode: 'story',
-        navigate,
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      selectStory('a');
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.selectStory('a');
       expect(navigate).toHaveBeenCalledWith('/story/a--1');
     });
-
     it('allows navigating to first story in group on call by group id', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const {
-        api: { setIndex, selectStory },
-      } = initStoriesAndSetState({
-        store,
-        storyId: 'a--1',
-        viewMode: 'story',
-        navigate,
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      selectStory('b');
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.selectStory('b');
       expect(navigate).toHaveBeenCalledWith('/story/b-c--1');
     });
-
     it('allows navigating to first story in component on call by title', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const {
-        api: { setIndex, selectStory },
-      } = initStoriesAndSetState({
-        store,
-        storyId: 'a--1',
-        viewMode: 'story',
-        navigate,
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      selectStory('A');
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.selectStory('A');
       expect(navigate).toHaveBeenCalledWith('/story/a--1');
     });
-
     it('allows navigating to the first story of the current component if passed nothing', () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const {
-        api: { setIndex, selectStory },
-      } = initStoriesAndSetState({
-        store,
-        storyId: 'a--2',
-        viewMode: 'story',
-        navigate,
-        provider,
-      } as any);
-      setIndex({ v: 4, entries: navigationEntries });
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { navigate } = moduleArgs;
 
-      selectStory();
+      api.setIndex({ v: 4, entries: navigationEntries });
+      api.selectStory();
       expect(navigate).toHaveBeenCalledWith('/story/a--1');
     });
-
     describe('component permalinks', () => {
       it('allows navigating to kind/storyname (legacy api)', () => {
-        const navigate = jest.fn();
-        const store = createMockStore();
+        const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+        const moduleArgs = createMockModuleArgs({ initialState });
+        const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+        const { navigate } = moduleArgs;
 
-        const {
-          api: { selectStory, setIndex },
-        } = initStoriesAndSetState({ store, navigate, provider } as any);
-        setIndex({ v: 4, entries: navigationEntries });
-
-        selectStory('b/e', '1');
+        api.setIndex({ v: 4, entries: navigationEntries });
+        api.selectStory('b/e', '1');
         expect(navigate).toHaveBeenCalledWith('/story/custom-id--1');
       });
-
       it('allows navigating to component permalink/storyname (legacy api)', () => {
-        const navigate = jest.fn();
-        const store = createMockStore();
+        const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+        const moduleArgs = createMockModuleArgs({ initialState });
+        const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+        const { navigate } = moduleArgs;
 
-        const {
-          api: { selectStory, setIndex },
-        } = initStoriesAndSetState({ store, navigate, provider } as any);
-        setIndex({ v: 4, entries: navigationEntries });
-
-        selectStory('custom-id', '1');
+        api.setIndex({ v: 4, entries: navigationEntries });
+        api.selectStory('custom-id', '1');
         expect(navigate).toHaveBeenCalledWith('/story/custom-id--1');
       });
-
       it('allows navigating to first story in kind on call by kind', () => {
-        const navigate = jest.fn();
-        const store = createMockStore();
+        const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+        const moduleArgs = createMockModuleArgs({ initialState });
+        const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+        const { navigate } = moduleArgs;
 
-        const {
-          api: { selectStory, setIndex },
-        } = initStoriesAndSetState({ store, navigate, provider } as any);
-        setIndex({ v: 4, entries: navigationEntries });
-
-        selectStory('b/e');
+        api.setIndex({ v: 4, entries: navigationEntries });
+        api.selectStory('b/e');
         expect(navigate).toHaveBeenCalledWith('/story/custom-id--1');
       });
     });
   });
-
   describe('STORY_PREPARED', () => {
     it('prepares the story', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        setStories: jest.fn(),
-        setOptions: jest.fn(),
-      });
+      const fullAPI = { setOptions: jest.fn() };
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState, fullAPI });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider, store } = moduleArgs;
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
+      api.setIndex({ v: 4, entries: mockEntries });
 
-      await init();
-      fullAPI.emit(STORY_PREPARED, {
+      provider.channel.emit(STORY_PREPARED, {
         id: 'component-a--story-1',
         parameters: { a: 'b' },
         args: { c: 'd' },
       });
-
       const { index } = store.getState();
       expect(index['component-a--story-1']).toMatchObject({
         type: 'story',
@@ -1472,54 +1029,42 @@ describe('stories API', () => {
         args: { c: 'd' },
       });
     });
-
     it('sets options the first time it is called', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        setStories: jest.fn(),
-        setOptions: jest.fn(),
-      });
+      const fullAPI = { setOptions: jest.fn() };
+      const initialState = { path: '/story/a--1', storyId: 'a--1', viewMode: 'story' };
+      const moduleArgs = createMockModuleArgs({ initialState, fullAPI });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider } = moduleArgs;
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
+      api.setIndex({ v: 4, entries: mockEntries });
 
-      await init();
-      fullAPI.emit(STORY_PREPARED, {
+      provider.channel.emit(STORY_PREPARED, {
         id: 'component-a--story-1',
         parameters: { options: 'options' },
       });
-
       expect(fullAPI.setOptions).toHaveBeenCalledWith('options');
 
       fullAPI.setOptions.mockClear();
-      fullAPI.emit(STORY_PREPARED, {
+
+      provider.channel.emit(STORY_PREPARED, {
         id: 'component-a--story-1',
         parameters: { options: 'options2' },
       });
-
       expect(fullAPI.setOptions).not.toHaveBeenCalled();
     });
   });
-
   describe('DOCS_PREPARED', () => {
     it('prepares the docs entry', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        setStories: jest.fn(),
-        setOptions: jest.fn(),
-      });
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider, store } = moduleArgs;
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
+      api.setIndex({ v: 4, entries: mockEntries });
 
-      await init();
-      fullAPI.emit(DOCS_PREPARED, {
+      provider.channel.emit(DOCS_PREPARED, {
         id: 'component-a--docs',
         parameters: { a: 'b' },
       });
-
       const { index } = store.getState();
       expect(index['component-a--docs']).toMatchObject({
         type: 'docs',
@@ -1532,104 +1077,75 @@ describe('stories API', () => {
       });
     });
   });
-
   describe('CONFIG_ERROR', () => {
     it('sets previewInitialized to true, local', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter(), {});
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider, store } = moduleArgs;
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
+      api.setIndex({ v: 4, entries: mockEntries });
 
-      await init();
-
-      fullAPI.emit(CONFIG_ERROR, { message: 'Failed to run configure' });
-
+      provider.channel.emit(CONFIG_ERROR, { message: 'Failed to run configure' });
       const { previewInitialized } = store.getState();
       expect(previewInitialized).toBe(true);
     });
-
     it('sets previewInitialized to true, ref', async () => {
-      const navigate = jest.fn();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        updateRef: jest.fn(),
-      });
-      const store = createMockStore();
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
+      const fullAPI = { updateRef: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider } = moduleArgs;
 
-      Object.assign(fullAPI, api);
+      api.setIndex({ v: 4, entries: mockEntries });
 
-      getEventMetadataMock.mockReturnValueOnce({
+      getEventMetadata.mockReturnValueOnce({
         sourceType: 'external',
         ref: { id: 'refId', stories: { 'a--1': { args: { a: 'b' } } } },
       } as any);
-      await init();
-      fullAPI.emit(CONFIG_ERROR, { message: 'Failed to run configure' });
-
+      provider.channel.emit(CONFIG_ERROR, { message: 'Failed to run configure' });
       expect(fullAPI.updateRef.mock.calls.length).toBe(1);
       expect(fullAPI.updateRef.mock.calls[0][1]).toEqual({
         previewInitialized: true,
       });
     });
   });
-
   describe('STORY_MISSING', () => {
     it('sets previewInitialized to true, local', async () => {
-      const navigate = jest.fn();
-      const store = createMockStore();
-      const fullAPI = Object.assign(new EventEmitter(), {});
+      const moduleArgs = createMockModuleArgs({});
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider, store } = moduleArgs;
 
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api);
-
-      await init();
-
-      fullAPI.emit(STORY_MISSING, { message: 'Failed to run configure' });
-
+      provider.channel.emit(STORY_MISSING, { message: 'Failed to run configure' });
       const { previewInitialized } = store.getState();
       expect(previewInitialized).toBe(true);
     });
-
     it('sets previewInitialized to true, ref', async () => {
-      const navigate = jest.fn();
-      const fullAPI = Object.assign(new EventEmitter(), {
-        updateRef: jest.fn(),
-      });
-      const store = createMockStore();
-      const { api, init } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
+      const fullAPI = { updateRef: jest.fn() };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider } = moduleArgs;
 
-      Object.assign(fullAPI, api);
-
-      getEventMetadataMock.mockReturnValueOnce({
+      getEventMetadata.mockReturnValueOnce({
         sourceType: 'external',
         ref: { id: 'refId', stories: { 'a--1': { args: { a: 'b' } } } },
       } as any);
-      await init();
-      fullAPI.emit(STORY_MISSING, { message: 'Failed to run configure' });
-
+      provider.channel.emit(STORY_MISSING, { message: 'Failed to run configure' });
       expect(fullAPI.updateRef.mock.calls.length).toBe(1);
       expect(fullAPI.updateRef.mock.calls[0][1]).toEqual({
         previewInitialized: true,
       });
     });
   });
-
   describe('v2 SET_STORIES event', () => {
     it('normalizes parameters and calls setRef for external stories', () => {
-      const fullAPI = Object.assign(new EventEmitter(), {});
-      const navigate = jest.fn();
-      const store = createMockStore();
-
-      const { init, api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      const finalAPI = Object.assign(fullAPI, api, {
-        setIndex: jest.fn(),
+      const fullAPI = {
         findRef: jest.fn(),
         setRef: jest.fn(),
-      });
-      init();
+      };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider, store } = moduleArgs;
 
-      getEventMetadataMock.mockReturnValueOnce({
+      getEventMetadata.mockReturnValueOnce({
         sourceType: 'external',
         ref: { id: 'ref' },
       } as any);
@@ -1639,10 +1155,9 @@ describe('stories API', () => {
         kindParameters: { a: { kind: 'kind' } },
         stories: { 'a--1': { kind: 'a', parameters: { story: 'story' } } },
       };
-      finalAPI.emit(SET_STORIES, setStoriesPayload);
-
-      expect(finalAPI.setIndex).not.toHaveBeenCalled();
-      expect(finalAPI.setRef).toHaveBeenCalledWith(
+      provider.channel.emit(SET_STORIES, setStoriesPayload);
+      expect(store.getState().index).toBeUndefined();
+      expect(fullAPI.setRef).toHaveBeenCalledWith(
         'ref',
         {
           id: 'ref',
@@ -1656,28 +1171,23 @@ describe('stories API', () => {
   });
   describe('legacy (v1) SET_STORIES event', () => {
     it('calls setRef with stories', () => {
-      const fullAPI = Object.assign(new EventEmitter());
-      const navigate = jest.fn();
-      const store = createMockStore();
-
-      const { init, api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-      Object.assign(fullAPI, api, {
-        setIndex: jest.fn(),
+      const fullAPI = {
         findRef: jest.fn(),
         setRef: jest.fn(),
-      });
-      init();
+      };
+      const moduleArgs = createMockModuleArgs({ fullAPI });
+      initStories(moduleArgs as unknown as ModuleArgs);
+      const { provider, store } = moduleArgs;
 
-      getEventMetadataMock.mockReturnValueOnce({
+      getEventMetadata.mockReturnValueOnce({
         sourceType: 'external',
         ref: { id: 'ref' },
       } as any);
       const setStoriesPayload = {
         stories: { 'a--1': {} },
       };
-      fullAPI.emit(SET_STORIES, setStoriesPayload);
-
-      expect(fullAPI.setIndex).not.toHaveBeenCalled();
+      provider.channel.emit(SET_STORIES, setStoriesPayload);
+      expect(store.getState().index).toBeUndefined();
       expect(fullAPI.setRef).toHaveBeenCalledWith(
         'ref',
         {
@@ -1690,47 +1200,33 @@ describe('stories API', () => {
       );
     });
   });
+});
+describe('experimental_updateStatus', () => {
+  it('is included in the initial state', () => {
+    const moduleArgs = createMockModuleArgs({});
+    const { state } = initStories(moduleArgs as unknown as ModuleArgs);
 
-  describe('experimental_updateStatus', () => {
-    it('is included in the initial state', () => {
-      const { state } = initStoriesAndSetState({
-        storyId: 'id',
-        viewMode: 'story',
-      } as ModuleArgs);
+    expect(state).toEqual(
+      expect.objectContaining({
+        status: {},
+      })
+    );
+  });
+  it('updates a story', async () => {
+    const moduleArgs = createMockModuleArgs({});
+    const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+    const { store } = moduleArgs;
 
-      expect(state).toEqual(
-        expect.objectContaining({
-          status: {},
-        })
-      );
-    });
-
-    it('updates a story', async () => {
-      const fullAPI = Object.assign(new EventEmitter());
-      const navigate = jest.fn();
-      const store = createMockStore();
-
-      const { init, api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-
-      const API: SubAPI = Object.assign(fullAPI, api, {
-        setIndex: jest.fn(),
-        findRef: jest.fn(),
-        setRef: jest.fn(),
-      });
-
-      await init();
-
-      await expect(
-        API.experimental_updateStatus('a-addon-id', {
-          'a-story-id': {
-            status: 'pending',
-            title: 'an addon title',
-            description: 'an addon description',
-          },
-        })
-      ).resolves.not.toThrow();
-
-      expect(store.getState().status).toMatchInlineSnapshot(`
+    await expect(
+      api.experimental_updateStatus('a-addon-id', {
+        'a-story-id': {
+          status: 'pending',
+          title: 'an addon title',
+          description: 'an addon description',
+        },
+      })
+    ).resolves.not.toThrow();
+    expect(store.getState().status).toMatchInlineSnapshot(`
         Object {
           "a-story-id": Object {
             "a-addon-id": Object {
@@ -1741,35 +1237,23 @@ describe('stories API', () => {
           },
         }
       `);
-    });
+  });
+  it('updates multiple stories', async () => {
+    const moduleArgs = createMockModuleArgs({});
+    const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+    const { store } = moduleArgs;
 
-    it('updates multiple stories', async () => {
-      const fullAPI = Object.assign(new EventEmitter());
-      const navigate = jest.fn();
-      const store = createMockStore();
-
-      const { init, api } = initStoriesAndSetState({ store, navigate, provider, fullAPI } as any);
-
-      const API: SubAPI = Object.assign(fullAPI, api, {
-        setIndex: jest.fn(),
-        findRef: jest.fn(),
-        setRef: jest.fn(),
-      });
-
-      await init();
-
-      await expect(
-        API.experimental_updateStatus('a-addon-id', {
-          'a-story-id': {
-            status: 'pending',
-            title: 'an addon title',
-            description: 'an addon description',
-          },
-          'another-story-id': { status: 'success', title: 'a addon title', description: '' },
-        })
-      ).resolves.not.toThrow();
-
-      expect(store.getState().status).toMatchInlineSnapshot(`
+    await expect(
+      api.experimental_updateStatus('a-addon-id', {
+        'a-story-id': {
+          status: 'pending',
+          title: 'an addon title',
+          description: 'an addon description',
+        },
+        'another-story-id': { status: 'success', title: 'a addon title', description: '' },
+      })
+    ).resolves.not.toThrow();
+    expect(store.getState().status).toMatchInlineSnapshot(`
         Object {
           "a-story-id": Object {
             "a-addon-id": Object {
@@ -1787,6 +1271,5 @@ describe('stories API', () => {
           },
         }
       `);
-    });
   });
 });

--- a/code/lib/manager-api/src/tests/stories.test.ts
+++ b/code/lib/manager-api/src/tests/stories.test.ts
@@ -16,7 +16,7 @@ import {
 import { EventEmitter } from 'events';
 import { global } from '@storybook/global';
 
-import type { API_IndexHash, API_StoryEntry } from '@storybook/types';
+import type { API_StoryEntry } from '@storybook/types';
 import { getEventMetadata as getEventMetadataOriginal } from '../lib/events';
 
 import { init as initStories } from '../modules/stories';
@@ -24,8 +24,6 @@ import type Store from '../store';
 import type { API, State } from '..';
 import { mockEntries, docsEntries, preparedEntries, navigationEntries } from './mockStoriesEntries';
 import type { ModuleArgs } from '../lib/types';
-
-import { getAncestorIds } from '../../../../ui/manager/src/utils/tree';
 
 const mockGetEntries = jest.fn();
 const fetch = global.fetch as jest.Mock<ReturnType<typeof global.fetch>>;

--- a/code/lib/types/src/modules/addons.ts
+++ b/code/lib/types/src/modules/addons.ts
@@ -10,6 +10,7 @@ import type {
 } from 'react';
 import type { RenderData as RouterData } from '../../../router/src/types';
 import type { ThemeVars } from '../../../theming/src/types';
+import type { API_SidebarOptions } from './api';
 import type {
   Args,
   ArgsStoryFn as ArgsStoryFnForFramework,
@@ -477,6 +478,7 @@ export interface Addon_Config {
   toolbar?: {
     [id: string]: Addon_ToolbarConfig;
   };
+  sidebar?: API_SidebarOptions;
   [key: string]: any;
 }
 

--- a/code/lib/types/src/modules/api-stories.ts
+++ b/code/lib/types/src/modules/api-stories.ts
@@ -130,7 +130,7 @@ export interface API_IndexHash {
 }
 // We used to received a bit more data over the channel on the SET_STORIES event, including
 // the full parameters for each story.
-type API_PreparedIndexEntry = IndexEntry & {
+export type API_PreparedIndexEntry = IndexEntry & {
   parameters?: Parameters;
   argTypes?: ArgTypes;
   args?: Args;


### PR DESCRIPTION
## What I did

When adding the API to set this from `manager.ts` I discovered the `setConfig` API seems broken due to a race condition between the manager UI rendering async and the manager being initiated before the `manager.ts` file is executed.

This was the order of operation:
1. CONSTRUCT - `manager-api` context is contructed. The initial state is set.
2. RENDER - the manager UI renders
3. MANAGER - the `manager.ts` code is executed
4. MOUNT - the manager UI mounts
5. INIT - react call a hook to initiate all state/api modules in `manager-api`.

Due to this order + the fact that the event subscribers listening for the channel get executed upon the INIT phase, the fact the MANAGER phase emits and event, is missed.

My solution in this PR is not to change the order, but to change the location of the event-subscribers.
I moved them to the CONSTRUCT phase.

This should have no affects to use, but I had to change 2 things:
- the unit tests that test the api/state modules
- the api/state modules should use the provider given to them to listen/emit on the channel, because there's no fixed order in which the modules get created.

I hope this explains the changes in this PR enough.
I made and effort to cleanup some code, including the tests.

## How to test

The changes are covered by unit tests.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
