### PR TITLE
Build: Allow sandboxes to be excluded

### DIFF
--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -57,9 +57,16 @@ export type Template = {
   skipTasks?: SkippableTask[];
   /**
    * Set this only while developing a newly created framework, to avoid using it in CI.
+   * This will still generate sandboxes for this template.
    * NOTE: Make sure to always add a TODO comment to remove this flag in a subsequent PR.
    */
   inDevelopment?: boolean;
+
+  /**
+   * Set this to exclude a template complete. This will also generate sandboxes for this template.
+   */
+  exclude?: boolean;
+
   /**
    * Some sandboxes might need extra modifications in the initialized Storybook,
    * such as extend main.js, for setting specific feature flags like storyStoreV7, etc.

--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -63,7 +63,7 @@ export type Template = {
   inDevelopment?: boolean;
 
   /**
-   * Set this to exclude a template complete. This will also generate sandboxes for this template.
+   * Set this to exclude a template complete. This will also make sure that no sandboxes are generated for this template.
    */
   exclude?: boolean;
 

--- a/scripts/get-template.ts
+++ b/scripts/get-template.ts
@@ -15,7 +15,7 @@ import { SANDBOX_DIRECTORY } from './utils/constants';
 
 const sandboxDir = process.env.SANDBOX_ROOT || SANDBOX_DIRECTORY;
 
-type Template = Pick<TTemplate, 'inDevelopment' | 'skipTasks'>;
+type Template = Pick<TTemplate, 'inDevelopment' | 'skipTasks' | 'exclude'>;
 export type TemplateKey = keyof typeof allTemplates;
 export type Templates = Record<TemplateKey, Template>;
 
@@ -53,6 +53,7 @@ export async function getTemplate(
     const currentTemplate = allTemplates[t] as Template;
     return (
       currentTemplate.inDevelopment !== true &&
+      currentTemplate.exclude !== true &&
       !currentTemplate.skipTasks?.includes(scriptName as SkippableTask)
     );
   });

--- a/scripts/sandbox/generate.ts
+++ b/scripts/sandbox/generate.ts
@@ -229,12 +229,11 @@ export const generate = async ({
       dirName,
       ...configuration,
     }))
-    .filter(({ dirName }) => {
+    .filter(({ dirName, exclude }) => {
       if (template) {
         return dirName === template;
       }
-
-      return true;
+      return !exclude;
     });
 
   await runGenerators(generatorConfigs, localRegistry, debug);


### PR DESCRIPTION
## What I did

Add an option for sandboxes to be exlucded completely. Not only for runnning in CI, but also for generating sandboxes.

We need this to get CI green, as the angular prerelease sandbox is not working in Node 18 anymore.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
