### PR TITLE
UI: Remove deprecated WithTooltip props

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -31,6 +31,7 @@
     - [--use-npm flag in storybook CLI](#--use-npm-flag-in-storybook-cli)
     - [`setGlobalConfig` from `@storybook/react`](#setglobalconfig-from-storybookreact)
     - [StorybookViteConfig type from @storybook/builder-vite](#storybookviteconfig-type-from-storybookbuilder-vite)
+    - [props from WithTooltipComponent from @storybook/components](#props-from-withtooltipcomponent-from-storybookcomponents)
 - [From version 7.5.0 to 7.6.0](#from-version-750-to-760)
     - [CommonJS with Vite is deprecated](#commonjs-with-vite-is-deprecated)
     - [Using implicit actions during rendering is deprecated](#using-implicit-actions-during-rendering-is-deprecated)
@@ -589,6 +590,20 @@ The `StorybookViteConfig` type is now removed in favor of `StorybookConfig`:
 
 ```ts
 import type { StorybookConfig } from '@storybook/react-vite';
+```
+
+#### props from WithTooltipComponent from @storybook/components
+
+The deprecated properties `tooltipShown`, `closeOnClick`, and `onVisibilityChange` of `WithTooltipComponent` from `@storybook/components` are now removed. Please replace them:
+
+```tsx
+<WithTooltip
+  closeOnClick       // becomes closeOnOutsideClick
+  tooltipShown       // becomes defaultVisible
+  onVisibilityChange // becomes onVisibleChange
+>
+  ...
+</WithTooltip>
 ```
 
 ## From version 7.5.0 to 7.6.0

--- a/code/addons/themes/src/theme-switcher.tsx
+++ b/code/addons/themes/src/theme-switcher.tsx
@@ -57,7 +57,7 @@ export const ThemeSwitcher = () => {
       <WithTooltip
         placement="top"
         trigger="click"
-        closeOnClick
+        closeOnOutsideClick
         tooltip={({ onHide }) => {
           return (
             <TooltipLinkList

--- a/code/ui/blocks/package.json
+++ b/code/ui/blocks/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "@storybook/addon-actions": "workspace:*",
+    "@storybook/test": "workspace:*",
     "@types/color-convert": "^2.0.0"
   },
   "peerDependencies": {

--- a/code/ui/blocks/src/blocks/Story.stories.tsx
+++ b/code/ui/blocks/src/blocks/Story.stories.tsx
@@ -87,6 +87,11 @@ export const IFrameProps: Story = {
     of: StoryParametersStories.NoParameters,
     inline: false,
   },
+  parameters: {
+    chromatic: {
+      delay: 3000,
+    },
+  },
   play: async ({ canvasElement }) => {
     // this is mostly to fix flakiness in chromatic, specifically on Safari
     // where the scrollbar appears inconsistently and causes the snapshot to be different

--- a/code/ui/blocks/src/blocks/Story.stories.tsx
+++ b/code/ui/blocks/src/blocks/Story.stories.tsx
@@ -99,7 +99,7 @@ export const IFrameProps: Story = {
       async () => {
         const iframeEl = canvasElement.querySelector('iframe');
         await expect(
-          iframeEl.contentDocument.querySelector('[data-testid="sb-iframe-text"]')
+          iframeEl!.contentDocument!.querySelector('[data-testid="sb-iframe-text"]')
         ).toBeVisible();
       },
       { timeout: 10000 }

--- a/code/ui/blocks/src/blocks/Story.stories.tsx
+++ b/code/ui/blocks/src/blocks/Story.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor } from '@storybook/test';
 
 import { Story as StoryBlock } from './Story';
 import * as ButtonStories from '../examples/Button.stories';
@@ -85,6 +86,19 @@ export const IFrameProps: Story = {
   args: {
     of: StoryParametersStories.NoParameters,
     inline: false,
+  },
+  play: async ({ canvasElement }) => {
+    // this is mostly to fix flakiness in chromatic, specifically on Safari
+    // where the scrollbar appears inconsistently and causes the snapshot to be different
+    await waitFor(
+      async () => {
+        const iframeEl = canvasElement.querySelector('iframe');
+        await expect(
+          iframeEl.contentDocument.querySelector('[data-testid="sb-iframe-text"]')
+        ).toBeVisible();
+      },
+      { timeout: 10000 }
+    );
   },
 };
 

--- a/code/ui/blocks/src/examples/SimpleSizeTest.tsx
+++ b/code/ui/blocks/src/examples/SimpleSizeTest.tsx
@@ -12,7 +12,7 @@ export const SimpleSizeTest = () => {
         margin: '-4rem -20px',
       }}
     >
-      <p>
+      <p data-testid="sb-iframe-text">
         This story does nothing. Its only purpose is to show how its size renders in different
         conditions (inline/iframe/fixed height) when used in a <code>{'<Story />'}</code> block.
       </p>

--- a/code/ui/components/package.json
+++ b/code/ui/components/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@popperjs/core": "^2.6.0",
     "@radix-ui/react-scroll-area": "^1.0.5",
+    "@storybook/test": "workspace:*",
     "@types/react-syntax-highlighter": "11.0.5",
     "@types/util-deprecate": "^1.0.0",
     "css": "^3.0.0",

--- a/code/ui/components/src/components/tooltip/WithTooltip.stories.tsx
+++ b/code/ui/components/src/components/tooltip/WithTooltip.stories.tsx
@@ -1,7 +1,7 @@
 import type { FunctionComponent, ComponentProps } from 'react';
 import React from 'react';
 import type { StoryObj } from '@storybook/react';
-import { within, expect, userEvent, screen } from '@storybook/test';
+import { expect, screen } from '@storybook/test';
 import { styled } from '@storybook/theming';
 import { TooltipMessage } from './TooltipMessage';
 import { WithToolTipState as WithTooltip } from './WithTooltip';
@@ -120,14 +120,6 @@ export const SimpleClickCloseOnClick: StoryObj<ComponentProps<typeof WithTooltip
       <Trigger>Click me!</Trigger>
     </WithTooltip>
   ),
-  play: async (context) => {
-    const canvas = within(context.canvasElement);
-    const trigger = canvas.getByText('Click me!');
-    await userEvent.click(trigger);
-
-    await expect(await screen.findByText('Lorem ipsum dolor sit')).toBeInTheDocument();
-    await userEvent.click(document.body);
-  },
 };
 
 export const WithoutChrome: StoryObj<ComponentProps<typeof WithTooltip>> = {

--- a/code/ui/components/src/components/tooltip/WithTooltip.stories.tsx
+++ b/code/ui/components/src/components/tooltip/WithTooltip.stories.tsx
@@ -1,6 +1,7 @@
 import type { FunctionComponent, ComponentProps } from 'react';
 import React from 'react';
 import type { StoryObj } from '@storybook/react';
+import { within, expect, userEvent, screen } from '@storybook/test';
 import { styled } from '@storybook/theming';
 import { TooltipMessage } from './TooltipMessage';
 import { WithToolTipState as WithTooltip } from './WithTooltip';
@@ -104,6 +105,9 @@ export const SimpleClickStartOpen: StoryObj<ComponentProps<typeof WithTooltip>> 
       <Trigger>Click me!</Trigger>
     </WithTooltip>
   ),
+  play: async () => {
+    await expect(await screen.findByText('Lorem ipsum dolor sit')).toBeInTheDocument();
+  },
 };
 
 export const SimpleClickCloseOnClick: StoryObj<ComponentProps<typeof WithTooltip>> = {
@@ -116,6 +120,14 @@ export const SimpleClickCloseOnClick: StoryObj<ComponentProps<typeof WithTooltip
       <Trigger>Click me!</Trigger>
     </WithTooltip>
   ),
+  play: async (context) => {
+    const canvas = within(context.canvasElement);
+    const trigger = canvas.getByText('Click me!');
+    await userEvent.click(trigger);
+
+    await expect(await screen.findByText('Lorem ipsum dolor sit')).toBeInTheDocument();
+    await userEvent.click(document.body);
+  },
 };
 
 export const WithoutChrome: StoryObj<ComponentProps<typeof WithTooltip>> = {

--- a/code/ui/components/src/components/tooltip/WithTooltip.tsx
+++ b/code/ui/components/src/components/tooltip/WithTooltip.tsx
@@ -37,18 +37,6 @@ export interface WithTooltipPureProps
   children: ReactNode;
   onDoubleClick?: () => void;
   /**
-   * @deprecated use `defaultVisible` property instead. This property will be removed in SB 8.0
-   */
-  tooltipShown?: boolean;
-  /**
-   * @deprecated use `closeOnOutsideClick` property instead. This property will be removed in SB 8.0
-   */
-  closeOnClick?: boolean;
-  /**
-   * @deprecated use `onVisibleChange` property instead. This property will be removed in SB 8.0
-   */
-  onVisibilityChange?: (visibility: boolean) => void | boolean;
-  /**
    * If `true`, a click outside the trigger element closes the tooltip
    * @default false
    */
@@ -68,9 +56,6 @@ const WithTooltipPure: FC<WithTooltipPureProps> = ({
   children,
   closeOnTriggerHidden,
   mutationObserverOptions,
-  closeOnClick,
-  tooltipShown,
-  onVisibilityChange,
   defaultVisible,
   delayHide,
   visible,
@@ -94,15 +79,12 @@ const WithTooltipPure: FC<WithTooltipPureProps> = ({
     {
       trigger,
       placement,
-      defaultVisible: defaultVisible ?? tooltipShown,
+      defaultVisible,
       delayHide,
       interactive,
-      closeOnOutsideClick: closeOnOutsideClick ?? closeOnClick,
+      closeOnOutsideClick,
       closeOnTriggerHidden,
-      onVisibleChange: (_isVisible) => {
-        onVisibilityChange?.(_isVisible);
-        onVisibleChange?.(_isVisible);
-      },
+      onVisibleChange,
       delayShow,
       followCursor,
       mutationObserverOptions,

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5070,6 +5070,7 @@ __metadata:
     "@storybook/icons": "npm:^1.2.1"
     "@storybook/manager-api": "workspace:*"
     "@storybook/preview-api": "workspace:*"
+    "@storybook/test": "workspace:*"
     "@storybook/theming": "workspace:*"
     "@storybook/types": "workspace:*"
     "@types/color-convert": "npm:^2.0.0"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5343,6 +5343,7 @@ __metadata:
     "@storybook/csf": "npm:^0.1.2"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.2.1"
+    "@storybook/test": "workspace:*"
     "@storybook/theming": "workspace:*"
     "@storybook/types": "workspace:*"
     "@types/react-syntax-highlighter": "npm:11.0.5"


### PR DESCRIPTION
Closes #25332 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR does the following:
- The deprecated properties `tooltipShown`, `closeOnClick`, and `onVisibilityChange` of `WithTooltipComponent` from `@storybook/components` are now removed.
- replaces the deprecated prop from Addon-themes 
- Adds tests to some Tooltip stories to test its functionality

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
