### PR TITLE
Core: Remove CSF batching, as it isn't required any more

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,6 +28,7 @@
     - [Removed stories.json](#removed-storiesjson)
     - [Removed `sb babelrc` command](#removed-sb-babelrc-command)
     - [Changed interfaces for `@storybook/router` components](#changed-interfaces-for-storybookrouter-components)
+    - [Extract no longer batches](#extract-no-longer-batches)
   - [Framework-specific changes](#framework-specific-changes)
     - [React](#react)
       - [`react-docgen` component analysis by default](#react-docgen-component-analysis-by-default)
@@ -711,6 +712,10 @@ The reasoning behind is to condense and provide some clarity to what's happened 
 #### Changed interfaces for `@storybook/router` components
 
 The `hideOnly` prop has been removed from the `<Route />` component in `@storybook/router`. If needed this can be implemented manually with the `<Match />` component.
+
+#### Extract no longer batches
+
+`Preview.extract()` no longer loads CSF files in batches. This was a workaround for resource limitations that slowed down extract. This shouldn't affect behaviour.
 
 ### Framework-specific changes
 

--- a/code/lib/preview-api/src/modules/store/StoryStore.test.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.test.ts
@@ -28,14 +28,6 @@ vi.mock('@storybook/global', async (importOriginal) => ({
 
 vi.mock('@storybook/client-logger');
 
-const createGate = (): [Promise<any | undefined>, (_?: any) => void] => {
-  let openGate = (_?: any) => {};
-  const gate = new Promise<any | undefined>((resolve) => {
-    openGate = resolve;
-  });
-  return [gate, openGate];
-};
-
 const componentOneExports = {
   default: { title: 'Component One' },
   a: { args: { foo: 'a' } },
@@ -434,22 +426,6 @@ describe('StoryStore', () => {
         './src/ComponentOne.stories.js',
         './src/ComponentTwo.stories.js',
       ]);
-    });
-
-    it('imports in batches', async () => {
-      const [gate, openGate] = createGate();
-      const blockedImportFn = vi.fn(async (file) => {
-        await gate;
-        return importFn(file);
-      });
-      const store = new StoryStore(storyIndex, blockedImportFn, projectAnnotations);
-
-      const promise = store.loadAllCSFFiles({ batchSize: 1 });
-      expect(blockedImportFn).toHaveBeenCalledTimes(1);
-
-      openGate();
-      await promise;
-      expect(blockedImportFn).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/code/lib/preview-api/src/modules/store/StoryStore.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.ts
@@ -41,9 +41,9 @@ import {
   prepareContext,
 } from './csf';
 
+// TODO -- what are reasonable values for these?
 const CSF_CACHE_SIZE = 1000;
 const STORY_CACHE_SIZE = 10000;
-const EXTRACT_BATCH_SIZE = 20;
 
 export class StoryStore<TRenderer extends Renderer> {
   public storyIndex: StoryIndexStore;
@@ -127,38 +127,27 @@ export class StoryStore<TRenderer extends Renderer> {
     return this.processCSFFileWithCache(moduleExports, importPath, title);
   }
 
-  async loadAllCSFFiles({ batchSize = EXTRACT_BATCH_SIZE } = {}): Promise<
-    StoryStore<TRenderer>['cachedCSFFiles']
-  > {
-    const importPaths = Object.entries(this.storyIndex.entries).map(([storyId, { importPath }]) => [
-      importPath,
-      storyId,
-    ]);
+  async loadAllCSFFiles(): Promise<StoryStore<TRenderer>['cachedCSFFiles']> {
+    const importPaths: Record<Path, StoryId> = {};
+    Object.entries(this.storyIndex.entries).forEach(([storyId, { importPath }]) => {
+      importPaths[importPath] = storyId;
+    });
 
-    const loadInBatches = async (
-      remainingImportPaths: typeof importPaths
-    ): Promise<{ importPath: Path; csfFile: CSFFile<TRenderer> }[]> => {
-      if (remainingImportPaths.length === 0) return Promise.resolve([]);
+    const csfFilePromiseList = Object.entries(importPaths).map(([importPath, storyId]) =>
+      this.loadCSFFileByStoryId(storyId).then((csfFile) => ({
+        importPath,
+        csfFile,
+      }))
+    );
 
-      const csfFilePromiseList = remainingImportPaths
-        .slice(0, batchSize)
-        .map(async ([importPath, storyId]) => ({
-          importPath,
-          csfFile: await this.loadCSFFileByStoryId(storyId),
-        }));
-
-      const firstResults = await Promise.all(csfFilePromiseList);
-      const restResults = await loadInBatches(remainingImportPaths.slice(batchSize));
-      return firstResults.concat(restResults);
-    };
-
-    const list = await loadInBatches(importPaths);
-    return list.reduce(
-      (acc, { importPath, csfFile }) => {
-        acc[importPath] = csfFile;
-        return acc;
-      },
-      {} as Record<Path, CSFFile<TRenderer>>
+    return Promise.all(csfFilePromiseList).then((list) =>
+      list.reduce(
+        (acc, { importPath, csfFile }) => {
+          acc[importPath] = csfFile;
+          return acc;
+        },
+        {} as Record<Path, CSFFile<TRenderer>>
+      )
     );
   }
 

--- a/code/lib/preview-api/src/modules/store/StoryStore.ts
+++ b/code/lib/preview-api/src/modules/store/StoryStore.ts
@@ -133,21 +133,19 @@ export class StoryStore<TRenderer extends Renderer> {
       importPaths[importPath] = storyId;
     });
 
-    const csfFilePromiseList = Object.entries(importPaths).map(([importPath, storyId]) =>
-      this.loadCSFFileByStoryId(storyId).then((csfFile) => ({
+    const list = await Promise.all(
+      Object.entries(importPaths).map(async ([importPath, storyId]) => ({
         importPath,
-        csfFile,
+        csfFile: await this.loadCSFFileByStoryId(storyId),
       }))
     );
 
-    return Promise.all(csfFilePromiseList).then((list) =>
-      list.reduce(
-        (acc, { importPath, csfFile }) => {
-          acc[importPath] = csfFile;
-          return acc;
-        },
-        {} as Record<Path, CSFFile<TRenderer>>
-      )
+    return list.reduce(
+      (acc, { importPath, csfFile }) => {
+        acc[importPath] = csfFile;
+        return acc;
+      },
+      {} as Record<Path, CSFFile<TRenderer>>
     );
   }
 


### PR DESCRIPTION
Revert "Batch the loading of CSF files for `extract()` etc"

This reverts commit 8e52fb71df73605c346a020fc3b9663f1544b53a.

## What I did

Stopped batching requests for CSF files in `extract()` etc.

This is due to the batching slowing down `extract` and not being required for Chromatic any more.

Alternatively (if we think anyone else is relying on this), we could leave the code, but change the default batch size to infinity.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
