### PR TITLE
Indexer: Add metaTags and make autodocs inherit them

### DIFF
--- a/code/e2e-tests/tags.spec.ts
+++ b/code/e2e-tests/tags.spec.ts
@@ -44,5 +44,20 @@ test.describe('tags', () => {
     // Sidebar should exclude test-only stories and their docs
     const componentEntry = await page.locator('#lib-preview-api-test-only-tag').all();
     expect(componentEntry.length).toBe(0);
+
+    // Even though test-only autodocs not sidebar, it is still in the preview
+    // Even though the test-only story is filtered out of the stories, it is still the primary story (should it be?)
+    await sbPage.deepLinkToStory(storybookUrl, 'lib/preview-api/test-only-tag', 'docs');
+    await sbPage.waitUntilLoaded();
+    let root = sbPage.previewRoot();
+    let button = await root.locator('button', { hasText: 'button' });
+    expect(button).toBeVisible();
+
+    // Even though test-only story not sidebar, it is still in the preview
+    await sbPage.deepLinkToStory(storybookUrl, 'lib/preview-api/test-only-tag', 'default');
+    await sbPage.waitUntilLoaded();
+    root = sbPage.previewRoot();
+    button = await root.locator('button', { hasText: 'button' });
+    expect(button).toBeVisible();
   });
 });

--- a/code/e2e-tests/tags.spec.ts
+++ b/code/e2e-tests/tags.spec.ts
@@ -39,6 +39,7 @@ test.describe('tags', () => {
 
   test('should correctly filter out test-only autodocs pages', async ({ page }) => {
     const sbPage = new SbPage(page);
+
     await sbPage.selectToolbar('#lib-preview-api');
 
     // Sidebar should exclude test-only stories and their docs
@@ -49,15 +50,13 @@ test.describe('tags', () => {
     // Even though the test-only story is filtered out of the stories, it is still the primary story (should it be?)
     await sbPage.deepLinkToStory(storybookUrl, 'lib/preview-api/test-only-tag', 'docs');
     await sbPage.waitUntilLoaded();
-    let root = sbPage.previewRoot();
-    let button = await root.locator('button', { hasText: 'button' });
-    expect(button).toBeVisible();
+    const docsButton = await sbPage.previewRoot().locator('button', { hasText: 'Button' });
+    await expect(docsButton).toBeVisible();
 
     // Even though test-only story not sidebar, it is still in the preview
     await sbPage.deepLinkToStory(storybookUrl, 'lib/preview-api/test-only-tag', 'default');
     await sbPage.waitUntilLoaded();
-    root = sbPage.previewRoot();
-    button = await root.locator('button', { hasText: 'button' });
-    expect(button).toBeVisible();
+    const storyButton = await sbPage.previewRoot().locator('button', { hasText: 'Button' });
+    await expect(storyButton).toBeVisible();
   });
 });

--- a/code/e2e-tests/tags.spec.ts
+++ b/code/e2e-tests/tags.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { SbPage } from './util';
+
+const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:8001';
+
+test.describe('tags', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(storybookUrl);
+    await new SbPage(page).waitUntilLoaded();
+  });
+
+  test('should correctly filter dev-only, docs-only, test-only stories', async ({ page }) => {
+    const sbPage = new SbPage(page);
+
+    await sbPage.navigateToStory('lib/preview-api/tags', 'docs');
+
+    // Sidebar should include dev-only and exclude docs-only and test-only
+    const devOnlyEntry = await page.locator('#lib-preview-api-tags--dev-only').all();
+    expect(devOnlyEntry.length).toBe(1);
+
+    const docsOnlyEntry = await page.locator('#lib-preview-api-tags--docs-only').all();
+    expect(docsOnlyEntry.length).toBe(0);
+
+    const testOnlyEntry = await page.locator('#lib-preview-api-tags--test-only').all();
+    expect(testOnlyEntry.length).toBe(0);
+
+    // Autodocs should include docs-only and exclude dev-only and test-only
+    const root = sbPage.previewRoot();
+
+    const devOnlyAnchor = await root.locator('#anchor--lib-preview-api-tags--dev-only').all();
+    expect(devOnlyAnchor.length).toBe(0);
+
+    const docsOnlyAnchor = await root.locator('#anchor--lib-preview-api-tags--docs-only').all();
+    expect(docsOnlyAnchor.length).toBe(1);
+
+    const testOnlyAnchor = await root.locator('#anchor--lib-preview-api-tags--test-only').all();
+    expect(testOnlyAnchor.length).toBe(0);
+  });
+
+  test('should correctly filter out test-only autodocs pages', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    await sbPage.selectToolbar('#lib-preview-api');
+
+    // Sidebar should exclude test-only stories and their docs
+    const componentEntry = await page.locator('#lib-preview-api-test-only-tag').all();
+    expect(componentEntry.length).toBe(0);
+  });
+});

--- a/code/e2e-tests/util.ts
+++ b/code/e2e-tests/util.ts
@@ -33,6 +33,9 @@ export class SbPage {
     const storyLinkId = `${titleId}--${storyId}`;
     const viewMode = name === 'docs' ? 'docs' : 'story';
     await this.page.goto(`${baseURL}/?path=/${viewMode}/${storyLinkId}`);
+
+    await this.page.waitForURL((url) => url.search.includes(`path=/${viewMode}/${storyLinkId}`));
+    await this.previewRoot();
   }
 
   /**

--- a/code/lib/core-server/src/presets/common-manager.ts
+++ b/code/lib/core-server/src/presets/common-manager.ts
@@ -3,15 +3,17 @@ import { global } from '@storybook/global';
 
 const STATIC_FILTER = 'static-filter';
 
-const excludeTags = Object.entries(global.TAGS_OPTIONS ?? {}).reduce((acc, entry) => {
-  const [tag, option] = entry;
-  if ((option as any).excludeFromSidebar) {
-    acc[tag] = true;
-  }
-  return acc;
-}, {} as Record<string, boolean>);
-
 addons.register(STATIC_FILTER, (api) => {
+  // FIXME: this ensures the filter is applied after the first render
+  //        to avoid a strange race condition in Webkit only.
+  const excludeTags = Object.entries(global.TAGS_OPTIONS ?? {}).reduce((acc, entry) => {
+    const [tag, option] = entry;
+    if ((option as any).excludeFromSidebar) {
+      acc[tag] = true;
+    }
+    return acc;
+  }, {} as Record<string, boolean>);
+
   api.experimental_setFilter(STATIC_FILTER, (item) => {
     const tags = item.tags || [];
     return tags.filter((tag) => excludeTags[tag]).length === 0;

--- a/code/lib/core-server/src/presets/common-manager.ts
+++ b/code/lib/core-server/src/presets/common-manager.ts
@@ -14,11 +14,6 @@ const excludeTags = Object.entries(global.TAGS_OPTIONS ?? {}).reduce((acc, entry
 addons.register(STATIC_FILTER, (api) => {
   api.experimental_setFilter(STATIC_FILTER, (item) => {
     const tags = item.tags || [];
-    // very strange behavior here. Auto-generated docs entries get
-    // the tags of the primary story by default, so if that story
-    // happens to be `docs-only`, then filtering it out of the sidebar
-    // ALSO filter out the sidebar entry, which is not what we want.
-    // Here we special case it, but there should be a better solution.
-    return tags.includes('docs') || tags.filter((tag) => excludeTags[tag]).length === 0;
+    return tags.filter((tag) => excludeTags[tag]).length === 0;
   });
 });

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -319,7 +319,7 @@ export class StoryIndexGenerator {
       const name = this.options.docs.defaultName ?? 'Docs';
       const { metaId } = indexInputs[0];
       const { title } = entries[0];
-      const tags = indexInputs[0].tags || [];
+      const metaTags = indexInputs[0].metaTags || [];
       const id = toId(metaId ?? title, name);
       entries.unshift({
         id,
@@ -327,7 +327,7 @@ export class StoryIndexGenerator {
         name,
         importPath,
         type: 'docs',
-        tags: [...tags, 'docs', ...(!hasAutodocsTag && !isStoriesMdx ? [AUTODOCS_TAG] : [])],
+        tags: [...metaTags, 'docs', ...(!hasAutodocsTag && !isStoriesMdx ? [AUTODOCS_TAG] : [])],
         storiesImports: [],
       });
     }
@@ -438,6 +438,7 @@ export class StoryIndexGenerator {
         importPath,
         storiesImports: sortedDependencies.map((dep) => dep.entries[0].importPath),
         type: 'docs',
+        // FIXME: update this to use the index entry's metaTags once we update this to run on `IndexInputs`
         tags: [...(result.tags || []), csfEntry ? 'attached-mdx' : 'unattached-mdx', 'docs'],
       };
       return docsEntry;

--- a/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
@@ -406,7 +406,6 @@ describe('docs entries from story extraction', () => {
             "name": "docs",
             "storiesImports": [],
             "tags": [
-              "story-tag-from-indexer",
               "docs",
               "autodocs",
             ],
@@ -467,8 +466,6 @@ describe('docs entries from story extraction', () => {
             "name": "docs",
             "storiesImports": [],
             "tags": [
-              "autodocs",
-              "story-tag-from-indexer",
               "docs",
             ],
             "title": "A",
@@ -578,8 +575,6 @@ describe('docs entries from story extraction', () => {
             "name": "docs",
             "storiesImports": [],
             "tags": [
-              "stories-mdx",
-              "story-tag-from-indexer",
               "docs",
             ],
             "title": "A",

--- a/code/lib/csf-tools/src/CsfFile.test.ts
+++ b/code/lib/csf-tools/src/CsfFile.test.ts
@@ -1098,6 +1098,8 @@ describe('CsfFile', () => {
             - component-tag
             - story-tag
             - play-fn
+          metaTags: &ref_0
+            - component-tag
           __id: component-id--a
         - type: story
           importPath: foo/bar.stories.js
@@ -1109,6 +1111,7 @@ describe('CsfFile', () => {
             - component-tag
             - story-tag
             - play-fn
+          metaTags: *ref_0
           __id: component-id--b
       `);
     });
@@ -1137,6 +1140,8 @@ describe('CsfFile', () => {
           title: custom foo title
           metaId: component-id
           tags:
+            - component-tag
+          metaTags:
             - component-tag
           __id: custom-story-id
       `);
@@ -1169,6 +1174,11 @@ describe('CsfFile', () => {
             - inherit-tag-dup
             - story-tag
             - story-tag-dup
+          metaTags:
+            - component-tag
+            - component-tag-dup
+            - component-tag-dup
+            - inherit-tag-dup
           __id: custom-foo-title--a
       `);
     });

--- a/code/lib/csf-tools/src/CsfFile.ts
+++ b/code/lib/csf-tools/src/CsfFile.ts
@@ -572,6 +572,7 @@ export class CsfFile {
         title: this.meta?.title,
         metaId: this.meta?.id,
         tags,
+        metaTags: this.meta?.tags,
         __id: story.id,
       };
     });

--- a/code/lib/preview-api/template/stories/tags.stories.ts
+++ b/code/lib/preview-api/template/stories/tags.stories.ts
@@ -13,6 +13,7 @@ export default {
       });
     },
   ],
+  parameters: { chromatic: { disable: true } },
 };
 
 export const Inheritance = {
@@ -23,6 +24,7 @@ export const Inheritance = {
       tags: ['story-one', 'story-two', 'story'],
     });
   },
+  parameters: { chromatic: { disable: false } },
 };
 
 export const DocsOnly = {

--- a/code/lib/preview-api/template/stories/tags.stories.ts
+++ b/code/lib/preview-api/template/stories/tags.stories.ts
@@ -5,7 +5,7 @@ import { expect } from '@storybook/jest';
 
 export default {
   component: globalThis.Components.Pre,
-  tags: ['component-one', 'component-two'],
+  tags: ['component-one', 'component-two', 'autodocs'],
   decorators: [
     (storyFn: PartialStoryFn, context: StoryContext) => {
       return storyFn({
@@ -23,4 +23,16 @@ export const Inheritance = {
       tags: ['story-one', 'story-two', 'story'],
     });
   },
+};
+
+export const DocsOnly = {
+  tags: ['docs-only'],
+};
+
+export const TestOnly = {
+  tags: ['test-only'],
+};
+
+export const DevOnly = {
+  tags: ['dev-only'],
 };

--- a/code/lib/preview-api/template/stories/test-only-tag.stories.ts
+++ b/code/lib/preview-api/template/stories/test-only-tag.stories.ts
@@ -1,0 +1,10 @@
+import { global as globalThis } from '@storybook/global';
+
+export default {
+  component: globalThis.Components.Button,
+  tags: ['autodocs', 'test-only'],
+};
+
+export const Default = {
+  args: { label: 'Button' },
+};

--- a/code/lib/preview-api/template/stories/test-only-tag.stories.ts
+++ b/code/lib/preview-api/template/stories/test-only-tag.stories.ts
@@ -3,6 +3,7 @@ import { global as globalThis } from '@storybook/global';
 export default {
   component: globalThis.Components.Button,
   tags: ['autodocs', 'test-only'],
+  parameters: { chromatic: { disable: true } },
 };
 
 export const Default = {

--- a/code/lib/types/src/modules/indexer.ts
+++ b/code/lib/types/src/modules/indexer.ts
@@ -107,6 +107,8 @@ export type BaseIndexInput = {
   metaId?: MetaId;
   /** Tags for filtering entries in Storybook and its tools. */
   tags?: Tag[];
+  /** Tags from the meta for filtering entries in Storybook and its tools. */
+  metaTags?: Tag[];
   /**
    * The id of the entry, auto-generated from {@link title}/{@link metaId} and {@link exportName} if unspecified.
    * If specified, the story in the CSF file _must_ have a matching id set at `parameters.__id`, to be correctly matched.

--- a/code/ui/manager/src/runtime.ts
+++ b/code/ui/manager/src/runtime.ts
@@ -55,4 +55,9 @@ class ReactProvider extends Provider {
 
 const { document } = global;
 const rootEl = document.getElementById('root');
-renderStorybookUI(rootEl, new ReactProvider());
+
+// We need to wait for the script tag containing the global objects
+// to be run by Webkit before rendering the UI. This is fine in most browsers.
+setTimeout(() => {
+  renderStorybookUI(rootEl, new ReactProvider());
+}, 0);


### PR DESCRIPTION
Telescopes off #25328

## What I did

In the current code, the Autodocs index entry inherits all the tags from the "primary" (first) story on the page it is being generated from. This results in the following weird behavior.

Suppose I have a component Foo with three stories, A, B, and C. The component's meta adds the `autodocs` tag, meaning that the sidebar shows "Foo > Autodocs, A, B, C". A has the tags `['a']`. Then I filter the sidebar to remove everything with the tag `'a'`. The story A disappears as expected, but the autodocs also disappears because it inherits all of A's tags!

This change means that the Autodocs entry only inherit's the CSF meta tags. So if the meta has tags `['m']` and I exclude `'m'`, it will remove Autodocs and A, B, C because the stories also inherit meta's tags. If I exclude `'a'`, it will only exclude A (and any other entries tagged with `'a'`)

**NOTE:** this PR doesn't fix the behavior for attached MDX pages, which currently don't inherit any tags. So that is a known corner case bug.

**NOTE:** this extends the `Indexer` API. I think this is OK because: (1) the API is still experimental, and (2) we already include `metaId` in the API, so this is consistent with that.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
