### PR TITLE
Test: Downgrade @testing-library/user-event to 14.3.0

### DIFF
--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -49,7 +49,7 @@
     "@storybook/preview-api": "workspace:*",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^6.1.3",
-    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/user-event": "14.3.0",
     "@types/chai": "^4",
     "@vitest/expect": "^0.34.2",
     "@vitest/spy": "^0.34.1",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7697,7 +7697,7 @@ __metadata:
     "@storybook/preview-api": "workspace:*"
     "@testing-library/dom": "npm:^9.3.1"
     "@testing-library/jest-dom": "npm:^6.1.3"
-    "@testing-library/user-event": "npm:^14.4.3"
+    "@testing-library/user-event": "npm:14.3.0"
     "@types/chai": "npm:^4"
     "@vitest/expect": "npm:^0.34.2"
     "@vitest/spy": "npm:^0.34.1"
@@ -8368,6 +8368,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/user-event@npm:14.3.0":
+  version: 14.3.0
+  resolution: "@testing-library/user-event@npm:14.3.0"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 8a0e708709f2510287568dff668bc7d6f5c4e7e17407452b7aa0fcf74732dccf511c63fc76ac514d753cb1f0586c1def59ba7f5245a9523715d37a8f198745d3
+  languageName: node
+  linkType: hard
+
 "@testing-library/user-event@npm:^13.2.1":
   version: 13.5.0
   resolution: "@testing-library/user-event@npm:13.5.0"
@@ -8379,7 +8388,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:^14.4.0, @testing-library/user-event@npm:^14.4.3":
+"@testing-library/user-event@npm:^14.4.0":
   version: 14.5.1
   resolution: "@testing-library/user-event@npm:14.5.1"
   peerDependencies:


### PR DESCRIPTION
## What I did

Downgrade testing library to 14.3.0 to prevent firefox issues https://github.com/testing-library/user-event/issues/1075

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-25004-sha-c5268c93`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-25004-sha-c5268c93). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-25004-sha-c5268c93`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-25004-sha-c5268c93) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/downgrade-testing-lib`](https://github.com/storybookjs/storybook/tree/kasper/downgrade-testing-lib) |
| **Commit** | [`c5268c93`](https://github.com/storybookjs/storybook/commit/c5268c9382d8238503f46026a2dd5dece1c671fc) |
| **Datetime** | Tue Nov 28 11:29:09 UTC 2023 (`1701170949`) |
| **Workflow run** | [7018090961](https://github.com/storybookjs/storybook/actions/runs/7018090961) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=25004`_
</details>
<!-- CANARY_RELEASE_SECTION -->
