### PR TITLE
NextJS: Call storybook binary directly

### DIFF
--- a/code/frameworks/nextjs-server/src/next-config.ts
+++ b/code/frameworks/nextjs-server/src/next-config.ts
@@ -60,9 +60,12 @@ export const withStorybook = ({
   };
 
   childProcess = spawn(
-    'yarn',
+    'npm',
     [
+      'exec',
       'storybook',
+      '--',
+      'dev',
       '--preview-url',
       `http://localhost:${port}/${previewPath}`,
       '-p',


### PR DESCRIPTION
#### Manual testing

1. Run the NextJS app & observe everything running correctly
2. Modify your `storybook` package script in a weird way (e.g. run in `--docs` mode) and observe that config is not applied

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
