### PR TITLE
React-Native: Fixes for v8 compatibility

### DIFF
--- a/code/lib/manager-api/package.json
+++ b/code/lib/manager-api/package.json
@@ -30,6 +30,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
+  "react-native": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",

--- a/code/lib/preview-api/package.json
+++ b/code/lib/preview-api/package.json
@@ -30,6 +30,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
+  "react-native": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",

--- a/code/lib/preview-api/src/index.ts
+++ b/code/lib/preview-api/src/index.ts
@@ -68,4 +68,4 @@ export type { PropDescriptor } from './store';
  * STORIES API
  */
 export { StoryStore } from './store';
-export { Preview, PreviewWeb } from './preview-web';
+export { Preview, PreviewWithSelection, PreviewWeb } from './preview-web';

--- a/code/lib/preview-api/src/modules/preview-web/Preview.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/Preview.tsx
@@ -384,6 +384,13 @@ export class Preview<TRenderer extends Renderer> {
     return this.storyStoreValue.loadStory({ storyId });
   }
 
+  getStoryContext(story: PreparedStory<TRenderer>, { forceInitialArgs = false } = {}) {
+    if (!this.storyStoreValue)
+      throw new CalledPreviewMethodBeforeInitializationError({ methodName: 'getStoryContext' });
+
+    return this.storyStoreValue.getStoryContext(story, { forceInitialArgs });
+  }
+
   async extract(options?: { includeDocsOnly: boolean }) {
     if (!this.storyStoreValue)
       throw new CalledPreviewMethodBeforeInitializationError({ methodName: 'extract' });


### PR DESCRIPTION
Closes N/A

## What I did

- Export `PreviewWithSelection` which was accidentally (?) removed
- Export a proxy for the story store's `getStoryContext`
- Set up `react-native` entry points for `preview-api`/`manager-api`

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-25678-sha-560d4141`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-25678-sha-560d4141 sandbox` or in an existing project with `npx storybook@0.0.0-pr-25678-sha-560d4141 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-25678-sha-560d4141`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-25678-sha-560d4141) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/rn8`](https://github.com/storybookjs/storybook/tree/shilman/rn8) |
| **Commit** | [`560d4141`](https://github.com/storybookjs/storybook/commit/560d41413e7629c7ced3880505ec1c531a46359c) |
| **Datetime** | Mon Jan 22 13:14:46 UTC 2024 (`1705929286`) |
| **Workflow run** | [7611700495](https://github.com/storybookjs/storybook/actions/runs/7611700495) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=25678`_
</details>
<!-- CANARY_RELEASE_SECTION -->
