### PR TITLE
Next.js: Fix react-docgen usage with preset-env settings

### DIFF
--- a/code/presets/react-webpack/src/framework-preset-react-docs.test.ts
+++ b/code/presets/react-webpack/src/framework-preset-react-docs.test.ts
@@ -18,11 +18,23 @@ describe('framework-preset-react-docgen', () => {
 
       const config = await preset.webpackFinal?.(webpackConfig, {
         presets: {
-          apply: async () =>
-            ({
-              check: false,
-              reactDocgen: 'react-docgen',
-            } as Partial<TypescriptOptions>),
+          apply: async (name: string) => {
+            if (name === 'typescript') {
+              return {
+                check: false,
+                reactDocgen: 'react-docgen',
+              } as Partial<TypescriptOptions>;
+            }
+
+            if (name === 'babel') {
+              return {
+                plugins: [],
+                presets: [],
+              };
+            }
+
+            return undefined;
+          },
         },
         presetsList: presetsListWithDocs,
       } as any);
@@ -33,6 +45,7 @@ describe('framework-preset-react-docgen', () => {
             {
               exclude: /node_modules\/.*/,
               loader: '@storybook/preset-react-webpack/dist/loaders/react-docgen-loader',
+              options: { babelOptions: { plugins: [], presets: [] } },
               test: /\.(cjs|mjs|tsx?|jsx?)$/,
             },
           ],
@@ -50,11 +63,23 @@ describe('framework-preset-react-docgen', () => {
       const config = await preset.webpackFinal?.(webpackConfig, {
         presets: {
           // @ts-expect-error (not strict)
-          apply: async () =>
-            ({
-              check: false,
-              reactDocgen: 'react-docgen-typescript',
-            } as Partial<TypescriptOptions>),
+          apply: async (name: string) => {
+            if (name === 'typescript') {
+              return {
+                check: false,
+                reactDocgen: 'react-docgen-typescript',
+              } as Partial<TypescriptOptions>;
+            }
+
+            if (name === 'babel') {
+              return {
+                plugins: [],
+                presets: [],
+              };
+            }
+
+            return undefined;
+          },
         },
         presetsList: presetsListWithDocs,
       });
@@ -65,6 +90,7 @@ describe('framework-preset-react-docgen', () => {
             {
               exclude: /node_modules\/.*/,
               loader: '@storybook/preset-react-webpack/dist/loaders/react-docgen-loader',
+              options: { babelOptions: { plugins: [], presets: [] } },
               test: /\.(cjs|mjs|jsx?)$/,
             },
           ],

--- a/code/presets/react-webpack/src/framework-preset-react-docs.ts
+++ b/code/presets/react-webpack/src/framework-preset-react-docs.ts
@@ -22,6 +22,7 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (
   }
 
   if (reactDocgen !== 'react-docgen-typescript') {
+    const babelOptions = await options.presets.apply('babel', {});
     return {
       ...config,
       module: {
@@ -34,6 +35,9 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (
               require.resolve,
               '@storybook/preset-react-webpack/dist/loaders/react-docgen-loader'
             ),
+            options: {
+              babelOptions,
+            },
             exclude: /node_modules\/.*/,
           },
         ],
@@ -42,6 +46,8 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (
   }
 
   const { ReactDocgenTypeScriptPlugin } = await import('@storybook/react-docgen-typescript-plugin');
+
+  const babelOptions = await options.presets.apply('babel', {});
 
   return {
     ...config,
@@ -55,6 +61,9 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (
             require.resolve,
             '@storybook/preset-react-webpack/dist/loaders/react-docgen-loader'
           ),
+          options: {
+            babelOptions,
+          },
           exclude: /node_modules\/.*/,
         },
       ],

--- a/code/presets/react-webpack/src/loaders/react-docgen-loader.ts
+++ b/code/presets/react-webpack/src/loaders/react-docgen-loader.ts
@@ -58,6 +58,11 @@ const handlers = [...defaultHandlers, actualNameHandler];
 
 export default async function reactDocgenLoader(this: LoaderContext<any>, source: string) {
   const callback = this.async();
+  // get options
+  const options = this.getOptions() || {};
+  const { babelOptions = {} } = options;
+
+  const { plugins, presets } = babelOptions;
 
   try {
     const docgenResults = parse(source, {
@@ -65,6 +70,12 @@ export default async function reactDocgenLoader(this: LoaderContext<any>, source
       resolver: defaultResolver,
       handlers,
       importer: defaultImporter,
+      babelOptions: {
+        babelrc: false,
+        configFile: false,
+        plugins,
+        presets,
+      },
     }) as DocObj[];
 
     const magicString = new MagicString(source);


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Fixes react-docgen loader in Next.js environments, where the preset-env option is configured for `next/babel` and it matches opera_mobile.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
