### PR TITLE
CLI: Add `legacyMdx1` & `@storybook/mdx1-csf` automigration

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/index.ts
+++ b/code/lib/cli/src/automigrate/fixes/index.ts
@@ -5,6 +5,7 @@ import { webpack5 } from './webpack5';
 import { vite4 } from './vite4';
 import { vue3 } from './vue3';
 import { mdxgfm } from './mdx-gfm';
+import { removeLegacyMDX1 } from './remove-legacymdx1';
 import { eslintPlugin } from './eslint-plugin';
 import { builderVite } from './builder-vite';
 import { viteConfigFile } from './vite-config-file';
@@ -51,6 +52,7 @@ export const allFixes: Fix[] = [
   reactDocgen,
   storyshotsMigration,
   removeReactDependency,
+  removeLegacyMDX1,
   webpack5CompilerSetup,
 ];
 

--- a/code/lib/cli/src/automigrate/fixes/mdx-gfm.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/mdx-gfm.test.ts
@@ -40,6 +40,7 @@ describe('no-ops', () => {
         packageManager: {},
         main: {
           features: {
+            // @ts-expect-error (user might be upgrading from a version that had this option)
             legacyMdx1: true,
           },
         },

--- a/code/lib/cli/src/automigrate/fixes/mdx-gfm.ts
+++ b/code/lib/cli/src/automigrate/fixes/mdx-gfm.ts
@@ -54,6 +54,7 @@ export const mdxgfm: Fix<Options> = {
       return files.some((f) => f.endsWith('.mdx'));
     }, Promise.resolve(false));
 
+    // @ts-expect-error (user might be upgrading from an older version that still had it)
     const usesMDX1 = mainConfig?.features?.legacyMdx1 === true || false;
     const skip =
       usesMDX1 ||

--- a/code/lib/cli/src/automigrate/fixes/remove-legacymdx1.ts
+++ b/code/lib/cli/src/automigrate/fixes/remove-legacymdx1.ts
@@ -1,0 +1,56 @@
+import { dedent } from 'ts-dedent';
+
+import { writeConfig } from '@storybook/csf-tools';
+
+import type { Fix } from '../types';
+import { updateMainConfig } from '../helpers/mainConfigFile';
+
+const logger = console;
+
+interface RemoveLegacyMDX1Options {
+  hasFeature: boolean;
+}
+
+/**
+ * Does the user have 'legacyMdx1' in their main.ts?
+ *
+ * If so, prompt them to upgrade to delete it.
+ */
+export const removeLegacyMDX1: Fix<RemoveLegacyMDX1Options> = {
+  id: 'builder-vite',
+
+  async check({ mainConfig }) {
+    if (mainConfig.features) {
+      //
+      return {
+        hasFeature: !!Object.hasOwn(mainConfig.features, 'legacyMdx1'),
+      };
+    }
+
+    return null;
+  },
+
+  prompt({}) {
+    return dedent`
+      You have features.legacyMdx1 in your Storybook main config file, this feature has been removed, shall we remove it from you main.ts file?
+
+      Link: https://storybook.js.org/docs/7.6/migration-guide
+    `;
+  },
+
+  async run({ dryRun, mainConfigPath, skipInstall, packageManager }) {
+    logger.info(`✅ Removing legacyMdx1 feature`);
+    if (!dryRun) {
+      await updateMainConfig({ dryRun: !!dryRun, mainConfigPath }, async (main) => {
+        main.removeField(['features', 'legacyMdx1']);
+        await writeConfig(main);
+      });
+
+      const packageJson = await packageManager.retrievePackageJson();
+
+      await packageManager.removeDependencies({ skipInstall: skipInstall, packageJson }, [
+        '@storybook/mdx1-csf',
+      ]);
+    }
+  },
+};

--- a/code/lib/cli/src/automigrate/fixes/remove-legacymdx1.ts
+++ b/code/lib/cli/src/automigrate/fixes/remove-legacymdx1.ts
@@ -32,9 +32,9 @@ export const removeLegacyMDX1: Fix<RemoveLegacyMDX1Options> = {
 
   prompt({}) {
     return dedent`
-      You have features.legacyMdx1 in your Storybook main config file, this feature has been removed, shall we remove it from you main.ts file?
+      You have features.legacyMdx1 in your Storybook main config file. This feature has been removed. Shall we remove it from your Storybook main config file?
 
-      Link: https://storybook.js.org/docs/7.6/migration-guide
+      Link: https://storybook.js.org/docs/8.0/migration-guide
     `;
   },
 

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -356,11 +356,6 @@ export interface StorybookConfigRaw {
     argTypeTargetsV7?: boolean;
 
     /**
-     * Use legacy MDX1, to help smooth migration to 7.0
-     */
-    legacyMdx1?: boolean;
-
-    /**
      * Apply decorators from preview.js before decorators from addons or frameworks
      */
     legacyDecoratorFileOrder?: boolean;

--- a/docs/api/main-config-features.md
+++ b/docs/api/main-config-features.md
@@ -10,7 +10,6 @@ Type:
 {
   argTypeTargetsV7?: boolean;
   legacyDecoratorFileOrder?: boolean;
-  legacyMdx1?: boolean;
 }
 ```
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25433

## What I did

apply more migrations listed in https://github.com/storybookjs/storybook/issues/25433

- remove the `features. legacyMdx1` field from `main.ts`
- un-install the `@storybook/mdx1-csf` package

I do not know how I'd do this:
> jsxOptions (addon option from addon-docs) should be removed (though I'm not sure if there's more to it)

Perhaps @shilman or @yannbf should elaborate this task?

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- Create a sandbox
- force this sandbox to use `legacyMdx1`
- upgrade this sandbox by running the CLI manually
- expect the `legacyMdx1` property to be removed from `main.ts` `features` object.
- expect the `@storybook/mdx1-csf` dependency to get uninstalled.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
