### PR TITLE
Core: Remove storyIndexers in favor of experimental_indexers

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -36,6 +36,7 @@
     - [DecoratorFn, Story, ComponentStory, ComponentStoryObj, ComponentStoryFn and ComponentMeta TypeScript types](#decoratorfn-story-componentstory-componentstoryobj-componentstoryfn-and-componentmeta-typescript-types)
     - ["Framework" TypeScript types](#framework-typescript-types)
     - [`navigateToSettingsPage` method from Storybook's manager-api](#navigatetosettingspage-method-from-storybooks-manager-api)
+    - [storyIndexers](#storyindexers)
 - [From version 7.5.0 to 7.6.0](#from-version-750-to-760)
     - [CommonJS with Vite is deprecated](#commonjs-with-vite-is-deprecated)
     - [Using implicit actions during rendering is deprecated](#using-implicit-actions-during-rendering-is-deprecated)
@@ -650,6 +651,10 @@ export const Component = () => {
   // ...
 }
 ```
+
+#### storyIndexers
+
+The Storybook's main.js configuration property `storyIndexers` is now removed in favor of `experimental_indexers`. [More info](#storyindexers-is-replaced-with-experimental_indexers).
 
 ## From version 7.5.0 to 7.6.0
 

--- a/code/lib/core-server/src/build-static.ts
+++ b/code/lib/core-server/src/build-static.ts
@@ -94,16 +94,14 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
     build,
   });
 
-  const [features, core, staticDirs, indexers, deprecatedStoryIndexers, stories, docsOptions] =
-    await Promise.all([
-      presets.apply('features'),
-      presets.apply('core'),
-      presets.apply('staticDirs'),
-      presets.apply('experimental_indexers', []),
-      presets.apply('storyIndexers', []),
-      presets.apply('stories'),
-      presets.apply('docs', {}),
-    ]);
+  const [features, core, staticDirs, indexers, stories, docsOptions] = await Promise.all([
+    presets.apply('features'),
+    presets.apply('core'),
+    presets.apply('staticDirs'),
+    presets.apply('experimental_indexers', []),
+    presets.apply('stories'),
+    presets.apply('docs', {}),
+  ]);
 
   if (features?.storyStoreV7 === false) {
     deprecate(
@@ -150,7 +148,6 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
     const normalizedStories = normalizeStories(stories, directories);
     const generator = new StoryIndexGenerator(normalizedStories, {
       ...directories,
-      storyIndexers: deprecatedStoryIndexers,
       indexers,
       docs: docsOptions,
       storyStoreV7: !!features?.storyStoreV7,

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -42,7 +42,6 @@ const getStorySortParameterMock = vi.mocked(getStorySortParameter);
 const options: StoryIndexGeneratorOptions = {
   configDir: path.join(__dirname, '__mockdata__'),
   workingDir: path.join(__dirname, '__mockdata__'),
-  storyIndexers: [],
   indexers: [csfIndexer],
   storyStoreV7: true,
   docs: { defaultName: 'docs', autodocs: false },

--- a/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
@@ -15,7 +15,6 @@ vi.mock('@storybook/node-logger');
 const options: StoryIndexGeneratorOptions = {
   configDir: path.join(__dirname, '..', '__mockdata__'),
   workingDir: path.join(__dirname, '..', '__mockdata__'),
-  storyIndexers: [],
   indexers: [],
   storyStoreV7: true,
   docs: { defaultName: 'docs', autodocs: false },

--- a/code/lib/core-server/src/utils/getStoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/getStoryIndexGenerator.ts
@@ -23,14 +23,12 @@ export async function getStoryIndexGenerator(
     workingDir,
   };
   const stories = options.presets.apply('stories');
-  const deprecatedStoryIndexers = options.presets.apply('storyIndexers', []);
   const indexers = options.presets.apply('experimental_indexers', []);
   const docsOptions = options.presets.apply<DocsOptions>('docs', {});
   const normalizedStories = normalizeStories(await stories, directories);
 
   const generator = new StoryIndexGenerator(normalizedStories, {
     ...directories,
-    storyIndexers: await deprecatedStoryIndexers,
     indexers: await indexers,
     docs: await docsOptions,
     workingDir,

--- a/code/lib/core-server/src/utils/stories-json.test.ts
+++ b/code/lib/core-server/src/utils/stories-json.test.ts
@@ -42,7 +42,6 @@ const getInitializedStoryIndexGenerator = async (
   inputNormalizedStories = normalizedStories
 ) => {
   const options: StoryIndexGeneratorOptions = {
-    storyIndexers: [],
     indexers: [csfIndexer],
     configDir: workingDir,
     workingDir,

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -7,7 +7,7 @@ import type { Router } from 'express';
 import type { Server } from 'http';
 import type { PackageJson as PackageJsonFromTypeFest } from 'type-fest';
 
-import type { StoriesEntry, Indexer, StoryIndexer } from './indexer';
+import type { StoriesEntry, Indexer } from './indexer';
 
 /**
  * ⚠️ This file contains internal WIP types they MUST NOT be exported outside this package for now!
@@ -416,8 +416,6 @@ export interface StorybookConfigRaw {
 
   previewAnnotations?: Entry[];
 
-  storyIndexers?: StoryIndexer[];
-
   experimental_indexers?: Indexer[];
 
   docs?: DocsOptions;
@@ -508,12 +506,6 @@ export interface StorybookConfig {
    * Add additional scripts to run in the preview a la `.storybook/preview.js`
    */
   previewAnnotations?: PresetValue<StorybookConfigRaw['previewAnnotations']>;
-
-  /**
-   * Process CSF files for the story index.
-   * @deprecated use {@link experimental_indexers} instead
-   */
-  storyIndexers?: PresetValue<StorybookConfigRaw['storyIndexers']>;
 
   /**
    * Process CSF files for the story index.

--- a/code/lib/types/src/modules/indexer.ts
+++ b/code/lib/types/src/modules/indexer.ts
@@ -67,21 +67,7 @@ export type Indexer = BaseIndexer & {
    * @returns A promise that resolves to an array of {@link IndexInput} objects.
    */
   createIndex: (fileName: string, options: IndexerOptions) => Promise<IndexInput[]>;
-  /**
-   * @deprecated Use {@link index} instead
-   */
-  indexer?: never;
 };
-
-export type DeprecatedIndexer = BaseIndexer & {
-  indexer: (fileName: string, options: IndexerOptions) => Promise<IndexedCSFFile>;
-  createIndex?: never;
-};
-
-/**
- * @deprecated Use {@link Indexer} instead
- */
-export type StoryIndexer = Indexer | DeprecatedIndexer;
 
 export interface BaseIndexEntry {
   id: StoryId;


### PR DESCRIPTION
Closes #25343

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Storybook's main.js configuration property `storyIndexers` is now removed in favor of `experimental_indexers`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
