### PR TITLE
Next.js: Pass jsConfig to SWC Loader and load config with defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -706,22 +706,22 @@ workflows:
           requires:
             - build
       - create-sandboxes:
-          parallelism: 32
+          parallelism: 33
           requires:
             - build
       # - smoke-test-sandboxes: # disabled for now
       #     requires:
       #       - create-sandboxes
       - build-sandboxes:
-          parallelism: 32
+          parallelism: 33
           requires:
             - create-sandboxes
       - chromatic-sandboxes:
-          parallelism: 29
+          parallelism: 30
           requires:
             - build-sandboxes
       - e2e-production:
-          parallelism: 27
+          parallelism: 28
           requires:
             - build-sandboxes
       - e2e-dev:
@@ -729,7 +729,7 @@ workflows:
           requires:
             - create-sandboxes
       - test-runner-production:
-          parallelism: 27
+          parallelism: 28
           requires:
             - build-sandboxes
 

--- a/code/frameworks/nextjs/src/config/webpack.ts
+++ b/code/frameworks/nextjs/src/config/webpack.ts
@@ -15,13 +15,11 @@ const tryResolve = (path: string) => {
 export const configureConfig = async ({
   baseConfig,
   nextConfigPath,
-  configDir,
 }: {
   baseConfig: WebpackConfig;
   nextConfigPath?: string;
-  configDir: string;
 }): Promise<NextConfig> => {
-  const nextConfig = await resolveNextConfig({ baseConfig, nextConfigPath, configDir });
+  const nextConfig = await resolveNextConfig({ nextConfigPath });
 
   addScopedAlias(baseConfig, 'next/config');
   if (tryResolve('next/dist/compiled/react')) {

--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -146,7 +146,6 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (baseConfig, 
   const nextConfig = await configureConfig({
     baseConfig,
     nextConfigPath,
-    configDir: options.configDir,
   });
 
   const babelRCPath = join(getProjectRoot(), '.babelrc');

--- a/code/frameworks/nextjs/src/swc/loader.ts
+++ b/code/frameworks/nextjs/src/swc/loader.ts
@@ -3,6 +3,7 @@ import { getVirtualModules } from '@storybook/builder-webpack5';
 import type { Options } from '@storybook/types';
 import type { NextConfig } from 'next';
 import path from 'path';
+import loadJsConfig from 'next/dist/build/load-jsconfig';
 
 export const configureSWCLoader = async (
   baseConfig: any,
@@ -14,6 +15,8 @@ export const configureSWCLoader = async (
   const dir = getProjectRoot();
 
   const { virtualModules } = await getVirtualModules(options);
+
+  const { jsConfig } = await loadJsConfig(dir, nextConfig as any);
 
   baseConfig.module.rules = [
     ...baseConfig.module.rules,
@@ -32,6 +35,7 @@ export const configureSWCLoader = async (
           pagesDir: `${dir}/pages`,
           appDir: `${dir}/apps`,
           hasReactRefresh: isDevelopment,
+          jsConfig,
           nextConfig,
           supportedBrowsers: require('next/dist/build/utils').getSupportedBrowsers(
             dir,

--- a/code/frameworks/nextjs/src/utils.ts
+++ b/code/frameworks/nextjs/src/utils.ts
@@ -1,11 +1,10 @@
 import path from 'path';
 import { DefinePlugin } from 'webpack';
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
-import findUp from 'find-up';
-import { pathExists } from 'fs-extra';
 import type { Configuration as WebpackConfig } from 'webpack';
 import type { NextConfig } from 'next';
-import { pathToFileURL } from 'node:url';
+import loadConfig from 'next/dist/server/config';
+import { getProjectRoot } from '@storybook/core-common';
 
 export const configureRuntimeNextjsVersionResolution = (baseConfig: WebpackConfig): void => {
   baseConfig.plugins?.push(
@@ -17,46 +16,13 @@ export const configureRuntimeNextjsVersionResolution = (baseConfig: WebpackConfi
 
 export const getNextjsVersion = (): string => require(scopedResolve('next/package.json')).version;
 
-const findNextConfigFile = async (configDir: string) => {
-  const supportedExtensions = ['mjs', 'js'];
-  return supportedExtensions.reduce<Promise<undefined | string>>(
-    async (acc, ext: string | undefined) => {
-      const resolved = await acc;
-      if (!resolved) {
-        acc = findUp(`next.config.${ext}`, { cwd: configDir });
-      }
-
-      return acc;
-    },
-    Promise.resolve(undefined)
-  );
-};
-
 export const resolveNextConfig = async ({
-  baseConfig = {},
   nextConfigPath,
-  configDir,
 }: {
-  baseConfig?: WebpackConfig;
   nextConfigPath?: string;
-  configDir: string;
 }): Promise<NextConfig> => {
-  const nextConfigFile = nextConfigPath || (await findNextConfigFile(configDir));
-
-  if (!nextConfigFile || (await pathExists(nextConfigFile)) === false) {
-    return {};
-  }
-
-  const nextConfigExport = await import(pathToFileURL(nextConfigFile).href);
-
-  const nextConfig =
-    typeof nextConfigExport === 'function'
-      ? nextConfigExport(PHASE_DEVELOPMENT_SERVER, {
-          defaultConfig: baseConfig,
-        })
-      : nextConfigExport;
-
-  return nextConfig.default || nextConfig;
+  const dir = nextConfigPath ? path.dirname(nextConfigPath) : getProjectRoot();
+  return loadConfig(PHASE_DEVELOPMENT_SERVER, dir, undefined);
 };
 
 // This is to help the addon in development

--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -116,7 +116,7 @@ const baseTemplates = {
   'nextjs/13-ts': {
     name: 'Next.js v13.5 (Webpack | TypeScript)',
     script:
-      'yarn create next-app {{beforeDir}} -e https://github.com/vercel/next.js/tree/next-13/examples/hello-world && cd {{beforeDir}} && npm pkg set "dependencies.next"="^12.2.0" && yarn && git add . && git commit --amend --no-edit && cd ..',
+      'yarn create next-app {{beforeDir}} -e https://github.com/vercel/next.js/tree/next-13/examples/hello-world && cd {{beforeDir}} && npm pkg set "dependencies.next"="^13.5.6" && yarn && git add . && git commit --amend --no-edit && cd ..',
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',

--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -129,7 +129,6 @@ const baseTemplates = {
       extraDependencies: ['server-only'],
     },
     skipTasks: ['e2e-tests-dev', 'bench'],
-    inDevelopment: true,
   },
   'nextjs/default-js': {
     name: 'Next.js Latest (Webpack | JavaScript)',


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/discussions/25175

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Load jsConfig and pass it to SWC Loader and load Next.js config with defaults

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a Next.js 14 sandbox
2. Go to the tsconfig.json and add the following config:
```json
{
  "compilerOptions": {
    "jsxImportSource": "nativewind"
  }
}
```
3. Storybook should complain that `nativewind`'s jsx runtime cannot be found (sure, its not installed). The point is not to fix this issue, but to make sure that Storybook respects the `jsxImportSource` option and to pass it to Next.js' swc loader.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
