### PR TITLE
CI: Inform the user how to dedupe and strip color from info command

### DIFF
--- a/code/lib/cli/src/automigrate/helpers/getMigrationSummary.test.ts
+++ b/code/lib/cli/src/automigrate/helpers/getMigrationSummary.test.ts
@@ -147,7 +147,9 @@ describe('getMigrationSummary', () => {
       @storybook/addon-essentials:
       7.0.0, 7.1.0
 
-      You can find more information for a given dependency by running yarn why <package-name>"
+      You can find more information for a given dependency by running yarn why <package-name>
+
+      Please try de-duplicating these dependencies by running yarn dedupe"
     `);
   });
 

--- a/code/lib/cli/src/automigrate/helpers/getMigrationSummary.test.ts
+++ b/code/lib/cli/src/automigrate/helpers/getMigrationSummary.test.ts
@@ -32,6 +32,7 @@ describe('getMigrationSummary', () => {
     },
     dependencies: {},
     infoCommand: 'yarn why',
+    dedupeCommand: 'yarn dedupe',
   };
 
   const logFile = '/path/to/log/file';

--- a/code/lib/cli/src/automigrate/helpers/getMigrationSummary.ts
+++ b/code/lib/cli/src/automigrate/helpers/getMigrationSummary.ts
@@ -184,6 +184,11 @@ function getWarnings(installationMetadata: InstallationMetadata) {
       `${installationMetadata.infoCommand} <package-name>`
     )}`
   );
+  messages.push(
+    `Please try de-duplicating these dependencies by running ${chalk.cyan(
+      `${installationMetadata.dedupeCommand}`
+    )}`
+  );
 
   return messages;
 }

--- a/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.test.ts
@@ -379,6 +379,7 @@ describe('NPM Proxy', () => {
 
       expect(installations).toMatchInlineSnapshot(`
         Object {
+          "dedupeCommand": "npm dedupe",
           "dependencies": Object {
             "@storybook/addon-interactions": Array [
               Object {

--- a/code/lib/cli/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/NPMProxy.ts
@@ -142,6 +142,9 @@ export class NPMProxy extends JsPackageManager {
       args: ['ls', '--json', '--depth=99', pipeToNull],
       // ignore errors, because npm ls will exit with code 1 if there are e.g. unmet peer dependencies
       ignoreError: true,
+      env: {
+        FORCE_COLOR: 'false',
+      },
     });
 
     try {
@@ -272,6 +275,7 @@ export class NPMProxy extends JsPackageManager {
       dependencies: acc,
       duplicatedDependencies,
       infoCommand: 'npm ls --depth=1',
+      dedupeCommand: 'npm dedupe',
     };
   }
 

--- a/code/lib/cli/src/js-package-manager/PNPMProxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/PNPMProxy.test.ts
@@ -316,6 +316,7 @@ describe('PNPM Proxy', () => {
 
       expect(installations).toMatchInlineSnapshot(`
         Object {
+          "dedupeCommand": "pnpm dedupe",
           "dependencies": Object {
             "@storybook/addon-interactions": Array [
               Object {

--- a/code/lib/cli/src/js-package-manager/PNPMProxy.ts
+++ b/code/lib/cli/src/js-package-manager/PNPMProxy.ts
@@ -101,6 +101,9 @@ export class PNPMProxy extends JsPackageManager {
     const commandResult = await this.executeCommand({
       command: 'pnpm',
       args: ['list', pattern.map((p) => `"${p}"`).join(' '), '--json', '--depth=99'],
+      env: {
+        FORCE_COLOR: 'false',
+      },
     });
 
     try {
@@ -287,6 +290,7 @@ export class PNPMProxy extends JsPackageManager {
       dependencies: acc,
       duplicatedDependencies,
       infoCommand: 'pnpm list --depth=1',
+      dedupeCommand: 'pnpm dedupe',
     };
   }
 

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.test.ts
@@ -241,6 +241,7 @@ describe('Yarn 1 Proxy', () => {
 
       expect(installations).toMatchInlineSnapshot(`
         Object {
+          "dedupeCommand": "yarn dedupe",
           "dependencies": Object {
             "@storybook/addon-interactions": Array [
               Object {

--- a/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn1Proxy.ts
@@ -91,6 +91,9 @@ export class Yarn1Proxy extends JsPackageManager {
     const commandResult = await this.executeCommand({
       command: 'yarn',
       args: ['list', '--pattern', pattern.map((p) => `"${p}"`).join(' '), '--recursive', '--json'],
+      env: {
+        FORCE_COLOR: 'false',
+      },
     });
 
     try {
@@ -215,6 +218,7 @@ export class Yarn1Proxy extends JsPackageManager {
         dependencies: acc,
         duplicatedDependencies,
         infoCommand: 'yarn why',
+        dedupeCommand: 'yarn dedupe',
       };
     }
 

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.test.ts
@@ -219,6 +219,7 @@ describe('Yarn 2 Proxy', () => {
 
       expect(installations).toMatchInlineSnapshot(`
         Object {
+          "dedupeCommand": "yarn dedupe",
           "dependencies": Object {
             "@storybook/global": Array [
               Object {

--- a/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/cli/src/js-package-manager/Yarn2Proxy.ts
@@ -114,6 +114,9 @@ export class Yarn2Proxy extends JsPackageManager {
         pattern.map((p) => `"${p}"`).join(' '),
         `"${pattern}"`,
       ],
+      env: {
+        FORCE_COLOR: 'false',
+      },
     });
 
     try {
@@ -286,6 +289,7 @@ export class Yarn2Proxy extends JsPackageManager {
       dependencies: acc,
       duplicatedDependencies,
       infoCommand: 'yarn why',
+      dedupeCommand: 'yarn dedupe',
     };
   }
 

--- a/code/lib/cli/src/js-package-manager/types.ts
+++ b/code/lib/cli/src/js-package-manager/types.ts
@@ -3,4 +3,5 @@ export type InstallationMetadata = {
   dependencies: Record<string, PackageMetadata[]>;
   duplicatedDependencies: Record<string, string[]>;
   infoCommand: string;
+  dedupeCommand: string;
 };


### PR DESCRIPTION
<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Will fix this action:
https://github.com/storybookjs/test-runner/actions/runs/6067616875

As semver chokes on the the color of the output.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Let's see if the test runner action will be green again.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
