### PR TITLE
Addons: Remove Node.js internal aliasing for Node builds

### DIFF
--- a/code/addons/interactions/package.json
+++ b/code/addons/interactions/package.json
@@ -30,6 +30,7 @@
     },
     "./manager": "./dist/manager.js",
     "./preview": "./dist/preview.js",
+    "./preset": "./dist/preset.js",
     "./register.js": "./dist/manager.js",
     "./package.json": "./package.json"
   },

--- a/scripts/prepare/addon-bundle.ts
+++ b/scripts/prepare/addon-bundle.ts
@@ -71,6 +71,11 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
     shims: false,
     watch,
     clean: false,
+  };
+
+  const browserOptions: Options = {
+    target: ['chrome100', 'safari15', 'firefox91'],
+    platform: 'browser',
     esbuildPlugins: [
       aliasPlugin({
         process: require.resolve('../node_modules/process/browser.js'),
@@ -78,6 +83,14 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
         assert: require.resolve('browser-assert'),
       }),
     ],
+    format: ['esm'],
+    esbuildOptions: (options) => {
+      /* eslint-disable no-param-reassign */
+      options.conditions = ['module'];
+      options.platform = 'browser';
+      Object.assign(options, getESBuildOptions(optimized));
+      /* eslint-enable no-param-reassign */
+    },
   };
 
   const commonExternals = [
@@ -98,18 +111,9 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
       build({
         ...commonOptions,
         ...(optimized ? dtsConfig : {}),
+        ...browserOptions,
         entry: exportEntries,
-        format: ['esm'],
-        target: ['chrome100', 'safari15', 'firefox91'],
-        platform: 'browser',
         external: [...commonExternals, ...globalManagerPackages, ...globalPreviewPackages],
-        esbuildOptions: (options) => {
-          /* eslint-disable no-param-reassign */
-          options.conditions = ['module'];
-          options.platform = 'browser';
-          Object.assign(options, getESBuildOptions(optimized));
-          /* eslint-enable no-param-reassign */
-        },
       }),
       build({
         ...commonOptions,
@@ -138,21 +142,12 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
     tasks.push(
       build({
         ...commonOptions,
+        ...browserOptions,
         entry: managerEntries.map((e: string) => slash(join(cwd, e))),
         outExtension: () => ({
           js: '.js',
         }),
-        format: ['esm'],
-        target: ['chrome100', 'safari15', 'firefox91'],
-        platform: 'browser',
         external: [...commonExternals, ...globalManagerPackages],
-        esbuildOptions: (options) => {
-          /* eslint-disable no-param-reassign */
-          options.conditions = ['module'];
-          options.platform = 'browser';
-          Object.assign(options, getESBuildOptions(optimized));
-          /* eslint-enable no-param-reassign */
-        },
       })
     );
   }
@@ -160,21 +155,12 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
     tasks.push(
       build({
         ...commonOptions,
+        ...browserOptions,
         entry: previewEntries.map((e: string) => slash(join(cwd, e))),
         outExtension: () => ({
           js: '.js',
         }),
-        format: ['esm'],
-        target: ['chrome100', 'safari15', 'firefox91'],
-        platform: 'browser',
         external: [...commonExternals, ...globalPreviewPackages],
-        esbuildOptions: (c) => {
-          /* eslint-disable no-param-reassign */
-          c.conditions = ['module'];
-          c.platform = 'browser';
-          Object.assign(c, getESBuildOptions(optimized));
-          /* eslint-enable no-param-reassign */
-        },
       })
     );
   }


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Currently, all entries, even the ones meant to be executed in Node.js, will set up some aliasing for `process`, `assert` and util`. This aliasing should only apply to browser entries. 

Additionally, `preset.js` was added to the export map of `@storybook/addon-interactions`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
