### PR TITLE
Dependencies: Upgrade `escodegen` to fix security issue

### DIFF
--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -66,7 +66,7 @@
     "acorn": "^7.4.1",
     "acorn-jsx": "^5.3.1",
     "acorn-walk": "^7.2.0",
-    "escodegen": "^2.0.0",
+    "escodegen": "^2.1.0",
     "html-tags": "^3.1.0",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7603,7 +7603,7 @@ __metadata:
     acorn: ^7.4.1
     acorn-jsx: ^5.3.1
     acorn-walk: ^7.2.0
-    escodegen: ^2.0.0
+    escodegen: ^2.1.0
     expect-type: ^0.15.0
     html-tags: ^3.1.0
     jest-specific-snapshot: ^8.0.0
@@ -15519,7 +15519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escodegen@npm:^2.0.0":
+"escodegen@npm:^2.0.0, escodegen@npm:^2.1.0":
   version: 2.1.0
   resolution: "escodegen@npm:2.1.0"
   dependencies:


### PR DESCRIPTION
Closes #23734

## What I did

Upgrade escodegen

## Checklist for Contributors

### Testing


#### The changes in this PR are covered in the following automated tests:

These codepaths are tested by existing stories for react propType handling

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

We already have stories that exercise this codepath so I did not spend time on manual testing.

### Documentation

N/A


### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
