### PR TITLE
Core: Throw an error when critical presets fail to load

### DIFF
--- a/code/lib/core-common/src/presets.test.ts
+++ b/code/lib/core-common/src/presets.test.ts
@@ -102,6 +102,12 @@ describe('presets', () => {
     await expect(testPresets()).resolves.toBeUndefined();
   });
 
+  it('throws when preset can not be loaded and is critical', async () => {
+    const { getPresets } = jest.requireActual('./presets');
+
+    await expect(getPresets(['preset-foo'], { isCritical: true })).rejects.toThrow();
+  });
+
   it('loads and applies presets when they are combined in another preset', async () => {
     mockPreset('preset-foo', {
       foo: (exec: string[]) => exec.concat('foo'),

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -279,3 +279,30 @@ export class AngularLegacyBuildOptionsError extends StorybookError {
     `;
   }
 }
+
+export class CriticalPresetLoadError extends StorybookError {
+  readonly category = Category.CORE_SERVER;
+
+  readonly code = 2;
+
+  constructor(
+    public data: {
+      error: Error;
+      presetName: string;
+    }
+  ) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      Storybook failed to load the following preset: ${this.data.presetName}.
+
+      Please check whether your setup is correct, the Storybook dependencies (and their peer dependencies) are installed correctly and there are no package version clashes.
+
+      If you believe this is a bug, please open an issue on Github.
+
+      ${this.data.error.stack || this.data.error.message}
+    `;
+  }
+}

--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -84,6 +84,7 @@ export async function buildDevStandalone(
       require.resolve('@storybook/core-server/dist/presets/common-override-preset'),
     ],
     ...options,
+    isCritical: true,
   });
 
   const { renderer, builder, disableTelemetry } = await presets.apply<CoreConfig>('core', {});

--- a/code/lib/core-server/src/build-static.ts
+++ b/code/lib/core-server/src/build-static.ts
@@ -87,6 +87,7 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
     overridePresets: [
       require.resolve('@storybook/core-server/dist/presets/common-override-preset'),
     ],
+    isCritical: true,
     ...options,
   });
 


### PR DESCRIPTION
Relates to #24071

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Many users are having issues that say "No builder configured" which are cryptic, because it might mean something else is broken, and the "No builder configured" message is just a red herring. This PR will make sure that before we try to access a Storybook builder, if there is a failure when loading presets, it will result in a crash instead of warnings. This should help us and users to understand what is happening.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox for nextjs, e.g. `yarn task --task sandbox --start-from auto --template nextjs/default-ts`
2. Uninstall `next`
3. Run Storybook dev


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
