### PR TITLE
Scripts: Fix the changelog writer to escape doublequotes

### DIFF
--- a/scripts/release/__tests__/write-changelog.test.ts
+++ b/scripts/release/__tests__/write-changelog.test.ts
@@ -82,6 +82,45 @@ describe('Write changelog', () => {
     `);
   });
 
+  it('should escape double quotes for json files', async () => {
+    getChangesMock.mockResolvedValue({
+      changes: [],
+      changelogText: `## 7.0.1
+
+- React: Make it reactive
+- Revert "CLI: Not UI"
+- CLI: Not UI`,
+    });
+
+    await writeChangelog(['7.0.1'], {});
+
+    expect(fsExtra.writeFile).toHaveBeenCalledTimes(1);
+    expect(fsExtra.writeFile.mock.calls[0][0]).toBe(STABLE_CHANGELOG_PATH);
+    expect(fsExtra.writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
+      "## 7.0.1
+
+      - React: Make it reactive
+      - Revert "CLI: Not UI"
+      - CLI: Not UI
+
+      ## 7.0.0
+
+      - Core: Some change"
+    `);
+    expect(fsExtra.writeJson).toBeCalledTimes(1);
+    expect(fsExtra.writeJson.mock.calls[0][0]).toBe(LATEST_VERSION_PATH);
+    expect(fsExtra.writeJson.mock.calls[0][1]).toMatchInlineSnapshot(`
+      {
+        "info": {
+          "plain": "- React: Make it reactive
+      - Revert \\"CLI: Not UI\\"
+      - CLI: Not UI",
+        },
+        "version": "7.0.1",
+      }
+    `);
+  });
+
   it('should write to prerelase changelogs and version files in docs', async () => {
     getChangesMock.mockResolvedValue({
       changes: [],

--- a/scripts/release/write-changelog.ts
+++ b/scripts/release/write-changelog.ts
@@ -94,7 +94,7 @@ const writeToDocsVersionFile = async ({
     console.log(`📝 Writing changelog to ${chalk.blue(path)}`);
   }
 
-  const textWithoutHeading = changelogText.split('\n').slice(2).join('\n');
+  const textWithoutHeading = changelogText.split('\n').slice(2).join('\n').replaceAll('"', '\\"');
 
   const content = {
     version,


### PR DESCRIPTION
## What I did
- [x] Escape doublequotes when writing to json changelog files
- [x] Update write-changlelog tests to make sure doublequotes are escaped

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>
