### PR TITLE
CLI: Fix add command for non monorepo deps

### DIFF
--- a/code/lib/cli/src/add.ts
+++ b/code/lib/cli/src/add.ts
@@ -1,7 +1,7 @@
 import {
   getStorybookInfo,
   serverRequire,
-  getStorybookVersion,
+  getCoercedStorybookVersion,
   isCorePackage,
   JsPackageManagerFactory,
   type PackageManagerName,
@@ -107,8 +107,9 @@ export async function add(
   // add to package.json
   const isStorybookAddon = addonName.startsWith('@storybook/');
   const isAddonFromCore = isCorePackage(addonName);
-  const storybookVersion = await getStorybookVersion(packageManager);
+  const storybookVersion = await getCoercedStorybookVersion(packageManager);
   const version = versionSpecifier || (isAddonFromCore ? storybookVersion : latestVersion);
+
   const addonWithVersion = SemVer.valid(version)
     ? `${addonName}@^${version}`
     : `${addonName}@${version}`;

--- a/code/lib/cli/src/automigrate/helpers/mainConfigFile.ts
+++ b/code/lib/cli/src/automigrate/helpers/mainConfigFile.ts
@@ -12,7 +12,7 @@ import chalk from 'chalk';
 import dedent from 'ts-dedent';
 import path from 'path';
 import type { JsPackageManager } from '@storybook/core-common';
-import { getStorybookVersion } from '@storybook/core-common';
+import { getCoercedStorybookVersion } from '@storybook/core-common';
 
 const logger = console;
 
@@ -93,7 +93,7 @@ export const getStorybookData = async ({
     configDir: configDirFromScript,
     previewConfig: previewConfigPath,
   } = getStorybookInfo(packageJson, userDefinedConfigDir);
-  const storybookVersion = await getStorybookVersion(packageManager);
+  const storybookVersion = await getCoercedStorybookVersion(packageManager);
 
   const configDir = userDefinedConfigDir || configDirFromScript || '.storybook';
 

--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -10,7 +10,7 @@ import invariant from 'tiny-invariant';
 import {
   getStorybookInfo,
   loadMainConfig,
-  getStorybookVersion,
+  getCoercedStorybookVersion,
   JsPackageManagerFactory,
 } from '@storybook/core-common';
 import type { PackageManagerName } from '@storybook/core-common';
@@ -156,7 +156,7 @@ export async function runFixes({
     userSpecifiedConfigDir
   );
 
-  const storybookVersion = await getStorybookVersion(packageManager);
+  const storybookVersion = await getCoercedStorybookVersion(packageManager);
 
   if (!storybookVersion) {
     logger.info(dedent`

--- a/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
@@ -55,7 +55,10 @@ export abstract class JsPackageManager {
     basePath?: string
   ): Promise<PackageJson | null>;
 
-  public abstract getPackageVersion(packageName: string, basePath?: string): Promise<string | null>;
+  async getPackageVersion(packageName: string, basePath = this.cwd): Promise<string | null> {
+    const packageJSON = await this.getPackageJSON(packageName, basePath);
+    return packageJSON ? packageJSON.version ?? null : null;
+  }
 
   // NOTE: for some reason yarn prefers the npm registry in
   // local development, so always use npm

--- a/code/lib/core-common/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/core-common/src/js-package-manager/NPMProxy.ts
@@ -4,7 +4,6 @@ import dedent from 'ts-dedent';
 import { sync as findUpSync } from 'find-up';
 import { existsSync, readFileSync } from 'fs';
 import path from 'path';
-import semver from 'semver';
 import { logger } from '@storybook/node-logger';
 import { JsPackageManager } from './JsPackageManager';
 import type { PackageJson } from './PackageJson';
@@ -100,11 +99,6 @@ export class NPMProxy extends JsPackageManager {
 
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
     return packageJson;
-  }
-
-  public async getPackageVersion(packageName: string, basePath = this.cwd): Promise<string | null> {
-    const packageJson = await this.getPackageJSON(packageName, basePath);
-    return packageJson ? semver.coerce(packageJson.version)?.version ?? null : null;
   }
 
   getInstallArgs(): string[] {

--- a/code/lib/core-common/src/js-package-manager/PNPMProxy.ts
+++ b/code/lib/core-common/src/js-package-manager/PNPMProxy.ts
@@ -3,7 +3,6 @@ import dedent from 'ts-dedent';
 import { sync as findUpSync } from 'find-up';
 import path from 'path';
 import fs from 'fs';
-import semver from 'semver';
 import { JsPackageManager } from './JsPackageManager';
 import type { PackageJson } from './PackageJson';
 import type { InstallationMetadata, PackageMetadata } from './types';
@@ -157,12 +156,6 @@ export class PNPMProxy extends JsPackageManager {
     }
 
     return JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-  }
-
-  async getPackageVersion(packageName: string, basePath = this.cwd): Promise<string | null> {
-    const packageJSON = await this.getPackageJSON(packageName, basePath);
-
-    return packageJSON ? semver.coerce(packageJSON.version)?.version ?? null : null;
   }
 
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {

--- a/code/lib/core-common/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/core-common/src/js-package-manager/Yarn1Proxy.ts
@@ -2,7 +2,6 @@ import dedent from 'ts-dedent';
 import { sync as findUpSync } from 'find-up';
 import { existsSync, readFileSync } from 'fs';
 import path from 'path';
-import semver from 'semver';
 import { createLogStream } from '../utils/cli';
 import { JsPackageManager } from './JsPackageManager';
 import type { PackageJson } from './PackageJson';
@@ -80,11 +79,6 @@ export class Yarn1Proxy extends JsPackageManager {
     }
 
     return JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as Record<string, any>;
-  }
-
-  public async getPackageVersion(packageName: string, basePath = this.cwd): Promise<string | null> {
-    const packageJson = await this.getPackageJSON(packageName, basePath);
-    return packageJson ? semver.coerce(packageJson.version)?.version ?? null : null;
   }
 
   public async findInstallations(pattern: string[]) {

--- a/code/lib/core-common/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/core-common/src/js-package-manager/Yarn2Proxy.ts
@@ -4,7 +4,6 @@ import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 import { PosixFS, VirtualFS, ZipOpenFS } from '@yarnpkg/fslib';
 import { getLibzipSync } from '@yarnpkg/libzip';
-import semver from 'semver';
 import { createLogStream } from '../utils/cli';
 import { JsPackageManager } from './JsPackageManager';
 import type { PackageJson } from './PackageJson';
@@ -172,11 +171,6 @@ export class Yarn2Proxy extends JsPackageManager {
 
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
     return packageJson;
-  }
-
-  async getPackageVersion(packageName: string, basePath = this.cwd): Promise<string | null> {
-    const packageJSON = await this.getPackageJSON(packageName, basePath);
-    return packageJSON ? semver.coerce(packageJSON.version)?.version ?? null : null;
   }
 
   protected getResolutions(packageJson: PackageJson, versions: Record<string, string>) {

--- a/code/lib/core-common/src/utils/cli.test.ts
+++ b/code/lib/core-common/src/utils/cli.test.ts
@@ -5,13 +5,12 @@ describe('UTILS', () => {
   describe.each([
     ['@storybook/react', true],
     ['@storybook/node-logger', true],
-    ['@storybook/addon-info', true],
-    ['@storybook/something-random', true],
-    ['@storybook/preset-create-react-app', false],
     ['@storybook/linter-config', false],
     ['@storybook/design-system', false],
     ['@storybook/addon-styling', false],
     ['@storybook/addon-styling-webpack', false],
+    ['@storybook/addon-webpack5-compiler-swc', false],
+    ['@storybook/addon-webpack5-compiler-babel', false],
     ['@nx/storybook', false],
     ['@nrwl/storybook', false],
   ])('isCorePackage', (input, output) => {

--- a/code/lib/core-common/src/utils/cli.ts
+++ b/code/lib/core-common/src/utils/cli.ts
@@ -13,6 +13,12 @@ export function parseList(str: string): string[] {
     .filter((item) => item.length > 0);
 }
 
+/**
+ * Given a package manager, returns the coerced version of Storybook.
+ * It tries to find renderer packages in the project and returns the coerced version of the first one found.
+ * Example:
+ * If @storybook/react version 8.0.0-alpha.14 is installed, it returns the coerced version 8.0.0
+ */
 export async function getCoercedStorybookVersion(packageManager: JsPackageManager) {
   const packages = (
     await Promise.all(

--- a/code/lib/core-common/src/utils/cli.ts
+++ b/code/lib/core-common/src/utils/cli.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import tempy from 'tempy';
 import { rendererPackages } from './get-storybook-info';
 import type { JsPackageManager } from '../js-package-manager';
+import versions from '../versions';
 
 export function parseList(str: string): string[] {
   return str
@@ -12,7 +13,7 @@ export function parseList(str: string): string[] {
     .filter((item) => item.length > 0);
 }
 
-export async function getStorybookVersion(packageManager: JsPackageManager) {
+export async function getCoercedStorybookVersion(packageManager: JsPackageManager) {
   const packages = (
     await Promise.all(
       Object.keys(rendererPackages).map(async (pkg) => ({

--- a/code/lib/core-common/src/utils/cli.ts
+++ b/code/lib/core-common/src/utils/cli.ts
@@ -97,34 +97,4 @@ export const createLogStream = async (
   });
 };
 
-const PACKAGES_EXCLUDED_FROM_CORE = [
-  '@storybook/addon-bench',
-  '@storybook/addon-console',
-  '@storybook/addon-onboarding',
-  '@storybook/addon-postcss',
-  '@storybook/addon-designs',
-  '@storybook/addon-styling',
-  '@storybook/addon-styling-webpack',
-  '@storybook/bench',
-  '@storybook/builder-vite',
-  '@storybook/csf',
-  '@storybook/design-system',
-  '@storybook/ember-cli-storybook',
-  '@storybook/eslint-config-storybook',
-  '@storybook/expect',
-  '@storybook/jest',
-  '@storybook/linter-config',
-  '@storybook/mdx1-csf',
-  '@storybook/mdx2-csf',
-  '@storybook/react-docgen-typescript-plugin',
-  '@storybook/storybook-deployer',
-  '@storybook/test-runner',
-  '@storybook/testing-library',
-  '@storybook/testing-react',
-  '@nrwl/storybook',
-  '@nx/storybook',
-];
-export const isCorePackage = (pkg: string) =>
-  pkg.startsWith('@storybook/') &&
-  !pkg.startsWith('@storybook/preset-') &&
-  !PACKAGES_EXCLUDED_FROM_CORE.includes(pkg);
+export const isCorePackage = (pkg: string) => Object.keys(versions).includes(pkg);


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25790

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Running `npx storybook@next add <package>` on non-mono-repo addons sometimes failed because the wrong version number was taken. Now, the check to determine whether a package is a mono repo package or not was adjusted to take the `versions.ts` file into account.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Run `/path-to-storybook/code/lib/cli/bin/index.js add @storybook/addon-webpack5-compiler-babel`
3. The latest version of the addon should be installed


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-25791-sha-731531eb`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-25791-sha-731531eb sandbox` or in an existing project with `npx storybook@0.0.0-pr-25791-sha-731531eb upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-25791-sha-731531eb`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-25791-sha-731531eb) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-add-command-for-non-monorepo-deps`](https://github.com/storybookjs/storybook/tree/valentin/fix-add-command-for-non-monorepo-deps) |
| **Commit** | [`731531eb`](https://github.com/storybookjs/storybook/commit/731531ebcfe32e9a5a348a7b1ed633ad97a95055) |
| **Datetime** | Tue Jan 30 17:12:51 UTC 2024 (`1706634771`) |
| **Workflow run** | [7714884306](https://github.com/storybookjs/storybook/actions/runs/7714884306) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=25791`_
</details>
<!-- CANARY_RELEASE_SECTION -->
