### PR TITLE
Addon-docs: Fix pnpm+Vite failing to build with `@storybook/theming` Rollup error

### DIFF
--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -153,9 +153,9 @@ export const viteFinal = async (config: any, options: Options) => {
            * The following aliases are used to ensure a single instance of these packages are used in situations where they are duplicated
            * The packages will be duplicated by the package manager when the user has react installed with another version than 18.2.0
            */
-          '@storybook/theming': require.resolve('@storybook/theming'),
-          '@storybook/components': require.resolve('@storybook/components'),
-          '@storybook/blocks': require.resolve('@storybook/blocks'),
+          '@storybook/theming': dirname(require.resolve('@storybook/theming')),
+          '@storybook/components': dirname(require.resolve('@storybook/components')),
+          '@storybook/blocks': dirname(require.resolve('@storybook/blocks')),
         },
       },
     }),

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -149,8 +149,14 @@ export const viteFinal = async (config: any, options: Options) => {
           react,
           'react-dom': reactDom,
           '@mdx-js/react': mdx,
+          /**
+           * The following aliases are used to ensure a single instance of these packages are used in situations where they are duplicated
+           * The packages will be duplicated by the package manager when the user has react installed with another version than 18.2.0
+           */
+          '@storybook/theming': require.resolve('@storybook/theming'),
+          '@storybook/components': require.resolve('@storybook/components'),
+          '@storybook/blocks': require.resolve('@storybook/blocks'),
         },
-        dedupe: ['@storybook/theming', '@storybook/components', '@storybook/blocks'],
       },
     }),
   };


### PR DESCRIPTION
Closes #25964 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Deduplicated the three Storybook packages using aliasing instead of the `dedupe` configuration. I'm guessing there's something internal to Vite's `dedupe` feature that doesn't play well with our dependency setup and pnpm.

The original deduplication was done to remove the warning about `@emotion/react` getting loaded multiple times. That happened when users would have a React version other than 18.2.0 installed, because that would cause package managers to unhoist the dependencies in `@storybook/addon-docs`, creating multiple copies of the same dependencies. Package managers still do that, but with aliasing we ensure that the same exact dependency is always loaded.

I found that the unhoisting issue was only a problem in Yarn and never a problem in npm nor pnpm, for some reason.
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Given that this bug relies heavily on package manager's resolution, this should not be tested in monorepo sandboxes.

1. Create a Vite-based sandbox with this branch's canary version
2. remove resolutions from `package.json`
3. Install dependencies
5. Start Storybook
6. Open the console in the browser
7. Navigate to the "Configure" doc
8. Don't see any warnings about `@emotion/react` in the console
9. Build the Storybook successfully
10. Repeat with npm, pnpm, Yarn v4 and Yarn PnP

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
11. Open Storybook in your browser
12. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26024-sha-c64041e4`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26024-sha-c64041e4 sandbox` or in an existing project with `npx storybook@0.0.0-pr-26024-sha-c64041e4 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26024-sha-c64041e4`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26024-sha-c64041e4) |
| **Triggered by** | @JReinhold |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`jeppe/25964`](https://github.com/storybookjs/storybook/tree/jeppe/25964) |
| **Commit** | [`c64041e4`](https://github.com/storybookjs/storybook/commit/c64041e4b66462715eb4c8ca22c4cb1afd0ef956) |
| **Datetime** | Tue Feb 13 22:50:34 UTC 2024 (`1707864634`) |
| **Workflow run** | [7893771706](https://github.com/storybookjs/storybook/actions/runs/7893771706) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26024`_
</details>
<!-- CANARY_RELEASE_SECTION -->
