### PR TITLE
Next.js: Fix next/font/local usage in babel mode

### DIFF
--- a/code/frameworks/nextjs/src/font/webpack/loader/local/get-font-face-declarations.ts
+++ b/code/frameworks/nextjs/src/font/webpack/loader/local/get-font-face-declarations.ts
@@ -8,13 +8,17 @@ import type { LoaderOptions } from '../types';
 
 type LocalFontSrc = string | Array<{ path: string; weight?: string; style?: string }>;
 
-export async function getFontFaceDeclarations(options: LoaderOptions, rootContext: string) {
+export async function getFontFaceDeclarations(
+  options: LoaderOptions,
+  rootContext: string,
+  swcMode: boolean
+) {
   const localFontSrc = options.props.src as LocalFontSrc;
 
   // Parent folder relative to the root context
-  const parentFolder = path
-    .dirname(path.join(getProjectRoot(), options.filename))
-    .replace(rootContext, '');
+  const parentFolder = swcMode
+    ? path.dirname(path.join(getProjectRoot(), options.filename)).replace(rootContext, '')
+    : path.dirname(options.filename).replace(rootContext, '');
 
   const { validateData } = require('../utils/local-font-utils');
   const { weight, style, variable } = validateData('', options.props);

--- a/code/frameworks/nextjs/src/font/webpack/loader/storybook-nextjs-font-loader.ts
+++ b/code/frameworks/nextjs/src/font/webpack/loader/storybook-nextjs-font-loader.ts
@@ -15,6 +15,7 @@ type FontFaceDeclaration = {
 
 export default async function storybookNextjsFontLoader(this: any) {
   const loaderOptions = this.getOptions() as LoaderOptions;
+  let swcMode = false;
   let options;
 
   if (Object.keys(loaderOptions).length > 0) {
@@ -23,6 +24,7 @@ export default async function storybookNextjsFontLoader(this: any) {
   } else {
     // handles SWC mode
     const importQuery = JSON.parse(this.resourceQuery.slice(1));
+    swcMode = true;
 
     options = {
       filename: importQuery.path,
@@ -42,7 +44,7 @@ export default async function storybookNextjsFontLoader(this: any) {
   }
 
   if (options.source.endsWith('next/font/local') || options.source.endsWith('@next/font/local')) {
-    fontFaceDeclaration = await getLocalFontFaceDeclarations(options, rootCtx);
+    fontFaceDeclaration = await getLocalFontFaceDeclarations(options, rootCtx, swcMode);
   }
 
   if (typeof fontFaceDeclaration !== 'undefined') {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25044

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixes `next/font/local` usage in Babel mode for Next.js

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a Next.js sandbox
2. Setup a local font as described [here](https://github.com/storybookjs/storybook/tree/next/code/frameworks/nextjs#nextfontlocal)
3. Check whether local font works

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version [`0.0.0-pr-25045-sha-cc9ccee0`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-25045-sha-cc9ccee0). Install it by pinning all your Storybook dependencies to that version.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-25045-sha-cc9ccee0`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-25045-sha-cc9ccee0) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/nextjs-fix-local-font-issue`](https://github.com/storybookjs/storybook/tree/valentin/nextjs-fix-local-font-issue) |
| **Commit** | [`cc9ccee0`](https://github.com/storybookjs/storybook/commit/cc9ccee0575557602b11c52158fa6ec4e6c0a6a2) |
| **Datetime** | Wed Nov 29 19:54:42 UTC 2023 (`1701287682`) |
| **Workflow run** | [7037799834](https://github.com/storybookjs/storybook/actions/runs/7037799834) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=25045`_
</details>
<!-- CANARY_RELEASE_SECTION -->
