### PR TITLE
Next.js: Fix AppRouterProvider usage

### DIFF
--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -32,6 +32,16 @@
       "require": "./dist/image-context.js",
       "import": "./dist/image-context.mjs"
     },
+    "./dist/routing/app-router-provider": {
+      "types": "./dist/routing/app-router-provider.d.ts",
+      "require": "./dist/routing/app-router-provider.js",
+      "import": "./dist/routing/app-router-provider.mjs"
+    },
+    "./dist/routing/app-router-provider-mock": {
+      "types": "./dist/routing/app-router-provider-mock.d.ts",
+      "require": "./dist/routing/app-router-provider-mock.js",
+      "import": "./dist/routing/app-router-provider-mock.mjs"
+    },
     "./preset": {
       "types": "./dist/preset.d.ts",
       "require": "./dist/preset.js"
@@ -161,6 +171,8 @@
       "./src/images/next-future-image.tsx",
       "./src/images/next-legacy-image.tsx",
       "./src/images/next-image.tsx",
+      "./src/routing/app-router-provider.tsx",
+      "./src/routing/app-router-provider-mock.tsx",
       "./src/font/webpack/loader/storybook-nextjs-font-loader.ts",
       "./src/swc/next-swc-loader-patch.ts"
     ],

--- a/code/frameworks/nextjs/src/dependency-map.ts
+++ b/code/frameworks/nextjs/src/dependency-map.ts
@@ -13,6 +13,10 @@ const mapping: Record<string, Record<string, string>> = {
     'next/dist/shared/lib/hooks-client-context.shared-runtime':
       'next/dist/shared/lib/hooks-client-context',
   },
+  '<13.0.0': {
+    '@storybook/nextjs/dist/routing/app-router-provider':
+      '@storybook/nextjs/dist/routing/app-router-provider-mock',
+  },
   '<13.5.0': {
     'next/dist/shared/lib/router-context.shared-runtime': 'next/dist/shared/lib/router-context',
     'next/dist/shared/lib/head-manager-context.shared-runtime':

--- a/code/frameworks/nextjs/src/routing/app-router-provider-mock.tsx
+++ b/code/frameworks/nextjs/src/routing/app-router-provider-mock.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+// The mock is used for Next.js < 13, where the AppRouterProvider doesn't exist
+export const AppRouterProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return <>{children}</>;
+};

--- a/code/frameworks/nextjs/src/routing/decorator.tsx
+++ b/code/frameworks/nextjs/src/routing/decorator.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import type { Addon_StoryContext } from '@storybook/types';
 import { action } from '@storybook/addon-actions';
+// @ts-expect-error Using absolute path import to 1) avoid prebundling and 2) being able to substitute the module for Next.js < 13
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { AppRouterProvider } from '@storybook/nextjs/dist/routing/app-router-provider';
 import { PageRouterProvider } from './page-router-provider';
-import type { AppRouterProvider as TAppRouterProvider } from './app-router-provider';
 import type { RouteParams, NextAppDirectory } from './types';
 
 const defaultRouterParams: RouteParams = {
@@ -16,19 +18,6 @@ export const RouterDecorator = (
 ): React.ReactNode => {
   const nextAppDirectory =
     (parameters.nextjs?.appDirectory as NextAppDirectory | undefined) ?? false;
-
-  const [AppRouterProvider, setAppRouterProvider] = React.useState<
-    typeof TAppRouterProvider | undefined
-  >();
-
-  React.useEffect(() => {
-    if (!nextAppDirectory) {
-      return;
-    }
-    import('./app-router-provider').then((exports) =>
-      setAppRouterProvider(() => exports.AppRouterProvider)
-    );
-  }, [nextAppDirectory]);
 
   if (nextAppDirectory) {
     if (!AppRouterProvider) {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25016

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Removed the dynamic loading of the AppRouterProvider to fix an issue with preview hooks.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Checkout https://github.com/storybookjs/storybook/issues/25016
2. Install canary release of this branch
3. Make sure, that the `Checkbox` component works.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
