### PR TITLE
Webpack5: Make export-order-loader compatible with both esm and cjs

### DIFF
--- a/code/builders/builder-webpack5/package.json
+++ b/code/builders/builder-webpack5/package.json
@@ -75,6 +75,7 @@
     "@types/semver": "^7.3.4",
     "browser-assert": "^1.2.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
+    "cjs-module-lexer": "^1.2.3",
     "constants-browserify": "^1.0.0",
     "css-loader": "^6.7.1",
     "es-module-lexer": "^1.4.1",

--- a/code/builders/builder-webpack5/src/loaders/export-order-loader.ts
+++ b/code/builders/builder-webpack5/src/loaders/export-order-loader.ts
@@ -1,5 +1,4 @@
 import assert from 'assert';
-// @ts-expect-error No types
 import { parse as parseCjs, init as initCjsParser } from 'cjs-module-lexer';
 import { parse as parseEs } from 'es-module-lexer';
 import MagicString from 'magic-string';

--- a/code/builders/builder-webpack5/src/loaders/export-order-loader.ts
+++ b/code/builders/builder-webpack5/src/loaders/export-order-loader.ts
@@ -1,34 +1,66 @@
-import { parse } from 'es-module-lexer';
+import { parse as parseCjs, init as initCjsParser } from 'cjs-module-lexer';
+import { parse as parseEs } from 'es-module-lexer';
 import MagicString from 'magic-string';
 import type { LoaderContext } from 'webpack';
 
-export default async function loader(this: LoaderContext<any>, source: string) {
+export default async function loader(
+  this: LoaderContext<any>,
+  source: string,
+  map: any,
+  meta: any
+) {
   const callback = this.async();
 
   try {
-    // Do NOT remove await here. The types are wrong! It has to be awaited,
-    // otherwise it will return a Promise<Promise<...>> when wasm isn't loaded.
-    const [, exports = []] = await parse(source);
+    let isEsModule = true, esImports, moduleExports, namedExportsOrder;
+    
+    try {
+      // Do NOT remove await here. The types are wrong! It has to be awaited,
+      // otherwise it will return a Promise<Promise<...>> when wasm isn't loaded.
+      const parseResult = await parseEs(source);
+      esImports = parseResult[0] || [];
+      moduleExports = parseResult[1] || [];
+    } catch {
+      esImports = [];
+      moduleExports = [];
+    }
+    
+    if (!moduleExports.length && !esImports.length) {
+      isEsModule = false;
+      try {
+        await initCjsParser();
+        moduleExports = (parseCjs(source)).exports || [];
+      } catch {
+        moduleExports = [];
+      }
+      namedExportsOrder = moduleExports.filter(
+        (e) => e !== 'default' && e !== '__esModule'
+      );
+    } else {
+      namedExportsOrder = moduleExports.map(
+        (e) => source.substring(e.s, e.e)
+      ).filter((e) => e !== 'default');
+    }
 
-    const namedExportsOrder = exports.some(
-      (e) => source.substring(e.s, e.e) === '__namedExportsOrder'
-    );
-
-    if (namedExportsOrder) {
-      return callback(null, source);
+    if (namedExportsOrder.indexOf('__namedExportsOrder') >= 0) {
+      return callback(null, source, map, meta);
     }
 
     const magicString = new MagicString(source);
-    const orderedExports = exports.filter((e) => source.substring(e.s, e.e) !== 'default');
-    magicString.append(
-      `;export const __namedExportsOrder = ${JSON.stringify(
-        orderedExports.map((e) => source.substring(e.s, e.e))
-      )};`
-    );
+    const namedExportsOrderString = JSON.stringify(namedExportsOrder);
+    if (isEsModule) {
+      magicString.append(
+        `;export const __namedExportsOrder = ${namedExportsOrderString};`
+      );
+    } else {
+      magicString.append(
+        `;module.exports.__namedExportsOrder = ${namedExportsOrderString};`
+      );
+    }
 
-    const map = magicString.generateMap({ hires: true });
-    return callback(null, magicString.toString(), map);
+    const generatedMap = magicString.generateMap({ hires: true });
+    return callback(null, magicString.toString(), generatedMap, meta);
   } catch (err) {
-    return callback(err as any);
+    return callback(null, source, map, meta);
   }
 }

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5228,6 +5228,7 @@ __metadata:
     "@types/webpack-virtual-modules": "npm:^0.1.1"
     browser-assert: "npm:^1.2.1"
     case-sensitive-paths-webpack-plugin: "npm:^2.4.0"
+    cjs-module-lexer: "npm:^1.2.3"
     constants-browserify: "npm:^1.0.0"
     css-loader: "npm:^6.7.1"
     es-module-lexer: "npm:^1.4.1"
@@ -11214,6 +11215,13 @@ __metadata:
     inherits: "npm:^2.0.1"
     safe-buffer: "npm:^5.0.1"
   checksum: d8d005f8b64d8a77b3d3ce531301ae7b45902c9cab4ec8b66bdbd2bf2a1d9fceb9a2133c293eb3c060b2d964da0f14c47fb740366081338aa3795dd1faa8984b
+  languageName: node
+  linkType: hard
+
+"cjs-module-lexer@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "cjs-module-lexer@npm:1.2.3"
+  checksum: 0de9a9c3fad03a46804c0d38e7b712fb282584a9c7ef1ed44cae22fb71d9bb600309d66a9711ac36a596fd03422f5bb03e021e8f369c12a39fa1786ae531baab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #25383

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

The new webpack loader added in https://github.com/storybookjs/storybook/pull/24749 assumes the code is ES (parses it with `es-module-lexer` to find the exports). Sometimes the code is CommonJS though, for example if `@babel/plugin-transform-modules-commonjs` is used directly or indirectly. In that case the loader doesn't find the exports and the source output is CommonJS mixed with ES which leads to an "exports is not defined" error.
This change will try to get the named exports with `cjs-module-lexer` if it can't find any exports or imports with `es-module-lexer`, and will add `;module.exports.__namedExportsOrder = ${namedExportsOrderString};` instead of `;export const __namedExportsOrder = ${namedExportsOrderString};` in that case.
This also includes the changes in https://github.com/storybookjs/storybook/pull/25506 to skip the loader if it fails for some reason, as it isn't crucial for Storybook to work properly.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

I tested the change in https://github.com/mlazari/sbsandbox/commit/c63f4fe4212b4df18cc5460d0352dbf1c1230293
Output source of the loader with and without `@babel/plugin-transform-modules-commonjs`: https://github.com/mlazari/sbsandbox/blob/main/loader-changes.md

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-25540-sha-c0037961`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-25540-sha-c0037961 sandbox` or in an existing project with `npx storybook@0.0.0-pr-25540-sha-c0037961 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-25540-sha-c0037961`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-25540-sha-c0037961) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [mlazari/storybook](https://github.com/mlazari/storybook) |
| **Branch** | [`next`](https://github.com/mlazari/storybook/tree/next) |
| **Commit** | [`c0037961`](https://github.com/mlazari/storybook/commit/c0037961c54681d2cca03ee29103145d3ca0f627) |
| **Datetime** | Tue Jan 16 12:07:31 UTC 2024 (`1705406851`) |
| **Workflow run** | [7541327976](https://github.com/storybookjs/storybook/actions/runs/7541327976) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=25540`_
</details>
<!-- CANARY_RELEASE_SECTION -->
