### PR TITLE
Test: Add testing library and user event to the test package

### DIFF
--- a/code/.yarn/patches/@vitest-expect-npm-0.34.3-313878cdb4.patch
+++ b/code/.yarn/patches/@vitest-expect-npm-0.34.3-313878cdb4.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/index.js b/dist/index.js
+index 9fd849550098f37f44ac6f9f64ad174cc821759a..44afa9ccbc42dd81e07ffa794b4be89c61d00c37 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -6,7 +6,9 @@ import { isMockFunction } from '@vitest/spy';
+ import { processError } from '@vitest/utils/error';
+
+ const MATCHERS_OBJECT = Symbol.for("matchers-object");
+-const JEST_MATCHERS_OBJECT = Symbol.for("$$jest-matchers-object");
++// Patched this symbol for storybook, so that @storybook/test can be used in a jest environment as well.
++// Otherwise, vitest will override global jest matchers, and crash.
++const JEST_MATCHERS_OBJECT = Symbol.for("$$jest-matchers-object-storybook");
+ const GLOBAL_EXPECT = Symbol.for("expect-global");
+
+ if (!Object.prototype.hasOwnProperty.call(globalThis, MATCHERS_OBJECT)) {

--- a/code/addons/actions/src/addArgsHelpers.ts
+++ b/code/addons/actions/src/addArgsHelpers.ts
@@ -32,7 +32,7 @@ export const inferActionsFromArgTypesRegex: ArgsEnhancer<Renderer> = (context) =
 
   return argTypesMatchingRegex.reduce((acc, [name, argType]) => {
     if (isInInitialArgs(name, initialArgs)) {
-      acc[name] = action(name);
+      acc[name] = action(name, { implicit: true });
     }
     return acc;
   }, {} as Args);

--- a/code/addons/actions/src/models/ActionOptions.ts
+++ b/code/addons/actions/src/models/ActionOptions.ts
@@ -4,6 +4,7 @@ interface Options {
   depth: number; // backards compatibility, remove in 7.0
   clearOnStoryChange: boolean;
   limit: number;
+  implicit: boolean;
 }
 
 export type ActionOptions = Partial<Options> & Partial<TelejsonOptions>;

--- a/code/addons/actions/src/runtime/action.ts
+++ b/code/addons/actions/src/runtime/action.ts
@@ -1,5 +1,9 @@
+/* eslint-disable no-underscore-dangle */
 import { v4 as uuidv4 } from 'uuid';
+import type { PreviewWeb } from '@storybook/preview-api';
 import { addons } from '@storybook/preview-api';
+import type { Renderer } from '@storybook/types';
+import { global } from '@storybook/global';
 import { EVENT_ID } from '../constants';
 import type { ActionDisplay, ActionOptions, HandlerFunction } from '../models';
 import { config } from './configureActions';
@@ -46,6 +50,22 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
   };
 
   const handler = function actionHandler(...args: any[]) {
+    if (options.implicit) {
+      const preview =
+        '__STORYBOOK_PREVIEW__' in global
+          ? (global.__STORYBOOK_PREVIEW__ as PreviewWeb<Renderer>)
+          : undefined;
+      if (
+        preview?.storyRenders.some(
+          (render) => render.phase === 'playing' || render.phase === 'rendering'
+        )
+      ) {
+        console.warn(
+          'Can not use implicit actions during rendering or playing of a story. \nSee: [docs page]'
+        );
+      }
+    }
+
     const channel = addons.getChannel();
     const id = uuidv4();
     const minDepth = 5; // anything less is really just storybook internals

--- a/code/addons/actions/src/runtime/action.ts
+++ b/code/addons/actions/src/runtime/action.ts
@@ -1,9 +1,5 @@
-/* eslint-disable no-underscore-dangle */
 import { v4 as uuidv4 } from 'uuid';
-import type { PreviewWeb } from '@storybook/preview-api';
 import { addons } from '@storybook/preview-api';
-import type { Renderer } from '@storybook/types';
-import { global } from '@storybook/global';
 import { EVENT_ID } from '../constants';
 import type { ActionDisplay, ActionOptions, HandlerFunction } from '../models';
 import { config } from './configureActions';
@@ -50,21 +46,22 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
   };
 
   const handler = function actionHandler(...args: any[]) {
-    if (options.implicit) {
-      const preview =
-        '__STORYBOOK_PREVIEW__' in global
-          ? (global.__STORYBOOK_PREVIEW__ as PreviewWeb<Renderer>)
-          : undefined;
-      if (
-        preview?.storyRenders.some(
-          (render) => render.phase === 'playing' || render.phase === 'rendering'
-        )
-      ) {
-        console.warn(
-          'Can not use implicit actions during rendering or playing of a story. \nSee: [docs page]'
-        );
-      }
-    }
+    // TODO: Enable once codemods are finished
+    // if (options.implicit) {
+    //   const preview =
+    //     '__STORYBOOK_PREVIEW__' in global
+    //       ? (global.__STORYBOOK_PREVIEW__ as PreviewWeb<Renderer>)
+    //       : undefined;
+    //   if (
+    //     preview?.storyRenders.some(
+    //       (render) => render.phase === 'playing' || render.phase === 'rendering'
+    //     )
+    //   ) {
+    //     console.warn(
+    //       'Can not use implicit actions during rendering or playing of a story.'
+    //     );
+    //   }
+    // }
 
     const channel = addons.getChannel();
     const id = uuidv4();

--- a/code/addons/interactions/src/preview.ts
+++ b/code/addons/interactions/src/preview.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign,no-underscore-dangle */
 /// <reference types="node" />
 
 import { addons } from '@storybook/preview-api';
@@ -9,10 +10,10 @@ import type {
   PlayFunction,
   PlayFunctionContext,
   StepLabel,
+  Args,
 } from '@storybook/types';
 import { instrument } from '@storybook/instrumenter';
 import { ModuleMocker } from 'jest-mock';
-import { Args } from '@storybook/types';
 
 const JestMock = new ModuleMocker(global);
 const fn = JestMock.fn.bind(JestMock);
@@ -34,7 +35,7 @@ const addSpies = (id: string, val: any, key?: string): any => {
   try {
     if (Object.prototype.toString.call(val) === '[object Object]') {
       // We have to mutate the original object for this to survive HMR.
-      // eslint-disable-next-line no-restricted-syntax, no-param-reassign
+      // eslint-disable-next-line no-restricted-syntax
       for (const [k, v] of Object.entries(val)) val[k] = addSpies(id, v, k);
       return val;
     }

--- a/code/jest.config.base.js
+++ b/code/jest.config.base.js
@@ -23,6 +23,7 @@ const modulesToTransform = [
   '@angular',
   '@lit',
   '@mdx-js',
+  '@vitest',
   'ccount',
   'character-entities',
   'decode-named-character-reference',

--- a/code/lib/instrumenter/src/instrumenter.ts
+++ b/code/lib/instrumenter/src/instrumenter.ts
@@ -351,8 +351,9 @@ export class Instrumenter {
     const interceptable = typeof intercept === 'function' ? intercept(method, path) : intercept;
     const call = { id, cursor, storyId, ancestors, path, method, args, interceptable, retain };
     const interceptOrInvoke = interceptable && !ancestors.length ? this.intercept : this.invoke;
-    const promisifyFn = function (this: unknown, ...args: unknown[]) {
-      const value = fn.apply(this, args);
+    // eslint-disable-next-line func-names
+    const promisifyFn = function (this: unknown, ...argz: unknown[]) {
+      const value = fn.apply(this, argz);
       return interceptable && typeof value?.then !== 'function' ? Promise.resolve(value) : value;
     };
     const result = interceptOrInvoke.call(this, promisifyFn, object, call, options);

--- a/code/lib/instrumenter/src/instrumenter.ts
+++ b/code/lib/instrumenter/src/instrumenter.ts
@@ -303,19 +303,17 @@ export class Instrumenter {
     return keys.reduce(
       (acc, key) => {
         const value = (obj as Record<string, any>)[key];
-
         // Nothing to patch, but might be instrumentable, so we recurse
         if (typeof value !== 'function') {
-          const instrumented = this.instrument(
-            value,
-            { ...options, path: path.concat(key) },
-            depth
-          );
           const descriptor = getPropertyDescriptor(obj, key);
           if (typeof descriptor?.get === 'function') {
-            Object.defineProperty(acc, key, { get: () => instrumented });
+            Object.defineProperty(acc, key, {
+              get: () => {
+                return this.instrument(value, { ...options, path: path.concat(key) }, depth);
+              },
+            });
           } else {
-            acc[key] = instrumented;
+            acc[key] = this.instrument(value, { ...options, path: path.concat(key) }, depth);
           }
           return acc;
         }

--- a/code/lib/instrumenter/src/types.ts
+++ b/code/lib/instrumenter/src/types.ts
@@ -90,5 +90,5 @@ export interface Options {
   mutate?: boolean;
   path?: Array<string | CallRef>;
   getArgs?: (call: Call, state: State) => Call['args'];
-  getKeys?: (originalObject: Record<string, unknown>) => string[];
+  getKeys?: (originalObject: Record<string, unknown>, depth: number) => string[];
 }

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -50,16 +50,18 @@
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/user-event": "^14.4.3",
-    "@vitest/expect": "^0.34.2",
-    "@vitest/spy": "^0.34.1",
     "chai": "^4.3.7",
     "expect": "^29.6.2",
+    "loupe": "^2.3.1",
     "ts-dedent": "^2.2.0"
   },
   "devDependencies": {
     "@types/chai": "^4",
+    "@vitest/expect": "^0.34.2",
+    "@vitest/spy": "^0.34.1",
     "type-fest": "~2.19",
-    "typescript": "~4.9.3"
+    "typescript": "~4.9.3",
+    "util": "^0.12.4"
   },
   "publishConfig": {
     "access": "public"

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4",
-    "type-fest": "^2.19.0",
+    "type-fest": "~2.19",
     "typescript": "~4.9.3"
   },
   "publishConfig": {

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -45,8 +45,8 @@
   "dependencies": {
     "@storybook/client-logger": "workspace:^",
     "@storybook/core-events": "workspace:^",
-    "@storybook/preview-api": "workspace:^",
     "@storybook/instrumenter": "workspace:^",
+    "@storybook/preview-api": "workspace:^",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/user-event": "^14.4.3",

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4",
-    "type-fest": "~2.19",
+    "type-fest": "^2.19.0",
     "typescript": "~4.9.3"
   },
   "publishConfig": {

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -43,10 +43,10 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/client-logger": "workspace:^",
-    "@storybook/core-events": "workspace:^",
-    "@storybook/instrumenter": "workspace:^",
-    "@storybook/preview-api": "workspace:^",
+    "@storybook/client-logger": "workspace:*",
+    "@storybook/core-events": "workspace:*",
+    "@storybook/instrumenter": "workspace:*",
+    "@storybook/preview-api": "workspace:*",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/user-event": "^14.4.3",

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -43,12 +43,16 @@
     "prep": "../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
+    "@storybook/client-logger": "workspace:^",
     "@storybook/instrumenter": "workspace:^",
-    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/dom": "^9.3.1",
+    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/user-event": "^14.4.3",
     "@vitest/expect": "^0.34.2",
     "@vitest/spy": "^0.34.1",
     "chai": "^4.3.7",
-    "expect": "^29.6.2"
+    "expect": "^29.6.2",
+    "ts-dedent": "^2.2.0"
   },
   "devDependencies": {
     "@types/chai": "^4",

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -44,6 +44,8 @@
   },
   "dependencies": {
     "@storybook/client-logger": "workspace:^",
+    "@storybook/core-events": "workspace:^",
+    "@storybook/preview-api": "workspace:^",
     "@storybook/instrumenter": "workspace:^",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^6.1.3",

--- a/code/lib/test/src/expect.ts
+++ b/code/lib/test/src/expect.ts
@@ -15,10 +15,13 @@ import {
   setState,
 } from '@vitest/expect';
 import * as matchers from '@testing-library/jest-dom/matchers';
+import type { TestingLibraryMatchers } from '@testing-library/jest-dom/types/matchers';
 import type { PromisifyObject } from './utils';
 
 // We only expose the jest compatible API for now
-export interface Assertion<T> extends PromisifyObject<JestAssertion<T>> {
+export interface Assertion<T>
+  extends PromisifyObject<JestAssertion<T>>,
+    TestingLibraryMatchers<ReturnType<ExpectStatic['stringContaining']>, Promise<void>> {
   toHaveBeenCalledOnce(): Promise<void>;
   toSatisfy<E>(matcher: (value: E) => boolean, message?: string): Promise<void>;
   resolves: Assertion<T>;
@@ -80,7 +83,8 @@ export function createExpect() {
           expect.getState().assertionCalls
         }`
       );
-    if (Error.captureStackTrace) Error.captureStackTrace(errorGen(), assertions);
+    if ('captureStackTrace' in Error && typeof Error.captureStackTrace === 'function')
+      Error.captureStackTrace(errorGen(), assertions);
 
     expect.setState({
       expectedAssertionsNumber: expected,
@@ -90,7 +94,8 @@ export function createExpect() {
 
   function hasAssertions() {
     const error = new Error('expected any number of assertion, but got none');
-    if (Error.captureStackTrace) Error.captureStackTrace(error, hasAssertions);
+    if ('captureStackTrace' in Error && typeof Error.captureStackTrace === 'function')
+      Error.captureStackTrace(error, hasAssertions);
 
     expect.setState({
       isExpectingAssertions: true,

--- a/code/lib/test/src/expect.ts
+++ b/code/lib/test/src/expect.ts
@@ -6,7 +6,6 @@ import type {
   MatchersObject,
   MatcherState,
 } from '@vitest/expect';
-
 import {
   getState,
   GLOBAL_EXPECT,
@@ -16,21 +15,15 @@ import {
   setState,
 } from '@vitest/expect';
 import * as matchers from '@testing-library/jest-dom/matchers';
-
-type Promisify<O> = {
-  [K in keyof O]: O[K] extends (...args: infer A) => infer R
-    ? O extends R
-      ? Promisify<O[K]>
-      : (...args: A) => Promise<R>
-    : O[K];
-};
+import type { PromisifyObject } from './utils';
 
 // We only expose the jest compatible API for now
-export interface Assertion<T> extends Promisify<JestAssertion<T>> {
+export interface Assertion<T> extends PromisifyObject<JestAssertion<T>> {
   toHaveBeenCalledOnce(): Promise<void>;
   toSatisfy<E>(matcher: (value: E) => boolean, message?: string): Promise<void>;
-  resolves: Promisify<Assertion<T>>;
-  rejects: Promisify<Assertion<T>>;
+  resolves: Assertion<T>;
+  rejects: Assertion<T>;
+  not: Assertion<T>;
 }
 
 export interface Expect extends AsymmetricMatchersContaining {

--- a/code/lib/test/src/index.ts
+++ b/code/lib/test/src/index.ts
@@ -1,9 +1,10 @@
 import { instrument } from '@storybook/instrumenter';
 import * as spy from '@vitest/spy';
 import chai from 'chai';
-import { expect as rawExpect } from './expect';
 import { FORCE_REMOUNT, STORY_RENDER_PHASE_CHANGED } from '@storybook/core-events';
 import { addons } from '@storybook/preview-api';
+import { expect as rawExpect } from './expect';
+
 export * from '@vitest/spy';
 
 const channel = addons.getChannel();

--- a/code/lib/test/src/index.ts
+++ b/code/lib/test/src/index.ts
@@ -20,3 +20,5 @@ export const { expect } = instrument(
     intercept: true,
   }
 );
+
+export * from './testing-library';

--- a/code/lib/test/src/index.ts
+++ b/code/lib/test/src/index.ts
@@ -2,10 +2,16 @@ import { instrument } from '@storybook/instrumenter';
 import * as spy from '@vitest/spy';
 import chai from 'chai';
 import { expect as rawExpect } from './expect';
-
+import { FORCE_REMOUNT, STORY_RENDER_PHASE_CHANGED } from '@storybook/core-events';
+import { addons } from '@storybook/preview-api';
 export * from '@vitest/spy';
 
-export const { fn } = instrument({ fn: spy.fn }, { retain: true });
+const channel = addons.getChannel();
+
+channel.on(FORCE_REMOUNT, () => spy.spies.forEach((mock) => mock.mockClear()));
+channel.on(STORY_RENDER_PHASE_CHANGED, ({ newPhase }) => {
+  if (newPhase === 'loading') spy.spies.forEach((mock) => mock.mockClear());
+});
 
 export const { expect } = instrument(
   { expect: rawExpect },

--- a/code/lib/test/src/index.ts
+++ b/code/lib/test/src/index.ts
@@ -17,10 +17,13 @@ channel.on(STORY_RENDER_PHASE_CHANGED, ({ newPhase }) => {
 export const { expect } = instrument(
   { expect: rawExpect },
   {
-    getKeys: (obj: Record<string, unknown>) => {
+    getKeys: (obj: Record<string, unknown>, depth) => {
       const privateApi = ['assert', '__methods', '__flags'];
       if (obj.constructor === chai.Assertion) {
-        return Object.keys(Object.getPrototypeOf(obj)).filter((it) => !privateApi.includes(it));
+        const keys = Object.keys(Object.getPrototypeOf(obj)).filter(
+          (it) => !privateApi.includes(it)
+        );
+        return depth > 2 ? keys : [...keys, 'not'];
       }
       return Object.keys(obj);
     },

--- a/code/lib/test/src/index.ts
+++ b/code/lib/test/src/index.ts
@@ -17,7 +17,7 @@ export const { expect } = instrument(
       }
       return Object.keys(obj);
     },
-    intercept: true,
+    intercept: (method) => method !== 'expect',
   }
 );
 

--- a/code/lib/test/src/testing-library.ts
+++ b/code/lib/test/src/testing-library.ts
@@ -1,4 +1,4 @@
-/* eslint-disable prefer-destructuring,@typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/ban-types */
 import { once } from '@storybook/client-logger';
 import { instrument } from '@storybook/instrumenter';
 import * as domTestingLibrary from '@testing-library/dom';

--- a/code/lib/test/src/testing-library.ts
+++ b/code/lib/test/src/testing-library.ts
@@ -1,0 +1,116 @@
+/* eslint-disable prefer-destructuring,@typescript-eslint/ban-types */
+import { once } from '@storybook/client-logger';
+import { instrument } from '@storybook/instrumenter';
+import * as domTestingLibrary from '@testing-library/dom';
+import _userEvent from '@testing-library/user-event';
+import dedent from 'ts-dedent';
+import type { FireFunction, FireObject } from '@testing-library/dom/types/events';
+import type { BoundFunctions } from '@testing-library/dom';
+import type { Promisify, PromisifyObject } from './utils';
+
+type TestingLibraryDom = typeof domTestingLibrary;
+
+const testingLibrary = instrument(
+  { ...domTestingLibrary },
+  {
+    intercept: (method, path) =>
+      path[0] === 'fireEvent' ||
+      method.startsWith('find') ||
+      method.startsWith('waitFor') ||
+      method.startsWith('query') ||
+      method.startsWith('get'),
+  }
+) as {} as PromisifyObject<Omit<TestingLibraryDom, 'fireEvent' | 'within'>> & {
+  fireEvent: Promisify<FireFunction> & PromisifyObject<FireObject>;
+  within: (
+    element: HTMLElement
+  ) => PromisifyObject<BoundFunctions<typeof domTestingLibrary.queries>>;
+};
+
+testingLibrary.screen = new Proxy(testingLibrary.screen, {
+  get(target, prop, receiver) {
+    once.warn(dedent`
+          You are using Testing Library's \`screen\` object. Use \`within(canvasElement)\` instead.
+          More info: https://storybook.js.org/docs/react/essentials/interactions
+        `);
+    return Reflect.get(target, prop, receiver);
+  },
+});
+
+export const {
+  buildQueries,
+  configure,
+  createEvent,
+  fireEvent,
+  findAllByAltText,
+  findAllByDisplayValue,
+  findAllByLabelText,
+  findAllByPlaceholderText,
+  findAllByRole,
+  findAllByTestId,
+  findAllByText,
+  findAllByTitle,
+  findByAltText,
+  findByDisplayValue,
+  findByLabelText,
+  findByPlaceholderText,
+  findByRole,
+  findByTestId,
+  findByText,
+  findByTitle,
+  getAllByAltText,
+  getAllByDisplayValue,
+  getAllByLabelText,
+  getAllByPlaceholderText,
+  getAllByRole,
+  getAllByTestId,
+  getAllByText,
+  getAllByTitle,
+  getByAltText,
+  getByDisplayValue,
+  getByLabelText,
+  getByPlaceholderText,
+  getByRole,
+  getByTestId,
+  getByText,
+  getByTitle,
+  getConfig,
+  getDefaultNormalizer,
+  getElementError,
+  getNodeText,
+  getQueriesForElement,
+  getRoles,
+  getSuggestedQuery,
+  isInaccessible,
+  logDOM,
+  logRoles,
+  prettyDOM,
+  queries,
+  queryAllByAltText,
+  queryAllByAttribute,
+  queryAllByDisplayValue,
+  queryAllByLabelText,
+  queryAllByPlaceholderText,
+  queryAllByRole,
+  queryAllByTestId,
+  queryAllByText,
+  queryAllByTitle,
+  queryByAltText,
+  queryByAttribute,
+  queryByDisplayValue,
+  queryByLabelText,
+  queryByPlaceholderText,
+  queryByRole,
+  queryByTestId,
+  queryByText,
+  queryByTitle,
+  queryHelpers,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+  prettyFormat,
+} = testingLibrary;
+
+export const screen = testingLibrary.screen;
+
+export const { userEvent } = instrument({ userEvent: _userEvent }, { intercept: true });

--- a/code/lib/test/src/testing-library.ts
+++ b/code/lib/test/src/testing-library.ts
@@ -5,6 +5,7 @@ import * as domTestingLibrary from '@testing-library/dom';
 import _userEvent from '@testing-library/user-event';
 import dedent from 'ts-dedent';
 import type { FireFunction, FireObject } from '@testing-library/dom/types/events';
+import type { Writable } from 'type-fest';
 import type { Promisify, PromisifyObject } from './utils';
 
 type TestingLibraryDom = typeof domTestingLibrary;
@@ -15,7 +16,7 @@ const testingLibrary = instrument(
     intercept: (method, path) =>
       path[0] === 'fireEvent' || method.startsWith('find') || method.startsWith('waitFor'),
   }
-) as {} as PromisifyObject<Omit<TestingLibraryDom, 'fireEvent'>> & {
+) as {} as Writable<Omit<TestingLibraryDom, 'fireEvent'>> & {
   fireEvent: Promisify<FireFunction> & PromisifyObject<FireObject>;
 };
 

--- a/code/lib/test/src/testing-library.ts
+++ b/code/lib/test/src/testing-library.ts
@@ -5,7 +5,6 @@ import * as domTestingLibrary from '@testing-library/dom';
 import _userEvent from '@testing-library/user-event';
 import dedent from 'ts-dedent';
 import type { FireFunction, FireObject } from '@testing-library/dom/types/events';
-import type { BoundFunctions } from '@testing-library/dom';
 import type { Promisify, PromisifyObject } from './utils';
 
 type TestingLibraryDom = typeof domTestingLibrary;
@@ -14,17 +13,10 @@ const testingLibrary = instrument(
   { ...domTestingLibrary },
   {
     intercept: (method, path) =>
-      path[0] === 'fireEvent' ||
-      method.startsWith('find') ||
-      method.startsWith('waitFor') ||
-      method.startsWith('query') ||
-      method.startsWith('get'),
+      path[0] === 'fireEvent' || method.startsWith('find') || method.startsWith('waitFor'),
   }
-) as {} as PromisifyObject<Omit<TestingLibraryDom, 'fireEvent' | 'within'>> & {
+) as {} as PromisifyObject<Omit<TestingLibraryDom, 'fireEvent'>> & {
   fireEvent: Promisify<FireFunction> & PromisifyObject<FireObject>;
-  within: (
-    element: HTMLElement
-  ) => PromisifyObject<BoundFunctions<typeof domTestingLibrary.queries>>;
 };
 
 testingLibrary.screen = new Proxy(testingLibrary.screen, {
@@ -105,12 +97,11 @@ export const {
   queryByText,
   queryByTitle,
   queryHelpers,
+  screen,
   waitFor,
   waitForElementToBeRemoved,
   within,
   prettyFormat,
 } = testingLibrary;
-
-export const screen = testingLibrary.screen;
 
 export const { userEvent } = instrument({ userEvent: _userEvent }, { intercept: true });

--- a/code/lib/test/src/utils.ts
+++ b/code/lib/test/src/utils.ts
@@ -1,0 +1,5 @@
+export type Promisify<Fn> = Fn extends (...args: infer A) => infer R
+  ? (...args: A) => R extends Promise<any> ? R : Promise<R>
+  : Fn;
+
+export type PromisifyObject<O> = { -readonly [K in keyof O]: Promisify<O[K]> };

--- a/code/lib/test/src/utils.ts
+++ b/code/lib/test/src/utils.ts
@@ -2,4 +2,4 @@ export type Promisify<Fn> = Fn extends (...args: infer A) => infer R
   ? (...args: A) => R extends Promise<any> ? R : Promise<R>
   : Fn;
 
-export type PromisifyObject<O> = { -readonly [K in keyof O]: Promisify<O[K]> };
+export type PromisifyObject<O> = { [K in keyof O]: Promisify<O[K]> };

--- a/code/package.json
+++ b/code/package.json
@@ -88,7 +88,8 @@
     "playwright": "1.36.0",
     "playwright-core": "1.36.0",
     "serialize-javascript": "^3.1.0",
-    "type-fest": "~2.19"
+    "type-fest": "~2.19",
+    "@vitest/expect@^0.34.2": "patch:@vitest/expect@npm%3A0.34.3#./.yarn/patches/@vitest-expect-npm-0.34.3-313878cdb4.patch"
   },
   "dependencies": {
     "@babel/core": "^7.22.9",

--- a/code/package.json
+++ b/code/package.json
@@ -200,6 +200,7 @@
     "@testing-library/dom": "^7.29.4",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.2",
+    "@testing-library/user-event": "^13.2.1",
     "@types/express": "^4.17.11",
     "@types/fs-extra": "^11.0.1",
     "@types/lodash": "^4.14.167",

--- a/code/package.json
+++ b/code/package.json
@@ -80,7 +80,6 @@
   ],
   "resolutions": {
     "@playwright/test": "1.36.0",
-    "@testing-library/jest-dom": "^5.11.9",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/experimental-utils": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",

--- a/code/package.json
+++ b/code/package.json
@@ -201,7 +201,6 @@
     "@testing-library/dom": "^7.29.4",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.2",
-    "@testing-library/user-event": "^13.2.1",
     "@types/express": "^4.17.11",
     "@types/fs-extra": "^11.0.1",
     "@types/lodash": "^4.14.167",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -8165,7 +8165,7 @@ __metadata:
     chai: ^4.3.7
     expect: ^29.6.2
     ts-dedent: ^2.2.0
-    type-fest: ^2.19.0
+    type-fest: ~2.19
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7893,6 +7893,7 @@ __metadata:
     "@testing-library/dom": ^7.29.4
     "@testing-library/jest-dom": ^5.11.9
     "@testing-library/react": ^11.2.2
+    "@testing-library/user-event": ^13.2.1
     "@types/express": ^4.17.11
     "@types/fs-extra": ^11.0.1
     "@types/lodash": ^4.14.167
@@ -8827,6 +8828,17 @@ __metadata:
     react: "*"
     react-dom: "*"
   checksum: 5c97aa5fb28a867d674e292e9e556b0890385e729972f8e0c3386001903e5975f6798632a038558750101fc1ff20d5faf7a0fb4d382ee3afe28d0118e9bd2f36
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^13.2.1":
+  version: 13.5.0
+  resolution: "@testing-library/user-event@npm:13.5.0"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: ff57edaeab31322c80c3f01d55404b4cebb907b9ec7672b96a1a14d053f172046b01c5f27b45677927ebee8ed91bce695a7d09edec9a48875cfacabe39d0426a
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6740,7 +6740,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@workspace:*, @storybook/client-logger@workspace:lib/client-logger":
+"@storybook/client-logger@workspace:*, @storybook/client-logger@workspace:^, @storybook/client-logger@workspace:lib/client-logger":
   version: 0.0.0-use.local
   resolution: "@storybook/client-logger@workspace:lib/client-logger"
   dependencies:
@@ -7893,7 +7893,6 @@ __metadata:
     "@testing-library/dom": ^7.29.4
     "@testing-library/jest-dom": ^5.11.9
     "@testing-library/react": ^11.2.2
-    "@testing-library/user-event": ^13.2.1
     "@types/express": ^4.17.11
     "@types/fs-extra": ^11.0.1
     "@types/lodash": ^4.14.167
@@ -8152,13 +8151,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/test@workspace:lib/test"
   dependencies:
+    "@storybook/client-logger": "workspace:^"
     "@storybook/instrumenter": "workspace:^"
-    "@testing-library/jest-dom": ^6.0.0
+    "@testing-library/dom": ^9.3.1
+    "@testing-library/jest-dom": ^6.1.3
+    "@testing-library/user-event": ^14.4.3
     "@types/chai": ^4
     "@vitest/expect": ^0.34.2
     "@vitest/spy": ^0.34.1
     chai: ^4.3.7
     expect: ^29.6.2
+    ts-dedent: ^2.2.0
     type-fest: ~2.19
     typescript: ~4.9.3
   languageName: unknown
@@ -8751,7 +8754,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^9.0.0":
+"@testing-library/dom@npm:^9.0.0, @testing-library/dom@npm:^9.3.1":
   version: 9.3.1
   resolution: "@testing-library/dom@npm:9.3.1"
   dependencies:
@@ -8797,18 +8800,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:^13.2.1":
-  version: 13.5.0
-  resolution: "@testing-library/user-event@npm:13.5.0"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-  peerDependencies:
-    "@testing-library/dom": ">=7.21.4"
-  checksum: ff57edaeab31322c80c3f01d55404b4cebb907b9ec7672b96a1a14d053f172046b01c5f27b45677927ebee8ed91bce695a7d09edec9a48875cfacabe39d0426a
-  languageName: node
-  linkType: hard
-
-"@testing-library/user-event@npm:^14.0.0":
+"@testing-library/user-event@npm:^14.0.0, @testing-library/user-event@npm:^14.4.3":
   version: 14.4.3
   resolution: "@testing-library/user-event@npm:14.4.3"
   peerDependencies:

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -8165,7 +8165,7 @@ __metadata:
     chai: ^4.3.7
     expect: ^29.6.2
     ts-dedent: ^2.2.0
-    type-fest: ~2.19
+    type-fest: ^4.3.1
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6740,7 +6740,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@workspace:*, @storybook/client-logger@workspace:^, @storybook/client-logger@workspace:lib/client-logger":
+"@storybook/client-logger@workspace:*, @storybook/client-logger@workspace:lib/client-logger":
   version: 0.0.0-use.local
   resolution: "@storybook/client-logger@workspace:lib/client-logger"
   dependencies:
@@ -6866,7 +6866,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-events@workspace:*, @storybook/core-events@workspace:^, @storybook/core-events@workspace:lib/core-events":
+"@storybook/core-events@workspace:*, @storybook/core-events@workspace:lib/core-events":
   version: 0.0.0-use.local
   resolution: "@storybook/core-events@workspace:lib/core-events"
   dependencies:
@@ -7158,7 +7158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/instrumenter@workspace:*, @storybook/instrumenter@workspace:^, @storybook/instrumenter@workspace:lib/instrumenter":
+"@storybook/instrumenter@workspace:*, @storybook/instrumenter@workspace:lib/instrumenter":
   version: 0.0.0-use.local
   resolution: "@storybook/instrumenter@workspace:lib/instrumenter"
   dependencies:
@@ -7617,7 +7617,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/preview-api@workspace:*, @storybook/preview-api@workspace:^, @storybook/preview-api@workspace:lib/preview-api":
+"@storybook/preview-api@workspace:*, @storybook/preview-api@workspace:lib/preview-api":
   version: 0.0.0-use.local
   resolution: "@storybook/preview-api@workspace:lib/preview-api"
   dependencies:
@@ -8152,10 +8152,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/test@workspace:lib/test"
   dependencies:
-    "@storybook/client-logger": "workspace:^"
-    "@storybook/core-events": "workspace:^"
-    "@storybook/instrumenter": "workspace:^"
-    "@storybook/preview-api": "workspace:^"
+    "@storybook/client-logger": "workspace:*"
+    "@storybook/core-events": "workspace:*"
+    "@storybook/instrumenter": "workspace:*"
+    "@storybook/preview-api": "workspace:*"
     "@testing-library/dom": ^9.3.1
     "@testing-library/jest-dom": ^6.1.3
     "@testing-library/user-event": ^14.4.3
@@ -8165,7 +8165,7 @@ __metadata:
     chai: ^4.3.7
     expect: ^29.6.2
     ts-dedent: ^2.2.0
-    type-fest: ^4.3.1
+    type-fest: ^2.19.0
     typescript: ~4.9.3
   languageName: unknown
   linkType: soft

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -24,7 +24,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/css-tools@npm:^4.0.1":
+"@adobe/css-tools@npm:^4.0.1, @adobe/css-tools@npm:^4.3.0":
   version: 4.3.1
   resolution: "@adobe/css-tools@npm:4.3.1"
   checksum: 05672719b544cc0c21ae3ed0eb6349bf458e9d09457578eeeb07cf0f696469ac6417e9c9be1b129e5d6a18098a061c1db55b2275591760ef30a79822436fcbfa
@@ -8770,7 +8770,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^5.11.9":
+"@testing-library/jest-dom@npm:^5.11.9, @testing-library/jest-dom@npm:^5.16.2":
   version: 5.17.0
   resolution: "@testing-library/jest-dom@npm:5.17.0"
   dependencies:
@@ -8784,6 +8784,36 @@ __metadata:
     lodash: ^4.17.15
     redent: ^3.0.0
   checksum: 24e09c5779ea44644945ec26f2e4e5f48aecfe57d469decf2317a3253a5db28d865c55ad0ea4818d8d1df7572a6486c45daa06fa09644a833a7dd84563881939
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^6.1.3":
+  version: 6.1.3
+  resolution: "@testing-library/jest-dom@npm:6.1.3"
+  dependencies:
+    "@adobe/css-tools": ^4.3.0
+    "@babel/runtime": ^7.9.2
+    aria-query: ^5.0.0
+    chalk: ^3.0.0
+    css.escape: ^1.5.1
+    dom-accessibility-api: ^0.5.6
+    lodash: ^4.17.15
+    redent: ^3.0.0
+  peerDependencies:
+    "@jest/globals": ">= 28"
+    "@types/jest": ">= 28"
+    jest: ">= 28"
+    vitest: ">= 0.32"
+  peerDependenciesMeta:
+    "@jest/globals":
+      optional: true
+    "@types/jest":
+      optional: true
+    jest:
+      optional: true
+    vitest:
+      optional: true
+  checksum: 544e01939d3c14a3d44ae2e2bb9fe2a0cb5a9e4992ca2728f41188fb9fb2d56e25f1a2e1c12000be2a94d8da36cb220b24020e1b5c5c4c4bede9058a0d80583d
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6866,7 +6866,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/core-events@workspace:*, @storybook/core-events@workspace:lib/core-events":
+"@storybook/core-events@workspace:*, @storybook/core-events@workspace:^, @storybook/core-events@workspace:lib/core-events":
   version: 0.0.0-use.local
   resolution: "@storybook/core-events@workspace:lib/core-events"
   dependencies:
@@ -7617,7 +7617,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/preview-api@workspace:*, @storybook/preview-api@workspace:lib/preview-api":
+"@storybook/preview-api@workspace:*, @storybook/preview-api@workspace:^, @storybook/preview-api@workspace:lib/preview-api":
   version: 0.0.0-use.local
   resolution: "@storybook/preview-api@workspace:lib/preview-api"
   dependencies:
@@ -8153,7 +8153,9 @@ __metadata:
   resolution: "@storybook/test@workspace:lib/test"
   dependencies:
     "@storybook/client-logger": "workspace:^"
+    "@storybook/core-events": "workspace:^"
     "@storybook/instrumenter": "workspace:^"
+    "@storybook/preview-api": "workspace:^"
     "@testing-library/dom": ^9.3.1
     "@testing-library/jest-dom": ^6.1.3
     "@testing-library/user-event": ^14.4.3

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -89,6 +89,7 @@
     "@types/express": "^4.17.11",
     "@types/fs-extra": "^11.0.1",
     "@types/http-server": "^0.12.1",
+    "@types/jest": "^29.5.5",
     "@types/lodash": "^4",
     "@types/node": "^16.0.0",
     "@types/node-fetch": "^2.5.7",


### PR DESCRIPTION
## What I did

Added testing library and user event to the test package and fixed some bugs as not all methods were properly instrumented and the types were incorrect.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-24225-sha-d42b137f`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24225-sha-d42b137f). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-24225-sha-d42b137f`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24225-sha-d42b137f) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/testing-library`](https://github.com/storybookjs/storybook/tree/kasper/testing-library) |
| **Commit** | [`d42b137f`](https://github.com/storybookjs/storybook/commit/d42b137fd89fff2d676576b89457397226e77f8d) |
| **Datetime** | Fri Sep 22 10:05:01 UTC 2023 (`1695377101`) |
| **Workflow run** | [6272903355](https://github.com/storybookjs/storybook/actions/runs/6272903355) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=24225`_
</details>
<!-- CANARY_RELEASE_SECTION -->
