### PR TITLE
feat: add `defineMeta`

### DIFF
--- a/code/frameworks/angular/src/client/index.ts
+++ b/code/frameworks/angular/src/client/index.ts
@@ -7,6 +7,8 @@ export * from './public-api';
 // eslint-disable-next-line import/export
 export * from './public-types';
 
+export * from './public-helpers';
+
 export type { StoryFnAngularReturnType as IStory } from './types';
 
 export { moduleMetadata, componentWrapperDecorator, applicationConfig } from './decorators';

--- a/code/frameworks/angular/src/client/public-helpers.ts
+++ b/code/frameworks/angular/src/client/public-helpers.ts
@@ -1,0 +1,10 @@
+import { Meta } from './public-types';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export function defineMeta(meta: Meta): Meta {
+  return meta;
+}

--- a/code/lib/csf-tools/src/CsfFile.test.ts
+++ b/code/lib/csf-tools/src/CsfFile.test.ts
@@ -592,6 +592,22 @@ describe('CsfFile', () => {
               stories: []
             `);
     });
+
+    it('defineMeta', () => {
+      expect(
+        parse(
+          dedent`
+          import { defineMeta } from '@storybook/react';
+          export default defineMeta({ title: 'foo/bar' });
+        `,
+          true
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories: []
+      `);
+    });
   });
 
   describe('error handling', () => {

--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -252,7 +252,7 @@ export class CsfFile {
           const isVariableReference = t.isIdentifier(node.declaration) && t.isProgram(parent);
           let decl;
           if (isVariableReference) {
-            // const meta = { ... };
+            // const meta = { ... }; or const meta = defineMeta({ ... })
             // export default meta;
             const variableName = (node.declaration as t.Identifier).name;
             const isVariableDeclarator = (declaration: t.VariableDeclarator) =>
@@ -269,6 +269,15 @@ export class CsfFile {
           } else {
             self._metaStatement = node;
             decl = node.declaration;
+          }
+
+          // defineMeta({ ... })
+          if (
+            t.isCallExpression(decl) &&
+            (decl.callee as t.Identifier).name === 'defineMeta' &&
+            t.isObjectExpression(decl.arguments[0])
+          ) {
+            [decl] = decl.arguments;
           }
 
           if (t.isObjectExpression(decl)) {
@@ -455,7 +464,7 @@ export class CsfFile {
             throw new Error(dedent`
               Unexpected \`storiesOf\` usage: ${formatLocation(node, self._fileName)}.
 
-              In SB7, we use the next-generation \`storyStoreV7\` by default, which does not support \`storiesOf\`. 
+              In SB7, we use the next-generation \`storyStoreV7\` by default, which does not support \`storiesOf\`.
               More info, with details about how to opt-out here: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#storystorev7-enabled-by-default
             `);
           }

--- a/code/renderers/html/src/index.ts
+++ b/code/renderers/html/src/index.ts
@@ -3,6 +3,7 @@
 import './globals';
 
 export * from './public-types';
+export * from './public-helpers';
 
 // optimization: stop HMR propagation in webpack
 if (typeof module !== 'undefined') module?.hot?.decline();

--- a/code/renderers/html/src/public-helpers.ts
+++ b/code/renderers/html/src/public-helpers.ts
@@ -1,0 +1,10 @@
+import type { Meta } from './public-types';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export function defineMeta(meta: Meta): Meta {
+  return meta;
+}

--- a/code/renderers/preact/src/index.ts
+++ b/code/renderers/preact/src/index.ts
@@ -3,6 +3,7 @@
 import './globals';
 
 export * from './public-types';
+export * from './public-helpers';
 
 // optimization: stop HMR propagation in webpack
 if (typeof module !== 'undefined') module?.hot?.decline();

--- a/code/renderers/preact/src/public-helpers.ts
+++ b/code/renderers/preact/src/public-helpers.ts
@@ -1,0 +1,10 @@
+import type { Meta } from './public-types';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export function defineMeta(meta: Meta): Meta {
+  return meta;
+}

--- a/code/renderers/react/src/index.ts
+++ b/code/renderers/react/src/index.ts
@@ -3,6 +3,7 @@
 import './globals';
 
 export * from './public-types';
+export * from './public-helpers';
 
 export * from './testing-api';
 

--- a/code/renderers/react/src/public-helpers.ts
+++ b/code/renderers/react/src/public-helpers.ts
@@ -1,0 +1,10 @@
+import type { Meta } from './public-types';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export function defineMeta(meta: Meta): Meta {
+  return meta;
+}

--- a/code/renderers/react/src/public-types.test.tsx
+++ b/code/renderers/react/src/public-types.test.tsx
@@ -13,6 +13,7 @@ import { fn } from '@storybook/test';
 
 import type { Decorator, Meta, StoryObj } from './public-types';
 import type { ReactRenderer } from './types';
+import { defineMeta } from './public-helpers';
 
 type ReactStory<TArgs, TRequiredArgs> = StoryAnnotations<ReactRenderer, TArgs, TRequiredArgs>;
 
@@ -224,6 +225,10 @@ test('StoryObj<typeof meta> is allowed when all arguments are optional', () => {
 
 test('Meta can be used without generic', () => {
   expectTypeOf({ component: Button }).toMatchTypeOf<Meta>();
+});
+
+test('defineMeta matches Meta', () => {
+  expectTypeOf(defineMeta({})).toMatchTypeOf<Meta>();
 });
 
 test('Props can be defined as interfaces, issue #21768', () => {

--- a/code/renderers/server/src/index.ts
+++ b/code/renderers/server/src/index.ts
@@ -3,6 +3,7 @@
 import './globals';
 
 export * from './public-types';
+export * from './public-helpers';
 
 // optimization: stop HMR propagation in webpack
 if (typeof module !== 'undefined') module?.hot?.decline();

--- a/code/renderers/server/src/public-helpers.ts
+++ b/code/renderers/server/src/public-helpers.ts
@@ -1,0 +1,10 @@
+import type { Meta } from './public-types';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export function defineMeta(meta: Meta): Meta {
+  return meta;
+}

--- a/code/renderers/svelte/src/index.ts
+++ b/code/renderers/svelte/src/index.ts
@@ -3,6 +3,7 @@
 import './globals';
 
 export * from './public-types';
+export * from './public-helpers';
 
 // optimization: stop HMR propagation in webpack
 if (typeof module !== 'undefined') module?.hot?.decline();

--- a/code/renderers/svelte/src/public-helpers.ts
+++ b/code/renderers/svelte/src/public-helpers.ts
@@ -1,0 +1,10 @@
+import type { Meta } from './public-types';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export function defineMeta(meta: Meta): Meta {
+  return meta;
+}

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -9,6 +9,7 @@ import Decorator2 from './__test__/Decorator2.svelte';
 
 import type { Decorator, Meta, StoryObj } from './public-types';
 import type { SvelteRenderer } from './types';
+import { defineMeta } from './public-helpers';
 
 type SvelteStory<Component extends SvelteComponentTyped, Args, RequiredArgs> = StoryAnnotations<
   SvelteRenderer<Component>,
@@ -77,6 +78,10 @@ describe('Meta', () => {
       }),
     };
     expectTypeOf(meta).toMatchTypeOf<Meta<Button>>();
+  });
+
+  test('defineMeta matches Meta', () => {
+    expectTypeOf(defineMeta({})).toMatchTypeOf<Meta>();
   });
 });
 

--- a/code/renderers/vue/src/index.ts
+++ b/code/renderers/vue/src/index.ts
@@ -3,6 +3,7 @@
 import './globals';
 
 export * from './public-types';
+export * from './public-helpers';
 
 // optimization: stop HMR propagation in webpack
 if (typeof module !== 'undefined') module?.hot?.decline();

--- a/code/renderers/vue/src/public-helpers.ts
+++ b/code/renderers/vue/src/public-helpers.ts
@@ -1,0 +1,10 @@
+import type { Meta } from './public-types';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export function defineMeta(meta: Meta): Meta {
+  return meta;
+}

--- a/code/renderers/vue/src/public-types.test.ts
+++ b/code/renderers/vue/src/public-types.test.ts
@@ -8,6 +8,7 @@ import { Vue } from 'vue/types/vue';
 import type { Decorator, Meta, StoryObj } from './public-types';
 import Button from './__tests__/Button.vue';
 import type { VueRenderer } from './types';
+import { defineMeta } from './public-helpers';
 
 describe('Meta', () => {
   test('Generic parameter of Meta can be a component', () => {
@@ -36,6 +37,10 @@ describe('Meta', () => {
     expectTypeOf(meta).toEqualTypeOf<
       ComponentAnnotations<VueRenderer, { disabled: boolean; label: string }>
     >();
+  });
+
+  test('defineMeta matches Meta', () => {
+    expectTypeOf(defineMeta({})).toMatchTypeOf<Meta>();
   });
 });
 

--- a/code/renderers/vue3/src/index.ts
+++ b/code/renderers/vue3/src/index.ts
@@ -4,6 +4,7 @@ import './globals';
 
 export * from './public-api';
 export * from './public-types';
+export * from './public-helpers';
 
 // optimization: stop HMR propagation in webpack
 try {

--- a/code/renderers/vue3/src/public-helpers.ts
+++ b/code/renderers/vue3/src/public-helpers.ts
@@ -1,0 +1,10 @@
+import type { Meta } from './public-types';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export function defineMeta(meta: Meta): Meta {
+  return meta;
+}

--- a/code/renderers/vue3/src/public-types.test.ts
+++ b/code/renderers/vue3/src/public-types.test.ts
@@ -9,6 +9,7 @@ import BaseLayout from './__tests__/BaseLayout.vue';
 import Button from './__tests__/Button.vue';
 import DecoratorTsVue from './__tests__/Decorator.vue';
 import Decorator2TsVue from './__tests__/Decorator2.vue';
+import { defineMeta } from './public-helpers';
 
 type ButtonProps = ComponentPropsAndSlots<typeof Button>;
 
@@ -53,6 +54,10 @@ describe('Meta', () => {
       },
     };
     expectTypeOf(meta).toMatchTypeOf<Meta<typeof Button>>();
+  });
+
+  test('defineMeta matches Meta', () => {
+    expectTypeOf(defineMeta({})).toMatchTypeOf<Meta>();
   });
 });
 

--- a/code/renderers/web-components/src/index.ts
+++ b/code/renderers/web-components/src/index.ts
@@ -7,6 +7,7 @@ import './globals';
 const { window, EventSource } = global;
 
 export * from './public-types';
+export * from './public-helpers';
 export * from './framework-api';
 
 // TODO: disable HMR and do full page loads because of customElements.define

--- a/code/renderers/web-components/src/public-helpers.ts
+++ b/code/renderers/web-components/src/public-helpers.ts
@@ -1,0 +1,10 @@
+import type { Meta } from './public-types';
+
+/**
+ * Metadata to configure the stories for a component.
+ *
+ * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
+ */
+export function defineMeta(meta: Meta): Meta {
+  return meta;
+}


### PR DESCRIPTION
Closes #18228

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->
Adds new helper utility `defineMeta`.

```tsx
import { defineMeta } from '@storybook/react';
import { Button } from './Button';

// Type-safety out-of-the-box without writing any Typescript!
export default defineMeta({
  title: 'Example/Button',
  component: Button,
});
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. `cd sandbox/react-vite-default-ts`
3. Open `sandbox/react-vite-default-ts/src/stories/Button.stories.ts` in your code editor
4. Apply following changes:

```diff
-  3 | import type { Meta, StoryObj } from '@storybook/react';
+  3 | import { type  StoryObj, defineMeta } from '@storybook/react';
   4 |
   5 | import { Button } from './Button';
   6 |
   7 | // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
-  8 | const meta = {
+  8 | const meta = defineMeta({
   9 |   title: 'Example/Button',
     | ...
- 21 | } satisfies Meta<typeof Button>;
+ 21 | });
```

5. `yarn storybook` and verify Button stories work in browser
6. Apply following changes to same file:

```diff
-  8 | const meta = defineMeta({
+  8 | export default defineMeta({
     | ...
- 22 | type Story = StoryObj<typeof meta>;
+ 22 | type Story = StoryObj;
```

7. Verify Button stories work in browser
8. Intentionally break the implementation, e.g. `csf-tools/src/CsfFile.ts` and see how stories no longer work.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Should I add documentation to `docs/writing-stories/typescript.md`? Maybe under the `## Using 'satisfies' for better type safety`?

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
