### PR TITLE
CLI: Fix existing version detection in `upgrade`

### DIFF
--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -110,7 +110,8 @@ export const doUpgrade = async ({
 }: UpgradeOptions) => {
   const packageManager = JsPackageManagerFactory.getPackageManager({ force: pkgMgr });
 
-  const beforeVersion = await getStorybookCoreVersion();
+  // If we can't determine the existing version (Yarn PnP), fallback to v0.0.0 to not block the upgrade
+  const beforeVersion = (await getStorybookCoreVersion()) ?? '0.0.0';
   const currentVersion = versions['@storybook/cli'];
   const isCanary = currentVersion.startsWith('0.0.0');
 

--- a/code/lib/telemetry/src/package-json.ts
+++ b/code/lib/telemetry/src/package-json.ts
@@ -28,10 +28,8 @@ export const getActualPackageJson = async (packageName: string) => {
   return packageJson;
 };
 
-// Note that this probably doesn't work in PNPM mode
+// Note that this probably doesn't work in Yarn PNP mode because @storybook/telemetry doesn't depend on @storybook/cli
 export const getStorybookCoreVersion = async () => {
-  const coreVersions = await Promise.all(
-    ['@storybook/core-common', '@storybook/core-server'].map(getActualPackageVersion)
-  );
-  return coreVersions.find((v) => v.version)?.version;
+  const { version } = await getActualPackageVersion('@storybook/cli');
+  return version;
 };


### PR DESCRIPTION
Works on https://github.com/storybookjs/storybook/issues/25293

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR changes the code that detects the existing version installed to use `@storybook/cli` instead of `@storybook/core-common` or `@storybook/core-server`. This is because many packages depends on `@storybook/core-common` and sometimes a project can get into a state where multiple versions of that package exists. This could cause the upgrade to fail with `SB_CLI_UPGRADE_0004 (UpgradeStorybookToSameVersionError)`. Using the version of `@storybook/cli` instead is safer because it will only be in the project once since no other packages depend on it.

I tested this with the canary version in both npm, pnpm, Yarn 4 and Yarn PnP and it worked everywhere. Yarn PnP expectedly did not find a version, so I've added a fallback version. It's not the best user experience to see "You're upgrading from 0.0.0" but this is just a quick fix in the interest of time.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-25642-sha-bb79636f`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-25642-sha-bb79636f sandbox` or in an existing project with `npx storybook@0.0.0-pr-25642-sha-bb79636f upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-25642-sha-bb79636f`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-25642-sha-bb79636f) |
| **Triggered by** | @JReinhold |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`jeppe/fix-version-detection`](https://github.com/storybookjs/storybook/tree/jeppe/fix-version-detection) |
| **Commit** | [`bb79636f`](https://github.com/storybookjs/storybook/commit/bb79636fa2168c474d1af7b1b3105ae858c17c45) |
| **Datetime** | Thu Jan 18 08:33:31 UTC 2024 (`1705566811`) |
| **Workflow run** | [7567312543](https://github.com/storybookjs/storybook/actions/runs/7567312543) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=25642`_
</details>
<!-- CANARY_RELEASE_SECTION -->
