### PR TITLE
Webpack5: Add react-docgen loader and remove babel-plugin-react-docgen

### DIFF
--- a/code/addons/docs/src/typings.d.ts
+++ b/code/addons/docs/src/typings.d.ts
@@ -1,7 +1,6 @@
 declare module '@egoist/vue-to-react';
 declare module 'remark-slug';
 declare module 'remark-external-links';
-declare module 'babel-plugin-react-docgen';
 declare module 'acorn-jsx';
 declare module 'vue/dist/vue';
 declare module '@storybook/mdx1-csf';

--- a/code/jest.config.js
+++ b/code/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
     '<rootDir>/lib/*',
     '<rootDir>/builders/*',
     '<rootDir>/renderers/*',
+    '<rootDir>/presets/*',
     '<rootDir>/ui/!(node_modules)*',
   ],
   collectCoverage: false,

--- a/code/lib/docs-tools/package.json
+++ b/code/lib/docs-tools/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
+    "babel-plugin-react-docgen": "4.2.1",
     "jest-specific-snapshot": "^8.0.0",
     "require-from-string": "^2.0.2",
     "typescript": "~4.9.3"

--- a/code/presets/create-react-app/package.json
+++ b/code/presets/create-react-app/package.json
@@ -53,7 +53,6 @@
     "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
     "@storybook/types": "workspace:*",
     "@types/babel__core": "^7.1.7",
-    "babel-plugin-react-docgen": "^4.1.0",
     "pnp-webpack-plugin": "^1.7.0",
     "semver": "^7.3.5"
   },

--- a/code/presets/react-webpack/jest.config.js
+++ b/code/presets/react-webpack/jest.config.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const baseConfig = require('../../jest.config.node');
+
+module.exports = {
+  ...baseConfig,
+  displayName: __dirname.split(path.sep).slice(-2).join(path.posix.sep),
+};

--- a/code/presets/react-webpack/package.json
+++ b/code/presets/react-webpack/package.json
@@ -47,6 +47,11 @@
       "require": "./dist/framework-preset-react.js",
       "import": "./dist/framework-preset-react.mjs"
     },
+    "./dist/loaders/react-docgen-loader": {
+      "types": "./dist/loaders/react-docgen-loader.d.ts",
+      "require": "./dist/loaders/react-docgen-loader.js",
+      "import": "./dist/loaders/react-docgen-loader.mjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",
@@ -75,8 +80,9 @@
     "@types/node": "^18.0.0",
     "@types/semver": "^7.3.4",
     "babel-plugin-add-react-displayname": "^0.0.5",
-    "babel-plugin-react-docgen": "^4.2.1",
     "fs-extra": "^11.1.0",
+    "magic-string": "^0.30.5",
+    "react-docgen": "^7.0.0",
     "react-refresh": "^0.11.0",
     "semver": "^7.3.7",
     "webpack": "5"
@@ -108,7 +114,8 @@
       "./src/index.ts",
       "./src/framework-preset-cra.ts",
       "./src/framework-preset-react-docs.ts",
-      "./src/framework-preset-react.ts"
+      "./src/framework-preset-react.ts",
+      "./src/loaders/react-docgen-loader.ts"
     ],
     "platform": "node"
   },

--- a/code/presets/react-webpack/src/framework-preset-react-docs.test.ts
+++ b/code/presets/react-webpack/src/framework-preset-react-docs.test.ts
@@ -1,20 +1,22 @@
 import ReactDocgenTypescriptPlugin from '@storybook/react-docgen-typescript-plugin';
 import type { TypescriptOptions } from '@storybook/core-webpack';
+import type { Configuration } from 'webpack';
 import * as preset from './framework-preset-react-docs';
 
+jest.mock('./requirer', () => ({
+  requirer: (resolver: any, path: string) => path,
+}));
+
 describe('framework-preset-react-docgen', () => {
-  const babelPluginReactDocgenPath = require.resolve('babel-plugin-react-docgen');
   const presetsListWithDocs = [{ name: '@storybook/addon-docs', options: {}, preset: null }];
 
-  describe('react-docgen', () => {
-    it('should return the babel config with the extra plugin', async () => {
-      const babelConfig = {
-        babelrc: false,
-        presets: ['env', 'foo-preset'],
-        plugins: ['foo-plugin'],
-      };
+  // mock requirer
 
-      const config = await preset.babel?.(babelConfig, {
+  describe('react-docgen', () => {
+    it('should return the webpack config with the extra webpack loader', async () => {
+      const webpackConfig: Configuration = {};
+
+      const config = await preset.webpackFinal?.(webpackConfig, {
         presets: {
           apply: async () =>
             ({
@@ -26,15 +28,15 @@ describe('framework-preset-react-docgen', () => {
       } as any);
 
       expect(config).toEqual({
-        babelrc: false,
-        plugins: ['foo-plugin'],
-        presets: ['env', 'foo-preset'],
-        overrides: [
-          {
-            test: /\.(cjs|mjs|tsx?|jsx?)$/,
-            plugins: [[babelPluginReactDocgenPath]],
-          },
-        ],
+        module: {
+          rules: [
+            {
+              exclude: /node_modules\/.*/,
+              loader: '@storybook/preset-react-webpack/dist/loaders/react-docgen-loader',
+              test: /\.(cjs|mjs|tsx?|jsx?)$/,
+            },
+          ],
+        },
       });
     });
   });
@@ -58,6 +60,15 @@ describe('framework-preset-react-docgen', () => {
       });
 
       expect(config).toEqual({
+        module: {
+          rules: [
+            {
+              exclude: /node_modules\/.*/,
+              loader: '@storybook/preset-react-webpack/dist/loaders/react-docgen-loader',
+              test: /\.(cjs|mjs|jsx?)$/,
+            },
+          ],
+        },
         plugins: [expect.any(ReactDocgenTypescriptPlugin)],
       });
     });
@@ -65,27 +76,10 @@ describe('framework-preset-react-docgen', () => {
 
   describe('no docgen', () => {
     it('should not add any extra plugins', async () => {
-      const babelConfig = {
-        babelrc: false,
-        presets: ['env', 'foo-preset'],
-        plugins: ['foo-plugin'],
-      };
-
       const webpackConfig = {
         plugins: [],
       };
 
-      const outputBabelconfig = await preset.babel?.(babelConfig, {
-        presets: {
-          // @ts-expect-error (Converted from ts-ignore)
-          apply: async () =>
-            ({
-              check: false,
-              reactDocgen: false,
-            } as Partial<TypescriptOptions>),
-        },
-        presetsList: presetsListWithDocs,
-      });
       const outputWebpackconfig = await preset.webpackFinal?.(webpackConfig, {
         presets: {
           // @ts-expect-error (Converted from ts-ignore)
@@ -98,40 +92,16 @@ describe('framework-preset-react-docgen', () => {
         presetsList: presetsListWithDocs,
       });
 
-      expect(outputBabelconfig).toEqual({
-        babelrc: false,
-        presets: ['env', 'foo-preset'],
-        plugins: ['foo-plugin'],
-      });
-      expect(outputWebpackconfig).toEqual({
-        plugins: [],
-      });
+      expect(outputWebpackconfig).toEqual({ plugins: [] });
     });
   });
 
   describe('no docs or controls addon used', () => {
     it('should not add any extra plugins', async () => {
-      const babelConfig = {
-        babelrc: false,
-        presets: ['env', 'foo-preset'],
-        plugins: ['foo-plugin'],
-      };
-
       const webpackConfig = {
         plugins: [],
       };
 
-      const outputBabelconfig = await preset.babel?.(babelConfig, {
-        presets: {
-          // @ts-expect-error (Converted from ts-ignore)
-          apply: async () =>
-            ({
-              check: false,
-              reactDocgen: 'react-docgen-typescript',
-            } as Partial<TypescriptOptions>),
-        },
-        presetsList: [],
-      });
       const outputWebpackconfig = await preset.webpackFinal?.(webpackConfig, {
         presets: {
           // @ts-expect-error (Converted from ts-ignore)
@@ -144,11 +114,6 @@ describe('framework-preset-react-docgen', () => {
         presetsList: [],
       });
 
-      expect(outputBabelconfig).toEqual({
-        babelrc: false,
-        presets: ['env', 'foo-preset'],
-        plugins: ['foo-plugin'],
-      });
       expect(outputWebpackconfig).toEqual({
         plugins: [],
       });

--- a/code/presets/react-webpack/src/framework-preset-react-docs.ts
+++ b/code/presets/react-webpack/src/framework-preset-react-docs.ts
@@ -1,34 +1,13 @@
 import { hasDocsOrControls } from '@storybook/docs-tools';
 
+import type { Configuration } from 'webpack';
 import type { StorybookConfig } from './types';
+import { requirer } from './requirer';
 
-export const babel: StorybookConfig['babel'] = async (config, options) => {
-  if (!hasDocsOrControls(options)) return config;
-
-  const typescriptOptions = await options.presets.apply<StorybookConfig['typescript']>(
-    'typescript',
-    {} as any
-  );
-
-  const { reactDocgen } = typescriptOptions || {};
-
-  if (typeof reactDocgen !== 'string') {
-    return config;
-  }
-
-  return {
-    ...config,
-    overrides: [
-      ...(config?.overrides || []),
-      {
-        test: reactDocgen === 'react-docgen' ? /\.(cjs|mjs|tsx?|jsx?)$/ : /\.(cjs|mjs|jsx?)$/,
-        plugins: [[require.resolve('babel-plugin-react-docgen')]],
-      },
-    ],
-  };
-};
-
-export const webpackFinal: StorybookConfig['webpackFinal'] = async (config, options) => {
+export const webpackFinal: StorybookConfig['webpackFinal'] = async (
+  config,
+  options
+): Promise<Configuration> => {
   if (!hasDocsOrControls(options)) return config;
 
   const typescriptOptions = await options.presets.apply<StorybookConfig['typescript']>(
@@ -38,14 +17,48 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (config, opti
 
   const { reactDocgen, reactDocgenTypescriptOptions } = typescriptOptions || {};
 
-  if (reactDocgen !== 'react-docgen-typescript') {
+  if (typeof reactDocgen !== 'string') {
     return config;
+  }
+
+  if (reactDocgen !== 'react-docgen-typescript') {
+    return {
+      ...config,
+      module: {
+        ...(config.module ?? {}),
+        rules: [
+          ...(config.module?.rules ?? []),
+          {
+            test: /\.(cjs|mjs|tsx?|jsx?)$/,
+            loader: requirer(
+              require.resolve,
+              '@storybook/preset-react-webpack/dist/loaders/react-docgen-loader'
+            ),
+            exclude: /node_modules\/.*/,
+          },
+        ],
+      },
+    };
   }
 
   const { ReactDocgenTypeScriptPlugin } = await import('@storybook/react-docgen-typescript-plugin');
 
   return {
     ...config,
+    module: {
+      ...(config.module ?? {}),
+      rules: [
+        ...(config.module?.rules ?? []),
+        {
+          test: /\.(cjs|mjs|jsx?)$/,
+          loader: requirer(
+            require.resolve,
+            '@storybook/preset-react-webpack/dist/loaders/react-docgen-loader'
+          ),
+          exclude: /node_modules\/.*/,
+        },
+      ],
+    },
     plugins: [
       ...(config.plugins || []),
       new ReactDocgenTypeScriptPlugin({

--- a/code/presets/react-webpack/src/loaders/react-docgen-loader.ts
+++ b/code/presets/react-webpack/src/loaders/react-docgen-loader.ts
@@ -1,0 +1,89 @@
+import {
+  parse,
+  builtinResolvers as docgenResolver,
+  builtinHandlers as docgenHandlers,
+  builtinImporters as docgenImporters,
+  ERROR_CODES,
+  utils,
+} from 'react-docgen';
+import MagicString from 'magic-string';
+import type { LoaderContext } from 'webpack';
+import type { Handler, NodePath, babelTypes as t, Documentation } from 'react-docgen';
+
+const { getNameOrValue, isReactForwardRefCall } = utils;
+
+const actualNameHandler: Handler = function actualNameHandler(documentation, componentDefinition) {
+  if (
+    (componentDefinition.isClassDeclaration() || componentDefinition.isFunctionDeclaration()) &&
+    componentDefinition.has('id')
+  ) {
+    documentation.set(
+      'actualName',
+      getNameOrValue(componentDefinition.get('id') as NodePath<t.Identifier>)
+    );
+  } else if (
+    componentDefinition.isArrowFunctionExpression() ||
+    componentDefinition.isFunctionExpression() ||
+    isReactForwardRefCall(componentDefinition)
+  ) {
+    let currentPath: NodePath = componentDefinition;
+
+    while (currentPath.parentPath) {
+      if (currentPath.parentPath.isVariableDeclarator()) {
+        documentation.set('actualName', getNameOrValue(currentPath.parentPath.get('id')));
+        return;
+      }
+      if (currentPath.parentPath.isAssignmentExpression()) {
+        const leftPath = currentPath.parentPath.get('left');
+
+        if (leftPath.isIdentifier() || leftPath.isLiteral()) {
+          documentation.set('actualName', getNameOrValue(leftPath));
+          return;
+        }
+      }
+
+      currentPath = currentPath.parentPath;
+    }
+    // Could not find an actual name
+    documentation.set('actualName', '');
+  }
+};
+
+type DocObj = Documentation & { actualName: string };
+
+const defaultHandlers = Object.values(docgenHandlers).map((handler) => handler);
+const defaultResolver = new docgenResolver.FindExportedDefinitionsResolver();
+const defaultImporter = docgenImporters.fsImporter;
+const handlers = [...defaultHandlers, actualNameHandler];
+
+export default async function reactDocgenLoader(this: LoaderContext<any>, source: string) {
+  const callback = this.async();
+
+  try {
+    const docgenResults = parse(source, {
+      filename: this.resourcePath,
+      resolver: defaultResolver,
+      handlers,
+      importer: defaultImporter,
+    }) as DocObj[];
+
+    const magicString = new MagicString(source);
+
+    docgenResults.forEach((info) => {
+      const { actualName, ...docgenInfo } = info;
+      if (actualName) {
+        const docNode = JSON.stringify(docgenInfo);
+        magicString.append(`;${actualName}.__docgenInfo=${docNode}`);
+      }
+    });
+
+    const map = magicString.generateMap({ hires: true });
+    callback(null, magicString.toString(), map);
+  } catch (error: any) {
+    if (error.code === ERROR_CODES.MISSING_DEFINITION) {
+      callback(null, source);
+    } else {
+      callback(error);
+    }
+  }
+}

--- a/code/presets/react-webpack/src/requirer.ts
+++ b/code/presets/react-webpack/src/requirer.ts
@@ -1,0 +1,4 @@
+// Use it in favour of require.resolve() to be able to mock it in tests.
+export function requirer(resolver: (path: string) => string, path: string) {
+  return resolver(path);
+}

--- a/code/presets/server-webpack/jest.config.js
+++ b/code/presets/server-webpack/jest.config.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const baseConfig = require('../../jest.config.node');
+
+module.exports = {
+  ...baseConfig,
+  displayName: __dirname.split(path.sep).slice(-2).join(path.posix.sep),
+};

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2371,25 +2371,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.4.5, @babel/traverse@npm:^7.7.0":
-  version: 7.23.0
-  resolution: "@babel/traverse@npm:7.23.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.22.13"
-    "@babel/generator": "npm:^7.23.0"
-    "@babel/helper-environment-visitor": "npm:^7.22.20"
-    "@babel/helper-function-name": "npm:^7.23.0"
-    "@babel/helper-hoist-variables": "npm:^7.22.5"
-    "@babel/helper-split-export-declaration": "npm:^7.22.6"
-    "@babel/parser": "npm:^7.23.0"
-    "@babel/types": "npm:^7.23.0"
-    debug: "npm:^4.1.0"
-    globals: "npm:^11.1.0"
-  checksum: 84f93e64179965a0de6109a8b1ce92d66eb52a76e8ba325d27bdec6952cedd8fc98eabf09fe443ef667a051300dc7ed8924e7bf61a87ad456501d1da46657509
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.23.2":
+"@babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.23.2":
   version: 7.23.2
   resolution: "@babel/traverse@npm:7.23.2"
   dependencies:
@@ -2404,6 +2386,24 @@ __metadata:
     debug: "npm:^4.1.0"
     globals: "npm:^11.1.0"
   checksum: d096c7c4bab9262a2f658298a3c630ae4a15a10755bb257ae91d5ab3e3b2877438934859c8d34018b7727379fe6b26c4fa2efc81cf4c462a7fe00caf79fa02ff
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.4.5, @babel/traverse@npm:^7.7.0":
+  version: 7.23.0
+  resolution: "@babel/traverse@npm:7.23.0"
+  dependencies:
+    "@babel/code-frame": "npm:^7.22.13"
+    "@babel/generator": "npm:^7.23.0"
+    "@babel/helper-environment-visitor": "npm:^7.22.20"
+    "@babel/helper-function-name": "npm:^7.23.0"
+    "@babel/helper-hoist-variables": "npm:^7.22.5"
+    "@babel/helper-split-export-declaration": "npm:^7.22.6"
+    "@babel/parser": "npm:^7.23.0"
+    "@babel/types": "npm:^7.23.0"
+    debug: "npm:^4.1.0"
+    globals: "npm:^11.1.0"
+  checksum: 84f93e64179965a0de6109a8b1ce92d66eb52a76e8ba325d27bdec6952cedd8fc98eabf09fe443ef667a051300dc7ed8924e7bf61a87ad456501d1da46657509
   languageName: node
   linkType: hard
 
@@ -6607,6 +6607,7 @@ __metadata:
     "@storybook/types": "workspace:*"
     "@types/doctrine": "npm:^0.0.3"
     assert: "npm:^2.1.0"
+    babel-plugin-react-docgen: "npm:4.2.1"
     doctrine: "npm:^3.0.0"
     jest-specific-snapshot: "npm:^8.0.0"
     lodash: "npm:^4.17.21"
@@ -7014,7 +7015,6 @@ __metadata:
     "@storybook/types": "workspace:*"
     "@types/babel__core": "npm:^7.1.7"
     "@types/node": "npm:^18.0.0"
-    babel-plugin-react-docgen: "npm:^4.1.0"
     pnp-webpack-plugin: "npm:^1.7.0"
     semver: "npm:^7.3.5"
     typescript: "npm:~4.9.3"
@@ -7069,8 +7069,9 @@ __metadata:
     "@types/node": "npm:^18.0.0"
     "@types/semver": "npm:^7.3.4"
     babel-plugin-add-react-displayname: "npm:^0.0.5"
-    babel-plugin-react-docgen: "npm:^4.2.1"
     fs-extra: "npm:^11.1.0"
+    magic-string: "npm:^0.30.5"
+    react-docgen: "npm:^7.0.0"
     react-refresh: "npm:^0.11.0"
     semver: "npm:^7.3.7"
     typescript: "npm:~4.9.3"
@@ -11548,7 +11549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-react-docgen@npm:^4.1.0, babel-plugin-react-docgen@npm:^4.2.1":
+"babel-plugin-react-docgen@npm:4.2.1":
   version: 4.2.1
   resolution: "babel-plugin-react-docgen@npm:4.2.1"
   dependencies:
@@ -30096,7 +30097,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"v8-to-istanbul@npm:^9.0.0, v8-to-istanbul@npm:^9.0.1":
+"v8-to-istanbul@npm:^9.0.0":
+  version: 9.1.3
+  resolution: "v8-to-istanbul@npm:9.1.3"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.12"
+    "@types/istanbul-lib-coverage": "npm:^2.0.1"
+    convert-source-map: "npm:^2.0.0"
+  checksum: 7acfc460731b629a0d547b231e9d510aaa826df67f4deeaeeb991b492f78faf3bb1aa4b54fa0f9b06d815bc69eb0a04a6c2180c16ba43a83cc5e5490fa160a96
+  languageName: node
+  linkType: hard
+
+"v8-to-istanbul@npm:^9.0.1":
   version: 9.1.2
   resolution: "v8-to-istanbul@npm:9.1.2"
   dependencies:


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/24750

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

In Webpack5-based projects, the babel-plugin-react-docgen plugin is used to generate types for Javascript and Typescript components. In the future, the Webpack5 builder will not only support Babel, but another compiler like SWC. Therefore, we have to change the implementation of this transformation for being compiler agnostic.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a Webpack5-based sandbox
2. Go to `.storybook/main.ts` and change set { typescript: { react-docgen: "react-docgen" }}
3. Controls are properly generated in Storybook

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
