### PR TITLE
TestBuild: Revert defaulting to SWC in test build, but keep using esbuild for minification

### DIFF
--- a/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -323,7 +323,7 @@ export default async (
             fullySpecified: false,
           },
         },
-        builderOptions.useSWC || options.build?.test?.fastCompilation
+        builderOptions.useSWC
           ? await createSWCLoader(Object.keys(virtualModuleMapping), options)
           : createBabelLoader(babelOptions, typescriptOptions, Object.keys(virtualModuleMapping)),
         {
@@ -362,7 +362,7 @@ export default async (
         ? {
             minimize: true,
             // eslint-disable-next-line no-nested-ternary
-            minimizer: options.build?.test?.fastCompilation
+            minimizer: options.build?.test?.esbuildMinify
               ? [
                   new TerserWebpackPlugin<EsbuildOptions>({
                     parallel: true,

--- a/code/lib/core-server/src/presets/common-override-preset.ts
+++ b/code/lib/core-server/src/presets/common-override-preset.ts
@@ -19,7 +19,7 @@ export const framework: PresetProperty<'framework', StorybookConfig> = async (co
 
 export const stories: PresetProperty<'stories', StorybookConfig> = async (entries, options) => {
   if (options?.build?.test?.disableMDXEntries) {
-    const out = (
+    return (
       await Promise.all(
         normalizeStories(entries, {
           configDir: options.configDir,
@@ -34,9 +34,15 @@ export const stories: PresetProperty<'stories', StorybookConfig> = async (entrie
           });
         })
       )
-    ).reduce((carry, s) => carry.concat(s), []);
-
-    return out.filter((s) => !s.endsWith('.mdx'));
+    ).flatMap((expanded, i) => {
+      const filteredEntries = expanded.filter((s) => !s.endsWith('.mdx'));
+      // only return the filtered entries when there is something to filter
+      // as webpack is faster with unexpanded globs
+      if (filteredEntries.length < expanded.length) {
+        return filteredEntries;
+      }
+      return entries[i];
+    });
   }
   return entries;
 };

--- a/code/lib/core-server/src/presets/common-override-preset.ts
+++ b/code/lib/core-server/src/presets/common-override-preset.ts
@@ -63,7 +63,7 @@ const createTestBuildFeatures = (value: boolean): Required<TestBuildFlags> => ({
   disableDocgen: value,
   disableSourcemaps: value,
   disableTreeShaking: value,
-  fastCompilation: value,
+  esbuildMinify: value,
 });
 
 export const build = async (value: StorybookConfig['build'], options: Options) => {

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -292,9 +292,9 @@ export interface TestBuildFlags {
    */
   disableTreeShaking?: boolean;
   /**
-   * Compile/Optimize with SWC/ESbuild.
+   * Minify with ESBuild when using webpack.
    */
-  fastCompilation?: boolean;
+  esbuildMinify?: boolean;
 }
 
 export interface TestBuildConfig {


### PR DESCRIPTION
## What I did

Revert defaulting to SWC in test build, but keep using esbuild for minification

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
