### PR TITLE
Core: Add class name to Storybook error name

### DIFF
--- a/code/lib/core-events/src/errors/storybook-error.test.ts
+++ b/code/lib/core-events/src/errors/storybook-error.test.ts
@@ -13,7 +13,7 @@ describe('StorybookError', () => {
 
   it('should generate the correct error name', () => {
     const error = new TestError();
-    expect(error.name).toBe('SB_TEST_CATEGORY_0123');
+    expect(error.name).toBe('SB_TEST_CATEGORY_0123 (TestError)');
   });
 
   it('should generate the correct message without documentation link', () => {

--- a/code/lib/core-events/src/errors/storybook-error.ts
+++ b/code/lib/core-events/src/errors/storybook-error.ts
@@ -33,12 +33,18 @@ export abstract class StorybookError extends Error {
    */
   readonly fromStorybook: true = true as const;
 
+  get fullErrorCode() {
+    const paddedCode = String(this.code).padStart(4, '0');
+    return `SB_${this.category}_${paddedCode}` as `SB_${this['category']}_${string}`;
+  }
+
   /**
    * Overrides the default `Error.name` property in the format: SB_<CATEGORY>_<CODE>.
    */
   get name() {
-    const paddedCode = String(this.code).padStart(4, '0');
-    return `SB_${this.category}_${paddedCode}` as `SB_${this['category']}_${string}`;
+    const errorName = this.constructor.name;
+
+    return `${this.fullErrorCode} (${errorName})`;
   }
 
   /**
@@ -48,13 +54,13 @@ export abstract class StorybookError extends Error {
     let page: string | undefined;
 
     if (this.documentation === true) {
-      page = `https://storybook.js.org/error/${this.name}`;
+      page = `https://storybook.js.org/error/${this.fullErrorCode}`;
     } else if (typeof this.documentation === 'string') {
       page = this.documentation;
     } else if (Array.isArray(this.documentation)) {
       page = `\n${this.documentation.map((doc) => `\t- ${doc}`).join('\n')}`;
     }
 
-    return this.template() + (page != null ? `\n\nMore info: ${page}\n` : '');
+    return `${this.template()}${page != null ? `\n\nMore info: ${page}\n` : ''}`;
   }
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Changed the error framework to include the class name, making it easier to understand and search the errors.

From:
![image](https://github.com/storybookjs/storybook/assets/1671563/8045a6d0-7162-4d89-b253-5850f76abcf2)

To:
![image](https://github.com/storybookjs/storybook/assets/1671563/a0209491-d64d-48d1-8c7d-e8322567259b)


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No need. Check unit tests

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
