### PR TITLE
Core: Fix boolean `true` args in URL getting ignored

### DIFF
--- a/code/lib/preview-api/src/modules/store/args.test.ts
+++ b/code/lib/preview-api/src/modules/store/args.test.ts
@@ -67,8 +67,9 @@ describe('mapArgsToTypes', () => {
   });
 
   it('maps booleans', () => {
+    expect(mapArgsToTypes({ a: true }, { a: { type: booleanType } })).toStrictEqual({ a: true });
     expect(mapArgsToTypes({ a: 'true' }, { a: { type: booleanType } })).toStrictEqual({ a: true });
-    expect(mapArgsToTypes({ a: 'false' }, { a: { type: booleanType } })).toStrictEqual({
+    expect(mapArgsToTypes({ a: false }, { a: { type: booleanType } })).toStrictEqual({
       a: false,
     });
     expect(mapArgsToTypes({ a: 'yes' }, { a: { type: booleanType } })).toStrictEqual({ a: false });
@@ -127,7 +128,7 @@ describe('mapArgsToTypes', () => {
         {
           key: {
             arr: ['1', '2'],
-            obj: { bool: 'true' },
+            obj: { bool: true },
           },
         },
         {
@@ -157,7 +158,7 @@ describe('mapArgsToTypes', () => {
           key: [
             {
               arr: ['1', '2'],
-              obj: { bool: 'true' },
+              obj: { bool: true },
             },
           ],
         },

--- a/code/lib/preview-api/src/modules/store/args.ts
+++ b/code/lib/preview-api/src/modules/store/args.ts
@@ -19,7 +19,7 @@ const map = (arg: unknown, argType: InputType): any => {
     case 'number':
       return Number(arg);
     case 'boolean':
-      return arg === 'true';
+      return String(arg) === 'true';
     case 'array':
       if (!type.value || !Array.isArray(arg)) return INCOMPATIBLE;
       return arg.reduce((acc, item, index) => {


### PR DESCRIPTION
Closes #25035
Closes #23623 (although it probably doesn't fix https://github.com/storybookjs/storybook/issues/23623#issuecomment-1731010085 which sounds like a separate issue)

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Changed the args mapping to expect actual booleans as input instead of `'true'` and `'false'`. Now it recognises both `'true'` and `true` as `true` and anything else as `false`. meaning that both `myArg:!true` (what Storybook does) and `myArg:true` (a user could manually do this) in the URL will be parsed as true.

Thanks to @dcherman [for the suggestion](https://github.com/storybookjs/storybook/issues/23623#issuecomment-1721478751) which pinpointed the exact issue.

This bug was likely introduced in https://github.com/storybookjs/storybook/pull/21102 that explicitly converts string boolean types to boolean types before sending them throughout the system, and then the mapper just wasn't updated with it.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Open the _secondary button_ story in any sandbox.
2. Set primary to `true` in controls
3. Reload and still see the button being primary and the arg in the URL still being there

Before this fix, the button would revert back to being secondary because the arg would be removed from the URL

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
5. Open Storybook in your browser
6. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
