### PR TITLE
Build: Ignore changing `version` in SvelteKit story

### DIFF
--- a/code/frameworks/sveltekit/template/stories_svelte-kit-skeleton-js/Environment.svelte
+++ b/code/frameworks/sveltekit/template/stories_svelte-kit-skeleton-js/Environment.svelte
@@ -1,8 +1,8 @@
 <script>
-	import { browser, dev, building, version } from '$app/environment';
+  import { browser, dev, building, version } from '$app/environment';
 </script>
 
 <div data-testid="browser">{browser}</div>
 <div data-testid="dev">{dev}</div>
 <div data-testid="building">{building}</div>
-<div data-testid="version">{version}</div>
+<div data-testid="version" data-chromatic="ignore">{version}</div>

--- a/code/frameworks/sveltekit/template/stories_svelte-kit-skeleton-ts/Environment.svelte
+++ b/code/frameworks/sveltekit/template/stories_svelte-kit-skeleton-ts/Environment.svelte
@@ -1,8 +1,8 @@
 <script>
-	import { browser, dev, building, version } from '$app/environment';
+  import { browser, dev, building, version } from '$app/environment';
 </script>
 
 <div data-testid="browser">{browser}</div>
 <div data-testid="dev">{dev}</div>
 <div data-testid="building">{building}</div>
-<div data-testid="version">{version}</div>
+<div data-testid="version" data-chromatic="ignore">{version}</div>


### PR DESCRIPTION
Closes N/A

## What I did

The `version` environment variable seems to change across builds so it shows up as a chromatic diff. I removed it to avoid false positives.

Example: https://www.chromatic.com/test?appId=634ff621f2a0d0f01971eae7&id=657bc3b34892b800b040fd32

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
