### PR TITLE
Core: Unify error when builder is missing

### DIFF
--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -306,3 +306,25 @@ export class CriticalPresetLoadError extends StorybookError {
     `;
   }
 }
+
+export class MissingBuilderError extends StorybookError {
+  readonly category = Category.CORE_SERVER;
+
+  readonly code = 3;
+
+  public readonly documentation = 'https://github.com/storybookjs/storybook/issues/24071';
+
+  template() {
+    return dedent`
+      Storybook could not find a builder configuration for your project. 
+      Builders normally come from a framework package e.g. '@storybook/react-vite', or from builder packages e.g. '@storybook/builder-vite'.
+      
+      - Does your main config file contain a 'framework' field configured correctly?
+      - Is the Storybook framework package installed correctly?
+      - If you don't use a framework, does your main config contain a 'core.builder' configured correctly?
+      - Are you in a monorepo and perhaps the framework package is hoisted incorrectly?
+
+      If you believe this is a bug, please describe your issue in detail on Github.
+    `;
+  }
+}

--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -19,6 +19,7 @@ import { global } from '@storybook/global';
 import { telemetry } from '@storybook/telemetry';
 
 import { join, resolve } from 'path';
+import { MissingBuilderError } from '@storybook/core-events/server-errors';
 import { storybookDevServer } from './dev-server';
 import { outputStats } from './utils/output-stats';
 import { outputStartupInformation } from './utils/output-startup-information';
@@ -89,7 +90,9 @@ export async function buildDevStandalone(
 
   const { renderer, builder, disableTelemetry } = await presets.apply<CoreConfig>('core', {});
 
-  invariant(builder, 'No builder configured in core.builder');
+  if (!builder) {
+    throw new MissingBuilderError();
+  }
 
   if (!options.disableTelemetry && !disableTelemetry) {
     if (versionCheck.success && !versionCheck.cached) {

--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -7,6 +7,7 @@ import type { CoreConfig, Options, StorybookConfig } from '@storybook/types';
 import { logConfig } from '@storybook/core-common';
 
 import { logger } from '@storybook/node-logger';
+import { MissingBuilderError } from '@storybook/core-events/server-errors';
 import { getMiddleware } from './utils/middleware';
 import { getServerAddresses } from './utils/server-address';
 import { getServer } from './utils/server-init';
@@ -67,7 +68,10 @@ export async function storybookDevServer(options: Options) {
     server.listen({ port, host }, (error: Error) => (error ? reject(error) : resolve()));
   });
 
-  invariant(core?.builder, 'no builder configured!');
+  if (!core?.builder) {
+    throw new MissingBuilderError();
+  }
+
   const builderName = typeof core?.builder === 'string' ? core.builder : core?.builder?.name;
 
   const [previewBuilder, managerBuilder] = await Promise.all([

--- a/code/lib/core-server/src/utils/get-builders.ts
+++ b/code/lib/core-server/src/utils/get-builders.ts
@@ -1,6 +1,6 @@
 import type { Builder, CoreConfig, Options } from '@storybook/types';
+import { MissingBuilderError } from '@storybook/core-events/server-errors';
 import { pathToFileURL } from 'node:url';
-import invariant from 'tiny-invariant';
 
 export async function getManagerBuilder(): Promise<Builder<unknown>> {
   return import('@storybook/builder-manager');
@@ -20,7 +20,11 @@ export async function getPreviewBuilder(
 
 export async function getBuilders({ presets, configDir }: Options): Promise<Builder<unknown>[]> {
   const { builder } = await presets.apply<CoreConfig>('core', {});
-  invariant(builder, 'no builder configured!');
+
+  if (!builder) {
+    throw new MissingBuilderError();
+  }
+
   const builderName = typeof builder === 'string' ? builder : builder.name;
 
   return Promise.all([getPreviewBuilder(builderName, configDir), getManagerBuilder()]);


### PR DESCRIPTION
Relates to #24071

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

This PR creates a categorized error for the previous scenario of "No builder configured!".
Additionally, it improves its messaging and encourages users who really get into this scenario, to add their reproduction detail in the official "No builder configured" Github issue.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
