### PR TITLE
CLI: Fix wording for `react-docgen` automigration

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/react-docgen.ts
+++ b/code/lib/cli/src/automigrate/fixes/react-docgen.ts
@@ -26,11 +26,12 @@ export const reactDocgen: Fix<Options> = {
       but "typescript.reactDocgen" is unset.
       
       In Storybook 8.0, we changed the default React docgen analysis from 
-      "react-docgen-typescript" to "react-docgen", which dramatically faster
-      but doesn't handle all TypeScript constructs.
-
-      We can update your config to continue to use "react-docgen-typescript",
-      though we recommend giving "react-docgen" for a much faster dev experience.
+      "react-docgen-typescript" to "react-docgen". We recommend "react-docgen"
+      for most projects, since it is dramatically faster. However, it doesn't
+      handle all TypeScript constructs, and may generate different results
+      than "react-docgen-typescript".
+      
+      Should we update your config to continue to use "react-docgen-typescript"?
 
       https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-docgen-component-analysis-by-default
     `;


### PR DESCRIPTION
Closes N/A

## What I did

Updated wording per https://github.com/storybookjs/storybook/discussions/25686#discussioncomment-8255873. @yannbf is this more clear?

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
