### PR TITLE
Webpack: Update StorybookConfig import in core-webpack types.ts

### DIFF
--- a/code/builders/builder-webpack5/src/types.ts
+++ b/code/builders/builder-webpack5/src/types.ts
@@ -3,11 +3,12 @@ import type {
   Options,
   BuilderResult as BuilderResultBase,
   StorybookConfig,
+  TypescriptOptions as WebpackTypescriptOptions,
 } from '@storybook/core-webpack';
 
 import type ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
-type TypeScriptOptionsBase = Required<StorybookConfig>['typescript'];
+type TypeScriptOptionsBase = Partial<WebpackTypescriptOptions>;
 
 /**
  * Options for TypeScript usage within Storybook.
@@ -19,7 +20,7 @@ export interface TypescriptOptions extends TypeScriptOptionsBase {
   checkOptions?: ConstructorParameters<typeof ForkTsCheckerWebpackPlugin>[0];
 }
 
-export interface StorybookConfigWebpack extends Pick<StorybookConfig, 'webpack' | 'webpackFinal'> {
+export interface StorybookConfigWebpack extends Omit<StorybookConfig, 'webpack' | 'webpackFinal'> {
   /**
    * Modify or return a custom Webpack config after the Storybook's default configuration
    * has run (mostly used by addons).

--- a/code/frameworks/angular/src/preset.ts
+++ b/code/frameworks/angular/src/preset.ts
@@ -22,7 +22,7 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entries
   return annotations;
 };
 
-export const core: PresetProperty<'core', StorybookConfig> = async (config, options) => {
+export const core: PresetProperty<'core'> = async (config, options) => {
   const framework = await options.presets.apply('framework');
 
   return {
@@ -34,7 +34,7 @@ export const core: PresetProperty<'core', StorybookConfig> = async (config, opti
   };
 };
 
-export const typescript: PresetProperty<'typescript', StorybookConfig> = async (config) => {
+export const typescript: PresetProperty<'typescript'> = async (config) => {
   return {
     ...config,
     skipCompiler: true,

--- a/code/frameworks/ember/src/preset.ts
+++ b/code/frameworks/ember/src/preset.ts
@@ -43,7 +43,7 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (baseConfig, 
   };
 };
 
-export const core: PresetProperty<'core', StorybookConfig> = async (config, options) => {
+export const core: PresetProperty<'core'> = async (config, options) => {
   const framework = await options.presets.apply('framework');
 
   return {

--- a/code/frameworks/html-vite/src/preset.ts
+++ b/code/frameworks/html-vite/src/preset.ts
@@ -1,12 +1,11 @@
 import type { PresetProperty } from '@storybook/types';
 import { dirname, join } from 'path';
-import type { StorybookConfig } from './types';
 
 function getAbsolutePath<I extends string>(value: I): I {
   return dirname(require.resolve(join(value, 'package.json'))) as any;
 }
 
-export const core: PresetProperty<'core', StorybookConfig> = {
+export const core: PresetProperty<'core'> = {
   builder: getAbsolutePath('@storybook/builder-vite'),
   renderer: getAbsolutePath('@storybook/html'),
 };

--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -27,33 +27,6 @@ export const addons: PresetProperty<'addons'> = [
   dirname(require.resolve(join('@storybook/preset-react-webpack', 'package.json'))),
 ];
 
-const defaultFrameworkOptions: FrameworkOptions = {};
-
-export const frameworkOptions: PresetProperty<'framework'> = async (_, options) => {
-  const config = await options.presets.apply('framework');
-
-  if (typeof config === 'string') {
-    return {
-      name: config,
-      options: defaultFrameworkOptions,
-    };
-  }
-  if (typeof config === 'undefined') {
-    return {
-      name: require.resolve('@storybook/nextjs') as '@storybook/nextjs',
-      options: defaultFrameworkOptions,
-    };
-  }
-
-  return {
-    name: config.name,
-    options: {
-      ...defaultFrameworkOptions,
-      ...config.options,
-    },
-  };
-};
-
 export const core: PresetProperty<'core'> = async (config, options) => {
   const framework = await options.presets.apply('framework');
 
@@ -136,7 +109,6 @@ export const babel: PresetProperty<'babel'> = async (baseConfig: TransformOption
 };
 
 export const webpackFinal: StorybookConfig['webpackFinal'] = async (baseConfig, options) => {
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   const frameworkOptions = await options.presets.apply<{ options: FrameworkOptions }>(
     'frameworkOptions'
   );

--- a/code/frameworks/preact-vite/src/preset.ts
+++ b/code/frameworks/preact-vite/src/preset.ts
@@ -5,7 +5,7 @@ import type { StorybookConfig } from './types';
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;
 
-export const core: PresetProperty<'core', StorybookConfig> = {
+export const core: PresetProperty<'core'> = {
   builder: getAbsolutePath('@storybook/builder-vite'),
   renderer: getAbsolutePath('@storybook/preact'),
 };

--- a/code/frameworks/react-vite/src/preset.ts
+++ b/code/frameworks/react-vite/src/preset.ts
@@ -5,7 +5,7 @@ import type { StorybookConfig } from './types';
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;
 
-export const core: PresetProperty<'core', StorybookConfig> = {
+export const core: PresetProperty<'core'> = {
   builder: getAbsolutePath('@storybook/builder-vite'),
   renderer: getAbsolutePath('@storybook/react'),
 };

--- a/code/frameworks/react-webpack5/src/preset.ts
+++ b/code/frameworks/react-webpack5/src/preset.ts
@@ -10,13 +10,13 @@ export const addons: PresetProperty<'addons'> = [
 ];
 
 export const core: PresetProperty<'core'> = async (config, options) => {
-  const presetFramework = await options.presets.apply('framework');
+  const framework = await options.presets.apply('framework');
 
   return {
     ...config,
     builder: {
       name: getAbsolutePath('@storybook/builder-webpack5'),
-      options: typeof presetFramework === 'string' ? {} : presetFramework.options.builder || {},
+      options: typeof framework === 'string' ? {} : framework.options.builder || {},
     },
     renderer: getAbsolutePath('@storybook/react'),
   };

--- a/code/frameworks/react-webpack5/src/preset.ts
+++ b/code/frameworks/react-webpack5/src/preset.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from 'path';
-import type { PresetProperty, Options } from '@storybook/types';
-import type { FrameworkOptions, StorybookConfig } from './types';
+import type { PresetProperty } from '@storybook/types';
+import type { StorybookConfig } from './types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;
@@ -9,46 +9,14 @@ export const addons: PresetProperty<'addons'> = [
   getAbsolutePath('@storybook/preset-react-webpack'),
 ];
 
-const defaultFrameworkOptions: FrameworkOptions = {
-  legacyRootApi: true,
-};
-
-export const frameworkOptions = async (
-  _: never,
-  options: Options
-): Promise<StorybookConfig['framework']> => {
-  const config = await options.presets.apply<StorybookConfig['framework']>('framework');
-
-  if (typeof config === 'string') {
-    return {
-      name: config,
-      options: defaultFrameworkOptions,
-    };
-  }
-  if (typeof config === 'undefined') {
-    return {
-      name: getAbsolutePath('@storybook/react-webpack5'),
-      options: defaultFrameworkOptions,
-    };
-  }
-
-  return {
-    name: config.name,
-    options: {
-      ...defaultFrameworkOptions,
-      ...config.options,
-    },
-  };
-};
-
 export const core: PresetProperty<'core'> = async (config, options) => {
-  const framework = await options.presets.apply('framework');
+  const presetFramework = await options.presets.apply('framework');
 
   return {
     ...config,
     builder: {
       name: getAbsolutePath('@storybook/builder-webpack5'),
-      options: typeof framework === 'string' ? {} : framework.options.builder || {},
+      options: typeof presetFramework === 'string' ? {} : presetFramework.options.builder || {},
     },
     renderer: getAbsolutePath('@storybook/react'),
   };

--- a/code/frameworks/svelte-vite/src/preset.ts
+++ b/code/frameworks/svelte-vite/src/preset.ts
@@ -7,7 +7,7 @@ import { svelteDocgen } from './plugins/svelte-docgen';
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;
 
-export const core: PresetProperty<'core', StorybookConfig> = {
+export const core: PresetProperty<'core'> = {
   builder: getAbsolutePath('@storybook/builder-vite'),
   renderer: getAbsolutePath('@storybook/svelte'),
 };

--- a/code/frameworks/vue3-webpack5/src/preset.ts
+++ b/code/frameworks/vue3-webpack5/src/preset.ts
@@ -1,13 +1,10 @@
 import { dirname, join } from 'path';
 import type { PresetProperty } from '@storybook/types';
-import type { StorybookConfig } from './types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;
 
-export const addons: PresetProperty<'addons', StorybookConfig> = [
-  getAbsolutePath('@storybook/preset-vue3-webpack'),
-];
+export const addons: PresetProperty<'addons'> = [getAbsolutePath('@storybook/preset-vue3-webpack')];
 
 export const core: PresetProperty<'core'> = async (config, options) => {
   const framework = await options.presets.apply('framework');

--- a/code/frameworks/web-components-vite/src/preset.ts
+++ b/code/frameworks/web-components-vite/src/preset.ts
@@ -1,11 +1,10 @@
 import type { PresetProperty } from '@storybook/types';
 import { dirname, join } from 'path';
-import type { StorybookConfig } from './types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;
 
-export const core: PresetProperty<'core', StorybookConfig> = {
+export const core: PresetProperty<'core'> = {
   builder: getAbsolutePath('@storybook/builder-vite'),
   renderer: getAbsolutePath('@storybook/web-components'),
 };

--- a/code/lib/core-webpack/src/types.ts
+++ b/code/lib/core-webpack/src/types.ts
@@ -1,4 +1,4 @@
-import type { Options, StorybookConfigRaw as StorybookConfigBase } from '@storybook/types';
+import type { Options, StorybookConfig as StorybookConfigBase } from '@storybook/types';
 
 export type { Options, Preset, BuilderResult, TypescriptOptions } from '@storybook/types';
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25739
Closes https://github.com/storybookjs/storybook/issues/22472

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Updated StorybookConfig import in core-webpack types.ts to use the proper StorybookConfig type and fix type bugs, which were introduced by this change.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_


1. Run a Webpack sandbox
2. Adjust your `.storybook/main.ts` to add the `env` property

```tsx
import { StorybookConfig } from "@storybook/angular";

const config: StorybookConfig = {
  stories: [...],
  framework: {
    name: "@storybook/angular"
    options: {},
  },
  env: (config) => ({
    ...config,
    FLAGS: JSON.stringify({
      flag1: true,
    }),
  }),
};

export default config;
```

3. TypeScript shouldn't complain about the type of `env`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
