### PR TITLE
NextJS: Turn withStorybook into ergonomic module export

### DIFF
--- a/code/frameworks/nextjs-server/package.json
+++ b/code/frameworks/nextjs-server/package.json
@@ -122,7 +122,7 @@
       "./src/null-renderer.ts",
       "./src/preset.ts",
       "./src/mock.ts",
-      "./src/next-config.ts",
+      "./src/next-config.cts",
       "./src/pages/index.ts",
       "./src/reexports/channels.ts",
       "./src/reexports/core-events.ts",

--- a/code/frameworks/nextjs-server/src/next-config.cts
+++ b/code/frameworks/nextjs-server/src/next-config.cts
@@ -48,7 +48,7 @@ function addRewrites(
   };
 }
 
-export const withStorybook = ({
+const withStorybook = ({
   port = process.env.PORT ?? 3000,
   sbPort = 34567,
   managerPath = 'storybook',
@@ -132,3 +132,5 @@ export const withStorybook = ({
     ]),
   });
 };
+
+module.exports = withStorybook;

--- a/code/frameworks/nextjs-server/src/next-config.cts
+++ b/code/frameworks/nextjs-server/src/next-config.cts
@@ -50,31 +50,31 @@ function addRewrites(
 
 interface WithStorybookOptions {
   /**
-   * The port that the Next.js app will run on.
+   * Port that the Next.js app will run on.
    * @default 3000
    */
   port: string | number;
 
   /**
-   * The port that Storybook will run on.
+   * Internal port that Storybook will run on.
    * @default 34567
    */
   sbPort: string | number;
 
   /**
-   * The URL path to Storybook's manager UI.
+   * URL path to Storybook's "manager" UI.
    * @default 'storybook'
    */
   managerPath: string;
 
   /**
-   * The URL path to Storybook's story preview.
+   * URL path to Storybook's story preview iframe.
    * @default 'storybook-preview'
    */
   previewPath: string;
 
   /**
-   * The directory where Storybook's config files are located.
+   * Directory where Storybook's config files are located.
    * @default '.storybook'
    */
   configDir: string;

--- a/code/frameworks/nextjs-server/src/next-config.cts
+++ b/code/frameworks/nextjs-server/src/next-config.cts
@@ -48,6 +48,44 @@ function addRewrites(
   };
 }
 
+interface WithStorybookOptions {
+  /**
+   * The port that the Next.js app will run on.
+   * @default 3000
+   */
+  port: string | number;
+
+  /**
+   * The port that Storybook will run on.
+   * @default 34567
+   */
+  sbPort: string | number;
+
+  /**
+   * The URL path to Storybook's manager UI.
+   * @default 'storybook'
+   */
+  managerPath: string;
+
+  /**
+   * The URL path to Storybook's story preview.
+   * @default 'storybook-preview'
+   */
+  previewPath: string;
+
+  /**
+   * The directory where Storybook's config files are located.
+   * @default '.storybook'
+   */
+  configDir: string;
+
+  /**
+   * Whether to use the NextJS app directory.
+   * @default undefined
+   */
+  appDir: boolean;
+}
+
 const withStorybook = ({
   port = process.env.PORT ?? 3000,
   sbPort = 34567,
@@ -55,7 +93,7 @@ const withStorybook = ({
   previewPath = 'storybook-preview',
   configDir = '.storybook',
   appDir = undefined,
-} = {}) => {
+}: Partial<WithStorybookOptions> = {}) => {
   const isAppDir = appDir ?? existsSync('app');
   const storybookNextJSOptions: StorybookNextJSOptions = {
     appDir: isAppDir,

--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -404,9 +404,8 @@ async function doInitiate(
     logger.log(chalk.yellow('NOTE: installation is not 100% automated.\n'));
     logger.log(`To set up Storybook, replace contents of ${chalk.cyan('next-config.js')} with:\n`);
     codeLog([
-      "const { withStorybook } = require('@storybook/nextjs-server/next-config');",
-      'const nextConfig = withStorybook()({ /* your custom config here */ });',
-      'module.exports = nextConfig;',
+      "const withStorybook = require('@storybook/nextjs-server/next-config')(/* storybook config */);",
+      'module.exports = withStorybook({ /* nextjs config */ });',
     ]);
     logger.log('\n Then to run your NextJS app:\n');
     codeLog([packageManager.getRunCommand('dev')]);


### PR DESCRIPTION
This is a little cleaner in your `next.config.js` and matches what other NextJS plugins are doing

### Testing

Update your `next.config.js` to:

```js
const withStorybook = require('@storybook/nextjs-server/next-config')();
module.exports = withStorybook({ /* existing nextjs config */ });
```

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
