### PR TITLE
Vite: Fix bug that meant we always warned about TS plugin

### DIFF
--- a/code/builders/builder-vite/src/build.ts
+++ b/code/builders/builder-vite/src/build.ts
@@ -41,7 +41,7 @@ export async function build(options: Options) {
 
   const turbosnapPluginName = 'rollup-plugin-turbosnap';
   const hasTurbosnapPlugin =
-    finalConfig.plugins && hasVitePlugins(finalConfig.plugins, [turbosnapPluginName]);
+    finalConfig.plugins && (await hasVitePlugins(finalConfig.plugins, [turbosnapPluginName]));
   if (hasTurbosnapPlugin) {
     logger.warn(dedent`Found '${turbosnapPluginName}' which is now included by default in Storybook 8.
       Removing from your plugins list. Ensure you pass \`--webpack-stats-json\` to generate stats.


### PR DESCRIPTION
Thanks @acid-chicken! https://github.com/storybookjs/storybook/pull/25923/files#r1489101715

## What I did

Fix broken check by awaiting promise

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- Run `build-storybook` on a vite sandbox, check there is no warning.
- Add https://github.com/IanVS/vite-plugin-turbosnap, check there is a warning.