### PR TITLE
Release tooling: Fix patch preparation not cancelling when no patches available

### DIFF
--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -89,7 +89,7 @@ jobs:
           yarn release:pick-patches
 
       - name: Cancel when no patches to pick
-        if: steps.pick-patches.outputs.pr-count == '0' && steps.pick-patches.outputs.pr-count != null
+        if: steps.pick-patches.outputs.pr-count == 0 && steps.pick-patches.outputs.pr-count != null
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # From https://stackoverflow.com/a/75809743
@@ -123,7 +123,7 @@ jobs:
         run: |
           yarn release:write-changelog ${{ steps.versions.outputs.next }} --unpicked-patches --verbose
 
-      - name: 'Commit changes to branch: version-patch-from-${{ steps.versions.outputs.current }}'
+      - name: "Commit changes to branch: version-patch-from-${{ steps.versions.outputs.current }}"
         working-directory: .
         run: |
           git config --global user.name 'storybook-bot'
@@ -185,4 +185,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_URL }}
         uses: Ilshidur/action-discord@master
         with:
-          args: 'The GitHub Action for preparing the release pull request bumping from v${{ steps.versions.outputs.current }} to v${{ steps.versions.outputs.next }} (triggered by ${{ github.triggering_actor }}) failed! See run at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          args: "The GitHub Action for preparing the release pull request bumping from v${{ steps.versions.outputs.current }} to v${{ steps.versions.outputs.next }} (triggered by ${{ github.triggering_actor }}) failed! See run at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -89,7 +89,7 @@ jobs:
           yarn release:pick-patches
 
       - name: Cancel when no patches to pick
-        if: steps.pick-patches.outputs.pr-count == 0 && steps.pick-patches.outputs.pr-count != null
+        if: steps.pick-patches.outputs.no-patch-prs == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # From https://stackoverflow.com/a/75809743

--- a/scripts/release/pick-patches.ts
+++ b/scripts/release/pick-patches.ts
@@ -81,7 +81,7 @@ export const run = async (_: unknown) => {
   }
 
   if (process.env.GITHUB_ACTIONS === 'true') {
-    setOutput('pr-count', JSON.stringify(patchPRs.length));
+    setOutput('no-patch-prs', patchPRs.length === 0);
     setOutput('failed-cherry-picks', JSON.stringify(failedCherryPicks));
   }
 };


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Changed the logic for checking if any PRs are available to patch. GitHub for some reason thinks `'0' == null`, so the previous condition would always be false. This caused patch preparation to always be done, even when no patching was needed, eg. see this current state of [the empty prepared patch PR](https://github.com/storybookjs/storybook/pull/25933):

![image](https://github.com/storybookjs/storybook/assets/5678122/bbacf5b7-7e7f-4488-88d6-1c6c27595b64)

After every patch release the workflow would fail because it would result in opening an empty PR, eg. this run: https://github.com/storybookjs/storybook/actions/runs/7803855460/job/21284534067

Now we instead pass in `'true'` when no patches or `'false'` when there are patches. This is still compatible with the "no output" scenario, which would not be `true` and thus not cancel. There won't be an output until this PR is patches back to `main`, which I'll manually do afterwards.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I tested this manually in the following run: https://github.com/storybookjs/storybook/actions/runs/7815398511/job/21318658549

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
