### PR TITLE
Docs: Add details for React version used by addon-docs

### DIFF
--- a/docs/addons/addon-types.md
+++ b/docs/addons/addon-types.md
@@ -90,7 +90,7 @@ Use this boilerplate code while writing your own preset addon.
 
 <!-- prettier-ignore-end -->
 
-## Learn more about the Storybook addon ecosystem
+**Learn more about the Storybook addon ecosystem**
 
 - Types of addons for other types of addons
 - [Writing addons](./writing-addons.md) for the basics of addon development

--- a/docs/addons/addons-api.md
+++ b/docs/addons/addons-api.md
@@ -378,7 +378,7 @@ Hook that allows you to retrieve or update a story's [`args`](../writing-stories
 
 <!-- prettier-ignore-end -->
 
-## Learn more about the Storybook addon ecosystem
+**Learn more about the Storybook addon ecosystem**
 
 - [Types of addons](./addon-types.md) for other types of addons
 - [Writing addons](./writing-addons.md) for the basics of addon development

--- a/docs/addons/integration-catalog.md
+++ b/docs/addons/integration-catalog.md
@@ -104,7 +104,7 @@ Not finding the recipe that you want? If it's popular in the community, our docs
 
 If you'd like to request a recipe, open a [new discussion](https://github.com/storybookjs/storybook/discussions/new?category=ideas) in our GitHub repo. We'll review your request, and if it's popular, we'll add it to our backlog and prioritize it.
 
-## Learn more about the Storybook addon ecosystem
+**Learn more about the Storybook addon ecosystem**
 
 - [Types of addons](./addon-types.md) for other types of addons
 - [Writing addons](./writing-addons.md) for the basics of addon development

--- a/docs/addons/writing-addons.md
+++ b/docs/addons/writing-addons.md
@@ -315,7 +315,7 @@ By default, the Addon Kit comes pre-configured with a GitHub Actions workflow, e
 
 Then, click the **New repository secret**, name it `NPM_TOKEN`, and paste the token you generated earlier. Whenever you merge a pull request to the default branch, the workflow will run and publish a new release, automatically incrementing the version number and updating the changelog.
 
-## Learn more about the Storybook addon ecosystem
+**Learn more about the Storybook addon ecosystem**
 
 - [Types of addons](./addon-types.md) for other types of addons
 - Writing addons for the basics of addon development

--- a/docs/builders/builder-api.md
+++ b/docs/builders/builder-api.md
@@ -157,7 +157,7 @@ While running in development mode, the builder's development server must be able
 
 This area is under rapid development, and the associated documentation is still in progress and subject to change. If you are interested in creating a builder, you can learn more about implementing a builder in Storybook by checking the source code for [Vite](https://github.com/storybookjs/storybook/tree/next/code/builders/builder-vite), [Webpack](https://github.com/storybookjs/storybook/tree/next/code/builders/builder-webpack5), or Modern Web's [dev-server-storybook](https://github.com/modernweb-dev/web/blob/master/packages/dev-server-storybook/src/serve/storybookPlugin.ts). When you're ready, open an [RFC](../contribute/RFC.md) to discuss your proposal with the Storybook community and maintainers.
 
-#### Learn more about builders
+**Learn more about builders**
 
 - [Vite builder](./vite.md) for bundling with Vite
 - [Webpack builder](./webpack.md) for bundling with Webpack

--- a/docs/builders/vite.md
+++ b/docs/builders/vite.md
@@ -140,7 +140,7 @@ If you are migrating from a Webpack-based project, such as [CRA](https://create-
 
 <!-- prettier-ignore-end -->
 
-#### Learn more about builders
+**Learn more about builders**
 
 - Vite builder for bundling with Vite
 - [Webpack builder](./webpack.md) for bundling with Webpack

--- a/docs/builders/webpack.md
+++ b/docs/builders/webpack.md
@@ -145,7 +145,7 @@ However, if you're working with a framework that provides a default aliasing con
 
 As Storybook relies on [esbuild](https://esbuild.github.io/) to build its internal manager, support for bundling assets with the `managerWebpack` will no longer have an impact on the Storybook UI. We recommend removing existing `managerWebpack` configuration elements from your Storybook configuration file and bundling assets other than images or CSS into JavaScript beforehand.
 
-#### Learn more about builders
+**Learn more about builders**
 
 - [Vite builder](./vite.md) for bundling with Vite
 - Webpack builder for bundling with Webpack

--- a/docs/contribute/RFC.md
+++ b/docs/contribute/RFC.md
@@ -46,7 +46,7 @@ If you are interested in implementing an "active" RFC, but cannot determine if s
 
 This RFC process took heavy inspiration from the RFC processes from [Rust](https://github.com/rust-lang/rfcs) and [Gatsby](https://www.gatsbyjs.com/contributing/rfc-process/).
 
-## Learn more about contributing to Storybook
+**Learn more about contributing to Storybook**
 
 - RFC process for authoring feature requests
 - [Code](./code.md) for features and bug fixes

--- a/docs/contribute/code.md
+++ b/docs/contribute/code.md
@@ -261,7 +261,7 @@ It's troublesome to know which packages you'll change ahead of time, and watchin
 
 </details>
 
-## Learn more about contributing to Storybook
+**Learn more about contributing to Storybook**
 
 - [RFC process](./RFC.md) for authoring feature requests
 - Code for features and bug fixes

--- a/docs/contribute/documentation-updates.md
+++ b/docs/contribute/documentation-updates.md
@@ -22,7 +22,7 @@ Scroll down to the bottom of the document page on GitHub and describe what you c
 
 In the Storybook repository, create a pull request that describes changes and includes additional context that would help maintainers review. Once you submit the PR, a maintainer will guide you through the triage and merge process.
 
-## Learn more about contributing to Storybook
+**Learn more about contributing to Storybook**
 
 - [RFC process](./RFC.md) for authoring feature requests
 - [Code](./code.md) for features and bug fixes

--- a/docs/contribute/framework.md
+++ b/docs/contribute/framework.md
@@ -143,7 +143,7 @@ Test it in a fresh project using a Storybook set up as close as possible to your
 
 Once it's fully tested and released, please let us know about your framework by either announcing it in the [`#showcase`](https://discord.com/channels/486522875931656193/1048740936953376859) Discord channel or tweeting it and mentioning `@storybookjs`. It's our hope that well-made community frameworks can eventually move into the Storybook codebase and be considered "officially" supported.
 
-## Learn more about contributing to Storybook
+**Learn more about contributing to Storybook**
 
 - [RFC process](./RFC.md) for authoring feature requests
 - [Code](./code.md) for features and bug fixes

--- a/docs/contribute/new-snippets.md
+++ b/docs/contribute/new-snippets.md
@@ -131,7 +131,7 @@ Go through the documentation and check your work.
 
 Finally, commit, push and open a pull request in the Storybook monorepo. Add a clear description of the work you've done, and one of the maintainers will guide you through the merge process.
 
-## Learn more about contributing to Storybook
+**Learn more about contributing to Storybook**
 
 - [RFC process](./RFC.md) for authoring feature requests
 - [Code](./code.md) for features and bug fixes

--- a/docs/writing-docs/autodocs.md
+++ b/docs/writing-docs/autodocs.md
@@ -290,7 +290,7 @@ If you're still encountering issues, we recommend reaching out to the community 
 
 If you turned off inline rendering for your stories via the [`inline`](../api/doc-block-story.md#inline) configuration option, you would run into a situation where the associated controls are not updating the story within the documentation page. This is a known limitation of the current implementation and will be addressed in a future release.
 
-#### Learn more about Storybook documentation
+**Learn more about Storybook documentation**
 
 - Autodocs for creating documentation for your stories
 - [MDX](./mdx.md) for customizing your documentation

--- a/docs/writing-docs/build-documentation.md
+++ b/docs/writing-docs/build-documentation.md
@@ -50,7 +50,7 @@ You can use any hosting provider to deploy your documentation, for instance:
 - [Netlify](https://www.netlify.com/)
 - [S3](https://aws.amazon.com/en/s3/)
 
-#### Learn more about Storybook documentation
+**Learn more about Storybook documentation**
 
 - [Autodocs](./autodocs.md) for creating documentation for your stories
 - [MDX](./mdx.md) for customizing your documentation

--- a/docs/writing-docs/doc-blocks.md
+++ b/docs/writing-docs/doc-blocks.md
@@ -278,7 +278,7 @@ Storybook's Doc Blocks are highly customizable and helpful building blocks to as
 
 <!-- prettier-ignore-end -->
 
-#### Learn more about Storybook documentation
+**Learn more about Storybook documentation**
 
 - [Autodocs](./autodocs.md) for creating documentation for your stories
 - [MDX](./mdx.md) for customizing your documentation

--- a/docs/writing-docs/mdx.md
+++ b/docs/writing-docs/mdx.md
@@ -459,6 +459,15 @@ If you're still encountering issues, we recommend reaching out to the community 
 
 If you turned off inline rendering for your stories via the [`inline`](../api/doc-block-story.md#inline) configuration option, you would run into a situation where the associated controls are not updating the story within the documentation page. This is a known limitation of the current implementation and will be addressed in a future release.
 
+### The React version used is unexpected
+
+For most projects, Storybook's addon-docs uses the React version listed in your project's dependencies. If it does not find one, it will use React 18.2.0. There are two exceptions to this:
+
+- Preact projects will always use React 17
+- Next.js projects will always use the canary version that comes with the Next.js version installed, regardless of which React version is listed in the project’s dependencies.
+
+If you're having issues with the React version used, you may need to re-create your project's `node_modules` folder to ensure the correct version is used.
+
 **Learn more about Storybook documentation**
 
 - [Autodocs](./autodocs.md) for creating documentation for your stories

--- a/docs/writing-docs/mdx.md
+++ b/docs/writing-docs/mdx.md
@@ -459,7 +459,7 @@ If you're still encountering issues, we recommend reaching out to the community 
 
 If you turned off inline rendering for your stories via the [`inline`](../api/doc-block-story.md#inline) configuration option, you would run into a situation where the associated controls are not updating the story within the documentation page. This is a known limitation of the current implementation and will be addressed in a future release.
 
-#### Learn more about Storybook documentation
+**Learn more about Storybook documentation**
 
 - [Autodocs](./autodocs.md) for creating documentation for your stories
 - MDX for customizing your documentation


### PR DESCRIPTION
## What I did

- Add details about React version for addon-docs
- Fix formatting of "Learn more" sections
    - Use bold text instead of heading
        - The correct heading level is often h2, which is much more attention grabbing than we want
        - Using a better heading level size, h4, is often incorrect, semantically
            - h4's styles are just bold normal text
        - There's no value in having these headings in the "On this page" TOCs, because it's just duplicating what's in the sidebar navigation

## Checklist for Contributors

### Testing

#### Manual testing

1. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `docs-no-react-peer-for-addon-docs`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
