### PR TITLE
CLI: Install latest version of non-core addon

### DIFF
--- a/code/lib/cli/src/add.ts
+++ b/code/lib/cli/src/add.ts
@@ -7,7 +7,7 @@ import {
   useNpmWarning,
   type PackageManagerName,
 } from './js-package-manager';
-import { getStorybookVersion } from './utils';
+import { getStorybookVersion, isCorePackage } from './utils';
 
 const logger = console;
 
@@ -76,8 +76,9 @@ export async function add(
 
   // add to package.json
   const isStorybookAddon = addonName.startsWith('@storybook/');
+  const isAddonFromCore = isCorePackage(addonName);
   const storybookVersion = await getStorybookVersion(packageManager);
-  const version = versionSpecifier || (isStorybookAddon ? storybookVersion : latestVersion);
+  const version = versionSpecifier || (isAddonFromCore ? storybookVersion : latestVersion);
   const addonWithVersion = SemVer.valid(version)
     ? `${addonName}@^${version}`
     : `${addonName}@${version}`;

--- a/code/lib/cli/src/upgrade.test.ts
+++ b/code/lib/cli/src/upgrade.test.ts
@@ -1,9 +1,4 @@
-import {
-  addExtraFlags,
-  addNxPackagesToReject,
-  getStorybookVersion,
-  isCorePackage,
-} from './upgrade';
+import { addExtraFlags, addNxPackagesToReject, getStorybookVersion } from './upgrade';
 
 describe.each([
   ['│ │ │ ├── @babel/code-frame@7.10.3 deduped', null],
@@ -23,24 +18,6 @@ describe.each([
 ])('getStorybookVersion', (input, output) => {
   it(`${input}`, () => {
     expect(getStorybookVersion(input)).toEqual(output);
-  });
-});
-
-describe.each([
-  ['@storybook/react', true],
-  ['@storybook/node-logger', true],
-  ['@storybook/addon-info', true],
-  ['@storybook/something-random', true],
-  ['@storybook/preset-create-react-app', false],
-  ['@storybook/linter-config', false],
-  ['@storybook/design-system', false],
-  ['@storybook/addon-styling', false],
-  ['@storybook/addon-styling-webpack', false],
-  ['@nx/storybook', false],
-  ['@nrwl/storybook', false],
-])('isCorePackage', (input, output) => {
-  it(`${input}`, () => {
-    expect(isCorePackage(input)).toEqual(output);
   });
 });
 

--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -8,6 +8,7 @@ import type { PackageJsonWithMaybeDeps, PackageManagerName } from './js-package-
 import { getPackageDetails, JsPackageManagerFactory, useNpmWarning } from './js-package-manager';
 import { commandLog } from './helpers';
 import { automigrate } from './automigrate';
+import { isCorePackage } from './utils';
 
 type Package = {
   package: string;
@@ -24,37 +25,6 @@ export const getStorybookVersion = (line: string) => {
     version: match[2],
   };
 };
-
-const excludeList = [
-  '@storybook/addon-bench',
-  '@storybook/addon-console',
-  '@storybook/addon-postcss',
-  '@storybook/addon-styling',
-  '@storybook/addon-styling-webpack',
-  '@storybook/babel-plugin-require-context-hook',
-  '@storybook/bench',
-  '@storybook/builder-vite',
-  '@storybook/csf',
-  '@storybook/design-system',
-  '@storybook/ember-cli-storybook',
-  '@storybook/eslint-config-storybook',
-  '@storybook/expect',
-  '@storybook/jest',
-  '@storybook/linter-config',
-  '@storybook/mdx1-csf',
-  '@storybook/mdx2-csf',
-  '@storybook/react-docgen-typescript-plugin',
-  '@storybook/storybook-deployer',
-  '@storybook/test-runner',
-  '@storybook/testing-library',
-  '@storybook/testing-react',
-  '@nrwl/storybook',
-  '@nx/storybook',
-];
-export const isCorePackage = (pkg: string) =>
-  pkg.startsWith('@storybook/') &&
-  !pkg.startsWith('@storybook/preset-') &&
-  !excludeList.includes(pkg);
 
 const deprecatedPackages = [
   {

--- a/code/lib/cli/src/utils.test.ts
+++ b/code/lib/cli/src/utils.test.ts
@@ -1,0 +1,21 @@
+import { isCorePackage } from './utils';
+
+describe('UTILS', () => {
+  describe.each([
+    ['@storybook/react', true],
+    ['@storybook/node-logger', true],
+    ['@storybook/addon-info', true],
+    ['@storybook/something-random', true],
+    ['@storybook/preset-create-react-app', false],
+    ['@storybook/linter-config', false],
+    ['@storybook/design-system', false],
+    ['@storybook/addon-styling', false],
+    ['@storybook/addon-styling-webpack', false],
+    ['@nx/storybook', false],
+    ['@nrwl/storybook', false],
+  ])('isCorePackage', (input, output) => {
+    it(`It should return "${output}" when given "${input}"`, () => {
+      expect(isCorePackage(input)).toEqual(output);
+    });
+  });
+});

--- a/code/lib/cli/src/utils.ts
+++ b/code/lib/cli/src/utils.ts
@@ -97,3 +97,34 @@ export const createLogStream = async (
     logStream.once('error', reject);
   });
 };
+
+const PACKAGES_EXCLUDED_FROM_CORE = [
+  '@storybook/addon-bench',
+  '@storybook/addon-console',
+  '@storybook/addon-postcss',
+  '@storybook/addon-styling',
+  '@storybook/addon-styling-webpack',
+  '@storybook/babel-plugin-require-context-hook',
+  '@storybook/bench',
+  '@storybook/builder-vite',
+  '@storybook/csf',
+  '@storybook/design-system',
+  '@storybook/ember-cli-storybook',
+  '@storybook/eslint-config-storybook',
+  '@storybook/expect',
+  '@storybook/jest',
+  '@storybook/linter-config',
+  '@storybook/mdx1-csf',
+  '@storybook/mdx2-csf',
+  '@storybook/react-docgen-typescript-plugin',
+  '@storybook/storybook-deployer',
+  '@storybook/test-runner',
+  '@storybook/testing-library',
+  '@storybook/testing-react',
+  '@nrwl/storybook',
+  '@nx/storybook',
+];
+export const isCorePackage = (pkg: string) =>
+  pkg.startsWith('@storybook/') &&
+  !pkg.startsWith('@storybook/preset-') &&
+  !PACKAGES_EXCLUDED_FROM_CORE.includes(pkg);


### PR DESCRIPTION
Closes https://github.com/storybookjs/addon-styling-webpack/issues/2

## What I did

- Move `isCorePackage` from upgrade to utils folder
- Use latest version instead of storybook version for non-core packages

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-webpack/default-ts`
2. Build CLI locally
3. Run `storybook add @storybook/addon-styling-webpack` with local copy of CLI
4. CLI should not blow up on not finding v7.x.x of styling webpack

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
