### PR TITLE
Core: Throw an error when detecting empty stories field

### DIFF
--- a/code/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
+++ b/code/lib/core-common/src/utils/__tests__/normalize-stories.test.ts
@@ -2,8 +2,14 @@
 /// <reference path="../../test-typings.d.ts" />
 
 import { dedent } from 'ts-dedent';
+import { sep } from 'path';
 
-import { normalizeStoriesEntry } from '../normalize-stories';
+import { InvalidStoriesEntryError } from '@storybook/core-events/server-errors';
+import {
+  getDirectoryFromWorkingDir,
+  normalizeStories,
+  normalizeStoriesEntry,
+} from '../normalize-stories';
 
 expect.addSnapshotSerializer({
   print: (val: any) => JSON.stringify(val, null, 2),
@@ -47,12 +53,12 @@ jest.mock('fs', () => {
   };
 });
 
-describe('normalizeStoriesEntry', () => {
-  const options = {
-    configDir: '/path/to/project/.storybook',
-    workingDir: '/path/to/project',
-  };
+const options = {
+  configDir: '/path/to/project/.storybook',
+  workingDir: '/path/to/project',
+};
 
+describe('normalizeStoriesEntry', () => {
   it('direct file path', () => {
     const specifier = normalizeStoriesEntry('../path/to/file.stories.mdx', options);
     expect(specifier).toMatchInlineSnapshot(`
@@ -308,5 +314,22 @@ describe('normalizeStoriesEntry', () => {
       './file.stories.mdx',
       '../file.stories.mdx',
     ]);
+  });
+});
+
+describe('getDirectoryFromWorkingDir', () => {
+  it('should return normalized story path', () => {
+    const normalizedPath = getDirectoryFromWorkingDir({
+      configDir: '/path/to/project/.storybook',
+      workingDir: '/path/to/project',
+      directory: '/path/to/project/src',
+    });
+    expect(normalizedPath).toBe(`.${sep}src`);
+  });
+});
+
+describe('normalizeStories', () => {
+  it('should throw InvalidStoriesEntryError for empty entries', () => {
+    expect(() => normalizeStories([], options)).toThrow(InvalidStoriesEntryError);
   });
 });

--- a/code/lib/core-common/src/utils/normalize-stories.ts
+++ b/code/lib/core-common/src/utils/normalize-stories.ts
@@ -4,6 +4,7 @@ import * as pico from 'picomatch';
 import slash from 'slash';
 
 import type { StoriesEntry, NormalizedStoriesSpecifier } from '@storybook/types';
+import { InvalidStoriesEntryError } from '@storybook/core-events/server-errors';
 import { normalizeStoryPath } from './paths';
 import { globToRegexp } from './glob-to-regexp';
 
@@ -100,5 +101,10 @@ interface NormalizeOptions {
   workingDir: string;
 }
 
-export const normalizeStories = (entries: StoriesEntry[], options: NormalizeOptions) =>
-  entries.map((entry) => normalizeStoriesEntry(entry, options));
+export const normalizeStories = (entries: StoriesEntry[], options: NormalizeOptions) => {
+  if (!entries || (Array.isArray(entries) && entries.length === 0)) {
+    throw new InvalidStoriesEntryError();
+  }
+
+  return entries.map((entry) => normalizeStoriesEntry(entry, options));
+};

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -119,3 +119,21 @@ export class ConflictingStaticDirConfigError extends StorybookError {
     `;
   }
 }
+
+export class InvalidStoriesEntryError extends StorybookError {
+  readonly category = Category.CORE_COMMON;
+
+  readonly code = 4;
+
+  public readonly documentation =
+    'https://storybook.js.org/docs/react/faq#can-i-have-a-storybook-with-no-local-stories';
+
+  template() {
+    return dedent`
+      Storybook could not index your stories.
+      Your main configuration somehow does not contain a 'stories' field, or it resolved to an empty array.
+
+      Please check your main configuration file and make sure it exports a 'stories' field that is not an empty array.
+    `;
+  }
+}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,6 +16,7 @@ Here are some answers to frequently asked questions. If you have a question, you
 - [Why is there no addons channel?](#why-is-there-no-addons-channel)
 - [Why aren't Controls visible in the Canvas panel but visible in Docs?](#why-arent-controls-visible-in-the-canvas-panel-but-visible-in-docs)
 - [Why aren't the addons working in a composed Storybook?](#why-arent-the-addons-working-in-a-composed-storybook)
+- [Can I have a Storybook with no local stories?](#can-i-have-a-storybook-with-no-local-stories)
 - [Which community addons are compatible with the latest version of Storybook?](#which-community-addons-are-compatible-with-the-latest-version-of-storybook)
 - [Is it possible to browse the documentation for past versions of Storybook?](#is-it-possible-to-browse-the-documentation-for-past-versions-of-storybook)
 - [What icons are available for my toolbar or my addon?](#what-icons-are-available-for-my-toolbar-or-my-addon)
@@ -217,6 +218,36 @@ Composition is a new feature that we released with version 6.0, and there are st
 For now, the addons you're using in a composed Storybook will not work.
 
 We're working on overcoming this limitation, and soon you'll be able to use them as if you are working with a non-composed Storybook.
+
+## Can I have a Storybook with no local stories?
+
+Storybook does not work unless you define at least one local story.
+
+If you're in a Storybook composition scenario, where you have multiple Storybooks, and want to have an extra Storybook with no stories of its own, that serves as a "glue" for all the other Storybooks in a project for demo/documentation purposes, you can do the following steps:
+
+Introduce a single `.mdx` story (addon-essentials or addon-docs required), that serves as an Introduction page, like so:
+
+```mdx
+// Introduction.mdx
+# Welcome
+
+Some description here
+```
+
+And then refer to it in your main.js file:
+
+```ts
+// .storybook/main.js
+const config = {
+  stories: ['../Introduction.mdx'],
+  refs: {
+    firstProject: { title: 'First', url: 'some-url' },
+    secondProject: { title: 'Second', url: 'other-url' },
+  }
+  // ...
+}
+export default config;
+```
 
 ## Which community addons are compatible with the latest version of Storybook?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -221,25 +221,27 @@ We're working on overcoming this limitation, and soon you'll be able to use them
 
 ## Can I have a Storybook with no local stories?
 
-Storybook does not work unless you define at least one local story.
+Storybook does not work unless you have at least one local story (or docs page) defined in your project. In this context, local means a `.stories.*` or `.mdx` file that is referenced in your project's `.storybook/main.js` config.
 
-If you're in a Storybook composition scenario, where you have multiple Storybooks, and want to have an extra Storybook with no stories of its own, that serves as a "glue" for all the other Storybooks in a project for demo/documentation purposes, you can do the following steps:
+If you're in a [Storybook composition](https://storybook.js.org/docs/react/sharing/storybook-composition) scenario, where you have multiple Storybooks, and want to have an extra Storybook with no stories of its own, that serves as a "glue" for all the other Storybooks in a project for demo/documentation purposes, you can do the following steps:
 
-Introduce a single `.mdx` story (addon-essentials or addon-docs required), that serves as an Introduction page, like so:
+Introduce a single `.mdx` docs page (addon-essentials or addon-docs required), that serves as an Introduction page, like so:
 
 ```mdx
-// Introduction.mdx
+<!-- Introduction.mdx -->
 # Welcome
 
 Some description here
 ```
 
-And then refer to it in your main.js file:
+And then refer to it in your Storybook config file:
 
 ```ts
 // .storybook/main.js
 const config = {
+  // define at least one local story/page here
   stories: ['../Introduction.mdx'],
+  // define composed Storybooks here
   refs: {
     firstProject: { title: 'First', url: 'some-url' },
     secondProject: { title: 'Second', url: 'other-url' },


### PR DESCRIPTION
Closes #23928

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

This PR introduces a new error which is thrown when users don't have a stories field in their main.js file.
Projects using the StorybookConfig type already have a type error, but if it's a js project, or users don't use the types, they could face this scenario. Now they will get a proper error message rather than an uncaught exception.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Delete the `stories` field from main.ts
3. run `yarn storybook` - see the failure

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
