### PR TITLE
Maintenance: Move filtering of sidebar into the state

### DIFF
--- a/code/lib/manager-api/src/modules/refs.ts
+++ b/code/lib/manager-api/src/modules/refs.ts
@@ -283,10 +283,15 @@ export const init: ModuleFn<SubAPI, SubState> = (
       if (setStoriesData) {
         index = transformSetStoriesStoryDataToStoriesHash(
           map(setStoriesData, ref, { storyMapper }),
-          { provider, docsOptions }
+          { provider, docsOptions, filters: {}, status: {} }
         );
       } else if (storyIndex) {
-        index = transformStoryIndexToStoriesHash(storyIndex, { provider, docsOptions });
+        index = transformStoryIndexToStoriesHash(storyIndex, {
+          provider,
+          docsOptions,
+          filters: {},
+          status: {},
+        });
       }
       if (index) index = addRefIds(index, ref);
 

--- a/code/lib/manager-api/src/tests/stories.test.ts
+++ b/code/lib/manager-api/src/tests/stories.test.ts
@@ -16,7 +16,7 @@ import {
 import { EventEmitter } from 'events';
 import { global } from '@storybook/global';
 
-import type { API_IndexHash, API_StoryEntry } from '@storybook/types';
+import type { API_StoryEntry } from '@storybook/types';
 import { getEventMetadata as getEventMetadataOriginal } from '../lib/events';
 
 import { init as initStories } from '../modules/stories';
@@ -24,8 +24,6 @@ import type Store from '../store';
 import type { API, State } from '..';
 import { mockEntries, docsEntries, preparedEntries, navigationEntries } from './mockStoriesEntries';
 import type { ModuleArgs } from '../lib/types';
-
-import { getAncestorIds } from '../../../../ui/manager/src/utils/tree';
 
 const mockGetEntries = jest.fn();
 const fetch = global.fetch as jest.Mock<ReturnType<typeof global.fetch>>;

--- a/code/lib/types/src/modules/api-stories.ts
+++ b/code/lib/types/src/modules/api-stories.ts
@@ -186,5 +186,5 @@ export type API_StatusState = Record<StoryId, Record<string, API_StatusObject>>;
 export type API_StatusUpdate = Record<StoryId, API_StatusObject>;
 
 export type API_FilterFunction = (
-  item: API_IndexHash[keyof API_IndexHash] & { status: Record<string, API_StatusObject> }
+  item: API_PreparedIndexEntry & { status: Record<string, API_StatusObject> }
 ) => boolean;

--- a/code/ui/manager/src/containers/sidebar.tsx
+++ b/code/ui/manager/src/containers/sidebar.tsx
@@ -1,11 +1,10 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import type { Combo, StoriesHash } from '@storybook/manager-api';
 import { Consumer } from '@storybook/manager-api';
 
 import { Sidebar as SidebarComponent } from '../components/sidebar/Sidebar';
 import { useMenu } from './menu';
-import { getAncestorIds } from '../utils/tree';
 
 export type Item = StoriesHash[keyof StoriesHash];
 
@@ -17,12 +16,11 @@ const Sidebar = React.memo(function Sideber() {
       storyId,
       refId,
       layout: { showToolbar, isFullscreen, showPanel, showNav },
-      index: originalIndex,
+      index,
       status,
       indexError,
       previewInitialized,
       refs,
-      filters,
     } = state;
 
     const menu = useMenu(
@@ -37,34 +35,6 @@ const Sidebar = React.memo(function Sideber() {
 
     const whatsNewNotificationsEnabled =
       state.whatsNewData?.status === 'SUCCESS' && !state.disableWhatsNewNotifications;
-
-    const index = useMemo(() => {
-      if (!originalIndex) {
-        return originalIndex;
-      }
-
-      const filtered = new Set();
-      Object.values(originalIndex).forEach((item) => {
-        if (item.type === 'story' || item.type === 'docs') {
-          let result = true;
-
-          Object.values(filters).forEach((filter) => {
-            if (result === true) {
-              result = filter({ ...item, status: status[item.id] });
-            }
-          });
-
-          if (result) {
-            filtered.add(item.id);
-            getAncestorIds(originalIndex, item.id).forEach((id) => {
-              filtered.add(id);
-            });
-          }
-        }
-      });
-
-      return Object.fromEntries(Object.entries(originalIndex).filter(([key]) => filtered.has(key)));
-    }, [originalIndex, filters, status]);
 
     return {
       title: name,


### PR DESCRIPTION
## What I did

When implementing filtering I forgot about the effect this would have on keyboard navigation.

I had left the index in state untouched, which would cause navigating via keyboard shortcuts to be incorrect.

I've moved the logic for filtering into the state manager (`manager-api`).
The `index` kept in state is now filtered before reaching the sidebar.

The interface for FilterFunctions changed slightly.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Set the `ui/.storybook/manager.tsx` code to this:
```tsx
import React from 'react';
import { addons, types } from '@storybook/manager-api';
import startCase from 'lodash/startCase.js';

addons.register('XYYYZZ', (api) => {
  addons.add('XYYYZZ/panel', {
    type: types.TOOL,
    title: 'TEST',
    match: ({ viewMode }) => true,

    render: () => (
      <div>
        <button type="button" onClick={() => api.experimental_setFilter('manager', () => true)}>
          TEST
        </button>
      </div>
    ),
  });
});
addons.setConfig({
  sidebar: {
    renderLabel: ({ name, type }) => (type === 'story' ? name : startCase(name)),
    filters: {
      manager: ({ title }) => title.includes('core'),
    },
  },
});
```

And start the UI storybook.

Expect the sidebar to be filtered when storybook opens.
Only stories that have the word `core` in them (anywhere in the path) should be visisble.

Use the keyboard shurtcuts to navigate between stories & components.

Now click the "TEST" button in the toolbar.

Expect the sidebar to now display all items (though collepsed)

Use the keyboard shurtcuts to navigate between stories & components.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
