### PR TITLE
Webpack5: Add export-order-loader and remove babel-plugin-named-exports-order

### DIFF
--- a/code/builders/builder-webpack5/package.json
+++ b/code/builders/builder-webpack5/package.json
@@ -36,6 +36,11 @@
       "node": "./dist/presets/preview-preset.js",
       "require": "./dist/presets/preview-preset.js"
     },
+    "./loaders/export-order-loader": {
+      "types": "./dist/loaders/export-order-loader.d.ts",
+      "node": "./dist/loaders/export-order-loader.js",
+      "require": "./dist/loaders/export-order-loader.js"
+    },
     "./templates/virtualModuleModernEntry.js.handlebars": "./templates/virtualModuleModernEntry.js.handlebars",
     "./templates/preview.ejs": "./templates/preview.ejs",
     "./package.json": "./package.json"
@@ -69,15 +74,16 @@
     "@types/node": "^18.0.0",
     "@types/semver": "^7.3.4",
     "babel-loader": "^9.0.0",
-    "babel-plugin-named-exports-order": "^0.0.2",
     "browser-assert": "^1.2.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "constants-browserify": "^1.0.0",
     "css-loader": "^6.7.1",
+    "es-module-lexer": "^0.9.3",
     "express": "^4.17.3",
     "fork-ts-checker-webpack-plugin": "^8.0.0",
     "fs-extra": "^11.1.0",
     "html-webpack-plugin": "^5.5.0",
+    "magic-string": "^0.30.5",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "semver": "^7.3.7",
@@ -114,7 +120,8 @@
     "entries": [
       "./src/index.ts",
       "./src/presets/custom-webpack-preset.ts",
-      "./src/presets/preview-preset.ts"
+      "./src/presets/preview-preset.ts",
+      "./src/loaders/export-order-loader.ts"
     ],
     "platform": "node"
   },

--- a/code/builders/builder-webpack5/src/loaders/export-order-loader.ts
+++ b/code/builders/builder-webpack5/src/loaders/export-order-loader.ts
@@ -1,11 +1,12 @@
 import { parse } from 'es-module-lexer';
 import MagicString from 'magic-string';
-import { LoaderContext } from 'webpack';
+import type { LoaderContext } from 'webpack';
 
 export default async function loader(this: LoaderContext<any>, source: string) {
   const callback = this.async();
 
   try {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     const [_, exports] = parse(source);
 
     if (exports.includes('__namedExportsOrder')) {
@@ -21,4 +22,4 @@ export default async function loader(this: LoaderContext<any>, source: string) {
   } catch (err) {
     return callback(err as any);
   }
-};
+}

--- a/code/builders/builder-webpack5/src/loaders/export-order-loader.ts
+++ b/code/builders/builder-webpack5/src/loaders/export-order-loader.ts
@@ -1,0 +1,24 @@
+import { parse } from 'es-module-lexer';
+import MagicString from 'magic-string';
+import { LoaderContext } from 'webpack';
+
+export default async function loader(this: LoaderContext<any>, source: string) {
+  const callback = this.async();
+
+  try {
+    const [_, exports] = parse(source);
+
+    if (exports.includes('__namedExportsOrder')) {
+      return callback(null, source);
+    }
+
+    const magicString = new MagicString(source);
+    const orderedExports = exports.filter((e) => e !== 'default');
+    magicString.append(`;export const __namedExportsOrder = ${JSON.stringify(orderedExports)};`);
+
+    const map = magicString.generateMap({ hires: true });
+    return callback(null, magicString.toString(), map);
+  } catch (err) {
+    return callback(err as any);
+  }
+};

--- a/code/builders/builder-webpack5/src/presets/preview-preset.ts
+++ b/code/builders/builder-webpack5/src/presets/preview-preset.ts
@@ -18,16 +18,5 @@ export const entries = async (_: unknown, options: any) => {
   return result;
 };
 
-export const babel = async (config: any, options: any) => ({
-  ...config,
-  overrides: [
-    ...(config?.overrides || []),
-    {
-      test: /\.(story|stories).*$/,
-      plugins: [require.resolve('babel-plugin-named-exports-order')],
-    },
-  ],
-});
-
 export const previewMainTemplate = () =>
   require.resolve('@storybook/builder-webpack5/templates/preview.ejs');

--- a/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -302,6 +302,14 @@ export default async (
     module: {
       rules: [
         {
+          test: /\.stories\.([tj])sx?$|(stories|story)\.mdx$/,
+          use: [
+            {
+              loader: require.resolve('@storybook/builder-webpack5/loaders/export-order-loader'),
+            },
+          ],
+        },
+        {
           test: /\.m?js$/,
           type: 'javascript/auto',
         },

--- a/code/lib/cli/src/generators/REACT_SCRIPTS/index.ts
+++ b/code/lib/cli/src/generators/REACT_SCRIPTS/index.ts
@@ -44,8 +44,6 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
 
   const extraPackages = [];
   extraPackages.push('webpack');
-  // Miscellaneous dependency used in `babel-preset-react-app` but not listed as dep there
-  extraPackages.push('babel-plugin-named-exports-order');
   // Miscellaneous dependency to add to be sure Storybook + CRA is working fine with Yarn PnP mode
   extraPackages.push('prop-types');
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6165,15 +6165,16 @@ __metadata:
     "@types/webpack-hot-middleware": "npm:^2.25.6"
     "@types/webpack-virtual-modules": "npm:^0.1.1"
     babel-loader: "npm:^9.0.0"
-    babel-plugin-named-exports-order: "npm:^0.0.2"
     browser-assert: "npm:^1.2.1"
     case-sensitive-paths-webpack-plugin: "npm:^2.4.0"
     constants-browserify: "npm:^1.0.0"
     css-loader: "npm:^6.7.1"
+    es-module-lexer: "npm:^0.9.3"
     express: "npm:^4.17.3"
     fork-ts-checker-webpack-plugin: "npm:^8.0.0"
     fs-extra: "npm:^11.1.0"
     html-webpack-plugin: "npm:^5.5.0"
+    magic-string: "npm:^0.30.5"
     path-browserify: "npm:^1.0.1"
     pretty-hrtime: "npm:^1.0.3"
     process: "npm:^0.11.10"
@@ -11508,13 +11509,6 @@ __metadata:
     reselect: "npm:^3.0.1"
     resolve: "npm:^1.4.0"
   checksum: d0011e5aa28ed2d36d720e43d9704bcbf7faac143318c7556dea1bd31bf029c2620137aa8c643b4aab6a5d10fba59886d831d1451806e432fb0b3b63b71703dd
-  languageName: node
-  linkType: hard
-
-"babel-plugin-named-exports-order@npm:^0.0.2":
-  version: 0.0.2
-  resolution: "babel-plugin-named-exports-order@npm:0.0.2"
-  checksum: e1d001722bddabc296b74f7cd020418a3cce9ca7052d5dd5dbd2870745d9566e286d14707c0bbfc9d4b4b643031052b358124ec735069f214d22b0b6768daf9d
   languageName: node
   linkType: hard
 
@@ -21278,6 +21272,15 @@ __metadata:
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.4.15"
   checksum: 076c0402334a8f7c69d83175b4ff10c83b50fd2c6d884a758a563ad9bea312db3b5c7b16cf717229c11505a1deb52d6225503b3b638e1879101d65d08f03c467
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.5":
+  version: 0.30.5
+  resolution: "magic-string@npm:0.30.5"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.4.15"
+  checksum: 38ac220ca7539e96da7ea2f38d85796bdf5c69b6bcae728c4bc2565084e6dc326b9174ee9770bea345cf6c9b3a24041b767167874fab5beca874d2356a9d1520
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/24748

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Removed babel-plugin-named-exports-order and added a new export-order-loader to `@storybook/builder-webpack5` to make the AST transformation compiler independent

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a Webpack5-based sandbox
2. Open a Story
3. Analyze the compiled code of the Story. It should export a `__namedExportsOrder` field with the preserved Story order
![Bildschirmfoto 2023-11-07 um 14 57 47](https://github.com/storybookjs/storybook/assets/5889929/1b7eb1ce-aa15-4c61-b32b-0f56e3eb6944)
(The variable is also exported, but not visible on the screenshot)

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
