### PR TITLE
Types: Remove Framework in favor of Renderer types

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,6 +34,7 @@
     - [props from WithTooltipComponent from @storybook/components](#props-from-withtooltipcomponent-from-storybookcomponents)
     - [LinkTo direct import from addon-links](#linkto-direct-import-from-addon-links)
     - [DecoratorFn, Story, ComponentStory, ComponentStoryObj, ComponentStoryFn and ComponentMeta TypeScript types](#decoratorfn-story-componentstory-componentstoryobj-componentstoryfn-and-componentmeta-typescript-types)
+    - ["Framework" TypeScript types](#framework-typescript-types)
 - [From version 7.5.0 to 7.6.0](#from-version-750-to-760)
     - [CommonJS with Vite is deprecated](#commonjs-with-vite-is-deprecated)
     - [Using implicit actions during rendering is deprecated](#using-implicit-actions-during-rendering-is-deprecated)
@@ -627,6 +628,10 @@ The `Story` type is now removed in favor of `StoryFn` and `StoryObj`. More info 
 The `DecoratorFn` type is now removed in favor of `Decorator`. [More info](#renamed-decoratorfn-to-decorator).
 
 For React, the `ComponentStory`, `ComponentStoryObj`, `ComponentStoryFn` and `ComponentMeta` types are now removed in favor of `StoryFn`, `StoryObj` and `Meta`. [More info](#componentstory-componentstoryobj-componentstoryfn-and-componentmeta-types-are-deprecated).
+
+#### "Framework" TypeScript types
+
+The Framework types such as `ReactFramework` are now removed in favor of Renderer types such as `ReactRenderer`. This affects all frameworks. [More info](#renamed-xframework-to-xrenderer).
 
 ## From version 7.5.0 to 7.6.0
 

--- a/code/frameworks/angular/src/client/types.ts
+++ b/code/frameworks/angular/src/client/types.ts
@@ -37,10 +37,6 @@ export interface StoryFnAngularReturnType {
   userDefinedTemplate?: boolean;
 }
 
-/**
- * @deprecated Use `AngularRenderer` instead.
- */
-export type AngularFramework = AngularRenderer;
 export interface AngularRenderer extends WebRenderer {
   component: any;
   storyResult: StoryFnAngularReturnType;

--- a/code/frameworks/ember/src/client/preview/types.ts
+++ b/code/frameworks/ember/src/client/preview/types.ts
@@ -13,10 +13,6 @@ export interface OptionsArgs {
   element: any;
 }
 
-/**
- * @deprecated Use `EmberRenderer` instead.
- */
-export type EmberFramework = EmberRenderer;
 export interface EmberRenderer extends WebRenderer {
   component: any;
   storyResult: OptionsArgs;

--- a/code/renderers/html/src/types.ts
+++ b/code/renderers/html/src/types.ts
@@ -14,10 +14,6 @@ export interface ShowErrorArgs {
   description: string;
 }
 
-/**
- * @deprecated Use `HtmlRenderer` instead.
- */
-export type HtmlFramework = HtmlRenderer;
 export interface HtmlRenderer extends WebRenderer {
   component: string | HTMLElement | ArgsStoryFn<HtmlRenderer>;
   storyResult: StoryFnHtmlReturnType;

--- a/code/renderers/preact/src/types.ts
+++ b/code/renderers/preact/src/types.ts
@@ -10,13 +10,6 @@ export interface ShowErrorArgs {
   description: string;
 }
 
-/**
- * @dep
- */
-/**
- * @deprecated Use `PreactRenderer` instead.
- */
-export type PreactFramework = PreactRenderer;
 export interface PreactRenderer extends WebRenderer {
   component: AnyComponent<any, any>;
   storyResult: StoryFnPreactReturnType;

--- a/code/renderers/react/src/types.ts
+++ b/code/renderers/react/src/types.ts
@@ -3,10 +3,6 @@ import type { WebRenderer } from '@storybook/types';
 
 export type { RenderContext, StoryContext } from '@storybook/types';
 
-/**
- * @deprecated Use `ReactRenderer` instead.
- */
-export type ReactFramework = ReactRenderer;
 export interface ReactRenderer extends WebRenderer {
   component: ComponentType<this['T']>;
   storyResult: StoryFnReactReturnType;

--- a/code/renderers/server/src/types.ts
+++ b/code/renderers/server/src/types.ts
@@ -5,10 +5,6 @@ export type { RenderContext } from '@storybook/types';
 export type StoryFnServerReturnType = any;
 export type StoryContext = StoryContextBase<ServerRenderer>;
 
-/**
- * @deprecated Use `ServerRenderer` instead.
- */
-export type ServerFramework = ServerRenderer;
 export interface ServerRenderer extends WebRenderer {
   component: string;
   storyResult: StoryFnServerReturnType;

--- a/code/renderers/vue3/src/types.ts
+++ b/code/renderers/vue3/src/types.ts
@@ -16,10 +16,6 @@ export type StoryContext = StoryContextBase<VueRenderer>;
 
 export type StorybookVueApp = { vueApp: App<any>; storyContext: StoryContext };
 
-/**
- * @deprecated Use `VueRenderer` instead.
- */
-export type VueFramework = VueRenderer;
 export interface VueRenderer extends WebRenderer {
   // We are omitting props, as we don't use it internally, and more importantly, it completely changes the assignability of meta.component.
   // Try not omitting, and check the type errros in the test file, if you want to learn more.

--- a/code/renderers/web-components/src/types.ts
+++ b/code/renderers/web-components/src/types.ts
@@ -10,10 +10,6 @@ export type StoryFnHtmlReturnType =
 
 export type StoryContext = StoryContextBase<WebComponentsRenderer>;
 
-/**
- * @deprecated Use `WebComponentsRenderer` instead.
- */
-export type WebComponentsFramework = WebComponentsRenderer;
 export interface WebComponentsRenderer extends WebRenderer {
   component: string;
   storyResult: StoryFnHtmlReturnType;


### PR DESCRIPTION
Closes #25340 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did


The Framework types such as `ReactFramework` are now removed in favor of Renderer types such as `ReactRenderer`. This affects all frameworks.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
