### PR TITLE
Improve mdx to csf codemod

### DIFF
--- a/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
@@ -473,6 +473,43 @@ test('story name equals component name', () => {
   `);
 });
 
+test('story name equals component name for vue', () => {
+  const input = dedent`
+      import { Meta, Story } from '@storybook/addon-docs';
+      import Button from './Button.vue';
+
+      <Meta title="Button" />
+
+      <Story name="Button"><Button label='Story 1' /></Story>
+    `;
+
+  const mdx = jscodeshift({ source: input, path: 'Foobar.stories.mdx' });
+  const [, csf] = fs.writeFileSync.mock.calls[0];
+
+  expect(mdx).toMatchInlineSnapshot(`
+    import { Meta, Story } from '@storybook/blocks';
+    import Button from './Button.vue';
+    import * as FoobarStories from './Foobar.stories';
+
+    <Meta of={FoobarStories} />
+
+    <Story of={FoobarStories.Button_} />
+
+  `);
+  expect(csf).toMatchInlineSnapshot(`
+    import Button from './Button.vue';
+
+    export default {
+      title: 'Button',
+    };
+
+    export const Button_ = {
+      render: () => <Button label="Story 1" />,
+    };
+
+  `);
+});
+
 test('kebab case file name', () => {
   const input = dedent`
       import { Meta, Story } from '@storybook/addon-docs';

--- a/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
@@ -247,9 +247,6 @@ test('extract esm into csf head code', () => {
 
     # hello
 
-    export const args = { bla: 1 };
-    export const Template = (args) => <Button {...args} />;
-
     <Meta of={FoobarStories} />
 
     world {2 + 1}
@@ -412,8 +409,6 @@ test('duplicate story name', () => {
     import { Button } from './Button';
     import * as FoobarStories from './Foobar.stories';
 
-    export const Default = (args) => <Button {...args} />;
-
     <Meta of={FoobarStories} />
 
     <Story of={FoobarStories.Default_} />
@@ -501,8 +496,6 @@ test('kebab case file name', () => {
     import { Meta, Story } from '@storybook/blocks';
     import { Kebab } from './my-component/some-kebab-case';
     import * as SomeKebabCaseStories from './some-kebab-case.stories';
-
-    export const Template = (args) => <Kebab {...args} />;
 
     <Meta of={SomeKebabCaseStories} />
 

--- a/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
@@ -149,7 +149,6 @@ test('convert correct story nodes', () => {
 
     export const Primary = {
       render: () => 'Story',
-      name: 'Primary',
     };
 
   `);
@@ -208,7 +207,6 @@ test('convert story nodes with spaces', () => {
 
     export const PrimarySpace = {
       render: () => 'Story',
-      name: 'Primary Space',
     };
 
   `);
@@ -281,7 +279,6 @@ test('extract esm into csf head code', () => {
 
     export const Unchecked = {
       render: Template.bind({}),
-      name: 'Unchecked',
 
       args: {
         ...args,
@@ -376,7 +373,6 @@ test('extract all story attributes', () => {
 
     export const Unchecked = {
       render: Template.bind({}),
-      name: 'Unchecked',
 
       args: {
         ...args,
@@ -386,7 +382,6 @@ test('extract all story attributes', () => {
 
     export const Second = {
       render: Template.bind({}),
-      name: 'Second',
     };
 
   `);
@@ -437,12 +432,10 @@ test('duplicate story name', () => {
 
     export const Default_ = {
       render: Default.bind({}),
-      name: 'Default',
     };
 
     export const Second = {
       render: Default.bind({}),
-      name: 'Second',
     };
 
   `);
@@ -480,7 +473,6 @@ test('story name equals component name', () => {
 
     export const Button_ = {
       render: () => <Button label="Story 1" />,
-      name: 'Button',
     };
 
   `);
@@ -570,8 +562,6 @@ test('story child is jsx', () => {
             <div>Hello!</div>
           </Button>
         ),
-
-        name: 'Primary',
       };
 
     `);
@@ -594,7 +584,6 @@ test('story child is CSF3', () => {
     export default {};
 
     export const Primary = {
-      name: 'Primary',
       render: (args) => <Button {...args}></Button>,
 
       args: {
@@ -625,7 +614,6 @@ test('story child is arrow function', () => {
 
       export const Primary = {
         render: (args) => <Button />,
-        name: 'Primary',
       };
 
     `);
@@ -651,7 +639,6 @@ test('story child is identifier', () => {
 
       export const Primary = {
         render: Button,
-        name: 'Primary',
       };
 
     `);

--- a/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
@@ -448,6 +448,44 @@ test('duplicate story name', () => {
   `);
 });
 
+test('story name equals component name', () => {
+  const input = dedent`
+      import { Meta, Story } from '@storybook/addon-docs';
+      import { Button } from './Button';
+
+      <Meta title="Button" />
+
+      <Story name="Button"><Button label='Story 1' /></Story>
+    `;
+
+  const mdx = jscodeshift({ source: input, path: 'Foobar.stories.mdx' });
+  const [, csf] = fs.writeFileSync.mock.calls[0];
+
+  expect(mdx).toMatchInlineSnapshot(`
+    import { Meta, Story } from '@storybook/blocks';
+    import { Button } from './Button';
+    import * as FoobarStories from './Foobar.stories';
+
+    <Meta of={FoobarStories} />
+
+    <Story of={FoobarStories.Button_} />
+
+  `);
+  expect(csf).toMatchInlineSnapshot(`
+    import { Button } from './Button';
+
+    export default {
+      title: 'Button',
+    };
+
+    export const Button_ = {
+      render: () => <Button label="Story 1" />,
+      name: 'Button',
+    };
+
+  `);
+});
+
 test('kebab case file name', () => {
   const input = dedent`
       import { Meta, Story } from '@storybook/addon-docs';

--- a/code/lib/codemod/src/transforms/mdx-to-csf.ts
+++ b/code/lib/codemod/src/transforms/mdx-to-csf.ts
@@ -253,7 +253,7 @@ export function transform(source: string, baseName: string): [mdx: string, csf: 
       },
       ImportDeclaration: (path) => {
         path.node.specifiers.forEach((specifier) => {
-          if (specifier.type === 'ImportSpecifier' && specifier.local.name === name) {
+          if (specifier.local.name === name) {
             found = true;
           }
         });

--- a/code/lib/codemod/src/transforms/mdx-to-csf.ts
+++ b/code/lib/codemod/src/transforms/mdx-to-csf.ts
@@ -21,6 +21,7 @@ import * as path from 'node:path';
 import prettier from 'prettier';
 import * as fs from 'node:fs';
 import camelCase from 'lodash/camelCase';
+import startCase from 'lodash/startCase';
 import type { MdxFlowExpression } from 'mdast-util-mdx-expression';
 
 const mdxProcessor = remark().use(remarkMdx) as ReturnType<typeof remark>;
@@ -58,6 +59,7 @@ export function transform(source: string, baseName: string): [mdx: string, csf: 
     string,
     | {
         type: 'value';
+        name: string;
         attributes: Array<MdxJsxAttribute | MdxJsxExpressionAttribute>;
         children: (MdxJsxFlowElement | MdxJsxTextElement)['children'];
       }
@@ -111,6 +113,7 @@ export function transform(source: string, baseName: string): [mdx: string, csf: 
 
           storiesMap.set(name, {
             type: 'value',
+            name,
             attributes: node.attributes,
             children: node.children,
           });
@@ -273,6 +276,9 @@ export function transform(source: string, baseName: string): [mdx: string, csf: 
         ...value.attributes.flatMap((attribute) => {
           if (attribute.type === 'mdxJsxAttribute') {
             if (typeof attribute.value === 'string') {
+              if (attribute.name === 'name' && attribute.value === startCase(value.name)) {
+                return [];
+              }
               return [
                 t.objectProperty(t.identifier(attribute.name), t.stringLiteral(attribute.value)),
               ];

--- a/code/lib/codemod/src/transforms/mdx-to-csf.ts
+++ b/code/lib/codemod/src/transforms/mdx-to-csf.ts
@@ -107,7 +107,7 @@ export function transform(source: string, baseName: string): [mdx: string, csf: 
         );
         if (typeof nameAttribute?.value === 'string') {
           let name = nameToValidExport(nameAttribute.value);
-          while (variableNameExists(name)) name += '_';
+          while (identifierExists(name)) name += '_';
 
           storiesMap.set(name, {
             type: 'value',
@@ -239,12 +239,19 @@ export function transform(source: string, baseName: string): [mdx: string, csf: 
     return t.arrowFunctionExpression([], expression);
   }
 
-  function variableNameExists(name: string) {
+  function identifierExists(name: string) {
     let found = false;
     file.path.traverse({
       VariableDeclarator: (path) => {
         const lVal = path.node.id;
         if (t.isIdentifier(lVal) && lVal.name === name) found = true;
+      },
+      ImportDeclaration: (path) => {
+        path.node.specifiers.forEach((specifier) => {
+          if (specifier.type === 'ImportSpecifier' && specifier.local.name === name) {
+            found = true;
+          }
+        });
       },
     });
     return found;


### PR DESCRIPTION
## What I did

This is my attempt to solve the issues I am having with the mdx-to-csf migration.
I realize that these code transformations might be too opinionated for the general audience.
So please tell me which ones are fine, and which ones should be refined, removed or somehow made optional.

- Do not generate the story name attribute if it is redundant with the story identifier.
   Otherwise eslint-plugin-storybook complains.
- Story names can conflict with the component name, leading to invalid js.
  I have widened the existing logic to deduplicate identifiers, that appends an underscore.
  TODO: I have to add the case of default exports, because that is how vue components are usually imported.
- Lots of leftover unused imports and definitions. eslint can't remove them automatically.
  Here I am removing all exports from the .mdx result files.
  Earlier I also removed all imports which are not for doc blocks, but I encountered an instance in my own project where the component was imported to be used with ArgsTable.
  So for the imports I opted for the [unused-imports eslint-plugin](https://github.com/sweepline/eslint-plugin-unused-imports) instead.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Are the snapshots in `code/lib/codemod/src/transform/__testfixtures__/mdx-to-csf ` used anywhere? How can I check them locally?

#### Manual testing

I have tested the code mod with a local project and it works as expected.

### Documentation

Is there any documentation regarding the codemod that should be updated?

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
