### PR TITLE
NextJS-server: Fix storybook process management

### DIFF
--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -219,6 +219,7 @@ command('dev')
   )
   .option('--force-build-preview', 'Build the preview iframe even if you are using --preview-url')
   .option('--docs', 'Build a documentation-only site using addon-docs')
+  .option('--exact-port', 'Exit early if the desired port is not available')
   .option(
     '--initial-path [path]',
     'URL path to be appended when visiting Storybook for the first time'

--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -37,7 +37,7 @@ export async function buildDevStandalone(
   );
   // updateInfo are cached, so this is typically pretty fast
   const [port, versionCheck] = await Promise.all([
-    getServerPort(options.port),
+    getServerPort(options.port, { exactPort: options.exactPort }),
     versionUpdates
       ? updateCheck(packageJson.version)
       : Promise.resolve({ success: false, cached: false, data: {}, time: Date.now() }),

--- a/code/lib/core-server/src/utils/server-address.ts
+++ b/code/lib/core-server/src/utils/server-address.ts
@@ -26,11 +26,22 @@ export function getServerAddresses(
   };
 }
 
-export const getServerPort = (port?: number) =>
-  detectFreePort(port).catch((error) => {
-    logger.error(error);
-    process.exit(-1);
-  });
+interface PortOptions {
+  exactPort?: boolean;
+}
+
+export const getServerPort = (port?: number, { exactPort }: PortOptions = {}) =>
+  detectFreePort(port)
+    .then((freePort) => {
+      if (freePort !== port && exactPort) {
+        process.exit(-1);
+      }
+      return freePort;
+    })
+    .catch((error) => {
+      logger.error(error);
+      process.exit(-1);
+    });
 
 export const getServerChannelUrl = (port: number, { https }: { https?: boolean }) => {
   return `${https ? 'wss' : 'ws'}://localhost:${port}/storybook-server-channel`;

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -139,6 +139,7 @@ export interface CLIOptions {
   enableCrashReports?: boolean;
   host?: string;
   initialPath?: string;
+  exactPort?: boolean;
   /**
    * @deprecated Use 'staticDirs' Storybook Configuration option instead
    */


### PR DESCRIPTION


### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-24740-sha-c34bd874`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24740-sha-c34bd874). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-24740-sha-c34bd874`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24740-sha-c34bd874) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/nextjs-server-process-management`](https://github.com/storybookjs/storybook/tree/shilman/nextjs-server-process-management) |
| **Commit** | [`c34bd874`](https://github.com/storybookjs/storybook/commit/c34bd87435ce76dff25b187dadb22595eb5e8939) |
| **Datetime** | Tue Nov  7 00:47:55 UTC 2023 (`1699318075`) |
| **Workflow run** | [6778442909](https://github.com/storybookjs/storybook/actions/runs/6778442909) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=24740`_
</details>
<!-- CANARY_RELEASE_SECTION -->
