### PR TITLE
AutoTitle: Fix case-insensitive trailing duplicate

### DIFF
--- a/code/lib/preview-api/src/modules/store/autoTitle.test.ts
+++ b/code/lib/preview-api/src/modules/store/autoTitle.test.ts
@@ -177,6 +177,16 @@ describe('userOrAutoTitleFromSpecifier', () => {
         ).toMatchInlineSnapshot(`to/button`);
       });
 
+      it('match with case-insensitive trailing duplicate', () => {
+        expect(
+          userOrAuto(
+            './path/to/button/Button.stories.js',
+            normalizeStoriesEntry({ directory: './path' }, options),
+            undefined
+          )
+        ).toMatchInlineSnapshot(`to/Button`);
+      });
+
       it('match with trailing index', () => {
         expect(
           userOrAuto(

--- a/code/lib/preview-api/src/modules/store/autoTitle.ts
+++ b/code/lib/preview-api/src/modules/store/autoTitle.ts
@@ -15,11 +15,12 @@ const sanitize = (parts: string[]) => {
   if (parts.length === 1) return [lastStripped];
 
   const nextToLast = parts[parts.length - 2];
+  if (lastStripped && nextToLast && lastStripped.toLowerCase() === nextToLast.toLowerCase()) {
+    return [...parts.slice(0, -2), lastStripped];
+  }
+
   return lastStripped &&
-    nextToLast &&
-    (lastStripped === nextToLast ||
-      /^(story|stories)([.][^.]+)$/i.test(last) ||
-      /^index$/i.test(lastStripped))
+    (/^(story|stories)([.][^.]+)$/i.test(last) || /^index$/i.test(lastStripped))
     ? parts.slice(0, -1)
     : [...parts.slice(0, -1), lastStripped];
 };


### PR DESCRIPTION
Closes  #25451

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create case-insenstive directory and story file in sandbox env ex) `src/stories/button/Button.stories.ts`
2. Remove title parameter from `Button.stories.ts`
3. Access local storybook server and you can confirm `stories/Button`

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
4. Open Storybook in your browser
5. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
