### PR TITLE
Release tooling: Fix prerelease-detection in non-patch preparation

### DIFF
--- a/.github/workflows/prepare-non-patch-release.yml
+++ b/.github/workflows/prepare-non-patch-release.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Check release vs prerelease
         id: is-prerelease
-        run: yarn release:is-prerelease
+        run: yarn release:is-prerelease ${{ steps.bump-version.outputs.next-version }} --verbose
 
       - name: Write changelog
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Check release vs prerelease
         if: steps.publish-needed.outputs.published == 'false'
         id: is-prerelease
-        run: yarn release:is-prerelease
+        run: yarn release:is-prerelease ${{ steps.version.outputs.current-version }} --verbose
 
       - name: Install code dependencies
         if: steps.publish-needed.outputs.published == 'false'

--- a/scripts/release/get-changelog-from-file.ts
+++ b/scripts/release/get-changelog-from-file.ts
@@ -11,7 +11,7 @@ import { getCurrentVersion } from './get-current-version';
 program
   .name('get-changelog-from-file')
   .description(
-    'get changelog entry for specific version. If not version argument specified it will use the current version in code/package.json'
+    'get changelog entry for specific version. If no version argument specified it will use the current version in code/package.json'
   )
   .arguments('[version]')
   .option('-E, --no-escape', 'Escape quote-like characters, so the output is safe in CLIs', true)

--- a/scripts/release/is-prerelease.ts
+++ b/scripts/release/is-prerelease.ts
@@ -7,19 +7,31 @@ import { getCurrentVersion } from './get-current-version';
 
 program
   .name('is-prerelease')
-  .description('returns true if the current version is a prerelease')
+  .description(
+    'returns true if the specified version is a prerelease. If no version argument specified it will use the current version in code/package.json'
+  )
+  .arguments('[version]')
   .option('-V, --verbose', 'Enable verbose logging', false);
 
-export const isPrerelease = async (versionArg?: string) => {
-  const version = versionArg || (await getCurrentVersion());
+export const isPrerelease = async (args: { version?: string; verbose?: boolean }) => {
+  if (args.verbose) {
+    if (args.version) {
+      console.log(`📦 Checking if version ${chalk.blue(args.version)} is a prerelease`);
+    } else {
+      console.log(
+        `📦 Checking if current version in ${chalk.blue('code/package.json')} is a prerelease`
+      );
+    }
+  }
+  const version = args.version || (await getCurrentVersion());
   const result = semver.prerelease(version) !== null;
 
   if (process.env.GITHUB_ACTIONS === 'true') {
     setOutput('prerelease', result);
   }
   console.log(
-    `📦 Current version ${chalk.green(version)} ${
-      result ? chalk.blue('IS') : chalk.red('IS NOT')
+    `📦 Version ${chalk.blue(version)} ${
+      result ? chalk.green('IS') : chalk.red('IS NOT')
     } a prerelease`
   );
 
@@ -27,7 +39,11 @@ export const isPrerelease = async (versionArg?: string) => {
 };
 
 if (require.main === module) {
-  isPrerelease().catch((err) => {
+  const parsed = program.parse();
+  isPrerelease({
+    version: parsed.args[0],
+    verbose: parsed.opts().verbose,
+  }).catch((err) => {
     console.error(err);
     process.exit(1);
   });


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

This fixes the issue of the non-patch preparation workflow detecting prereleases wrong. It would check if the current version found in `code/package.json` was a prerelease, where in fact it needs to check the version we're bumping to is a prerelease. It correctly does that now.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
