### PR TITLE
Pin glob dep to 10.1.0

### DIFF
--- a/code/addons/storyshots-core/package.json
+++ b/code/addons/storyshots-core/package.json
@@ -46,7 +46,7 @@
     "@storybook/preview-api": "workspace:*",
     "@storybook/types": "workspace:*",
     "@types/jest-specific-snapshot": "^0.5.6",
-    "glob": "^10.0.0",
+    "glob": "~10.1.0",
     "jest-specific-snapshot": "^8.0.0",
     "preact-render-to-string": "^5.1.19",
     "pretty-format": "^29.0.0",

--- a/code/builders/builder-vite/package.json
+++ b/code/builders/builder-vite/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/node": "^16.0.0",
-    "glob": "^10.0.0",
+    "glob": "~10.1.0",
     "rollup": "^3.20.1",
     "slash": "^5.0.0",
     "typescript": "~4.9.3",

--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -57,7 +57,7 @@
     "find-cache-dir": "^3.0.0",
     "find-up": "^5.0.0",
     "fs-extra": "^11.1.0",
-    "glob": "^10.0.0",
+    "glob": "~10.1.0",
     "handlebars": "^4.7.7",
     "lazy-universal-dotenv": "^4.0.0",
     "node-fetch": "^2.0.0",

--- a/code/package.json
+++ b/code/package.json
@@ -230,7 +230,7 @@
     "eslint-plugin-storybook": "^0.6.6",
     "fs-extra": "^11.1.0",
     "github-release-from-changelog": "^2.1.1",
-    "glob": "^10.0.0",
+    "glob": "~10.1.0",
     "http-server": "^14.1.1",
     "husky": "^4.3.7",
     "jest": "^29.5.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6059,7 +6059,7 @@ __metadata:
     enzyme: ^3.11.0
     enzyme-adapter-react-16: ^1.15.5
     enzyme-to-json: ^3.6.1
-    glob: ^10.0.0
+    glob: ~10.1.0
     jest-preset-angular: ^13.0.1
     jest-specific-snapshot: ^8.0.0
     jest-vue-preprocessor: ^1.7.1
@@ -6439,7 +6439,7 @@ __metadata:
     express: ^4.17.3
     find-cache-dir: ^3.0.0
     fs-extra: ^11.1.0
-    glob: ^10.0.0
+    glob: ~10.1.0
     magic-string: ^0.30.0
     remark-external-links: ^8.0.0
     remark-slug: ^6.0.0
@@ -6723,7 +6723,7 @@ __metadata:
     find-cache-dir: ^3.0.0
     find-up: ^5.0.0
     fs-extra: ^11.1.0
-    glob: ^10.0.0
+    glob: ~10.1.0
     handlebars: ^4.7.7
     lazy-universal-dotenv: ^4.0.0
     mock-fs: ^5.2.0
@@ -7767,7 +7767,7 @@ __metadata:
     eslint-plugin-storybook: ^0.6.6
     fs-extra: ^11.1.0
     github-release-from-changelog: ^2.1.1
-    glob: ^10.0.0
+    glob: ~10.1.0
     http-server: ^14.1.1
     husky: ^4.3.7
     jest: ^29.5.0
@@ -17566,7 +17566,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.0.0, glob@npm:^10.2.2":
+"glob@npm:^10.2.2":
   version: 10.3.3
   resolution: "glob@npm:10.3.3"
   dependencies:
@@ -17630,6 +17630,18 @@ __metadata:
     minipass: ^4.2.4
     path-scurry: ^1.6.1
   checksum: 2f6c2b9ee019ee21dc258ae97a88719614591e4c979cb4580b1b9df6f0f778a3cb38b4bdaf18dfa584637ea10f89a3c5f2533a5e449cf8741514ad18b0951f2e
+  languageName: node
+  linkType: hard
+
+"glob@npm:~10.1.0":
+  version: 10.1.0
+  resolution: "glob@npm:10.1.0"
+  dependencies:
+    fs.realpath: ^1.0.0
+    minimatch: ^9.0.0
+    minipass: ^5.0.0
+    path-scurry: ^1.7.0
+  checksum: c04acd81b1275a390bdecca3f8753e1a4c934f0e0c8fc40b6a3fb93a63e23ddf9f6d50fc03007c7652458b45d8fcdac1b6c717201913cec776b49cf47f803d5d
   languageName: node
   linkType: hard
 
@@ -24855,7 +24867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^1.10.1, path-scurry@npm:^1.6.1":
+"path-scurry@npm:^1.10.1, path-scurry@npm:^1.6.1, path-scurry@npm:^1.7.0":
   version: 1.10.1
   resolution: "path-scurry@npm:1.10.1"
   dependencies:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -130,7 +130,7 @@
     "find-up": "^5.0.0",
     "fs-extra": "^11.1.0",
     "github-release-from-changelog": "^2.1.1",
-    "glob": "^10.0.0",
+    "glob": "~10.1.0",
     "http-server": "^14.1.1",
     "husky": "^4.3.7",
     "jest": "^29.3.1",


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/pull/22171#issuecomment-1698307748

## What I did

Glob 10.2 and above adds some problematic dependencies which contain ESM-only code that trips up some node tooling including Jest and ESlint. Pinning this to an older version for now.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

TBD. @tmeasday @yannbf do you know how to test this?

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
