### PR TITLE
Docs: Document CLI version support

### DIFF
--- a/docs/api/cli-options.md
+++ b/docs/api/cli-options.md
@@ -16,7 +16,7 @@ All of the following documentation is available in the CLI by running `storybook
 
 <Callout variant="info" icon="💡">
 
-The commands work slightly differently if you're using npm instead of Yarn to publish Storybook. For example, `npm run storybook build -- -o ./path/to/build`.
+Passing options to these commands works slightly differently if you're using npm instead of Yarn. You must prefix all of your options with `--`. For example, `npm run storybook build -- -o ./path/to/build --quiet`.
 
 </Callout>
 
@@ -84,11 +84,13 @@ Options include:
 
 ### `init`
 
-Installs Storybook into your project per specified version (e.g., `@latest`, `@next`). Read more in the [installation guide](../get-started/install.md).
+Installs and initializes the specified version (e.g., `@latest`, `@8`, `@next`) of Storybook into your project. Read more in the [installation guide](../get-started/install.md).
 
 ```shell
 storybook[@version] init [options]
 ```
+
+For example, `storybook@latest init` will install the latest version of Storybook into your project.
 
 Options include:
 
@@ -133,11 +135,13 @@ Options include:
 
 ### `upgrade`
 
-Upgrades your Storybook instance to the latest version. Read more in the [upgrade guide](../configure/upgrading.md).
+Upgrades your Storybook instance to the specified version (e.g., `@latest`, `@8`, `@next`). Read more in the [upgrade guide](../configure/upgrading.md).
 
 ```shell
-storybook upgrade [options]
+storybook[@version] upgrade [options]
 ```
+
+For example, `storybook@latest upgrade --dry-run` will perform a dry run (no actual changes) of upgrading your project to the latest version of Storybook.
 
 Options include:
 
@@ -203,17 +207,15 @@ Storybook Environment Info:
 
 ### `sandbox`
 
-Generates a local sandbox project for testing Storybook features based on the list of supported [frameworks](../configure/frameworks.md). Useful for reproducing bugs when opening an issue or a discussion.
+Generates a local sandbox project using the specified version (e.g., `@latest`, `@8`, `@next`) for testing Storybook features based on the list of supported [frameworks](../configure/frameworks.md). Useful for reproducing bugs when opening an issue or a discussion.
 
 ```shell
-storybook sandbox [framework-filter] [options]
+storybook[@version] sandbox [framework-filter] [options]
 ```
 
-<Callout variant="info">
+For example, `storybook@next sandbox` will generated sandboxes using the newest pre-release version of Storybook.
 
-The `framework-filter` argument is optional and can filter the list of available frameworks. For example, `storybook sandbox react` will only show React-based sandboxes.
-
-</Callout>
+The `framework-filter` argument is optional and can filter the list of available frameworks. For example, `storybook@next sandbox react` will only offer to generate React-based sandboxes.
 
 Options include:
 

--- a/docs/configure/upgrading.md
+++ b/docs/configure/upgrading.md
@@ -22,10 +22,16 @@ To help ease the pain of keeping Storybook up-to-date, we provide a command-line
 
 <!-- prettier-ignore-end -->
 
+The `upgrade` command will use whichever version you specify. For example:
+
+- `storybook@latest upgrade` will upgrade to the latest version
+- `storybook@7.6.10 upgrade` will upgrade to `7.6.10`
+- `storybook@7 upgrade` will upgrade to the newest `7.x.x` version
+
 After running the command, the script will:
 
-- Upgrade all Storybook packages in your project to the latest stable version
-- Run the relevant [automigrations](../migration-guide.md#automatic-upgrade) factoring in the [breaking changes](../migration-guide.md#major-breaking-changes) between your current version and the latest stable version
+- Upgrade all Storybook packages in your project to the specified version
+- Run the relevant [automigrations](../migration-guide.md#automatic-upgrade) factoring in the [breaking changes](../migration-guide.md#major-breaking-changes) between your current version and the specified version
 
 <Callout variant="info">
 
@@ -84,6 +90,12 @@ To upgrade to the latest pre-release:
 />
 
 <!-- prettier-ignore-end -->
+
+The `upgrade` command will use whichever version you specify. For example:
+
+- `storybook@next upgrade` will upgrade to the newest pre-release version
+- `storybook@8.0.0-beta.1 upgrade` will upgrade to `8.0.0-beta.1`
+- `storybook@8 upgrade` will upgrade to the newest `8.x` version
 
 If you'd like to downgrade to a stable version, manually edit the package version numbers in your `package.json` and re-install.
 

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -16,6 +16,17 @@ Use the Storybook CLI to install it in a single command. Run this inside your pr
 
 <!-- prettier-ignore-end -->
 
+<details>
+<summary>Install a specific version</summary>
+
+The `init` command will use whichever version you specify. For example:
+
+- `storybook@latest init` will initialize the latest version
+- `storybook@7.6.10 init` will initialize `7.6.10`
+- `storybook@7 init` will initialize the newest `7.x.x` version
+
+</details>
+
 Storybook will look into your project's dependencies during its install process and provide you with the best configuration available.
 
 The command above will make the following changes to your local environment:

--- a/docs/snippets/common/storybook-upgrade-prerelease.npm.js.mdx
+++ b/docs/snippets/common/storybook-upgrade-prerelease.npm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-npx storybook@latest upgrade --prerelease
+npx storybook@next upgrade
 ```

--- a/docs/snippets/common/storybook-upgrade-prerelease.pnpm.js.mdx
+++ b/docs/snippets/common/storybook-upgrade-prerelease.pnpm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-pnpm dlx storybook@latest upgrade --prerelease
+pnpm dlx storybook@next upgrade
 ```

--- a/docs/snippets/common/storybook-upgrade-prerelease.yarn.js.mdx
+++ b/docs/snippets/common/storybook-upgrade-prerelease.yarn.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-yarn dlx storybook@latest upgrade --prerelease
+yarn dlx storybook@next upgrade
 ```


### PR DESCRIPTION
## What I did

Document CLI version support.

## Checklist for Contributors

### Testing

#### Manual testing

1. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `docs-cli-versioning`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
