### PR TITLE
[FIX]: docs iframe width doesn't fill container in centered layout.

### DIFF
--- a/code/lib/cli/rendererAssets/common/button.css
+++ b/code/lib/cli/rendererAssets/common/button.css
@@ -6,6 +6,7 @@
   cursor: pointer;
   display: inline-block;
   line-height: 1;
+  max-width: 100px;
 }
 .storybook-button--primary {
   color: white;


### PR DESCRIPTION
FIX #25388 

## What I did

add max width of the button. 

### Testing

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [x] unit tests
- [x] integration tests
- [x] end-to-end tests


