### PR TITLE
Telejson: Update stringify options in codebase

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
@@ -201,7 +201,7 @@ export abstract class AbstractRenderer {
 
     const currentStoryRender = {
       storyFnAngular,
-      moduleMetadataSnapshot: stringify(moduleMetadata),
+      moduleMetadataSnapshot: stringify(moduleMetadata, { allowFunction: false }),
     };
 
     this.previousStoryRenderInfo.set(targetDOMNode, currentStoryRender);

--- a/code/frameworks/angular/template/stories/basics/component-with-provider/di.component.ts
+++ b/code/frameworks/angular/template/stories/basics/component-with-provider/di.component.ts
@@ -23,6 +23,6 @@ export class DiComponent {
   }
 
   elRefStr(): string {
-    return stringify(this.elRef, { maxDepth: 1 });
+    return stringify(this.elRef, { maxDepth: 1, allowFunction: false });
   }
 }

--- a/code/lib/channels/src/postmessage/index.ts
+++ b/code/lib/channels/src/postmessage/index.ts
@@ -20,7 +20,7 @@ const { document, location } = global;
 
 export const KEY = 'storybook-channel';
 
-const defaultEventOptions = { allowFunction: true, maxDepth: 25 };
+const defaultEventOptions = { allowFunction: false, maxDepth: 25 };
 
 // TODO: we should export a method for opening child windows here and keep track of em.
 // that way we can send postMessage to child windows as well, not just iframe

--- a/code/lib/channels/src/websocket/index.ts
+++ b/code/lib/channels/src/websocket/index.ts
@@ -60,7 +60,11 @@ export class WebsocketTransport implements ChannelTransport {
   }
 
   private sendNow(event: any) {
-    const data = stringify(event, { maxDepth: 15, allowFunction: true });
+    const data = stringify(event, {
+      maxDepth: 15,
+      allowFunction: false,
+      ...global.CHANNEL_OPTIONS,
+    });
     this.socket.send(data);
   }
 

--- a/code/ui/blocks/src/blocks/SourceContainer.tsx
+++ b/code/ui/blocks/src/blocks/SourceContainer.tsx
@@ -11,7 +11,7 @@ import { stringify } from 'telejson';
 
 type ArgsHash = string;
 export function argsHash(args: Args): ArgsHash {
-  return stringify(args);
+  return stringify(args, { allowFunction: false });
 }
 
 export interface SourceItem {


### PR DESCRIPTION
Relates to https://github.com/storybookjs/storybook/issues/22859

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Set `allowFunction` option for `telejson.stringify` to `false`. This will forbid stringifying functions. In some places, the user can still override the default behavior. 

The television package can be updated in the next major version of Storybook (9), and the code, which uses `eval` can be removed.

A documentation update is unnecessary since the [documented default](https://storybook.js.org/docs/api/main-config-core#channeloptionsallowfunction) was already declared as `false`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
