### PR TITLE
Core: Replace `ip` package with `internal-ip` to address security concerns

### DIFF
--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -83,7 +83,7 @@
     "express": "^4.17.3",
     "fs-extra": "^11.1.0",
     "globby": "^11.0.2",
-    "ip": "^2.0.0",
+    "internal-ip": "^8.0.0",
     "lodash": "^4.17.21",
     "open": "^8.4.0",
     "pretty-hrtime": "^1.0.3",
@@ -101,7 +101,6 @@
   "devDependencies": {
     "@storybook/addon-docs": "workspace:*",
     "@types/compression": "^1.7.0",
-    "@types/ip": "^1.1.0",
     "@types/node-fetch": "^2.5.7",
     "@types/ws": "^8",
     "boxen": "^7.1.1",

--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -61,7 +61,7 @@ export async function storybookDevServer(options: Options) {
   const { port, host, initialPath } = options;
   invariant(port, 'expected options to have a port');
   const proto = options.https ? 'https' : 'http';
-  const { address, networkAddress } = await getServerAddresses(port, host, proto, initialPath);
+  const { address, networkAddress } = await getServerAddresses(port, host, proto, initialPath).catch();
 
   const listening = new Promise<void>((resolve, reject) => {
     // @ts-expect-error (Following line doesn't match TypeScript signature at all 🤔)

--- a/code/lib/core-server/src/dev-server.ts
+++ b/code/lib/core-server/src/dev-server.ts
@@ -61,7 +61,7 @@ export async function storybookDevServer(options: Options) {
   const { port, host, initialPath } = options;
   invariant(port, 'expected options to have a port');
   const proto = options.https ? 'https' : 'http';
-  const { address, networkAddress } = getServerAddresses(port, host, proto, initialPath);
+  const { address, networkAddress } = await getServerAddresses(port, host, proto, initialPath);
 
   const listening = new Promise<void>((resolve, reject) => {
     // @ts-expect-error (Following line doesn't match TypeScript signature at all 🤔)

--- a/code/lib/core-server/src/utils/__tests__/server-address.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/server-address.test.ts
@@ -1,13 +1,13 @@
 import { describe, beforeEach, it, expect, vi } from 'vitest';
-import ip from 'ip';
+import internalIp from 'internal-ip';
 import { getServerAddresses } from '../server-address';
 
-vi.mock('ip');
-const mockedIp = vi.mocked(ip);
+vi.mock('internal-ip');
+const mockedInternalIp = vi.mocked(internalIp);
 
 describe('getServerAddresses', () => {
   beforeEach(() => {
-    mockedIp.address.mockReturnValue('192.168.0.5');
+    mockedInternalIp.internalIpV4Sync.mockReturnValue('192.168.0.5');
   });
 
   it('builds addresses with a specified host', () => {

--- a/code/lib/core-server/src/utils/__tests__/server-address.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/server-address.test.ts
@@ -1,12 +1,13 @@
 import { describe, beforeEach, it, expect, vi } from 'vitest';
-import internalIp from 'internal-ip';
 import { getServerAddresses } from '../server-address';
 
 vi.mock('internal-ip');
-const mockedInternalIp = vi.mocked(internalIp);
+let mockedInternalIp;
 
 describe('getServerAddresses', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    const importIp = await import('internal-ip');
+    mockedInternalIp = vi.mocked(importIp);
     mockedInternalIp.internalIpV4Sync.mockReturnValue('192.168.0.5');
   });
 

--- a/code/lib/core-server/src/utils/__tests__/server-address.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/server-address.test.ts
@@ -1,24 +1,26 @@
 import { describe, beforeEach, it, expect, vi } from 'vitest';
 import { getServerAddresses } from '../server-address';
+import internalIP from 'internal-ip';
 
-vi.mock('internal-ip');
-let mockedInternalIp;
+vi.mock('internal-ip', () => ({
+  default: {
+    internalIpV4Sync: vi.fn(),
+  },
+}));
 
 describe('getServerAddresses', () => {
   beforeEach(async () => {
-    const importIp = await import('internal-ip');
-    mockedInternalIp = vi.mocked(importIp);
-    mockedInternalIp.internalIpV4Sync.mockReturnValue('192.168.0.5');
+    vi.mocked(internalIP).internalIpV4Sync.mockReturnValue('192.168.0.5');
   });
 
-  it('builds addresses with a specified host', () => {
-    const { address, networkAddress } = getServerAddresses(9009, '192.168.89.89', 'http');
+  it('builds addresses with a specified host', async () => {
+    const { address, networkAddress } = await getServerAddresses(9009, '192.168.89.89', 'http');
     expect(address).toEqual('http://localhost:9009/');
     expect(networkAddress).toEqual('http://192.168.89.89:9009/');
   });
 
-  it('builds addresses with local IP when host is not specified', () => {
-    const { address, networkAddress } = getServerAddresses(9009, '', 'http');
+  it('builds addresses with local IP when host is not specified', async () => {
+    const { address, networkAddress } = await getServerAddresses(9009, '', 'http');
     expect(address).toEqual('http://localhost:9009/');
     expect(networkAddress).toEqual('http://192.168.0.5:9009/');
   });

--- a/code/lib/core-server/src/utils/__tests__/server-address.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/server-address.test.ts
@@ -11,14 +11,14 @@ describe('getServerAddresses', () => {
     mockedInternalIp.internalIpV4Sync.mockReturnValue('192.168.0.5');
   });
 
-  it('builds addresses with a specified host', () => {
-    const { address, networkAddress } = getServerAddresses(9009, '192.168.89.89', 'http');
+  it('builds addresses with a specified host', async () => {
+    const { address, networkAddress } = await getServerAddresses(9009, '192.168.89.89', 'http');
     expect(address).toEqual('http://localhost:9009/');
     expect(networkAddress).toEqual('http://192.168.89.89:9009/');
   });
 
-  it('builds addresses with local IP when host is not specified', () => {
-    const { address, networkAddress } = getServerAddresses(9009, '', 'http');
+  it('builds addresses with local IP when host is not specified', async () => {
+    const { address, networkAddress } = await getServerAddresses(9009, '', 'http');
     expect(address).toEqual('http://localhost:9009/');
     expect(networkAddress).toEqual('http://192.168.0.5:9009/');
   });

--- a/code/lib/core-server/src/utils/__tests__/server-address.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/server-address.test.ts
@@ -1,16 +1,13 @@
 import { describe, beforeEach, it, expect, vi } from 'vitest';
 import { getServerAddresses } from '../server-address';
-import internalIP from 'internal-ip';
 
 vi.mock('internal-ip', () => ({
-  default: {
-    internalIpV4Sync: vi.fn(),
-  },
+  internalIpV4Sync: vi.fn(),
 }));
 
 describe('getServerAddresses', () => {
   beforeEach(async () => {
-    vi.mocked(internalIP).internalIpV4Sync.mockReturnValue('192.168.0.5');
+    vi.mocked(await import('internal-ip')).internalIpV4Sync.mockReturnValue('192.168.0.5');
   });
 
   it('builds addresses with a specified host', async () => {

--- a/code/lib/core-server/src/utils/server-address.test.ts
+++ b/code/lib/core-server/src/utils/server-address.test.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getServerAddresses, getServerPort, getServerChannelUrl } from './server-address';
 import detectPort from 'detect-port';
-import internalIP from 'internal-ip';
 
 vi.mock('internal-ip', () => ({
-  default: {
-    internalIpV4Sync: vi.fn(),
-  },
+  internalIpV4Sync: vi.fn(),
 }));
 vi.mock('detect-port');
 vi.mock('@storybook/node-logger');
@@ -57,7 +54,7 @@ describe('getServerAddresses', () => {
     const expectedAddress = `${proto}://localhost:${port}/?path=/foo/bar`;
     const expectedNetworkAddress = `${proto}://${mockedNetworkIP}:${port}/?path=/foo/bar`;
 
-    vi.mocked(internalIP).internalIpV4Sync.mockReturnValue('192.168.0.5');
+    vi.mocked(await import('internal-ip')).internalIpV4Sync.mockReturnValue('192.168.0.5');
 
     const result = await getServerAddresses(port, undefined, proto, initialPath);
 

--- a/code/lib/core-server/src/utils/server-address.test.ts
+++ b/code/lib/core-server/src/utils/server-address.test.ts
@@ -11,35 +11,35 @@ describe('getServerAddresses', () => {
   const host = 'localhost';
   const proto = 'http';
 
-  it('should return server addresses without initial path by default', () => {
+  it('should return server addresses without initial path by default', async () => {
     const expectedAddress = `${proto}://localhost:${port}/`;
     const expectedNetworkAddress = `${proto}://${host}:${port}/`;
 
-    const result = getServerAddresses(port, host, proto);
+    const result = await getServerAddresses(port, host, proto);
 
     expect(result.address).toBe(expectedAddress);
     expect(result.networkAddress).toBe(expectedNetworkAddress);
   });
 
-  it('should return server addresses with initial path', () => {
+  it('should return server addresses with initial path', async () => {
     const initialPath = '/foo/bar';
 
     const expectedAddress = `${proto}://localhost:${port}/?path=/foo/bar`;
     const expectedNetworkAddress = `${proto}://${host}:${port}/?path=/foo/bar`;
 
-    const result = getServerAddresses(port, host, proto, initialPath);
+    const result = await getServerAddresses(port, host, proto, initialPath);
 
     expect(result.address).toBe(expectedAddress);
     expect(result.networkAddress).toBe(expectedNetworkAddress);
   });
 
-  it('should return server addresses with initial path and add slash if missing', () => {
+  it('should return server addresses with initial path and add slash if missing', async () => {
     const initialPath = 'foo/bar';
 
     const expectedAddress = `${proto}://localhost:${port}/?path=/foo/bar`;
     const expectedNetworkAddress = `${proto}://${host}:${port}/?path=/foo/bar`;
 
-    const result = getServerAddresses(port, host, proto, initialPath);
+    const result = await getServerAddresses(port, host, proto, initialPath);
 
     expect(result.address).toBe(expectedAddress);
     expect(result.networkAddress).toBe(expectedNetworkAddress);

--- a/code/lib/core-server/src/utils/server-address.test.ts
+++ b/code/lib/core-server/src/utils/server-address.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import detectPort from 'detect-port';
 import { getServerAddresses, getServerPort, getServerChannelUrl } from './server-address';
 
-vi.mock('ip');
+vi.mock('internal-ip');
 vi.mock('detect-port');
 vi.mock('@storybook/node-logger');
 

--- a/code/lib/core-server/src/utils/server-address.ts
+++ b/code/lib/core-server/src/utils/server-address.ts
@@ -1,16 +1,20 @@
-import { internalIpV4Sync } from 'internal-ip';
+const logger = require('@storybook/node-logger');
+const detectFreePort = require('detect-port');
 
-import { logger } from '@storybook/node-logger';
-import detectFreePort from 'detect-port';
-
-export function getServerAddresses(
+export async function getServerAddresses(
   port: number,
   host: string | undefined,
   proto: string,
   initialPath?: string
 ) {
   const address = new URL(`${proto}://localhost:${port}/`);
-  const networkAddress = new URL(`${proto}://${host || internalIpV4Sync()}:${port}/`);
+
+  // importing purely ESM 'internal-ip' package asynchronously to support CommonJS outputs
+  const internalIp = await import('internal-ip');
+
+  const networkAddress = new URL(
+    `${proto}://${host || internalIp.internalIpV4Sync()}:${port}/`
+  );
 
   if (initialPath) {
     const searchParams = `?path=${decodeURIComponent(

--- a/code/lib/core-server/src/utils/server-address.ts
+++ b/code/lib/core-server/src/utils/server-address.ts
@@ -1,4 +1,4 @@
-import ip from 'ip';
+import { internalIpV4Sync } from 'internal-ip';
 
 import { logger } from '@storybook/node-logger';
 import detectFreePort from 'detect-port';
@@ -10,7 +10,7 @@ export function getServerAddresses(
   initialPath?: string
 ) {
   const address = new URL(`${proto}://localhost:${port}/`);
-  const networkAddress = new URL(`${proto}://${host || ip.address()}:${port}/`);
+  const networkAddress = new URL(`${proto}://${host || internalIpV4Sync()}:${port}/`);
 
   if (initialPath) {
     const searchParams = `?path=${decodeURIComponent(

--- a/code/lib/core-server/src/utils/server-address.ts
+++ b/code/lib/core-server/src/utils/server-address.ts
@@ -1,5 +1,5 @@
-const logger = require('@storybook/node-logger');
-const detectFreePort = require('detect-port');
+import { logger } from '@storybook/node-logger';
+import detectFreePort from 'detect-port';
 
 export async function getServerAddresses(
   port: number,
@@ -9,11 +9,9 @@ export async function getServerAddresses(
 ) {
   const address = new URL(`${proto}://localhost:${port}/`);
 
-  // importing purely ESM 'internal-ip' package asynchronously to support CommonJS outputs
-  const internalIp = await import('internal-ip');
-
   const networkAddress = new URL(
-    `${proto}://${host || internalIp.internalIpV4Sync()}:${port}/`
+    // importing purely ESM 'internal-ip' package asynchronously to support CommonJS outputs
+    `${proto}://${host || (await import('internal-ip')).default.internalIpV4Sync()}:${port}/`
   );
 
   if (initialPath) {

--- a/code/lib/core-server/src/utils/server-address.ts
+++ b/code/lib/core-server/src/utils/server-address.ts
@@ -11,7 +11,7 @@ export async function getServerAddresses(
 
   const networkAddress = new URL(
     // importing purely ESM 'internal-ip' package asynchronously to support CommonJS outputs
-    `${proto}://${host || (await import('internal-ip')).default.internalIpV4Sync()}:${port}/`
+    `${proto}://${host || (await import('internal-ip')).internalIpV4Sync()}:${port}/`
   );
 
   if (initialPath) {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5556,7 +5556,6 @@ __metadata:
     "@storybook/types": "workspace:*"
     "@types/compression": "npm:^1.7.0"
     "@types/detect-port": "npm:^1.3.0"
-    "@types/ip": "npm:^1.1.0"
     "@types/node": "npm:^18.0.0"
     "@types/node-fetch": "npm:^2.5.7"
     "@types/pretty-hrtime": "npm:^1.0.0"
@@ -5571,7 +5570,7 @@ __metadata:
     express: "npm:^4.17.3"
     fs-extra: "npm:^11.1.0"
     globby: "npm:^11.0.2"
-    ip: "npm:^2.0.0"
+    internal-ip: "npm:^8.0.0"
     lodash: "npm:^4.17.21"
     node-fetch: "npm:^3.3.1"
     open: "npm:^8.4.0"
@@ -7488,15 +7487,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 06719371ece6bdf9fd28b90b03bd56e48ffca675dfaadca81ae12ca18db6e77e70a509537ebfa3b2c37810d77dc52e5a3190c09bc490668dde7e384c7b579090
-  languageName: node
-  linkType: hard
-
-"@types/ip@npm:^1.1.0":
-  version: 1.1.3
-  resolution: "@types/ip@npm:1.1.3"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: af576e33830196be01b71c48ad5f83380a1c51d62f394a5601e8c2a5b8b31cf6dc8fe71ac39c38d806bcf1d6f1c5c8205c129eca6b6d168c0df7ab3722df23b9
   languageName: node
   linkType: hard
 
@@ -11354,6 +11344,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cidr-regex@npm:4.0.3":
+  version: 4.0.3
+  resolution: "cidr-regex@npm:4.0.3"
+  dependencies:
+    ip-regex: "npm:^5.0.0"
+  checksum: df12a5aecbae4fbafc38ca679d7654de97f0dc9ee0759ae1da3c001fadf063cf735ef7bec49e1421319e1adcc142a6603671ee562898cf16ff4ae8e29eddeec2
+  languageName: node
+  linkType: hard
+
+"cidr-tools@npm:^6.4.1":
+  version: 6.4.2
+  resolution: "cidr-tools@npm:6.4.2"
+  dependencies:
+    cidr-regex: "npm:4.0.3"
+    ip-bigint: "npm:7.3.0"
+    ip-regex: "npm:5.0.0"
+    string-natural-compare: "npm:3.0.1"
+  checksum: 0b856af13162f4a92b306897369b987cacc1e98c7fd7c26c64202312945eb283c6728063b7dfa727547cd566052c7fe375581bad8142d251f699e45367df8bb3
+  languageName: node
+  linkType: hard
+
 "cipher-base@npm:^1.0.0, cipher-base@npm:^1.0.1, cipher-base@npm:^1.0.3":
   version: 1.0.4
   resolution: "cipher-base@npm:1.0.4"
@@ -11534,6 +11545,15 @@ __metadata:
     kind-of: "npm:^6.0.2"
     shallow-clone: "npm:^3.0.0"
   checksum: 637753615aa24adf0f2d505947a1bb75e63964309034a1cf56ba4b1f30af155201edd38d26ffe26911adaae267a3c138b344a4947d39f5fc1b6d6108125aa758
+  languageName: node
+  linkType: hard
+
+"clone-regexp@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "clone-regexp@npm:3.0.0"
+  dependencies:
+    is-regexp: "npm:^3.0.0"
+  checksum: 892b6103ae9319d0283f9bb125e07cba7c043cbcc516ecc135be817769257c659eae42749d450ed3041af63fb79505e4c5b90105cf9c97cadbff712e2f72726b
   languageName: node
   linkType: hard
 
@@ -11944,6 +11964,13 @@ __metadata:
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: b76ebed15c000aee4678c3707e0860cb6abd4e680a598c0a26e17f0bfae723ec9cc2802f0ff1bc6e4d80603719010431d2231018373d4dde10f9ccff9dadf5af
+  languageName: node
+  linkType: hard
+
+"convert-hrtime@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "convert-hrtime@npm:5.0.0"
+  checksum: 2092e51aab205e1141440e84e2a89f8881e68e47c1f8bc168dfd7c67047d8f1db43bac28044bc05749205651fead4e7910f52c7bb6066213480df99e333e9f47
   languageName: node
   linkType: hard
 
@@ -12630,6 +12657,15 @@ __metadata:
   dependencies:
     execa: "npm:^5.0.0"
   checksum: 5184f9e6e105d24fb44ade9e8741efa54bb75e84625c1ea78c4ef8b81dff09ca52d6dbdd1185cf0dc655bb6b282a64fffaf7ed2dd561b8d9ad6f322b1f039aba
+  languageName: node
+  linkType: hard
+
+"default-gateway@npm:^7.2.2":
+  version: 7.2.2
+  resolution: "default-gateway@npm:7.2.2"
+  dependencies:
+    execa: "npm:^7.1.1"
+  checksum: 71338e8bd3eea4a2b5fd9371f3a4d7afe4218849da8035fa0d6a65df07ef3a8e7a81bb245983d85cf842872d79f4675d7382edc342507374b3732d151a9b5fc4
   languageName: node
   linkType: hard
 
@@ -14577,7 +14613,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:7.2.0":
+"execa@npm:7.2.0, execa@npm:^7.1.1":
   version: 7.2.0
   resolution: "execa@npm:7.2.0"
   dependencies:
@@ -15651,6 +15687,13 @@ __metadata:
   version: 1.1.2
   resolution: "function-bind@npm:1.1.2"
   checksum: d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
+  languageName: node
+  linkType: hard
+
+"function-timeout@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "function-timeout@npm:0.1.1"
+  checksum: 45f0517907e541b7ea8238500429ac9ace50e596295c01931cbe61e176150aa2ad50d05dcfeeee9377ae48eb99a6fd0759e4ebc97cde8f4c38492d1c99db8f14
   languageName: node
   linkType: hard
 
@@ -17243,6 +17286,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"internal-ip@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "internal-ip@npm:8.0.0"
+  dependencies:
+    cidr-tools: "npm:^6.4.1"
+    default-gateway: "npm:^7.2.2"
+    is-ip: "npm:^5.0.0"
+    p-event: "npm:^5.0.1"
+  checksum: 68812fa59e92df7236c104c4bba1cbcea62e35e025ff8bf7799c22095c5bd1d05f7996d40bc82e723643ce007e40d03299584242cdd494ecf8bb8148a9b9728d
+  languageName: node
+  linkType: hard
+
 "internal-slot@npm:^1.0.4, internal-slot@npm:^1.0.5":
   version: 1.0.5
   resolution: "internal-slot@npm:1.0.5"
@@ -17260,6 +17315,20 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.0.0"
   checksum: 5af133a917c0bcf65e84e7f23e779e7abc1cd49cb7fdc62d00d1de74b0d8c1b5ee74ac7766099fb3be1b05b26dfc67bab76a17030d2fe7ea2eef867434362dfc
+  languageName: node
+  linkType: hard
+
+"ip-bigint@npm:7.3.0":
+  version: 7.3.0
+  resolution: "ip-bigint@npm:7.3.0"
+  checksum: f9f77176ef3b2a506d3167287ebcd3eaf5db1ba3dac9c3758c04eade30855918f93e850e79036d14d0521c414af0e186f764d7f0c0d194c41ebc89b780d8fff2
+  languageName: node
+  linkType: hard
+
+"ip-regex@npm:5.0.0, ip-regex@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "ip-regex@npm:5.0.0"
+  checksum: 23f07cf393436627b3a91f7121eee5bc831522d07c95ddd13f5a6f7757698b08551480f12e5dbb3bf248724da135d54405c9687733dba7314f74efae593bdf06
   languageName: node
   linkType: hard
 
@@ -17640,6 +17709,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-ip@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "is-ip@npm:5.0.1"
+  dependencies:
+    ip-regex: "npm:^5.0.0"
+    super-regex: "npm:^0.2.0"
+  checksum: ec7d833acaca68b5a11b7ee1d605ff26e6864f83cae6c1413aaf5be19975c4c8a9d0c2d4b339f3b9dd94f26851fc80c6942e4b02c2b42f5e42b40ecd900b7a5c
+  languageName: node
+  linkType: hard
+
 "is-lambda@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
@@ -17786,6 +17865,13 @@ __metadata:
     call-bind: "npm:^1.0.2"
     has-tostringtag: "npm:^1.0.0"
   checksum: bb72aae604a69eafd4a82a93002058c416ace8cde95873589a97fc5dac96a6c6c78a9977d487b7b95426a8f5073969124dd228f043f9f604f041f32fcc465fc1
+  languageName: node
+  linkType: hard
+
+"is-regexp@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "is-regexp@npm:3.1.0"
+  checksum: 99dbaea41bddee2205db468c0946f5fee25cc4ae486333cb4d2b8095ab4b0a500e74ba61afd9e6e4f63ececcd55b4df5ae2a555b1c3e26308e516ff53c9533cd
   languageName: node
   linkType: hard
 
@@ -22225,6 +22311,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-event@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "p-event@npm:5.0.1"
+  dependencies:
+    p-timeout: "npm:^5.0.2"
+  checksum: 2317171489537f316661fa863f3bb711b2ceb89182937238422cec10223cbb958c432d6c26a238446a622d788187bdd295b1d8ecedbe2e467e045930d60202b0
+  languageName: node
+  linkType: hard
+
 "p-finally@npm:^1.0.0":
   version: 1.0.0
   resolution: "p-finally@npm:1.0.0"
@@ -22354,6 +22449,13 @@ __metadata:
   dependencies:
     p-finally: "npm:^1.0.0"
   checksum: 524b393711a6ba8e1d48137c5924749f29c93d70b671e6db761afa784726572ca06149c715632da8f70c090073afb2af1c05730303f915604fd38ee207b70a61
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^5.0.2":
+  version: 5.1.0
+  resolution: "p-timeout@npm:5.1.0"
+  checksum: 1b026cf9d5878c64bec4341ca9cda8ec6b8b3aea8a57885ca0fe2b35753a20d767fb6f9d3aa41e1252f42bc95432c05ea33b6b18f271fb10bfb0789591850a41
   languageName: node
   linkType: hard
 
@@ -26633,6 +26735,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-natural-compare@npm:3.0.1":
+  version: 3.0.1
+  resolution: "string-natural-compare@npm:3.0.1"
+  checksum: 85a6a9195736be500af5d817c7ea36b7e1ac278af079a807f70f79a56602359ee6743ca409af6291b94557de550ff60d1ec31b3c4fc8e7a08d0e12cdab57c149
+  languageName: node
+  linkType: hard
+
 "string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -26925,6 +27034,17 @@ __metadata:
   version: 4.2.0
   resolution: "stylis@npm:4.2.0"
   checksum: a7128ad5a8ed72652c6eba46bed4f416521bc9745a460ef5741edc725252cebf36ee45e33a8615a7057403c93df0866ab9ee955960792db210bb80abd5ac6543
+  languageName: node
+  linkType: hard
+
+"super-regex@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "super-regex@npm:0.2.0"
+  dependencies:
+    clone-regexp: "npm:^3.0.0"
+    function-timeout: "npm:^0.1.0"
+    time-span: "npm:^5.1.0"
+  checksum: a8ff56aa521530df098433692c0a4c92353dd2fa3f7187785d654268031cc2876c8acc91e90bbd7b6b1ebabd68fb306f4fa61fc46f9fe0db04ed5f960fc2afc8
   languageName: node
   linkType: hard
 
@@ -27403,6 +27523,15 @@ __metadata:
   version: 1.1.0
   resolution: "thunky@npm:1.1.0"
   checksum: 369764f39de1ce1de2ba2fa922db4a3f92e9c7f33bcc9a713241bc1f4a5238b484c17e0d36d1d533c625efb00e9e82c3e45f80b47586945557b45abb890156d2
+  languageName: node
+  linkType: hard
+
+"time-span@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "time-span@npm:5.1.0"
+  dependencies:
+    convert-hrtime: "npm:^5.0.0"
+  checksum: 37b8284c53f4ee320377512ac19e3a034f2b025f5abd6959b8c1d0f69e0f06ab03681df209f2e452d30129e7b1f25bf573fb0f29d57e71f9b4a6b5b99f4c4b9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #26014

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The `ip` package has been switched out for `internal-ip` (with identical functionality coverage) because of the high-level security vulnerability in the former. The change is done at the consuming utility function and the corresponding test cases.

My research shown that the [`internal-ip` package](https://www.npmjs.com/package/internal-ip) by @sindresorhus provides sufficiently identical (to `ip.address()`) functionality via the `internalIpV4Sync()` function. So the suggestion is to go with this package further on instead of the poorly maintained (and vulnerable, see the linked issue details) `ip` package.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26025-sha-9ddb0c81`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26025-sha-9ddb0c81 sandbox` or in an existing project with `npx storybook@0.0.0-pr-26025-sha-9ddb0c81 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26025-sha-9ddb0c81`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26025-sha-9ddb0c81) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [fyodorio/storybook](https://github.com/fyodorio/storybook) |
| **Branch** | [`fyodorio/26014-fix-ip-vulnerability`](https://github.com/fyodorio/storybook/tree/fyodorio/26014-fix-ip-vulnerability) |
| **Commit** | [`9ddb0c81`](https://github.com/fyodorio/storybook/commit/9ddb0c816e343ea34ddcf3a03e9501b6c45f4d48) |
| **Datetime** | Thu Feb 15 12:53:49 UTC 2024 (`1708001629`) |
| **Workflow run** | [7916213544](https://github.com/storybookjs/storybook/actions/runs/7916213544) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26025`_
</details>
<!-- CANARY_RELEASE_SECTION -->
