### PR TITLE
React Native: Fix errors on compose story

### DIFF
--- a/code/lib/preview-api/src/modules/preview-web/UrlStore.ts
+++ b/code/lib/preview-api/src/modules/preview-web/UrlStore.ts
@@ -65,7 +65,7 @@ const getFirstString = (v: ValueOf<qs.ParsedQs>): string | void => {
 };
 
 export const getSelectionSpecifierFromPath: () => SelectionSpecifier | null = () => {
-  const query = qs.parse(document.location.search, { ignoreQueryPrefix: true });
+  const query = qs.parse(document?.location?.search, { ignoreQueryPrefix: true });
   const args = typeof query.args === 'string' ? parseArgsParam(query.args) : undefined;
   const globals = typeof query.globals === 'string' ? parseArgsParam(query.globals) : undefined;
 

--- a/code/lib/preview-api/src/modules/preview-web/WebView.ts
+++ b/code/lib/preview-api/src/modules/preview-web/WebView.ts
@@ -47,7 +47,7 @@ export class WebView implements View<HTMLElement> {
   constructor() {
     // Special code for testing situations
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { __SPECIAL_TEST_PARAMETER__ } = qs.parse(document.location.search, {
+    const { __SPECIAL_TEST_PARAMETER__ } = qs.parse(document?.location?.search, {
       ignoreQueryPrefix: true,
     });
     switch (__SPECIAL_TEST_PARAMETER__) {


### PR DESCRIPTION
cherry picked changes from #25894

Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

minimum changes to not error when document doesn't exist

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

see the repro here

https://github.com/dannyhw/rn-sb-test-repro

see components/Button/Button.test.tsx

1. run yarn install
2. yarn test

<img width="1060" alt="image" src="https://github.com/storybookjs/storybook/assets/3481514/cc633462-ebc6-421a-87c4-3a7c007c3f8b">

If I just update getSelectionSpecifierFromPath then I get the webview error

<img width="1060" alt="image" src="https://github.com/storybookjs/storybook/assets/3481514/ef36c3ae-65fd-4fb4-9e30-a6cabf0d3883">

after making these same changes in the nodemodules tests pass

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
