### PR TITLE
UI: Fix layout height

### DIFF
--- a/code/ui/manager/src/components/layout/Layout.tsx
+++ b/code/ui/manager/src/components/layout/Layout.tsx
@@ -173,7 +173,7 @@ const LayoutContainer = styled.div<LayoutState>(
   ({ navSize, rightPanelWidth, bottomPanelHeight, viewMode, panelPosition }) => {
     return {
       width: '100%',
-      height: ['100vh', '100dvh'],
+      height: ['100vh', '100dvh'], // This array is a special Emotion syntax to set a fallback if 100dvh is not supported
       overflow: 'hidden',
       display: 'flex',
       flexDirection: 'column',

--- a/code/ui/manager/src/components/layout/Layout.tsx
+++ b/code/ui/manager/src/components/layout/Layout.tsx
@@ -171,22 +171,9 @@ export const Layout = ({ managerLayoutState, setManagerLayoutState, ...slots }: 
 
 const LayoutContainer = styled.div<LayoutState>(
   ({ navSize, rightPanelWidth, bottomPanelHeight, viewMode, panelPosition }) => {
-    // To support older browsers we need to set the layout height using JS
-    // In the future we can use the CSS `height: 100dvh` instead
-    const setHeight = () => {
-      const currentHeight = window.innerHeight;
-      document.documentElement.style.setProperty('--vh', `${currentHeight}px`);
-    };
-
-    useEffect(() => {
-      setHeight();
-      window.addEventListener('resize', setHeight);
-      return () => window.removeEventListener('resize', setHeight);
-    }, []);
-
     return {
       width: '100%',
-      height: 'var(--vh, 100vh)',
+      height: ['100vh', '100dvh'],
       overflow: 'hidden',
       display: 'flex',
       flexDirection: 'column',

--- a/code/ui/manager/src/components/layout/Layout.tsx
+++ b/code/ui/manager/src/components/layout/Layout.tsx
@@ -186,7 +186,7 @@ const LayoutContainer = styled.div<LayoutState>(
 
     return {
       width: '100%',
-      height: 'var(--vh)',
+      height: 'var(--vh, 100vh)',
       overflow: 'hidden',
       display: 'flex',
       flexDirection: 'column',

--- a/code/ui/manager/src/components/layout/Layout.tsx
+++ b/code/ui/manager/src/components/layout/Layout.tsx
@@ -171,9 +171,22 @@ export const Layout = ({ managerLayoutState, setManagerLayoutState, ...slots }: 
 
 const LayoutContainer = styled.div<LayoutState>(
   ({ navSize, rightPanelWidth, bottomPanelHeight, viewMode, panelPosition }) => {
+    // To support older browsers we need to set the layout height using JS
+    // In the future we can use the CSS `height: 100dvh` instead
+    const setHeight = () => {
+      const currentHeight = window.innerHeight;
+      document.documentElement.style.setProperty('--vh', `${currentHeight}px`);
+    };
+
+    useEffect(() => {
+      setHeight();
+      window.addEventListener('resize', setHeight);
+      return () => window.removeEventListener('resize', setHeight);
+    }, []);
+
     return {
       width: '100%',
-      height: '100svh', // We are using svh to use the minimum space on mobile
+      height: 'var(--vh)',
       overflow: 'hidden',
       display: 'flex',
       flexDirection: 'column',


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/24261

## What I did

To support older browsers we can't use `100dvh` to set the height of the layout to be always visible on mobile. Instead, the most reliable way is to set the height using javascript. A common pattern is to set a css variable for `--vh` that you can then use elsewhere if needed it on your app.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
