### PR TITLE
CLI: Improve autotitle stories format handling in GFM automigration

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/mdx-gfm.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/mdx-gfm.test.ts
@@ -128,4 +128,26 @@ describe('continue', () => {
       })
     ).resolves.toBeTruthy();
   });
+  test('stories object with directory + files', async () => {
+    await expect(
+      check({
+        packageManager: {},
+        main: {
+          stories: [{ directory: 'src', titlePrefix: 'src', files: '' }],
+          addons: ['@storybook/addon-essentials'],
+        },
+      })
+    ).resolves.toBeTruthy();
+  });
+  test('stories object with directory and no files', async () => {
+    await expect(
+      check({
+        packageManager: {},
+        main: {
+          stories: [{ directory: 'src', titlePrefix: 'src' }],
+          addons: ['@storybook/addon-essentials'],
+        },
+      })
+    ).resolves.toBeTruthy();
+  });
 });

--- a/code/lib/cli/src/automigrate/fixes/mdx-gfm.ts
+++ b/code/lib/cli/src/automigrate/fixes/mdx-gfm.ts
@@ -31,10 +31,15 @@ export const mdxgfm: Fix<Options> = {
         return true;
       }
 
-      const pattern =
-        typeof item === 'string'
-          ? slash(join(configDir, item))
-          : slash(join(configDir, item.directory, item.files));
+      let pattern;
+
+      if (typeof item === 'string') {
+        pattern = slash(join(configDir, item));
+      } else if (typeof item === 'object') {
+        const directory = item.directory || '..';
+        const files = item.files || '**/*.@(mdx|stories.@(mdx|js|jsx|mjs|ts|tsx))';
+        pattern = slash(join(configDir, directory, files));
+      }
 
       const files = await glob(pattern, commonGlobOptions(pattern));
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Fixed a bug where the MDX github-flavored-markdown automigration would fail for main.js that did not contain `files` field in a stories entry object:

```ts
.storybook/main.js

export default = {
  stories: [{
    directory: '../stories',
    // files: '*.stories.ts' <-- no files field!
  }]
}
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

No need for testing, but if you want to, just run automigrations against a main.js that has the issue described above. It should just work.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
