### PR TITLE
UI: Fix SVG override fill when path has a fill attribute

### DIFF
--- a/code/ui/components/src/components/Button/Button.tsx
+++ b/code/ui/components/src/components/Button/Button.tsx
@@ -167,7 +167,7 @@ const ButtonWrapper = styled.button<{
           boxShadow: `${color} 0 0 0 1px inset`,
           color,
 
-          'svg path': {
+          'svg path:not([fill])': {
             fill: color,
           },
 
@@ -205,7 +205,7 @@ const ButtonWrapper = styled.button<{
           boxShadow: `${color} 0 0 0 1px inset`,
           color,
 
-          'svg path': {
+          'svg path:not([fill])': {
             fill: color,
           },
 

--- a/code/ui/components/src/components/tooltip/ListItem.stories.tsx
+++ b/code/ui/components/src/components/tooltip/ListItem.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import ListItem from './ListItem';
 import { Icons } from '../icon/icon';
 
@@ -49,6 +49,93 @@ export const ActiveIcon = {
     title: 'Active icon',
     active: true,
     right: <Icons icon="eye" />,
+  },
+};
+export const ActiveIconLeft = {
+  args: {
+    title: 'Active icon',
+    active: true,
+    left: <Icons icon="eye" />,
+  },
+};
+export const ActiveIconLeftColored = {
+  args: {
+    title: 'Active icon',
+    active: true,
+    left: (
+      <Fragment>
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-label="Chrome"
+        >
+          <path
+            d="M5.06982 9.68493L7.99484 4.63927L14.5786 4.62406C14.5252 4.52043 14.4696 4.41742 14.4109 4.31532C12.372 0.768556 7.84405 -0.453864 4.29726 1.58495C3.24614 2.1892 2.39921 3.01211 1.78076 3.96327L5.06982 9.68493Z"
+            fill="#DB4437"
+          />
+          <path
+            d="M10.9276 9.68457L5.09539 9.6743L1.79036 3.98022C1.72727 4.07822 1.66591 4.17795 1.60682 4.27985C-0.445348 7.81892 0.759985 12.3515 4.29905 14.4037C5.34791 15.0118 6.48403 15.3338 7.617 15.3939L10.9276 9.68457Z"
+            fill="#0F9D58"
+          />
+          <path
+            d="M7.98649 4.61194L10.9032 9.66241L7.63525 15.3778C7.75167 15.3833 7.86871 15.3863 7.98649 15.3863C12.0775 15.3863 15.3939 12.0699 15.3939 7.97893C15.3939 6.76648 15.1025 5.62211 14.5861 4.61194L7.98649 4.61194Z"
+            fill="#FFCD40"
+          />
+          <path
+            d="M8.01367 4.6366V6.40005L14.613 4.6366H8.01367Z"
+            fill="url(#paint0_radial_466_21161)"
+          />
+          <path
+            d="M1.78198 4.00098L6.60102 8.8192L5.09764 9.687L1.78198 4.00098Z"
+            fill="url(#paint1_radial_466_21161)"
+          />
+          <path
+            d="M7.6626 15.4017L9.42689 8.81921L10.9303 9.68702L7.6626 15.4017Z"
+            fill="url(#paint2_radial_466_21161)"
+          />
+          <ellipse cx="8.01347" cy="8.00358" rx="3.36699" ry="3.36699" fill="#F1F1F1" />
+          <ellipse cx="8.01367" cy="8.00354" rx="2.69361" ry="2.6936" fill="#4285F4" />
+          <defs>
+            <radialGradient
+              id="paint0_radial_466_21161"
+              cx="0"
+              cy="0"
+              r="1"
+              gradientUnits="userSpaceOnUse"
+              gradientTransform="translate(7.69229 4.63226) scale(7.07721 1.89116)"
+            >
+              <stop stopColor="#3E2723" stopOpacity="0.2" />
+              <stop offset="1" stopColor="#3E2723" stopOpacity="0.01" />
+            </radialGradient>
+            <radialGradient
+              id="paint1_radial_466_21161"
+              cx="0"
+              cy="0"
+              r="1"
+              gradientUnits="userSpaceOnUse"
+              gradientTransform="translate(1.77445 4.00677) scale(6.56938 7.75127)"
+            >
+              <stop stopColor="#3E2723" stopOpacity="0.2" />
+              <stop offset="1" stopColor="#3E2723" stopOpacity="0.01" />
+            </radialGradient>
+            <radialGradient
+              id="paint2_radial_466_21161"
+              cx="0"
+              cy="0"
+              r="1"
+              gradientUnits="userSpaceOnUse"
+              gradientTransform="translate(8.00025 8.01489) scale(7.39644 14.8995)"
+            >
+              <stop stopColor="#263238" stopOpacity="0.2" />
+              <stop offset="1" stopColor="#263238" stopOpacity="0.01" />
+            </radialGradient>
+          </defs>
+        </svg>
+      </Fragment>
+    ),
   },
 };
 

--- a/code/ui/components/src/components/tooltip/ListItem.tsx
+++ b/code/ui/components/src/components/tooltip/ListItem.tsx
@@ -107,7 +107,7 @@ const Left = styled.span<LeftProps>(
           '& svg': {
             opacity: 1,
           },
-          '& svg path': {
+          '& svg path:not([fill])': {
             fill: theme.color.secondary,
           },
         }

--- a/code/ui/components/src/components/typography/link/link.tsx
+++ b/code/ui/components/src/components/typography/link/link.tsx
@@ -73,13 +73,13 @@ const A = styled.a<LinkStylesProps>(
     '&:hover, &:focus': {
       cursor: 'pointer',
       color: darken(0.07, theme.color.secondary),
-      'svg path': {
+      'svg path:not([fill])': {
         fill: darken(0.07, theme.color.secondary),
       },
     },
     '&:active': {
       color: darken(0.1, theme.color.secondary),
-      'svg path': {
+      'svg path:not([fill])': {
         fill: darken(0.1, theme.color.secondary),
       },
     },
@@ -110,20 +110,20 @@ const A = styled.a<LinkStylesProps>(
     return colors
       ? {
           color: colors[0],
-          'svg path': {
+          'svg path:not([fill])': {
             fill: colors[0],
           },
 
           '&:hover': {
             color: colors[1],
-            'svg path': {
+            'svg path:not([fill])': {
               fill: colors[1],
             },
           },
 
           '&:active': {
             color: colors[2],
-            'svg path': {
+            'svg path:not([fill])': {
               fill: colors[2],
             },
           },
@@ -145,20 +145,20 @@ const A = styled.a<LinkStylesProps>(
     inverse
       ? {
           color: theme.color.lightest,
-          'svg path': {
+          ':not([fill])': {
             fill: theme.color.lightest,
           },
 
           '&:hover': {
             color: theme.color.lighter,
-            'svg path': {
+            'svg path:not([fill])': {
               fill: theme.color.lighter,
             },
           },
 
           '&:active': {
             color: theme.color.light,
-            'svg path': {
+            'svg path:not([fill])': {
               fill: theme.color.light,
             },
           },


### PR DESCRIPTION
## What I did

I changed some selectors that are created to override the color of SVG in listItems.
They will no longer select `path`-elements, if they have an `fill` attribute defined on them.

This was causing an issue where all the `path` elements were getting their color overridden:

<img width="869" alt="Screenshot 2023-09-12 at 15 35 39" src="https://github.com/storybookjs/storybook/assets/3070389/cd7685a6-d1d4-44da-a86a-5fb4ef8641f2">

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I don't THINK we need any tests.. Though maybe I should add a story.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
