### PR TITLE
UI: Fix `display=true` warning in console

### DIFF
--- a/code/ui/manager/src/components/preview/Preview.tsx
+++ b/code/ui/manager/src/components/preview/Preview.tsx
@@ -103,7 +103,7 @@ const Preview = React.memo<PreviewProps>(function Preview(props) {
           />
           <S.FrameWrap key="frame">
             {tabContent && <S.IframeWrapper>{tabContent({ active: true })}</S.IframeWrapper>}
-            <S.CanvasWrap display={!tabId}>
+            <S.CanvasWrap show={!tabId}>
               <Canvas {...{ withLoader, baseUrl }} wrappers={wrappers} />
             </S.CanvasWrap>
           </S.FrameWrap>

--- a/code/ui/manager/src/components/preview/utils/components.ts
+++ b/code/ui/manager/src/components/preview/utils/components.ts
@@ -16,21 +16,20 @@ export const FrameWrap = styled.div({
   background: 'transparent',
   flex: 1,
 });
-export const CanvasWrap = styled.div<{ display: boolean }>(
+export const CanvasWrap = styled.div<{ show: boolean }>(
   {
     alignContent: 'center',
     alignItems: 'center',
     justifyContent: 'center',
     justifyItems: 'center',
     overflow: 'auto',
-    display: 'grid',
     gridTemplateColumns: '100%',
     gridTemplateRows: '100%',
     position: 'relative',
     width: '100%',
     height: '100%',
   },
-  ({ display }) => (display ? {} : { display: 'none' })
+  ({ show }) => ({ display: show ? 'grid' : 'none' })
 );
 
 export const UnstyledLink = styled(Link)({


### PR DESCRIPTION
Closes #25946

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Use a `show` prop instead of `display`, because `display` is a native HTML attribute that Emotion components will apparently pass down to the native `div`, however `display=true` is not valid and thus is shows a warning.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a sandbox
2. add a tab addon in `.storybook/manager.tsx`:

```tsx
import React from 'react';
import { addons } from '@storybook/manager-api';
import { Addon_TypesEnum } from '@storybook/types';

addons.register('test-tab', () => {
  addons.add('test-tab', {
    title: 'Test Tab',
    type: Addon_TypesEnum.TAB,
    render: () => (<div>my tab</div>),
  });
})

```

3. Start Storybook
4. See that switching between Canvas and the tab still works
5. See that the error is gone from the console.


_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
6. Open Storybook in your browser
7. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
