### PR TITLE
Refactor app/pages indexers & add auto-detect of appDir

### DIFF
--- a/code/frameworks/nextjs-server/src/indexers.ts
+++ b/code/frameworks/nextjs-server/src/indexers.ts
@@ -1,0 +1,158 @@
+import { cp, readFile, writeFile } from 'fs/promises';
+import { ensureDir, exists } from 'fs-extra';
+import { join, relative, resolve } from 'path';
+import { dedent } from 'ts-dedent';
+import type { Indexer, PreviewAnnotation } from '@storybook/types';
+import { loadCsf } from '@storybook/csf-tools';
+
+const LAYOUT_FILES = ['layout.tsx', 'layout.jsx'];
+
+export const appIndexer = (allPreviewAnnotations: PreviewAnnotation[]): Indexer => {
+  return {
+    test: /(stories|story)\.[tj]sx?$/,
+    createIndex: async (fileName, opts) => {
+      console.log('indexing', fileName);
+      const code = (await readFile(fileName, 'utf-8')).toString();
+      const csf = await loadCsf(code, { ...opts, fileName }).parse();
+
+      const routeDir = join('app', '(sb)');
+      const inputStorybookDir = resolve(__dirname, `../template/${routeDir}/storybookPreview`);
+      const storybookDir = join(process.cwd(), routeDir, 'storybookPreview');
+      await ensureDir(storybookDir);
+
+      try {
+        await cp(inputStorybookDir, storybookDir, { recursive: true });
+        const hasRootLayout = await Promise.any(
+          LAYOUT_FILES.map((file) => exists(join(process.cwd(), routeDir, file)))
+        );
+        const inputLayout = hasRootLayout ? 'layout-nested.tsx' : 'layout-root.tsx';
+        await cp(`${inputStorybookDir}/${inputLayout}`, join(storybookDir, 'layout.tsx'));
+      } catch (err) {
+        // FIXME: assume we've copied already
+      }
+
+      await Promise.all(
+        csf.stories.map(async (story) => {
+          const storyDir = join(storybookDir, story.id);
+          await ensureDir(storyDir);
+          const relativeStoryPath = relative(storyDir, fileName).replace(/\.tsx?$/, '');
+          const { exportName } = story;
+
+          const pageTsx = dedent`
+            import React from 'react';
+            import { composeStory } from '@storybook/react/testing-api';
+            import { getArgs } from '../components/args';
+            import { Prepare, StoryAnnotations } from '../components/Prepare';
+            import { Args } from '@storybook/react';
+            
+            const page = async () => {
+              const stories = await import('${relativeStoryPath}');
+              const projectAnnotations = {};
+              const Composed = composeStory(stories.${exportName}, stories.default, projectAnnotations?.default || {}, '${exportName}');
+              const extraArgs = await getArgs(Composed.id);
+              
+              const { id, parameters, argTypes, initialArgs } = Composed;
+              const args = { ...initialArgs, ...extraArgs };
+              
+              const storyAnnotations: StoryAnnotations<Args> = {
+                id,
+                parameters,
+                argTypes,
+                initialArgs,
+                args,
+              };
+              return (
+                <>
+                <Prepare story={storyAnnotations} />
+                {/* @ts-ignore TODO -- why? */}
+                <Composed {...extraArgs} />
+                </>
+                );
+              };
+              export default page;
+            `;
+
+          const pageFile = join(storyDir, 'page.tsx');
+          await writeFile(pageFile, pageTsx);
+        })
+      );
+
+      return csf.indexInputs;
+    },
+  };
+};
+
+export const pagesIndexer = (allPreviewAnnotations: PreviewAnnotation[]): Indexer => {
+  const workingDir = process.cwd(); // TODO we should probably put this on the preset options
+
+  return {
+    test: /(stories|story)\.[tj]sx?$/,
+    createIndex: async (fileName, opts) => {
+      console.log('indexing', fileName);
+      const code = (await readFile(fileName, 'utf-8')).toString();
+      const csf = await loadCsf(code, { ...opts, fileName }).parse();
+
+      const routeDir = 'pages';
+      const storybookDir = join(process.cwd(), routeDir, 'storybookPreview');
+      await ensureDir(storybookDir);
+
+      const indexTsx = dedent`
+        import React from 'react';
+        import { Storybook } from './components/Storybook';
+        
+        const page = () => <Storybook />;
+        export default page;
+      `;
+      const indexFile = join(storybookDir, 'index.tsx');
+      await writeFile(indexFile, indexTsx);
+
+      const projectAnnotationImports = allPreviewAnnotations
+        .map((path, index) => `const projectAnnotations${index} = await import('${path}');`)
+        .join('\n');
+
+      const projectAnnotationArray = allPreviewAnnotations
+        .map((_, index) => `projectAnnotations${index}`)
+        .join(',');
+
+      const storybookTsx = dedent`
+        import React, { useEffect } from 'react';
+        import { composeConfigs } from '@storybook/preview-api';
+        import { Preview } from '@storybook/nextjs-server/pages';
+
+        const getProjectAnnotations = async () => {
+          ${projectAnnotationImports}
+          return composeConfigs([${projectAnnotationArray}]);
+        }
+
+        export const Storybook = () => <Preview getProjectAnnotations={getProjectAnnotations} />;
+      `;
+
+      const componentsDir = join(storybookDir, 'components');
+      await ensureDir(componentsDir);
+      const storybookFile = join(componentsDir, 'Storybook.tsx');
+      await writeFile(storybookFile, storybookTsx);
+
+      const componentId = csf.stories[0].id.split('--')[0];
+      const relativeStoryPath = relative(storybookDir, fileName).replace(/\.tsx?$/, '');
+      const importPath = relative(workingDir, fileName).replace(/^([^./])/, './$1');
+
+      const csfImportTsx = dedent`
+        import React from 'react';
+        import { Storybook } from './components/Storybook';
+        import * as stories from '${relativeStoryPath}';
+        
+        if (typeof window !== 'undefined') {
+          window._storybook_onImport('${importPath}', stories);
+        }
+
+        const page = () => <Storybook />;
+        export default page;
+      `;
+
+      const csfImportFile = join(storybookDir, `${componentId}.tsx`);
+      await writeFile(csfImportFile, csfImportTsx);
+
+      return csf.indexInputs;
+    },
+  };
+};

--- a/code/frameworks/nextjs-server/src/indexers.ts
+++ b/code/frameworks/nextjs-server/src/indexers.ts
@@ -16,7 +16,7 @@ export const appIndexer = (allPreviewAnnotations: PreviewAnnotation[]): Indexer 
       const csf = await loadCsf(code, { ...opts, fileName }).parse();
 
       const routeDir = join('app', '(sb)');
-      const inputStorybookDir = resolve(__dirname, `../template/${routeDir}/storybookPreview`);
+      const inputStorybookDir = resolve(__dirname, `../template/app/storybookPreview`);
       const storybookDir = join(process.cwd(), routeDir, 'storybookPreview');
       await ensureDir(storybookDir);
 

--- a/code/frameworks/nextjs-server/src/indexers.ts
+++ b/code/frameworks/nextjs-server/src/indexers.ts
@@ -15,20 +15,21 @@ export const appIndexer = (allPreviewAnnotations: PreviewAnnotation[]): Indexer 
       const code = (await readFile(fileName, 'utf-8')).toString();
       const csf = await loadCsf(code, { ...opts, fileName }).parse();
 
-      const routeDir = join('app', '(sb)');
       const inputStorybookDir = resolve(__dirname, `../template/app/storybookPreview`);
-      const storybookDir = join(process.cwd(), routeDir, 'storybookPreview');
+      const appDir = join(process.cwd(), 'app');
+      const storybookDir = join(appDir, '(sb)', 'storybookPreview');
       await ensureDir(storybookDir);
 
       try {
         await cp(inputStorybookDir, storybookDir, { recursive: true });
         const hasRootLayout = await Promise.any(
-          LAYOUT_FILES.map((file) => exists(join(process.cwd(), routeDir, file)))
+          LAYOUT_FILES.map((file) => exists(join(appDir, file)))
         );
         const inputLayout = hasRootLayout ? 'layout-nested.tsx' : 'layout-root.tsx';
         await cp(`${inputStorybookDir}/${inputLayout}`, join(storybookDir, 'layout.tsx'));
       } catch (err) {
         // FIXME: assume we've copied already
+        // console.log({ err });
       }
 
       await Promise.all(

--- a/code/frameworks/nextjs-server/src/next-config.ts
+++ b/code/frameworks/nextjs-server/src/next-config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from 'next';
 import type { ChildProcess } from 'child_process';
 import { spawn } from 'child_process';
+import { existsSync } from 'fs';
+import type { StorybookNextJSOptions } from './types';
 
 const logger = console;
 let childProcess: ChildProcess | undefined;
@@ -51,7 +53,12 @@ export const withStorybook = ({
   managerPath = 'storybook',
   // TODO -- how to pass this to codegen if changed?
   previewPath = 'storybookPreview',
+  appDir = undefined,
 } = {}) => {
+  const storybookNextJSOptions: StorybookNextJSOptions = {
+    appDir: appDir ?? existsSync('./app'),
+  };
+
   childProcess = spawn(
     'yarn',
     [
@@ -66,7 +73,10 @@ export const withStorybook = ({
       // a more graceful way to handle this.
       '--exact-port',
     ],
-    { stdio: 'inherit' }
+    {
+      stdio: 'inherit',
+      env: { ...process.env, STORYBOOK_NEXTJS_OPTIONS: JSON.stringify(storybookNextJSOptions) },
+    }
   );
 
   return (config: NextConfig) => ({

--- a/code/frameworks/nextjs-server/src/preset.ts
+++ b/code/frameworks/nextjs-server/src/preset.ts
@@ -1,160 +1,14 @@
-import { cp, readFile, writeFile } from 'fs/promises';
-import { ensureDir, exists } from 'fs-extra';
-import { dirname, join, relative, resolve } from 'path';
-import { dedent } from 'ts-dedent';
+import { dirname, join } from 'path';
 
-import type { PresetProperty, Indexer, PreviewAnnotation } from '@storybook/types';
-import { loadCsf } from '@storybook/csf-tools';
-import type { StorybookConfig } from './types';
+import type { PresetProperty, PreviewAnnotation } from '@storybook/types';
+import type { StorybookConfig, StorybookNextJSOptions } from './types';
+import { appIndexer, pagesIndexer } from './indexers';
 
 const wrapForPnP = (input: string) => dirname(require.resolve(join(input, 'package.json')));
 
-// TODO
-const appDir = false;
-
-// export const addons: PresetProperty<'addons', StorybookConfig> = [
-//   wrapForPnP('@storybook/preset-server-webpack'),
-// ];
-
-const LAYOUT_FILES = ['layout.tsx', 'layout.jsx'];
-
-const rewritingIndexer = (allPreviewAnnotations: PreviewAnnotation[]): Indexer => {
-  const workingDir = process.cwd(); // TODO we should probably put this on the preset options
-
-  return {
-    test: /(stories|story)\.[tj]sx?$/,
-    createIndex: async (fileName, opts) => {
-      console.log('indexing', fileName);
-      const code = (await readFile(fileName, 'utf-8')).toString();
-      const csf = await loadCsf(code, { ...opts, fileName }).parse();
-
-      const routeDir = appDir ? join('app', '(sb)') : 'pages';
-      const inputStorybookDir = resolve(__dirname, `../template/${routeDir}/storybookPreview`);
-      const storybookDir = join(process.cwd(), routeDir, 'storybookPreview');
-      await ensureDir(storybookDir);
-
-      if (appDir) {
-        try {
-          await cp(inputStorybookDir, storybookDir, { recursive: true });
-          const hasRootLayout = await Promise.any(
-            LAYOUT_FILES.map((file) => exists(join(process.cwd(), routeDir, file)))
-          );
-          const inputLayout = hasRootLayout ? 'layout-nested.tsx' : 'layout-root.tsx';
-          await cp(`${inputStorybookDir}/${inputLayout}`, join(storybookDir, 'layout.tsx'));
-        } catch (err) {
-          // FIXME: assume we've copied already
-        }
-      } else {
-        const indexTsx = dedent`
-          import React from 'react';
-          import { Storybook } from './components/Storybook';
-          
-          const page = () => <Storybook />;
-          export default page;
-        `;
-        const indexFile = join(storybookDir, 'index.tsx');
-        await writeFile(indexFile, indexTsx);
-
-        const projectAnnotationImports = allPreviewAnnotations
-          .map((path, index) => `const projectAnnotations${index} = await import('${path}');`)
-          .join('\n');
-
-        const projectAnnotationArray = allPreviewAnnotations
-          .map((_, index) => `projectAnnotations${index}`)
-          .join(',');
-
-        const storybookTsx = dedent`
-          import React, { useEffect } from 'react';
-          import { composeConfigs } from '@storybook/preview-api';
-          import { Preview } from '@storybook/nextjs-server/pages';
-
-          const getProjectAnnotations = async () => {
-            ${projectAnnotationImports}
-            return composeConfigs([${projectAnnotationArray}]);
-          }
-
-          export const Storybook = () => <Preview getProjectAnnotations={getProjectAnnotations} />;
-        `;
-
-        const componentsDir = join(storybookDir, 'components');
-        await ensureDir(componentsDir);
-        const storybookFile = join(componentsDir, 'Storybook.tsx');
-        await writeFile(storybookFile, storybookTsx);
-      }
-
-      if (appDir) {
-        await Promise.all(
-          csf.stories.map(async (story) => {
-            const storyDir = join(storybookDir, story.id);
-            await ensureDir(storyDir);
-            const relativeStoryPath = relative(storyDir, fileName).replace(/\.tsx?$/, '');
-            const { exportName } = story;
-
-            const pageTsx = dedent`
-              import React from 'react';
-              import { composeStory } from '@storybook/react/testing-api';
-              import { getArgs } from '../components/args';
-              import { Prepare, StoryAnnotations } from '../components/Prepare';
-              import { Args } from '@storybook/react';
-              
-              const page = async () => {
-                const stories = await import('${relativeStoryPath}');
-                const projectAnnotations = {};
-                const Composed = composeStory(stories.${exportName}, stories.default, projectAnnotations?.default || {}, '${exportName}');
-                const extraArgs = await getArgs(Composed.id);
-                
-                const { id, parameters, argTypes, initialArgs } = Composed;
-                const args = { ...initialArgs, ...extraArgs };
-                
-                const storyAnnotations: StoryAnnotations<Args> = {
-                  id,
-                  parameters,
-                  argTypes,
-                  initialArgs,
-                  args,
-                };
-                return (
-                  <>
-                  <Prepare story={storyAnnotations} />
-                  {/* @ts-ignore TODO -- why? */}
-                  <Composed {...extraArgs} />
-                  </>
-                  );
-                };
-                export default page;
-              `;
-
-            const pageFile = join(storyDir, 'page.tsx');
-            await writeFile(pageFile, pageTsx);
-          })
-        );
-      } else {
-        const componentId = csf.stories[0].id.split('--')[0];
-        const relativeStoryPath = relative(storybookDir, fileName).replace(/\.tsx?$/, '');
-        const importPath = relative(workingDir, fileName).replace(/^([^./])/, './$1');
-
-        const csfImportTsx = dedent`
-          import React from 'react';
-          import { Storybook } from './components/Storybook';
-          import * as stories from '${relativeStoryPath}';
-          
-          if (typeof window !== 'undefined') {
-            window._storybook_onImport('${importPath}', stories);
-          }
-          
-
-          const page = () => <Storybook />;
-          export default page;
-        `;
-
-        const csfImportFile = join(storybookDir, `${componentId}.tsx`);
-        await writeFile(csfImportFile, csfImportTsx);
-      }
-
-      return csf.indexInputs;
-    },
-  };
-};
+const { appDir }: StorybookNextJSOptions = process.env.STORYBOOK_NEXTJS_OPTIONS
+  ? JSON.parse(process.env.STORYBOOK_NEXTJS_OPTIONS)
+  : {};
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const experimental_indexers: StorybookConfig['experimental_indexers'] = async (
@@ -174,7 +28,10 @@ export const experimental_indexers: StorybookConfig['experimental_indexers'] = a
     // loadPreviewOrConfigFile(options),
   ].filter(Boolean);
 
-  return [rewritingIndexer(allPreviewAnnotations), ...(existingIndexers || [])];
+  const rewritingIndexer = appDir
+    ? appIndexer(allPreviewAnnotations)
+    : pagesIndexer(allPreviewAnnotations);
+  return [rewritingIndexer, ...(existingIndexers || [])];
 };
 
 export const core: PresetProperty<'core', StorybookConfig> = async (config) => {

--- a/code/frameworks/nextjs-server/src/types.ts
+++ b/code/frameworks/nextjs-server/src/types.ts
@@ -19,3 +19,7 @@ type StorybookConfigFramework = {
  * The interface for Storybook configuration in `main.ts` files.
  */
 export type StorybookConfig = StorybookConfigBase & StorybookConfigFramework;
+
+export interface StorybookNextJSOptions {
+  appDir: boolean;
+}


### PR DESCRIPTION
## How to test

No config:
- [ ] Run in an app dir project
- [ ] Run in a pages dir project

Manual config:
- [ ] Run in an app dir project and configure with `withStorybook({ appDir: false })`
- [ ] Observe `pages/storybookPreview` generated
