### PR TITLE
feat: Added vue docgen options for vite builds

### DIFF
--- a/code/addons/docs/vue/README.md
+++ b/code/addons/docs/vue/README.md
@@ -36,24 +36,22 @@ export default {
 
 ## Preset options
 
-The `addon-docs` preset for Vue has a configuration option that can be used to configure [`vue-docgen-api`](https://github.com/vue-styleguidist/vue-styleguidist/tree/dev/packages/vue-docgen-api), a tool which extracts information from Vue components. Here's an example of how to use the preset with options for Vue app:
+The `framework` preset for Vue has a configuration option that can be used to configure [`vue-docgen-api`](https://github.com/vue-styleguidist/vue-styleguidist/tree/dev/packages/vue-docgen-api), a tool which extracts information from Vue components. Here's an example of how to use the preset with options for Vue app:
 
 ```js
 import * as path from 'path';
 
 export default {
-  addons: [
-    {
-      name: '@storybook/addon-docs',
-      options: {
-        vueDocgenOptions: {
-          alias: {
-            '@': path.resolve(__dirname, '../'),
-          },
-        },
-      },
+  framework: {
+    name: '@storybook/vue-vite',
+    options: {
+      docgenOptions: {
+        alias: {
+          '@': path.resolve(__dirname, '../'),
+        }
+      }
     },
-  ],
+  },
 };
 ```
 

--- a/code/addons/docs/vue3/README.md
+++ b/code/addons/docs/vue3/README.md
@@ -36,24 +36,22 @@ export default {
 
 ## Preset options
 
-The `addon-docs` preset for Vue has a configuration option that can be used to configure [`vue-docgen-api`](https://github.com/vue-styleguidist/vue-styleguidist/tree/dev/packages/vue-docgen-api), a tool which extracts information from Vue components. Here's an example of how to use the preset with options for Vue app:
+The `framework` preset for Vue has a configuration option that can be used to configure [`vue-docgen-api`](https://github.com/vue-styleguidist/vue-styleguidist/tree/dev/packages/vue-docgen-api), a tool which extracts information from Vue components. Here's an example of how to use the preset with options for Vue app:
 
 ```js
 import * as path from 'path';
 
 export default {
-  addons: [
-    {
-      name: '@storybook/addon-docs',
-      options: {
-        vueDocgenOptions: {
-          alias: {
-            '@': path.resolve(__dirname, '../'),
-          },
-        },
-      },
+  framework: {
+    name: '@storybook/vue3-vite',
+    options: {
+      docgenOptions: {
+        alias: {
+          '@': path.resolve(__dirname, '../'),
+        }
+      }
     },
-  ],
+  },
 };
 ```
 

--- a/code/frameworks/vue-vite/src/types.ts
+++ b/code/frameworks/vue-vite/src/types.ts
@@ -1,11 +1,13 @@
 import type { StorybookConfig as StorybookConfigBase } from '@storybook/types';
 import type { StorybookConfigVite, BuilderOptions } from '@storybook/builder-vite';
+import type { DocGenOptions } from 'vue-docgen-api';
 
 type FrameworkName = '@storybook/vue-vite';
 type BuilderName = '@storybook/builder-vite';
 
 export type FrameworkOptions = {
   builder?: BuilderOptions;
+  docgenOptions?: DocGenOptions;
 };
 
 type StorybookConfigFramework = {

--- a/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
@@ -3,7 +3,7 @@ import type { PluginOption } from 'vite';
 import { createFilter } from 'vite';
 import MagicString from 'magic-string';
 
-export function vueDocgen(): PluginOption {
+export function vueDocgen(options): PluginOption {
   const include = /\.(vue)$/;
   const filter = createFilter(include);
 
@@ -13,7 +13,7 @@ export function vueDocgen(): PluginOption {
     async transform(src: string, id: string) {
       if (!filter(id)) return undefined;
 
-      const metaData = await parse(id);
+      const metaData = await parse(id, options);
       const metaSource = JSON.stringify(metaData);
       const s = new MagicString(src);
       s.append(`;_sfc_main.__docgenInfo = ${metaSource}`);

--- a/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
@@ -1,9 +1,9 @@
-import { parse } from 'vue-docgen-api';
+import { DocGenOptions, parse } from 'vue-docgen-api';
 import type { PluginOption } from 'vite';
 import { createFilter } from 'vite';
 import MagicString from 'magic-string';
 
-export function vueDocgen(options): PluginOption {
+export function vueDocgen(options?: DocGenOptions): PluginOption {
   const include = /\.(vue)$/;
   const filter = createFilter(include);
 

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -22,8 +22,10 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets 
     plugins.push(vue());
   }
 
+  const framework = await presets.apply<StorybookConfig['framework']>('framework');
+
   // Add docgen plugin
-  plugins.push(vueDocgen());
+  plugins.push(vueDocgen(typeof framework === 'string' ? undefined : framework.options.docgenOptions));
 
   return mergeConfig(config, {
     plugins,

--- a/code/frameworks/vue3-vite/src/types.ts
+++ b/code/frameworks/vue3-vite/src/types.ts
@@ -1,11 +1,13 @@
 import type { StorybookConfig as StorybookConfigBase } from '@storybook/types';
 import type { StorybookConfigVite, BuilderOptions } from '@storybook/builder-vite';
+import type { DocGenOptions } from 'vue-docgen-api';
 
 type FrameworkName = '@storybook/vue3-vite';
 type BuilderName = '@storybook/builder-vite';
 
 export type FrameworkOptions = {
   builder?: BuilderOptions;
+  docgenOptions?: DocGenOptions;
 };
 
 type StorybookConfigFramework = {


### PR DESCRIPTION
Closes #22909 

## What I did

I added the possibility to configure the  vue docgen options for advanced usage in Vite. For example for monorepo file aliases for docs.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Added logging to the `preset.ts` and `vue-docgen.ts`.
2. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template vue3-vite/default-ts`.
3. Change the main.ts options (repeatedly based on those options: https://vue-styleguidist.github.io/docs/Docgen.html#api)
4. Checked if the variables are passed correctly and output.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
