### PR TITLE
Telemetry: Filter addon options to protect sensitive info

### DIFF
--- a/code/lib/telemetry/src/storybook-metadata.test.ts
+++ b/code/lib/telemetry/src/storybook-metadata.test.ts
@@ -349,6 +349,33 @@ describe('storybook-metadata', () => {
       expect(res.refCount).toEqual(2);
     });
 
+    test('only reports addon options for addon-essentials', async () => {
+      const res = await computeStorybookMetadata({
+        packageJson: packageJsonMock,
+        mainConfig: {
+          ...mainJsMock,
+          addons: [
+            { name: '@storybook/addon-essentials', options: { controls: false } },
+            { name: 'addon-foo', options: { foo: 'bar' } },
+          ],
+        },
+      });
+      expect(res.addons).toMatchInlineSnapshot(`
+        Object {
+          "@storybook/addon-essentials": Object {
+            "options": Object {
+              "controls": false,
+            },
+            "version": "x.x.x",
+          },
+          "addon-foo": Object {
+            "options": undefined,
+            "version": "x.x.x",
+          },
+        }
+      `);
+    });
+
     test.each(Object.entries(metaFrameworks))(
       'should detect the supported metaframework: %s',
       async (metaFramework, name) => {

--- a/code/lib/telemetry/src/storybook-metadata.ts
+++ b/code/lib/telemetry/src/storybook-metadata.ts
@@ -114,7 +114,9 @@ export const computeStorybookMetadata = async ({
       if (typeof addon === 'string') {
         addonName = sanitizeAddonName(addon);
       } else {
-        options = addon.options;
+        if (addon.name.includes('addon-essentials')) {
+          options = addon.options;
+        }
         addonName = sanitizeAddonName(addon.name);
       }
 


### PR DESCRIPTION
Closes N/A

Don't send addon options in telemetry since it could contain sensitve info like PII or keys

## What I did

Only send essentials options, which don't contain either of these things and we care about.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Run a sandbox with `STORYBOOK_TELEMETRY_DEBUG=1` or view `project.json`

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
