### PR TITLE
Svelte: Fix source with decorators always showing the `SlotDecorator` component

### DIFF
--- a/code/e2e-tests/framework-svelte.spec.ts
+++ b/code/e2e-tests/framework-svelte.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable jest/no-disabled-tests */
 import { test, expect } from '@playwright/test';
 import process from 'process';
+import dedent from 'ts-dedent';
 import { SbPage } from './util';
 
 const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:6006';
@@ -36,5 +37,17 @@ test.describe('Svelte', () => {
     const root = sbPage.previewRoot();
     const argsTable = root.locator('.docblock-argstable');
     await expect(argsTable).toContainText('Rounds the button');
+  });
+
+  test('Decorators are excluded from generated source code', async ({ page }) => {
+    const sbPage = new SbPage(page);
+
+    await sbPage.navigateToStory('stories/renderers/svelte/slot-decorators', 'docs');
+    const root = sbPage.previewRoot();
+    const showCodeButton = (await root.locator('button', { hasText: 'Show Code' }).all())[0];
+    await showCodeButton.click();
+    const sourceCode = root.locator('pre.prismjs');
+    const expectedSource = '<ButtonJavaScript primary/>';
+    await expect(sourceCode.textContent()).resolves.toContain(expectedSource);
   });
 });

--- a/code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts
+++ b/code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts
@@ -3,7 +3,7 @@ import MagicString from 'magic-string';
 import path from 'path';
 import fs from 'fs';
 import svelteDoc from 'sveltedoc-parser';
-import type { SvelteParserOptions } from 'sveltedoc-parser';
+import type { SvelteComponentDoc, SvelteParserOptions } from 'sveltedoc-parser';
 import { logger } from '@storybook/node-logger';
 import { preprocess } from 'svelte/compiler';
 import { createFilter } from 'vite';
@@ -120,7 +120,7 @@ export function svelteDocgen(svelteOptions: Record<string, any> = {}): PluginOpt
 
       const s = new MagicString(src);
 
-      let componentDoc: any;
+      let componentDoc: SvelteComponentDoc & { keywords?: string[] };
       try {
         componentDoc = await svelteDoc.parse(options);
       } catch (error: any) {

--- a/code/renderers/svelte/src/docs/sourceDecorator.ts
+++ b/code/renderers/svelte/src/docs/sourceDecorator.ts
@@ -1,10 +1,17 @@
 /* eslint-disable no-underscore-dangle */
 import { addons, useEffect } from '@storybook/preview-api';
 import { deprecate } from '@storybook/client-logger';
-import type { ArgTypes, Args, StoryContext } from '@storybook/types';
+import type {
+  ArgTypes,
+  Args,
+  ArgsStoryFn,
+  DecoratorFunction,
+  StoryContext,
+} from '@storybook/types';
 
 import { SourceType, SNIPPET_RENDERED } from '@storybook/docs-tools';
-import type { SvelteRenderer } from '../types';
+import type { SvelteComponentDoc } from 'sveltedoc-parser';
+import type { SvelteRenderer, SvelteStoryResult } from '../types';
 
 /**
  * Check if the source-code should be generated.
@@ -140,19 +147,23 @@ export function generateSvelteSource(
  *
  * @param component Component
  */
-function getWrapperProperties(component: any) {
+function getWrapperProperties(
+  component?: SvelteStoryResult['Component'] & {
+    __docgen?: SvelteComponentDoc & { keywords?: string[] };
+  }
+) {
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { __docgen } = component;
+  const { __docgen } = component || {};
   if (!__docgen) {
     return { wrapper: false };
   }
 
   // the component should be declared as a wrapper
-  if (!__docgen.keywords.find((kw: any) => kw.name === 'wrapper')) {
+  if (!__docgen.keywords?.find((kw: any) => kw.name === 'wrapper')) {
     return { wrapper: false };
   }
 
-  const slotProp = __docgen.data.find((prop: any) =>
+  const slotProp = __docgen.data?.find((prop: any) =>
     prop.keywords.find((kw: any) => kw.name === 'slot')
   );
   return { wrapper: true, slotProperty: slotProp?.name as string };
@@ -163,7 +174,7 @@ function getWrapperProperties(component: any) {
  * @param storyFn Fn
  * @param context  StoryContext
  */
-export const sourceDecorator = (storyFn: any, context: StoryContext<SvelteRenderer>) => {
+export const sourceDecorator: DecoratorFunction<SvelteRenderer> = (storyFn, context) => {
   const channel = addons.getChannel();
   const skip = skipSourceRender(context);
   const story = storyFn();
@@ -181,16 +192,21 @@ export const sourceDecorator = (storyFn: any, context: StoryContext<SvelteRender
     return story;
   }
 
-  const { parameters = {}, args = {}, component: ctxtComponent } = context || {};
-  let { Component: component = {} } = story;
+  const { parameters = {}, args = {}, component: ctxComponent } = context || {};
 
+  // excludeDecorators from source generation as they'll generate the wrong code
+  // instead get the component directly from the original story function instead
+  let { Component: component } = (context.originalStoryFn as ArgsStoryFn<SvelteRenderer>)(
+    args,
+    context
+  );
   const { wrapper, slotProperty } = getWrapperProperties(component);
   if (wrapper) {
     if (parameters.component) {
       deprecate('parameters.component is deprecated. Using context.component instead.');
     }
 
-    component = ctxtComponent;
+    component = ctxComponent;
   }
 
   const generated = generateSvelteSource(component, args, context?.argTypes, slotProperty);

--- a/code/renderers/svelte/template/stories/slot-decorators.stories.js
+++ b/code/renderers/svelte/template/stories/slot-decorators.stories.js
@@ -9,6 +9,7 @@ export default {
   args: {
     primary: true,
   },
+  tags: ['autodocs'],
 };
 
 export const WithDefaultRedBorder = {};


### PR DESCRIPTION
Closes #21477

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Defaulted the Svelte source decorator to always exclude decorators from the source generation.

We have a similar pattern in React, HTML and Web components, however for them `excludeDecorators` is configurable. I didn't think that was necessary here, since including decorators leads to a broken result, so I don't know why you would want that.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

1. Create a Svelte-based sandbox or open a published Storybook from this PR
2. Navigate to `/?path=/docs/stories-renderers-svelte-slot-decorators--docs`
3. Open the source view
4. See that it says `<ButtonJavaScript primary/>` and _not_ `<SlotDecorator primary/>`
<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
5. Open Storybook in your browser
6. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
