### PR TITLE
Scripts: Change check-dependencies script to js

### DIFF
--- a/.github/workflows/generate-sandboxes-main.yml
+++ b/.github/workflows/generate-sandboxes-main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd ./scripts
-          node --loader esbuild-register/loader -r esbuild-register ./check-dependencies.ts
+          node --experimental-modules ./check-dependencies.js
           cd ..
       - name: Compile Storybook libraries
         run: yarn task --task compile --start-from=auto --no-link

--- a/.github/workflows/generate-sandboxes-next.yml
+++ b/.github/workflows/generate-sandboxes-next.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd ./scripts
-          node --loader esbuild-register/loader -r esbuild-register ./check-dependencies.ts
+          node --experimental-modules ./check-dependencies.js
           cd ..
       - name: Compile Storybook libraries
         run: yarn task --task compile --start-from=auto --no-link

--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -120,7 +120,8 @@ const baseTemplates = {
   },
   'nextjs/default-js': {
     name: 'Next.js Latest (Webpack | JavaScript)',
-    script: 'yarn create next-app {{beforeDir}} --javascript --eslint',
+    script:
+      'yarn create next-app {{beforeDir}} --javascript --eslint --tailwind --app --import-alias="@/*" --src-dir',
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',
@@ -130,7 +131,8 @@ const baseTemplates = {
   },
   'nextjs/default-ts': {
     name: 'Next.js Latest (Webpack | TypeScript)',
-    script: 'yarn create next-app {{beforeDir}} --typescript --eslint',
+    script:
+      'yarn create next-app {{beforeDir}} --typescript --eslint --tailwind --app --import-alias="@/*" --src-dir',
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',

--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -303,7 +303,7 @@ const baseTemplates = {
   'angular-cli/prerelease': {
     name: 'Angular CLI Prerelease (Webpack | TypeScript)',
     script:
-      'npx -p @angular/cli@next ng new angular-v16 --directory {{beforeDir}} --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
+      'npx -p @angular/cli@next ng new angular-v16 --directory {{beforeDir}} --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn --ssr',
     expected: {
       framework: '@storybook/angular',
       renderer: '@storybook/angular',
@@ -314,7 +314,7 @@ const baseTemplates = {
   'angular-cli/default-ts': {
     name: 'Angular CLI Latest (Webpack | TypeScript)',
     script:
-      'npx -p @angular/cli ng new angular-latest --directory {{beforeDir}} --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn',
+      'npx -p @angular/cli ng new angular-latest --directory {{beforeDir}} --routing=true --minimal=true --style=scss --strict --skip-git --skip-install --package-manager=yarn --ssr',
     expected: {
       framework: '@storybook/angular',
       renderer: '@storybook/angular',

--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -1,0 +1,72 @@
+/**
+ * This file needs to be run before any other script to ensure dependencies are installed
+ * Therefore, we cannot transform this file to Typescript, because it would require esbuild to be installed
+ */
+import { spawn } from 'child_process';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import * as url from 'url';
+
+const logger = console;
+
+const filename = url.fileURLToPath(import.meta.url);
+const dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+const checkDependencies = async () => {
+  const scriptsPath = join(dirname);
+  const codePath = join(dirname, '..', 'code');
+
+  const tasks = [];
+
+  if (!existsSync(join(scriptsPath, 'node_modules'))) {
+    tasks.push(
+      spawn('yarn', ['install'], {
+        cwd: scriptsPath,
+        shell: true,
+        stdio: ['inherit', 'inherit', 'inherit'],
+      })
+    );
+  }
+  if (!existsSync(join(codePath, 'node_modules'))) {
+    tasks.push(
+      spawn('yarn', ['install'], {
+        cwd: codePath,
+        shell: true,
+        stdio: ['inherit', 'inherit', 'inherit'],
+      })
+    );
+  }
+
+  if (tasks.length > 0) {
+    logger.log('installing dependencies');
+
+    await Promise.all(
+      tasks.map(
+        (t) =>
+          new Promise((res, rej) => {
+            t.on('exit', (code) => {
+              if (code !== 0) {
+                rej();
+              } else {
+                res();
+              }
+            });
+          })
+      )
+    ).catch(() => {
+      tasks.forEach((t) => t.kill());
+      throw new Error('Failed to install dependencies');
+    });
+
+    // give the filesystem some time
+    await new Promise((res) => {
+      setTimeout(res, 1000);
+    });
+  }
+};
+
+checkDependencies().catch((e) => {
+  // eslint-disable-next-line no-console
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/check-dependencies.ts
+++ b/scripts/check-dependencies.ts
@@ -1,7 +1,0 @@
-import { checkDependencies } from './utils/cli-utils';
-
-checkDependencies().catch((e) => {
-  // eslint-disable-next-line no-console
-  console.error(e);
-  process.exit(1);
-});

--- a/scripts/sandbox/generate.ts
+++ b/scripts/sandbox/generate.ts
@@ -15,8 +15,6 @@ import { allTemplates as sandboxTemplates } from '../../code/lib/cli/src/sandbox
 import storybookVersions from '../../code/lib/cli/src/versions';
 import { JsPackageManagerFactory } from '../../code/lib/cli/src/js-package-manager/JsPackageManagerFactory';
 
-import { maxConcurrentTasks } from '../utils/maxConcurrentTasks';
-
 // eslint-disable-next-line import/no-cycle
 import { localizeYarnConfigFiles, setupYarn } from './utils/yarn';
 import type { GeneratorConfig } from './utils/types';
@@ -139,9 +137,9 @@ const runGenerators = async (
     console.log('Debug mode enabled. Verbose logs will be printed to the console.');
   }
 
-  console.log(`🤹‍♂️ Generating sandboxes with a concurrency of ${maxConcurrentTasks}`);
+  console.log(`🤹‍♂️ Generating sandboxes with a concurrency of ${1}`);
 
-  const limit = pLimit(maxConcurrentTasks);
+  const limit = pLimit(1);
 
   await Promise.all(
     generators.map(({ dirName, name, script, expected }) =>


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Fixed the check-dependency script. It required dependencies being installed, which the script itself make sure.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
