### PR TITLE
 CLI: Ensure errors with opening the browser are caught

### DIFF
--- a/code/lib/core-server/src/utils/open-in-browser.ts
+++ b/code/lib/core-server/src/utils/open-in-browser.ts
@@ -25,7 +25,7 @@ export function openInBrowser(address: string) {
       ) {
         // We use betterOpn for Chrome because it is better at handling which chrome tab
         // or window the preview loads in.
-        betterOpn(address);
+        await betterOpn(address);
       } else {
         await open(address, openOptions);
       }


### PR DESCRIPTION
## What I did

If user default browser is Chrome or Chromium, then cli will use better-opn to open browser, but this command may facing error and not been captured, then it will block the whole start process.

Solution:
add await to betterOpn in order to catch error in betterOpn, otherwise it will be a unhandled promise error.

- Add await to betterOpn to catch unhandled promise error.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

No test cases created for open-in-browser.ts file.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
