### PR TITLE
Core: Remove the `-s` flag from build & dev

### DIFF
--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -196,7 +196,6 @@ command('doctor')
 command('dev')
   .option('-p, --port <number>', 'Port to run Storybook', (str) => parseInt(str, 10))
   .option('-h, --host <string>', 'Host to run Storybook')
-  .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
   .option('-c, --config-dir <dir-name>', 'Directory where to load Storybook configurations from')
   .option(
     '--https',
@@ -251,7 +250,6 @@ command('dev')
   });
 
 command('build')
-  .option('-s, --static-dir <dir-names>', 'Directory where to load static files from', parseList)
   .option('-o, --output-dir <dir-name>', 'Directory where to store built files')
   .option('-c, --config-dir <dir-name>', 'Directory where to load Storybook configurations from')
   .option('--quiet', 'Suppress verbose build output')

--- a/code/lib/core-server/src/build-static.ts
+++ b/code/lib/core-server/src/build-static.ts
@@ -12,21 +12,15 @@ import {
   normalizeStories,
   resolveAddonName,
 } from '@storybook/core-common';
-import { ConflictingStaticDirConfigError } from '@storybook/core-events/server-errors';
 
-import isEqual from 'lodash/isEqual.js';
 import dedent from 'ts-dedent';
 import { outputStats } from './utils/output-stats';
-import {
-  copyAllStaticFiles,
-  copyAllStaticFilesRelativeToMain,
-} from './utils/copy-all-static-files';
+import { copyAllStaticFilesRelativeToMain } from './utils/copy-all-static-files';
 import { getBuilders } from './utils/get-builders';
 import { extractStoriesJson } from './utils/stories-json';
 import { extractStorybookMetadata } from './utils/metadata';
 import { StoryIndexGenerator } from './utils/StoryIndexGenerator';
 import { summarizeIndex } from './utils/summarizeIndex';
-import { defaultStaticDirs } from './utils/constants';
 import { buildOrThrow } from './utils/build-or-throw';
 
 export type BuildStaticStandaloneOptions = CLIOptions &
@@ -39,10 +33,6 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
 
   if (options.outputDir === '') {
     throw new Error("Won't remove current directory. Check your outputDir!");
-  }
-
-  if (options.staticDir?.includes('/')) {
-    throw new Error("Won't copy root directory. Check your staticDirs!");
   }
 
   options.outputDir = isAbsolute(options.outputDir)
@@ -131,10 +121,6 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
     build,
   };
 
-  if (options.staticDir && !isEqual(staticDirs, defaultStaticDirs)) {
-    throw new ConflictingStaticDirConfigError();
-  }
-
   const effects: Promise<void>[] = [];
 
   global.FEATURES = features;
@@ -147,9 +133,6 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
     effects.push(
       copyAllStaticFilesRelativeToMain(staticDirs, options.outputDir, options.configDir)
     );
-  }
-  if (options.staticDir) {
-    effects.push(copyAllStaticFiles(options.staticDir, options.outputDir));
   }
 
   const coreServerPublicDir = join(

--- a/code/lib/core-server/src/presets/common-preset.ts
+++ b/code/lib/core-server/src/presets/common-preset.ts
@@ -55,7 +55,7 @@ export const favicon = async (
 
   const statics = staticDirsValue
     ? staticDirsValue.map((dir) => (typeof dir === 'string' ? dir : `${dir.from}:${dir.to}`))
-    : options.staticDir;
+    : [];
 
   if (statics && statics.length > 0) {
     const lists = await Promise.all(

--- a/code/lib/core-server/src/utils/server-statics.ts
+++ b/code/lib/core-server/src/utils/server-statics.ts
@@ -1,28 +1,20 @@
 import { logger } from '@storybook/node-logger';
 import type { Options } from '@storybook/types';
 import { getDirectoryFromWorkingDir } from '@storybook/core-common';
-import { ConflictingStaticDirConfigError } from '@storybook/core-events/server-errors';
 import chalk from 'chalk';
 import type { Router } from 'express';
 import express from 'express';
 import { pathExists } from 'fs-extra';
 import path, { basename, isAbsolute } from 'path';
-import isEqual from 'lodash/isEqual.js';
 
 import { dedent } from 'ts-dedent';
-import { defaultStaticDirs } from './constants';
 
 export async function useStatics(router: Router, options: Options) {
   const staticDirs = (await options.presets.apply('staticDirs')) ?? [];
   const faviconPath = await options.presets.apply<string>('favicon');
 
-  if (options.staticDir && !isEqual(staticDirs, defaultStaticDirs)) {
-    throw new ConflictingStaticDirConfigError();
-  }
-
   const statics = [
     ...staticDirs.map((dir) => (typeof dir === 'string' ? dir : `${dir.from}:${dir.to}`)),
-    ...(options.staticDir || []),
   ];
 
   if (statics && statics.length > 0) {


### PR DESCRIPTION
## What I did

We said we'd remove it, let's remove it.

The CLI now no longer supports `-s` or `--static-dir` flags.
The only way to configure this is via `main.ts`

This PR likely needs documentation changes.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
