### PR TITLE
Core: Add an option to disable `warnOnIncompatibleAddons`

### DIFF
--- a/code/lib/core-server/src/presets/common-preset.ts
+++ b/code/lib/core-server/src/presets/common-preset.ts
@@ -194,6 +194,7 @@ export const features = async (
   storyStoreV7: true,
   argTypeTargetsV7: true,
   legacyDecoratorFileOrder: false,
+  warnOnIncompatibleAddons: true,
 });
 
 export const csfIndexer: Indexer = {

--- a/code/lib/core-server/src/utils/warnOnIncompatibleAddons.ts
+++ b/code/lib/core-server/src/utils/warnOnIncompatibleAddons.ts
@@ -6,8 +6,8 @@ import dedent from 'ts-dedent';
 import { getIncompatibleAddons } from '../../../cli/src/automigrate/helpers/getIncompatibleAddons';
 
 export const warnOnIncompatibleAddons = async (config: StorybookConfig) => {
-  if (config.features.warnOnIncompatibleAddons === false) {
-    return 
+  if (config.features?.warnOnIncompatibleAddons === false) {
+    return;
   }
 
   const incompatibleAddons = await getIncompatibleAddons(config);

--- a/code/lib/core-server/src/utils/warnOnIncompatibleAddons.ts
+++ b/code/lib/core-server/src/utils/warnOnIncompatibleAddons.ts
@@ -6,6 +6,10 @@ import dedent from 'ts-dedent';
 import { getIncompatibleAddons } from '../../../cli/src/automigrate/helpers/getIncompatibleAddons';
 
 export const warnOnIncompatibleAddons = async (config: StorybookConfig) => {
+  if (config.features.warnOnIncompatibleAddons === false) {
+    return 
+  }
+
   const incompatibleAddons = await getIncompatibleAddons(config);
 
   if (incompatibleAddons.length > 0) {

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -313,7 +313,7 @@ export interface StorybookConfig {
     legacyDecoratorFileOrder?: boolean;
 
     /**
-     * Warn when there are incompatible addons detected.
+     * Warn when there are incompatible addons detected, default to true.
      */
     warnOnIncompatibleAddons?: boolean;
   };

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -159,6 +159,7 @@ export interface CLIOptions {
   debugWebpack?: boolean;
   webpackStatsJson?: string | boolean;
   outputDir?: string;
+  warnOnIncompatibleAddons?: boolean;
 }
 
 export interface BuilderOptions {
@@ -310,6 +311,11 @@ export interface StorybookConfig {
      * Apply decorators from preview.js before decorators from addons or frameworks
      */
     legacyDecoratorFileOrder?: boolean;
+
+    /**
+     * Warn when there are incompatible addons detected.
+     */
+    warnOnIncompatibleAddons?: boolean;
   };
 
   /**


### PR DESCRIPTION
Closes #23846

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

adding an option to turn off `warnOnIncompatibleAddons`, this does not fix the issue in #23846 but does provide a workaround other than patching storybook.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

did not find existing test case for new feature flags, let me know if I need to test it somehow.

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

checked with local repo that has incompatible addons

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

not sure if it should be documented anywhere, seems no for `warnOnLegacyHierarchySeparator`, so keep it in code only for now.

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
