### PR TITLE
Core: Fix indexing for non-prefixed `stories.*` stories

### DIFF
--- a/code/lib/core-server/src/presets/common-preset.ts
+++ b/code/lib/core-server/src/presets/common-preset.ts
@@ -196,7 +196,7 @@ export const features = async (
 });
 
 export const csfIndexer: Indexer = {
-  test: /\.(stories|story)\.(m?js|ts)x?$/,
+  test: /(stories|story)\.(m?js|ts)x?$/,
   index: async (fileName, options) => (await readCsf(fileName, options)).parse().indexInputs,
 };
 

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -129,6 +129,36 @@ describe('StoryIndexGenerator', () => {
         `);
       });
     });
+    describe('no prefix stories specifier', () => {
+      it.only('extracts stories from the right files', async () => {
+        const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
+          './src/stories.ts',
+          options
+        );
+
+        const generator = new StoryIndexGenerator([specifier], options);
+        await generator.initialize();
+
+        expect(await generator.getIndex()).toMatchInlineSnapshot(`
+          Object {
+            "entries": Object {
+              "stories--story-one": Object {
+                "id": "stories--story-one",
+                "importPath": "./src/stories.ts",
+                "name": "Story One",
+                "tags": Array [
+                  "autodocs",
+                  "story",
+                ],
+                "title": "stories",
+                "type": "story",
+              },
+            },
+            "v": 4,
+          }
+        `);
+      });
+    });
     describe('non-recursive specifier', () => {
       it('extracts stories from the right files', async () => {
         const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -130,7 +130,7 @@ describe('StoryIndexGenerator', () => {
       });
     });
     describe('no prefix stories specifier', () => {
-      it.only('extracts stories from the right files', async () => {
+      it('extracts stories from the right files', async () => {
         const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(
           './src/stories.ts',
           options

--- a/code/lib/core-server/src/utils/__mockdata__/src/stories.ts
+++ b/code/lib/core-server/src/utils/__mockdata__/src/stories.ts
@@ -1,0 +1,7 @@
+const component = {};
+export default {
+  component,
+  tags: ['autodocs'],
+};
+
+export const StoryOne = {};


### PR DESCRIPTION
Closes #23923

## What I did

Add support for `(stories|story)\.*` files

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

Add a `stories.ts` file to a sandbox

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
