### PR TITLE
Types: Fix `React.ReactElement` not found

### DIFF
--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -47,12 +47,12 @@
     "@storybook/channels": "workspace:*",
     "@types/babel__core": "^7.0.0",
     "@types/express": "^4.7.0",
+    "@types/react": "^16.14.34",
     "file-system-cache": "2.3.0"
   },
   "devDependencies": {
     "@storybook/csf": "^0.1.0",
     "@types/node": "^16.0.0",
-    "@types/react": "^16.14.34",
     "typescript": "~4.9.3"
   },
   "publishConfig": {

--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@storybook/csf": "^0.1.0",
     "@types/node": "^16.0.0",
+    "@types/react": "^16.14.34",
     "typescript": "~4.9.3"
   },
   "publishConfig": {

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
+import type { ReactElement } from 'react';
 import type { RenderData } from '../../../router/src/types';
 import type { Channel } from '../../../channels/src';
 import type { ThemeVars } from '../../../theming/src/types';
@@ -8,8 +9,6 @@ import type { API_FilterFunction, API_HashEntry, API_IndexHash } from './api-sto
 import type { SetStoriesStory, SetStoriesStoryData } from './channelApi';
 import type { Addon_BaseType, Addon_Collection, Addon_RenderOptions, Addon_Type } from './addons';
 import type { StoryIndex } from './indexer';
-import React from 'react';
-
 
 type OrString<T extends string> = T | (string & {});
 
@@ -76,7 +75,7 @@ export type API_IframeRenderer = (
   baseUrl: string,
   scale: number,
   queryParams: Record<string, any>
-) => React.ReactElement<any, any> | null;
+) => ReactElement<any, any> | null;
 
 export interface API_UIOptions {
   name?: string;

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -8,6 +8,8 @@ import type { API_FilterFunction, API_HashEntry, API_IndexHash } from './api-sto
 import type { SetStoriesStory, SetStoriesStoryData } from './channelApi';
 import type { Addon_BaseType, Addon_Collection, Addon_RenderOptions, Addon_Type } from './addons';
 import type { StoryIndex } from './indexer';
+import React from 'react';
+
 
 type OrString<T extends string> = T | (string & {});
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -8037,6 +8037,7 @@ __metadata:
     "@types/babel__core": ^7.0.0
     "@types/express": ^4.7.0
     "@types/node": ^16.0.0
+    "@types/react": ^16.14.34
     file-system-cache: 2.3.0
     typescript: ~4.9.3
   languageName: unknown


### PR DESCRIPTION
Closes #23961

## What I did

Just imported the React to the api.ts type file, since it's missing the import

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ x] stories
- [x ] unit tests
- [x ] integration tests
- [x ] end-to-end tests

#### Manual testing

No manual test is mandotory since it's a type issue

-->

### Documentation

Not applicable

## Checklist for Maintainers

- [x ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
