### PR TITLE
fix actions addon "cannot read count" error

### DIFF
--- a/code/addons/actions/src/manager.tsx
+++ b/code/addons/actions/src/manager.tsx
@@ -10,7 +10,7 @@ function Title() {
 
   useChannel({
     [EVENT_ID]: () => {
-      setCount((c) => ({ ...c, count: c.count + 1 }));
+      setCount((c) => ({ ...c, count: (c?.count ?? 0) + 1 }));
     },
     [STORY_CHANGED]: () => {
       setCount((c) => ({ ...c, count: 0 }));


### PR DESCRIPTION
I ran into this error when using the actions plugin on version `7.3.2`

Specifically coming from [addons/actions/src/manager.tsx#L13](https://github.com/storybookjs/storybook/blob/next/code/addons/actions/src/manager.tsx#L13), where `c` would initially be `undefined`.

```
manager-bundle.js:150 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'count')
    at manager-bundle.js:150:13268
    at Object.setAddonState (chunk-UBXIQABM.js:39:13762)
    at setState (chunk-UBXIQABM.js:53:35093)
    at chunk-UBXIQABM.js:53:36196
    at storybook/actions/action-event (manager-bundle.js:150:13248)
    at chunk-UBXIQABM.js:39:3795
    at Array.forEach (<anonymous>)
    at Channel.handleEvent (chunk-UBXIQABM.js:39:3779)
    at PostMessageTransport.<anonymous> (chunk-UBXIQABM.js:39:2430)
    at PostMessageTransport.handler (chunk-UBXIQABM.js:39:5469)
```

## What I did

Added a optional chain and nullish coalesce to default `count` to 0

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual testing necessary

### Documentation

N/A

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
