### PR TITLE
Vite: Prevent non-deterministic build output

### DIFF
--- a/code/builders/builder-vite/src/list-stories.ts
+++ b/code/builders/builder-vite/src/list-stories.ts
@@ -9,21 +9,27 @@ export async function listStories(options: Options) {
   const { normalizePath } = await import('vite');
 
   return (
-    await Promise.all(
-      normalizeStories(await options.presets.apply('stories', [], options), {
-        configDir: options.configDir,
-        workingDir: options.configDir,
-      }).map(({ directory, files }) => {
-        const pattern = path.join(directory, files);
-        const absolutePattern = path.isAbsolute(pattern)
-          ? pattern
-          : path.join(options.configDir, pattern);
+    (
+      await Promise.all(
+        normalizeStories(await options.presets.apply('stories', [], options), {
+          configDir: options.configDir,
+          workingDir: options.configDir,
+        }).map(({ directory, files }) => {
+          const pattern = path.join(directory, files);
+          const absolutePattern = path.isAbsolute(pattern)
+            ? pattern
+            : path.join(options.configDir, pattern);
 
-        return glob(slash(absolutePattern), {
-          ...commonGlobOptions(absolutePattern),
-          follow: true,
-        });
-      })
+          return glob(slash(absolutePattern), {
+            ...commonGlobOptions(absolutePattern),
+            follow: true,
+          });
+        })
+      )
     )
-  ).reduce((carry, stories) => carry.concat(stories.map(normalizePath)), []);
+      .reduce((carry, stories) => carry.concat(stories.map(normalizePath)), [])
+      // Sort stories to prevent a non-deterministic build. The result of Glob is not sorted an may differ
+      // for each invocation. This results in a different bundle file hashes from one build to the next.
+      .sort()
+  );
 }


### PR DESCRIPTION
Closes #24747


## What I did

<!-- Briefly describe what your PR does -->
Sorted stories to prevent a non-deterministic build in `list-stories` function of the vite-builder. 

The result of Glob is not sorted an may differ for each invocation. This results in a different bundle file 
hashes from one build to the next. This breaks caching of unchanged chunks and breaks artifact based build systems like Bazel or Buck2. 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
