### PR TITLE
Close icon mobile

### DIFF
--- a/code/ui/manager/src/components/sidebar/Menu.tsx
+++ b/code/ui/manager/src/components/sidebar/Menu.tsx
@@ -65,6 +65,11 @@ export const SidebarIconButton: FC<
   }),
 }));
 
+const MenuButtonGroup = styled.div({
+  display: 'flex',
+  gap: 5,
+});
+
 const Img = styled.img(sharedStyles);
 const Placeholder = styled.div(sharedStyles);
 
@@ -119,15 +124,20 @@ export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick
 
   if (!isDesktop) {
     return (
-      <SidebarIconButton
-        title="About Storybook"
-        aria-label="About Storybook"
-        highlighted={isHighlighted}
-        active={false}
-        onClick={onClick}
-      >
-        <Icons icon="cog" />
-      </SidebarIconButton>
+      <MenuButtonGroup>
+        <SidebarIconButton
+          title="About Storybook"
+          aria-label="About Storybook"
+          highlighted={isHighlighted}
+          active={false}
+          onClick={onClick}
+        >
+          <Icons icon="cog" />
+        </SidebarIconButton>
+        <CloseIconButton title="Close menu" aria-label="Close menu" onClick={onClick}>
+          <Icons icon="cross" />
+        </CloseIconButton>
+      </MenuButtonGroup>
     );
   }
 
@@ -173,3 +183,9 @@ export const ToolbarMenu: FC<{
     </WithTooltip>
   );
 };
+
+// We should not have to reset the margin-top here
+// TODO: remove this once we have a the new IconButton component
+const CloseIconButton = styled(IconButton)({
+  marginTop: 0,
+});

--- a/code/ui/manager/src/components/sidebar/Menu.tsx
+++ b/code/ui/manager/src/components/sidebar/Menu.tsx
@@ -66,7 +66,7 @@ export const SidebarIconButton: FC<
 
 const MenuButtonGroup = styled.div({
   display: 'flex',
-  gap: 5,
+  gap: 4,
 });
 
 const Img = styled.img(sharedStyles);
@@ -119,7 +119,7 @@ export interface SidebarMenuProps {
 
 export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick }) => {
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
-  const { isDesktop } = useLayout();
+  const { isDesktop, setMobileMenuOpen } = useLayout();
 
   if (!isDesktop) {
     return (
@@ -133,8 +133,12 @@ export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick
         >
           <Icons icon="cog" />
         </SidebarIconButton>
-        <CloseIconButton title="Close menu" aria-label="Close menu" onClick={onClick}>
-          <Icons icon="cross" />
+        <CloseIconButton
+          title="Close menu"
+          aria-label="Close menu"
+          onClick={() => setMobileMenuOpen(false)}
+        >
+          <Icons icon="close" />
         </CloseIconButton>
       </MenuButtonGroup>
     );


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/24254

## What I did

In this PR I'm adding a close button that's only visible on mobile to close the main navigation on mobile.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
