### PR TITLE
UI: Embed `react-textarea-autosize` types

### DIFF
--- a/code/ui/components/package.json
+++ b/code/ui/components/package.json
@@ -67,7 +67,6 @@
     "@storybook/theming": "workspace:*",
     "@storybook/types": "workspace:*",
     "memoizerific": "^1.11.3",
-    "use-resize-observer": "^9.1.0",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
@@ -82,7 +81,8 @@
     "react-syntax-highlighter": "^15.4.5",
     "react-textarea-autosize": "^8.3.0",
     "ts-dedent": "^2.0.0",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "use-resize-observer": "^9.1.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
@@ -94,8 +94,7 @@
   "bundler": {
     "entries": [
       "./src/index.ts"
-    ],
-    "platform": "neutral"
+    ]
   },
   "gitHead": "e6a7fd8a655c69780bc20b9749c2699e44beae17"
 }

--- a/code/ui/components/src/components/form/input/input.tsx
+++ b/code/ui/components/src/components/form/input/input.tsx
@@ -3,8 +3,27 @@ import React, { forwardRef } from 'react';
 import type { Theme, CSSObject } from '@storybook/theming';
 import { styled } from '@storybook/theming';
 
-import type { TextareaAutosizeProps } from 'react-textarea-autosize';
 import TextareaAutoResize from 'react-textarea-autosize';
+
+/**
+ * these types are copied from `react-textarea-autosize`.
+ * I copied them because of https://github.com/storybookjs/storybook/issues/18734
+ * Maybe there's some bug in `tsup` or `react-textarea-autosize`?
+ */
+type TextareaPropsRaw = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+type Style = Omit<NonNullable<TextareaPropsRaw['style']>, 'maxHeight' | 'minHeight'> & {
+  height?: number;
+};
+type TextareaHeightChangeMeta = {
+  rowHeight: number;
+};
+interface TextareaAutosizeProps extends Omit<TextareaPropsRaw, 'style'> {
+  maxRows?: number;
+  minRows?: number;
+  onHeightChange?: (height: number, meta: TextareaHeightChangeMeta) => void;
+  cacheMeasurements?: boolean;
+  style?: Style;
+}
 
 const styleResets: CSSObject = {
   // resets

--- a/code/ui/components/src/components/form/input/input.tsx
+++ b/code/ui/components/src/components/form/input/input.tsx
@@ -208,7 +208,7 @@ type TextareaProps = Omit<
   align?: Alignments;
   valid?: ValidationStates;
   height?: number;
-};
+} & React.RefAttributes<HTMLTextAreaElement>;
 export const Textarea: FC<TextareaProps> = Object.assign(
   styled(
     forwardRef<any, TextareaProps>(function Textarea({ size, valid, align, ...props }, ref) {

--- a/code/ui/components/src/components/form/input/input.tsx
+++ b/code/ui/components/src/components/form/input/input.tsx
@@ -1,4 +1,4 @@
-import type { HTMLProps, SelectHTMLAttributes } from 'react';
+import type { FC, HTMLProps, SelectHTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
 import type { Theme, CSSObject } from '@storybook/theming';
 import { styled } from '@storybook/theming';
@@ -17,7 +17,7 @@ type Style = Omit<NonNullable<TextareaPropsRaw['style']>, 'maxHeight' | 'minHeig
 type TextareaHeightChangeMeta = {
   rowHeight: number;
 };
-interface TextareaAutosizeProps extends Omit<TextareaPropsRaw, 'style'> {
+export interface TextareaAutosizeProps extends Omit<TextareaPropsRaw, 'style'> {
   maxRows?: number;
   minRows?: number;
   onHeightChange?: (height: number, meta: TextareaHeightChangeMeta) => void;
@@ -209,7 +209,7 @@ type TextareaProps = Omit<
   valid?: ValidationStates;
   height?: number;
 };
-export const Textarea = Object.assign(
+export const Textarea: FC<TextareaProps> = Object.assign(
   styled(
     forwardRef<any, TextareaProps>(function Textarea({ size, valid, align, ...props }, ref) {
       return <TextareaAutoResize {...props} ref={ref} />;


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/18734

## What I did

- Embed the types of `react-textarea-autosize` manually.
- bundle in `use-resize-observer`

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
