### PR TITLE
UI: Fix theming not updating

### DIFF
--- a/code/lib/manager-api/src/modules/layout.ts
+++ b/code/lib/manager-api/src/modules/layout.ts
@@ -385,13 +385,12 @@ export const init: ModuleFn<SubAPI, SubState> = ({ store, provider, singleStory 
 
   const persisted = pick(store.getState(), 'layout', 'selectedPanel');
 
+  provider.channel.on(SET_CONFIG, () => {
+    api.setOptions(merge(api.getInitialOptions(), persisted));
+  });
+
   return {
     api,
     state: merge(api.getInitialOptions(), persisted),
-    init: () => {
-      provider.channel.on(SET_CONFIG, () => {
-        api.setOptions(merge(api.getInitialOptions(), persisted));
-      });
-    },
   };
 };

--- a/code/lib/manager-api/src/tests/layout.test.ts
+++ b/code/lib/manager-api/src/tests/layout.test.ts
@@ -1,5 +1,6 @@
 import { themes } from '@storybook/theming';
 import type { API_Provider } from 'lib/types/src';
+import EventEmitter from 'events';
 import type { SubAPI, SubState } from '../modules/layout';
 import type { SubState as AddonsSubState } from '../modules/addons';
 import { defaultLayoutState, init as initLayout } from '../modules/layout';
@@ -33,7 +34,10 @@ describe('layout API', () => {
         return currentState as unknown as State;
       }),
     } as unknown as Store;
-    provider = { getConfig: jest.fn(() => ({})) } as unknown as API_Provider<API>;
+    provider = {
+      getConfig: jest.fn(() => ({})),
+      channel: new EventEmitter(),
+    } as unknown as API_Provider<API>;
     layoutApi = initLayout({
       store,
       provider,


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/24365

## What I did

Based on @ndelangen's recommendation, there was an issue where `setOptions` was not set at the right place. With this change, the theme now gets updated.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run Storybook UI locally
2. Add a custom theme
3. You should be able to see your theme.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
