### PR TITLE
Build: Fix publish script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ code/playwright-results/
 code/playwright-report/
 code/playwright/.cache/
 code/bench-results/
+
+/packs

--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -7,6 +7,8 @@ import program from 'commander';
 import { runServer, parseConfigFile } from 'verdaccio';
 import pLimit from 'p-limit';
 import type { Server } from 'http';
+import { mkdir } from 'fs/promises';
+import { PACKS_DIRECTORY } from './utils/constants';
 // @ts-expect-error (Converted from ts-ignore)
 import { maxConcurrentTasks } from './utils/concurrency';
 import { listOfPackages } from './utils/list-packages';
@@ -53,11 +55,26 @@ const currentVersion = async () => {
   return version;
 };
 
-const publish = (packages: { name: string; location: string }[], url: string) => {
+const publish = async (packages: { name: string; location: string }[], url: string) => {
   logger.log(`Publishing packages with a concurrency of ${maxConcurrentTasks}`);
 
   const limit = pLimit(maxConcurrentTasks);
   let i = 0;
+
+  /**
+   * We need to "pack" our packages before publishing to npm because our package.json files contain yarn specific version "ranges".
+   * such as "workspace:*"
+   *
+   * We can't publish to npm if the package.json contains these ranges. So with `yarn pack` we create a tarball that we can publish.
+   *
+   * However this bug exists in NPM: https://github.com/npm/cli/issues/4533!
+   * Which causes the NPM CLI to disregard the tarball CLI argument and instead re-create a tarball.
+   * But NPM doesn't replace the yarn version ranges.
+   *
+   * So we create the tarball ourselves and move it to another location on the FS.
+   * Then we change-directory to that directory and publish the tarball from there.
+   */
+  await mkdir(PACKS_DIRECTORY, { recursive: true }).catch(() => {});
 
   return Promise.all(
     packages.map(({ name, location }) =>
@@ -70,7 +87,9 @@ const publish = (packages: { name: string; location: string }[], url: string) =>
                 '.'
               )})`
             );
-            const command = `cd ${location} && yarn pack && npm publish ./package.tgz --registry ${url} --force --access restricted --ignore-scripts && rm ./package.tgz`;
+
+            const tarballFilename = `${name.replace('@', '').replace('/', '-')}.tgz`;
+            const command = `cd ${location} && yarn pack --out=${PACKS_DIRECTORY}/${tarballFilename} && cd ${PACKS_DIRECTORY} && npm publish ./${tarballFilename} --registry ${url} --force --access restricted --ignore-scripts`;
             exec(command, (e) => {
               if (e) {
                 rej(e);

--- a/scripts/utils/constants.ts
+++ b/scripts/utils/constants.ts
@@ -3,7 +3,9 @@ import { join } from 'path';
 export const AFTER_DIR_NAME = 'after-storybook';
 export const BEFORE_DIR_NAME = 'before-storybook';
 
+export const ROOT_DIRECTORY = join(__dirname, '..', '..');
 export const CODE_DIRECTORY = join(__dirname, '..', '..', 'code');
+export const PACKS_DIRECTORY = join(__dirname, '..', '..', 'packs');
 export const REPROS_DIRECTORY = join(__dirname, '..', '..', 'repros');
 export const SANDBOX_DIRECTORY = join(__dirname, '..', '..', 'sandbox');
 export const JUNIT_DIRECTORY = join(__dirname, '..', '..', 'test-results');

--- a/scripts/utils/constants.ts
+++ b/scripts/utils/constants.ts
@@ -4,11 +4,11 @@ export const AFTER_DIR_NAME = 'after-storybook';
 export const BEFORE_DIR_NAME = 'before-storybook';
 
 export const ROOT_DIRECTORY = join(__dirname, '..', '..');
-export const CODE_DIRECTORY = join(__dirname, '..', '..', 'code');
-export const PACKS_DIRECTORY = join(__dirname, '..', '..', 'packs');
-export const REPROS_DIRECTORY = join(__dirname, '..', '..', 'repros');
-export const SANDBOX_DIRECTORY = join(__dirname, '..', '..', 'sandbox');
-export const JUNIT_DIRECTORY = join(__dirname, '..', '..', 'test-results');
+export const CODE_DIRECTORY = join(ROOT_DIRECTORY, 'code');
+export const PACKS_DIRECTORY = join(ROOT_DIRECTORY, 'packs');
+export const REPROS_DIRECTORY = join(ROOT_DIRECTORY, 'repros');
+export const SANDBOX_DIRECTORY = join(ROOT_DIRECTORY, 'sandbox');
+export const JUNIT_DIRECTORY = join(ROOT_DIRECTORY, 'test-results');
 
 export const LOCAL_REGISTRY_URL = 'http://localhost:6001';
 export const SCRIPT_TIMEOUT = 5 * 60 * 1000;


### PR DESCRIPTION
## What I did

I found out that when running the local registry the `workspace:*` version ranges were present inside the package.json files by the local registry.

They should be replaced by running `yarn pack`.

I found that `yarn pack` is working as advertised, but there's a bug in the npm CLI: https://github.com/npm/cli/issues/4533.
This bug causes the tarball CLI parameter to get ignored.

@JReinhold and me figured out that the way around the npm bug is to generate the tarball to a different directory and publish from there.

We hypothesise the npm bug somehow only occurs when npm can find a package.json with the same name upwards.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. run `yarn task publish -s install --no-link`
2. open into the `.verdaccio-cache/@storybook/addon-a11y/package.json`
3. assert that there are no packages with version range `"workspace:*"`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
