### PR TITLE
UI: Fix infinite hook call causing browsers to freeze

### DIFF
--- a/code/lib/manager-api/src/index.tsx
+++ b/code/lib/manager-api/src/index.tsx
@@ -397,7 +397,6 @@ export function useSharedState<S>(stateId: string, defaultState?: S) {
     existingState,
     STORYBOOK_ADDON_STATE[stateId] ? STORYBOOK_ADDON_STATE[stateId] : defaultState
   );
-
   let quicksync = false;
 
   if (state === defaultState && defaultState !== undefined) {
@@ -409,7 +408,7 @@ export function useSharedState<S>(stateId: string, defaultState?: S) {
     if (quicksync) {
       api.setAddonState<S>(stateId, defaultState);
     }
-  });
+  }, [quicksync]);
 
   const setState = async (s: S | API_StateMerger<S>, options?: Options) => {
     const result = await api.setAddonState<S>(stateId, s, options);


### PR DESCRIPTION
Closes #24275

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Added a missing dependency to a useEffect hook which, by declaring no dependencies, was getting called infinitely. Thank you so much for spotting this out @eneaaliko0, you're the best!

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I was able to reproduce the issue in [Mealdrop](https://github.com/yannbf/mealdrop), and tested by getting the compiled output of the monorepo and pasting into Mealdrop's node_modules.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-24291-sha-4df967a3`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24291-sha-4df967a3). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-24291-sha-4df967a3`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24291-sha-4df967a3) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/fix-infinite-effect-call`](https://github.com/storybookjs/storybook/tree/yann/fix-infinite-effect-call) |
| **Commit** | [`4df967a3`](https://github.com/storybookjs/storybook/commit/4df967a37b4f1c2238cac5e3a778d38450a9bb4a) |
| **Datetime** | Sun Sep 24 16:39:09 UTC 2023 (`1695573549`) |
| **Workflow run** | [6291224280](https://github.com/storybookjs/storybook/actions/runs/6291224280) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=24291`_
</details>
<!-- CANARY_RELEASE_SECTION -->
