### PR TITLE
Test: Fix vitest patch to work with portable stories and upgrade testing-library/jest-dom

### DIFF
--- a/code/.yarn/patches/@vitest-expect-npm-1.1.3-2062bf533f.patch
+++ b/code/.yarn/patches/@vitest-expect-npm-1.1.3-2062bf533f.patch
@@ -1,10 +1,10 @@
 diff --git a/dist/index.js b/dist/index.js
-index 974d6b26f626024fc9904908100c9ecaa54f43e1..5be2d35267e7f0525c6588758dbebe72599f88a9 100644
+index 974d6b26f626024fc9904908100c9ecaa54f43e1..5d9d92a0796e02630ccdd1174d4fd25e016d2b06 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -6,31 +6,37 @@ import { processError } from '@vitest/utils/error';
+@@ -6,28 +6,35 @@ import { processError } from '@vitest/utils/error';
  import { util } from 'chai';
- 
+
  const MATCHERS_OBJECT = Symbol.for("matchers-object");
 -const JEST_MATCHERS_OBJECT = Symbol.for("$$jest-matchers-object");
 +// Patched this symbol for storybook, so that @storybook/test can be used in a jest environment as well.
@@ -12,17 +12,14 @@ index 974d6b26f626024fc9904908100c9ecaa54f43e1..5be2d35267e7f0525c6588758dbebe72
 +const JEST_MATCHERS_OBJECT = Symbol.for("$$jest-matchers-object-storybook");
  const GLOBAL_EXPECT = Symbol.for("expect-global");
  const ASYMMETRIC_MATCHERS_OBJECT = Symbol.for("asymmetric-matchers-object");
- 
+
  if (!Object.prototype.hasOwnProperty.call(globalThis, MATCHERS_OBJECT)) {
    const globalState = /* @__PURE__ */ new WeakMap();
 -  const matchers = /* @__PURE__ */ Object.create(null);
-   const assymetricMatchers = /* @__PURE__ */ Object.create(null);
+-  const assymetricMatchers = /* @__PURE__ */ Object.create(null);
    Object.defineProperty(globalThis, MATCHERS_OBJECT, {
      get: () => globalState
    });
-+  Object.defineProperty(globalThis, ASYMMETRIC_MATCHERS_OBJECT, {
-+    get: () => assymetricMatchers
-+  });
 +}
 +if (!Object.prototype.hasOwnProperty.call(globalThis, JEST_MATCHERS_OBJECT)) {
 +  const matchers = /* @__PURE__ */ Object.create(null);
@@ -34,15 +31,14 @@ index 974d6b26f626024fc9904908100c9ecaa54f43e1..5be2d35267e7f0525c6588758dbebe72
        matchers
      })
    });
--  Object.defineProperty(globalThis, ASYMMETRIC_MATCHERS_OBJECT, {
--    get: () => assymetricMatchers
--  });
++}
++if (!Object.prototype.hasOwnProperty.call(globalThis, ASYMMETRIC_MATCHERS_OBJECT)) {
++  const assymetricMatchers = /* @__PURE__ */ Object.create(null);
+   Object.defineProperty(globalThis, ASYMMETRIC_MATCHERS_OBJECT, {
+     get: () => assymetricMatchers
+   });
  }
 +
  function getState(expect) {
    return globalThis[MATCHERS_OBJECT].get(expect);
  }
-+
- function setState(state, expect) {
-   const map = globalThis[MATCHERS_OBJECT];
-   const current = map.get(expect) || {};

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -48,7 +48,7 @@
     "@storybook/instrumenter": "workspace:*",
     "@storybook/preview-api": "workspace:*",
     "@testing-library/dom": "^9.3.1",
-    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/user-event": "14.3.0",
     "@vitest/expect": "1.1.3",
     "@vitest/spy": "^1.1.3",

--- a/code/lib/test/src/expect.ts
+++ b/code/lib/test/src/expect.ts
@@ -16,9 +16,10 @@ import {
 } from '@vitest/expect';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import type { PromisifyObject } from './utils';
+import type { TestingLibraryMatchers } from '@testing-library/jest-dom/types/matchers';
 
 type Matchers<T> = PromisifyObject<JestAssertion<T>> &
-  matchers.TestingLibraryMatchers<ReturnType<ExpectStatic['stringContaining']>, Promise<void>>;
+  TestingLibraryMatchers<ReturnType<ExpectStatic['stringContaining']>, Promise<void>>;
 
 // We only expose the jest compatible API for now
 export interface Assertion<T> extends Matchers<T> {

--- a/code/lib/test/src/index.test.ts
+++ b/code/lib/test/src/index.test.ts
@@ -1,0 +1,8 @@
+import { it } from 'vitest';
+import { expect, fn } from '@storybook/test';
+
+it('storybook expect and fn can be used in vitest test', () => {
+  const spy = fn();
+  spy(1);
+  expect(spy).toHaveBeenCalledWith(1);
+});

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -8479,12 +8479,12 @@ __metadata:
 
 "@vitest/expect@patch:@vitest/expect@npm%3A1.1.3#~/.yarn/patches/@vitest-expect-npm-1.1.3-2062bf533f.patch":
   version: 1.1.3
-  resolution: "@vitest/expect@patch:@vitest/expect@npm%3A1.1.3#~/.yarn/patches/@vitest-expect-npm-1.1.3-2062bf533f.patch::version=1.1.3&hash=5d51c9"
+  resolution: "@vitest/expect@patch:@vitest/expect@npm%3A1.1.3#~/.yarn/patches/@vitest-expect-npm-1.1.3-2062bf533f.patch::version=1.1.3&hash=8fb073"
   dependencies:
     "@vitest/spy": "npm:1.1.3"
     "@vitest/utils": "npm:1.1.3"
     chai: "npm:^4.3.10"
-  checksum: 426287f864f58b05b1c4689bc87b4ef2ca7b3316a22e8e42d94ee9c125cbc0caf294618c9a1201a8ddf8ab68ce1ab194d1e34589f7d608906a3dc679074cfe22
+  checksum: c3bbcae82050b7e92438c85e679ef2cb09162dc5638a10b3f0b5a8fc5600dfb0be578a244d84012ae2f1715748189393ac0fc72b891efff3503338221795ebe5
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -31,6 +31,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/css-tools@npm:^4.3.2":
+  version: 4.3.3
+  resolution: "@adobe/css-tools@npm:4.3.3"
+  checksum: e76e712df713964b87cdf2aca1f0477f19bebd845484d5fcba726d3ec7782366e2f26ec8cb2dcfaf47081a5c891987d8a9f5c3f30d11e1eb3c1848adc27fcb24
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:2.2.1, @ampproject/remapping@npm:^2.2.0, @ampproject/remapping@npm:^2.2.1":
   version: 2.2.1
   resolution: "@ampproject/remapping@npm:2.2.1"
@@ -6663,7 +6670,7 @@ __metadata:
     "@storybook/instrumenter": "workspace:*"
     "@storybook/preview-api": "workspace:*"
     "@testing-library/dom": "npm:^9.3.1"
-    "@testing-library/jest-dom": "npm:^6.1.3"
+    "@testing-library/jest-dom": "npm:^6.4.0"
     "@testing-library/user-event": "npm:14.3.0"
     "@vitest/expect": "npm:1.1.3"
     "@vitest/spy": "npm:^1.1.3"
@@ -6925,7 +6932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^6.1.3, @testing-library/jest-dom@npm:^6.1.4":
+"@testing-library/jest-dom@npm:^6.1.4":
   version: 6.1.5
   resolution: "@testing-library/jest-dom@npm:6.1.5"
   dependencies:
@@ -6952,6 +6959,39 @@ __metadata:
     vitest:
       optional: true
   checksum: f3643a56fcd970b5c7e8fd10faf3c4817d8ab0e74fb1198d726643bdc5ac675ceaac3b0068c5b4fbad254470e8f98ed50028741de875a29ceaa2f854570979c9
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@testing-library/jest-dom@npm:6.4.0"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.3.2"
+    "@babel/runtime": "npm:^7.9.2"
+    aria-query: "npm:^5.0.0"
+    chalk: "npm:^3.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    lodash: "npm:^4.17.15"
+    redent: "npm:^3.0.0"
+  peerDependencies:
+    "@jest/globals": ">= 28"
+    "@types/bun": "*"
+    "@types/jest": ">= 28"
+    jest: ">= 28"
+    vitest: ">= 0.32"
+  peerDependenciesMeta:
+    "@jest/globals":
+      optional: true
+    "@types/bun":
+      optional: true
+    "@types/jest":
+      optional: true
+    jest:
+      optional: true
+    vitest:
+      optional: true
+  checksum: 6b7eba9ca388986a721fb12f84adf0f5534bf7ec5851982023a889c4a0afac6e9e91291bdac39e1f59a05adefd7727e30463d98b21c3da32fbfec229ccb11ef1
   languageName: node
   linkType: hard
 
@@ -12990,6 +13030,13 @@ __metadata:
   version: 0.5.16
   resolution: "dom-accessibility-api@npm:0.5.16"
   checksum: b2c2eda4fae568977cdac27a9f0c001edf4f95a6a6191dfa611e3721db2478d1badc01db5bb4fa8a848aeee13e442a6c2a4386d65ec65a1436f24715a2f8d053
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: 10bee5aa514b2a9a37c87cd81268db607a2e933a050074abc2f6fa3da9080ebed206a320cbc123567f2c3087d22292853bdfdceaffdd4334ffe2af9510b29360
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #25750
Fixes #25794
## What I did

Fix vitest patch to work with portable stories
And upgrade testing-library/jest-dom

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
