### PR TITLE
Core: Detect no matching export error in storybook start and build

### DIFF
--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -385,3 +385,28 @@ export class NextjsSWCNotSupportedError extends StorybookError {
     `;
   }
 }
+
+export class NoMatchingExportError extends StorybookError {
+  readonly category = Category.CORE_SERVER;
+
+  readonly code = 4;
+
+  constructor(public data: { error: unknown | Error }) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      There was an exports mismatch error when trying to build Storybook.
+      Please check whether the versions of your Storybook packages match whenever possible, as this might be the cause.
+      
+      Problematic example:
+      { "@storybook/react": "7.5.3", "@storybook/react-vite": "7.4.5", "storybook": "7.3.0" }
+
+      Correct example:
+      { "@storybook/react": "7.5.3", "@storybook/react-vite": "7.5.3", "storybook": "7.5.3" }
+
+      Clearing your lock file and reinstalling your dependencies might help as well.
+    `;
+  }
+}

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -406,7 +406,7 @@ export class NoMatchingExportError extends StorybookError {
       Correct example:
       { "@storybook/react": "7.5.3", "@storybook/react-vite": "7.5.3", "storybook": "7.5.3" }
 
-      Clearing your lock file and reinstalling your dependencies might help as well.
+      Clearing your lock file and reinstalling your dependencies might help as well, as sometimes the version you see in your package.json might not be the one defined in your lock file, leading to version inconsistency issues.
     `;
   }
 }

--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -27,6 +27,7 @@ import { updateCheck } from './utils/update-check';
 import { getServerPort, getServerChannelUrl } from './utils/server-address';
 import { getManagerBuilder, getPreviewBuilder } from './utils/get-builders';
 import { warnOnIncompatibleAddons } from './utils/warnOnIncompatibleAddons';
+import { buildOrThrow } from './utils/build-or-throw';
 
 export async function buildDevStandalone(
   options: CLIOptions & LoadOptions & BuilderOptions
@@ -134,8 +135,8 @@ export async function buildDevStandalone(
     features,
   };
 
-  const { address, networkAddress, managerResult, previewResult } = await storybookDevServer(
-    fullOptions
+  const { address, networkAddress, managerResult, previewResult } = await buildOrThrow(async () =>
+    storybookDevServer(fullOptions)
   );
 
   const previewTotalTime = previewResult?.totalTime;

--- a/code/lib/core-server/src/build-static.ts
+++ b/code/lib/core-server/src/build-static.ts
@@ -35,6 +35,7 @@ import { extractStorybookMetadata } from './utils/metadata';
 import { StoryIndexGenerator } from './utils/StoryIndexGenerator';
 import { summarizeIndex } from './utils/summarizeIndex';
 import { defaultStaticDirs } from './utils/constants';
+import { buildOrThrow } from './utils/build-or-throw';
 
 export type BuildStaticStandaloneOptions = CLIOptions &
   LoadOptions &
@@ -146,7 +147,9 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
 
   global.FEATURES = features;
 
-  await managerBuilder.build({ startTime: process.hrtime(), options: fullOptions });
+  await buildOrThrow(async () =>
+    managerBuilder.build({ startTime: process.hrtime(), options: fullOptions })
+  );
 
   if (staticDirs) {
     effects.push(

--- a/code/lib/core-server/src/utils/build-or-throw.ts
+++ b/code/lib/core-server/src/utils/build-or-throw.ts
@@ -1,0 +1,20 @@
+import { NoMatchingExportError } from '@storybook/core-events/server-errors';
+
+export async function buildOrThrow<T>(callback: () => Promise<T>): Promise<T> {
+  try {
+    return await callback();
+  } catch (err: any) {
+    const builderErrors = err.errors as { text: string }[];
+    if (builderErrors) {
+      const inconsistentVersionsError = builderErrors.find((er) =>
+        er.text.includes('No matching export')
+      );
+
+      if (inconsistentVersionsError) {
+        throw new NoMatchingExportError(err);
+      }
+    }
+
+    throw err;
+  }
+}

--- a/code/lib/core-server/src/utils/build-or-throw.ts
+++ b/code/lib/core-server/src/utils/build-or-throw.ts
@@ -7,7 +7,7 @@ export async function buildOrThrow<T>(callback: () => Promise<T>): Promise<T> {
     const builderErrors = err.errors as { text: string }[];
     if (builderErrors) {
       const inconsistentVersionsError = builderErrors.find((er) =>
-        er.text.includes('No matching export')
+        er.text?.includes('No matching export')
       );
 
       if (inconsistentVersionsError) {


### PR DESCRIPTION
Closes #23992 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

This PR adds a detection step when running `storybook dev` or `storybook build` for the infamous `No matching exports` error (refer to the issue), which is mostly caused by version inconsistencies in Storybook.

Hopefully this will aid users to fix the issues themselves, but ideally this error should give them a command to run, like `storybook doctor`, which could tell exactly what package to upgrade. For now, we do our best with an error message.


Before:
<img width="673" alt="image" src="https://github.com/storybookjs/storybook/assets/1671563/4bf8bdeb-27ce-415f-a8f7-d366d1305163">

After:
<img width="766" alt="image" src="https://github.com/storybookjs/storybook/assets/1671563/2391ce6c-a41a-46ee-b9e1-3e73a79adc9e">

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

This is tricky to test, I don't know if it's possible in the monorepo.

1. Create a sandbox
2. Change the version of `storybook` to something old, e.g. `7.0.3`
3. It's crucial that this results in duplicated versions of different Storybook packages, which is why this is tricky in the monorepo given the portaled resolutions which are used.
4. Run Storybook build

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
