### PR TITLE
UI: Fix sidebar top and bottom addons not showing

### DIFF
--- a/code/ui/manager/src/container/Sidebar.tsx
+++ b/code/ui/manager/src/container/Sidebar.tsx
@@ -45,9 +45,9 @@ const Sidebar = React.memo(function Sideber({ onMenuClick }: SidebarProps) {
     const bottomItems = api.getElements(Addon_TypesEnum.experimental_SIDEBAR_BOTTOM);
     const topItems = api.getElements(Addon_TypesEnum.experimental_SIDEBAR_TOP);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const bottom = useMemo(() => Object.values(bottomItems), [...Object.values(bottomItems)]);
+    const bottom = useMemo(() => Object.values(bottomItems), [Object.keys(bottomItems).join('')]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const top = useMemo(() => Object.values(topItems), [...Object.values(topItems)]);
+    const top = useMemo(() => Object.values(topItems), [Object.keys(topItems).join('')]);
 
     return {
       title: name,


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25809

## What I did

The memoization was broken, because the result of getElements is a constant that gets mutated upstream, so the useMemo never gets re-executed.

By making the concatinated keys of the object (a single string) the memo key, it will get re-evaluated and thus we'll get a consistent array, but a new one, as soon as an new addon gets injected.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-25825-sha-bbd3f181`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-25825-sha-bbd3f181 sandbox` or in an existing project with `npx storybook@0.0.0-pr-25825-sha-bbd3f181 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-25825-sha-bbd3f181`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-25825-sha-bbd3f181) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/fix-memo-in-ui`](https://github.com/storybookjs/storybook/tree/norbert/fix-memo-in-ui) |
| **Commit** | [`bbd3f181`](https://github.com/storybookjs/storybook/commit/bbd3f181c0f51cd35af8057fbbbec1d6704c7cae) |
| **Datetime** | Tue Jan 30 20:22:01 UTC 2024 (`1706646121`) |
| **Workflow run** | [7717006552](https://github.com/storybookjs/storybook/actions/runs/7717006552) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=25825`_
</details>
<!-- CANARY_RELEASE_SECTION -->
