### PR TITLE
Core: Set bundle target to `node18`

### DIFF
--- a/scripts/prepare/addon-bundle.ts
+++ b/scripts/prepare/addon-bundle.ts
@@ -116,7 +116,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
         ...(optimized ? dtsConfig : {}),
         entry: exportEntries,
         format: ['cjs'],
-        target: 'node16',
+        target: 'node18',
         platform: 'node',
         external: commonExternals,
         esbuildOptions: (options) => {
@@ -184,7 +184,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
         ...commonOptions,
         entry: nodeEntries.map((e: string) => slash(join(cwd, e))),
         format: ['cjs'],
-        target: 'node16',
+        target: 'node18',
         platform: 'node',
         external: commonExternals,
         esbuildOptions: (c) => {

--- a/scripts/prepare/bundle.ts
+++ b/scripts/prepare/bundle.ts
@@ -126,7 +126,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
         outDir,
         sourcemap: false,
         format: ['cjs'],
-        target: 'node16',
+        target: 'node18',
         ...(dtsBuild === 'cjs' ? dtsConfig : {}),
         platform: 'node',
         clean: false,

--- a/scripts/prepare/esm-bundle.ts
+++ b/scripts/prepare/esm-bundle.ts
@@ -120,7 +120,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
         outExtension: () => ({
           js: '.js',
         }),
-        target: 'node16',
+        target: 'node18',
         clean: false,
         ...(dtsBuild ? dtsConfig : {}),
         platform: 'node',

--- a/scripts/prepare/facade.ts
+++ b/scripts/prepare/facade.ts
@@ -53,7 +53,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
       entry: entries.map((e: string) => slash(join(cwd, e))),
       outDir: join(process.cwd(), 'dist'),
       format: ['cjs'],
-      target: 'node16',
+      target: 'node18',
       platform: 'node',
       external: [name, ...Object.keys(dependencies || {}), ...Object.keys(peerDependencies || {})],
 


### PR DESCRIPTION
Closes N/A

## What I did

Updated the bundling target to Node 18.

## Checklist for Contributors

### Testing

### Documentation

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
