### PR TITLE
Logger: Fix double error messages/stack

### DIFF
--- a/code/frameworks/angular/src/builders/utils/error-handler.ts
+++ b/code/frameworks/angular/src/builders/utils/error-handler.ts
@@ -12,7 +12,7 @@ export const printErrorDetails = (error: any): void => {
     } else if ((error as any).stats && (error as any).stats.compilation.errors) {
       (error as any).stats.compilation.errors.forEach((e: any) => logger.plain(e));
     } else {
-      logger.error(error as any);
+      logger.error(error);
     }
   } else if (error.compilation?.errors) {
     error.compilation.errors.forEach((e: any) => logger.plain(e));

--- a/code/lib/core-server/src/withTelemetry.ts
+++ b/code/lib/core-server/src/withTelemetry.ts
@@ -151,7 +151,7 @@ export async function withTelemetry<T>(
 
   try {
     return await run();
-  } catch (error) {
+  } catch (error: any) {
     if (canceled) {
       return undefined;
     }

--- a/code/lib/node-logger/src/index.test.ts
+++ b/code/lib/node-logger/src/index.test.ts
@@ -1,4 +1,4 @@
-import { info, warn, error } from 'npmlog';
+import { info, warn } from 'npmlog';
 import { logger } from '.';
 
 globalThis.console = { log: jest.fn() } as any;

--- a/code/lib/node-logger/src/index.test.ts
+++ b/code/lib/node-logger/src/index.test.ts
@@ -1,11 +1,27 @@
 import { info, warn, error } from 'npmlog';
 import { logger } from '.';
 
+globalThis.console = { log: jest.fn() } as any;
+
 jest.mock('npmlog', () => ({
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
+  levels: {
+    silly: -Infinity,
+    verbose: 1000,
+    info: 2000,
+    timing: 2500,
+    http: 3000,
+    notice: 3500,
+    warn: 4000,
+    error: 5000,
+    silent: Infinity,
+  },
+  level: 'info',
 }));
+
+//
 
 describe('node-logger', () => {
   it('should have an info method', () => {
@@ -21,6 +37,13 @@ describe('node-logger', () => {
   it('should have an error method', () => {
     const message = 'error message';
     logger.error(message);
-    expect(error).toHaveBeenCalledWith('', message);
+    expect(globalThis.console.log).toHaveBeenCalledWith(expect.stringMatching('message'));
+  });
+  it('should format errors', () => {
+    const message = new Error('A complete disaster');
+    logger.error(message);
+    expect(globalThis.console.log).toHaveBeenCalledWith(
+      expect.stringMatching('A complete disaster')
+    );
   });
 });

--- a/code/lib/node-logger/src/index.ts
+++ b/code/lib/node-logger/src/index.ts
@@ -25,8 +25,6 @@ export const logger = {
   plain: (message: string): void => console.log(message),
   line: (count = 1): void => console.log(`${Array(count - 1).fill('\n')}`),
   warn: (message: string): void => npmLog.warn('', message),
-  // npmLog supports anything we log, it will just stringify it
-  // error: (message: unknown): void => npmLog.error('', message as string),
   trace: ({ message, time }: { message: string; time: [number, number] }): void =>
     npmLog.info('', `${message} (${colors.purple(prettyTime(time))})`),
   setLevel: (level = 'info'): void => {

--- a/code/lib/node-logger/src/index.ts
+++ b/code/lib/node-logger/src/index.ts
@@ -42,8 +42,8 @@ export const logger = {
 
       console.log(
         msg
-          .replaceAll(process.cwd(), '.')
           .replace(message.toString(), chalk.red(message.toString()))
+          .replaceAll(process.cwd(), '.')
       );
     }
   },

--- a/code/lib/node-logger/src/index.ts
+++ b/code/lib/node-logger/src/index.ts
@@ -26,11 +26,28 @@ export const logger = {
   line: (count = 1): void => console.log(`${Array(count - 1).fill('\n')}`),
   warn: (message: string): void => npmLog.warn('', message),
   // npmLog supports anything we log, it will just stringify it
-  error: (message: unknown): void => npmLog.error('', message as string),
+  // error: (message: unknown): void => npmLog.error('', message as string),
   trace: ({ message, time }: { message: string; time: [number, number] }): void =>
     npmLog.info('', `${message} (${colors.purple(prettyTime(time))})`),
   setLevel: (level = 'info'): void => {
     npmLog.level = level;
+  },
+  error: (message: Error | string): void => {
+    if (npmLog.levels[npmLog.level] < npmLog.levels.error) {
+      let msg: string;
+
+      if (message instanceof Error && message.stack) {
+        msg = message.stack.toString();
+      } else {
+        msg = message.toString();
+      }
+
+      console.log(
+        msg
+          .replaceAll(process.cwd(), '.')
+          .replace(message.toString(), chalk.red(message.toString()))
+      );
+    }
   },
 };
 


### PR DESCRIPTION
## What I did

Before:
![Screenshot 2023-08-22 at 20 16 17](https://github.com/storybookjs/storybook/assets/3070389/9adab8d3-1cf6-485f-a607-94d450b72bc2)

After:
![Screenshot 2023-08-22 at 20 16 43](https://github.com/storybookjs/storybook/assets/3070389/3f85cdb8-e087-4918-8387-10328b8aa6b6)

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Break the build/dev somehow that would normally break storybook. I opted to breaking the manager builder.
   ```tsx
    export const executor = {
      get: async () => {
        const { build } = await import('esbuild');
        // return build;

        return undefined;
      },
    };
   ```
2. run any sandbox or the ui storybook
3. expect the error displayed in the console to only list the stack once!

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
