### PR TITLE
Update babel.md since Babel does not recommend babelrc

### DIFF
--- a/docs/configure/babel.md
+++ b/docs/configure/babel.md
@@ -110,7 +110,7 @@ Babel has two different configuration modes: babelrc and Babel config. As explai
 - **babelrc** configures Babel for files in the same folder (or descendant folders) of the location of the babelrc
 - **Babel config** configures Babel globally
 
-Babel recommends to use babelrc, and it's what Storybook generates when you run `npx storybook babelrc`. If your stories are located in the current project directory (e.g., `stories: ['../src/**/*.stories.js']`) this approach will work well.
+We chose babelrc, and it's what Storybook generates when you run `npx storybook babelrc`. If your stories are located in the current project directory (e.g., `stories: ['../src/**/*.stories.js']`) this approach will work well.
 However, when your Storybook refers to files outside of the current project directory (e.g., `stories: ['../../some-other-directory/**/*.stories.js']`), the babelrc will not apply to those files. However, a Babel config will, and is the recommended approach in that situation.
 
 ## Troubleshooting


### PR DESCRIPTION
## What I did
Just a little one but just updated the documentation under the Babel docs since Babel does not recommend babelrc, babel [recommends babel.config.js](https://babeljs.io/docs/configuration#whats-your-use-case). Happy to change wording here but just chose something off the top of my head.