### PR TITLE
Documentation: fix decorators' render order mistake in doc.

### DIFF
--- a/docs/writing-stories/decorators.md
+++ b/docs/writing-stories/decorators.md
@@ -166,6 +166,6 @@ Like parameters, decorators can be defined globally, at the component level, and
 
 All decorators relevant to a story will run in the following order once the story renders:
 
-- Global decorators, in the order they are defined
-- Component decorators, in the order they are defined
 - Story decorators, in the order they are defined
+- Component decorators, in the order they are defined
+- Global decorators, in the order they are defined


### PR DESCRIPTION
## What I did

Fix doc mistake about decorators' render order in "Decorator inheritance".

Actually, the render order should be like:
```jsx
...
  <GlobalDecorator2>
    <GlobalDecorator1>
      ...
        <ComponentDecorator2>
          <ComponentDecorator1>
            ...
              <StoryDecorator2>
                <StoryDecorator1>
                  <Story />
                <StoryDecorator1>
              <StoryDecorator2>
            ...
          </ComponentDecorator1>
        </ComponentDecorator2>
      ...
    </GlobalDecorator1>
  </GlobalDecorator2>
...
```
