### PR TITLE
Sandboxes: Update wait-on command to use TCP instead of HTTP

### DIFF
--- a/.github/workflows/generate-sandboxes-main.yml
+++ b/.github/workflows/generate-sandboxes-main.yml
@@ -43,7 +43,7 @@ jobs:
         run: yarn local-registry --open &
         working-directory: ./code
       - name: Wait for registry
-        run: yarn wait-on http://localhost:6001
+        run: yarn wait-on tcp:127.0.0.1:6001
         working-directory: ./code
       - name: Generate
         run: yarn generate-sandboxes --local-registry

--- a/.github/workflows/generate-sandboxes-next.yml
+++ b/.github/workflows/generate-sandboxes-next.yml
@@ -43,7 +43,7 @@ jobs:
         run: yarn local-registry --open &
         working-directory: ./code
       - name: Wait for registry
-        run: yarn wait-on http://localhost:6001
+        run: yarn wait-on tcp:127.0.0.1:6001
         working-directory: ./code
       - name: Generate
         run: yarn generate-sandboxes --local-registry --debug

--- a/scripts/tasks/run-registry.ts
+++ b/scripts/tasks/run-registry.ts
@@ -15,7 +15,7 @@ export async function runRegistry({ dryRun, debug }: { dryRun?: boolean; debug?:
     // If aborted, we want to make sure the rejection is handled.
     if (!err.killed) throw err;
   });
-  await exec('yarn wait-on http://localhost:6001', { cwd: CODE_DIRECTORY }, { dryRun, debug });
+  await exec('yarn wait-on tcp:127.0.0.1:6001', { cwd: CODE_DIRECTORY }, { dryRun, debug });
 
   return controller;
 }

--- a/scripts/tasks/serve.ts
+++ b/scripts/tasks/serve.ts
@@ -27,7 +27,7 @@ export const serve: Task = {
         throw err;
       }
     });
-    await waitOn({ resources: [`http://localhost:${PORT}`], interval: 16 });
+    await waitOn({ resources: [`tcp:127.0.0.1:${PORT}`], interval: 16 });
 
     return controller;
   },


### PR DESCRIPTION
Relates to https://github.com/jeffbski/wait-on/issues/133

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Currently, it is not possible to run E2E tests locally. It also seems that CI sometimes takes pretty long to continue, and it waits for more than 10 minutes before actually the E2E tests are executed. It seems that the library `wait-on` currently has a [bug](https://github.com/jeffbski/wait-on/issues/133), where it is not able to properly await a server if it is given as, e.g., `http://localhost:PORT.` Only `tcp:127.0.0.1:PORT` seems to work.

## Checklist for Contributors

### Testing

- Run E2E tests locally in a Node.js 18 environment. They should work appropriately. (e.g. `yarn task --task e2e-tests --template lit-vite/default-ts --no-link --junit`)

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
