### PR TITLE
Test: Model loaders as before each and restore mocks properly

### DIFF
--- a/code/addons/actions/src/addArgs.ts
+++ b/code/addons/actions/src/addArgs.ts
@@ -1,12 +1,7 @@
 import type { ArgsEnhancer } from '@storybook/types';
-import {
-  addActionsFromArgTypes,
-  attachActionsToFunctionMocks,
-  inferActionsFromArgTypesRegex,
-} from './addArgsHelpers';
+import { addActionsFromArgTypes, inferActionsFromArgTypesRegex } from './addArgsHelpers';
 
 export const argsEnhancers: ArgsEnhancer[] = [
   addActionsFromArgTypes,
   inferActionsFromArgTypesRegex,
-  attachActionsToFunctionMocks,
 ];

--- a/code/addons/actions/src/addArgsHelpers.ts
+++ b/code/addons/actions/src/addArgsHelpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle,no-param-reassign */
 import type { Args, Renderer, ArgsEnhancer } from '@storybook/types';
 import { action } from './runtime/action';
 
@@ -60,36 +59,6 @@ export const addActionsFromArgTypes: ArgsEnhancer<Renderer> = (context) => {
     if (isInInitialArgs(name, initialArgs)) {
       acc[name] = action(typeof argType['action'] === 'string' ? argType['action'] : name);
     }
-    return acc;
-  }, {} as Args);
-};
-
-export const attachActionsToFunctionMocks: ArgsEnhancer<Renderer> = (context) => {
-  const {
-    initialArgs,
-    argTypes,
-    parameters: { actions },
-  } = context;
-  if (actions?.disable || !argTypes) {
-    return {};
-  }
-
-  const argTypesWithAction = Object.entries(initialArgs).filter(
-    ([, value]) =>
-      typeof value === 'function' &&
-      '_isMockFunction' in value &&
-      value._isMockFunction &&
-      !value._actionAttached
-  );
-
-  return argTypesWithAction.reduce((acc, [key, value]) => {
-    const previous = value.getMockImplementation();
-    value.mockImplementation((...args: unknown[]) => {
-      action(key)(...args);
-      return previous?.(...args);
-    });
-    // this enhancer is being called multiple times
-    value._actionAttached = true;
     return acc;
   }, {} as Args);
 };

--- a/code/addons/actions/src/loaders.ts
+++ b/code/addons/actions/src/loaders.ts
@@ -1,0 +1,30 @@
+/* eslint-disable no-underscore-dangle */
+import type { LoaderFunction } from '@storybook/types';
+import { action } from './runtime';
+
+const attachActionsToFunctionMocks: LoaderFunction = (context) => {
+  const {
+    args,
+    parameters: { actions },
+  } = context;
+  if (actions?.disable) return;
+
+  Object.entries(args)
+    .filter(
+      ([, value]) =>
+        typeof value === 'function' && '_isMockFunction' in value && value._isMockFunction
+    )
+    .forEach(([key, value]) => {
+      const previous = value.getMockImplementation();
+      if (previous?._actionAttached !== true) {
+        const implementation = (...params: unknown[]) => {
+          action(key)(...params);
+          return previous?.(...params);
+        };
+        implementation._actionAttached = true;
+        value.mockImplementation(implementation);
+      }
+    });
+};
+
+export const loaders: LoaderFunction[] = [attachActionsToFunctionMocks];

--- a/code/addons/actions/src/preview.ts
+++ b/code/addons/actions/src/preview.ts
@@ -1,1 +1,2 @@
 export * from './addArgs';
+export * from './loaders';

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -63,7 +63,7 @@
     "prep": "node --loader ../../../scripts/node_modules/esbuild-register/loader.js -r ../../../scripts/node_modules/esbuild-register/register.js ../../../scripts/prepare/addon-bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/global": "^5.0.0",
     "ts-dedent": "^2.0.0"
   },

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -63,7 +63,7 @@
     "prep": "node --loader ../../../scripts/node_modules/esbuild-register/loader.js -r ../../../scripts/node_modules/esbuild-register/register.js ../../../scripts/prepare/addon-bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/global": "^5.0.0",
     "ts-dedent": "^2.0.0"
   },

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -63,7 +63,7 @@
     "prep": "node --loader ../../../scripts/node_modules/esbuild-register/loader.js -r ../../../scripts/node_modules/esbuild-register/register.js ../../../scripts/prepare/addon-bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/global": "^5.0.0",
     "ts-dedent": "^2.0.0"
   },

--- a/code/addons/storyshots-puppeteer/package.json
+++ b/code/addons/storyshots-puppeteer/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@axe-core/puppeteer": "^4.2.0",
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/node-logger": "workspace:*",
     "@storybook/types": "workspace:*",
     "@types/jest-image-snapshot": "^6.0.0",

--- a/code/addons/storyshots-puppeteer/package.json
+++ b/code/addons/storyshots-puppeteer/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@axe-core/puppeteer": "^4.2.0",
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/node-logger": "workspace:*",
     "@storybook/types": "workspace:*",
     "@types/jest-image-snapshot": "^6.0.0",

--- a/code/addons/storyshots-puppeteer/package.json
+++ b/code/addons/storyshots-puppeteer/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@axe-core/puppeteer": "^4.2.0",
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/node-logger": "workspace:*",
     "@storybook/types": "workspace:*",
     "@types/jest-image-snapshot": "^6.0.0",

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -55,7 +55,7 @@
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
     "@babel/types": "^7.23.0",
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/node-logger": "workspace:*",
     "@storybook/types": "workspace:*",

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -55,7 +55,7 @@
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
     "@babel/types": "^7.23.0",
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/node-logger": "workspace:*",
     "@storybook/types": "workspace:*",

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -55,7 +55,7 @@
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
     "@babel/types": "^7.23.0",
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/node-logger": "workspace:*",
     "@storybook/types": "workspace:*",

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -66,7 +66,7 @@
     "@storybook/channels": "workspace:*",
     "@storybook/core-common": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/docs-mdx": "^0.1.0",
     "@storybook/global": "^5.0.0",

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -66,7 +66,7 @@
     "@storybook/channels": "workspace:*",
     "@storybook/core-common": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/docs-mdx": "^0.1.0",
     "@storybook/global": "^5.0.0",

--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -66,7 +66,7 @@
     "@storybook/channels": "workspace:*",
     "@storybook/core-common": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/docs-mdx": "^0.1.0",
     "@storybook/global": "^5.0.0",

--- a/code/lib/csf-tools/package.json
+++ b/code/lib/csf-tools/package.json
@@ -46,7 +46,7 @@
     "@babel/parser": "^7.23.0",
     "@babel/traverse": "^7.23.2",
     "@babel/types": "^7.23.0",
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/types": "workspace:*",
     "fs-extra": "^11.1.0",
     "recast": "^0.23.1",

--- a/code/lib/csf-tools/package.json
+++ b/code/lib/csf-tools/package.json
@@ -46,7 +46,7 @@
     "@babel/parser": "^7.23.0",
     "@babel/traverse": "^7.23.2",
     "@babel/types": "^7.23.0",
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/types": "workspace:*",
     "fs-extra": "^11.1.0",
     "recast": "^0.23.1",

--- a/code/lib/csf-tools/package.json
+++ b/code/lib/csf-tools/package.json
@@ -46,7 +46,7 @@
     "@babel/parser": "^7.23.0",
     "@babel/traverse": "^7.23.2",
     "@babel/types": "^7.23.0",
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/types": "workspace:*",
     "fs-extra": "^11.1.0",
     "recast": "^0.23.1",

--- a/code/lib/manager-api/package.json
+++ b/code/lib/manager-api/package.json
@@ -46,7 +46,7 @@
     "@storybook/channels": "workspace:*",
     "@storybook/client-logger": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/global": "^5.0.0",
     "@storybook/router": "workspace:*",
     "@storybook/theming": "workspace:*",

--- a/code/lib/manager-api/package.json
+++ b/code/lib/manager-api/package.json
@@ -46,7 +46,7 @@
     "@storybook/channels": "workspace:*",
     "@storybook/client-logger": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/global": "^5.0.0",
     "@storybook/router": "workspace:*",
     "@storybook/theming": "workspace:*",

--- a/code/lib/manager-api/package.json
+++ b/code/lib/manager-api/package.json
@@ -46,7 +46,7 @@
     "@storybook/channels": "workspace:*",
     "@storybook/client-logger": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/global": "^5.0.0",
     "@storybook/router": "workspace:*",
     "@storybook/theming": "workspace:*",

--- a/code/lib/preview-api/package.json
+++ b/code/lib/preview-api/package.json
@@ -71,7 +71,7 @@
     "@storybook/channels": "workspace:*",
     "@storybook/client-logger": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/global": "^5.0.0",
     "@storybook/types": "workspace:*",
     "@types/qs": "^6.9.5",

--- a/code/lib/preview-api/package.json
+++ b/code/lib/preview-api/package.json
@@ -71,7 +71,7 @@
     "@storybook/channels": "workspace:*",
     "@storybook/client-logger": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/global": "^5.0.0",
     "@storybook/types": "workspace:*",
     "@types/qs": "^6.9.5",

--- a/code/lib/preview-api/package.json
+++ b/code/lib/preview-api/package.json
@@ -71,7 +71,7 @@
     "@storybook/channels": "workspace:*",
     "@storybook/client-logger": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/global": "^5.0.0",
     "@storybook/types": "workspace:*",
     "@types/qs": "^6.9.5",

--- a/code/lib/preview-api/src/modules/client-api/ClientApi.ts
+++ b/code/lib/preview-api/src/modules/client-api/ClientApi.ts
@@ -168,9 +168,11 @@ export class ClientApi<TRenderer extends Renderer> {
     }
   };
 
-  addStepRunner = (stepRunner: StepRunner) => {
+  addStepRunner = (stepRunner: StepRunner<TRenderer>) => {
     this.facade.projectAnnotations.runStep = composeStepRunners(
-      [this.facade.projectAnnotations.runStep, stepRunner].filter(Boolean) as StepRunner[]
+      [this.facade.projectAnnotations.runStep, stepRunner].filter(
+        Boolean
+      ) as StepRunner<TRenderer>[]
     );
   };
 
@@ -297,7 +299,7 @@ export class ClientApi<TRenderer extends Renderer> {
     this._addedExports[fileName] = { default: meta };
 
     let counter = 0;
-    api.add = (storyName: string, storyFn: StoryFn<TRenderer>, parameters: Parameters = {}) => {
+    api.add = (storyName: string, storyFn: StoryFn, parameters: Parameters = {}) => {
       hasAdded = true;
 
       if (typeof storyName !== 'string') {

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
@@ -34,7 +34,7 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
   constructor(
     public channel: Channel,
     protected store: StoryStore<TRenderer>,
-    public renderStoryToElement: DocsContextProps['renderStoryToElement'],
+    public renderStoryToElement: DocsContextProps<TRenderer>['renderStoryToElement'],
     /** The CSF files known (via the index) to be refererenced by this docs file */
     csfFiles: CSFFile<TRenderer>[]
   ) {

--- a/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts
@@ -95,7 +95,7 @@ export class CsfDocsRender<TRenderer extends Renderer> implements Render<TRender
     );
   }
 
-  docsContext(renderStoryToElement: DocsContextProps['renderStoryToElement']) {
+  docsContext(renderStoryToElement: DocsContextProps<TRenderer>['renderStoryToElement']) {
     if (!this.csfFiles) throw new Error('Cannot render docs before preparing');
     const docsContext = new DocsContext<TRenderer>(
       this.channel,
@@ -112,7 +112,7 @@ export class CsfDocsRender<TRenderer extends Renderer> implements Render<TRender
 
   async renderToElement(
     canvasElement: TRenderer['canvasElement'],
-    renderStoryToElement: DocsContextProps['renderStoryToElement']
+    renderStoryToElement: DocsContextProps<TRenderer>['renderStoryToElement']
   ) {
     if (!this.story || !this.csfFiles) throw new Error('Cannot render docs before preparing');
 

--- a/code/lib/preview-api/src/modules/preview-web/render/MdxDocsRender.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/MdxDocsRender.ts
@@ -79,7 +79,7 @@ export class MdxDocsRender<TRenderer extends Renderer> implements Render<TRender
     );
   }
 
-  docsContext(renderStoryToElement: DocsContextProps['renderStoryToElement']) {
+  docsContext(renderStoryToElement: DocsContextProps<TRenderer>['renderStoryToElement']) {
     if (!this.csfFiles) throw new Error('Cannot render docs before preparing');
 
     // NOTE we do *not* attach any CSF file yet. We wait for `referenceMeta(..., true)`
@@ -94,7 +94,7 @@ export class MdxDocsRender<TRenderer extends Renderer> implements Render<TRender
 
   async renderToElement(
     canvasElement: TRenderer['canvasElement'],
-    renderStoryToElement: DocsContextProps['renderStoryToElement']
+    renderStoryToElement: DocsContextProps<TRenderer>['renderStoryToElement']
   ) {
     if (!this.exports || !this.csfFiles || !this.store.projectAnnotations)
       throw new Error('Cannot render docs before preparing');

--- a/code/lib/preview-api/src/modules/store/csf/normalizeArrays.ts
+++ b/code/lib/preview-api/src/modules/store/csf/normalizeArrays.ts
@@ -1,4 +1,4 @@
 export const normalizeArrays = <T>(array: T[] | T | undefined): T[] => {
   if (Array.isArray(array)) return array;
-  return typeof array === 'function' ? [array] : [];
+  return array ? [array] : [];
 };

--- a/code/lib/preview-api/src/modules/store/csf/normalizeArrays.ts
+++ b/code/lib/preview-api/src/modules/store/csf/normalizeArrays.ts
@@ -1,0 +1,4 @@
+export const normalizeArrays = <T>(array: T[] | T | undefined): T[] => {
+  if (Array.isArray(array)) return array;
+  return typeof array === 'function' ? [array] : [];
+};

--- a/code/lib/preview-api/src/modules/store/csf/normalizeProjectAnnotations.ts
+++ b/code/lib/preview-api/src/modules/store/csf/normalizeProjectAnnotations.ts
@@ -8,16 +8,21 @@ import type {
 import { inferArgTypes } from '../inferArgTypes';
 import { inferControls } from '../inferControls';
 import { normalizeInputTypes } from './normalizeInputTypes';
+import { normalizeArrays } from './normalizeArrays';
 
 export function normalizeProjectAnnotations<TRenderer extends Renderer>({
   argTypes,
   globalTypes,
   argTypesEnhancers,
+  decorators,
+  loaders,
   ...annotations
 }: ProjectAnnotations<TRenderer>): NormalizedProjectAnnotations<TRenderer> {
   return {
     ...(argTypes && { argTypes: normalizeInputTypes(argTypes as ArgTypes) }),
     ...(globalTypes && { globalTypes: normalizeInputTypes(globalTypes) }),
+    decorators: normalizeArrays(decorators),
+    loaders: normalizeArrays(loaders),
     argTypesEnhancers: [
       ...(argTypesEnhancers || []),
       inferArgTypes,

--- a/code/lib/preview-api/src/modules/store/csf/normalizeStory.ts
+++ b/code/lib/preview-api/src/modules/store/csf/normalizeStory.ts
@@ -13,6 +13,7 @@ import { dedent } from 'ts-dedent';
 import { logger } from '@storybook/client-logger';
 import deprecate from 'util-deprecate';
 import { normalizeInputTypes } from './normalizeInputTypes';
+import { normalizeArrays } from './normalizeArrays';
 
 const deprecatedStoryAnnotation = dedent`
 CSF .story annotations deprecated; annotate story functions directly:
@@ -44,11 +45,15 @@ export function normalizeStory<TRenderer extends Renderer>(
     storyObject.storyName ||
     story?.name ||
     exportName;
-  const decorators = [...(storyObject.decorators || []), ...(story?.decorators || [])];
+
+  const decorators = [
+    ...normalizeArrays(storyObject.decorators),
+    ...normalizeArrays(story?.decorators),
+  ];
   const parameters = { ...story?.parameters, ...storyObject.parameters };
   const args = { ...story?.args, ...storyObject.args };
   const argTypes = { ...(story?.argTypes as ArgTypes), ...(storyObject.argTypes as ArgTypes) };
-  const loaders = [...(storyObject.loaders || []), ...(story?.loaders || [])];
+  const loaders = [...normalizeArrays(storyObject.loaders), ...normalizeArrays(story?.loaders)];
   const { render, play, tags = [] } = storyObject;
 
   // eslint-disable-next-line no-underscore-dangle

--- a/code/lib/preview-api/src/modules/store/csf/prepareStory.test.ts
+++ b/code/lib/preview-api/src/modules/store/csf/prepareStory.test.ts
@@ -343,9 +343,9 @@ describe('prepareStory', () => {
       );
 
       const storyContext = { context: 'value' } as any;
-      const loadedContext = await applyLoaders(storyContext);
+      const loadedContext = await applyLoaders({ ...storyContext });
 
-      expect(loader).toHaveBeenCalledWith(storyContext);
+      expect(loader).toHaveBeenCalledWith({ ...storyContext, loaded: {} });
       expect(loadedContext).toEqual({
         context: 'value',
         loaded: { foo: 7 },

--- a/code/lib/preview-api/src/modules/store/csf/prepareStory.test.ts
+++ b/code/lib/preview-api/src/modules/store/csf/prepareStory.test.ts
@@ -345,7 +345,7 @@ describe('prepareStory', () => {
       const storyContext = { context: 'value' } as any;
       const loadedContext = await applyLoaders(storyContext);
 
-      expect(loader).toHaveBeenCalledWith(storyContext);
+      expect(loader).toHaveBeenCalledWith({ ...storyContext, loaded: {} });
       expect(loadedContext).toEqual({
         context: 'value',
         loaded: { foo: 7 },

--- a/code/lib/preview-api/src/modules/store/csf/prepareStory.ts
+++ b/code/lib/preview-api/src/modules/store/csf/prepareStory.ts
@@ -1,24 +1,25 @@
+/* eslint-disable no-restricted-syntax,no-await-in-loop,@typescript-eslint/no-loop-func */
 import { global } from '@storybook/global';
 
 import type {
-  Renderer,
   Args,
   ArgsStoryFn,
   LegacyStoryFn,
-  Parameters,
-  PlayFunction,
-  PlayFunctionContext,
-  StepLabel,
+  ModuleExport,
   NormalizedComponentAnnotations,
   NormalizedProjectAnnotations,
   NormalizedStoryAnnotations,
+  Parameters,
+  PlayFunction,
+  PlayFunctionContext,
+  PreparedMeta,
   PreparedStory,
+  Renderer,
+  StepLabel,
   StoryContext,
   StoryContextForEnhancers,
   StoryContextForLoaders,
   StrictArgTypes,
-  PreparedMeta,
-  ModuleExport,
 } from '@storybook/types';
 import { includeConditionalArg } from '@storybook/csf';
 
@@ -26,6 +27,7 @@ import { applyHooks } from '../../addons';
 import { combineParameters } from '../parameters';
 import { defaultDecorateStory } from '../decorators';
 import { groupArgsByTarget, UNTARGETED } from '../args';
+import { normalizeArrays } from './normalizeArrays';
 
 // Combine all the metadata about a story (both direct and inherited from the component/global scope)
 // into a "renderable" story function, with all decorators applied, parameters passed as context etc
@@ -48,15 +50,23 @@ export function prepareStory<TRenderer extends Renderer>(
     projectAnnotations
   );
 
-  const loaders = [
-    ...(projectAnnotations.loaders || []),
-    ...(componentAnnotations.loaders || []),
-    ...(storyAnnotations?.loaders || []),
-  ];
-  const applyLoaders = async (context: StoryContextForLoaders<TRenderer>) => {
-    const loadResults = await Promise.all(loaders.map((loader) => loader(context)));
-    const loaded = Object.assign({}, ...loadResults);
-    return { ...context, loaded };
+  const applyLoaders = async (
+    context: StoryContextForLoaders<TRenderer>
+  ): Promise<StoryContextForLoaders<TRenderer> & { loaded: StoryContext<TRenderer>['loaded'] }> => {
+    let updatedContext = { ...context, loaded: {} };
+    for (const loaders of [
+      ...('testPackageLoaders' in global && Array.isArray(global.testPackageLoaders)
+        ? [global.testPackageLoaders]
+        : []),
+      normalizeArrays(projectAnnotations.loaders),
+      normalizeArrays(componentAnnotations.loaders),
+      normalizeArrays(storyAnnotations.loaders),
+    ]) {
+      const loadResults = await Promise.all(loaders.map((loader) => loader(updatedContext)));
+      const loaded: Record<string, any> = Object.assign({}, ...loadResults);
+      updatedContext = { ...updatedContext, loaded: { ...updatedContext.loaded, ...loaded } };
+    }
+    return updatedContext;
   };
 
   const undecoratedStoryFn: LegacyStoryFn<TRenderer> = (context: StoryContext<TRenderer>) => {
@@ -70,9 +80,9 @@ export function prepareStory<TRenderer extends Renderer>(
   const { applyDecorators = defaultDecorateStory, runStep } = projectAnnotations;
 
   const decorators = [
-    ...(storyAnnotations?.decorators || []),
-    ...(componentAnnotations.decorators || []),
-    ...(projectAnnotations.decorators || []),
+    ...normalizeArrays(storyAnnotations?.decorators),
+    ...normalizeArrays(componentAnnotations?.decorators),
+    ...normalizeArrays(projectAnnotations?.decorators),
   ];
 
   // The render function on annotations *has* to be an `ArgsStoryFn`, so when we normalize
@@ -115,7 +125,6 @@ export function prepareStory<TRenderer extends Renderer>(
     playFunction,
   };
 }
-
 export function prepareMeta<TRenderer extends Renderer>(
   componentAnnotations: NormalizedComponentAnnotations<TRenderer>,
   projectAnnotations: NormalizedProjectAnnotations<TRenderer>,

--- a/code/lib/preview-api/src/modules/store/csf/prepareStory.ts
+++ b/code/lib/preview-api/src/modules/store/csf/prepareStory.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-syntax,no-await-in-loop,@typescript-eslint/no-loop-func */
+/* eslint-disable no-restricted-syntax,no-await-in-loop,@typescript-eslint/no-loop-func,no-underscore-dangle */
 import { global } from '@storybook/global';
 
 import type {
@@ -55,8 +55,8 @@ export function prepareStory<TRenderer extends Renderer>(
   ): Promise<StoryContextForLoaders<TRenderer> & { loaded: StoryContext<TRenderer>['loaded'] }> => {
     let updatedContext = { ...context, loaded: {} };
     for (const loaders of [
-      ...('testPackageLoaders' in global && Array.isArray(global.testPackageLoaders)
-        ? [global.testPackageLoaders]
+      ...('__STORYBOOK_TEST_LOADERS__' in global && Array.isArray(global.__STORYBOOK_TEST_LOADERS__)
+        ? [global.__STORYBOOK_TEST_LOADERS__]
         : []),
       normalizeArrays(projectAnnotations.loaders),
       normalizeArrays(componentAnnotations.loaders),
@@ -173,7 +173,6 @@ function preparePartialAnnotations<TRenderer extends Renderer>(
 
     const { passArgsFirst = true } = parameters;
 
-    // eslint-disable-next-line no-underscore-dangle
     parameters.__isArgsStory = passArgsFirst && render && render.length > 0;
   }
 

--- a/code/lib/preview-api/src/modules/store/csf/testing-utils/index.ts
+++ b/code/lib/preview-api/src/modules/store/csf/testing-utils/index.ts
@@ -82,7 +82,7 @@ export function composeStory<TRenderer extends Renderer = Renderer, TArgs extend
         args: { ...story.initialArgs, ...extraArgs },
       };
 
-      return story.unboundStoryFn(prepareContext(context as StoryContext));
+      return story.unboundStoryFn(prepareContext(context as StoryContext<TRenderer>));
     },
     {
       storyName,

--- a/code/lib/preview-api/src/modules/store/sortStories.ts
+++ b/code/lib/preview-api/src/modules/store/sortStories.ts
@@ -9,6 +9,7 @@ import type {
   Parameters,
   Path,
   PreparedStory,
+  Renderer,
 } from '@storybook/types';
 import { storySort } from './storySort';
 
@@ -58,8 +59,8 @@ const toIndexEntry = (story: any): StoryIndexEntry => {
   return { id, title, name, importPath: parameters.fileName, type };
 };
 
-export const sortStoriesV6 = (
-  stories: [string, PreparedStory, Parameters, Parameters][],
+export const sortStoriesV6 = <TRenderer extends Renderer>(
+  stories: [string, PreparedStory<TRenderer>, Parameters, Parameters][],
   storySortParameter: Addon_StorySortParameter,
   fileNameOrder: Path[]
 ) => {

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -45,7 +45,7 @@
     "prep": "node --loader ../../../scripts/node_modules/esbuild-register/loader.js -r ../../../scripts/node_modules/esbuild-register/register.js ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/types": "workspace:*",
     "estraverse": "^5.2.0",
     "lodash": "^4.17.21",

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -45,7 +45,7 @@
     "prep": "node --loader ../../../scripts/node_modules/esbuild-register/loader.js -r ../../../scripts/node_modules/esbuild-register/register.js ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/types": "workspace:*",
     "estraverse": "^5.2.0",
     "lodash": "^4.17.21",

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -45,7 +45,7 @@
     "prep": "node --loader ../../../scripts/node_modules/esbuild-register/loader.js -r ../../../scripts/node_modules/esbuild-register/register.js ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/types": "workspace:*",
     "estraverse": "^5.2.0",
     "lodash": "^4.17.21",

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -19,7 +19,7 @@
     "url": "https://opencollective.com/storybook"
   },
   "license": "MIT",
-  "sideEffects": false,
+  "sideEffects": true,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/code/lib/test/src/index.ts
+++ b/code/lib/test/src/index.ts
@@ -1,18 +1,11 @@
 import { instrument } from '@storybook/instrumenter';
-import * as spy from '@vitest/spy';
+import { type LoaderFunction } from '@storybook/csf';
 import chai from 'chai';
-import { FORCE_REMOUNT, STORY_RENDER_PHASE_CHANGED } from '@storybook/core-events';
-import { addons } from '@storybook/preview-api';
+import { global } from '@storybook/global';
 import { expect as rawExpect } from './expect';
+import { clearAllMocks, resetAllMocks, restoreAllMocks } from './spy';
 
-export * from '@vitest/spy';
-
-const channel = addons.getChannel();
-
-channel.on(FORCE_REMOUNT, () => spy.spies.forEach((mock) => mock.mockClear()));
-channel.on(STORY_RENDER_PHASE_CHANGED, ({ newPhase }) => {
-  if (newPhase === 'loading') spy.spies.forEach((mock) => mock.mockClear());
-});
+export * from './spy';
 
 export const { expect } = instrument(
   { expect: rawExpect },
@@ -32,3 +25,16 @@ export const { expect } = instrument(
 );
 
 export * from './testing-library';
+
+const resetAllMocksLoader: LoaderFunction = ({ parameters }) => {
+  if (parameters?.test?.mockReset === true) {
+    resetAllMocks();
+  } else if (parameters?.test?.clearMocks === true) {
+    clearAllMocks();
+  } else if (parameters?.test?.restoreMocks !== false) {
+    restoreAllMocks();
+  }
+};
+
+// @ts-expect-error Wwe are using this as a default loader, if the test package is used. But we don't want to get into optional peer dep shenanigans.
+global.testPackageLoaders = [resetAllMocksLoader];

--- a/code/lib/test/src/index.ts
+++ b/code/lib/test/src/index.ts
@@ -36,5 +36,6 @@ const resetAllMocksLoader: LoaderFunction = ({ parameters }) => {
   }
 };
 
-// @ts-expect-error Wwe are using this as a default loader, if the test package is used. But we don't want to get into optional peer dep shenanigans.
-global.testPackageLoaders = [resetAllMocksLoader];
+// @ts-expect-error We are using this as a default Storybook loader, when the test package is used. This avoids the need for optional peer dependency workarounds.
+// eslint-disable-next-line no-underscore-dangle
+global.__STORYBOOK_TEST_LOADERS__ = [resetAllMocksLoader];

--- a/code/lib/test/src/spy.ts
+++ b/code/lib/test/src/spy.ts
@@ -1,0 +1,66 @@
+import {
+  spyOn,
+  isMockFunction,
+  fn,
+  spies as mocks,
+  type MaybeMocked,
+  type MaybeMockedDeep,
+  type MaybePartiallyMocked,
+  type MaybePartiallyMockedDeep,
+} from '@vitest/spy';
+
+export type * from '@vitest/spy';
+
+export { spyOn, isMockFunction, fn, mocks };
+
+/**
+ * Calls [`.mockClear()`](https://vitest.dev/api/mock#mockclear) on every mocked function. This will only empty `.mock` state, it will not reset implementation.
+ *
+ * It is useful if you need to clean up mock between different assertions.
+ */
+export function clearAllMocks() {
+  mocks.forEach((spy) => spy.mockClear());
+}
+
+/**
+ * Calls [`.mockReset()`](https://vitest.dev/api/mock#mockreset) on every mocked function. This will empty `.mock` state, reset "once" implementations and force the base implementation to return `undefined` when invoked.
+ *
+ * This is useful when you want to completely reset a mock to the default state.
+ */
+export function resetAllMocks() {
+  mocks.forEach((spy) => spy.mockReset());
+}
+
+/**
+ * Calls [`.mockRestore()`](https://vitest.dev/api/mock#mockrestore) on every mocked function. This will restore all original implementations.
+ */
+export function restoreAllMocks() {
+  mocks.forEach((spy) => spy.mockRestore());
+}
+
+/**
+ * Type helper for TypeScript. Just returns the object that was passed.
+ *
+ * When `partial` is `true` it will expect a `Partial<T>` as a return value. By default, this will only make TypeScript believe that
+ * the first level values are mocked. You can pass down `{ deep: true }` as a second argument to tell TypeScript that the whole object is mocked, if it actually is.
+ *
+ * @param item Anything that can be mocked
+ * @param deep If the object is deeply mocked
+ * @param options If the object is partially or deeply mocked
+ */
+export function mocked<T>(item: T, deep?: false): MaybeMocked<T>;
+export function mocked<T>(item: T, deep: true): MaybeMockedDeep<T>;
+export function mocked<T>(item: T, options: { partial?: false; deep?: false }): MaybeMocked<T>;
+export function mocked<T>(item: T, options: { partial?: false; deep: true }): MaybeMockedDeep<T>;
+export function mocked<T>(
+  item: T,
+  options: { partial: true; deep?: false }
+): MaybePartiallyMocked<T>;
+export function mocked<T>(
+  item: T,
+  options: { partial: true; deep: true }
+): MaybePartiallyMockedDeep<T>;
+export function mocked<T>(item: T): MaybeMocked<T>;
+export function mocked<T>(item: T, _options = {}): MaybeMocked<T> {
+  return item as any;
+}

--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -50,7 +50,7 @@
     "file-system-cache": "2.3.0"
   },
   "devDependencies": {
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^18.0.0",
     "typescript": "~4.9.3"

--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -50,7 +50,7 @@
     "file-system-cache": "2.3.0"
   },
   "devDependencies": {
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^18.0.0",
     "typescript": "~4.9.3"

--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -50,7 +50,7 @@
     "file-system-cache": "2.3.0"
   },
   "devDependencies": {
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^18.0.0",
     "typescript": "~4.9.3"

--- a/code/lib/types/src/modules/story.ts
+++ b/code/lib/types/src/modules/story.ts
@@ -1,4 +1,9 @@
-import type { Renderer, ProjectAnnotations as CsfProjectAnnotations } from '@storybook/csf';
+import type {
+  Renderer,
+  ProjectAnnotations as CsfProjectAnnotations,
+  DecoratorFunction,
+  LoaderFunction,
+} from '@storybook/csf';
 
 import type {
   ComponentAnnotations,
@@ -42,23 +47,31 @@ export type ProjectAnnotations<TRenderer extends Renderer> = CsfProjectAnnotatio
   renderToDOM?: RenderToCanvas<TRenderer>;
 };
 
-export type NormalizedProjectAnnotations<TRenderer extends Renderer = Renderer> =
-  ProjectAnnotations<TRenderer> & {
-    argTypes?: StrictArgTypes;
-    globalTypes?: StrictGlobalTypes;
-  };
+export type NormalizedProjectAnnotations<TRenderer extends Renderer = Renderer> = Omit<
+  ProjectAnnotations<TRenderer>,
+  'decorators' | 'loaders'
+> & {
+  argTypes?: StrictArgTypes;
+  globalTypes?: StrictGlobalTypes;
+  decorators?: DecoratorFunction<TRenderer>[];
+  loaders?: LoaderFunction<TRenderer>[];
+};
 
-export type NormalizedComponentAnnotations<TRenderer extends Renderer = Renderer> =
-  ComponentAnnotations<TRenderer> & {
-    // Useful to guarantee that id & title exists
-    id: ComponentId;
-    title: ComponentTitle;
-    argTypes?: StrictArgTypes;
-  };
+export type NormalizedComponentAnnotations<TRenderer extends Renderer = Renderer> = Omit<
+  ComponentAnnotations<TRenderer>,
+  'decorators' | 'loaders'
+> & {
+  // Useful to guarantee that id & title exists
+  id: ComponentId;
+  title: ComponentTitle;
+  argTypes?: StrictArgTypes;
+  decorators: DecoratorFunction<TRenderer>[];
+  loaders: LoaderFunction<TRenderer>[];
+};
 
 export type NormalizedStoryAnnotations<TRenderer extends Renderer = Renderer> = Omit<
   StoryAnnotations<TRenderer>,
-  'storyName' | 'story'
+  'storyName' | 'story' | 'decorators' | 'loaders'
 > & {
   moduleExport: ModuleExport;
   // You cannot actually set id on story annotations, but we normalize it to be there for convience
@@ -66,6 +79,8 @@ export type NormalizedStoryAnnotations<TRenderer extends Renderer = Renderer> = 
   argTypes?: StrictArgTypes;
   name: StoryName;
   userStoryFn?: StoryFn<TRenderer>;
+  decorators?: DecoratorFunction<TRenderer>[];
+  loaders?: LoaderFunction<TRenderer>[];
 };
 
 export type CSFFile<TRenderer extends Renderer = Renderer> = {

--- a/code/lib/types/src/modules/story.ts
+++ b/code/lib/types/src/modules/story.ts
@@ -65,8 +65,8 @@ export type NormalizedComponentAnnotations<TRenderer extends Renderer = Renderer
   id: ComponentId;
   title: ComponentTitle;
   argTypes?: StrictArgTypes;
-  decorators: DecoratorFunction<TRenderer>[];
-  loaders: LoaderFunction<TRenderer>[];
+  decorators?: DecoratorFunction<TRenderer>[];
+  loaders?: LoaderFunction<TRenderer>[];
 };
 
 export type NormalizedStoryAnnotations<TRenderer extends Renderer = Renderer> = Omit<

--- a/code/package.json
+++ b/code/package.json
@@ -140,7 +140,7 @@
     "@storybook/core-events": "workspace:*",
     "@storybook/core-server": "workspace:*",
     "@storybook/core-webpack": "workspace:*",
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/csf-plugin": "workspace:*",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/docs-tools": "workspace:*",

--- a/code/package.json
+++ b/code/package.json
@@ -140,7 +140,7 @@
     "@storybook/core-events": "workspace:*",
     "@storybook/core-server": "workspace:*",
     "@storybook/core-webpack": "workspace:*",
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/csf-plugin": "workspace:*",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/docs-tools": "workspace:*",

--- a/code/package.json
+++ b/code/package.json
@@ -140,7 +140,7 @@
     "@storybook/core-events": "workspace:*",
     "@storybook/core-server": "workspace:*",
     "@storybook/core-webpack": "workspace:*",
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/csf-plugin": "workspace:*",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/docs-tools": "workspace:*",

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@storybook/core-client": "workspace:*",
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/global": "^5.0.0",
     "@storybook/preview-api": "workspace:*",

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@storybook/core-client": "workspace:*",
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/global": "^5.0.0",
     "@storybook/preview-api": "workspace:*",

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@storybook/core-client": "workspace:*",
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/csf-tools": "workspace:*",
     "@storybook/global": "^5.0.0",
     "@storybook/preview-api": "workspace:*",

--- a/code/ui/blocks/package.json
+++ b/code/ui/blocks/package.json
@@ -48,7 +48,7 @@
     "@storybook/client-logger": "workspace:*",
     "@storybook/components": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/docs-tools": "workspace:*",
     "@storybook/global": "^5.0.0",
     "@storybook/manager-api": "workspace:*",

--- a/code/ui/blocks/package.json
+++ b/code/ui/blocks/package.json
@@ -48,7 +48,7 @@
     "@storybook/client-logger": "workspace:*",
     "@storybook/components": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/docs-tools": "workspace:*",
     "@storybook/global": "^5.0.0",
     "@storybook/manager-api": "workspace:*",

--- a/code/ui/blocks/package.json
+++ b/code/ui/blocks/package.json
@@ -48,7 +48,7 @@
     "@storybook/client-logger": "workspace:*",
     "@storybook/components": "workspace:*",
     "@storybook/core-events": "workspace:*",
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/docs-tools": "workspace:*",
     "@storybook/global": "^5.0.0",
     "@storybook/manager-api": "workspace:*",

--- a/code/ui/components/package.json
+++ b/code/ui/components/package.json
@@ -62,7 +62,7 @@
     "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-toolbar": "^1.0.4",
     "@storybook/client-logger": "workspace:*",
-    "@storybook/csf": "^0.1.0",
+    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
     "@storybook/global": "^5.0.0",
     "@storybook/theming": "workspace:*",
     "@storybook/types": "workspace:*",

--- a/code/ui/components/package.json
+++ b/code/ui/components/package.json
@@ -62,7 +62,7 @@
     "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-toolbar": "^1.0.4",
     "@storybook/client-logger": "workspace:*",
-    "@storybook/csf": "0.1.2-next.0",
+    "@storybook/csf": "^0.1.2",
     "@storybook/global": "^5.0.0",
     "@storybook/theming": "workspace:*",
     "@storybook/types": "workspace:*",

--- a/code/ui/components/package.json
+++ b/code/ui/components/package.json
@@ -62,7 +62,7 @@
     "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-toolbar": "^1.0.4",
     "@storybook/client-logger": "workspace:*",
-    "@storybook/csf": "0.1.2--canary.71.cad875c.0",
+    "@storybook/csf": "0.1.2-next.0",
     "@storybook/global": "^5.0.0",
     "@storybook/theming": "workspace:*",
     "@storybook/types": "workspace:*",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5655,7 +5655,7 @@ __metadata:
   dependencies:
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/manager-api": "workspace:*"
     "@storybook/preview-api": "workspace:*"
@@ -5724,7 +5724,7 @@ __metadata:
   resolution: "@storybook/addon-storyshots-puppeteer@workspace:addons/storyshots-puppeteer"
   dependencies:
     "@axe-core/puppeteer": "npm:^4.2.0"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/node-logger": "workspace:*"
     "@storybook/types": "workspace:*"
     "@types/jest-image-snapshot": "npm:^6.0.0"
@@ -6033,7 +6033,7 @@ __metadata:
     "@storybook/client-logger": "workspace:*"
     "@storybook/components": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/docs-tools": "workspace:*"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/manager-api": "workspace:*"
@@ -6306,7 +6306,7 @@ __metadata:
     "@babel/core": "npm:^7.23.2"
     "@babel/preset-env": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/node-logger": "workspace:*"
     "@storybook/types": "workspace:*"
@@ -6344,7 +6344,7 @@ __metadata:
     "@radix-ui/react-select": "npm:^1.2.2"
     "@radix-ui/react-toolbar": "npm:^1.0.4"
     "@storybook/client-logger": "workspace:*"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.1.6"
     "@storybook/theming": "workspace:*"
@@ -6434,7 +6434,7 @@ __metadata:
     "@storybook/channels": "workspace:*"
     "@storybook/core-common": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/docs-mdx": "npm:^0.1.0"
     "@storybook/global": "npm:^5.0.0"
@@ -6515,7 +6515,7 @@ __metadata:
     "@babel/parser": "npm:^7.23.0"
     "@babel/traverse": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/types": "workspace:*"
     "@types/fs-extra": "npm:^11.0.1"
     "@types/js-yaml": "npm:^4.0.5"
@@ -6527,21 +6527,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@storybook/csf@npm:0.1.2--canary.71.cad875c.0":
+  version: 0.1.2--canary.71.cad875c.0
+  resolution: "@storybook/csf@npm:0.1.2--canary.71.cad875c.0"
+  dependencies:
+    type-fest: "npm:^2.19.0"
+  checksum: 6a26cbcc41a5a73374fff6329b47479dacf1af46112c4d1e11bce2e3f6e9992c61765dcd99cf0de18a209d4a21a824c2162cec0758f83d0a977b0cd90c5191eb
+  languageName: node
+  linkType: hard
+
 "@storybook/csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/csf@npm:0.0.1"
   dependencies:
     lodash: "npm:^4.17.15"
   checksum: 7b0f75763415f9147692a460b44417ee56ea9639433716a1fd4d1df4c8b0221cbc71b8da0fbed4dcecb3ccd6c7ed64be39f5c255c713539a6088a1d6488aaa24
-  languageName: node
-  linkType: hard
-
-"@storybook/csf@npm:^0.1.0":
-  version: 0.1.1
-  resolution: "@storybook/csf@npm:0.1.1"
-  dependencies:
-    type-fest: "npm:^2.19.0"
-  checksum: 999bb87fbbe047a559bbaa5baf2ed84872fcd5cdcae3c1169f8e4c641eefe8759d09a09034a78ed114032c0e5cf6301b7fa89e5e3ce60d75cf0bd5e33ec0a6e7
   languageName: node
   linkType: hard
 
@@ -6765,7 +6765,7 @@ __metadata:
     "@storybook/channels": "workspace:*"
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/router": "workspace:*"
     "@storybook/theming": "workspace:*"
@@ -7174,7 +7174,7 @@ __metadata:
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-common": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/types": "workspace:*"
     "@types/qs": "npm:^6.9.5"
@@ -7383,7 +7383,7 @@ __metadata:
     "@storybook/core-events": "workspace:*"
     "@storybook/core-server": "workspace:*"
     "@storybook/core-webpack": "workspace:*"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/csf-plugin": "workspace:*"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/docs-tools": "workspace:*"
@@ -7556,7 +7556,7 @@ __metadata:
   resolution: "@storybook/server@workspace:renderers/server"
   dependencies:
     "@storybook/core-client": "workspace:*"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/preview-api": "workspace:*"
@@ -7573,7 +7573,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@workspace:lib/source-loader"
   dependencies:
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@storybook/types": "workspace:*"
     estraverse: "npm:^5.2.0"
     jest-specific-snapshot: "npm:^8.0.0"
@@ -7767,7 +7767,7 @@ __metadata:
   resolution: "@storybook/types@workspace:lib/types"
   dependencies:
     "@storybook/channels": "workspace:*"
-    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
     "@types/babel__core": "npm:^7.0.0"
     "@types/express": "npm:^4.7.0"
     "@types/fs-extra": "npm:^11.0.1"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5655,7 +5655,7 @@ __metadata:
   dependencies:
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/manager-api": "workspace:*"
     "@storybook/preview-api": "workspace:*"
@@ -5724,7 +5724,7 @@ __metadata:
   resolution: "@storybook/addon-storyshots-puppeteer@workspace:addons/storyshots-puppeteer"
   dependencies:
     "@axe-core/puppeteer": "npm:^4.2.0"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/node-logger": "workspace:*"
     "@storybook/types": "workspace:*"
     "@types/jest-image-snapshot": "npm:^6.0.0"
@@ -6033,7 +6033,7 @@ __metadata:
     "@storybook/client-logger": "workspace:*"
     "@storybook/components": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/docs-tools": "workspace:*"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/manager-api": "workspace:*"
@@ -6306,7 +6306,7 @@ __metadata:
     "@babel/core": "npm:^7.23.2"
     "@babel/preset-env": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/node-logger": "workspace:*"
     "@storybook/types": "workspace:*"
@@ -6344,7 +6344,7 @@ __metadata:
     "@radix-ui/react-select": "npm:^1.2.2"
     "@radix-ui/react-toolbar": "npm:^1.0.4"
     "@storybook/client-logger": "workspace:*"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.1.6"
     "@storybook/theming": "workspace:*"
@@ -6434,7 +6434,7 @@ __metadata:
     "@storybook/channels": "workspace:*"
     "@storybook/core-common": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/docs-mdx": "npm:^0.1.0"
     "@storybook/global": "npm:^5.0.0"
@@ -6515,7 +6515,7 @@ __metadata:
     "@babel/parser": "npm:^7.23.0"
     "@babel/traverse": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/types": "workspace:*"
     "@types/fs-extra": "npm:^11.0.1"
     "@types/js-yaml": "npm:^4.0.5"
@@ -6527,12 +6527,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/csf@npm:0.1.2--canary.71.cad875c.0":
-  version: 0.1.2--canary.71.cad875c.0
-  resolution: "@storybook/csf@npm:0.1.2--canary.71.cad875c.0"
+"@storybook/csf@npm:0.1.2-next.0":
+  version: 0.1.2-next.0
+  resolution: "@storybook/csf@npm:0.1.2-next.0"
   dependencies:
     type-fest: "npm:^2.19.0"
-  checksum: 6a26cbcc41a5a73374fff6329b47479dacf1af46112c4d1e11bce2e3f6e9992c61765dcd99cf0de18a209d4a21a824c2162cec0758f83d0a977b0cd90c5191eb
+  checksum: 9f9fd8ef2b15d06252d3d6e0abad642093ab09ded51391d426d0671ed8b9584acbd464ed8ba5c68a94a245f005af117afe74e20af0dd475b9f704b9a5c806648
   languageName: node
   linkType: hard
 
@@ -6765,7 +6765,7 @@ __metadata:
     "@storybook/channels": "workspace:*"
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/router": "workspace:*"
     "@storybook/theming": "workspace:*"
@@ -7174,7 +7174,7 @@ __metadata:
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-common": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/types": "workspace:*"
     "@types/qs": "npm:^6.9.5"
@@ -7383,7 +7383,7 @@ __metadata:
     "@storybook/core-events": "workspace:*"
     "@storybook/core-server": "workspace:*"
     "@storybook/core-webpack": "workspace:*"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/csf-plugin": "workspace:*"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/docs-tools": "workspace:*"
@@ -7556,7 +7556,7 @@ __metadata:
   resolution: "@storybook/server@workspace:renderers/server"
   dependencies:
     "@storybook/core-client": "workspace:*"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/preview-api": "workspace:*"
@@ -7573,7 +7573,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@workspace:lib/source-loader"
   dependencies:
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@storybook/types": "workspace:*"
     estraverse: "npm:^5.2.0"
     jest-specific-snapshot: "npm:^8.0.0"
@@ -7767,7 +7767,7 @@ __metadata:
   resolution: "@storybook/types@workspace:lib/types"
   dependencies:
     "@storybook/channels": "workspace:*"
-    "@storybook/csf": "npm:0.1.2--canary.71.cad875c.0"
+    "@storybook/csf": "npm:0.1.2-next.0"
     "@types/babel__core": "npm:^7.0.0"
     "@types/express": "npm:^4.7.0"
     "@types/fs-extra": "npm:^11.0.1"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5655,7 +5655,7 @@ __metadata:
   dependencies:
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/manager-api": "workspace:*"
     "@storybook/preview-api": "workspace:*"
@@ -5724,7 +5724,7 @@ __metadata:
   resolution: "@storybook/addon-storyshots-puppeteer@workspace:addons/storyshots-puppeteer"
   dependencies:
     "@axe-core/puppeteer": "npm:^4.2.0"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/node-logger": "workspace:*"
     "@storybook/types": "workspace:*"
     "@types/jest-image-snapshot": "npm:^6.0.0"
@@ -6033,7 +6033,7 @@ __metadata:
     "@storybook/client-logger": "workspace:*"
     "@storybook/components": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/docs-tools": "workspace:*"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/manager-api": "workspace:*"
@@ -6306,7 +6306,7 @@ __metadata:
     "@babel/core": "npm:^7.23.2"
     "@babel/preset-env": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/node-logger": "workspace:*"
     "@storybook/types": "workspace:*"
@@ -6344,7 +6344,7 @@ __metadata:
     "@radix-ui/react-select": "npm:^1.2.2"
     "@radix-ui/react-toolbar": "npm:^1.0.4"
     "@storybook/client-logger": "workspace:*"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.1.6"
     "@storybook/theming": "workspace:*"
@@ -6434,7 +6434,7 @@ __metadata:
     "@storybook/channels": "workspace:*"
     "@storybook/core-common": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/docs-mdx": "npm:^0.1.0"
     "@storybook/global": "npm:^5.0.0"
@@ -6515,7 +6515,7 @@ __metadata:
     "@babel/parser": "npm:^7.23.0"
     "@babel/traverse": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/types": "workspace:*"
     "@types/fs-extra": "npm:^11.0.1"
     "@types/js-yaml": "npm:^4.0.5"
@@ -6527,21 +6527,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/csf@npm:0.1.2-next.0":
-  version: 0.1.2-next.0
-  resolution: "@storybook/csf@npm:0.1.2-next.0"
-  dependencies:
-    type-fest: "npm:^2.19.0"
-  checksum: 9f9fd8ef2b15d06252d3d6e0abad642093ab09ded51391d426d0671ed8b9584acbd464ed8ba5c68a94a245f005af117afe74e20af0dd475b9f704b9a5c806648
-  languageName: node
-  linkType: hard
-
 "@storybook/csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/csf@npm:0.0.1"
   dependencies:
     lodash: "npm:^4.17.15"
   checksum: 7b0f75763415f9147692a460b44417ee56ea9639433716a1fd4d1df4c8b0221cbc71b8da0fbed4dcecb3ccd6c7ed64be39f5c255c713539a6088a1d6488aaa24
+  languageName: node
+  linkType: hard
+
+"@storybook/csf@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@storybook/csf@npm:0.1.2"
+  dependencies:
+    type-fest: "npm:^2.19.0"
+  checksum: b51a55292e5d2af8b1d135a28ecaa94f8860ddfedcb393adfa2cca1ee23853156066f737d8be1cb5412f572781aa525dc0b2f6e4a6f6ce805489f0149efe837c
   languageName: node
   linkType: hard
 
@@ -6765,7 +6765,7 @@ __metadata:
     "@storybook/channels": "workspace:*"
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/router": "workspace:*"
     "@storybook/theming": "workspace:*"
@@ -7174,7 +7174,7 @@ __metadata:
     "@storybook/client-logger": "workspace:*"
     "@storybook/core-common": "workspace:*"
     "@storybook/core-events": "workspace:*"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/types": "workspace:*"
     "@types/qs": "npm:^6.9.5"
@@ -7383,7 +7383,7 @@ __metadata:
     "@storybook/core-events": "workspace:*"
     "@storybook/core-server": "workspace:*"
     "@storybook/core-webpack": "workspace:*"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/csf-plugin": "workspace:*"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/docs-tools": "workspace:*"
@@ -7556,7 +7556,7 @@ __metadata:
   resolution: "@storybook/server@workspace:renderers/server"
   dependencies:
     "@storybook/core-client": "workspace:*"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/csf-tools": "workspace:*"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/preview-api": "workspace:*"
@@ -7573,7 +7573,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@workspace:lib/source-loader"
   dependencies:
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@storybook/types": "workspace:*"
     estraverse: "npm:^5.2.0"
     jest-specific-snapshot: "npm:^8.0.0"
@@ -7767,7 +7767,7 @@ __metadata:
   resolution: "@storybook/types@workspace:lib/types"
   dependencies:
     "@storybook/channels": "workspace:*"
-    "@storybook/csf": "npm:0.1.2-next.0"
+    "@storybook/csf": "npm:^0.1.2"
     "@types/babel__core": "npm:^7.0.0"
     "@types/express": "npm:^4.7.0"
     "@types/fs-extra": "npm:^11.0.1"


### PR DESCRIPTION
## What I did

Model loaders as before each and restore mocks properly

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

* Add console.log in preview, meta and story loaders. And check that they are run in that order, even if you gonna await something before it.
* Setup a spyOn in a play function, and see that the mock is reset when you are switching to a new story.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-24948-sha-12960c76`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24948-sha-12960c76). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-24948-sha-12960c76`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-24948-sha-12960c76) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/model-loaders-as-before-each`](https://github.com/storybookjs/storybook/tree/kasper/model-loaders-as-before-each) |
| **Commit** | [`12960c76`](https://github.com/storybookjs/storybook/commit/12960c76f2aaa56b01c1e9c3c13114e5c5b5542d) |
| **Datetime** | Wed Nov 22 16:24:00 UTC 2023 (`1700670240`) |
| **Workflow run** | [6960070947](https://github.com/storybookjs/storybook/actions/runs/6960070947) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=24948`_
</details>
<!-- CANARY_RELEASE_SECTION -->
