### PR TITLE
Addon-actions: Add spy to action for explicit actions

### DIFF
--- a/code/addons/actions/src/runtime/action.ts
+++ b/code/addons/actions/src/runtime/action.ts
@@ -103,6 +103,7 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
     channel.emit(EVENT_ID, actionDisplayToEmit);
   };
   handler.isAction = true;
+  handler.implicit = options.implicit;
 
   return handler;
 }

--- a/code/addons/interactions/src/preview.ts
+++ b/code/addons/interactions/src/preview.ts
@@ -2,7 +2,6 @@ import type { ArgsEnhancer, Renderer } from '@storybook/types';
 import { fn, isMockFunction } from '@storybook/test';
 
 const traverseArgs = (value: unknown, depth = 0, key?: string): any => {
-  console.log(1);
   // Make sure to not get in infinite loops with self referencing args
   if (depth > 5) return value;
   if (value == null) return value;

--- a/code/addons/interactions/src/preview.ts
+++ b/code/addons/interactions/src/preview.ts
@@ -24,13 +24,15 @@ const traverseArgs = (value: unknown, depth = 0, key?: string): any => {
   }
 
   if (Array.isArray(value)) {
-    return value.map((item) => traverseArgs(item, depth++));
+    depth++;
+    return value.map((item) => traverseArgs(item, depth));
   }
 
   if (typeof value === 'object' && value.constructor === Object) {
+    depth++;
     // We have to mutate the original object for this to survive HMR.
     for (const [k, v] of Object.entries(value)) {
-      (value as Record<string, unknown>)[k] = traverseArgs(v, depth++, k);
+      (value as Record<string, unknown>)[k] = traverseArgs(v, depth, k);
     }
     return value;
   }

--- a/code/addons/interactions/src/preview.ts
+++ b/code/addons/interactions/src/preview.ts
@@ -1,22 +1,41 @@
 /* eslint-disable no-underscore-dangle */
-import type {
-  Args,
-  LoaderFunction,
-  PlayFunction,
-  PlayFunctionContext,
-  StepLabel,
-} from '@storybook/types';
+import type { Args, ArgsEnhancer, Renderer } from '@storybook/types';
 import { instrument } from '@storybook/instrumenter';
+import { fn } from '@storybook/test';
 
-export const { step: runStep } = instrument(
-  {
-    step: (label: StepLabel, play: PlayFunction, context: PlayFunctionContext<any>) =>
-      play(context),
-  },
-  { intercept: true }
-);
+const addSpies = (value: unknown, depth = 0): any => {
+  // Make sure to not get in infinite loops with self referencing args
+  if (depth > 5) return value;
 
-const instrumentSpies: LoaderFunction = ({ initialArgs }) => {
+  if (value == null) return value;
+  if (
+    typeof value === 'function' &&
+    'isAction' in value &&
+    value.isAction &&
+    !('implicit' in value && value.implicit) &&
+    !('_isMockFunction' in value && value._isMockFunction)
+  ) {
+    return fn(value as any);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => addSpies(item, depth++));
+  }
+
+  if (typeof value === 'object') {
+    // We have to mutate the original object for this to survive HMR.
+
+    for (const [k, v] of Object.entries(value)) {
+      (value as Record<string, unknown>)[k] = addSpies(v, depth++);
+    }
+    return value;
+  }
+  return value;
+};
+
+const wrapActionsInSpyFns: ArgsEnhancer<Renderer> = ({ initialArgs }) => addSpies(initialArgs);
+
+const instrumentSpies: ArgsEnhancer = ({ initialArgs }) => {
   const argTypesWithAction = Object.entries(initialArgs).filter(
     ([, value]) =>
       typeof value === 'function' &&
@@ -29,13 +48,12 @@ const instrumentSpies: LoaderFunction = ({ initialArgs }) => {
     const instrumented = instrument({ [key]: () => value }, { retain: true })[key];
     acc[key] = instrumented();
     // this enhancer is being called multiple times
-
     value._instrumented = true;
     return acc;
   }, {} as Args);
 };
 
-export const argsEnhancers = [instrumentSpies];
+export const argsEnhancers = [wrapActionsInSpyFns, instrumentSpies];
 
 export const parameters = {
   throwPlayFunctionExceptions: false,

--- a/code/addons/interactions/src/preview.ts
+++ b/code/addons/interactions/src/preview.ts
@@ -1,5 +1,20 @@
-import type { ArgsEnhancer, Renderer } from '@storybook/types';
+import type {
+  ArgsEnhancer,
+  PlayFunction,
+  PlayFunctionContext,
+  Renderer,
+  StepLabel,
+} from '@storybook/types';
 import { fn, isMockFunction } from '@storybook/test';
+import { instrument } from '@storybook/instrumenter';
+
+export const { step: runStep } = instrument(
+  {
+    step: (label: StepLabel, play: PlayFunction, context: PlayFunctionContext<any>) =>
+      play(context),
+  },
+  { intercept: true }
+);
 
 const traverseArgs = (value: unknown, depth = 0, key?: string): any => {
   // Make sure to not get in infinite loops with self referencing args

--- a/code/addons/interactions/src/preview.ts
+++ b/code/addons/interactions/src/preview.ts
@@ -2,6 +2,7 @@ import type { ArgsEnhancer, Renderer } from '@storybook/types';
 import { fn, isMockFunction } from '@storybook/test';
 
 const traverseArgs = (value: unknown, depth = 0, key?: string): any => {
+  console.log(1);
   // Make sure to not get in infinite loops with self referencing args
   if (depth > 5) return value;
   if (value == null) return value;
@@ -30,7 +31,7 @@ const traverseArgs = (value: unknown, depth = 0, key?: string): any => {
   if (typeof value === 'object' && value.constructor === Object) {
     // We have to mutate the original object for this to survive HMR.
     for (const [k, v] of Object.entries(value)) {
-      (value as Record<string, unknown>)[k] = traverseArgs(v, depth++, key);
+      (value as Record<string, unknown>)[k] = traverseArgs(v, depth++, k);
     }
     return value;
   }

--- a/code/addons/interactions/src/preview.ts
+++ b/code/addons/interactions/src/preview.ts
@@ -1,59 +1,45 @@
-/* eslint-disable no-underscore-dangle */
-import type { Args, ArgsEnhancer, Renderer } from '@storybook/types';
-import { instrument } from '@storybook/instrumenter';
-import { fn } from '@storybook/test';
+import type { ArgsEnhancer, Renderer } from '@storybook/types';
+import { fn, isMockFunction } from '@storybook/test';
 
-const addSpies = (value: unknown, depth = 0): any => {
+const traverseArgs = (value: unknown, depth = 0, key?: string): any => {
   // Make sure to not get in infinite loops with self referencing args
   if (depth > 5) return value;
-
   if (value == null) return value;
+  if (isMockFunction(value)) {
+    // Makes sure we get the arg name in the interactions panel
+    if (key) value.mockName(key);
+    return value;
+  }
+
+  // wrap explicit actions in a spy
   if (
     typeof value === 'function' &&
     'isAction' in value &&
     value.isAction &&
-    !('implicit' in value && value.implicit) &&
-    !('_isMockFunction' in value && value._isMockFunction)
+    !('implicit' in value && value.implicit)
   ) {
-    return fn(value as any);
+    const mock = fn(value as any);
+    if (key) mock.mockName(key);
+    return mock;
   }
 
   if (Array.isArray(value)) {
-    return value.map((item) => addSpies(item, depth++));
+    return value.map((item) => traverseArgs(item, depth++));
   }
 
   if (typeof value === 'object') {
     // We have to mutate the original object for this to survive HMR.
-
     for (const [k, v] of Object.entries(value)) {
-      (value as Record<string, unknown>)[k] = addSpies(v, depth++);
+      (value as Record<string, unknown>)[k] = traverseArgs(v, depth++, key);
     }
     return value;
   }
   return value;
 };
 
-const wrapActionsInSpyFns: ArgsEnhancer<Renderer> = ({ initialArgs }) => addSpies(initialArgs);
+const wrapActionsInSpyFns: ArgsEnhancer<Renderer> = ({ initialArgs }) => traverseArgs(initialArgs);
 
-const instrumentSpies: ArgsEnhancer = ({ initialArgs }) => {
-  const argTypesWithAction = Object.entries(initialArgs).filter(
-    ([, value]) =>
-      typeof value === 'function' &&
-      '_isMockFunction' in value &&
-      value._isMockFunction &&
-      !value._instrumented
-  );
-
-  return argTypesWithAction.reduce((acc, [key, value]) => {
-    const instrumented = instrument({ [key]: () => value }, { retain: true })[key];
-    acc[key] = instrumented();
-    // this enhancer is being called multiple times
-    value._instrumented = true;
-    return acc;
-  }, {} as Args);
-};
-
-export const argsEnhancers = [wrapActionsInSpyFns, instrumentSpies];
+export const argsEnhancers = [wrapActionsInSpyFns];
 
 export const parameters = {
   throwPlayFunctionExceptions: false,

--- a/code/addons/interactions/src/preview.ts
+++ b/code/addons/interactions/src/preview.ts
@@ -27,7 +27,7 @@ const traverseArgs = (value: unknown, depth = 0, key?: string): any => {
     return value.map((item) => traverseArgs(item, depth++));
   }
 
-  if (typeof value === 'object') {
+  if (typeof value === 'object' && value.constructor === Object) {
     // We have to mutate the original object for this to survive HMR.
     for (const [k, v] of Object.entries(value)) {
       (value as Record<string, unknown>)[k] = traverseArgs(v, depth++, key);

--- a/code/addons/interactions/template/stories/basics.stories.ts
+++ b/code/addons/interactions/template/stories/basics.stories.ts
@@ -8,7 +8,6 @@ import {
   waitForElementToBeRemoved,
   within,
 } from '@storybook/test';
-import { action } from '@storybook/addon-actions';
 
 export default {
   component: globalThis.Components.Form,

--- a/code/addons/interactions/template/stories/basics.stories.ts
+++ b/code/addons/interactions/template/stories/basics.stories.ts
@@ -8,6 +8,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from '@storybook/test';
+import { action } from '@storybook/addon-actions';
 
 export default {
   component: globalThis.Components.Form,

--- a/code/lib/instrumenter/src/instrumenter.ts
+++ b/code/lib/instrumenter/src/instrumenter.ts
@@ -432,7 +432,9 @@ export class Instrumenter {
         return { __element__: { prefix, localName, id, classNames, innerText } };
       }
       if (typeof value === 'function') {
-        return { __function__: { name: value.name } };
+        return {
+          __function__: { name: 'getMockName' in value ? value.getMockName() : value.name },
+        };
       }
       if (typeof value === 'symbol') {
         return { __symbol__: { description: value.description } };


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25810

## What I did

We accidently also removed spies for explicit actions, allthough that was never the plan. This reverts that (and also improves on the old implementation)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26033-sha-fe0448b1`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26033-sha-fe0448b1 sandbox` or in an existing project with `npx storybook@0.0.0-pr-26033-sha-fe0448b1 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26033-sha-fe0448b1`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26033-sha-fe0448b1) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/spy-on-explicit-actions`](https://github.com/storybookjs/storybook/tree/kasper/spy-on-explicit-actions) |
| **Commit** | [`fe0448b1`](https://github.com/storybookjs/storybook/commit/fe0448b15c94d2ab1eeeb13b9bd10bad5983b0e5) |
| **Datetime** | Thu Feb 15 14:02:55 UTC 2024 (`1708005775`) |
| **Workflow run** | [7917111050](https://github.com/storybookjs/storybook/actions/runs/7917111050) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26033`_
</details>
<!-- CANARY_RELEASE_SECTION -->
