### PR TITLE
Core: Fix fail to load `main.ts` error message

### DIFF
--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -6,6 +6,7 @@ import { withTelemetry } from '@storybook/core-server';
 import {
   UpgradeStorybookToLowerVersionError,
   UpgradeStorybookToSameVersionError,
+  UpgradeStorybookUnknownCurrentVersionError,
 } from '@storybook/core-events/server-errors';
 
 import chalk from 'chalk';
@@ -189,26 +190,11 @@ export const doUpgrade = async ({
   );
   const configDir = userSpecifiedConfigDir || inferredConfigDir || '.storybook';
 
-  let mainConfigLoadingError = '';
-
-  const mainConfig = await loadMainConfig({ configDir }).catch((err) => {
-    mainConfigLoadingError = String(err);
-    return false;
-  });
+  const mainConfig = await loadMainConfig({ configDir });
 
   // GUARDS
   if (!storybookVersion) {
-    logger.info(missingStorybookVersionMessage());
-    results = { preCheckFailure: PreCheckFailure.UNDETECTED_SB_VERSION };
-  } else if (
-    typeof mainConfigPath === 'undefined' ||
-    mainConfigLoadingError.includes('No configuration files have been found')
-  ) {
-    logger.info(mainjsNotFoundMessage(configDir));
-    results = { preCheckFailure: PreCheckFailure.MAINJS_NOT_FOUND };
-  } else if (typeof mainConfig === 'boolean') {
-    logger.info(mainjsExecutionFailureMessage(mainConfigPath, mainConfigLoadingError));
-    results = { preCheckFailure: PreCheckFailure.MAINJS_EVALUATION };
+    throw new UpgradeStorybookUnknownCurrentVersionError();
   }
 
   // BLOCKERS
@@ -292,32 +278,6 @@ export const doUpgrade = async ({
     });
   }
 };
-
-function missingStorybookVersionMessage(): string {
-  return dedent`
-      [Storybook automigrate] ❌ Unable to determine Storybook version so that the automigrations will be skipped.
-        🤔 Are you running automigrate from your project directory? Please specify your Storybook config directory with the --config-dir flag.
-      `;
-}
-
-function mainjsExecutionFailureMessage(
-  mainConfigPath: string,
-  mainConfigLoadingError: string
-): string {
-  return dedent`
-    [Storybook automigrate] ❌ Failed trying to evaluate ${chalk.blue(
-      mainConfigPath
-    )} with the following error: ${mainConfigLoadingError}
-    
-    Please fix the error and try again.
-  `;
-}
-
-function mainjsNotFoundMessage(configDir: string): string {
-  return dedent`[Storybook automigrate] Could not find or evaluate your Storybook main.js config directory at ${chalk.blue(
-    configDir
-  )} so the automigrations will be skipped. You might be running this command in a monorepo or a non-standard project structure. If that is the case, please rerun this command by specifying the path to your Storybook config directory via the --config-dir option.`;
-}
 
 export async function upgrade(options: UpgradeOptions): Promise<void> {
   await withTelemetry('upgrade', { cliOptions: options }, () => doUpgrade(options));

--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -23,7 +23,6 @@ import {
 } from '@storybook/core-common';
 import { automigrate } from './automigrate/index';
 import { autoblock } from './autoblock/index';
-import { PreCheckFailure } from './automigrate/types';
 
 type Package = {
   package: string;

--- a/code/lib/core-common/src/utils/load-main-config.ts
+++ b/code/lib/core-common/src/utils/load-main-config.ts
@@ -5,7 +5,7 @@ import { validateConfigurationFiles } from './validate-configuration-files';
 import { readFile } from 'fs/promises';
 import {
   MainFileESMOnlyImportError,
-  MainFileFailedEvaluationError,
+  MainFileEvaluationError,
 } from '@storybook/core-events/server-errors';
 
 export async function loadMainConfig({
@@ -54,7 +54,7 @@ export async function loadMainConfig({
       throw out;
     }
 
-    throw new MainFileFailedEvaluationError({
+    throw new MainFileEvaluationError({
       location: relative(process.cwd(), mainJsPath),
       error: e,
     });

--- a/code/lib/core-common/src/utils/load-main-config.ts
+++ b/code/lib/core-common/src/utils/load-main-config.ts
@@ -1,7 +1,9 @@
-import path from 'path';
+import path, { relative } from 'path';
 import type { StorybookConfig } from '@storybook/types';
 import { serverRequire, serverResolve } from './interpret-require';
 import { validateConfigurationFiles } from './validate-configuration-files';
+import { readFile } from 'fs/promises';
+import chalk from 'chalk';
 
 export async function loadMainConfig({
   configDir = '.storybook',
@@ -18,5 +20,51 @@ export async function loadMainConfig({
     delete require.cache[mainJsPath];
   }
 
-  return serverRequire(mainJsPath);
+  try {
+    const out = await serverRequire(mainJsPath);
+    return out;
+  } catch (e) {
+    if (!(e instanceof Error)) {
+      throw e;
+    }
+    if (e.message.match(/Cannot use import statement outside a module/)) {
+      const a = relative(process.cwd(), mainJsPath);
+      const line = e.stack?.match(new RegExp(`${a}:(\\d+):(\\d+)`))?.[1];
+      const message = [
+        `Storybook failed to load ${a}..`,
+        '',
+        `It looks like the file tried to load/import an ESM only module.`,
+        `Support for this is currently limited in ${a}.`,
+        `You can import ESM modules in your main file, but only as imperative imports.`,
+        '',
+      ];
+
+      if (line) {
+        const contents = await readFile(mainJsPath, 'utf-8');
+        const lines = contents.split('\n');
+        const num = parseInt(line, 10) - 1;
+
+        message.push(
+          chalk.white(
+            `In your ${chalk.yellow(a)} file, this line threw an error: ${chalk.bold.cyan(
+              num
+            )}, which looks like this:`
+          ),
+          chalk.grey(lines[num])
+        );
+      }
+      message.push(
+        '',
+        `Convert the declarative import to an imperative import where they are used.`
+      );
+
+      const out = new Error(message.join('\n'));
+
+      delete out.stack;
+
+      throw out;
+    }
+    throw e;
+    //
+  }
 }

--- a/code/lib/core-common/src/utils/load-main-config.ts
+++ b/code/lib/core-common/src/utils/load-main-config.ts
@@ -28,14 +28,14 @@ export async function loadMainConfig({
       throw e;
     }
     if (e.message.match(/Cannot use import statement outside a module/)) {
-      const a = relative(process.cwd(), mainJsPath);
-      const line = e.stack?.match(new RegExp(`${a}:(\\d+):(\\d+)`))?.[1];
+      const location = relative(process.cwd(), mainJsPath);
+      const line = e.stack?.match(new RegExp(`${location}:(\\d+):(\\d+)`))?.[1];
       const message = [
-        `Storybook failed to load ${a}..`,
+        `Storybook failed to load ${location}..`,
         '',
         `It looks like the file tried to load/import an ESM only module.`,
-        `Support for this is currently limited in ${a}.`,
-        `You can import ESM modules in your main file, but only as imperative imports.`,
+        `Support for this is currently limited in ${location}.`,
+        `You can import ESM modules in your main file, but only as dynamic import.`,
         '',
       ];
 
@@ -46,7 +46,7 @@ export async function loadMainConfig({
 
         message.push(
           chalk.white(
-            `In your ${chalk.yellow(a)} file, this line threw an error: ${chalk.bold.cyan(
+            `In your ${chalk.yellow(location)} file, this line threw an error: ${chalk.bold.cyan(
               num
             )}, which looks like this:`
           ),
@@ -55,7 +55,8 @@ export async function loadMainConfig({
       }
       message.push(
         '',
-        `Convert the declarative import to an imperative import where they are used.`
+        chalk.white(`Convert the dynamic import to an dynamic import where they are used.`),
+        chalk.white(`Example:`) + ' ' + chalk.gray(`await import(<your ESM only module>);`)
       );
 
       const out = new Error(message.join('\n'));

--- a/code/lib/core-common/src/utils/load-main-config.ts
+++ b/code/lib/core-common/src/utils/load-main-config.ts
@@ -3,7 +3,10 @@ import type { StorybookConfig } from '@storybook/types';
 import { serverRequire, serverResolve } from './interpret-require';
 import { validateConfigurationFiles } from './validate-configuration-files';
 import { readFile } from 'fs/promises';
-import { MainFileESMOnlyImportError } from '@storybook/core-events/server-errors';
+import {
+  MainFileESMOnlyImportError,
+  MainFileFailedEvaluationError,
+} from '@storybook/core-events/server-errors';
 
 export async function loadMainConfig({
   configDir = '.storybook',
@@ -50,7 +53,10 @@ export async function loadMainConfig({
 
       throw out;
     }
-    throw e;
-    //
+
+    throw new MainFileFailedEvaluationError({
+      location: relative(process.cwd(), mainJsPath),
+      error: e,
+    });
   }
 }

--- a/code/lib/core-common/src/utils/validate-configuration-files.ts
+++ b/code/lib/core-common/src/utils/validate-configuration-files.ts
@@ -5,6 +5,7 @@ import slash from 'slash';
 import { once } from '@storybook/node-logger';
 
 import { boost } from './interpret-files';
+import { MainFileMissingError } from '@storybook/core-events/server-errors';
 
 export async function validateConfigurationFiles(configDir: string) {
   const extensionsPattern = `{${Array.from(boost).join(',')}}`;
@@ -20,9 +21,6 @@ export async function validateConfigurationFiles(configDir: string) {
   }
 
   if (!mainConfigPath) {
-    throw new Error(dedent`
-      No configuration files have been found in your configDir (${path.resolve(configDir)}).
-      Storybook needs "main.js" file, please add it (or pass a custom config dir flag to Storybook to tell where your main.js file is located at).
-    `);
+    throw new MainFileMissingError({ location: configDir });
   }
 }

--- a/code/lib/core-events/package.json
+++ b/code/lib/core-events/package.json
@@ -81,6 +81,7 @@
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
+    "chalk": "^4.1.0",
     "typescript": "^5.3.2"
   },
   "publishConfig": {

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -1,4 +1,4 @@
-import { bold, gray, grey, white, yellow } from 'chalk';
+import { bold, gray, grey, white, yellow, underline } from 'chalk';
 import dedent from 'ts-dedent';
 import { StorybookError } from './storybook-error';
 
@@ -421,9 +421,9 @@ export class MainFileESMOnlyImportError extends StorybookError {
     if (this.data.line) {
       message.push(
         white(
-          `In your ${yellow(this.data.location)} file, this line threw an error: ${bold.cyan(
+          `In your ${yellow(this.data.location)} file, line ${bold.cyan(
             this.data.num
-          )}, which looks like this:`
+          )} threw an error, which looks like this:`
         ),
         grey(this.data.line)
       );
@@ -431,8 +431,10 @@ export class MainFileESMOnlyImportError extends StorybookError {
 
     message.push(
       '',
-      white(`Convert the static import to an dynamic import where they are used.`),
-      white(`Example:`) + ' ' + gray(`await import(<your ESM only module>);`)
+      white(`Convert the static import to an dynamic import ${underline('where they are used')}.`),
+      white(`Example:`) + ' ' + gray(`await import(<your ESM only module>);`),
+      '',
+      'For more information, please read the documentation link below.'
     );
 
     return message.join('\n');
@@ -443,6 +445,8 @@ export class MainFileMissingError extends StorybookError {
   readonly category = Category.CORE_SERVER;
 
   readonly code = 6;
+
+  readonly stack = '';
 
   public readonly documentation = 'https://storybook.js.org/docs/configure';
 
@@ -460,22 +464,26 @@ export class MainFileMissingError extends StorybookError {
   }
 }
 
-export class MainFileFailedEvaluationError extends StorybookError {
+export class MainFileEvaluationError extends StorybookError {
   readonly category = Category.CORE_SERVER;
 
   readonly code = 7;
 
-  public readonly documentation = 'https://storybook.js.org/docs/configure';
+  readonly stack = '';
 
   constructor(public data: { location: string; error: Error }) {
     super();
   }
 
   template() {
+    const errorText = white(
+      (this.data.error.stack || this.data.error.message).replaceAll(process.cwd(), '')
+    );
+
     return dedent`
       Storybook couldn't evaluate your ${yellow(this.data.location)} file.
 
-      ${this.data.error.message}
+      ${errorText}
     `;
   }
 }

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -411,10 +411,10 @@ export class MainFileESMOnlyImportError extends StorybookError {
 
   template() {
     const message = [
-      `Storybook failed to load ${this.data.location}..`,
+      `Storybook failed to load ${this.data.location}`,
       '',
       `It looks like the file tried to load/import an ESM only module.`,
-      `Support for this is currently limited in ${this.data.location}.`,
+      `Support for this is currently limited in ${this.data.location}`,
       `You can import ESM modules in your main file, but only as dynamic import.`,
       '',
     ];
@@ -423,7 +423,7 @@ export class MainFileESMOnlyImportError extends StorybookError {
         white(
           `In your ${yellow(this.data.location)} file, line ${bold.cyan(
             this.data.num
-          )} threw an error, which looks like this:`
+          )} threw an error:`
         ),
         grey(this.data.line)
       );
@@ -431,10 +431,9 @@ export class MainFileESMOnlyImportError extends StorybookError {
 
     message.push(
       '',
-      white(`Convert the static import to an dynamic import ${underline('where they are used')}.`),
+      white(`Convert the static import to a dynamic import ${underline('where they are used')}.`),
       white(`Example:`) + ' ' + gray(`await import(<your ESM only module>);`),
       '',
-      'For more information, please read the documentation link below.'
     );
 
     return message.join('\n');
@@ -457,7 +456,7 @@ export class MainFileMissingError extends StorybookError {
   template() {
     return dedent`
       No configuration files have been found in your configDir: ${yellow(this.data.location)}.
-      Storybook needs "main.js" file, please add it.
+      Storybook needs a "main.js" file, please add it.
       
       You can pass a --config-dir flag to tell Storybook, where your main.js file is located at).
     `;
@@ -572,7 +571,7 @@ export class UpgradeStorybookUnknownCurrentVersionError extends StorybookError {
     return dedent`
       We couldn't determine the current version of Storybook in your project.
 
-      Are you running the storybook CLI in a project without Storybook?
+      Are you running the Storybook CLI in a project without Storybook?
       It might help if you specify your Storybook config directory with the --config-dir flag.
     `;
   }

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -400,6 +400,9 @@ export class MainFileESMOnlyImportError extends StorybookError {
 
   readonly code = 5;
 
+  public documentation =
+    'https://github.com/storybookjs/storybook/issues/23972#issuecomment-1948534058';
+
   constructor(
     public data: { location: string; line: string | undefined; num: number | undefined }
   ) {
@@ -428,11 +431,52 @@ export class MainFileESMOnlyImportError extends StorybookError {
 
     message.push(
       '',
-      white(`Convert the dynamic import to an dynamic import where they are used.`),
+      white(`Convert the static import to an dynamic import where they are used.`),
       white(`Example:`) + ' ' + gray(`await import(<your ESM only module>);`)
     );
 
     return message.join('\n');
+  }
+}
+
+export class MainFileMissingError extends StorybookError {
+  readonly category = Category.CORE_SERVER;
+
+  readonly code = 6;
+
+  public readonly documentation = 'https://storybook.js.org/docs/configure';
+
+  constructor(public data: { location: string }) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      No configuration files have been found in your configDir: ${yellow(this.data.location)}.
+      Storybook needs "main.js" file, please add it.
+      
+      You can pass a --config-dir flag to tell Storybook, where your main.js file is located at).
+    `;
+  }
+}
+
+export class MainFileFailedEvaluationError extends StorybookError {
+  readonly category = Category.CORE_SERVER;
+
+  readonly code = 7;
+
+  public readonly documentation = 'https://storybook.js.org/docs/configure';
+
+  constructor(public data: { location: string; error: Error }) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      Storybook couldn't evaluate your ${yellow(this.data.location)} file.
+
+      ${this.data.error.message}
+    `;
   }
 }
 
@@ -507,6 +551,21 @@ export class UpgradeStorybookToSameVersionError extends StorybookError {
       If you intended to re-run automigrations, you should run the "automigrate" command directly instead:
 
       "npx storybook@${this.data.beforeVersion} automigrate"
+    `;
+  }
+}
+
+export class UpgradeStorybookUnknownCurrentVersionError extends StorybookError {
+  readonly category = Category.CLI_UPGRADE;
+
+  readonly code = 5;
+
+  template() {
+    return dedent`
+      We couldn't determine the current version of Storybook in your project.
+
+      Are you running the storybook CLI in a project without Storybook?
+      It might help if you specify your Storybook config directory with the --config-dir flag.
     `;
   }
 }

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -433,7 +433,7 @@ export class MainFileESMOnlyImportError extends StorybookError {
       '',
       white(`Convert the static import to a dynamic import ${underline('where they are used')}.`),
       white(`Example:`) + ' ' + gray(`await import(<your ESM only module>);`),
-      '',
+      ''
     );
 
     return message.join('\n');

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -408,10 +408,10 @@ export class MainFileESMOnlyImportError extends StorybookError {
 
   template() {
     const message = [
-      `Storybook failed to load ${location}..`,
+      `Storybook failed to load ${this.data.location}..`,
       '',
       `It looks like the file tried to load/import an ESM only module.`,
-      `Support for this is currently limited in ${location}.`,
+      `Support for this is currently limited in ${this.data.location}.`,
       `You can import ESM modules in your main file, but only as dynamic import.`,
       '',
     ];

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { bold, gray, grey, white, yellow } from 'chalk';
 import dedent from 'ts-dedent';
 import { StorybookError } from './storybook-error';
 
@@ -417,21 +417,19 @@ export class MainFileESMOnlyImportError extends StorybookError {
     ];
     if (this.data.line) {
       message.push(
-        chalk.white(
-          `In your ${chalk.yellow(
-            this.data.location
-          )} file, this line threw an error: ${chalk.bold.cyan(
+        white(
+          `In your ${yellow(this.data.location)} file, this line threw an error: ${bold.cyan(
             this.data.num
           )}, which looks like this:`
         ),
-        chalk.grey(this.data.line)
+        grey(this.data.line)
       );
     }
 
     message.push(
       '',
-      chalk.white(`Convert the dynamic import to an dynamic import where they are used.`),
-      chalk.white(`Example:`) + ' ' + chalk.gray(`await import(<your ESM only module>);`)
+      white(`Convert the dynamic import to an dynamic import where they are used.`),
+      white(`Example:`) + ' ' + gray(`await import(<your ESM only module>);`)
     );
 
     return message.join('\n');

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import dedent from 'ts-dedent';
 import { StorybookError } from './storybook-error';
 
@@ -391,6 +392,49 @@ export class NoMatchingExportError extends StorybookError {
 
       Please run \`npx storybook@latest doctor\` for guidance on how to fix this issue.
     `;
+  }
+}
+
+export class MainFileESMOnlyImportError extends StorybookError {
+  readonly category = Category.CORE_SERVER;
+
+  readonly code = 5;
+
+  constructor(
+    public data: { location: string; line: string | undefined; num: number | undefined }
+  ) {
+    super();
+  }
+
+  template() {
+    const message = [
+      `Storybook failed to load ${location}..`,
+      '',
+      `It looks like the file tried to load/import an ESM only module.`,
+      `Support for this is currently limited in ${location}.`,
+      `You can import ESM modules in your main file, but only as dynamic import.`,
+      '',
+    ];
+    if (this.data.line) {
+      message.push(
+        chalk.white(
+          `In your ${chalk.yellow(
+            this.data.location
+          )} file, this line threw an error: ${chalk.bold.cyan(
+            this.data.num
+          )}, which looks like this:`
+        ),
+        chalk.grey(this.data.line)
+      );
+    }
+
+    message.push(
+      '',
+      chalk.white(`Convert the dynamic import to an dynamic import where they are used.`),
+      chalk.white(`Example:`) + ' ' + chalk.gray(`await import(<your ESM only module>);`)
+    );
+
+    return message.join('\n');
   }
 }
 

--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -15,7 +15,7 @@ import { telemetry, oneWayHash } from '@storybook/telemetry';
 
 import { join, relative, resolve } from 'path';
 import { deprecate } from '@storybook/node-logger';
-import dedent from 'ts-dedent';
+import { dedent } from 'ts-dedent';
 import { readFile } from 'fs-extra';
 import { MissingBuilderError } from '@storybook/core-events/server-errors';
 import { storybookDevServer } from './dev-server';

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5528,6 +5528,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/core-events@workspace:lib/core-events"
   dependencies:
+    chalk: "npm:^4.1.0"
     ts-dedent: "npm:^2.0.0"
     typescript: "npm:^5.3.2"
   languageName: unknown


### PR DESCRIPTION
Closes: https://github.com/storybookjs/storybook/issues/23972
Closes: https://github.com/storybookjs/storybook/issues/25814

## What I did

Catch the error in `loadMainConfig`, and transform the error to be more helpful.

The user was able to do something before  https://github.com/storybookjs/storybook/pull/23018/files but after that change, users can have a broken `main.ts` file simply by importing (with a declarative import) a module that has no `commonjs` variant.

This was an unnoticed breaking change in SB 7.1

Turning back the change is possible, but very much not preferable, because it would be a performance regression.

I hope that the message will be clear enough for users to act upon it.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- Create a sandbox (doesn't matter if linked or not)
- Add `"@nuxt/kit": "3.10.1"` as a dependency & install
- Add the following to the sandbox's `main.ts`:
   ```js
   import { buildNuxt, loadNuxt, tryUseNuxt } from '@nuxt/kit'
   console.log({ buildNuxt, loadNuxt, tryUseNuxt });
   ```
- start the sandbox

Before this change the command output looked like:
![Screenshot 2024-02-14 at 18 17 42](https://github.com/storybookjs/storybook/assets/3070389/fef94115-bd76-4054-ab85-3f5e845c6adf)

After this change it should look like:
![Screenshot 2024-02-14 at 18 19 45](https://github.com/storybookjs/storybook/assets/3070389/af73e681-1c79-45b6-9d0a-f37bb5798b79)

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26035-sha-a321a58d`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26035-sha-a321a58d sandbox` or in an existing project with `npx storybook@0.0.0-pr-26035-sha-a321a58d upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26035-sha-a321a58d`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26035-sha-a321a58d) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/handle-esm-main-error`](https://github.com/storybookjs/storybook/tree/norbert/handle-esm-main-error) |
| **Commit** | [`a321a58d`](https://github.com/storybookjs/storybook/commit/a321a58d7280f9b4475a89d0f8b0b2f907c7d725) |
| **Datetime** | Tue Feb 20 10:53:48 UTC 2024 (`1708426428`) |
| **Workflow run** | [7972315424](https://github.com/storybookjs/storybook/actions/runs/7972315424) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26035`_
</details>
<!-- CANARY_RELEASE_SECTION -->
