### PR TITLE
CLI: Improve dependency metadata detection in storybook doctor

### DIFF
--- a/code/lib/cli/src/doctor/getDuplicatedDepsWarnings.ts
+++ b/code/lib/cli/src/doctor/getDuplicatedDepsWarnings.ts
@@ -44,6 +44,7 @@ export function getDuplicatedDepsWarnings(
 ): string[] | undefined {
   try {
     if (
+      !installationMetadata ||
       !installationMetadata?.duplicatedDependencies ||
       Object.keys(installationMetadata.duplicatedDependencies).length === 0
     ) {

--- a/code/lib/cli/src/js-package-manager/util.ts
+++ b/code/lib/cli/src/js-package-manager/util.ts
@@ -1,7 +1,10 @@
 // input: @storybook/addon-essentials@npm:7.0.0
 // output: { name: '@storybook/addon-essentials', value: { version : '7.0.0', location: '' } }
 export const parsePackageData = (packageName = '') => {
-  const [first, second, third] = packageName.trim().split('@');
+  const [first, second, third] = packageName
+    .replace(/[└─├]+/g, '')
+    .trim()
+    .split('@');
   const version = (third || second).replace('npm:', '');
   const name = third ? `@${second}` : first;
 


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

There was an issue in the CLI doctor command where it would not detect the `storybook` package on certain package managers because they would output things like `└─ storybook@npm:7.4.0` and it would result in `└─ storybook` as a name. This PR fixes that and adds a couple more fixes along the way

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_


1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Make it wrong e.g. change storybook dependency to 7.3.0 and leave the rest as 7.6.0
3. run `/path/to/cli/bin/index.js doctor` and see it do the right work:

![image](https://github.com/storybookjs/storybook/assets/1671563/d54aea03-a2aa-4b6b-abcd-7e1c04daf08a)


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
