### PR TITLE
Core: Refactor preview and deprecate story store

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -63,6 +63,7 @@
     - [Canvas Doc block properties](#canvas-doc-block-properties)
     - [`Primary` Doc block properties](#primary-doc-block-properties)
     - [`createChannel` from `@storybook/postmessage` and  `@storybook/channel-websocket`](#createchannel-from-storybookpostmessage-and--storybookchannel-websocket)
+    - [StoryStore methods deprecated](#storystore-methods-deprecated)
 - [From version 7.5.0 to 7.6.0](#from-version-750-to-760)
     - [CommonJS with Vite is deprecated](#commonjs-with-vite-is-deprecated)
     - [Using implicit actions during rendering is deprecated](#using-implicit-actions-during-rendering-is-deprecated)
@@ -977,6 +978,11 @@ The `name` prop is now removed in favor of the `of` property. [More info](#doc-b
 The `createChannel` APIs from both `@storybook/channel-websocket` and `@storybook/postmessage` are now removed. Please use `createBrowserChannel` instead, from the `@storybook/channels` package.
 
 Additionally, the `PostmsgTransport` type is now removed in favor of `PostMessageTransport`.
+#### StoryStore methods deprecated
+
+The following methods on the `StoryStore` are deprecated and will be removed in 9.0:
+  - `store.fromId()` - please use `store.loadStory()` instead.
+  - `store.raw()` - please use `store.extract()` instead.
 
 ## From version 7.5.0 to 7.6.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -63,7 +63,7 @@
     - [Canvas Doc block properties](#canvas-doc-block-properties)
     - [`Primary` Doc block properties](#primary-doc-block-properties)
     - [`createChannel` from `@storybook/postmessage` and  `@storybook/channel-websocket`](#createchannel-from-storybookpostmessage-and--storybookchannel-websocket)
-    - [StoryStore methods deprecated](#storystore-methods-deprecated)
+    - [StoryStore and methods deprecated](#storystore-and-methods-deprecated)
 - [From version 7.5.0 to 7.6.0](#from-version-750-to-760)
     - [CommonJS with Vite is deprecated](#commonjs-with-vite-is-deprecated)
     - [Using implicit actions during rendering is deprecated](#using-implicit-actions-during-rendering-is-deprecated)
@@ -978,11 +978,17 @@ The `name` prop is now removed in favor of the `of` property. [More info](#doc-b
 The `createChannel` APIs from both `@storybook/channel-websocket` and `@storybook/postmessage` are now removed. Please use `createBrowserChannel` instead, from the `@storybook/channels` package.
 
 Additionally, the `PostmsgTransport` type is now removed in favor of `PostMessageTransport`.
-#### StoryStore methods deprecated
 
-The following methods on the `StoryStore` are deprecated and will be removed in 9.0:
-  - `store.fromId()` - please use `store.loadStory()` instead.
-  - `store.raw()` - please use `store.extract()` instead.
+
+#### StoryStore and methods deprecated
+
+The StoryStore (`__STORYBOOK_STORY_STORE__` and `__STORYBOOK_PREVIEW__.storyStore`) are deprecated, and will no longer be accessible in Storybook 9.0.
+
+In particular, the following methods on the `StoryStore` are deprecated and will be removed in 9.0:
+  - `store.fromId()` - please use `preview.loadStory({ storyId })` instead.
+  - `store.raw()` - please use `preview.extract()` instead.
+
+Note that both these methods require initialization, so you should await `preview.ready()`.
 
 ## From version 7.5.0 to 7.6.0
 

--- a/code/addons/a11y/src/a11yRunner.ts
+++ b/code/addons/a11y/src/a11yRunner.ts
@@ -3,7 +3,7 @@ import { addons } from '@storybook/preview-api';
 import { EVENTS } from './constants';
 import type { A11yParameters } from './params';
 
-const { document, window: globalWindow } = global;
+const { document } = global;
 
 const channel = addons.getChannel();
 // Holds axe core running state

--- a/code/addons/a11y/src/a11yRunner.ts
+++ b/code/addons/a11y/src/a11yRunner.ts
@@ -11,22 +11,21 @@ let active = false;
 // Holds latest story we requested a run
 let activeStoryId: string | undefined;
 
+const defaultParameters = { config: {}, options: {} };
+
 /**
  * Handle A11yContext events.
  * Because the event are sent without manual check, we split calls
  */
-const handleRequest = async (storyId: string) => {
-  const { manual } = await getParams(storyId);
-  if (!manual) {
-    await run(storyId);
+const handleRequest = async (storyId: string, input: A11yParameters = defaultParameters) => {
+  if (!input?.manual) {
+    await run(storyId, input);
   }
 };
 
-const run = async (storyId: string) => {
+const run = async (storyId: string, input: A11yParameters = defaultParameters) => {
   activeStoryId = storyId;
   try {
-    const input = await getParams(storyId);
-
     if (!active) {
       active = true;
       channel.emit(EVENTS.RUNNING);
@@ -67,18 +66,6 @@ const run = async (storyId: string) => {
   } finally {
     active = false;
   }
-};
-
-/** Returns story parameters or default ones. */
-const getParams = async (storyId: string): Promise<A11yParameters> => {
-  const { parameters } =
-    (await globalWindow.__STORYBOOK_STORY_STORE__.loadStory({ storyId })) || {};
-  return (
-    parameters.a11y || {
-      config: {},
-      options: {},
-    }
-  );
 };
 
 channel.on(EVENTS.REQUEST, handleRequest);

--- a/code/addons/a11y/src/components/A11YPanel.tsx
+++ b/code/addons/a11y/src/components/A11YPanel.tsx
@@ -6,7 +6,12 @@ import { ActionBar, ScrollArea } from '@storybook/components';
 import { SyncIcon, CheckIcon } from '@storybook/icons';
 
 import type { AxeResults } from 'axe-core';
-import { useChannel, useParameter, useStorybookState } from '@storybook/manager-api';
+import {
+  useChannel,
+  useParameter,
+  useStorybookApi,
+  useStorybookState,
+} from '@storybook/manager-api';
 
 import { Report } from './Report';
 
@@ -59,6 +64,7 @@ export const A11YPanel: React.FC = () => {
   const [error, setError] = React.useState<unknown>(undefined);
   const { setResults, results } = useA11yContext();
   const { storyId } = useStorybookState();
+  const api = useStorybookApi();
 
   React.useEffect(() => {
     setStatus(manual ? 'manual' : 'initial');
@@ -92,7 +98,7 @@ export const A11YPanel: React.FC = () => {
 
   const handleManual = useCallback(() => {
     setStatus('running');
-    emit(EVENTS.MANUAL, storyId);
+    emit(EVENTS.MANUAL, storyId, api.getParameters(storyId, 'a11y'));
   }, [storyId]);
 
   const manualActionItems = useMemo(

--- a/code/addons/a11y/src/components/A11yContext.test.tsx
+++ b/code/addons/a11y/src/components/A11yContext.test.tsx
@@ -57,6 +57,7 @@ describe('A11YPanel', () => {
   });
 
   const getCurrentStoryData = vi.fn();
+  const getParameters = vi.fn();
   beforeEach(() => {
     mockedApi.useChannel.mockReset();
     mockedApi.useStorybookApi.mockReset();
@@ -65,7 +66,8 @@ describe('A11YPanel', () => {
     mockedApi.useAddonState.mockImplementation((_, defaultState) => React.useState(defaultState));
     mockedApi.useChannel.mockReturnValue(vi.fn());
     getCurrentStoryData.mockReset().mockReturnValue({ id: storyId, type: 'story' });
-    mockedApi.useStorybookApi.mockReturnValue({ getCurrentStoryData } as any);
+    getParameters.mockReturnValue({});
+    mockedApi.useStorybookApi.mockReturnValue({ getCurrentStoryData, getParameters } as any);
   });
 
   it('should render children', () => {
@@ -94,7 +96,7 @@ describe('A11YPanel', () => {
     mockedApi.useChannel.mockReturnValue(emit);
     const { rerender } = render(<A11yContextProvider active={false} />);
     rerender(<A11yContextProvider active />);
-    expect(emit).toHaveBeenLastCalledWith(EVENTS.REQUEST, storyId);
+    expect(emit).toHaveBeenLastCalledWith(EVENTS.REQUEST, storyId, {});
   });
 
   it('should emit highlight with no values when inactive', () => {

--- a/code/addons/a11y/src/components/A11yContext.tsx
+++ b/code/addons/a11y/src/components/A11yContext.tsx
@@ -5,7 +5,6 @@ import { useChannel, useAddonState, useStorybookApi } from '@storybook/manager-a
 import { STORY_CHANGED, STORY_RENDERED } from '@storybook/core-events';
 import { HIGHLIGHT } from '@storybook/addon-highlight';
 import { ADDON_ID, EVENTS } from '../constants';
-import type { A11yParameters } from '../params';
 
 export interface Results {
   passes: Result[];

--- a/code/addons/a11y/src/components/A11yContext.tsx
+++ b/code/addons/a11y/src/components/A11yContext.tsx
@@ -5,6 +5,7 @@ import { useChannel, useAddonState, useStorybookApi } from '@storybook/manager-a
 import { STORY_CHANGED, STORY_RENDERED } from '@storybook/core-events';
 import { HIGHLIGHT } from '@storybook/addon-highlight';
 import { ADDON_ID, EVENTS } from '../constants';
+import type { A11yParameters } from '../params';
 
 export interface Results {
   passes: Result[];
@@ -70,7 +71,7 @@ export const A11yContextProvider: React.FC<React.PropsWithChildren<A11yContextPr
     );
   }, []);
   const handleRun = (renderedStoryId: string) => {
-    emit(EVENTS.REQUEST, renderedStoryId);
+    emit(EVENTS.REQUEST, renderedStoryId, api.getParameters(renderedStoryId, 'a11y'));
   };
   const handleClearHighlights = React.useCallback(() => setHighlighted([]), []);
   const handleSetTab = React.useCallback((index: number) => {

--- a/code/addons/docs/src/preview.ts
+++ b/code/addons/docs/src/preview.ts
@@ -1,13 +1,16 @@
 import type { PreparedStory } from '@storybook/types';
 import { global } from '@storybook/global';
 
-const excludeTags = Object.entries(global.TAGS_OPTIONS ?? {}).reduce((acc, entry) => {
-  const [tag, option] = entry;
-  if ((option as any).excludeFromDocsStories) {
-    acc[tag] = true;
-  }
-  return acc;
-}, {} as Record<string, boolean>);
+const excludeTags = Object.entries(global.TAGS_OPTIONS ?? {}).reduce(
+  (acc, entry) => {
+    const [tag, option] = entry;
+    if ((option as any).excludeFromDocsStories) {
+      acc[tag] = true;
+    }
+    return acc;
+  },
+  {} as Record<string, boolean>
+);
 
 export const parameters: any = {
   docs: {

--- a/code/addons/links/src/react/components/link.test.tsx
+++ b/code/addons/links/src/react/components/link.test.tsx
@@ -17,10 +17,6 @@ vi.mock('@storybook/global', () => ({
         search: 'search',
       },
     },
-    window: global,
-    __STORYBOOK_STORY_STORE__: {
-      fromId: vi.fn(() => ({})),
-    },
   },
 }));
 

--- a/code/builders/builder-vite/src/codegen-modern-iframe-script.ts
+++ b/code/builders/builder-vite/src/codegen-modern-iframe-script.ts
@@ -69,7 +69,6 @@ export async function generateModernIframeScriptCode(options: Options, projectRo
     window.__STORYBOOK_PREVIEW__ = window.__STORYBOOK_PREVIEW__ || new PreviewWeb(importFn, getProjectAnnotations);
     
     window.__STORYBOOK_STORY_STORE__ = window.__STORYBOOK_STORY_STORE__ || window.__STORYBOOK_PREVIEW__.storyStore;
-    window.__STORYBOOK_PREVIEW__.initialize();
     
     ${generateHMRHandler(frameworkName)};
     `.trim();

--- a/code/builders/builder-vite/src/codegen-modern-iframe-script.ts
+++ b/code/builders/builder-vite/src/codegen-modern-iframe-script.ts
@@ -66,10 +66,10 @@ export async function generateModernIframeScriptCode(options: Options, projectRo
   
     ${getPreviewAnnotationsFunction}
 
-    window.__STORYBOOK_PREVIEW__ = window.__STORYBOOK_PREVIEW__ || new PreviewWeb();
+    window.__STORYBOOK_PREVIEW__ = window.__STORYBOOK_PREVIEW__ || new PreviewWeb(importFn, getProjectAnnotations);
     
     window.__STORYBOOK_STORY_STORE__ = window.__STORYBOOK_STORY_STORE__ || window.__STORYBOOK_PREVIEW__.storyStore;
-    window.__STORYBOOK_PREVIEW__.initialize({ importFn, getProjectAnnotations });
+    window.__STORYBOOK_PREVIEW__.initialize();
     
     ${generateHMRHandler(frameworkName)};
     `.trim();

--- a/code/builders/builder-webpack5/templates/virtualModuleModernEntry.js.handlebars
+++ b/code/builders/builder-webpack5/templates/virtualModuleModernEntry.js.handlebars
@@ -21,8 +21,6 @@ window.__STORYBOOK_PREVIEW__ = preview;
 window.__STORYBOOK_STORY_STORE__ = preview.storyStore;
 window.__STORYBOOK_ADDONS_CHANNEL__ = channel;
 
-preview.initialize();
-
 if (import.meta.webpackHot) {
   import.meta.webpackHot.accept('./{{storiesFilename}}', () => {
     // importFn has changed so we need to patch the new one in

--- a/code/builders/builder-webpack5/templates/virtualModuleModernEntry.js.handlebars
+++ b/code/builders/builder-webpack5/templates/virtualModuleModernEntry.js.handlebars
@@ -15,13 +15,13 @@ if (global.CONFIG_TYPE === 'DEVELOPMENT'){
   window.__STORYBOOK_SERVER_CHANNEL__ = channel;
 }
 
-const preview = new PreviewWeb();
+const preview = new PreviewWeb(importFn, getProjectAnnotations);
 
 window.__STORYBOOK_PREVIEW__ = preview;
 window.__STORYBOOK_STORY_STORE__ = preview.storyStore;
 window.__STORYBOOK_ADDONS_CHANNEL__ = channel;
 
-preview.initialize({ importFn, getProjectAnnotations });
+preview.initialize();
 
 if (import.meta.webpackHot) {
   import.meta.webpackHot.accept('./{{storiesFilename}}', () => {

--- a/code/lib/cli/src/upgrade.test.ts
+++ b/code/lib/cli/src/upgrade.test.ts
@@ -11,10 +11,13 @@ vi.mock('@storybook/telemetry');
 vi.mock('./versions', async (importOriginal) => {
   const originalVersions = ((await importOriginal()) as { default: typeof versions }).default;
   return {
-    default: Object.keys(originalVersions).reduce((acc, key) => {
-      acc[key] = '8.0.0';
-      return acc;
-    }, {} as Record<string, string>),
+    default: Object.keys(originalVersions).reduce(
+      (acc, key) => {
+        acc[key] = '8.0.0';
+        return acc;
+      },
+      {} as Record<string, string>
+    ),
   };
 });
 

--- a/code/lib/core-events/src/errors/preview-errors.ts
+++ b/code/lib/core-events/src/errors/preview-errors.ts
@@ -80,10 +80,6 @@ export class CalledExtractOnStoreError extends StorybookError {
 
   readonly code = 3;
 
-  constructor(public data: object) {
-    super();
-  }
-
   template() {
     return dedent`
     Cannot call \`storyStore.extract()\` without calling \`storyStore.cacheAllCsfFiles()\` first.
@@ -96,7 +92,7 @@ export class MissingRenderToCanvasError extends StorybookError {
   readonly category = Category.PREVIEW_API;
 
   readonly code = 4;
-  
+
   readonly documentation =
     'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field';
 
@@ -176,10 +172,6 @@ export class EmptyIndexError extends StorybookError {
 
   readonly code = 8;
 
-  constructor(public data: object) {
-    super();
-  }
-
   template() {
     return dedent`
       Couldn't find any stories in your Storybook.
@@ -227,5 +219,19 @@ export class MissingStoryFromCsfFileError extends StorybookError {
     - You have a custom file loader that is removing or renaming exports.
 
     Please check your browser console and terminal for errors that may explain the issue.`;
+  }
+}
+
+export class StoryStoreAccessedBeforeInitializationError extends StorybookError {
+  readonly category = Category.PREVIEW_API;
+
+  readonly code = 11;
+
+  template() {
+    return dedent`
+    Cannot access the Story Store until the index is ready.
+
+    It is not recommended to use methods directly on the Story Store anyway, in Storybook 9 we will
+    remove access to the store entirely`;
   }
 }

--- a/code/lib/core-events/src/errors/preview-errors.ts
+++ b/code/lib/core-events/src/errors/preview-errors.ts
@@ -74,3 +74,161 @@ export class ImplicitActionsDuringRendering extends StorybookError {
     `;
   }
 }
+
+export class CalledExtractOnStoreError extends StorybookError {
+  readonly category = Category.PREVIEW_API;
+
+  readonly code = 3;
+
+  constructor(public data: object) {
+    super();
+  }
+
+  template() {
+    return dedent`
+    Cannot call \`storyStore.extract()\` without calling \`storyStore.cacheAllCsfFiles()\` first.
+
+    You probably meant to call \`await preview.extract()\` which does the above for you.`;
+  }
+}
+
+export class MissingRenderToCanvasError extends StorybookError {
+  readonly category = Category.PREVIEW_API;
+
+  readonly code = 4;
+
+  constructor(public data: object) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      Expected your framework's preset to export a \`renderToCanvas\` field.
+
+      Perhaps it needs to be upgraded for Storybook 6.4?
+
+      More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field`;
+  }
+}
+
+export class CalledPreviewMethodBeforeInitializationError extends StorybookError {
+  readonly category = Category.PREVIEW_API;
+
+  readonly code = 5;
+
+  constructor(public data: { methodName: string }) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      Called \`Preview.${this.data.methodName}()\` before initialization.
+      
+      The preview needs to load the story index before most methods can be called. If you want
+      to call \`${this.data.methodName}\`, try \`await preview.initializationPromise;\` first.
+      
+      If you didn't call the above code, then likely it was called by an addon that needs to
+      do the above.`;
+  }
+}
+
+export class StoryIndexFetchError extends StorybookError {
+  readonly category = Category.PREVIEW_API;
+
+  readonly code = 6;
+
+  constructor(public data: { text: string }) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      Error fetching \`/index.json\`:
+      
+      ${this.data.text}
+
+      If you are in development, this likely indicates a problem with your Storybook process,
+      check the terminal for errors.
+
+      If you are in a deployed Storybook, there may have been an issue deploying the full Storybook
+      build.`;
+  }
+}
+
+export class MdxFileWithNoCsfReferencesError extends StorybookError {
+  readonly category = Category.PREVIEW_API;
+
+  readonly code = 7;
+
+  constructor(public data: { storyId: string }) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      Tried to render docs entry ${this.data.storyId} but it is a MDX file that has no CSF
+      references, or autodocs for a CSF file that some doesn't refer to itself.
+      
+      This likely is an internal error in Storybook's indexing, or you've attached the
+      \`attached-mdx\` tag to an MDX file that is not attached.`;
+  }
+}
+
+export class EmptyIndexError extends StorybookError {
+  readonly category = Category.PREVIEW_API;
+
+  readonly code = 8;
+
+  constructor(public data: object) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      Couldn't find any stories in your Storybook.
+
+        - Please check your stories field of your main.js config: does it match correctly?
+        - Also check the browser console and terminal for error messages.`;
+  }
+}
+
+export class NoStoryMatchError extends StorybookError {
+  readonly category = Category.PREVIEW_API;
+
+  readonly code = 9;
+
+  constructor(public data: { storySpecifier: string }) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      Couldn't find story matching '${this.data.storySpecifier}'.
+
+        - Are you sure a story with that id exists?
+        - Please check your stories field of your main.js config.
+        - Also check the browser console and terminal for error messages.`;
+  }
+}
+
+export class MissingStoryFromCsfFileError extends StorybookError {
+  readonly category = Category.PREVIEW_API;
+
+  readonly code = 10;
+
+  constructor(public data: { storyId: string }) {
+    super();
+  }
+
+  template() {
+    return dedent`
+    Couldn't find story matching id '${this.data.storyId}' after importing a CSF file.
+
+    The file was indexed as if the story was there, but then after importing the file in the browser
+    we didn't find the story. Possible reasons:
+    - You are using a custom story indexer that is misbehaving.
+    - You have a custom file loader that is removing or renaming exports.
+
+    Please check your browser console and terminal for errors that may explain the issue.`;
+  }
+}

--- a/code/lib/core-events/src/errors/preview-errors.ts
+++ b/code/lib/core-events/src/errors/preview-errors.ts
@@ -96,18 +96,15 @@ export class MissingRenderToCanvasError extends StorybookError {
   readonly category = Category.PREVIEW_API;
 
   readonly code = 4;
-
-  constructor(public data: object) {
-    super();
-  }
+  
+  readonly documentation =
+    'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field';
 
   template() {
     return dedent`
       Expected your framework's preset to export a \`renderToCanvas\` field.
 
-      Perhaps it needs to be upgraded for Storybook 6.4?
-
-      More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field`;
+      Perhaps it needs to be upgraded for Storybook 6.4?`;
   }
 }
 

--- a/code/lib/core-server/src/presets/common-manager.ts
+++ b/code/lib/core-server/src/presets/common-manager.ts
@@ -6,13 +6,16 @@ const STATIC_FILTER = 'static-filter';
 addons.register(STATIC_FILTER, (api) => {
   // FIXME: this ensures the filter is applied after the first render
   //        to avoid a strange race condition in Webkit only.
-  const excludeTags = Object.entries(global.TAGS_OPTIONS ?? {}).reduce((acc, entry) => {
-    const [tag, option] = entry;
-    if ((option as any).excludeFromSidebar) {
-      acc[tag] = true;
-    }
-    return acc;
-  }, {} as Record<string, boolean>);
+  const excludeTags = Object.entries(global.TAGS_OPTIONS ?? {}).reduce(
+    (acc, entry) => {
+      const [tag, option] = entry;
+      if ((option as any).excludeFromSidebar) {
+        acc[tag] = true;
+      }
+      return acc;
+    },
+    {} as Record<string, boolean>
+  );
 
   api.experimental_setFilter(STATIC_FILTER, (item) => {
     const tags = item.tags || [];

--- a/code/lib/preview-api/package.json
+++ b/code/lib/preview-api/package.json
@@ -54,6 +54,7 @@
     "lodash": "^4.17.21",
     "memoizerific": "^1.11.3",
     "qs": "^6.10.0",
+    "tiny-invariant": "^1.3.1",
     "ts-dedent": "^2.0.0",
     "util-deprecate": "^1.0.2"
   },

--- a/code/lib/preview-api/src/modules/preview-web/Preview.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/Preview.tsx
@@ -377,6 +377,13 @@ export class Preview<TRenderer extends Renderer> {
   }
 
   // API
+  async loadStory({ storyId }: { storyId: StoryId }) {
+    if (!this.storyStoreValue)
+      throw new CalledPreviewMethodBeforeInitializationError({ methodName: 'loadStory' });
+
+    return this.storyStoreValue.loadStory({ storyId });
+  }
+
   async extract(options?: { includeDocsOnly: boolean }) {
     if (!this.storyStoreValue)
       throw new CalledPreviewMethodBeforeInitializationError({ methodName: 'extract' });

--- a/code/lib/preview-api/src/modules/preview-web/Preview.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/Preview.tsx
@@ -77,14 +77,21 @@ export class Preview<TRenderer extends Renderer> {
     this.storeInitializationPromise = new Promise((resolve) => {
       this.resolveStoreInitializationPromise = resolve;
     });
+
+    // Cannot await this in constructor, but if you want to await it, use `ready()`
+    this.initialize();
   }
 
   // INITIALIZATION
-  async initialize() {
+  private async initialize() {
     this.setupListeners();
 
     const projectAnnotations = await this.getProjectAnnotationsOrRenderError();
     await this.initializeWithProjectAnnotations(projectAnnotations);
+  }
+
+  ready() {
+    return this.storeInitializationPromise;
   }
 
   setupListeners() {

--- a/code/lib/preview-api/src/modules/preview-web/Preview.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/Preview.tsx
@@ -1,4 +1,3 @@
-import { dedent } from 'ts-dedent';
 import { global } from '@storybook/global';
 import {
   CONFIG_ERROR,
@@ -28,6 +27,11 @@ import type {
   StoryRenderOptions,
   SetGlobalsPayload,
 } from '@storybook/types';
+import {
+  CalledPreviewMethodBeforeInitializationError,
+  MissingRenderToCanvasError,
+  StoryIndexFetchError,
+} from '@storybook/core-events/preview-errors';
 import { addons } from '../addons';
 import { StoryStore } from '../../store';
 
@@ -97,15 +101,8 @@ export class Preview<TRenderer extends Renderer> {
       const projectAnnotations = await this.getProjectAnnotations();
 
       this.renderToCanvas = projectAnnotations.renderToCanvas;
-      if (!this.renderToCanvas) {
-        throw new Error(dedent`
-            Expected your framework's preset to export a \`renderToCanvas\` field.
+      if (!this.renderToCanvas) throw new MissingRenderToCanvasError({});
 
-            Perhaps it needs to be upgraded for Storybook 6.4?
-
-            More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field
-          `);
-      }
       return projectAnnotations;
     } catch (err) {
       // This is an error extracting the projectAnnotations (i.e. evaluating the previewEntries) and
@@ -133,12 +130,14 @@ export class Preview<TRenderer extends Renderer> {
       return result.json() as any as StoryIndex;
     }
 
-    throw new Error(await result.text());
+    throw new StoryIndexFetchError({ text: await result.text() });
   }
 
   // If initialization gets as far as the story index, this function runs.
-  initializeWithStoryIndex(storyIndex: StoryIndex): void {
+  protected initializeWithStoryIndex(storyIndex: StoryIndex): void {
     if (!this.projectAnnotationsBeforeInitialization)
+      // This is a protected method and so shouldn't be called out of order by users
+      // eslint-disable-next-line local-rules/no-uncategorized-errors
       throw new Error('Cannot call initializeWithStoryIndex until project annotations resolve');
 
     this.storyStore = new StoryStore(
@@ -158,7 +157,8 @@ export class Preview<TRenderer extends Renderer> {
   }
 
   emitGlobals() {
-    if (!this.storyStore) throw new Error(`Cannot emit before initialization`);
+    if (!this.storyStore)
+      throw new CalledPreviewMethodBeforeInitializationError({ methodName: 'emitGlobals' });
 
     const payload: SetGlobalsPayload = {
       globals: this.storyStore.globals.get() || {},
@@ -222,13 +222,14 @@ export class Preview<TRenderer extends Renderer> {
     importFn?: ModuleImportFn;
     storyIndex?: StoryIndex;
   }) {
-    if (!this.storyStore) throw new Error(`Cannot call onStoriesChanged before initialization`);
-
+    if (!this.storyStore)
+      throw new CalledPreviewMethodBeforeInitializationError({ methodName: 'onStoriesChanged' });
     await this.storyStore.onStoriesChanged({ importFn, storyIndex });
   }
 
   async onUpdateGlobals({ globals }: { globals: Globals }) {
-    if (!this.storyStore) throw new Error(`Cannot call onUpdateGlobals before initialization`);
+    if (!this.storyStore)
+      throw new CalledPreviewMethodBeforeInitializationError({ methodName: 'onUpdateGlobals' });
     this.storyStore.globals.update(globals);
 
     await Promise.all(this.storyRenders.map((r) => r.rerender()));
@@ -240,7 +241,8 @@ export class Preview<TRenderer extends Renderer> {
   }
 
   async onUpdateArgs({ storyId, updatedArgs }: { storyId: StoryId; updatedArgs: Args }) {
-    if (!this.storyStore) throw new Error(`Cannot call onUpdateArgs before initialization`);
+    if (!this.storyStore)
+      throw new CalledPreviewMethodBeforeInitializationError({ methodName: 'onUpdateArgs' });
     this.storyStore.args.update(storyId, updatedArgs);
 
     await Promise.all(
@@ -256,7 +258,8 @@ export class Preview<TRenderer extends Renderer> {
   }
 
   async onResetArgs({ storyId, argNames }: { storyId: string; argNames?: string[] }) {
-    if (!this.storyStore) throw new Error(`Cannot call onResetArgs before initialization`);
+    if (!this.storyStore)
+      throw new CalledPreviewMethodBeforeInitializationError({ methodName: 'onResetArgs' });
 
     // NOTE: we have to be careful here and avoid await-ing when updating a rendered's args.
     // That's because below in `renderStoryToElement` we have also bound to this event and will
@@ -302,7 +305,9 @@ export class Preview<TRenderer extends Renderer> {
     options: StoryRenderOptions
   ) {
     if (!this.renderToCanvas || !this.storyStore)
-      throw new Error(`Cannot call renderStoryToElement before initialization`);
+      throw new CalledPreviewMethodBeforeInitializationError({
+        methodName: 'renderStoryToElement',
+      });
 
     const render = new StoryRender<TRenderer>(
       this.channel,
@@ -333,19 +338,10 @@ export class Preview<TRenderer extends Renderer> {
 
   // API
   async extract(options?: { includeDocsOnly: boolean }) {
-    if (!this.storyStore) throw new Error(`Cannot call extract before initialization`);
+    if (!this.storyStore)
+      throw new CalledPreviewMethodBeforeInitializationError({ methodName: 'extract' });
 
-    if (this.previewEntryError) {
-      throw this.previewEntryError;
-    }
-
-    if (!this.storyStore.projectAnnotations) {
-      // In v6 mode, if your preview.js throws, we never get a chance to initialize the preview
-      // or store, and the error is simply logged to the browser console. This is the best we can do
-      throw new Error(dedent`Failed to initialize Storybook.
-
-      Do you have an error in your \`preview.js\`? Check your Storybook's browser console for errors.`);
-    }
+    if (this.previewEntryError) throw this.previewEntryError;
 
     await this.storyStore.cacheAllCSFFiles();
 

--- a/code/lib/preview-api/src/modules/preview-web/Preview.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/Preview.tsx
@@ -47,13 +47,21 @@ export class Preview<TRenderer extends Renderer> {
    */
   serverChannel?: Channel;
 
-  storyStore: StoryStore<TRenderer>;
+  storyStore?: StoryStore<TRenderer>;
 
   renderToCanvas?: RenderToCanvas<TRenderer>;
 
   storyRenders: StoryRender<TRenderer>[] = [];
 
   previewEntryError?: Error;
+
+  // While we wait for the index to load (note it may error for a while), we need to store the
+  // project annotations. Once the index loads, it is stored on the store and this will get unset.
+  private projectAnnotationsBeforeInitialization?: ProjectAnnotations<TRenderer>;
+
+  protected storeInitializationPromise: Promise<void>;
+
+  protected resolveStoreInitializationPromise!: () => void;
 
   constructor(
     public importFn: ModuleImportFn,
@@ -62,7 +70,9 @@ export class Preview<TRenderer extends Renderer> {
 
     protected channel: Channel = addons.getChannel()
   ) {
-    this.storyStore = new StoryStore();
+    this.storeInitializationPromise = new Promise((resolve) => {
+      this.resolveStoreInitializationPromise = resolve;
+    });
   }
 
   // INITIALIZATION
@@ -70,7 +80,7 @@ export class Preview<TRenderer extends Renderer> {
     this.setupListeners();
 
     const projectAnnotations = await this.getProjectAnnotationsOrRenderError();
-    return this.initializeWithProjectAnnotations(projectAnnotations);
+    await this.initializeWithProjectAnnotations(projectAnnotations);
   }
 
   setupListeners() {
@@ -107,10 +117,7 @@ export class Preview<TRenderer extends Renderer> {
 
   // If initialization gets as far as project annotations, this function runs.
   async initializeWithProjectAnnotations(projectAnnotations: ProjectAnnotations<TRenderer>) {
-    this.storyStore.setProjectAnnotations(projectAnnotations);
-
-    this.setInitialGlobals();
-
+    this.projectAnnotationsBeforeInitialization = projectAnnotations;
     try {
       const storyIndex = await this.getStoryIndexFromServer();
       return this.initializeWithStoryIndex(storyIndex);
@@ -118,21 +125,6 @@ export class Preview<TRenderer extends Renderer> {
       this.renderPreviewEntryError('Error loading story index:', err as Error);
       throw err;
     }
-  }
-
-  async setInitialGlobals() {
-    this.emitGlobals();
-  }
-
-  emitGlobals() {
-    if (!this.storyStore.globals || !this.storyStore.projectAnnotations)
-      throw new Error(`Cannot emit before initialization`);
-
-    const payload: SetGlobalsPayload = {
-      globals: this.storyStore.globals.get() || {},
-      globalTypes: this.storyStore.projectAnnotations.globalTypes || {},
-    };
-    this.channel.emit(SET_GLOBALS, payload);
   }
 
   async getStoryIndexFromServer() {
@@ -146,10 +138,33 @@ export class Preview<TRenderer extends Renderer> {
 
   // If initialization gets as far as the story index, this function runs.
   initializeWithStoryIndex(storyIndex: StoryIndex): void {
-    if (!this.importFn)
-      throw new Error(`Cannot call initializeWithStoryIndex before initialization`);
+    if (!this.projectAnnotationsBeforeInitialization)
+      throw new Error('Cannot call initializeWithStoryIndex until project annotations resolve');
 
-    this.storyStore.initialize({ storyIndex, importFn: this.importFn });
+    this.storyStore = new StoryStore(
+      storyIndex,
+      this.importFn,
+      this.projectAnnotationsBeforeInitialization
+    );
+    delete this.projectAnnotationsBeforeInitialization; // to avoid confusion
+
+    this.setInitialGlobals();
+
+    this.resolveStoreInitializationPromise();
+  }
+
+  async setInitialGlobals() {
+    this.emitGlobals();
+  }
+
+  emitGlobals() {
+    if (!this.storyStore) throw new Error(`Cannot emit before initialization`);
+
+    const payload: SetGlobalsPayload = {
+      globals: this.storyStore.globals.get() || {},
+      globalTypes: this.storyStore.projectAnnotations.globalTypes || {},
+    };
+    this.channel.emit(SET_GLOBALS, payload);
   }
 
   // EVENT HANDLERS
@@ -164,7 +179,7 @@ export class Preview<TRenderer extends Renderer> {
     this.getProjectAnnotations = getProjectAnnotations;
 
     const projectAnnotations = await this.getProjectAnnotationsOrRenderError();
-    if (!this.storyStore.projectAnnotations) {
+    if (!this.storyStore) {
       await this.initializeWithProjectAnnotations(projectAnnotations);
       return;
     }
@@ -176,18 +191,19 @@ export class Preview<TRenderer extends Renderer> {
   async onStoryIndexChanged() {
     delete this.previewEntryError;
 
-    if (!this.storyStore.projectAnnotations) {
-      // We haven't successfully set project annotations yet,
-      // we need to do that before we can do anything else.
+    // We haven't successfully set project annotations yet,
+    // we need to do that before we can do anything else.
+    if (!this.storyStore && !this.projectAnnotationsBeforeInitialization) {
       return;
     }
 
     try {
       const storyIndex = await this.getStoryIndexFromServer();
 
-      // This is the first time the story index worked, let's load it into the store
-      if (!this.storyStore.storyIndex) {
+      // We've been waiting for the index to resolve, now it has, so we can continue
+      if (this.projectAnnotationsBeforeInitialization) {
         this.initializeWithStoryIndex(storyIndex);
+        return;
       }
 
       // Update the store with the new stories.
@@ -206,12 +222,13 @@ export class Preview<TRenderer extends Renderer> {
     importFn?: ModuleImportFn;
     storyIndex?: StoryIndex;
   }) {
+    if (!this.storyStore) throw new Error(`Cannot call onStoriesChanged before initialization`);
+
     await this.storyStore.onStoriesChanged({ importFn, storyIndex });
   }
 
   async onUpdateGlobals({ globals }: { globals: Globals }) {
-    if (!this.storyStore.globals)
-      throw new Error(`Cannot call onUpdateGlobals before initialization`);
+    if (!this.storyStore) throw new Error(`Cannot call onUpdateGlobals before initialization`);
     this.storyStore.globals.update(globals);
 
     await Promise.all(this.storyRenders.map((r) => r.rerender()));
@@ -223,6 +240,7 @@ export class Preview<TRenderer extends Renderer> {
   }
 
   async onUpdateArgs({ storyId, updatedArgs }: { storyId: StoryId; updatedArgs: Args }) {
+    if (!this.storyStore) throw new Error(`Cannot call onUpdateArgs before initialization`);
     this.storyStore.args.update(storyId, updatedArgs);
 
     await Promise.all(
@@ -238,6 +256,8 @@ export class Preview<TRenderer extends Renderer> {
   }
 
   async onResetArgs({ storyId, argNames }: { storyId: string; argNames?: string[] }) {
+    if (!this.storyStore) throw new Error(`Cannot call onResetArgs before initialization`);
+
     // NOTE: we have to be careful here and avoid await-ing when updating a rendered's args.
     // That's because below in `renderStoryToElement` we have also bound to this event and will
     // render the story in the same tick.
@@ -281,7 +301,7 @@ export class Preview<TRenderer extends Renderer> {
     callbacks: RenderContextCallbacks<TRenderer>,
     options: StoryRenderOptions
   ) {
-    if (!this.renderToCanvas)
+    if (!this.renderToCanvas || !this.storyStore)
       throw new Error(`Cannot call renderStoryToElement before initialization`);
 
     const render = new StoryRender<TRenderer>(
@@ -313,6 +333,8 @@ export class Preview<TRenderer extends Renderer> {
 
   // API
   async extract(options?: { includeDocsOnly: boolean }) {
+    if (!this.storyStore) throw new Error(`Cannot call extract before initialization`);
+
     if (this.previewEntryError) {
       throw this.previewEntryError;
     }

--- a/code/lib/preview-api/src/modules/preview-web/Preview.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/Preview.tsx
@@ -49,40 +49,27 @@ export class Preview<TRenderer extends Renderer> {
 
   storyStore: StoryStore<TRenderer>;
 
-  getStoryIndex?: () => StoryIndex;
-
-  importFn?: ModuleImportFn;
-
   renderToCanvas?: RenderToCanvas<TRenderer>;
 
   storyRenders: StoryRender<TRenderer>[] = [];
 
   previewEntryError?: Error;
 
-  constructor(protected channel: Channel = addons.getChannel()) {
+  constructor(
+    public importFn: ModuleImportFn,
+
+    public getProjectAnnotations: () => MaybePromise<ProjectAnnotations<TRenderer>>,
+
+    protected channel: Channel = addons.getChannel()
+  ) {
     this.storyStore = new StoryStore();
   }
 
   // INITIALIZATION
-  async initialize({
-    getStoryIndex,
-    importFn,
-    getProjectAnnotations,
-  }: {
-    // In the case of the v6 store, we can only get the index from the facade *after*
-    // getProjectAnnotations has been run, thus this slightly awkward approach
-    getStoryIndex?: () => StoryIndex;
-    importFn: ModuleImportFn;
-    getProjectAnnotations: () => MaybePromise<ProjectAnnotations<TRenderer>>;
-  }) {
-    // We save these two on initialization in case `getProjectAnnotations` errors,
-    // in which case we may need them later when we recover.
-    this.getStoryIndex = getStoryIndex;
-    this.importFn = importFn;
-
+  async initialize() {
     this.setupListeners();
 
-    const projectAnnotations = await this.getProjectAnnotationsOrRenderError(getProjectAnnotations);
+    const projectAnnotations = await this.getProjectAnnotationsOrRenderError();
     return this.initializeWithProjectAnnotations(projectAnnotations);
   }
 
@@ -95,11 +82,9 @@ export class Preview<TRenderer extends Renderer> {
     this.channel.on(FORCE_REMOUNT, this.onForceRemount.bind(this));
   }
 
-  async getProjectAnnotationsOrRenderError(
-    getProjectAnnotations: () => MaybePromise<ProjectAnnotations<TRenderer>>
-  ): Promise<ProjectAnnotations<TRenderer>> {
+  async getProjectAnnotationsOrRenderError(): Promise<ProjectAnnotations<TRenderer>> {
     try {
-      const projectAnnotations = await getProjectAnnotations();
+      const projectAnnotations = await this.getProjectAnnotations();
 
       this.renderToCanvas = projectAnnotations.renderToCanvas;
       if (!this.renderToCanvas) {
@@ -176,8 +161,9 @@ export class Preview<TRenderer extends Renderer> {
     getProjectAnnotations: () => MaybePromise<ProjectAnnotations<TRenderer>>;
   }) {
     delete this.previewEntryError;
+    this.getProjectAnnotations = getProjectAnnotations;
 
-    const projectAnnotations = await this.getProjectAnnotationsOrRenderError(getProjectAnnotations);
+    const projectAnnotations = await this.getProjectAnnotationsOrRenderError();
     if (!this.storyStore.projectAnnotations) {
       await this.initializeWithProjectAnnotations(projectAnnotations);
       return;

--- a/code/lib/preview-api/src/modules/preview-web/Preview.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/Preview.tsx
@@ -108,7 +108,7 @@ export class Preview<TRenderer extends Renderer> {
       const projectAnnotations = await this.getProjectAnnotations();
 
       this.renderToCanvas = projectAnnotations.renderToCanvas;
-      if (!this.renderToCanvas) throw new MissingRenderToCanvasError({});
+      if (!this.renderToCanvas) throw new MissingRenderToCanvasError();
 
       return projectAnnotations;
     } catch (err) {

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.integration.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.integration.test.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
   vi.mocked(WebView.prototype).prepareForStory.mockReturnValue('story-element' as any);
 });
 
-describe.skip('PreviewWeb', () => {
+describe('PreviewWeb', () => {
   describe('initial render', () => {
     it('renders story mode through the stack', async () => {
       const { DocsRenderer } = await import('@storybook/addon-docs');
@@ -111,8 +111,7 @@ describe.skip('PreviewWeb', () => {
       // Error: Event was not emitted in time: storyRendered,docsRendered,storyThrewException,storyErrored,storyMissing
     }, 10_000);
 
-    // TODO @tmeasday please help fixing this test
-    it.skip('sends docs rendering exceptions to showException', async () => {
+    it('sends docs rendering exceptions to showException', async () => {
       const { DocsRenderer } = await import('@storybook/addon-docs');
       projectAnnotations.parameters.docs.renderer = () => new DocsRenderer() as any;
 
@@ -121,7 +120,7 @@ describe.skip('PreviewWeb', () => {
 
       const docsRoot = document.createElement('div');
       vi.mocked(preview.view.prepareForDocs).mockReturnValue(docsRoot as any);
-      componentOneExports.default.parameters.docs.container.mockImplementationOnce(() => {
+      componentOneExports.default.parameters.docs.container.mockImplementation(() => {
         throw new Error('Docs rendering error');
       });
 

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.integration.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.integration.test.ts
@@ -82,7 +82,7 @@ describe.skip('PreviewWeb', () => {
         storyFn()
       );
       document.location.search = '?id=component-one--a';
-      await new PreviewWeb().initialize({ importFn, getProjectAnnotations });
+      await new PreviewWeb(importFn, getProjectAnnotations).initialize();
 
       await waitForRender();
 
@@ -95,7 +95,7 @@ describe.skip('PreviewWeb', () => {
       projectAnnotations.parameters.docs.renderer = () => new DocsRenderer() as any;
 
       document.location.search = '?id=component-one--docs&viewMode=docs';
-      const preview = new PreviewWeb();
+      const preview = new PreviewWeb(importFn, getProjectAnnotations);
 
       const docsRoot = document.createElement('div');
       vi.mocked(preview.view.prepareForDocs).mockReturnValue(docsRoot as any);
@@ -103,7 +103,7 @@ describe.skip('PreviewWeb', () => {
         React.createElement('div', {}, 'INSIDE')
       );
 
-      await preview.initialize({ importFn, getProjectAnnotations });
+      await preview.initialize();
       await waitForRender();
 
       expect(docsRoot.outerHTML).toMatchInlineSnapshot('"<div><div>INSIDE</div></div>"');
@@ -117,7 +117,7 @@ describe.skip('PreviewWeb', () => {
       projectAnnotations.parameters.docs.renderer = () => new DocsRenderer() as any;
 
       document.location.search = '?id=component-one--docs&viewMode=docs';
-      const preview = new PreviewWeb();
+      const preview = new PreviewWeb(importFn, getProjectAnnotations);
 
       const docsRoot = document.createElement('div');
       vi.mocked(preview.view.prepareForDocs).mockReturnValue(docsRoot as any);
@@ -126,7 +126,8 @@ describe.skip('PreviewWeb', () => {
       });
 
       vi.mocked(preview.view.showErrorDisplay).mockClear();
-      await preview.initialize({ importFn, getProjectAnnotations });
+
+      await preview.initialize();
       await waitForRender();
 
       expect(preview.view.showErrorDisplay).toHaveBeenCalled();
@@ -149,8 +150,8 @@ describe.skip('PreviewWeb', () => {
       projectAnnotations.parameters.docs.renderer = () => new DocsRenderer() as any;
 
       document.location.search = '?id=component-one--a';
-      const preview = new PreviewWeb();
-      await preview.initialize({ importFn, getProjectAnnotations });
+      const preview = new PreviewWeb(importFn, getProjectAnnotations);
+      await preview.initialize();
       await waitForRender();
 
       projectAnnotations.renderToCanvas.mockImplementationOnce(({ storyFn }: RenderContext<any>) =>

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.integration.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.integration.test.ts
@@ -82,7 +82,7 @@ describe('PreviewWeb', () => {
         storyFn()
       );
       document.location.search = '?id=component-one--a';
-      await new PreviewWeb(importFn, getProjectAnnotations).initialize();
+      await new PreviewWeb(importFn, getProjectAnnotations).ready();
 
       await waitForRender();
 
@@ -103,7 +103,7 @@ describe('PreviewWeb', () => {
         React.createElement('div', {}, 'INSIDE')
       );
 
-      await preview.initialize();
+      await preview.ready();
       await waitForRender();
 
       expect(docsRoot.outerHTML).toMatchInlineSnapshot('"<div><div>INSIDE</div></div>"');
@@ -126,7 +126,7 @@ describe('PreviewWeb', () => {
 
       vi.mocked(preview.view.showErrorDisplay).mockClear();
 
-      await preview.initialize();
+      await preview.ready();
       await waitForRender();
 
       expect(preview.view.showErrorDisplay).toHaveBeenCalled();
@@ -150,7 +150,7 @@ describe('PreviewWeb', () => {
 
       document.location.search = '?id=component-one--a';
       const preview = new PreviewWeb(importFn, getProjectAnnotations);
-      await preview.initialize();
+      await preview.ready();
       await waitForRender();
 
       projectAnnotations.renderToCanvas.mockImplementationOnce(({ storyFn }: RenderContext<any>) =>

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable local-rules/no-uncategorized-errors */
 /**
  * @vitest-environment jsdom
  */
@@ -514,12 +513,12 @@ describe('PreviewWeb', () => {
 
         expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(vi.mocked(preview.view.showErrorDisplay).mock.calls[0][0]).toMatchInlineSnapshot(`
-                          [Error: Expected your framework's preset to export a \`renderToCanvas\` field.
+          [SB_PREVIEW_API_0004 (MissingRenderToCanvasError): Expected your framework's preset to export a \`renderToCanvas\` field.
 
-                          Perhaps it needs to be upgraded for Storybook 6.4?
+          Perhaps it needs to be upgraded for Storybook 6.4?
 
-                          More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field]
-                      `);
+          More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#mainjs-framework-field]
+        `);
       });
 
       describe('when `throwPlayFunctionExceptions` is set', () => {
@@ -3548,8 +3547,8 @@ describe('PreviewWeb', () => {
       const preview = new PreviewWeb(importFn, () => {
         throw err;
       });
-      await expect(preview.initialize()).rejects.toThrow(err);
-      await expect(preview.extract()).rejects.toThrow(err);
+      await expect(preview.initialize()).rejects.toThrow(/meta error/);
+      await expect(preview.extract()).rejects.toThrow();
     });
 
     it('shows an error if the stories.json endpoint 500s', async () => {
@@ -3559,7 +3558,7 @@ describe('PreviewWeb', () => {
       const preview = new PreviewWeb(importFn, getProjectAnnotations);
       await expect(preview.initialize()).rejects.toThrow('sort error');
 
-      await expect(preview.extract()).rejects.toThrow('sort error');
+      await expect(preview.extract()).rejects.toThrow();
     });
 
     it('waits for stories to be cached', async () => {

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -513,7 +513,7 @@ describe('PreviewWeb', () => {
 
         expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(vi.mocked(preview.view.showErrorDisplay).mock.calls[0][0]).toMatchInlineSnapshot(`
-          [SB_PREVIEW_API_0005 (MissingRenderToCanvasError): Expected your framework's preset to export a \`renderToCanvas\` field.
+          [SB_PREVIEW_API_0004 (MissingRenderToCanvasError): Expected your framework's preset to export a \`renderToCanvas\` field.
 
           Perhaps it needs to be upgraded for Storybook 6.4?
 

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -164,7 +164,7 @@ describe('PreviewWeb', () => {
 
       const preview = await createAndRenderPreview();
 
-      expect(preview.storyStore.globals!.get()).toEqual({ a: 'c' });
+      expect(preview.storyStore!.globals.get()).toEqual({ a: 'c' });
     });
 
     it('emits the SET_GLOBALS event', async () => {
@@ -225,7 +225,7 @@ describe('PreviewWeb', () => {
       });
       await preview.initialize();
 
-      expect(preview.storyStore.globals!.get()).toEqual({ a: 'b' });
+      expect(preview.storyStore!.globals.get()).toEqual({ a: 'b' });
     });
   });
 
@@ -798,7 +798,7 @@ describe('PreviewWeb', () => {
 
       emitter.emit(UPDATE_GLOBALS, { globals: { foo: 'bar' } });
 
-      expect(preview.storyStore.globals!.get()).toEqual({ a: 'b' });
+      expect(preview.storyStore!.globals.get()).toEqual({ a: 'b' });
     });
 
     it('passes globals in context to renderToCanvas', async () => {
@@ -3324,7 +3324,7 @@ describe('PreviewWeb', () => {
         preview.onGetProjectAnnotationsChanged({ getProjectAnnotations });
         await waitForRender();
 
-        expect(preview.storyStore.globals!.get()).toEqual({ a: 'c' });
+        expect(preview.storyStore!.globals.get()).toEqual({ a: 'c' });
       });
     });
 
@@ -3374,7 +3374,7 @@ describe('PreviewWeb', () => {
       preview.onGetProjectAnnotationsChanged({ getProjectAnnotations: newGetProjectAnnotations });
       await waitForRender();
 
-      expect(preview.storyStore.globals!.get()).toEqual({ a: 'edited' });
+      expect(preview.storyStore!.globals.get()).toEqual({ a: 'edited' });
     });
 
     it('emits SET_GLOBALS with new values', async () => {

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -53,6 +53,7 @@ import {
   teardownrenderToCanvas,
 } from './PreviewWeb.mockdata';
 import { WebView } from './WebView';
+import type { StoryStore } from '../store';
 
 const { history, document } = global;
 
@@ -163,7 +164,7 @@ describe('PreviewWeb', () => {
 
       const preview = await createAndRenderPreview();
 
-      expect(preview.storyStore!.globals.get()).toEqual({ a: 'c' });
+      expect((preview.storyStore as StoryStore<Renderer>)!.globals.get()).toEqual({ a: 'c' });
     });
 
     it('emits the SET_GLOBALS event', async () => {
@@ -202,7 +203,7 @@ describe('PreviewWeb', () => {
 
       const preview = await createAndRenderPreview();
 
-      expect(preview.storyStore?.args.get('component-one--a')).toEqual({
+      expect((preview.storyStore as StoryStore<Renderer>)?.args.get('component-one--a')).toEqual({
         foo: 'url',
         one: 1,
       });
@@ -224,7 +225,7 @@ describe('PreviewWeb', () => {
       });
       await preview.ready();
 
-      expect(preview.storyStore!.globals.get()).toEqual({ a: 'b' });
+      expect((preview.storyStore as StoryStore<Renderer>)!.globals.get()).toEqual({ a: 'b' });
     });
   });
 
@@ -780,7 +781,7 @@ describe('PreviewWeb', () => {
 
       emitter.emit(UPDATE_GLOBALS, { globals: { foo: 'bar' } });
 
-      expect(preview.storyStore!.globals.get()).toEqual({ a: 'b' });
+      expect((preview.storyStore as StoryStore<Renderer>)!.globals.get()).toEqual({ a: 'b' });
     });
 
     it('passes globals in context to renderToCanvas', async () => {
@@ -856,7 +857,11 @@ describe('PreviewWeb', () => {
         updatedArgs: { new: 'arg' },
       });
 
-      expect(preview.storyStore?.args.get('component-one--a')).toEqual({
+      expect(
+        (preview.storyStore as StoryStore<Renderer> as StoryStore<Renderer>)?.args.get(
+          'component-one--a'
+        )
+      ).toEqual({
         foo: 'a',
         new: 'arg',
         one: 1,
@@ -1119,8 +1124,9 @@ describe('PreviewWeb', () => {
           await waitForRender();
 
           mockChannel.emit.mockClear();
-          const story = await preview.storyStore?.loadStory({ storyId: 'component-one--a' });
-          // @ts-expect-error (tom will fix this)
+          const story = await (preview.storyStore as StoryStore<Renderer>)?.loadStory({
+            storyId: 'component-one--a',
+          });
           preview.renderStoryToElement(story, 'story-element' as any, callbacks, {});
           await waitForRender();
 
@@ -1158,8 +1164,9 @@ describe('PreviewWeb', () => {
           await waitForRender();
 
           mockChannel.emit.mockClear();
-          const story = await preview.storyStore?.loadStory({ storyId: 'component-one--a' });
-          // @ts-expect-error (tom will fix this)
+          const story = await (preview.storyStore as StoryStore<Renderer>)?.loadStory({
+            storyId: 'component-one--a',
+          });
           preview.renderStoryToElement(story, 'story-element' as any, callbacks, {
             forceInitialArgs: true,
           });
@@ -2091,7 +2098,7 @@ describe('PreviewWeb', () => {
           updatedArgs: { foo: 'updated' },
         });
         await waitForRender();
-        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
+        expect((preview.storyStore as StoryStore<Renderer>)?.args.get('component-one--a')).toEqual({
           foo: 'updated',
           one: 1,
         });
@@ -2103,7 +2110,7 @@ describe('PreviewWeb', () => {
         });
         await waitForSetCurrentStory();
         await waitForRender();
-        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
+        expect((preview.storyStore as StoryStore<Renderer>)?.args.get('component-one--a')).toEqual({
           foo: 'updated',
           one: 1,
         });
@@ -2115,7 +2122,7 @@ describe('PreviewWeb', () => {
         });
         await waitForSetCurrentStory();
         await waitForRender();
-        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
+        expect((preview.storyStore as StoryStore<Renderer>)?.args.get('component-one--a')).toEqual({
           foo: 'updated',
           one: 1,
         });
@@ -2717,7 +2724,7 @@ describe('PreviewWeb', () => {
         mockFetchResult = { status: 200, json: mockStoryIndex, text: () => 'error text' };
         preview.onStoryIndexChanged();
         await waitForRender();
-        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
+        expect((preview.storyStore as StoryStore<Renderer>)?.args.get('component-one--a')).toEqual({
           foo: 'url',
           one: 1,
         });
@@ -3123,7 +3130,7 @@ describe('PreviewWeb', () => {
         });
         await waitForSetCurrentStory();
         await waitForRender();
-        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
+        expect((preview.storyStore as StoryStore<Renderer>)?.args.get('component-one--a')).toEqual({
           foo: 'updated',
           one: 1,
         });
@@ -3142,7 +3149,7 @@ describe('PreviewWeb', () => {
         });
         await waitForSetCurrentStory();
         await waitForRender();
-        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
+        expect((preview.storyStore as StoryStore<Renderer>)?.args.get('component-one--a')).toEqual({
           foo: 'updated',
           bar: 'edited',
           one: 1,
@@ -3313,7 +3320,7 @@ describe('PreviewWeb', () => {
         preview.onGetProjectAnnotationsChanged({ getProjectAnnotations });
         await waitForRender();
 
-        expect(preview.storyStore!.globals.get()).toEqual({ a: 'c' });
+        expect((preview.storyStore as StoryStore<Renderer>)!.globals.get()).toEqual({ a: 'c' });
       });
     });
 
@@ -3363,7 +3370,7 @@ describe('PreviewWeb', () => {
       preview.onGetProjectAnnotationsChanged({ getProjectAnnotations: newGetProjectAnnotations });
       await waitForRender();
 
-      expect(preview.storyStore!.globals.get()).toEqual({ a: 'edited' });
+      expect((preview.storyStore as StoryStore<Renderer>)!.globals.get()).toEqual({ a: 'edited' });
     });
 
     it('emits SET_GLOBALS with new values', async () => {
@@ -3389,7 +3396,7 @@ describe('PreviewWeb', () => {
       preview.onGetProjectAnnotationsChanged({ getProjectAnnotations: newGetProjectAnnotations });
       await waitForRender();
 
-      expect(preview.storyStore?.args.get('component-one--a')).toEqual({
+      expect((preview.storyStore as StoryStore<Renderer>)?.args.get('component-one--a')).toEqual({
         foo: 'a',
         one: 1,
         global: 'added',
@@ -3514,7 +3521,9 @@ describe('PreviewWeb', () => {
       componentOneExports.b.play.mockImplementationOnce(async () => gate);
       // @ts-expect-error (not strict)
       preview.renderStoryToElement(
-        await preview.storyStore?.loadStory({ storyId: 'component-one--b' }),
+        await (preview.storyStore as StoryStore<Renderer>)?.loadStory({
+          storyId: 'component-one--b',
+        }),
         {} as any
       );
       await waitForRenderPhase('playing');

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -202,7 +202,7 @@ describe('PreviewWeb', () => {
 
       const preview = await createAndRenderPreview();
 
-      expect(preview.storyStore.args.get('component-one--a')).toEqual({
+      expect(preview.storyStore?.args.get('component-one--a')).toEqual({
         foo: 'url',
         one: 1,
       });
@@ -873,7 +873,7 @@ describe('PreviewWeb', () => {
         updatedArgs: { new: 'arg' },
       });
 
-      expect(preview.storyStore.args.get('component-one--a')).toEqual({
+      expect(preview.storyStore?.args.get('component-one--a')).toEqual({
         foo: 'a',
         new: 'arg',
         one: 1,
@@ -1132,7 +1132,8 @@ describe('PreviewWeb', () => {
           await waitForRender();
 
           mockChannel.emit.mockClear();
-          const story = await preview.storyStore.loadStory({ storyId: 'component-one--a' });
+          const story = await preview.storyStore?.loadStory({ storyId: 'component-one--a' });
+          // @ts-expect-error (tom will fix this)
           preview.renderStoryToElement(story, 'story-element' as any, callbacks, {});
           await waitForRender();
 
@@ -1170,7 +1171,8 @@ describe('PreviewWeb', () => {
           await waitForRender();
 
           mockChannel.emit.mockClear();
-          const story = await preview.storyStore.loadStory({ storyId: 'component-one--a' });
+          const story = await preview.storyStore?.loadStory({ storyId: 'component-one--a' });
+          // @ts-expect-error (tom will fix this)
           preview.renderStoryToElement(story, 'story-element' as any, callbacks, {
             forceInitialArgs: true,
           });
@@ -2102,7 +2104,7 @@ describe('PreviewWeb', () => {
           updatedArgs: { foo: 'updated' },
         });
         await waitForRender();
-        expect(preview.storyStore.args.get('component-one--a')).toEqual({
+        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
           foo: 'updated',
           one: 1,
         });
@@ -2114,7 +2116,7 @@ describe('PreviewWeb', () => {
         });
         await waitForSetCurrentStory();
         await waitForRender();
-        expect(preview.storyStore.args.get('component-one--a')).toEqual({
+        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
           foo: 'updated',
           one: 1,
         });
@@ -2126,7 +2128,7 @@ describe('PreviewWeb', () => {
         });
         await waitForSetCurrentStory();
         await waitForRender();
-        expect(preview.storyStore.args.get('component-one--a')).toEqual({
+        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
           foo: 'updated',
           one: 1,
         });
@@ -2727,7 +2729,7 @@ describe('PreviewWeb', () => {
         mockFetchResult = { status: 200, json: mockStoryIndex, text: () => 'error text' };
         preview.onStoryIndexChanged();
         await waitForRender();
-        expect(preview.storyStore.args.get('component-one--a')).toEqual({
+        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
           foo: 'url',
           one: 1,
         });
@@ -3133,7 +3135,7 @@ describe('PreviewWeb', () => {
         });
         await waitForSetCurrentStory();
         await waitForRender();
-        expect(preview.storyStore.args.get('component-one--a')).toEqual({
+        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
           foo: 'updated',
           one: 1,
         });
@@ -3152,7 +3154,7 @@ describe('PreviewWeb', () => {
         });
         await waitForSetCurrentStory();
         await waitForRender();
-        expect(preview.storyStore.args.get('component-one--a')).toEqual({
+        expect(preview.storyStore?.args.get('component-one--a')).toEqual({
           foo: 'updated',
           bar: 'edited',
           one: 1,
@@ -3399,7 +3401,7 @@ describe('PreviewWeb', () => {
       preview.onGetProjectAnnotationsChanged({ getProjectAnnotations: newGetProjectAnnotations });
       await waitForRender();
 
-      expect(preview.storyStore.args.get('component-one--a')).toEqual({
+      expect(preview.storyStore?.args.get('component-one--a')).toEqual({
         foo: 'a',
         one: 1,
         global: 'added',
@@ -3524,7 +3526,7 @@ describe('PreviewWeb', () => {
       componentOneExports.b.play.mockImplementationOnce(async () => gate);
       // @ts-expect-error (not strict)
       preview.renderStoryToElement(
-        await preview.storyStore.loadStory({ storyId: 'component-one--b' }),
+        await preview.storyStore?.loadStory({ storyId: 'component-one--b' }),
         {} as any
       );
       await waitForRenderPhase('playing');

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -104,7 +104,7 @@ async function createAndRenderPreview({
   getProjectAnnotations?: () => ProjectAnnotations<Renderer>;
 } = {}) {
   const preview = new PreviewWeb(inputImportFn, inputGetProjectAnnotations);
-  await preview.initialize();
+  await preview.ready();
   await waitForRender();
 
   return preview;
@@ -135,13 +135,13 @@ beforeEach(() => {
 });
 
 describe('PreviewWeb', () => {
-  describe('initialize', () => {
+  describe('ready', () => {
     it('shows an error if getProjectAnnotations throws', async () => {
       const err = new Error('meta error');
       const preview = new PreviewWeb(importFn, () => {
         throw err;
       });
-      await expect(preview.initialize()).rejects.toThrow(err);
+      await expect(preview.ready()).rejects.toThrow(err);
 
       expect(preview.view.showErrorDisplay).toHaveBeenCalled();
       expect(mockChannel.emit).toHaveBeenCalledWith(CONFIG_ERROR, err);
@@ -152,7 +152,7 @@ describe('PreviewWeb', () => {
       mockFetchResult = { status: 500, text: async () => err.toString() };
 
       const preview = new PreviewWeb(importFn, getProjectAnnotations);
-      await expect(preview.initialize()).rejects.toThrow('sort error');
+      await expect(preview.ready()).rejects.toThrow('sort error');
 
       expect(preview.view.showErrorDisplay).toHaveBeenCalled();
       expect(mockChannel.emit).toHaveBeenCalledWith(CONFIG_ERROR, expect.any(Error));
@@ -222,7 +222,7 @@ describe('PreviewWeb', () => {
       const preview = new PreviewWeb(importFn, async () => {
         return getProjectAnnotations();
       });
-      await preview.initialize();
+      await preview.ready();
 
       expect(preview.storyStore!.globals.get()).toEqual({ a: 'b' });
     });
@@ -509,7 +509,7 @@ describe('PreviewWeb', () => {
           renderToCanvas: undefined,
         });
         const preview = new PreviewWeb(importFn, getProjectAnnotations);
-        await expect(preview.initialize()).rejects.toThrow();
+        await expect(preview.ready()).rejects.toThrow();
 
         expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(vi.mocked(preview.view.showErrorDisplay).mock.calls[0][0]).toMatchInlineSnapshot(`
@@ -621,7 +621,7 @@ describe('PreviewWeb', () => {
         });
 
         const preview = new PreviewWeb(importFn, getProjectAnnotations);
-        await preview.initialize();
+        await preview.ready();
 
         await waitForRender();
 
@@ -925,7 +925,7 @@ describe('PreviewWeb', () => {
         document.location.search = '?id=component-one--a';
         componentOneExports.default.loaders[0].mockImplementationOnce(async () => gate);
 
-        await new PreviewWeb(importFn, getProjectAnnotations).initialize();
+        await new PreviewWeb(importFn, getProjectAnnotations).ready();
         await waitForRenderPhase('loading');
 
         expect(componentOneExports.default.loaders[0]).toHaveBeenCalledWith(
@@ -986,7 +986,7 @@ describe('PreviewWeb', () => {
         document.location.search = '?id=component-one--a';
         projectAnnotations.renderToCanvas.mockImplementation(async () => gate);
 
-        await new PreviewWeb(importFn, getProjectAnnotations).initialize();
+        await new PreviewWeb(importFn, getProjectAnnotations).ready();
         await waitForRenderPhase('rendering');
 
         emitter.emit(UPDATE_STORY_ARGS, {
@@ -1065,7 +1065,7 @@ describe('PreviewWeb', () => {
         });
 
         document.location.search = '?id=component-one--a';
-        await new PreviewWeb(importFn, getProjectAnnotations).initialize();
+        await new PreviewWeb(importFn, getProjectAnnotations).ready();
         await waitForRenderPhase('playing');
 
         await renderToCanvasCalled;
@@ -1485,7 +1485,7 @@ describe('PreviewWeb', () => {
 
       document.location.search = '?id=component-one--a';
       projectAnnotations.renderToCanvas.mockImplementation(async () => gate);
-      await new PreviewWeb(importFn, getProjectAnnotations).initialize();
+      await new PreviewWeb(importFn, getProjectAnnotations).ready();
       await waitForRenderPhase('rendering');
 
       expect(projectAnnotations.renderToCanvas).toHaveBeenCalledWith(
@@ -1580,11 +1580,11 @@ describe('PreviewWeb', () => {
       expect(mockChannel.emit).toHaveBeenCalledWith(STORY_MISSING, 'random');
     });
 
-    describe('if called before the preview is initialized', () => {
+    describe('if called before the preview is readyd', () => {
       it('works when there was no selection specifier', async () => {
         document.location.search = '';
         // We intentionally are *not* awaiting here
-        new PreviewWeb(importFn, getProjectAnnotations).initialize();
+        new PreviewWeb(importFn, getProjectAnnotations).ready();
 
         emitter.emit(SET_CURRENT_STORY, { storyId: 'component-one--b', viewMode: 'story' });
 
@@ -1609,11 +1609,11 @@ describe('PreviewWeb', () => {
       it('works when there was a selection specifier', async () => {
         document.location.search = '?id=component-one--a';
 
-        const initialized = new PreviewWeb(importFn, getProjectAnnotations).initialize();
+        const readyd = new PreviewWeb(importFn, getProjectAnnotations).ready();
 
         emitter.emit(SET_CURRENT_STORY, { storyId: 'component-one--b', viewMode: 'story' });
 
-        await initialized;
+        await readyd;
         await waitForEvents([STORY_RENDERED]);
 
         // If we emitted CURRENT_STORY_WAS_SET for the original selection, the manager might
@@ -1722,9 +1722,9 @@ describe('PreviewWeb', () => {
             });
 
           const preview = new PreviewWeb(importFn, getProjectAnnotations);
-          // We can't wait for the initialize function, as it waits for `renderSelection()`
+          // We can't wait for the ready function, as it waits for `renderSelection()`
           // which prepares, but it does emit `CURRENT_STORY_WAS_SET` right before that
-          preview.initialize();
+          preview.ready();
           await waitForEvents([CURRENT_STORY_WAS_SET]);
 
           mockChannel.emit.mockClear();
@@ -1769,9 +1769,9 @@ describe('PreviewWeb', () => {
             });
 
           const preview = new PreviewWeb(importFn, getProjectAnnotations);
-          // We can't wait for the initialize function, as it waits for `renderSelection()`
+          // We can't wait for the ready function, as it waits for `renderSelection()`
           // which prepares, but it does emit `CURRENT_STORY_WAS_SET` right before that
-          preview.initialize();
+          preview.ready();
           await waitForEvents([CURRENT_STORY_WAS_SET]);
 
           mockChannel.emit.mockClear();
@@ -1815,9 +1815,9 @@ describe('PreviewWeb', () => {
             });
 
           const preview = new PreviewWeb(importFn, getProjectAnnotations);
-          // We can't wait for the initialize function, as it waits for `renderSelection()`
+          // We can't wait for the ready function, as it waits for `renderSelection()`
           // which prepares, but it does emit `CURRENT_STORY_WAS_SET` right before that
-          preview.initialize();
+          preview.ready();
           await waitForEvents([CURRENT_STORY_WAS_SET]);
 
           mockChannel.emit.mockClear();
@@ -2150,7 +2150,7 @@ describe('PreviewWeb', () => {
           componentOneExports.default.loaders[0].mockImplementationOnce(async () => gate);
 
           document.location.search = '?id=component-one--a';
-          await new PreviewWeb(importFn, getProjectAnnotations).initialize();
+          await new PreviewWeb(importFn, getProjectAnnotations).ready();
           await waitForRenderPhase('loading');
 
           emitter.emit(SET_CURRENT_STORY, {
@@ -2183,7 +2183,7 @@ describe('PreviewWeb', () => {
 
           document.location.search = '?id=component-one--a';
           projectAnnotations.renderToCanvas.mockImplementation(async () => gate);
-          await new PreviewWeb(importFn, getProjectAnnotations).initialize();
+          await new PreviewWeb(importFn, getProjectAnnotations).ready();
           await waitForRenderPhase('rendering');
 
           mockChannel.emit.mockClear();
@@ -2217,7 +2217,7 @@ describe('PreviewWeb', () => {
           componentOneExports.a.play.mockImplementationOnce(async () => gate);
 
           document.location.search = '?id=component-one--a';
-          await new PreviewWeb(importFn, getProjectAnnotations).initialize();
+          await new PreviewWeb(importFn, getProjectAnnotations).ready();
           await waitForRenderPhase('playing');
 
           expect(projectAnnotations.renderToCanvas).toHaveBeenCalledWith(
@@ -2270,7 +2270,7 @@ describe('PreviewWeb', () => {
           componentOneExports.a.play.mockImplementationOnce(async () => gate);
 
           document.location.search = '?id=component-one--a';
-          await new PreviewWeb(importFn, getProjectAnnotations).initialize();
+          await new PreviewWeb(importFn, getProjectAnnotations).ready();
           await waitForRenderPhase('playing');
 
           expect(projectAnnotations.renderToCanvas).toHaveBeenCalledWith(
@@ -2700,7 +2700,7 @@ describe('PreviewWeb', () => {
         mockFetchResult = { status: 500, text: async () => err.toString() };
 
         const preview = new PreviewWeb(importFn, getProjectAnnotations);
-        await expect(preview.initialize()).rejects.toThrow('sort error');
+        await expect(preview.ready()).rejects.toThrow('sort error');
 
         expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(mockChannel.emit).toHaveBeenCalledWith(CONFIG_ERROR, expect.any(Error));
@@ -2718,7 +2718,7 @@ describe('PreviewWeb', () => {
         mockFetchResult = { status: 500, text: async () => err.toString() };
 
         const preview = new PreviewWeb(importFn, getProjectAnnotations);
-        await expect(preview.initialize()).rejects.toThrow('sort error');
+        await expect(preview.ready()).rejects.toThrow('sort error');
 
         expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(mockChannel.emit).toHaveBeenCalledWith(CONFIG_ERROR, expect.any(Error));
@@ -3303,7 +3303,7 @@ describe('PreviewWeb', () => {
         const preview = new PreviewWeb(importFn, () => {
           throw err;
         });
-        await expect(preview.initialize()).rejects.toThrow(err);
+        await expect(preview.ready()).rejects.toThrow(err);
 
         preview.onGetProjectAnnotationsChanged({ getProjectAnnotations });
         await waitForRender();
@@ -3318,7 +3318,7 @@ describe('PreviewWeb', () => {
         const preview = new PreviewWeb(importFn, () => {
           throw err;
         });
-        await expect(preview.initialize()).rejects.toThrow(err);
+        await expect(preview.ready()).rejects.toThrow(err);
 
         preview.onGetProjectAnnotationsChanged({ getProjectAnnotations });
         await waitForRender();
@@ -3500,7 +3500,7 @@ describe('PreviewWeb', () => {
       const [gate, openGate] = createGate();
       componentOneExports.a.play.mockImplementationOnce(async () => gate);
       const preview = new PreviewWeb(importFn, getProjectAnnotations);
-      await preview.initialize();
+      await preview.ready();
       await waitForRenderPhase('playing');
 
       await preview.onKeydown({
@@ -3547,7 +3547,7 @@ describe('PreviewWeb', () => {
       const preview = new PreviewWeb(importFn, () => {
         throw err;
       });
-      await expect(preview.initialize()).rejects.toThrow(/meta error/);
+      await expect(preview.ready()).rejects.toThrow(/meta error/);
       await expect(preview.extract()).rejects.toThrow();
     });
 
@@ -3556,7 +3556,7 @@ describe('PreviewWeb', () => {
       mockFetchResult = { status: 500, text: async () => err.toString() };
 
       const preview = new PreviewWeb(importFn, getProjectAnnotations);
-      await expect(preview.initialize()).rejects.toThrow('sort error');
+      await expect(preview.ready()).rejects.toThrow('sort error');
 
       await expect(preview.extract()).rejects.toThrow();
     });

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -103,11 +103,8 @@ async function createAndRenderPreview({
   importFn?: ModuleImportFn;
   getProjectAnnotations?: () => ProjectAnnotations<Renderer>;
 } = {}) {
-  const preview = new PreviewWeb();
-  await preview.initialize({
-    importFn: inputImportFn,
-    getProjectAnnotations: inputGetProjectAnnotations,
-  });
+  const preview = new PreviewWeb(inputImportFn, inputGetProjectAnnotations);
+  await preview.initialize();
   await waitForRender();
 
   return preview;
@@ -141,15 +138,10 @@ describe.skip('PreviewWeb', () => {
   describe('initialize', () => {
     it('shows an error if getProjectAnnotations throws', async () => {
       const err = new Error('meta error');
-      const preview = new PreviewWeb();
-      await expect(
-        preview.initialize({
-          importFn,
-          getProjectAnnotations: () => {
-            throw err;
-          },
-        })
-      ).rejects.toThrow(err);
+      const preview = new PreviewWeb(importFn, () => {
+        throw err;
+      });
+      await expect(preview.initialize()).rejects.toThrow(err);
 
       expect(preview.view.showErrorDisplay).toHaveBeenCalled();
       expect(mockChannel.emit).toHaveBeenCalledWith(CONFIG_ERROR, err);
@@ -159,10 +151,8 @@ describe.skip('PreviewWeb', () => {
       const err = new Error('sort error');
       mockFetchResult = { status: 500, text: async () => err.toString() };
 
-      const preview = new PreviewWeb();
-      await expect(preview.initialize({ importFn, getProjectAnnotations })).rejects.toThrow(
-        'sort error'
-      );
+      const preview = new PreviewWeb(importFn, getProjectAnnotations);
+      await expect(preview.initialize()).rejects.toThrow('sort error');
 
       expect(preview.view.showErrorDisplay).toHaveBeenCalled();
       expect(mockChannel.emit).toHaveBeenCalledWith(CONFIG_ERROR, expect.any(Error));
@@ -229,13 +219,10 @@ describe.skip('PreviewWeb', () => {
     });
 
     it('allows async getProjectAnnotations', async () => {
-      const preview = new PreviewWeb();
-      await preview.initialize({
-        importFn,
-        getProjectAnnotations: async () => {
-          return getProjectAnnotations();
-        },
+      const preview = new PreviewWeb(importFn, async () => {
+        return getProjectAnnotations();
       });
+      await preview.initialize();
 
       expect(preview.storyStore.globals!.get()).toEqual({ a: 'b' });
     });
@@ -521,8 +508,8 @@ describe.skip('PreviewWeb', () => {
           ...projectAnnotations,
           renderToCanvas: undefined,
         });
-        const preview = new PreviewWeb();
-        await expect(preview.initialize({ importFn, getProjectAnnotations })).rejects.toThrow();
+        const preview = new PreviewWeb(importFn, getProjectAnnotations);
+        await expect(preview.initialize()).rejects.toThrow();
 
         expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(vi.mocked(preview.view.showErrorDisplay).mock.calls[0][0]).toMatchInlineSnapshot(`
@@ -625,6 +612,24 @@ describe.skip('PreviewWeb', () => {
         await createAndRenderPreview();
 
         expect(mockChannel.emit).toHaveBeenCalledWith(STORY_RENDERED, 'component-one--a');
+      });
+
+      it('does not show error display if the render function throws IGNORED_EXCEPTION', async () => {
+        document.location.search = '?id=component-one--a';
+        projectAnnotations.renderToCanvas.mockImplementation(() => {
+          throw IGNORED_EXCEPTION;
+        });
+
+        const preview = new PreviewWeb(importFn, getProjectAnnotations);
+        await preview.initialize();
+
+        await waitForRender();
+
+        expect(mockChannel.emit).toHaveBeenCalledWith(
+          STORY_THREW_EXCEPTION,
+          serializeError(IGNORED_EXCEPTION)
+        );
+        expect(preview.view.showErrorDisplay).not.toHaveBeenCalled();
       });
     });
 
@@ -920,7 +925,7 @@ describe.skip('PreviewWeb', () => {
         document.location.search = '?id=component-one--a';
         componentOneExports.default.loaders[0].mockImplementationOnce(async () => gate);
 
-        await new PreviewWeb().initialize({ importFn, getProjectAnnotations });
+        await new PreviewWeb(importFn, getProjectAnnotations).initialize();
         await waitForRenderPhase('loading');
 
         expect(componentOneExports.default.loaders[0]).toHaveBeenCalledWith(
@@ -981,7 +986,7 @@ describe.skip('PreviewWeb', () => {
         document.location.search = '?id=component-one--a';
         projectAnnotations.renderToCanvas.mockImplementation(async () => gate);
 
-        await new PreviewWeb().initialize({ importFn, getProjectAnnotations });
+        await new PreviewWeb(importFn, getProjectAnnotations).initialize();
         await waitForRenderPhase('rendering');
 
         emitter.emit(UPDATE_STORY_ARGS, {
@@ -1060,7 +1065,7 @@ describe.skip('PreviewWeb', () => {
         });
 
         document.location.search = '?id=component-one--a';
-        await new PreviewWeb().initialize({ importFn, getProjectAnnotations });
+        await new PreviewWeb(importFn, getProjectAnnotations).initialize();
         await waitForRenderPhase('playing');
 
         await renderToCanvasCalled;
@@ -1480,7 +1485,7 @@ describe.skip('PreviewWeb', () => {
 
       document.location.search = '?id=component-one--a';
       projectAnnotations.renderToCanvas.mockImplementation(async () => gate);
-      await new PreviewWeb().initialize({ importFn, getProjectAnnotations });
+      await new PreviewWeb(importFn, getProjectAnnotations).initialize();
       await waitForRenderPhase('rendering');
 
       expect(projectAnnotations.renderToCanvas).toHaveBeenCalledWith(
@@ -1579,7 +1584,7 @@ describe.skip('PreviewWeb', () => {
       it('works when there was no selection specifier', async () => {
         document.location.search = '';
         // We intentionally are *not* awaiting here
-        new PreviewWeb().initialize({ importFn, getProjectAnnotations });
+        new PreviewWeb(importFn, getProjectAnnotations).initialize();
 
         emitter.emit(SET_CURRENT_STORY, { storyId: 'component-one--b', viewMode: 'story' });
 
@@ -1604,10 +1609,7 @@ describe.skip('PreviewWeb', () => {
       it('works when there was a selection specifier', async () => {
         document.location.search = '?id=component-one--a';
 
-        const initialized = new PreviewWeb().initialize({
-          importFn,
-          getProjectAnnotations,
-        });
+        const initialized = new PreviewWeb(importFn, getProjectAnnotations).initialize();
 
         emitter.emit(SET_CURRENT_STORY, { storyId: 'component-one--b', viewMode: 'story' });
 
@@ -1719,10 +1721,10 @@ describe.skip('PreviewWeb', () => {
               return importFn(m);
             });
 
-          const preview = new PreviewWeb();
+          const preview = new PreviewWeb(importFn, getProjectAnnotations);
           // We can't wait for the initialize function, as it waits for `renderSelection()`
           // which prepares, but it does emit `CURRENT_STORY_WAS_SET` right before that
-          preview.initialize({ importFn, getProjectAnnotations });
+          preview.initialize();
           await waitForEvents([CURRENT_STORY_WAS_SET]);
 
           mockChannel.emit.mockClear();
@@ -1766,10 +1768,10 @@ describe.skip('PreviewWeb', () => {
               return importFn(m);
             });
 
-          const preview = new PreviewWeb();
+          const preview = new PreviewWeb(importFn, getProjectAnnotations);
           // We can't wait for the initialize function, as it waits for `renderSelection()`
           // which prepares, but it does emit `CURRENT_STORY_WAS_SET` right before that
-          preview.initialize({ importFn, getProjectAnnotations });
+          preview.initialize();
           await waitForEvents([CURRENT_STORY_WAS_SET]);
 
           mockChannel.emit.mockClear();
@@ -1812,10 +1814,10 @@ describe.skip('PreviewWeb', () => {
               return importFn(m);
             });
 
-          const preview = new PreviewWeb();
+          const preview = new PreviewWeb(importFn, getProjectAnnotations);
           // We can't wait for the initialize function, as it waits for `renderSelection()`
           // which prepares, but it does emit `CURRENT_STORY_WAS_SET` right before that
-          preview.initialize({ importFn, getProjectAnnotations });
+          preview.initialize();
           await waitForEvents([CURRENT_STORY_WAS_SET]);
 
           mockChannel.emit.mockClear();
@@ -2148,7 +2150,7 @@ describe.skip('PreviewWeb', () => {
           componentOneExports.default.loaders[0].mockImplementationOnce(async () => gate);
 
           document.location.search = '?id=component-one--a';
-          await new PreviewWeb().initialize({ importFn, getProjectAnnotations });
+          await new PreviewWeb(importFn, getProjectAnnotations).initialize();
           await waitForRenderPhase('loading');
 
           emitter.emit(SET_CURRENT_STORY, {
@@ -2181,7 +2183,7 @@ describe.skip('PreviewWeb', () => {
 
           document.location.search = '?id=component-one--a';
           projectAnnotations.renderToCanvas.mockImplementation(async () => gate);
-          await new PreviewWeb().initialize({ importFn, getProjectAnnotations });
+          await new PreviewWeb(importFn, getProjectAnnotations).initialize();
           await waitForRenderPhase('rendering');
 
           mockChannel.emit.mockClear();
@@ -2215,7 +2217,7 @@ describe.skip('PreviewWeb', () => {
           componentOneExports.a.play.mockImplementationOnce(async () => gate);
 
           document.location.search = '?id=component-one--a';
-          await new PreviewWeb().initialize({ importFn, getProjectAnnotations });
+          await new PreviewWeb(importFn, getProjectAnnotations).initialize();
           await waitForRenderPhase('playing');
 
           expect(projectAnnotations.renderToCanvas).toHaveBeenCalledWith(
@@ -2268,7 +2270,7 @@ describe.skip('PreviewWeb', () => {
           componentOneExports.a.play.mockImplementationOnce(async () => gate);
 
           document.location.search = '?id=component-one--a';
-          await new PreviewWeb().initialize({ importFn, getProjectAnnotations });
+          await new PreviewWeb(importFn, getProjectAnnotations).initialize();
           await waitForRenderPhase('playing');
 
           expect(projectAnnotations.renderToCanvas).toHaveBeenCalledWith(
@@ -2697,10 +2699,8 @@ describe.skip('PreviewWeb', () => {
         const err = new Error('sort error');
         mockFetchResult = { status: 500, text: async () => err.toString() };
 
-        const preview = new PreviewWeb();
-        await expect(preview.initialize({ importFn, getProjectAnnotations })).rejects.toThrow(
-          'sort error'
-        );
+        const preview = new PreviewWeb(importFn, getProjectAnnotations);
+        await expect(preview.initialize()).rejects.toThrow('sort error');
 
         expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(mockChannel.emit).toHaveBeenCalledWith(CONFIG_ERROR, expect.any(Error));
@@ -2717,10 +2717,8 @@ describe.skip('PreviewWeb', () => {
         const err = new Error('sort error');
         mockFetchResult = { status: 500, text: async () => err.toString() };
 
-        const preview = new PreviewWeb();
-        await expect(preview.initialize({ importFn, getProjectAnnotations })).rejects.toThrow(
-          'sort error'
-        );
+        const preview = new PreviewWeb(importFn, getProjectAnnotations);
+        await expect(preview.initialize()).rejects.toThrow('sort error');
 
         expect(preview.view.showErrorDisplay).toHaveBeenCalled();
         expect(mockChannel.emit).toHaveBeenCalledWith(CONFIG_ERROR, expect.any(Error));
@@ -3302,15 +3300,10 @@ describe.skip('PreviewWeb', () => {
         document.location.search = '?id=component-one--a';
 
         const err = new Error('meta error');
-        const preview = new PreviewWeb();
-        await expect(
-          preview.initialize({
-            importFn,
-            getProjectAnnotations: () => {
-              throw err;
-            },
-          })
-        ).rejects.toThrow(err);
+        const preview = new PreviewWeb(importFn, () => {
+          throw err;
+        });
+        await expect(preview.initialize()).rejects.toThrow(err);
 
         preview.onGetProjectAnnotationsChanged({ getProjectAnnotations });
         await waitForRender();
@@ -3322,15 +3315,10 @@ describe.skip('PreviewWeb', () => {
         document.location.search = '?id=*&globals=a:c';
 
         const err = new Error('meta error');
-        const preview = new PreviewWeb();
-        await expect(
-          preview.initialize({
-            importFn,
-            getProjectAnnotations: () => {
-              throw err;
-            },
-          })
-        ).rejects.toThrow(err);
+        const preview = new PreviewWeb(importFn, () => {
+          throw err;
+        });
+        await expect(preview.initialize()).rejects.toThrow(err);
 
         preview.onGetProjectAnnotationsChanged({ getProjectAnnotations });
         await waitForRender();
@@ -3511,8 +3499,8 @@ describe.skip('PreviewWeb', () => {
 
       const [gate, openGate] = createGate();
       componentOneExports.a.play.mockImplementationOnce(async () => gate);
-      const preview = new PreviewWeb();
-      await preview.initialize({ importFn, getProjectAnnotations });
+      const preview = new PreviewWeb(importFn, getProjectAnnotations);
+      await preview.initialize();
       await waitForRenderPhase('playing');
 
       await preview.onKeydown({
@@ -3554,26 +3542,12 @@ describe.skip('PreviewWeb', () => {
   });
 
   describe('extract', () => {
-    // NOTE: if you are using storyStoreV6, and your `preview.js` throws, we do not currently
-    // detect it (as we do not wrap the import of `preview.js` in a `try/catch`). The net effect
-    // of that is that the `PreviewWeb`/`StoryStore` end up in an uninitalized state.
-    it('throws an error if the preview is uninitialized', async () => {
-      const preview = new PreviewWeb();
-      await expect(preview.extract()).rejects.toThrow(/Failed to initialize/);
-    });
-
     it('throws an error if preview.js throws', async () => {
       const err = new Error('meta error');
-      const preview = new PreviewWeb();
-      await expect(
-        preview.initialize({
-          importFn,
-          getProjectAnnotations: () => {
-            throw err;
-          },
-        })
-      ).rejects.toThrow(err);
-
+      const preview = new PreviewWeb(importFn, () => {
+        throw err;
+      });
+      await expect(preview.initialize()).rejects.toThrow(err);
       await expect(preview.extract()).rejects.toThrow(err);
     });
 
@@ -3581,10 +3555,8 @@ describe.skip('PreviewWeb', () => {
       const err = new Error('sort error');
       mockFetchResult = { status: 500, text: async () => err.toString() };
 
-      const preview = new PreviewWeb();
-      await expect(preview.initialize({ importFn, getProjectAnnotations })).rejects.toThrow(
-        'sort error'
-      );
+      const preview = new PreviewWeb(importFn, getProjectAnnotations);
+      await expect(preview.initialize()).rejects.toThrow('sort error');
 
       await expect(preview.extract()).rejects.toThrow('sort error');
     });

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable local-rules/no-uncategorized-errors */
 /**
  * @vitest-environment jsdom
  */
@@ -134,7 +135,7 @@ beforeEach(() => {
   vi.mocked(WebView.prototype).prepareForStory.mockReturnValue('story-element' as any);
 });
 
-describe.skip('PreviewWeb', () => {
+describe('PreviewWeb', () => {
   describe('initialize', () => {
     it('shows an error if getProjectAnnotations throws', async () => {
       const err = new Error('meta error');

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { global } from '@storybook/global';
-import type { Renderer, ProjectAnnotations, StoryIndex, ModuleImportFn } from '@storybook/types';
+import type { Renderer, ProjectAnnotations, ModuleImportFn } from '@storybook/types';
 
 import { PreviewWithSelection } from './PreviewWithSelection';
 import { UrlStore } from './UrlStore';

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.tsx
@@ -1,14 +1,19 @@
 /* eslint-disable no-underscore-dangle */
 import { global } from '@storybook/global';
-import type { Renderer } from '@storybook/types';
+import type { Renderer, ProjectAnnotations, StoryIndex, ModuleImportFn } from '@storybook/types';
 
 import { PreviewWithSelection } from './PreviewWithSelection';
 import { UrlStore } from './UrlStore';
 import { WebView } from './WebView';
+import type { MaybePromise } from './Preview';
 
-export class PreviewWeb<TFramework extends Renderer> extends PreviewWithSelection<TFramework> {
-  constructor() {
-    super(new UrlStore(), new WebView());
+export class PreviewWeb<TRenderer extends Renderer> extends PreviewWithSelection<TRenderer> {
+  constructor(
+    public importFn: ModuleImportFn,
+
+    public getProjectAnnotations: () => MaybePromise<ProjectAnnotations<TRenderer>>
+  ) {
+    super(importFn, getProjectAnnotations, new UrlStore(), new WebView());
 
     global.__STORYBOOK_PREVIEW__ = this;
   }

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWithSelection.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWithSelection.tsx
@@ -1,5 +1,4 @@
 import invariant from 'tiny-invariant';
-import { dedent } from 'ts-dedent';
 import {
   CURRENT_STORY_WAS_SET,
   DOCS_PREPARED,

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWithSelection.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWithSelection.tsx
@@ -99,7 +99,10 @@ export class PreviewWithSelection<TRenderer extends Renderer> extends Preview<TR
 
     public view: View<TRenderer['canvasElement']>
   ) {
-    super(importFn, getProjectAnnotations);
+    // We need to call initialize ourself (i.e. stop super() from doing it, with false)
+    // because otherwise this.view will not get set in time.
+    super(importFn, getProjectAnnotations, undefined, false);
+    this.initialize();
   }
 
   setupListeners() {

--- a/code/lib/preview-api/src/modules/preview-web/WebView.ts
+++ b/code/lib/preview-api/src/modules/preview-web/WebView.ts
@@ -137,7 +137,7 @@ export class WebView implements View<HTMLElement> {
     const parts = message.split('\n');
     if (parts.length > 1) {
       [header] = parts;
-      detail = parts.slice(1).join('\n');
+      detail = parts.slice(1).join('\n').replace(/^\n/, '');
     }
 
     document.getElementById('error-message')!.innerHTML = ansiConverter.toHtml(header);

--- a/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts
@@ -138,6 +138,7 @@ export class CsfDocsRender<TRenderer extends Renderer> implements Render<TRender
     };
 
     this.rerender = async () => renderDocs();
+    console.log('what');
     this.teardownRender = async ({ viewModeChanged }: { viewModeChanged?: boolean }) => {
       if (!viewModeChanged || !canvasElement) return;
       renderer.unmount(canvasElement);

--- a/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts
@@ -138,7 +138,6 @@ export class CsfDocsRender<TRenderer extends Renderer> implements Render<TRender
     };
 
     this.rerender = async () => renderDocs();
-    console.log('what');
     this.teardownRender = async ({ viewModeChanged }: { viewModeChanged?: boolean }) => {
       if (!viewModeChanged || !canvasElement) return;
       renderer.unmount(canvasElement);

--- a/code/lib/preview-api/src/modules/store/StoryStore.test.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.test.ts
@@ -26,6 +26,8 @@ vi.mock('@storybook/global', async (importOriginal) => ({
   },
 }));
 
+vi.mock('@storybook/client-logger');
+
 const createGate = (): [Promise<any | undefined>, (_?: any) => void] => {
   let openGate = (_?: any) => {};
   const gate = new Promise<any | undefined>((resolve) => {

--- a/code/lib/preview-api/src/modules/store/StoryStore.test.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.test.ts
@@ -457,7 +457,7 @@ describe('StoryStore', () => {
     it('throws if you have not called cacheAllCSFFiles', async () => {
       const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
-      expect(() => store.extract()).toThrow(/Cannot call extract/);
+      expect(() => store.extract()).toThrow(/Cannot call/);
     });
 
     it('produces objects with functions and hooks stripped', async () => {

--- a/code/lib/preview-api/src/modules/store/StoryStore.test.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.test.ts
@@ -84,9 +84,7 @@ const storyIndex: StoryIndex = {
 describe('StoryStore', () => {
   describe('projectAnnotations', () => {
     it('normalizes on initialization', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       expect(store.projectAnnotations!.globalTypes).toEqual({
         a: { name: 'a', type: { name: 'string' } },
@@ -97,9 +95,7 @@ describe('StoryStore', () => {
     });
 
     it('normalizes on updateGlobalAnnotations', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       store.setProjectAnnotations(projectAnnotations);
       expect(store.projectAnnotations!.globalTypes).toEqual({
@@ -113,9 +109,7 @@ describe('StoryStore', () => {
 
   describe('loadStory', () => {
     it('pulls the story via the importFn', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       importFn.mockClear();
       expect(await store.loadStory({ storyId: 'component-one--a' })).toMatchObject({
@@ -128,9 +122,7 @@ describe('StoryStore', () => {
     });
 
     it('uses a cache', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       const story = await store.loadStory({ storyId: 'component-one--a' });
       expect(processCSFFile).toHaveBeenCalledTimes(1);
@@ -149,33 +141,11 @@ describe('StoryStore', () => {
       expect(processCSFFile).toHaveBeenCalledTimes(2);
       expect(prepareStory).toHaveBeenCalledTimes(3);
     });
-
-    describe('if the store is not yet initialized', () => {
-      it('waits for initialization', async () => {
-        const store = new StoryStore();
-
-        importFn.mockClear();
-        const loadPromise = store.loadStory({ storyId: 'component-one--a' });
-
-        store.setProjectAnnotations(projectAnnotations);
-        store.initialize({ storyIndex, importFn });
-
-        expect(await loadPromise).toMatchObject({
-          id: 'component-one--a',
-          name: 'A',
-          title: 'Component One',
-          initialArgs: { foo: 'a' },
-        });
-        expect(importFn).toHaveBeenCalledWith('./src/ComponentOne.stories.js');
-      });
-    });
   });
 
   describe('setProjectAnnotations', () => {
     it('busts the loadStory cache', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       const story = await store.loadStory({ storyId: 'component-one--a' });
       expect(processCSFFile).toHaveBeenCalledTimes(1);
@@ -192,9 +162,7 @@ describe('StoryStore', () => {
 
   describe('onStoriesChanged', () => {
     it('busts the loadStory cache if the importFn returns a new module', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       const story = await store.loadStory({ storyId: 'component-one--a' });
       expect(processCSFFile).toHaveBeenCalledTimes(1);
@@ -214,9 +182,7 @@ describe('StoryStore', () => {
     });
 
     it('busts the loadStory cache if the csf file no longer appears in the index', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       await store.loadStory({ storyId: 'component-one--a' });
       expect(processCSFFile).toHaveBeenCalledTimes(1);
@@ -233,9 +199,7 @@ describe('StoryStore', () => {
     });
 
     it('reuses the cache if a story importPath has not changed', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       const story = await store.loadStory({ storyId: 'component-one--a' });
       expect(processCSFFile).toHaveBeenCalledTimes(1);
@@ -265,9 +229,7 @@ describe('StoryStore', () => {
     });
 
     it('imports with a new path for a story id if provided', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       await store.loadStory({ storyId: 'component-one--a' });
       expect(importFn).toHaveBeenCalledWith(storyIndex.entries['component-one--a'].importPath);
@@ -295,9 +257,7 @@ describe('StoryStore', () => {
     });
 
     it('re-caches stories if the were cached already', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
       await store.cacheAllCSFFiles();
 
       await store.loadStory({ storyId: 'component-one--a' });
@@ -368,9 +328,7 @@ describe('StoryStore', () => {
 
   describe('componentStoriesFromCSFFile', () => {
     it('returns all the stories in the file', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       const csfFile = await store.loadCSFFileByStoryId('component-one--a');
       const stories = store.componentStoriesFromCSFFile({ csfFile });
@@ -380,8 +338,6 @@ describe('StoryStore', () => {
     });
 
     it('returns them in the order they are in the index, not the file', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
       const reversedIndex = {
         v: 4,
         entries: {
@@ -389,7 +345,7 @@ describe('StoryStore', () => {
           'component-one--a': storyIndex.entries['component-one--a'],
         },
       };
-      store.initialize({ storyIndex: reversedIndex, importFn });
+      const store = new StoryStore(reversedIndex, importFn, projectAnnotations);
 
       const csfFile = await store.loadCSFFileByStoryId('component-one--a');
       const stories = store.componentStoriesFromCSFFile({ csfFile });
@@ -401,9 +357,7 @@ describe('StoryStore', () => {
 
   describe('getStoryContext', () => {
     it('returns the args and globals correctly', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       const story = await store.loadStory({ storyId: 'component-one--a' });
 
@@ -414,9 +368,7 @@ describe('StoryStore', () => {
     });
 
     it('returns the args and globals correctly when they change', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       const story = await store.loadStory({ storyId: 'component-one--a' });
 
@@ -430,9 +382,7 @@ describe('StoryStore', () => {
     });
 
     it('can force initial args', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       const story = await store.loadStory({ storyId: 'component-one--a' });
 
@@ -444,9 +394,7 @@ describe('StoryStore', () => {
     });
 
     it('returns the same hooks each time', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       const story = await store.loadStory({ storyId: 'component-one--a' });
 
@@ -461,9 +409,7 @@ describe('StoryStore', () => {
 
   describe('cleanupStory', () => {
     it('cleans the hooks from the context', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       const story = await store.loadStory({ storyId: 'component-one--a' });
 
@@ -476,9 +422,7 @@ describe('StoryStore', () => {
 
   describe('loadAllCSFFiles', () => {
     it('imports *all* csf files', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       importFn.mockClear();
       const csfFiles = await store.loadAllCSFFiles();
@@ -496,9 +440,7 @@ describe('StoryStore', () => {
         await gate;
         return importFn(file);
       });
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn: blockedImportFn });
+      const store = new StoryStore(storyIndex, blockedImportFn, projectAnnotations);
 
       const promise = store.loadAllCSFFiles({ batchSize: 1 });
       expect(blockedImportFn).toHaveBeenCalledTimes(1);
@@ -511,17 +453,13 @@ describe('StoryStore', () => {
 
   describe('extract', () => {
     it('throws if you have not called cacheAllCSFFiles', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
 
       expect(() => store.extract()).toThrow(/Cannot call extract/);
     });
 
     it('produces objects with functions and hooks stripped', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
       await store.cacheAllCSFFiles();
 
       expect(store.extract()).toMatchInlineSnapshot(`
@@ -653,12 +591,7 @@ describe('StoryStore', () => {
             }
           : componentTwoExports;
       });
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({
-        storyIndex,
-        importFn: docsOnlyImportFn,
-      });
+      const store = new StoryStore(storyIndex, docsOnlyImportFn, projectAnnotations);
       await store.cacheAllCSFFiles();
 
       expect(Object.keys(store.extract())).toEqual(['component-one--b', 'component-two--c']);
@@ -685,12 +618,7 @@ describe('StoryStore', () => {
           },
         },
       };
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({
-        storyIndex: unnattachedStoryIndex,
-        importFn,
-      });
+      const store = new StoryStore(unnattachedStoryIndex, importFn, projectAnnotations);
       await store.cacheAllCSFFiles();
 
       expect(Object.keys(store.extract())).toEqual([
@@ -709,9 +637,7 @@ describe('StoryStore', () => {
 
   describe('raw', () => {
     it('produces an array of stories', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
       await store.cacheAllCSFFiles();
 
       expect(store.raw()).toMatchInlineSnapshot(`
@@ -858,9 +784,7 @@ describe('StoryStore', () => {
 
   describe('getSetStoriesPayload', () => {
     it('maps stories list to payload correctly', async () => {
-      const store = new StoryStore();
-      store.setProjectAnnotations(projectAnnotations);
-      store.initialize({ storyIndex, importFn });
+      const store = new StoryStore(storyIndex, importFn, projectAnnotations);
       await store.cacheAllCSFFiles();
 
       expect(store.getSetStoriesPayload()).toMatchInlineSnapshot(`
@@ -998,9 +922,7 @@ describe('StoryStore', () => {
   describe('getStoriesJsonData', () => {
     describe('in back-compat mode', () => {
       it('maps stories list to payload correctly', async () => {
-        const store = new StoryStore();
-        store.setProjectAnnotations(projectAnnotations);
-        store.initialize({ storyIndex, importFn });
+        const store = new StoryStore(storyIndex, importFn, projectAnnotations);
         await store.cacheAllCSFFiles();
 
         expect(store.getStoriesJsonData()).toMatchInlineSnapshot(`
@@ -1046,22 +968,6 @@ describe('StoryStore', () => {
             "v": 3,
           }
         `);
-      });
-    });
-  });
-
-  describe('cacheAllCsfFiles', () => {
-    describe('if the store is not yet initialized', () => {
-      it('waits for initialization', async () => {
-        const store = new StoryStore();
-
-        importFn.mockClear();
-        const cachePromise = store.cacheAllCSFFiles();
-
-        store.setProjectAnnotations(projectAnnotations);
-        store.initialize({ storyIndex, importFn });
-
-        await expect(cachePromise).resolves.toEqual(undefined);
       });
     });
   });

--- a/code/lib/preview-api/src/modules/store/StoryStore.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.ts
@@ -335,13 +335,22 @@ export class StoryStore<TRenderer extends Renderer> {
   };
 
   raw(): BoundStory<TRenderer>[] {
+    deprecate(
+      'StoryStore.raw() is deprecated and will be removed in 9.0, please use extract() instead'
+    );
     return Object.values(this.extract())
       .map(({ id }: { id: StoryId }) => this.fromId(id))
       .filter(Boolean) as BoundStory<TRenderer>[];
   }
 
   fromId(storyId: StoryId): BoundStory<TRenderer> | null {
+    deprecate(
+      'StoryStore.fromId() is deprecated and will be removed in 9.0, please use loadStory() instead'
+    );
+
+    // Deprecated so won't make a proper error for this
     if (!this.cachedCSFFiles)
+      // eslint-disable-next-line local-rules/no-uncategorized-errors
       throw new Error('Cannot call fromId/raw() unless you call cacheAllCSFFiles() first.');
 
     let importPath;

--- a/code/lib/preview-api/src/modules/store/StoryStore.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.ts
@@ -24,6 +24,11 @@ import type {
 import mapValues from 'lodash/mapValues.js';
 import pick from 'lodash/pick.js';
 
+import {
+  CalledExtractOnStoreError,
+  MissingStoryFromCsfFileError,
+} from '@storybook/core-events/preview-errors';
+import { deprecate } from '@storybook/client-logger';
 import { HooksContext } from '../addons';
 import { StoryIndexStore } from './StoryIndexStore';
 import { ArgsStore } from './ArgsStore';
@@ -187,9 +192,8 @@ export class StoryStore<TRenderer extends Renderer> {
     csfFile: CSFFile<TRenderer>;
   }): PreparedStory<TRenderer> {
     const storyAnnotations = csfFile.stories[storyId];
-    if (!storyAnnotations) {
-      throw new Error(`Didn't find '${storyId}' in CSF file, this is unexpected`);
-    }
+    if (!storyAnnotations) throw new MissingStoryFromCsfFileError({ storyId });
+
     const componentAnnotations = csfFile.meta;
 
     const story = this.prepareStoryWithCache(
@@ -251,8 +255,7 @@ export class StoryStore<TRenderer extends Renderer> {
     options: { includeDocsOnly?: boolean } = { includeDocsOnly: false }
   ): Record<StoryId, StoryContextForEnhancers<TRenderer>> {
     const { cachedCSFFiles } = this;
-    if (!cachedCSFFiles)
-      throw new Error('Cannot call extract() unless you call cacheAllCSFFiles() first.');
+    if (!cachedCSFFiles) throw new CalledExtractOnStoreError({});
 
     return Object.entries(this.storyIndex.entries).reduce(
       (acc, [storyId, { type, importPath }]) => {

--- a/code/lib/preview-api/src/modules/store/StoryStore.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.ts
@@ -41,13 +41,11 @@ const STORY_CACHE_SIZE = 10000;
 const EXTRACT_BATCH_SIZE = 20;
 
 export class StoryStore<TRenderer extends Renderer> {
-  storyIndex?: StoryIndexStore;
+  public storyIndex: StoryIndexStore;
 
-  importFn?: ModuleImportFn;
+  projectAnnotations: NormalizedProjectAnnotations<TRenderer>;
 
-  projectAnnotations?: NormalizedProjectAnnotations<TRenderer>;
-
-  globals?: GlobalsStore;
+  globals: GlobalsStore;
 
   args: ArgsStore;
 
@@ -61,13 +59,20 @@ export class StoryStore<TRenderer extends Renderer> {
 
   prepareStoryWithCache: typeof prepareStory;
 
-  initializationPromise: Promise<void>;
+  constructor(
+    storyIndex: StoryIndex,
 
-  // This *does* get set in the constructor but the semantics of `new Promise` trip up TS
-  resolveInitializationPromise!: () => void;
+    public importFn: ModuleImportFn,
 
-  constructor() {
+    projectAnnotations: ProjectAnnotations<TRenderer>
+  ) {
+    this.storyIndex = new StoryIndexStore(storyIndex);
+
+    this.projectAnnotations = normalizeProjectAnnotations(projectAnnotations);
+    const { globals, globalTypes } = projectAnnotations;
+
     this.args = new ArgsStore();
+    this.globals = new GlobalsStore({ globals, globalTypes });
     this.hooks = {};
 
     // We use a cache for these two functions for two reasons:
@@ -76,37 +81,13 @@ export class StoryStore<TRenderer extends Renderer> {
     this.processCSFFileWithCache = memoize(CSF_CACHE_SIZE)(processCSFFile) as typeof processCSFFile;
     this.prepareMetaWithCache = memoize(CSF_CACHE_SIZE)(prepareMeta) as typeof prepareMeta;
     this.prepareStoryWithCache = memoize(STORY_CACHE_SIZE)(prepareStory) as typeof prepareStory;
-
-    // We cannot call `loadStory()` until we've been initialized properly. But we can wait for it.
-    this.initializationPromise = new Promise((resolve) => {
-      this.resolveInitializationPromise = resolve;
-    });
   }
 
   setProjectAnnotations(projectAnnotations: ProjectAnnotations<TRenderer>) {
     // By changing `this.projectAnnotations, we implicitly invalidate the `prepareStoryWithCache`
     this.projectAnnotations = normalizeProjectAnnotations(projectAnnotations);
     const { globals, globalTypes } = projectAnnotations;
-
-    if (this.globals) {
-      this.globals.set({ globals, globalTypes });
-    } else {
-      this.globals = new GlobalsStore({ globals, globalTypes });
-    }
-  }
-
-  initialize({
-    storyIndex,
-    importFn,
-  }: {
-    storyIndex?: StoryIndex;
-    importFn: ModuleImportFn;
-  }): void {
-    this.storyIndex = new StoryIndexStore(storyIndex);
-    this.importFn = importFn;
-
-    // We don't need the cache to be loaded to call `loadStory`, we just need the index ready
-    this.resolveInitializationPromise();
+    this.globals.set({ globals, globalTypes });
   }
 
   // This means that one of the CSF files has changed.
@@ -120,26 +101,20 @@ export class StoryStore<TRenderer extends Renderer> {
     importFn?: ModuleImportFn;
     storyIndex?: StoryIndex;
   }) {
-    await this.initializationPromise;
-
     if (importFn) this.importFn = importFn;
     // The index will always be set before the initialization promise returns
-    if (storyIndex) this.storyIndex!.entries = storyIndex.entries;
+    if (storyIndex) this.storyIndex.entries = storyIndex.entries;
     if (this.cachedCSFFiles) await this.cacheAllCSFFiles();
   }
 
   // Get an entry from the index, waiting on initialization if necessary
   async storyIdToEntry(storyId: StoryId): Promise<IndexEntry> {
-    await this.initializationPromise;
     // The index will always be set before the initialization promise returns
-    return this.storyIndex!.storyIdToEntry(storyId);
+    return this.storyIndex.storyIdToEntry(storyId);
   }
 
   // To load a single CSF file to service a story we need to look up the importPath in the index
   async loadCSFFileByStoryId(storyId: StoryId): Promise<CSFFile<TRenderer>> {
-    if (!this.storyIndex || !this.importFn)
-      throw new Error(`loadCSFFileByStoryId called before initialization`);
-
     const { importPath, title } = this.storyIndex.storyIdToEntry(storyId);
     const moduleExports = await this.importFn(importPath);
 
@@ -150,8 +125,6 @@ export class StoryStore<TRenderer extends Renderer> {
   async loadAllCSFFiles({ batchSize = EXTRACT_BATCH_SIZE } = {}): Promise<
     StoryStore<TRenderer>['cachedCSFFiles']
   > {
-    if (!this.storyIndex) throw new Error(`loadAllCSFFiles called before initialization`);
-
     const importPaths = Object.entries(this.storyIndex.entries).map(([storyId, { importPath }]) => [
       importPath,
       storyId,
@@ -185,13 +158,10 @@ export class StoryStore<TRenderer extends Renderer> {
   }
 
   async cacheAllCSFFiles(): Promise<void> {
-    await this.initializationPromise;
     this.cachedCSFFiles = await this.loadAllCSFFiles();
   }
 
   preparedMetaFromCSFFile({ csfFile }: { csfFile: CSFFile<TRenderer> }): PreparedMeta<TRenderer> {
-    if (!this.projectAnnotations) throw new Error(`storyFromCSFFile called before initialization`);
-
     const componentAnnotations = csfFile.meta;
 
     return this.prepareMetaWithCache(
@@ -203,7 +173,6 @@ export class StoryStore<TRenderer extends Renderer> {
 
   // Load the CSF file for a story and prepare the story from it and the project annotations.
   async loadStory({ storyId }: { storyId: StoryId }): Promise<PreparedStory<TRenderer>> {
-    await this.initializationPromise;
     const csfFile = await this.loadCSFFileByStoryId(storyId);
     return this.storyFromCSFFile({ storyId, csfFile });
   }
@@ -217,8 +186,6 @@ export class StoryStore<TRenderer extends Renderer> {
     storyId: StoryId;
     csfFile: CSFFile<TRenderer>;
   }): PreparedStory<TRenderer> {
-    if (!this.projectAnnotations) throw new Error(`storyFromCSFFile called before initialization`);
-
     const storyAnnotations = csfFile.stories[storyId];
     if (!storyAnnotations) {
       throw new Error(`Didn't find '${storyId}' in CSF file, this is unexpected`);
@@ -241,9 +208,6 @@ export class StoryStore<TRenderer extends Renderer> {
   }: {
     csfFile: CSFFile<TRenderer>;
   }): PreparedStory<TRenderer>[] {
-    if (!this.storyIndex)
-      throw new Error(`componentStoriesFromCSFFile called before initialization`);
-
     return Object.keys(this.storyIndex.entries)
       .filter((storyId: StoryId) => !!csfFile.stories[storyId])
       .map((storyId: StoryId) => this.storyFromCSFFile({ storyId, csfFile }));
@@ -252,15 +216,12 @@ export class StoryStore<TRenderer extends Renderer> {
   async loadEntry(id: StoryId) {
     const entry = await this.storyIdToEntry(id);
 
-    const { importFn, storyIndex } = this;
-    if (!storyIndex || !importFn) throw new Error(`loadEntry called before initialization`);
-
     const storyImports = entry.type === 'docs' ? entry.storiesImports : [];
 
     const [entryExports, ...csfFiles] = (await Promise.all([
-      importFn(entry.importPath),
+      this.importFn(entry.importPath),
       ...storyImports.map((storyImportPath) => {
-        const firstStoryEntry = storyIndex.importPathToEntry(storyImportPath);
+        const firstStoryEntry = this.storyIndex.importPathToEntry(storyImportPath);
         return this.loadCSFFileByStoryId(firstStoryEntry.id);
       }),
     ])) as [ModuleExports, ...CSFFile<TRenderer>[]];
@@ -274,8 +235,6 @@ export class StoryStore<TRenderer extends Renderer> {
     story: PreparedStory<TRenderer>,
     { forceInitialArgs = false } = {}
   ): Omit<StoryContextForLoaders, 'viewMode'> {
-    if (!this.globals) throw new Error(`getStoryContext called before initialization`);
-
     return prepareContext({
       ...story,
       args: forceInitialArgs ? story.initialArgs : this.args.get(story.id),
@@ -291,8 +250,6 @@ export class StoryStore<TRenderer extends Renderer> {
   extract(
     options: { includeDocsOnly?: boolean } = { includeDocsOnly: false }
   ): Record<StoryId, StoryContextForEnhancers<TRenderer>> {
-    if (!this.storyIndex) throw new Error(`extract called before initialization`);
-
     const { cachedCSFFiles } = this;
     if (!cachedCSFFiles)
       throw new Error('Cannot call extract() unless you call cacheAllCSFFiles() first.');
@@ -328,8 +285,6 @@ export class StoryStore<TRenderer extends Renderer> {
   }
 
   getSetStoriesPayload() {
-    if (!this.globals) throw new Error(`getSetStoriesPayload called before initialization`);
-
     const stories = this.extract({ includeDocsOnly: true });
 
     const kindParameters: Parameters = Object.values(stories).reduce(
@@ -353,14 +308,11 @@ export class StoryStore<TRenderer extends Renderer> {
   // It is used to allow v7 Storybooks to be composed in v6 Storybooks, which expect a
   // `stories.json` file with legacy fields (`kind` etc).
   getStoriesJsonData = (): StoryIndexV3 => {
-    const { storyIndex } = this;
-    if (!storyIndex) throw new Error(`getStoriesJsonData called before initialization`);
-
     const value = this.getSetStoriesPayload();
     const allowedParameters = ['fileName', 'docsOnly', 'framework', '__id', '__isArgsStory'];
 
     const stories: Record<StoryId, V3CompatIndexEntry> = mapValues(value.stories, (story) => {
-      const { importPath } = storyIndex.entries[story.id];
+      const { importPath } = this.storyIndex.entries[story.id];
       return {
         ...pick(story, ['id', 'name', 'title']),
         importPath,
@@ -389,8 +341,6 @@ export class StoryStore<TRenderer extends Renderer> {
   }
 
   fromId(storyId: StoryId): BoundStory<TRenderer> | null {
-    if (!this.storyIndex) throw new Error(`fromId called before initialization`);
-
     if (!this.cachedCSFFiles)
       throw new Error('Cannot call fromId/raw() unless you call cacheAllCSFFiles() first.');
 

--- a/code/lib/preview-api/src/modules/store/StoryStore.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.ts
@@ -255,7 +255,7 @@ export class StoryStore<TRenderer extends Renderer> {
     options: { includeDocsOnly?: boolean } = { includeDocsOnly: false }
   ): Record<StoryId, StoryContextForEnhancers<TRenderer>> {
     const { cachedCSFFiles } = this;
-    if (!cachedCSFFiles) throw new CalledExtractOnStoreError({});
+    if (!cachedCSFFiles) throw new CalledExtractOnStoreError();
 
     return Object.entries(this.storyIndex.entries).reduce(
       (acc, [storyId, { type, importPath }]) => {

--- a/code/ui/blocks/src/blocks/external/ExternalPreview.ts
+++ b/code/ui/blocks/src/blocks/external/ExternalPreview.ts
@@ -36,8 +36,10 @@ export class ExternalPreview<TRenderer extends Renderer = Renderer> extends Prev
   private moduleExportsByImportPath: Record<Path, ModuleExports> = {};
 
   constructor(public projectAnnotations: ProjectAnnotations<TRenderer>) {
+    // @ts-expect-error (tom will fix this)
     super(new Channel({}));
 
+    // @ts-expect-error (tom will fix this)
     this.initialize({
       getStoryIndex: () => this.storyIndex,
       importFn: (path: Path) => {

--- a/code/ui/blocks/src/blocks/external/ExternalPreview.ts
+++ b/code/ui/blocks/src/blocks/external/ExternalPreview.ts
@@ -36,21 +36,19 @@ export class ExternalPreview<TRenderer extends Renderer = Renderer> extends Prev
   private moduleExportsByImportPath: Record<Path, ModuleExports> = {};
 
   constructor(public projectAnnotations: ProjectAnnotations<TRenderer>) {
-    // @ts-expect-error (tom will fix this)
-    super(new Channel({}));
+    const importFn = (path: Path) => {
+      return Promise.resolve(this.moduleExportsByImportPath[path]);
+    };
+    const getProjectAnnotations = () =>
+      composeConfigs<TRenderer>([
+        { parameters: { docs: { story: { inline: true } } } },
+        this.projectAnnotations,
+      ]);
+    super(importFn, getProjectAnnotations, new Channel({}));
+  }
 
-    // @ts-expect-error (tom will fix this)
-    this.initialize({
-      getStoryIndex: () => this.storyIndex,
-      importFn: (path: Path) => {
-        return Promise.resolve(this.moduleExportsByImportPath[path]);
-      },
-      getProjectAnnotations: () =>
-        composeConfigs([
-          { parameters: { docs: { story: { inline: true } } } },
-          this.projectAnnotations,
-        ]),
-    });
+  async getStoryIndexFromServer() {
+    return this.storyIndex;
   }
 
   processMetaExports = (metaExports: MetaExports) => {
@@ -59,7 +57,7 @@ export class ExternalPreview<TRenderer extends Renderer = Renderer> extends Prev
 
     const title = metaExports.default.title || this.titles.get(metaExports);
 
-    const csfFile = this.storyStore.processCSFFileWithCache<TRenderer>(
+    const csfFile = this.storyStoreValue.processCSFFileWithCache<TRenderer>(
       metaExports,
       importPath,
       title
@@ -83,7 +81,7 @@ export class ExternalPreview<TRenderer extends Renderer = Renderer> extends Prev
   docsContext = () => {
     return new ExternalDocsContext(
       this.channel,
-      this.storyStore,
+      this.storyStoreValue,
       this.renderStoryToElement.bind(this),
       this.processMetaExports.bind(this)
     );

--- a/code/vitest-setup.ts
+++ b/code/vitest-setup.ts
@@ -10,6 +10,12 @@ const ignoreList = [
   (error: any) =>
     error.message.includes('react-async-component-lifecycle-hooks') &&
     error.stack.includes('addons/knobs/src/components/__tests__/Options.js'),
+  // React will log this error even if you catch an error with a boundary. I guess it's to
+  // help in development. See https://github.com/facebook/react/issues/15069
+  (error: any) =>
+    error.message.match(
+      /React will try to recreate this component tree from scratch using the error boundary you provided/
+    ),
 ];
 
 const throwMessage = (type: any, message: any) => {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6199,7 +6199,6 @@ __metadata:
   resolution: "@storybook/preview-api@workspace:lib/preview-api"
   dependencies:
     "@jest/globals": "npm:^29.5.0"
-    "@storybook/addon-docs": "workspace:*"
     "@storybook/channels": "workspace:*"
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-common": "workspace:*"
@@ -6214,6 +6213,7 @@ __metadata:
     memoizerific: "npm:^1.11.3"
     qs: "npm:^6.10.0"
     slash: "npm:^5.0.0"
+    tiny-invariant: "npm:^1.3.1"
     ts-dedent: "npm:^2.0.0"
     util-deprecate: "npm:^1.0.2"
   languageName: unknown

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6199,6 +6199,7 @@ __metadata:
   resolution: "@storybook/preview-api@workspace:lib/preview-api"
   dependencies:
     "@jest/globals": "npm:^29.5.0"
+    "@storybook/addon-docs": "workspace:*"
     "@storybook/channels": "workspace:*"
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-common": "workspace:*"


### PR DESCRIPTION
Relates to https://github.com/storybookjs/storybook/pull/24926

Telescoping on https://github.com/storybookjs/storybook/pull/24658


<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Got rid of StoryStore initialization -- now we just create it when we have everything we need. The only reason we didn't before was for SSv6.

We can't get rid of the "initialization promise" concept entirely, because we still need to cope with receiving messages (like `setCurrentStory`) while the index is still loading. However, now it is isolated (and private) to the preview classes, leading to a simpler store and less code overall.

This breaks `__STORYBOOK_STORY_STORE__` and we will need to remove that API also. In the meantime we've created a proxy object that recreates the old behaviour with a deprecation warning.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
