### PR TITLE
Vite: Add a `rollup-plugin-webpack-stats` to allow stats from preview builds

### DIFF
--- a/code/builders/builder-vite/src/build.ts
+++ b/code/builders/builder-vite/src/build.ts
@@ -2,6 +2,7 @@ import type { Options } from '@storybook/types';
 import { commonConfig } from './vite-config';
 
 import { sanitizeEnvVars } from './envs';
+import type { WebpackStatsPlugin } from './plugins';
 
 export async function build(options: Options) {
   const { build: viteBuild, mergeConfig } = await import('vite');
@@ -29,4 +30,9 @@ export async function build(options: Options) {
 
   const finalConfig = await presets.apply('viteFinal', config, options);
   await viteBuild(await sanitizeEnvVars(options, finalConfig));
+
+  const statsPlugin = config.plugins?.find(
+    (p) => p && 'name' in p && p.name === 'rollup-plugin-webpack-stats'
+  ) as WebpackStatsPlugin;
+  return statsPlugin?.storybookGetStats();
 }

--- a/code/builders/builder-vite/src/plugins/index.ts
+++ b/code/builders/builder-vite/src/plugins/index.ts
@@ -3,3 +3,4 @@ export * from './strip-story-hmr-boundaries';
 export * from './code-generator-plugin';
 export * from './csf-plugin';
 export * from './external-globals-plugin';
+export * from './webpack-stats-plugin';

--- a/code/builders/builder-vite/src/plugins/webpack-stats-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/webpack-stats-plugin.ts
@@ -83,7 +83,7 @@ export function pluginWebpackStats({ workingDir }: WebpackStatsPluginOptions): W
   const statsMap = new Map<string, Module>();
 
   return {
-    name: 'rollup-plugin-webpack-stats',
+    name: 'storybook:rollup-plugin-webpack-stats',
     // We want this to run after the vite build plugins (https://vitejs.dev/guide/api-plugin.html#plugin-ordering)
     enforce: 'post',
     moduleParsed: function (mod) {

--- a/code/builders/builder-vite/src/plugins/webpack-stats-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/webpack-stats-plugin.ts
@@ -1,0 +1,116 @@
+// This plugin is a direct port of https://github.com/IanVS/vite-plugin-turbosnap
+
+import type { BuilderStats } from '@storybook/types';
+import path from 'path';
+import type { Plugin } from 'vite';
+
+/*
+ * Reason, Module are copied from chromatic types
+ * https://github.com/chromaui/chromatic-cli/blob/145a5e295dde21042e96396c7e004f250d842182/bin-src/types.ts#L265-L276
+ */
+interface Reason {
+  moduleName: string;
+}
+interface Module {
+  id: string | number;
+  name: string;
+  modules?: Array<Pick<Module, 'name'>>;
+  reasons?: Reason[];
+}
+
+type WebpackStatsPluginOptions = {
+  workingDir: string;
+};
+
+/**
+ * Strips off query params added by rollup/vite to ids, to make paths compatible for comparison with git.
+ */
+function stripQueryParams(filePath: string): string {
+  return filePath.split('?')[0];
+}
+
+/**
+ * We only care about user code, not node_modules, vite files, or (most) virtual files.
+ */
+function isUserCode(moduleName: string) {
+  return Boolean(
+    moduleName &&
+      !moduleName.startsWith('vite/') &&
+      !moduleName.startsWith('\x00') &&
+      !moduleName.startsWith('\u0000') &&
+      moduleName !== 'react/jsx-runtime' &&
+      !moduleName.match(/node_modules\//)
+  );
+}
+
+export type WebpackStatsPlugin = Plugin & { storybookGetStats: () => BuilderStats };
+
+export function pluginWebpackStats({ workingDir }: WebpackStatsPluginOptions): WebpackStatsPlugin {
+  /**
+   * Convert an absolute path name to a path relative to the vite root, with a starting `./`
+   */
+  function normalize(filename: string) {
+    // Do not try to resolve virtual files
+    if (filename.startsWith('/virtual:')) {
+      return filename;
+    }
+    // Otherwise, we need them in the format `./path/to/file.js`.
+    else {
+      const relativePath = path.relative(workingDir, stripQueryParams(filename));
+      // This seems hacky, got to be a better way to add a `./` to the start of a path.
+      return `./${relativePath}`;
+    }
+  }
+
+  /**
+   * Helper to create Reason objects out of a list of string paths
+   */
+  function createReasons(importers?: readonly string[]): Reason[] {
+    return (importers || []).map((i) => ({ moduleName: normalize(i) }));
+  }
+
+  /**
+   * Helper function to build a `Module` given a filename and list of files that import it
+   */
+  function createStatsMapModule(filename: string, importers?: readonly string[]): Module {
+    return {
+      id: filename,
+      name: filename,
+      reasons: createReasons(importers),
+    };
+  }
+
+  const statsMap = new Map<string, Module>();
+
+  return {
+    name: 'rollup-plugin-webpack-stats',
+    // We want this to run after the vite build plugins (https://vitejs.dev/guide/api-plugin.html#plugin-ordering)
+    enforce: 'post',
+    moduleParsed: function (mod) {
+      if (isUserCode(mod.id)) {
+        mod.importedIds
+          .concat(mod.dynamicallyImportedIds)
+          .filter((name) => isUserCode(name))
+          .forEach((depIdUnsafe) => {
+            const depId = normalize(depIdUnsafe);
+            if (statsMap.has(depId)) {
+              const m = statsMap.get(depId);
+              if (m) {
+                m.reasons = (m.reasons ?? [])
+                  .concat(createReasons([mod.id]))
+                  .filter((r) => r.moduleName !== depId);
+                statsMap.set(depId, m);
+              }
+            } else {
+              statsMap.set(depId, createStatsMapModule(depId, [mod.id]));
+            }
+          });
+      }
+    },
+
+    storybookGetStats() {
+      const stats = { modules: Array.from(statsMap.values()) };
+      return { ...stats, toJson: () => stats };
+    },
+  };
+}

--- a/code/builders/builder-vite/src/vite-config.ts
+++ b/code/builders/builder-vite/src/vite-config.ts
@@ -20,6 +20,7 @@ import {
   injectExportOrderPlugin,
   stripStoryHMRBoundary,
   externalGlobalsPlugin,
+  pluginWebpackStats,
 } from './plugins';
 
 import type { BuilderOptions } from './types';
@@ -112,6 +113,7 @@ export async function pluginConfig(options: Options) {
       },
     },
     await externalGlobalsPlugin(externals),
+    pluginWebpackStats({ workingDir: process.cwd() }),
   ] as PluginOption[];
 
   // TODO: framework doesn't exist, should move into framework when/if built


### PR DESCRIPTION
## What I did

Integrated https://github.com/IanVS/vite-plugin-turbosnap (thanks @IanVS) so that the `--webpack-stats-json` flag works for Vite builds also.

One limitation is that it only works in build/production mode, as it is a rollup plugin. However AFAIK the only user of this flag is Chromatic and it only cares about built storybooks.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
