### PR TITLE
Core: Add CJS entrypoints to errors in core events

### DIFF
--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -61,6 +61,7 @@
     "@ndelangen/get-tarball": "^3.0.7",
     "@storybook/codemod": "workspace:*",
     "@storybook/core-common": "workspace:*",
+    "@storybook/core-events": "workspace:*",
     "@storybook/core-server": "workspace:*",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/node-logger": "workspace:*",

--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -44,6 +44,7 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
+    "@storybook/core-events": "workspace:*",
     "@storybook/node-logger": "workspace:*",
     "@storybook/types": "workspace:*",
     "@types/find-cache-dir": "^3.2.1",

--- a/code/lib/core-events/manager-errors.js
+++ b/code/lib/core-events/manager-errors.js
@@ -1,0 +1,4 @@
+// This is required for projects that require paths such as `@storybook/core-events/manager-errors`
+// but in CJS, while not in ESM mode. Else an error like this will occur:
+// ENOENT: no such file or directory, open '/xyz/node_modules/@storybook/core-events/manager-errors.js'
+module.exports = require('./dist/errors/manager-errors');

--- a/code/lib/core-events/preview-errors.js
+++ b/code/lib/core-events/preview-errors.js
@@ -1,0 +1,4 @@
+// This is required for projects that require paths such as `@storybook/core-events/preview-errors`
+// but in CJS, while not in ESM mode. Else an error like this will occur:
+// ENOENT: no such file or directory, open '/xyz/node_modules/@storybook/core-events/preview-errors.js'
+module.exports = require('./dist/errors/preview-errors');

--- a/code/lib/core-events/server-errors.js
+++ b/code/lib/core-events/server-errors.js
@@ -1,0 +1,4 @@
+// This is required for projects that require paths such as `@storybook/core-events/server-errors`
+// but in CJS, while not in ESM mode. Else an error like this will occur:
+// ENOENT: no such file or directory, open '/xyz/node_modules/@storybook/core-events/server-errors.js'
+module.exports = require('./dist/errors/server-errors');

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6560,6 +6560,7 @@ __metadata:
     "@storybook/client-api": "workspace:*"
     "@storybook/codemod": "workspace:*"
     "@storybook/core-common": "workspace:*"
+    "@storybook/core-events": "workspace:*"
     "@storybook/core-server": "workspace:*"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/node-logger": "workspace:*"
@@ -6708,6 +6709,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/core-common@workspace:lib/core-common"
   dependencies:
+    "@storybook/core-events": "workspace:*"
     "@storybook/node-logger": "workspace:*"
     "@storybook/types": "workspace:*"
     "@types/find-cache-dir": ^3.2.1


### PR DESCRIPTION
Closes #24009

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

When running tests with `composeStories` in Jest where node with ESM is not enabled, the tests fail with:
<img width="635" alt="image" src="https://github.com/storybookjs/storybook/assets/1671563/bd715d3f-2858-4007-9bb7-81653ebcddbd">

This PR solves that.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Use this repro:
- https://github.com/lukemcd-hero/storybook-test
- change a typo in `Button.test.js` in that repo:
```diff
- const { Default } = composeStories(stories)
+ const { Primary } = composeStories(stories)
```
- Update to the canary `0.0.0-pr-24038-sha-abd016e1`
- `npm run test` – it should work

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-24038-sha-abd016e1`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24038-sha-abd016e1). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-24038-sha-abd016e1`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24038-sha-abd016e1) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/fix-cjs-entries-on-core-events`](https://github.com/storybookjs/storybook/tree/yann/fix-cjs-entries-on-core-events) |
| **Commit** | [`abd016e1`](https://github.com/storybookjs/storybook/commit/abd016e1e583fe5be5b8efd9a7b1e49544899f70) |
| **Datetime** | Sun Sep  3 19:48:50 UTC 2023 (`1693770530`) |
| **Workflow run** | [6066425997](https://github.com/storybookjs/storybook/actions/runs/6066425997) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=24038`_
</details>
<!-- CANARY_RELEASE_SECTION -->
