### PR TITLE
CLI: Improve sanitization logic in crash reports

### DIFF
--- a/code/lib/core-server/src/withTelemetry.test.ts
+++ b/code/lib/core-server/src/withTelemetry.test.ts
@@ -1,10 +1,11 @@
+/* eslint-disable local-rules/no-uncategorized-errors */
 /// <reference types="@types/jest" />;
 
 import prompts from 'prompts';
 import { loadAllPresets, cache } from '@storybook/core-common';
-import { telemetry } from '@storybook/telemetry';
+import { telemetry, oneWayHash } from '@storybook/telemetry';
 
-import { withTelemetry } from './withTelemetry';
+import { getErrorLevel, sendTelemetryError, withTelemetry } from './withTelemetry';
 
 jest.mock('prompts');
 jest.mock('@storybook/core-common');
@@ -12,222 +13,463 @@ jest.mock('@storybook/telemetry');
 
 const cliOptions = {};
 
-it('works in happy path', async () => {
-  const run = jest.fn();
+describe('withTelemetry', () => {
+  it('works in happy path', async () => {
+    const run = jest.fn();
 
-  await withTelemetry('dev', { cliOptions }, run);
+    await withTelemetry('dev', { cliOptions }, run);
 
-  expect(telemetry).toHaveBeenCalledTimes(1);
-  expect(telemetry).toHaveBeenCalledWith('boot', { eventType: 'dev' }, { stripMetadata: true });
-});
-
-it('does not send boot when cli option is passed', async () => {
-  const run = jest.fn();
-
-  await withTelemetry('dev', { cliOptions: { disableTelemetry: true } }, run);
-
-  expect(telemetry).toHaveBeenCalledTimes(0);
-});
-
-describe('when command fails', () => {
-  const error = new Error('An Error!');
-  const run = jest.fn(async () => {
-    throw error;
-  });
-
-  it('sends boot message', async () => {
-    await expect(async () => withTelemetry('dev', { cliOptions }, run)).rejects.toThrow(error);
-
+    expect(telemetry).toHaveBeenCalledTimes(1);
     expect(telemetry).toHaveBeenCalledWith('boot', { eventType: 'dev' }, { stripMetadata: true });
   });
 
   it('does not send boot when cli option is passed', async () => {
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: { disableTelemetry: true } }, run)
-    ).rejects.toThrow(error);
+    const run = jest.fn();
+
+    await withTelemetry('dev', { cliOptions: { disableTelemetry: true } }, run);
 
     expect(telemetry).toHaveBeenCalledTimes(0);
   });
 
-  it('sends error message when no options are passed', async () => {
-    await expect(async () => withTelemetry('dev', { cliOptions }, run)).rejects.toThrow(error);
-
-    expect(telemetry).toHaveBeenCalledTimes(2);
-    expect(telemetry).toHaveBeenCalledWith(
-      'error',
-      { eventType: 'dev', error },
-      expect.objectContaining({})
-    );
-  });
-
-  it('does not send error message when cli opt out is passed', async () => {
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: { disableTelemetry: true } }, run)
-    ).rejects.toThrow(error);
-
-    expect(telemetry).toHaveBeenCalledTimes(0);
-    expect(telemetry).not.toHaveBeenCalledWith(
-      'error',
-      expect.objectContaining({}),
-      expect.objectContaining({})
-    );
-  });
-
-  it('does not send full error message when crash reports are disabled', async () => {
-    jest.mocked(loadAllPresets).mockResolvedValueOnce({
-      apply: async () => ({ enableCrashReports: false } as any),
+  describe('when command fails', () => {
+    const error = new Error('An Error!');
+    const run = jest.fn(async () => {
+      throw error;
     });
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: {} as any, presetOptions: {} as any }, run)
-    ).rejects.toThrow(error);
 
-    expect(telemetry).toHaveBeenCalledTimes(2);
+    it('sends boot message', async () => {
+      await expect(async () =>
+        withTelemetry('dev', { cliOptions, printError: jest.fn() }, run)
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledWith('boot', { eventType: 'dev' }, { stripMetadata: true });
+    });
+
+    it('does not send boot when cli option is passed', async () => {
+      await expect(async () =>
+        withTelemetry('dev', { cliOptions: { disableTelemetry: true }, printError: jest.fn() }, run)
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(0);
+    });
+
+    it('sends error message when no options are passed', async () => {
+      await expect(async () =>
+        withTelemetry('dev', { cliOptions, printError: jest.fn() }, run)
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(2);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ eventType: 'dev', error }),
+        expect.objectContaining({})
+      );
+    });
+
+    it('does not send error message when cli opt out is passed', async () => {
+      await expect(async () =>
+        withTelemetry('dev', { cliOptions: { disableTelemetry: true }, printError: jest.fn() }, run)
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(0);
+      expect(telemetry).not.toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({}),
+        expect.objectContaining({})
+      );
+    });
+
+    it('does not send full error message when crash reports are disabled', async () => {
+      jest.mocked(loadAllPresets).mockResolvedValueOnce({
+        apply: async () => ({ enableCrashReports: false } as any),
+      });
+      await expect(async () =>
+        withTelemetry(
+          'dev',
+          { cliOptions: {} as any, presetOptions: {} as any, printError: jest.fn() },
+          run
+        )
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(2);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ eventType: 'dev' }),
+        expect.objectContaining({})
+      );
+    });
+
+    it('does send error message when crash reports are enabled', async () => {
+      jest.mocked(loadAllPresets).mockResolvedValueOnce({
+        apply: async () => ({ enableCrashReports: true } as any),
+      });
+
+      await expect(async () =>
+        withTelemetry(
+          'dev',
+          { cliOptions: {} as any, presetOptions: {} as any, printError: jest.fn() },
+          run
+        )
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(2);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ eventType: 'dev', error }),
+        expect.objectContaining({})
+      );
+    });
+
+    it('does not send any error message when telemetry is disabled', async () => {
+      jest.mocked(loadAllPresets).mockResolvedValueOnce({
+        apply: async () => ({ disableTelemetry: true } as any),
+      });
+
+      await expect(async () =>
+        withTelemetry(
+          'dev',
+          { cliOptions: {} as any, presetOptions: {} as any, printError: jest.fn() },
+          run
+        )
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(1);
+      expect(telemetry).not.toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({}),
+        expect.objectContaining({})
+      );
+    });
+
+    it('does send error messages when telemetry is disabled, but crash reports are enabled', async () => {
+      jest.mocked(loadAllPresets).mockResolvedValueOnce({
+        apply: async () => ({ disableTelemetry: true, enableCrashReports: true } as any),
+      });
+
+      await expect(async () =>
+        withTelemetry(
+          'dev',
+          { cliOptions: {} as any, presetOptions: {} as any, printError: jest.fn() },
+          run
+        )
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(2);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ eventType: 'dev', error }),
+        expect.objectContaining({})
+      );
+    });
+
+    it('does not send  full  error messages when disabled crash reports are cached', async () => {
+      jest.mocked(loadAllPresets).mockResolvedValueOnce({
+        apply: async () => ({} as any),
+      });
+      jest.mocked(cache.get).mockResolvedValueOnce(false);
+
+      await expect(async () =>
+        withTelemetry(
+          'dev',
+          { cliOptions: {} as any, presetOptions: {} as any, printError: jest.fn() },
+          run
+        )
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(2);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ eventType: 'dev' }),
+        expect.objectContaining({})
+      );
+    });
+
+    it('does send error messages when enabled crash reports are cached', async () => {
+      jest.mocked(loadAllPresets).mockResolvedValueOnce({
+        apply: async () => ({} as any),
+      });
+      jest.mocked(cache.get).mockResolvedValueOnce(true);
+
+      await expect(async () =>
+        withTelemetry(
+          'dev',
+          { cliOptions: {} as any, presetOptions: {} as any, printError: jest.fn() },
+          run
+        )
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(2);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ eventType: 'dev', error }),
+        expect.objectContaining({})
+      );
+    });
+
+    it('does not send full error messages when disabled crash reports are prompted', async () => {
+      jest.mocked(loadAllPresets).mockResolvedValueOnce({
+        apply: async () => ({} as any),
+      });
+      jest.mocked(cache.get).mockResolvedValueOnce(undefined);
+      jest.mocked(prompts).mockResolvedValueOnce({ enableCrashReports: false });
+
+      await expect(async () =>
+        withTelemetry(
+          'dev',
+          { cliOptions: {} as any, presetOptions: {} as any, printError: jest.fn() },
+          run
+        )
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(2);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ eventType: 'dev' }),
+        expect.objectContaining({})
+      );
+    });
+
+    it('does send error messages when enabled crash reports are prompted', async () => {
+      jest.mocked(loadAllPresets).mockResolvedValueOnce({
+        apply: async () => ({} as any),
+      });
+      jest.mocked(cache.get).mockResolvedValueOnce(undefined);
+      jest.mocked(prompts).mockResolvedValueOnce({ enableCrashReports: true });
+
+      await expect(async () =>
+        withTelemetry(
+          'dev',
+          { cliOptions: {} as any, presetOptions: {} as any, printError: jest.fn() },
+          run
+        )
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(2);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ eventType: 'dev', error }),
+        expect.objectContaining({})
+      );
+    });
+
+    // if main.js has errors, we have no way to tell if they've disabled error reporting,
+    // so we assume they have.
+    it('does not send full error messages when presets fail to evaluate', async () => {
+      jest.mocked(loadAllPresets).mockRejectedValueOnce(error);
+
+      await expect(async () =>
+        withTelemetry(
+          'dev',
+          { cliOptions: {} as any, presetOptions: {} as any, printError: jest.fn() },
+          run
+        )
+      ).rejects.toThrow(error);
+
+      expect(telemetry).toHaveBeenCalledTimes(2);
+      expect(telemetry).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ eventType: 'dev' }),
+        expect.objectContaining({})
+      );
+    });
+  });
+});
+
+describe('sendTelemetryError', () => {
+  it('handles error instances and sends telemetry', async () => {
+    const options: any = {
+      cliOptions: {},
+      skipPrompt: false,
+    };
+    const mockError = new Error('Test error');
+    const eventType: any = 'testEventType';
+
+    jest.mocked(oneWayHash).mockReturnValueOnce('some-hash');
+
+    await sendTelemetryError(mockError, eventType, options);
+
     expect(telemetry).toHaveBeenCalledWith(
       'error',
-      { eventType: 'dev' },
-      expect.objectContaining({})
+      expect.objectContaining({
+        error: mockError,
+        eventType,
+        isErrorInstance: true,
+        errorHash: 'some-hash',
+      }),
+      expect.any(Object)
     );
   });
 
-  it('does send error message when crash reports are enabled', async () => {
+  it('handles non-error instances and sends telemetry with no-message hash', async () => {
+    const options: any = {
+      cliOptions: {},
+      skipPrompt: false,
+    };
+    const mockError = { error: new Error('Test error') };
+    const eventType: any = 'testEventType';
+
+    await sendTelemetryError(mockError, eventType, options);
+
+    expect(telemetry).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({
+        error: mockError,
+        eventType,
+        isErrorInstance: false,
+        errorHash: 'no-message',
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('handles error with empty message and sends telemetry with empty-message hash', async () => {
+    const options: any = {
+      cliOptions: {},
+      skipPrompt: false,
+    };
+    const mockError = new Error();
+    const eventType: any = 'testEventType';
+
+    await sendTelemetryError(mockError, eventType, options);
+
+    expect(telemetry).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({
+        error: mockError,
+        eventType,
+        isErrorInstance: true,
+        errorHash: 'empty-message',
+      }),
+      expect.any(Object)
+    );
+  });
+});
+
+describe('getErrorLevel', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns "none" when cliOptions.disableTelemetry is true', async () => {
+    const options: any = {
+      cliOptions: {
+        disableTelemetry: true,
+      },
+      presetOptions: undefined,
+      skipPrompt: false,
+    };
+
+    const errorLevel = await getErrorLevel(options);
+
+    expect(errorLevel).toBe('none');
+  });
+
+  it('returns "full" when presetOptions is not provided', async () => {
+    const options: any = {
+      cliOptions: {
+        disableTelemetry: false,
+      },
+      presetOptions: undefined,
+      skipPrompt: false,
+    };
+
+    const errorLevel = await getErrorLevel(options);
+
+    expect(errorLevel).toBe('full');
+  });
+
+  it('returns "full" when core.enableCrashReports is true', async () => {
+    const options: any = {
+      cliOptions: {
+        disableTelemetry: false,
+      },
+      presetOptions: {},
+      skipPrompt: false,
+    };
+
     jest.mocked(loadAllPresets).mockResolvedValueOnce({
       apply: async () => ({ enableCrashReports: true } as any),
     });
+    jest.mocked(cache.get).mockResolvedValueOnce(false);
 
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: {} as any, presetOptions: {} as any }, run)
-    ).rejects.toThrow(error);
+    const errorLevel = await getErrorLevel(options);
 
-    expect(telemetry).toHaveBeenCalledTimes(2);
-    expect(telemetry).toHaveBeenCalledWith(
-      'error',
-      { eventType: 'dev', error },
-      expect.objectContaining({})
-    );
+    expect(errorLevel).toBe('full');
   });
 
-  it('does not send any error message when telemetry is disabled', async () => {
+  it('returns "error" when core.enableCrashReports is false', async () => {
+    const options: any = {
+      cliOptions: {
+        disableTelemetry: false,
+      },
+      presetOptions: {},
+      skipPrompt: false,
+    };
+
     jest.mocked(loadAllPresets).mockResolvedValueOnce({
-      apply: async () => ({ disableTelemetry: true } as any),
-    });
-
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: {} as any, presetOptions: {} as any }, run)
-    ).rejects.toThrow(error);
-
-    expect(telemetry).toHaveBeenCalledTimes(1);
-    expect(telemetry).not.toHaveBeenCalledWith(
-      'error',
-      expect.objectContaining({}),
-      expect.objectContaining({})
-    );
-  });
-
-  it('does send error messages when telemetry is disabled, but crash reports are enabled', async () => {
-    jest.mocked(loadAllPresets).mockResolvedValueOnce({
-      apply: async () => ({ disableTelemetry: true, enableCrashReports: true } as any),
-    });
-
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: {} as any, presetOptions: {} as any }, run)
-    ).rejects.toThrow(error);
-
-    expect(telemetry).toHaveBeenCalledTimes(2);
-    expect(telemetry).toHaveBeenCalledWith(
-      'error',
-      { eventType: 'dev', error },
-      expect.objectContaining({})
-    );
-  });
-
-  it('does not send  full  error messages when disabled crash reports are cached', async () => {
-    jest.mocked(loadAllPresets).mockResolvedValueOnce({
-      apply: async () => ({} as any),
+      apply: async () => ({ enableCrashReports: false } as any),
     });
     jest.mocked(cache.get).mockResolvedValueOnce(false);
 
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: {} as any, presetOptions: {} as any }, run)
-    ).rejects.toThrow(error);
+    const errorLevel = await getErrorLevel(options);
 
-    expect(telemetry).toHaveBeenCalledTimes(2);
-    expect(telemetry).toHaveBeenCalledWith(
-      'error',
-      { eventType: 'dev' },
-      expect.objectContaining({})
-    );
+    expect(errorLevel).toBe('error');
   });
 
-  it('does send error messages when enabled crash reports are cached', async () => {
+  it('returns "none" when core.disableTelemetry is true', async () => {
+    const options: any = {
+      cliOptions: {
+        disableTelemetry: false,
+      },
+      presetOptions: {},
+      skipPrompt: false,
+    };
+
     jest.mocked(loadAllPresets).mockResolvedValueOnce({
-      apply: async () => ({} as any),
+      apply: async () => ({ disableTelemetry: true } as any),
     });
+    jest.mocked(cache.get).mockResolvedValueOnce(false);
+
+    const errorLevel = await getErrorLevel(options);
+
+    expect(errorLevel).toBe('none');
+  });
+
+  it('returns "full" if cache contains crashReports true', async () => {
+    const options: any = {
+      cliOptions: {
+        disableTelemetry: false,
+      },
+      presetOptions: {},
+      skipPrompt: false,
+    };
+
     jest.mocked(cache.get).mockResolvedValueOnce(true);
+    jest.mocked(loadAllPresets).mockResolvedValueOnce({
+      apply: async () => ({} as any),
+    });
 
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: {} as any, presetOptions: {} as any }, run)
-    ).rejects.toThrow(error);
+    const errorLevel = await getErrorLevel(options);
 
-    expect(telemetry).toHaveBeenCalledTimes(2);
-    expect(telemetry).toHaveBeenCalledWith(
-      'error',
-      { eventType: 'dev', error },
-      expect.objectContaining({})
-    );
+    expect(errorLevel).toBe('full');
   });
 
-  it('does not send full error messages when disabled crash reports are prompted', async () => {
+  it('returns "error" when skipPrompt is true', async () => {
+    const options: any = {
+      cliOptions: {
+        disableTelemetry: false,
+      },
+      presetOptions: {},
+      skipPrompt: true,
+    };
+
     jest.mocked(loadAllPresets).mockResolvedValueOnce({
       apply: async () => ({} as any),
     });
     jest.mocked(cache.get).mockResolvedValueOnce(undefined);
-    jest.mocked(prompts).mockResolvedValueOnce({ enableCrashReports: false });
 
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: {} as any, presetOptions: {} as any }, run)
-    ).rejects.toThrow(error);
+    const errorLevel = await getErrorLevel(options);
 
-    expect(telemetry).toHaveBeenCalledTimes(2);
-    expect(telemetry).toHaveBeenCalledWith(
-      'error',
-      { eventType: 'dev' },
-      expect.objectContaining({})
-    );
-  });
-
-  it('does send error messages when enabled crash reports are prompted', async () => {
-    jest.mocked(loadAllPresets).mockResolvedValueOnce({
-      apply: async () => ({} as any),
-    });
-    jest.mocked(cache.get).mockResolvedValueOnce(undefined);
-    jest.mocked(prompts).mockResolvedValueOnce({ enableCrashReports: true });
-
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: {} as any, presetOptions: {} as any }, run)
-    ).rejects.toThrow(error);
-
-    expect(telemetry).toHaveBeenCalledTimes(2);
-    expect(telemetry).toHaveBeenCalledWith(
-      'error',
-      { eventType: 'dev', error },
-      expect.objectContaining({})
-    );
-  });
-
-  // if main.js has errors, we have no way to tell if they've disabled error reporting,
-  // so we assume they have.
-  it('does not send full error messages when presets fail to evaluate', async () => {
-    jest.mocked(loadAllPresets).mockRejectedValueOnce(error);
-
-    await expect(async () =>
-      withTelemetry('dev', { cliOptions: {} as any, presetOptions: {} as any }, run)
-    ).rejects.toThrow(error);
-
-    expect(telemetry).toHaveBeenCalledTimes(2);
-    expect(telemetry).toHaveBeenCalledWith(
-      'error',
-      { eventType: 'dev' },
-      expect.objectContaining({})
-    );
+    expect(errorLevel).toBe('error');
   });
 });

--- a/code/lib/core-server/src/withTelemetry.ts
+++ b/code/lib/core-server/src/withTelemetry.ts
@@ -4,7 +4,6 @@ import { loadAllPresets, cache } from '@storybook/core-common';
 import { telemetry, getPrecedingUpgrade, oneWayHash } from '@storybook/telemetry';
 import type { EventType } from '@storybook/telemetry';
 import { logger } from '@storybook/node-logger';
-import invariant from 'tiny-invariant';
 
 type TelemetryOptions = {
   cliOptions: CLIOptions;
@@ -32,7 +31,7 @@ const promptCrashReports = async () => {
 
 type ErrorLevel = 'none' | 'error' | 'full';
 
-async function getErrorLevel({
+export async function getErrorLevel({
   cliOptions,
   presetOptions,
   skipPrompt,
@@ -67,7 +66,7 @@ async function getErrorLevel({
 }
 
 export async function sendTelemetryError(
-  error: unknown,
+  _error: unknown,
   eventType: EventType,
   options: TelemetryOptions
 ) {
@@ -81,10 +80,7 @@ export async function sendTelemetryError(
     if (errorLevel !== 'none') {
       const precedingUpgrade = await getPrecedingUpgrade();
 
-      invariant(
-        error instanceof Error,
-        'The error passed to sendTelemetryError was not an Error, please only send Errors'
-      );
+      const error = _error as Error | Record<string, any>;
 
       let storybookErrorProperties = {};
       // if it's an UNCATEGORIZED error, it won't have a coded name, so we just pass the category and source
@@ -104,14 +100,23 @@ export async function sendTelemetryError(
         };
       }
 
+      let errorHash;
+      if ('message' in error) {
+        errorHash = error.message ? oneWayHash(error.message) : 'empty-message';
+      } else {
+        errorHash = 'no-message';
+      }
+
       await telemetry(
         'error',
         {
+          ...storybookErrorProperties,
           eventType,
           precedingUpgrade,
           error: errorLevel === 'full' ? error : undefined,
-          errorHash: oneWayHash(error.message),
-          ...storybookErrorProperties,
+          errorHash,
+          // if we ever end up sending a non-error instance, we'd like to know
+          isErrorInstance: error instanceof Error,
         },
         {
           immediate: true,

--- a/code/lib/telemetry/src/sanitize.test.ts
+++ b/code/lib/telemetry/src/sanitize.test.ts
@@ -1,7 +1,23 @@
+/* eslint-disable local-rules/no-uncategorized-errors */
 import { sanitizeError, cleanPaths } from './sanitize';
 
 describe(`Errors Helpers`, () => {
   describe(`sanitizeError`, () => {
+    it(`Sanitizes ansi codes in error`, () => {
+      const errorMessage = `\u001B[4mStorybook\u001B[0m`;
+      let e: any;
+      try {
+        throw new Error(errorMessage);
+      } catch (error) {
+        e = error;
+      }
+
+      const sanitizedError = sanitizeError(e);
+
+      expect(sanitizedError.message).toEqual('Storybook');
+      expect(sanitizedError.stack).toContain('Error: Storybook');
+    });
+
     it(`Sanitizes current path from error stacktraces`, () => {
       const errorMessage = `this is a test`;
       let e: any;

--- a/code/lib/telemetry/src/sanitize.test.ts
+++ b/code/lib/telemetry/src/sanitize.test.ts
@@ -85,14 +85,12 @@ describe(`Errors Helpers`, () => {
       `should clean path on unix: %s`,
       (filePath) => {
         const cwdMockPath = `/Users/username/storybook-app`;
-        const fullPath = `${cwdMockPath}/${filePath}`;
-
         const mockCwd = jest.spyOn(process, `cwd`).mockImplementation(() => cwdMockPath);
 
-        const errorMessage = `This path should be sanitized ${fullPath}`;
+        const errorMessage = `Path 1 /Users/Username/storybook-app/${filePath} Path 2 /Users/username/storybook-app/${filePath}`;
 
         expect(cleanPaths(errorMessage, `/`)).toBe(
-          `This path should be sanitized $SNIP/${filePath}`
+          `Path 1 $SNIP/${filePath} Path 2 $SNIP/${filePath}`
         );
         mockCwd.mockRestore();
       }
@@ -102,14 +100,12 @@ describe(`Errors Helpers`, () => {
       `should clean path on windows: %s`,
       (filePath) => {
         const cwdMockPath = `C:\\Users\\username\\storybook-app`;
-        const fullPath = `${cwdMockPath}\\${filePath}`;
 
-        const mockCwd = jest.spyOn(process, `cwd`).mockImplementation(() => cwdMockPath);
+        const mockCwd = jest.spyOn(process, `cwd`).mockImplementationOnce(() => cwdMockPath);
 
-        const errorMessage = `This path should be sanitized ${fullPath}`;
-
+        const errorMessage = `Path 1 C:\\Users\\username\\storybook-app\\${filePath} Path 2 c:\\Users\\username\\storybook-app\\${filePath}`;
         expect(cleanPaths(errorMessage, `\\`)).toBe(
-          `This path should be sanitized $SNIP\\${filePath}`
+          `Path 1 $SNIP\\${filePath} Path 2 $SNIP\\${filePath}`
         );
         mockCwd.mockRestore();
       }

--- a/code/lib/telemetry/src/sanitize.ts
+++ b/code/lib/telemetry/src/sanitize.ts
@@ -12,7 +12,7 @@ function regexpEscape(str: string): string {
   return str.replace(/[-[/{}()*+?.\\^$|]/g, `\\$&`);
 }
 
-export function removeAnsiEscapeCodes(input: string): string {
+export function removeAnsiEscapeCodes(input = ''): string {
   // eslint-disable-next-line no-control-regex
   return input.replace(/\u001B\[[0-9;]*m/g, '');
 }
@@ -39,16 +39,13 @@ export function cleanPaths(str: string, separator: string = sep): string {
 // Takes an Error and returns a sanitized JSON String
 export function sanitizeError(error: Error, pathSeparator: string = sep) {
   try {
-    // Hack because Node
-    error = JSON.parse(
-      JSON.stringify(error, [...Object.getOwnPropertyNames(error), 'message', 'name'])
-    );
-    if (error.message) {
-      error.message = removeAnsiEscapeCodes(error.message);
-    }
-    if (error.stack) {
-      error.stack = removeAnsiEscapeCodes(error.stack);
-    }
+    error = {
+      ...JSON.parse(JSON.stringify(error)),
+      message: removeAnsiEscapeCodes(error.message),
+      stack: removeAnsiEscapeCodes(error.stack),
+      cause: error.cause,
+      name: error.name,
+    };
 
     // Removes all user paths
     const errorString = cleanPaths(JSON.stringify(error), pathSeparator);

--- a/code/lib/telemetry/src/sanitize.ts
+++ b/code/lib/telemetry/src/sanitize.ts
@@ -24,11 +24,11 @@ export function cleanPaths(str: string, separator: string = sep): string {
 
   while (stack.length > 1) {
     const currentPath = stack.join(separator);
-    const currentRegex = new RegExp(regexpEscape(currentPath), `g`);
+    const currentRegex = new RegExp(regexpEscape(currentPath), `gi`);
     str = str.replace(currentRegex, `$SNIP`);
 
     const currentPath2 = stack.join(separator + separator);
-    const currentRegex2 = new RegExp(regexpEscape(currentPath2), `g`);
+    const currentRegex2 = new RegExp(regexpEscape(currentPath2), `gi`);
     str = str.replace(currentRegex2, `$SNIP`);
 
     stack.pop();


### PR DESCRIPTION
Closes #24026, Closes #24027, Closes #24035

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

- ansi codes are now removed from error messages and error stacks
- non-error instances are now allowed to be sent to telemetry
- added tests related to ansi code stripping
- added tests non-related to this PR, but the file didn't have good coverage so now it does

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

No need, check the unit tests

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
