### PR TITLE
SBK-132 - The contrast ratio between foreground and background color of “RAW” button 3.6:1 which is less than required ratio 4.5:1.

### DIFF
--- a/code/ui/blocks/src/controls/Object.tsx
+++ b/code/ui/blocks/src/controls/Object.tsx
@@ -178,7 +178,7 @@ const RawButton = styled(IconButton)(({ theme }) => ({
   background: theme.background.bar,
   border: `1px solid ${theme.appBorderColor}`,
   borderRadius: 3,
-  color: theme.textMutedColor,
+  color: theme.color.defaultText,
   fontSize: '9px',
   fontWeight: 'bold',
   textDecoration: 'none',


### PR DESCRIPTION
Issue: [#22473](https://github.com/storybookjs/storybook/issues/23454)

## What I did

- change the text of `RAW` button to default text

## How to test

- Follow steps in https://github.com/storybookjs/storybook/issues/23454

## Demo
#### Before
![Screenshot 2023-10-03 at 19 48 50](https://github.com/storybookjs/storybook/assets/1501599/8ccb0cf0-4c6b-467e-968f-6aca2f9266c3)


#### After
![Screenshot 2023-10-03 at 19 53 32](https://github.com/storybookjs/storybook/assets/1501599/f186ae6d-7c28-46bf-9567-beedd2832a0f)

