### PR TITLE
Doc Blocks: Remove `defaultProps` in `Stories` block

### DIFF
--- a/code/ui/blocks/src/blocks/Stories.tsx
+++ b/code/ui/blocks/src/blocks/Stories.tsx
@@ -26,7 +26,7 @@ const StyledHeading: typeof Heading = styled(Heading)(({ theme }) => ({
   },
 }));
 
-export const Stories: FC<StoriesProps> = ({ title, includePrimary = true }) => {
+export const Stories: FC<StoriesProps> = ({ title = 'Stories', includePrimary = true }) => {
   const { componentStories } = useContext(DocsContext);
 
   let stories = componentStories().filter((story) => !story.parameters?.docs?.disable);
@@ -45,8 +45,4 @@ export const Stories: FC<StoriesProps> = ({ title, includePrimary = true }) => {
       )}
     </>
   );
-};
-
-Stories.defaultProps = {
-  title: 'Stories',
 };


### PR DESCRIPTION
Closes #24305

## What I did

Removed the use of `defaultProps` in [`Stories.tsx`](https://github.com/storybookjs/storybook/blob/next/code/ui/blocks/src/blocks/Stories.tsx) to future proof the component.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

_(I think most tests?)_

- [x] stories
- [x] unit tests
- [x] integration tests
- [x] end-to-end tests

#### Manual testing

1. Create an autodoc page as described in the issue: #24305
2. Observe no console error

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
