### PR TITLE
ManagerAPI: Fix bug with story redirection when URL has partial storyId

### DIFF
--- a/code/e2e-tests/navigation.spec.ts
+++ b/code/e2e-tests/navigation.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+import process from 'process';
+import { SbPage } from './util';
+
+const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:8001';
+
+test.describe('navigating', () => {
+  test('a URL with a partial storyId will redirect to the first story', async ({ page }) => {
+    // this is purposefully not using the SbPage class, and the URL is a partial (it does not contain the full storyId)
+    await page.goto(`${storybookUrl}?path=/story/example-button`);
+
+    const sbPage = new SbPage(page);
+
+    await sbPage.waitUntilLoaded();
+
+    await expect(sbPage.page.waitForURL('?path=/docs/example-button--docs')).resolves.toBeTruthy();
+  });
+});

--- a/code/e2e-tests/navigation.spec.ts
+++ b/code/e2e-tests/navigation.spec.ts
@@ -13,6 +13,6 @@ test.describe('navigating', () => {
 
     await sbPage.waitUntilLoaded();
 
-    await expect(sbPage.page.waitForURL('?path=/docs/example-button--docs')).resolves.toBeTruthy();
+    await expect(sbPage.page.url()).toContain('/docs/example-button--docs');
   });
 });

--- a/code/lib/manager-api/src/modules/stories.ts
+++ b/code/lib/manager-api/src/modules/stories.ts
@@ -637,15 +637,18 @@ export const init: ModuleFn<SubAPI, SubState> = ({
           state.path === '/' || state.viewMode === 'story' || state.viewMode === 'docs';
         const stateHasSelection = state.viewMode && state.storyId;
         const stateSelectionDifferent = state.viewMode !== viewMode || state.storyId !== storyId;
+        const { type } = state.index[state.storyId];
+        const isStory = !(type === 'root' || type === 'component' || type === 'group');
+
         /**
          * When storybook starts, we want to navigate to the first story.
          * But there are a few exceptions:
-         * - If the current storyId and viewMode are already set/correct.
+         * - If the current storyId and viewMode are already set/correct AND the url section is a leaf-type.
          * - If the user has navigated away already.
          * - If the user started storybook with a specific page-URL like "/settings/about"
          */
         if (isCanvasRoute) {
-          if (stateHasSelection && stateSelectionDifferent) {
+          if (stateHasSelection && stateSelectionDifferent && isStory) {
             // The manager state is correct, the preview state is lagging behind
             provider.channel.emit(SET_CURRENT_STORY, {
               storyId: state.storyId,

--- a/code/lib/manager-api/src/modules/stories.ts
+++ b/code/lib/manager-api/src/modules/stories.ts
@@ -637,7 +637,7 @@ export const init: ModuleFn<SubAPI, SubState> = ({
           state.path === '/' || state.viewMode === 'story' || state.viewMode === 'docs';
         const stateHasSelection = state.viewMode && state.storyId;
         const stateSelectionDifferent = state.viewMode !== viewMode || state.storyId !== storyId;
-        const { type } = state.index[state.storyId];
+        const { type } = state.index[state.storyId] || {};
         const isStory = !(type === 'root' || type === 'component' || type === 'group');
 
         /**

--- a/code/lib/manager-api/src/tests/stories.test.ts
+++ b/code/lib/manager-api/src/tests/stories.test.ts
@@ -542,7 +542,7 @@ describe('stories API', () => {
 
   describe('STORY_SPECIFIED event', () => {
     it('navigates to the story', async () => {
-      const moduleArgs = createMockModuleArgs({ initialState: { path: '/' } });
+      const moduleArgs = createMockModuleArgs({ initialState: { path: '/', index: {} } });
       initStories(moduleArgs as unknown as ModuleArgs);
       const { navigate, provider } = moduleArgs;
 
@@ -550,7 +550,7 @@ describe('stories API', () => {
       expect(navigate).toHaveBeenCalledWith('/story/a--1');
     });
     it('DOES not navigate if the story was already selected', async () => {
-      const moduleArgs = createMockModuleArgs({ initialState: { path: '/story/a--1' } });
+      const moduleArgs = createMockModuleArgs({ initialState: { path: '/story/a--1', index: {} } });
       initStories(moduleArgs as unknown as ModuleArgs);
       const { navigate, provider } = moduleArgs;
 
@@ -558,7 +558,9 @@ describe('stories API', () => {
       expect(navigate).not.toHaveBeenCalled();
     });
     it('DOES not navigate if a settings page was selected', async () => {
-      const moduleArgs = createMockModuleArgs({ initialState: { path: '/settings/about' } });
+      const moduleArgs = createMockModuleArgs({
+        initialState: { path: '/settings/about', index: {} },
+      });
       initStories(moduleArgs as unknown as ModuleArgs);
       const { navigate, provider } = moduleArgs;
 
@@ -566,7 +568,9 @@ describe('stories API', () => {
       expect(navigate).not.toHaveBeenCalled();
     });
     it('DOES not navigate if a custom page was selected', async () => {
-      const moduleArgs = createMockModuleArgs({ initialState: { path: '/custom/page' } });
+      const moduleArgs = createMockModuleArgs({
+        initialState: { path: '/custom/page', index: {} },
+      });
       initStories(moduleArgs as unknown as ModuleArgs);
       const { navigate, provider } = moduleArgs;
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/24292

## What I did

- fix bug where the preview story selection is ignored, when the id in the URL is incomplete
- add a e2e test

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

I tested this manually by

- create a sandbox
- run the sandbox & open
- navigate to a story
- remove the part of the storyId in the URL (`--primary`)
- refresh with the new URL
- expect the URl to get updated, to navigate to the first story.

It's normal to have it navigate to the auto-docs page, if that's the first item.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
