### PR TITLE
Core: Add addon removal telemetry

### DIFF
--- a/code/lib/cli/src/generate.ts
+++ b/code/lib/cli/src/generate.ts
@@ -6,13 +6,19 @@ import { sync as readUpSync } from 'read-pkg-up';
 import invariant from 'tiny-invariant';
 
 import { logger } from '@storybook/node-logger';
-import { addToGlobalContext } from '@storybook/telemetry';
-import { parseList, getEnvConfig, JsPackageManagerFactory, versions } from '@storybook/core-common';
+import { addToGlobalContext, telemetry } from '@storybook/telemetry';
+import {
+  parseList,
+  getEnvConfig,
+  JsPackageManagerFactory,
+  versions,
+  removeAddon as remove,
+} from '@storybook/core-common';
+import { withTelemetry } from '@storybook/core-server';
 
 import type { CommandOptions } from './generators/types';
 import { initiate } from './initiate';
 import { add } from './add';
-import { removeAddon as remove } from '@storybook/core-common';
 import { migrate } from './migrate';
 import { upgrade, type UpgradeOptions } from './upgrade';
 import { sandbox } from './sandbox';
@@ -71,7 +77,14 @@ command('remove <addon>')
     '--package-manager <npm|pnpm|yarn1|yarn2>',
     'Force package manager for installing dependencies'
   )
-  .action((addonName: string, options: any) => remove(addonName, options));
+  .action((addonName: string, options: any) =>
+    withTelemetry('remove', { cliOptions: options }, async () => {
+      await remove(addonName, options);
+      if (!options.disableTelemetry) {
+        await telemetry('remove', { addon: addonName, source: 'cli' });
+      }
+    })
+  );
 
 command('upgrade')
   .description(`Upgrade your Storybook packages to v${versions.storybook}`)

--- a/code/lib/core-server/src/presets/common-preset.ts
+++ b/code/lib/core-server/src/presets/common-preset.ts
@@ -7,7 +7,7 @@ import {
   getPreviewBodyTemplate,
   getPreviewHeadTemplate,
   loadEnvs,
-  removeAddon,
+  removeAddon as removeAddonBase,
 } from '@storybook/core-common';
 import type {
   CLIOptions,
@@ -162,10 +162,16 @@ const optionalEnvToBoolean = (input: string | undefined): boolean | undefined =>
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const experimental_serverAPI = (extension: Record<string, Function>) => ({
-  ...extension,
-  removeAddon,
-});
+export const experimental_serverAPI = (extension: Record<string, Function>, options: Options) => {
+  let removeAddon = removeAddonBase;
+  if (!options.disableTelemetry) {
+    removeAddon = async (id: string, opts: any) => {
+      await telemetry('remove', { addon: id, source: 'api' });
+      return removeAddonBase(id, opts);
+    };
+  }
+  return { ...extension, removeAddon };
+};
 
 /**
  * If for some reason this config is not applied, the reason is that

--- a/code/lib/telemetry/src/types.ts
+++ b/code/lib/telemetry/src/types.ts
@@ -15,7 +15,8 @@ export type EventType =
   | 'error'
   | 'error-metadata'
   | 'version-update'
-  | 'core-config';
+  | 'core-config'
+  | 'remove';
 
 export interface Dependency {
   version: string | undefined;


### PR DESCRIPTION
Closes N/A

## What I did

Adds telemetry for addon removal, either from the CLI or from addons

## Checklist for Contributors

### Testing

Build & run the CLI in a project with telemetry debugging enabled

```
STORYBOOK_TELEMETRY_DEBUG=true path/to/lib/cli/dist/index.js remove @storybook/addon-links
```

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26077-sha-aea7ea3d`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26077-sha-aea7ea3d sandbox` or in an existing project with `npx storybook@0.0.0-pr-26077-sha-aea7ea3d upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26077-sha-aea7ea3d`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26077-sha-aea7ea3d) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/addon-removal-telemetry`](https://github.com/storybookjs/storybook/tree/shilman/addon-removal-telemetry) |
| **Commit** | [`aea7ea3d`](https://github.com/storybookjs/storybook/commit/aea7ea3dbee02aec0bc769b8dfab58f6c8d5c4fc) |
| **Datetime** | Mon Feb 19 00:01:32 UTC 2024 (`1708300892`) |
| **Workflow run** | [7952606942](https://github.com/storybookjs/storybook/actions/runs/7952606942) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26077`_
</details>
<!-- CANARY_RELEASE_SECTION -->
