### PR TITLE
Portable stories: Pass story context to the play function of a composed story

### DIFF
--- a/code/lib/preview-api/src/modules/store/csf/portable-stories.test.ts
+++ b/code/lib/preview-api/src/modules/store/csf/portable-stories.test.ts
@@ -30,6 +30,38 @@ describe('composeStory', () => {
     );
   });
 
+  it('should compose with a play function', async () => {
+    const spy = vi.fn();
+    const Story = () => {};
+    Story.args = {
+      primary: true,
+    };
+    Story.play = async (context: any) => {
+      spy(context);
+    };
+
+    const composedStory = composeStory(Story, meta);
+    await composedStory.play({ canvasElement: null });
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: {
+          ...Story.args,
+          ...meta.args,
+        },
+      })
+    );
+  });
+
+  it('should throw when executing the play function but the story does not have one', async () => {
+    const Story = () => {};
+    Story.args = {
+      primary: true,
+    };
+
+    const composedStory = composeStory(Story, meta);
+    expect(composedStory.play({ canvasElement: null })).rejects.toThrow();
+  });
+
   it('should throw an error if Story is undefined', () => {
     expect(() => {
       // @ts-expect-error (invalid input)

--- a/code/lib/preview-api/src/modules/store/csf/portable-stories.ts
+++ b/code/lib/preview-api/src/modules/store/csf/portable-stories.ts
@@ -12,6 +12,7 @@ import type {
   Parameters,
   ComposedStoryFn,
   StrictArgTypes,
+  ComposedStoryPlayContext,
 } from '@storybook/types';
 
 import { HooksContext } from '../../../addons';
@@ -74,24 +75,42 @@ export function composeStory<TRenderer extends Renderer = Renderer, TArgs extend
 
   const defaultGlobals = getValuesFromArgTypes(projectAnnotations.globalTypes);
 
+  const context: StoryContext<TRenderer> = {
+    hooks: new HooksContext(),
+    globals: defaultGlobals,
+    args: { ...story.initialArgs },
+    viewMode: 'story',
+    loaded: {},
+    abortSignal: null as unknown as AbortSignal,
+    canvasElement: null,
+    ...story,
+  };
+
   const composedStory: ComposedStoryFn<TRenderer, Partial<TArgs>> = Object.assign(
     (extraArgs?: Partial<TArgs>) => {
-      const context: Partial<StoryContext> = {
-        ...story,
-        hooks: new HooksContext(),
-        globals: defaultGlobals,
-        args: { ...story.initialArgs, ...extraArgs },
+      const finalContext: StoryContext<TRenderer> = {
+        ...context,
+        args: { ...context.initialArgs, ...extraArgs },
       };
 
-      return story.unboundStoryFn(prepareContext(context as StoryContext<TRenderer>));
+      return story.unboundStoryFn(prepareContext(finalContext));
     },
     {
       storyName,
       args: story.initialArgs as Partial<TArgs>,
-      play: story.playFunction as ComposedStoryPlayFn<TRenderer, Partial<TArgs>>,
       parameters: story.parameters as Parameters,
       argTypes: story.argTypes as StrictArgTypes<TArgs>,
       id: story.id,
+      play: (async (extraContext: ComposedStoryPlayContext<TRenderer, TArgs>) => {
+        if (story.playFunction === undefined) {
+          throw new Error('The story does not have a play function. Make sure to add one.');
+        }
+
+        await story.playFunction({
+          ...context,
+          ...extraContext,
+        });
+      }) as unknown as ComposedStoryPlayFn<TRenderer, Partial<TArgs>>,
     }
   );
 


### PR DESCRIPTION
Closes #25877

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Before, the play function in a portable story would need to receive the entire story context. Now, the context is passed internally, plus the user can still override whatever they need.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

```
import { render, screen } from '@testing-library/react';
import { composeStory } from '@storybook/react';
import { vi, test, expect } from 'vitest';
import Meta, { Primary as PrimaryStory } from './Button.stories';

// Returns a component that already contain all decorators from story level, meta level and global level.
const Primary = composeStory(PrimaryStory, Meta);

test('onclick handler is called', async () => {
  const { container } = render(<Primary />);
  // this should call the play function with a full context, not just canvasElement
  await Primary.play({ canvasElement: container });
});
```

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
