### PR TITLE
CsfFile: Add parsing of inline parameters

### DIFF
--- a/code/lib/csf-tools/src/CsfFile.test.ts
+++ b/code/lib/csf-tools/src/CsfFile.test.ts
@@ -218,6 +218,8 @@ describe('CsfFile', () => {
             name: Just Custom Meta Id
           - id: custom-id
             name: Custom Paremeters Id
+            inlineParameters:
+              __id: custom-id
       `);
     });
 
@@ -1196,7 +1198,7 @@ describe('CsfFile', () => {
     });
   });
 
-  describe.only('inline parameters', () => {
+  describe('inline parameters', () => {
     it('meta parameters', () => {
       expect(
         parse(dedent`
@@ -1305,6 +1307,29 @@ describe('CsfFile', () => {
           const nonInline = 'non inline';
           export const A = {
             parameters: { nonInline, chromatic: { disable: true } }
+          };
+        `)
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--a
+            name: A
+            inlineParameters:
+              chromatic:
+                disable: true
+      `);
+    });
+
+    it('object spread', () => {
+      expect(
+        parse(dedent`
+          export default {
+            title: 'foo/bar'
+          }
+          const spread = { foo: 'bar' };
+          export const A = {
+            parameters: { ...spread, chromatic: { disable: true } }
           };
         `)
       ).toMatchInlineSnapshot(`

--- a/code/lib/csf-tools/src/CsfFile.test.ts
+++ b/code/lib/csf-tools/src/CsfFile.test.ts
@@ -1195,4 +1195,128 @@ describe('CsfFile', () => {
       `);
     });
   });
+
+  describe.only('inline parameters', () => {
+    it('meta parameters', () => {
+      expect(
+        parse(dedent`
+        export default {
+          title: 'foo/bar',
+          parameters: { chromatic: { disable: true } }
+        }
+        export const A = {};
+        `)
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+          inlineParameters:
+            chromatic:
+              disable: true
+        stories:
+          - id: foo-bar--a
+            name: A
+      `);
+    });
+    it('story parameters', () => {
+      expect(
+        parse(dedent`
+          export default {
+            title: 'foo/bar'
+          }
+          export const A = {
+            parameters: { chromatic: { disable: true } }
+          };
+        `)
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--a
+            name: A
+            inlineParameters:
+              chromatic:
+                disable: true
+      `);
+    });
+    it('non-inline parameters', () => {
+      expect(
+        parse(dedent`
+          export default {
+            title: 'foo/bar'
+          }
+          const chromaticParameters = { chromatic: { disable: true } }
+          export const A = {
+            parameters: chromaticParameters,
+          };
+        `)
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--a
+            name: A
+      `);
+
+      expect(
+        parse(dedent`
+          export default {
+            title: 'foo/bar'
+          }
+          const chromatic = { disable: true };
+          export const A = {
+            parameters: { chromatic },
+          };
+        `)
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--a
+            name: A
+            inlineParameters: {}
+      `);
+    });
+    it('non-JSON parameters', () => {
+      expect(
+        parse(dedent`
+          export default {
+            title: 'foo/bar'
+          }
+          export const A = {
+            parameters: { foo: (() => 'bar')() }
+          };
+        `)
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--a
+            name: A
+            inlineParameters:
+              foo: bar
+      `);
+    });
+    it('mixed parameters', () => {
+      expect(
+        parse(dedent`
+          export default {
+            title: 'foo/bar'
+          }
+          const nonInline = 'non inline';
+          export const A = {
+            parameters: { nonInline, chromatic: { disable: true } }
+          };
+        `)
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--a
+            name: A
+            inlineParameters:
+              chromatic:
+                disable: true
+      `);
+    });
+  });
 });

--- a/code/lib/csf-tools/src/CsfFile.test.ts
+++ b/code/lib/csf-tools/src/CsfFile.test.ts
@@ -1278,6 +1278,11 @@ describe('CsfFile', () => {
             inlineParameters: {}
       `);
     });
+
+    // This test was to show that you could also include functions like
+    // `() => 'bar'` in the inline parameters, but the YAML test serialization
+    // fails in that case. So instead I just included a more complex AST
+    // expression that can also be seralized in the test.
     it('non-JSON parameters', () => {
       expect(
         parse(dedent`


### PR DESCRIPTION
Closes N/A

## What I did

Generalized parsing of parameters is hard, but we can parse parameters that are defined inline, e.g.

```js
export default { title: 'foo', parameters: { chromatic: { disable: true } } }
```
This PR adds support for parsing such parameters to CsfFile. See included tests for more examples.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual tests.
