### PR TITLE
Addon-docs: Resolve `mdx-react-shim` & `@storybook/global` correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ code/playwright-results/
 code/playwright-report/
 code/playwright/.cache/
 code/bench-results/
+
+/packs

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -50,7 +50,7 @@ async function webpack(
     skipCsf: true,
     ...mdxPluginOptions,
     mdxCompileOptions: {
-      providerImportSource: '@storybook/addon-docs/mdx-react-shim',
+      providerImportSource: require.resolve('@storybook/addon-docs/dist/shims/mdx-react-shim'),
       ...mdxPluginOptions.mdxCompileOptions,
       remarkPlugins: [remarkSlug, remarkExternalLinks].concat(
         mdxPluginOptions?.mdxCompileOptions?.remarkPlugins ?? []

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { dirname, join } from 'path';
 import remarkSlug from 'remark-slug';
 import remarkExternalLinks from 'remark-external-links';
 import { dedent } from 'ts-dedent';
@@ -50,7 +51,10 @@ async function webpack(
     skipCsf: true,
     ...mdxPluginOptions,
     mdxCompileOptions: {
-      providerImportSource: require.resolve('@storybook/addon-docs/dist/shims/mdx-react-shim'),
+      providerImportSource: join(
+        dirname(require.resolve('@storybook/addon-docs/package.json')),
+        '/dist/shims/mdx-react-shim'
+      ),
       ...mdxPluginOptions.mdxCompileOptions,
       remarkPlugins: [remarkSlug, remarkExternalLinks].concat(
         mdxPluginOptions?.mdxCompileOptions?.remarkPlugins ?? []

--- a/code/addons/essentials/src/docs/preset.ts
+++ b/code/addons/essentials/src/docs/preset.ts
@@ -3,6 +3,8 @@ export * from '@storybook/addon-docs/dist/preset';
 
 export const mdxLoaderOptions = async (config: any) => {
   // eslint-disable-next-line no-param-reassign
-  config.mdxCompileOptions.providerImportSource = '@storybook/addon-essentials/docs/mdx-react-shim';
+  config.mdxCompileOptions.providerImportSource = require.resolve(
+    '@storybook/addon-docs/dist/shims/mdx-react-shim'
+  );
   return config;
 };

--- a/code/addons/essentials/src/docs/preset.ts
+++ b/code/addons/essentials/src/docs/preset.ts
@@ -1,10 +1,13 @@
-/* eslint-disable import/export */
+import { dirname, join } from 'path';
+
+// eslint-disable-next-line import/export
 export * from '@storybook/addon-docs/dist/preset';
 
 export const mdxLoaderOptions = async (config: any) => {
   // eslint-disable-next-line no-param-reassign
-  config.mdxCompileOptions.providerImportSource = require.resolve(
-    '@storybook/addon-docs/dist/shims/mdx-react-shim'
+  config.mdxCompileOptions.providerImportSource = join(
+    dirname(require.resolve('@storybook/addon-docs/package.json')),
+    '/dist/shims/mdx-react-shim'
   );
   return config;
 };

--- a/code/builders/builder-vite/src/plugins/mdx-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/mdx-plugin.ts
@@ -3,6 +3,7 @@ import type { Plugin } from 'vite';
 import remarkSlug from 'remark-slug';
 import remarkExternalLinks from 'remark-external-links';
 import { createFilter } from 'vite';
+import { dirname, join } from 'path';
 
 const isStorybookMdx = (id: string) => id.endsWith('stories.mdx') || id.endsWith('story.mdx');
 
@@ -33,7 +34,10 @@ export async function mdxPlugin(options: Options): Promise<Plugin> {
       const mdxLoaderOptions = await options.presets.apply('mdxLoaderOptions', {
         ...mdxPluginOptions,
         mdxCompileOptions: {
-          providerImportSource: require.resolve('@storybook/addon-docs/mdx-react-shim'),
+          providerImportSource: join(
+            dirname(require.resolve('@storybook/addon-docs/package.json')),
+            '/dist/shims/mdx-react-shim'
+          ),
           ...mdxPluginOptions?.mdxCompileOptions,
           remarkPlugins: [remarkSlug, remarkExternalLinks].concat(
             mdxPluginOptions?.mdxCompileOptions?.remarkPlugins ?? []

--- a/code/builders/builder-vite/src/plugins/mdx-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/mdx-plugin.ts
@@ -33,7 +33,7 @@ export async function mdxPlugin(options: Options): Promise<Plugin> {
       const mdxLoaderOptions = await options.presets.apply('mdxLoaderOptions', {
         ...mdxPluginOptions,
         mdxCompileOptions: {
-          providerImportSource: '@storybook/addon-docs/mdx-react-shim',
+          providerImportSource: require.resolve('@storybook/addon-docs/mdx-react-shim'),
           ...mdxPluginOptions?.mdxCompileOptions,
           remarkPlugins: [remarkSlug, remarkExternalLinks].concat(
             mdxPluginOptions?.mdxCompileOptions?.remarkPlugins ?? []

--- a/code/lib/preview/src/globals/runtime.ts
+++ b/code/lib/preview/src/globals/runtime.ts
@@ -4,6 +4,7 @@ import * as CHANNELS from '@storybook/channels';
 import * as CLIENT_LOGGER from '@storybook/client-logger';
 import * as CORE_EVENTS from '@storybook/core-events';
 import * as PREVIEW_API from '@storybook/preview-api';
+import * as GLOBAL from '@storybook/global';
 
 // DEPRECATED, remove in 8.0
 import * as ADDONS from '@storybook/preview-api/dist/addons';
@@ -22,6 +23,7 @@ export const values: Required<Record<keyof typeof globals, any>> = {
   '@storybook/client-logger': CLIENT_LOGGER,
   '@storybook/core-events': CORE_EVENTS,
   '@storybook/preview-api': PREVIEW_API,
+  '@storybook/global': GLOBAL,
 
   // DEPRECATED, remove in 8.0
   '@storybook/addons': ADDONS,

--- a/code/lib/preview/src/globals/types.ts
+++ b/code/lib/preview/src/globals/types.ts
@@ -1,6 +1,7 @@
 // Here we map the name of a module to their NAME in the global scope.
 export const globals = {
   '@storybook/addons': '__STORYBOOK_MODULE_ADDONS__',
+  '@storybook/global': '__STORYBOOK_MODULE_GLOBAL__',
   '@storybook/channel-postmessage': '__STORYBOOK_MODULE_CHANNEL_POSTMESSAGE__', // @deprecated: remove in 8.0
   '@storybook/channel-websocket': '__STORYBOOK_MODULE_CHANNEL_WEBSOCKET__', // @deprecated: remove in 8.0
   '@storybook/channels': '__STORYBOOK_MODULE_CHANNELS__',

--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -7,6 +7,8 @@ import program from 'commander';
 import { runServer, parseConfigFile } from 'verdaccio';
 import pLimit from 'p-limit';
 import type { Server } from 'http';
+import { mkdir } from 'fs/promises';
+import { PACKS_DIRECTORY } from './utils/constants';
 // @ts-expect-error (Converted from ts-ignore)
 import { maxConcurrentTasks } from './utils/concurrency';
 import { listOfPackages } from './utils/list-packages';
@@ -53,11 +55,26 @@ const currentVersion = async () => {
   return version;
 };
 
-const publish = (packages: { name: string; location: string }[], url: string) => {
+const publish = async (packages: { name: string; location: string }[], url: string) => {
   logger.log(`Publishing packages with a concurrency of ${maxConcurrentTasks}`);
 
   const limit = pLimit(maxConcurrentTasks);
   let i = 0;
+
+  /**
+   * We need to "pack" our packages before publishing to npm because our package.json files contain yarn specific version "ranges".
+   * such as "workspace:*"
+   *
+   * We can't publish to npm if the package.json contains these ranges. So with `yarn pack` we create a tarball that we can publish.
+   *
+   * However this bug exists in NPM: https://github.com/npm/cli/issues/4533!
+   * Which causes the NPM CLI to disregard the tarball CLI argument and instead re-create a tarball.
+   * But NPM doesn't replace the yarn version ranges.
+   *
+   * So we create the tarball ourselves and move it to another location on the FS.
+   * Then we change-directory to that directory and publish the tarball from there.
+   */
+  await mkdir(PACKS_DIRECTORY, { recursive: true }).catch(() => {});
 
   return Promise.all(
     packages.map(({ name, location }) =>
@@ -70,7 +87,9 @@ const publish = (packages: { name: string; location: string }[], url: string) =>
                 '.'
               )})`
             );
-            const command = `cd ${location} && yarn pack && npm publish ./package.tgz --registry ${url} --force --access restricted --ignore-scripts && rm ./package.tgz`;
+
+            const tarballFilename = `${name.replace('@', '').replace('/', '-')}.tgz`;
+            const command = `cd ${location} && yarn pack --out=${PACKS_DIRECTORY}/${tarballFilename} && cd ${PACKS_DIRECTORY} && npm publish ./${tarballFilename} --registry ${url} --force --access restricted --ignore-scripts`;
             exec(command, (e) => {
               if (e) {
                 rej(e);

--- a/scripts/utils/constants.ts
+++ b/scripts/utils/constants.ts
@@ -3,7 +3,9 @@ import { join } from 'path';
 export const AFTER_DIR_NAME = 'after-storybook';
 export const BEFORE_DIR_NAME = 'before-storybook';
 
+export const ROOT_DIRECTORY = join(__dirname, '..', '..');
 export const CODE_DIRECTORY = join(__dirname, '..', '..', 'code');
+export const PACKS_DIRECTORY = join(__dirname, '..', '..', 'packs');
 export const REPROS_DIRECTORY = join(__dirname, '..', '..', 'repros');
 export const SANDBOX_DIRECTORY = join(__dirname, '..', '..', 'sandbox');
 export const JUNIT_DIRECTORY = join(__dirname, '..', '..', 'test-results');


### PR DESCRIPTION
Closes #23217

## What I did

I added a `require.resolve`, which should cause the issue to no longer happen.

When manually testing I found that it was also failing to load `@storybook/global`.
So I found a solution for that too.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. run `yarn task --task run-registry --no-link`
2. wait for it to have the local registry running successfully
3. unzip the repro
4. navigate to the unzipped directory
5. change the pnpm config to use the local registry by making a change to the `.npmrc`-file: 
    ```diff
    + registry=http://localhost:6001/
    ```
6. prune the pnpm store cache (`pnpm store prune`)
7. remove `node_modules` (there are also 2 in the packages)
8. run the install (`pnpm install`)
9. navigate to the `./packages/storybook` directory
10. Run `yarn build`
11. Expect it to work.



### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:


### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-23941-sha-8f1ed079`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-23941-sha-8f1ed079). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-23941-sha-8f1ed079`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-23941-sha-8f1ed079) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/fix-23217`](https://github.com/storybookjs/storybook/tree/norbert/fix-23217) |
| **Commit** | [`8f1ed079`](https://github.com/storybookjs/storybook/commit/8f1ed079010e8f8a8c7f4b7c088d94e6246ba561) |
| **Datetime** | Fri Aug 25 12:43:08 UTC 2023 (`1692967388`) |
| **Workflow run** | [5976017700](https://github.com/storybookjs/storybook/actions/runs/5976017700) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=23941`_
</details>
<!-- CANARY_RELEASE_SECTION -->
