### PR TITLE
UI: Improve how the addon panel work on mobile

### DIFF
--- a/code/lib/router/src/router.tsx
+++ b/code/lib/router/src/router.tsx
@@ -3,7 +3,6 @@ import React, { useCallback } from 'react';
 import type { ReactNode, ReactElement, ComponentProps } from 'react';
 
 import * as R from 'react-router-dom';
-import { ToggleVisibility } from './visibility';
 import { queryFromString, parsePath, getMatch } from './utils';
 import type { LinkProps, NavigateOptions, RenderData } from './types';
 
@@ -31,13 +30,11 @@ interface MatchPropsDefault {
 interface RoutePropsStartsWith {
   path: string;
   startsWith?: boolean;
-  hideOnly?: boolean;
   children: ReactNode;
 }
 interface RoutePropsDefault {
   path: RegExp;
   startsWith?: false;
-  hideOnly?: boolean;
   children: ReactNode;
 }
 
@@ -128,23 +125,14 @@ Match.displayName = 'QueryMatch';
 function Route(props: RoutePropsDefault): ReactElement;
 function Route(props: RoutePropsStartsWith): ReactElement;
 function Route(input: RoutePropsDefault | RoutePropsStartsWith) {
-  const { children, hideOnly, ...rest } = input;
+  const { children, ...rest } = input;
   if (rest.startsWith === undefined) {
     rest.startsWith = false;
   }
 
   const matchProps = rest as Omit<ComponentProps<typeof Match>, 'children'>;
 
-  return (
-    <Match {...matchProps}>
-      {({ match }) => {
-        if (hideOnly) {
-          return <ToggleVisibility hidden={!match}>{children}</ToggleVisibility>;
-        }
-        return match ? children : null;
-      }}
-    </Match>
-  );
+  return <Match {...matchProps}>{({ match }) => (match ? children : null)}</Match>;
 }
 Route.displayName = 'Route';
 

--- a/code/ui/manager/src/App.tsx
+++ b/code/ui/manager/src/App.tsx
@@ -28,9 +28,9 @@ export const App = ({ managerLayoutState, setManagerLayoutState, pages }: Props)
         managerLayoutState={managerLayoutState}
         setManagerLayoutState={setManagerLayoutState}
         slotMain={
-          <Route path={/(^\/story|docs|onboarding\/|^\/$)/} hideOnly>
-            <Preview id="main" withLoader />
-          </Route>
+          // <Route path={/(^\/story|docs|onboarding\/|^\/$)/} hideOnly>
+          <Preview id="main" withLoader />
+          // </Route>
         }
         slotSidebar={<Sidebar onMenuClick={() => setMobileAboutOpen((state) => !state)} />}
         slotPanel={<Panel />}

--- a/code/ui/manager/src/App.tsx
+++ b/code/ui/manager/src/App.tsx
@@ -1,8 +1,5 @@
 import type { ComponentProps } from 'react';
 import React from 'react';
-
-import { Route } from '@storybook/router';
-
 import { Global, createGlobal } from '@storybook/theming';
 import type { Addon_PageType } from '@storybook/types';
 import Sidebar from './container/Sidebar';
@@ -27,11 +24,7 @@ export const App = ({ managerLayoutState, setManagerLayoutState, pages }: Props)
       <Layout
         managerLayoutState={managerLayoutState}
         setManagerLayoutState={setManagerLayoutState}
-        slotMain={
-          // <Route path={/(^\/story|docs|onboarding\/|^\/$)/} hideOnly>
-          <Preview id="main" withLoader />
-          // </Route>
-        }
+        slotMain={<Preview id="main" withLoader />}
         slotSidebar={<Sidebar onMenuClick={() => setMobileAboutOpen((state) => !state)} />}
         slotPanel={<Panel />}
         slotPages={pages.map(({ id, render: Content }) => (

--- a/code/ui/manager/src/components/layout/Layout.stories.tsx
+++ b/code/ui/manager/src/components/layout/Layout.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import { Layout } from './Layout';
 import { LayoutProvider } from './LayoutProvider';
+import { LocationProvider } from '@storybook/router';
 import MobileNavigationStoriesMeta from '../mobile/navigation/MobileNavigation.stories';
 
 const PlaceholderBlock = styled.div({
@@ -67,7 +68,11 @@ const meta = {
   },
   decorators: [
     MobileNavigationStoriesMeta.decorators[0] as any,
-    (storyFn) => <LayoutProvider>{storyFn()}</LayoutProvider>,
+    (storyFn) => (
+      <LocationProvider>
+        <LayoutProvider>{storyFn()}</LayoutProvider>
+      </LocationProvider>
+    ),
   ],
   render: (args) => {
     const [managerLayoutState, setManagerLayoutState] = useState(args.managerLayoutState);

--- a/code/ui/manager/src/components/layout/Layout.tsx
+++ b/code/ui/manager/src/components/layout/Layout.tsx
@@ -6,6 +6,7 @@ import { MobileNavigation } from '../mobile/navigation/MobileNavigation';
 import { MEDIA_DESKTOP_BREAKPOINT } from '../../constants';
 import { useLayout } from './LayoutProvider';
 import { Notifications } from '../../container/Notifications';
+import { Match } from '@storybook/router';
 
 interface InternalLayoutState {
   isDragging: boolean;
@@ -145,7 +146,9 @@ export const Layout = ({ managerLayoutState, setManagerLayoutState, ...slots }: 
     >
       <Notifications />
       {showPages && <PagesContainer>{slots.slotPages}</PagesContainer>}
-      <ContentContainer>{slots.slotMain}</ContentContainer>
+      <Match path={/(^\/story|docs|onboarding\/|^\/$)/} startsWith={false}>
+        {({ match }) => <ContentContainer shown={!!match}>{slots.slotMain}</ContentContainer>}
+      </Match>
       {isDesktop && (
         <>
           <SidebarContainer>
@@ -210,11 +213,12 @@ const SidebarContainer = styled.div(({ theme }) => ({
   borderRight: `1px solid ${theme.color.border}`,
 }));
 
-const ContentContainer = styled.div(({ theme }) => ({
+const ContentContainer = styled.div<{ shown: boolean }>(({ theme, shown }) => ({
   flex: 1,
   position: 'relative',
   backgroundColor: theme.background.content,
-  display: 'grid', // This is needed to make the content container fill the available space
+  display: shown ? 'grid' : 'none', // This is needed to make the content container fill the available space
+  overflow: 'auto',
 
   [MEDIA_DESKTOP_BREAKPOINT]: {
     flex: 'auto',

--- a/code/ui/manager/src/components/mobile/navigation/MobileAddonsDrawer.tsx
+++ b/code/ui/manager/src/components/mobile/navigation/MobileAddonsDrawer.tsx
@@ -1,59 +1,22 @@
 import type { FC, ReactNode } from 'react';
-import React, { useRef } from 'react';
+import React from 'react';
 import { styled } from '@storybook/theming';
-import { Transition } from 'react-transition-group';
-import type { TransitionStatus } from 'react-transition-group/Transition';
-import { useLayout } from '../../layout/LayoutProvider';
 
 interface MobileAddonsDrawerProps {
   children: ReactNode;
 }
 
-const TRANSITION_DURATION = 200;
-
-const Container = styled.div<{ state: TransitionStatus }>(({ theme, state }) => ({
-  position: 'fixed',
+const Container = styled.div(({ theme }) => ({
   boxSizing: 'border-box',
   width: '100%',
   background: theme.background.content,
-  height: '50%',
-  bottom: 0,
-  left: 0,
+  height: '42vh',
   zIndex: 11,
-  transition: `all ${TRANSITION_DURATION}ms ease-in-out`,
+  transition: 'all 200ms ease-in-out',
   overflow: 'hidden',
-  borderTop: `1px solid ${theme.appBorderColor}`,
-  transform: `${(() => {
-    switch (state) {
-      case 'entering':
-      case 'entered':
-        return 'translateY(0)';
-      case 'exiting':
-      case 'exited':
-        return 'translateY(100%)';
-      default:
-        return 'translateY(0)';
-    }
-  })()}`,
+  transform: 'translateY(0)',
 }));
 
 export const MobileAddonsDrawer: FC<MobileAddonsDrawerProps> = ({ children }) => {
-  const { isMobilePanelOpen } = useLayout();
-  const containerRef = useRef(null);
-
-  return (
-    <Transition
-      nodeRef={containerRef}
-      in={isMobilePanelOpen}
-      timeout={TRANSITION_DURATION}
-      mountOnEnter
-      unmountOnExit
-    >
-      {(state) => (
-        <Container ref={containerRef} state={state}>
-          {children}
-        </Container>
-      )}
-    </Transition>
-  );
+  return <Container>{children}</Container>;
 };

--- a/code/ui/manager/src/components/mobile/navigation/MobileAddonsDrawer.tsx
+++ b/code/ui/manager/src/components/mobile/navigation/MobileAddonsDrawer.tsx
@@ -7,14 +7,13 @@ interface MobileAddonsDrawerProps {
 }
 
 const Container = styled.div(({ theme }) => ({
+  position: 'relative',
   boxSizing: 'border-box',
   width: '100%',
   background: theme.background.content,
   height: '42vh',
   zIndex: 11,
-  transition: 'all 200ms ease-in-out',
   overflow: 'hidden',
-  transform: 'translateY(0)',
 }));
 
 export const MobileAddonsDrawer: FC<MobileAddonsDrawerProps> = ({ children }) => {

--- a/code/ui/manager/src/components/mobile/navigation/MobileNavigation.tsx
+++ b/code/ui/manager/src/components/mobile/navigation/MobileNavigation.tsx
@@ -35,39 +35,48 @@ const useFullStoryName = () => {
 };
 
 export const MobileNavigation: FC<MobileNavigationProps> = ({ menu, panel, showPanel }) => {
-  const { isMobileMenuOpen, setMobileMenuOpen, setMobilePanelOpen } = useLayout();
+  const { isMobileMenuOpen, isMobilePanelOpen, setMobileMenuOpen, setMobilePanelOpen } =
+    useLayout();
   const fullStoryName = useFullStoryName();
 
   return (
     <Container>
       <MobileMenuDrawer>{menu}</MobileMenuDrawer>
-      <MobileAddonsDrawer>{panel}</MobileAddonsDrawer>
-      <Button onClick={() => setMobileMenuOpen(!isMobileMenuOpen)} title="Open navigation menu">
-        <MenuIcon />
-        <Text>{fullStoryName}</Text>
-      </Button>
-      {showPanel && (
-        <IconButton onClick={() => setMobilePanelOpen(true)} title="Open addon panel">
-          <BottomBarToggleIcon />
-        </IconButton>
+      {!isMobilePanelOpen && (
+        <Nav>
+          <Button onClick={() => setMobileMenuOpen(!isMobileMenuOpen)} title="Open navigation menu">
+            <MenuIcon />
+            <Text>{fullStoryName}</Text>
+          </Button>
+          {showPanel && (
+            <IconButton onClick={() => setMobilePanelOpen(true)} title="Open addon panel">
+              <BottomBarToggleIcon />
+            </IconButton>
+          )}
+        </Nav>
       )}
+      {isMobilePanelOpen && <MobileAddonsDrawer>{panel}</MobileAddonsDrawer>}
     </Container>
   );
 };
 
 const Container = styled.div(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
   bottom: 0,
   left: 0,
   width: '100%',
-  height: 40,
   zIndex: 10,
   background: theme.barBg,
-  padding: '0 6px',
   borderTop: `1px solid ${theme.appBorderColor}`,
 }));
+
+const Nav = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+  height: 40,
+  padding: '0 6px',
+});
 
 const Button = styled.button(({ theme }) => ({
   all: 'unset',

--- a/code/ui/manager/src/components/mobile/navigation/MobileNavigation.tsx
+++ b/code/ui/manager/src/components/mobile/navigation/MobileNavigation.tsx
@@ -42,7 +42,9 @@ export const MobileNavigation: FC<MobileNavigationProps> = ({ menu, panel, showP
   return (
     <Container>
       <MobileMenuDrawer>{menu}</MobileMenuDrawer>
-      {!isMobilePanelOpen && (
+      {isMobilePanelOpen ? (
+        <MobileAddonsDrawer>{panel}</MobileAddonsDrawer>
+      ) : (
         <Nav>
           <Button onClick={() => setMobileMenuOpen(!isMobileMenuOpen)} title="Open navigation menu">
             <MenuIcon />
@@ -55,7 +57,6 @@ export const MobileNavigation: FC<MobileNavigationProps> = ({ menu, panel, showP
           )}
         </Nav>
       )}
-      {isMobilePanelOpen && <MobileAddonsDrawer>{panel}</MobileAddonsDrawer>}
     </Container>
   );
 };


### PR DESCRIPTION
## What I did

Closes #24424

On the new mobile layout we used to show the addon panel above the canvas. In cases where you use `layout: centred` the addon panel would hide quite a large part of the UI. To fix that, I replicated the desktop behaviour and made the addon panel appear below the canvas.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-25787-sha-ce3d85aa`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-25787-sha-ce3d85aa sandbox` or in an existing project with `npx storybook@0.0.0-pr-25787-sha-ce3d85aa upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-25787-sha-ce3d85aa`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-25787-sha-ce3d85aa) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`charles-fix-mobile-addon-panel`](https://github.com/storybookjs/storybook/tree/charles-fix-mobile-addon-panel) |
| **Commit** | [`ce3d85aa`](https://github.com/storybookjs/storybook/commit/ce3d85aa8213eb0a82d164a8185b480989715fae) |
| **Datetime** | Mon Jan 29 11:38:07 UTC 2024 (`1706528287`) |
| **Workflow run** | [7695438461](https://github.com/storybookjs/storybook/actions/runs/7695438461) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=25787`_
</details>
<!-- CANARY_RELEASE_SECTION -->
