### PR TITLE
Documentation: Add guide postcss plugin for prefers-color-scheme media

### DIFF
--- a/code/addons/themes/README.md
+++ b/code/addons/themes/README.md
@@ -27,6 +27,7 @@ For tool-specific setup, check out the recipes below
 - [`@emotion/styled`](https://github.com/storybookjs/storybook/tree/next/code/addons/themes/docs/getting-started/emotion.md)
 - [`@mui/material`](https://github.com/storybookjs/storybook/tree/next/code/addons/themes/docs/getting-started/material-ui.md)
 - [`bootstrap`](https://github.com/storybookjs/storybook/tree/next/code/addons/themes/docs/getting-started/bootstrap.md)
+- [`postcss`](https://github.com/storybookjs/storybook/tree/next/code/addons/themes/docs/getting-started/postcss.md)
 - [`styled-components`](https://github.com/storybookjs/storybook/tree/next/code/addons/themes/docs/getting-started/styled-components.md)
 - [`tailwind`](https://github.com/storybookjs/storybook/tree/next/code/addons/themes/docs/getting-started/tailwind.md)
 - [`vuetify@3.x`](https://github.com/storybookjs/storybook/blob/next/code/addons/themes/docs/api.md#writing-a-custom-decorator)

--- a/code/addons/themes/docs/getting-started/postcss.md
+++ b/code/addons/themes/docs/getting-started/postcss.md
@@ -2,8 +2,6 @@
 
 ## 📦 Install addon
 
-<!-- **NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Import your css"](#🥾-import-your-css). -->
-
 To get started, **install the package** as a dev dependency
 
 yarn:
@@ -41,6 +39,36 @@ module.exports = {
 };
 ```
 
+## 🏷️ Add class to `prefers-color-scheme` media
+
+CSS has special media at-rule for dark theme: `@media (prefers-color-scheme: dark)`. [`postcss-dark-theme-class`](https://github.com/postcss/postcss-dark-theme-class) can copy content of those at-rules to `.is-dark` selector.
+
+Check your project for existing PostCSS config: `postcss.config.js` in the project root, `"postcss"` section in `package.json` or postcss in bundle config.
+
+Add plugin to the list.
+
+```diff
+module.exports = {
+  plugins: [
++   require('postcss-dark-theme-class'),
+    require('autoprefixer')
+  ]
+}
+```
+
+Use `prefers-color-scheme` media in your CSS:
+
+```css
+:root {
+  --text-color: black;
+}
+@media (prefers-color-scheme: dark) {
+  html {
+    --text-color: white
+  }
+}
+```
+
 ## 🥾 Import your CSS
 
 To give your stories access to styles, import them into your `.storybook/preview.js` file.
@@ -58,8 +86,6 @@ export default preview;
 ```
 
 ## 🎨 Provide your theme(s)
-
-Tailwind supports light and dark color modes out of the box. These modes can be activated by setting a `.dark` class on a parent element.
 
 To enable switching between these modes in a click for your stories, use our `withThemeByClassName` decorator by adding the following code to your `.storybook/preview.js` file.
 
@@ -85,32 +111,4 @@ const preview: Preview = {
 };
 
 export default preview;
-```
-
-## 🏷️ Add class to `prefers-color-scheme` media
-
-Check your project for existing PostCSS config: postcss.config.js in the project root, "postcss" section in package.json or postcss in bundle config.
-
-Add plugin to the list.
-
-```diff
-module.exports = {
-  plugins: [
-+   require('postcss-dark-theme-class'),
-    require('autoprefixer')
-  ]
-}
-```
-
-Use `prefers-color-scheme` media in your CSS:
-
-```css
-:root {
-  --text-color: black;
-}
-@media (prefers-color-scheme: dark) {
-  html {
-    --text-color: white
-  }
-}
 ```

--- a/code/addons/themes/docs/getting-started/postcss.md
+++ b/code/addons/themes/docs/getting-started/postcss.md
@@ -1,0 +1,116 @@
+# 🏁 Getting started with `postcss`
+
+## 📦 Install addon
+
+<!-- **NOTE:** As of Storybook 7.2, `@storybook/addon-themes` ships in `@storybook/addon-essentials`. If you're using Storybook >= 7.2, skip to ["Import your css"](#🥾-import-your-css). -->
+
+To get started, **install the package** as a dev dependency
+
+yarn:
+
+```zsh
+yarn add -D @storybook/addon-themes postcss-dark-theme-class
+```
+
+npm:
+
+```zsh
+npm install -D @storybook/addon-themes postcss-dark-theme-class
+```
+
+pnpm:
+
+```zsh
+pnpm add -D @storybook/addon-themes postcss-dark-theme-class
+```
+
+## 🧩 Register Addon
+
+Now, **include the addon** in your `.storybook/main.js` file.
+
+```diff
+module.exports = {
+  stories: [
+    "../stories/**/*.stories.mdx",
+    "../stories/**/*.stories.@(js|jsx|ts|tsx)",
+  ],
+  addons: [
+    "@storybook/addon-essentials",
++   "@storybook/addon-themes"
+  ],
+};
+```
+
+## 🥾 Import your CSS
+
+To give your stories access to styles, import them into your `.storybook/preview.js` file.
+
+```diff
+import { Preview } from "@storybook/your-renderer";
+
++import "../src/index.css";
+
+const preview: Preview = {
+  parameters: { /* ... */ },
+};
+
+export default preview;
+```
+
+## 🎨 Provide your theme(s)
+
+Tailwind supports light and dark color modes out of the box. These modes can be activated by setting a `.dark` class on a parent element.
+
+To enable switching between these modes in a click for your stories, use our `withThemeByClassName` decorator by adding the following code to your `.storybook/preview.js` file.
+
+```diff
+-import { Preview } from "@storybook/your-renderer";
++import { Preview, Renderer } from "@storybook/your-renderer";
++import { withThemeByClassName } from "@storybook/addon-themes";
+
+import "../src/index.css";
+
+
+const preview: Preview = {
+  parameters: { /* ... */ },
++ decorators: [
++  withThemeByClassName<Renderer>({
++    themes: {
++      light: "is-light",
++      dark: "is-dark",
++    },
++    defaultTheme: "light",
++  }),
++ ]
+};
+
+export default preview;
+```
+
+## 🏷️ Add class to `prefers-color-scheme` media
+
+Check your project for existing PostCSS config: postcss.config.js in the project root, "postcss" section in package.json or postcss in bundle config.
+
+Add plugin to the list.
+
+```diff
+module.exports = {
+  plugins: [
++   require('postcss-dark-theme-class'),
+    require('autoprefixer')
+  ]
+}
+```
+
+Use `prefers-color-scheme` media in your CSS:
+
+```css
+:root {
+  --text-color: black;
+}
+@media (prefers-color-scheme: dark) {
+  html {
+    --text-color: white
+  }
+}
+```


### PR DESCRIPTION
Closes #25089

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I added a new guide for theme addon for standard CSS and `@media (prefers-color-scheme: dark)`.

It uses PostCSS to copy rule from media query to `html.is-light` selector.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
