### PR TITLE
Addon API: Improve the updateStatus API

### DIFF
--- a/code/lib/types/src/modules/api-stories.ts
+++ b/code/lib/types/src/modules/api-stories.ts
@@ -186,5 +186,5 @@ export type API_StatusState = Record<StoryId, Record<string, API_StatusObject>>;
 export type API_StatusUpdate = Record<StoryId, API_StatusObject>;
 
 export type API_FilterFunction = (
-  item: API_PreparedIndexEntry & { status: Record<string, API_StatusObject> }
+  item: API_PreparedIndexEntry & { status: Record<string, API_StatusObject | null> }
 ) => boolean;


### PR DESCRIPTION
## What I did

- add ability to remove via setting `null`
- add ability to update status via a state-setter-function

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual tests are needed

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x Make sure this PR contains **one** of the labels below

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-24007-sha-c31c498a`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24007-sha-c31c498a). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-24007-sha-c31c498a`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24007-sha-c31c498a) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/enhance-updateStatus`](https://github.com/storybookjs/storybook/tree/norbert/enhance-updateStatus) |
| **Commit** | [`c31c498a`](https://github.com/storybookjs/storybook/commit/c31c498a39445696957f424a1453b1f2bd40dba9) |
| **Datetime** | Wed Aug 30 09:48:37 UTC 2023 (`1693388917`) |
| **Workflow run** | [6023282677](https://github.com/storybookjs/storybook/actions/runs/6023282677) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=24007`_
</details>
<!-- CANARY_RELEASE_SECTION -->
