### PR TITLE
Maintenance: Revert "WebpackBuilder: Remove need for `react` as peerDependency"

### DIFF
--- a/code/builders/builder-webpack5/package.json
+++ b/code/builders/builder-webpack5/package.json
@@ -56,15 +56,23 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@babel/core": "^7.22.0",
+    "@babel/core": "^7.22.9",
+    "@storybook/addons": "workspace:*",
     "@storybook/channels": "workspace:*",
+    "@storybook/client-api": "workspace:*",
     "@storybook/client-logger": "workspace:*",
+    "@storybook/components": "workspace:*",
     "@storybook/core-common": "workspace:*",
     "@storybook/core-events": "workspace:*",
     "@storybook/core-webpack": "workspace:*",
+    "@storybook/global": "^5.0.0",
+    "@storybook/manager-api": "workspace:*",
     "@storybook/node-logger": "workspace:*",
     "@storybook/preview": "workspace:*",
     "@storybook/preview-api": "workspace:*",
+    "@storybook/router": "workspace:*",
+    "@storybook/store": "workspace:*",
+    "@storybook/theming": "workspace:*",
     "@swc/core": "^1.3.49",
     "@types/node": "^16.0.0",
     "@types/semver": "^7.3.4",
@@ -101,6 +109,10 @@
     "pretty-hrtime": "^1.0.3",
     "slash": "^5.0.0",
     "typescript": "~4.9.3"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -36,29 +36,19 @@ const storybookPaths: Record<string, string> = {
     `@storybook/components`
   )}/dist/experimental`,
   ...[
-    // these packages are not pre-bundled because of react dependencies.
-    // these are not dependencies of the builder anymore, thus resolving them can fail.
-    // we should remove the aliases in 8.0, I'm not sure why they are here in the first place.
+    // these packages are not pre-bundled because of react dependencies
     'components',
     'global',
     'manager-api',
     'router',
     'theming',
-  ].reduce((acc, sbPackage) => {
-    let packagePath;
-    try {
-      packagePath = getAbsolutePath(`@storybook/${sbPackage}`);
-    } catch (e) {
-      // ignore
-    }
-    if (packagePath) {
-      return {
-        ...acc,
-        [`@storybook/${sbPackage}`]: getAbsolutePath(`@storybook/${sbPackage}`),
-      };
-    }
-    return acc;
-  }, {}),
+  ].reduce(
+    (acc, sbPackage) => ({
+      ...acc,
+      [`@storybook/${sbPackage}`]: getAbsolutePath(`@storybook/${sbPackage}`),
+    }),
+    {}
+  ),
   // deprecated, remove in 8.0
   [`@storybook/api`]: getAbsolutePath(`@storybook/manager-api`),
 };

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -453,7 +453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.19.6, @babel/core@npm:^7.20.12, @babel/core@npm:^7.22.0, @babel/core@npm:^7.22.1, @babel/core@npm:^7.22.9, @babel/core@npm:^7.3.4, @babel/core@npm:^7.7.5":
+"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.19.6, @babel/core@npm:^7.20.12, @babel/core@npm:^7.22.1, @babel/core@npm:^7.22.9, @babel/core@npm:^7.3.4, @babel/core@npm:^7.7.5":
   version: 7.22.9
   resolution: "@babel/core@npm:7.22.9"
   dependencies:
@@ -6466,15 +6466,23 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/builder-webpack5@workspace:builders/builder-webpack5"
   dependencies:
-    "@babel/core": ^7.22.0
+    "@babel/core": ^7.22.9
+    "@storybook/addons": "workspace:*"
     "@storybook/channels": "workspace:*"
+    "@storybook/client-api": "workspace:*"
     "@storybook/client-logger": "workspace:*"
+    "@storybook/components": "workspace:*"
     "@storybook/core-common": "workspace:*"
     "@storybook/core-events": "workspace:*"
     "@storybook/core-webpack": "workspace:*"
+    "@storybook/global": ^5.0.0
+    "@storybook/manager-api": "workspace:*"
     "@storybook/node-logger": "workspace:*"
     "@storybook/preview": "workspace:*"
     "@storybook/preview-api": "workspace:*"
+    "@storybook/router": "workspace:*"
+    "@storybook/store": "workspace:*"
+    "@storybook/theming": "workspace:*"
     "@swc/core": ^1.3.49
     "@types/node": ^16.0.0
     "@types/pretty-hrtime": ^1.0.0
@@ -6509,6 +6517,9 @@ __metadata:
     webpack-dev-middleware: ^6.1.1
     webpack-hot-middleware: ^2.25.1
     webpack-virtual-modules: ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   peerDependenciesMeta:
     typescript:
       optional: true


### PR DESCRIPTION
Reverts storybookjs/storybook#23496. 
Resolves #23876



### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-23882-sha-6c4dd3dd`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-23882-sha-6c4dd3dd). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-23882-sha-6c4dd3dd`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-23882-sha-6c4dd3dd) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`revert-23496-norbert/react-peerdep-webpack-builder-removal`](https://github.com/storybookjs/storybook/tree/revert-23496-norbert/react-peerdep-webpack-builder-removal) |
| **Commit** | [`6c4dd3dd`](https://github.com/storybookjs/storybook/commit/6c4dd3dd3161e979589b5f04dbc42b83876e1334) |
| **Datetime** | Fri Aug 18 11:23:58 UTC 2023 (`1692357838`) |
| **Workflow run** | [5902057114](https://github.com/storybookjs/storybook/actions/runs/5902057114) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=23882`_
</details>
<!-- CANARY_RELEASE_SECTION -->

