### PR TITLE
NextJS-server: Generate route group for storybook

### DIFF
--- a/code/frameworks/nextjs-server/src/preset.ts
+++ b/code/frameworks/nextjs-server/src/preset.ts
@@ -15,7 +15,7 @@ const rewritingIndexer: Indexer = {
     const csf = await loadCsf(code, { ...opts, fileName }).parse();
 
     const inputStorybookDir = resolve(__dirname, '../template/storybookPreview');
-    const storybookDir = join(process.cwd(), 'app', 'storybookPreview');
+    const storybookDir = join(process.cwd(), 'app', '(sb)', 'storybookPreview');
     const storybookPreview = join(process.cwd(), '.storybook', 'preview');
 
     try {

--- a/code/frameworks/nextjs-server/src/preset.ts
+++ b/code/frameworks/nextjs-server/src/preset.ts
@@ -27,7 +27,7 @@ const rewritingIndexer: Indexer = {
         LAYOUT_FILES.map((file) => exists(join(appDir, file)))
       );
       const inputLayout = hasRootLayout ? 'layout-nested.tsx' : 'layout-root.tsx';
-      await cp(`${inputStorybookDir}/${inputLayout}`, `${storybookPreview}/layout.tsx`);
+      await cp(`${inputStorybookDir}/${inputLayout}`, `${storybookDir}/layout.tsx`);
     } catch (err) {
       // FIXME: assume we've copied already
     }

--- a/code/frameworks/nextjs-server/src/preset.ts
+++ b/code/frameworks/nextjs-server/src/preset.ts
@@ -27,7 +27,7 @@ const rewritingIndexer: Indexer = {
         LAYOUT_FILES.map((file) => exists(join(appDir, file)))
       );
       const inputLayout = hasRootLayout ? 'layout-nested.tsx' : 'layout-root.tsx';
-      await cp(`${inputStorybookDir}/${inputLayout}`, `${storybookDir}/layout.tsx`);
+      await cp(`${inputStorybookDir}/${inputLayout}`, join(storybookDir, 'layout.tsx'));
     } catch (err) {
       // FIXME: assume we've copied already
     }

--- a/code/frameworks/nextjs-server/template/storybookPreview/layout-nested.tsx
+++ b/code/frameworks/nextjs-server/template/storybookPreview/layout-nested.tsx
@@ -2,8 +2,6 @@ import type { PropsWithChildren } from 'react';
 import React from 'react';
 import { Storybook } from './components/Storybook';
 
-function Layout({ children }: PropsWithChildren<{}>) {
+export default function NestedLayout({ children }: PropsWithChildren<{}>) {
   return <Storybook>{children}</Storybook>;
 }
-
-export default Layout;

--- a/code/frameworks/nextjs-server/template/storybookPreview/layout-root.tsx
+++ b/code/frameworks/nextjs-server/template/storybookPreview/layout-root.tsx
@@ -1,0 +1,17 @@
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+import { Storybook } from './components/Storybook';
+
+export default function RootLayout({ children }: PropsWithChildren<{}>) {
+  return (
+    <html lang="en">
+      <body>
+        <main>
+          <div className="page">
+            <Storybook>{children}</Storybook>
+          </div>
+        </main>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION


### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-24820-sha-5859dece`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24820-sha-5859dece). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-24820-sha-5859dece`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24820-sha-5859dece) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/nextjs-route-groups`](https://github.com/storybookjs/storybook/tree/shilman/nextjs-route-groups) |
| **Commit** | [`5859dece`](https://github.com/storybookjs/storybook/commit/5859dece7fd3949e8118e6ea815bc90c6557f6bf) |
| **Datetime** | Mon Nov 13 08:22:14 UTC 2023 (`1699863734`) |
| **Workflow run** | [6847363621](https://github.com/storybookjs/storybook/actions/runs/6847363621) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=24820`_
</details>
<!-- CANARY_RELEASE_SECTION -->
