### PR TITLE
CLI: Add support for custom vite config to autoblocker

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/vite-config-file.ts
+++ b/code/lib/cli/src/automigrate/fixes/vite-config-file.ts
@@ -14,7 +14,7 @@ export const viteConfigFile = {
   id: 'viteConfigFile',
 
   async check({ mainConfig, packageManager }) {
-    const viteConfigPath = await findUp([
+    let viteConfigPath = await findUp([
       'vite.config.js',
       'vite.config.mjs',
       'vite.config.cjs',
@@ -44,6 +44,15 @@ export const viteConfigFile = {
       frameworkPackageName === 'sveltekit';
 
     const rendererName = frameworkToRenderer[frameworkName as keyof typeof frameworkToRenderer];
+
+    if (
+      !viteConfigFile &&
+      mainConfig.core?.builder &&
+      typeof mainConfig.core?.builder !== 'string' &&
+      mainConfig.core?.builder.options
+    ) {
+      viteConfigPath = mainConfig.core?.builder.options.viteConfigPath;
+    }
 
     if (!viteConfigPath && isUsingViteBuilder) {
       const plugins = [];

--- a/code/lib/cli/src/automigrate/fixes/vite-config-file.ts
+++ b/code/lib/cli/src/automigrate/fixes/vite-config-file.ts
@@ -14,12 +14,12 @@ export const viteConfigFile = {
   id: 'viteConfigFile',
 
   async check({ mainConfig, packageManager }) {
-    let viteConfigPath = await findUp([
+    let isViteConfigFileFound = !!(await findUp([
       'vite.config.js',
       'vite.config.mjs',
       'vite.config.cjs',
       'vite.config.ts',
-    ]);
+    ]));
 
     const rendererToVitePluginMap: Record<string, string> = {
       preact: '@preact/preset-vite',
@@ -46,15 +46,15 @@ export const viteConfigFile = {
     const rendererName = frameworkToRenderer[frameworkName as keyof typeof frameworkToRenderer];
 
     if (
-      !viteConfigFile &&
+      !isViteConfigFileFound &&
       mainConfig.core?.builder &&
       typeof mainConfig.core?.builder !== 'string' &&
       mainConfig.core?.builder.options
     ) {
-      viteConfigPath = mainConfig.core?.builder.options.viteConfigPath;
+      isViteConfigFileFound = !!mainConfig.core?.builder.options.viteConfigPath;
     }
 
-    if (!viteConfigPath && isUsingViteBuilder) {
+    if (!isViteConfigFileFound && isUsingViteBuilder) {
       const plugins = [];
 
       if (rendererToVitePluginMap[rendererName]) {
@@ -63,7 +63,7 @@ export const viteConfigFile = {
 
       return {
         plugins,
-        existed: !!viteConfigPath,
+        existed: isViteConfigFileFound,
       };
     }
 
@@ -75,7 +75,7 @@ export const viteConfigFile = {
 
     const pluginVersion = await packageManager.getPackageVersion(plugin);
 
-    if (viteConfigPath && isUsingViteBuilder && !pluginVersion) {
+    if (isViteConfigFileFound && isUsingViteBuilder && !pluginVersion) {
       const plugins = [];
 
       if (plugin) {
@@ -84,7 +84,7 @@ export const viteConfigFile = {
 
       return {
         plugins,
-        existed: !viteConfigPath,
+        existed: !isViteConfigFileFound,
       };
     }
 


### PR DESCRIPTION
Closes: https://github.com/storybookjs/storybook/pull/25934#pullrequestreview-1881973378

## What I did

fix https://github.com/storybookjs/storybook/pull/25934#pullrequestreview-1881973378

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
