### PR TITLE
Blocks: Fix `Stories` block rendering duplicate stories when globals are changed

### DIFF
--- a/code/addons/docs/template/stories/docs2/multiple-csf-files-a.stories.ts
+++ b/code/addons/docs/template/stories/docs2/multiple-csf-files-a.stories.ts
@@ -1,0 +1,23 @@
+import { global as globalThis } from '@storybook/global';
+
+export default {
+  title: 'Multiple CSF Files Same Title',
+  component: globalThis.Components.Html,
+  tags: ['autodocs'],
+  args: {
+    content: '<p>paragraph</p>',
+  },
+  parameters: {
+    chromatic: { disable: true },
+  },
+};
+
+export const DefaultA = {};
+
+export const SpanContent = {
+  args: { content: '<span>span</span>' },
+};
+
+export const CodeContent = {
+  args: { content: '<code>code</code>' },
+};

--- a/code/addons/docs/template/stories/docs2/multiple-csf-files-b.stories.ts
+++ b/code/addons/docs/template/stories/docs2/multiple-csf-files-b.stories.ts
@@ -1,0 +1,23 @@
+import { global as globalThis } from '@storybook/global';
+
+export default {
+  title: 'Multiple CSF Files Same Title',
+  component: globalThis.Components.Html,
+  tags: ['autodocs'],
+  args: {
+    content: '<p>paragraph</p>',
+  },
+  parameters: {
+    chromatic: { disable: true },
+  },
+};
+
+export const DefaultB = {};
+
+export const H1Content = {
+  args: { content: '<h1>heading 1</h1>' },
+};
+
+export const H2Content = {
+  args: { content: '<h2>heading 2</h2>' },
+};

--- a/code/e2e-tests/addon-docs.spec.ts
+++ b/code/e2e-tests/addon-docs.spec.ts
@@ -210,4 +210,19 @@ test.describe('addon-docs', () => {
     await expect(componentReactVersion).toHaveText(expectedReactVersion);
     await expect(componentReactDomVersion).toHaveText(expectedReactVersion);
   });
+
+  test('should have stories from multiple CSF files in autodocs', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    await sbPage.navigateToStory('/addons/docs/multiple-csf-files-same-title', 'docs');
+    const root = sbPage.previewRoot();
+
+    const storyHeadings = root.locator('.sb-anchor > h3');
+    await expect(await storyHeadings.count()).toBe(6);
+    await expect(storyHeadings.nth(0)).toHaveText('Default A');
+    await expect(storyHeadings.nth(1)).toHaveText('Span Content');
+    await expect(storyHeadings.nth(2)).toHaveText('Code Content');
+    await expect(storyHeadings.nth(3)).toHaveText('Default B');
+    await expect(storyHeadings.nth(4)).toHaveText('H 1 Content');
+    await expect(storyHeadings.nth(5)).toHaveText('H 2 Content');
+  });
 });

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.test.ts
@@ -33,6 +33,52 @@ describe('referenceCSFFile', () => {
   });
 });
 
+describe('attachCSFFile', () => {
+  const firstCsfParts = csfFileParts('first-meta--first-story', 'first-meta');
+  const secondCsfParts = csfFileParts('second-meta--second-story', 'second-meta');
+  const store = {
+    componentStoriesFromCSFFile: ({ csfFile }: { csfFile: CSFFile }) =>
+      csfFile === firstCsfParts.csfFile ? [firstCsfParts.story] : [secondCsfParts.story],
+  } as unknown as StoryStore<Renderer>;
+
+  it('attaches multiple CSF files', () => {
+    // Arrange - create a context with both CSF files
+    const context = new DocsContext(channel, store, renderStoryToElement, [
+      firstCsfParts.csfFile,
+      secondCsfParts.csfFile,
+    ]);
+
+    // Act - attach the first CSF file
+    context.attachCSFFile(firstCsfParts.csfFile);
+
+    // Assert - the first story is now the primary story and the only component story
+    expect(context.storyById()).toEqual(firstCsfParts.story);
+    expect(context.componentStories()).toEqual([firstCsfParts.story]);
+
+    // Assert - stories from both CSF files are available
+    expect(context.componentStoriesFromCSFFile(firstCsfParts.csfFile)).toEqual([
+      firstCsfParts.story,
+    ]);
+    expect(context.componentStoriesFromCSFFile(secondCsfParts.csfFile)).toEqual([
+      secondCsfParts.story,
+    ]);
+
+    // Act - attach the second CSF file
+    context.attachCSFFile(secondCsfParts.csfFile);
+
+    // Assert - the first story is still the primary story but both stories are available
+    expect(context.storyById()).toEqual(firstCsfParts.story);
+    expect(context.componentStories()).toEqual([firstCsfParts.story, secondCsfParts.story]);
+
+    // Act - attach the second CSF file again
+    context.attachCSFFile(secondCsfParts.csfFile);
+
+    // Assert - still only two stories are available
+    expect(context.storyById()).toEqual(firstCsfParts.story);
+    expect(context.componentStories()).toEqual([firstCsfParts.story, secondCsfParts.story]);
+  });
+});
+
 describe('resolveOf', () => {
   const { story, csfFile, storyExport, metaExport, moduleExports, component } = csfFileParts();
 

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
@@ -71,6 +71,10 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
     if (!this.exportsToCSFFile.has(csfFile.moduleExports)) {
       throw new Error('Cannot attach a CSF file that has not been referenced');
     }
+    if (this.attachedCSFFile === csfFile) {
+      // this CSF file is already attached, don't do anything
+      return;
+    }
 
     this.attachedCSFFile = csfFile;
 

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
@@ -17,7 +17,7 @@ import type { StoryStore } from '../../store';
 import type { DocsContextProps } from './DocsContextProps';
 
 export class DocsContext<TRenderer extends Renderer> implements DocsContextProps<TRenderer> {
-  private componentStoriesValue: PreparedStory<TRenderer>[];
+  private componentStoriesValue: Set<PreparedStory<TRenderer>>;
 
   private storyIdToCSFFile: Map<StoryId, CSFFile<TRenderer>>;
 
@@ -27,7 +27,7 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
 
   private nameToStoryId: Map<StoryName, StoryId>;
 
-  private attachedCSFFile?: CSFFile<TRenderer>;
+  private attachedCSFFiles: Set<CSFFile<TRenderer>>;
 
   private primaryStory?: PreparedStory<TRenderer>;
 
@@ -38,11 +38,12 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
     /** The CSF files known (via the index) to be refererenced by this docs file */
     csfFiles: CSFFile<TRenderer>[]
   ) {
+    this.componentStoriesValue = new Set();
     this.storyIdToCSFFile = new Map();
     this.exportToStory = new Map();
     this.exportsToCSFFile = new Map();
     this.nameToStoryId = new Map();
-    this.componentStoriesValue = [];
+    this.attachedCSFFiles = new Set();
 
     csfFiles.forEach((csfFile, index) => {
       this.referenceCSFFile(csfFile);
@@ -71,17 +72,18 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
     if (!this.exportsToCSFFile.has(csfFile.moduleExports)) {
       throw new Error('Cannot attach a CSF file that has not been referenced');
     }
-    if (this.attachedCSFFile === csfFile) {
+    if (this.attachedCSFFiles.has(csfFile)) {
       // this CSF file is already attached, don't do anything
       return;
     }
 
-    this.attachedCSFFile = csfFile;
+    this.attachedCSFFiles.add(csfFile);
 
     const stories = this.store.componentStoriesFromCSFFile({ csfFile });
+
     stories.forEach((story) => {
       this.nameToStoryId.set(story.name, story.id);
-      this.componentStoriesValue.push(story);
+      this.componentStoriesValue.add(story);
       if (!this.primaryStory) this.primaryStory = story;
     });
   }
@@ -119,15 +121,18 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
       return { type: 'story', story: this.primaryStory } as TResolvedExport;
     }
 
-    if (!this.attachedCSFFile)
+    if (this.attachedCSFFiles.size === 0)
       throw new Error(
         `No CSF file attached to this docs file, did you forget to use <Meta of={} />?`
       );
 
-    if (moduleExportType === 'meta')
-      return { type: 'meta', csfFile: this.attachedCSFFile } as TResolvedExport;
+    const firstAttachedCSFFile = Array.from(this.attachedCSFFiles)[0];
 
-    const { component } = this.attachedCSFFile.meta;
+    if (moduleExportType === 'meta') {
+      return { type: 'meta', csfFile: firstAttachedCSFFile } as TResolvedExport;
+    }
+
+    const { component } = firstAttachedCSFFile.meta;
     if (!component)
       throw new Error(
         `Attached CSF file does not defined a component, did you forget to export one?`
@@ -202,7 +207,7 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
   };
 
   componentStories = () => {
-    return this.componentStoriesValue;
+    return Array.from(this.componentStoriesValue);
   };
 
   componentStoriesFromCSFFile = (csfFile: CSFFile<TRenderer>) => {

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/DocsContext.ts
@@ -17,7 +17,7 @@ import type { StoryStore } from '../../store';
 import type { DocsContextProps } from './DocsContextProps';
 
 export class DocsContext<TRenderer extends Renderer> implements DocsContextProps<TRenderer> {
-  private componentStoriesValue: Set<PreparedStory<TRenderer>>;
+  private componentStoriesValue: PreparedStory<TRenderer>[];
 
   private storyIdToCSFFile: Map<StoryId, CSFFile<TRenderer>>;
 
@@ -38,7 +38,7 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
     /** The CSF files known (via the index) to be refererenced by this docs file */
     csfFiles: CSFFile<TRenderer>[]
   ) {
-    this.componentStoriesValue = new Set();
+    this.componentStoriesValue = [];
     this.storyIdToCSFFile = new Map();
     this.exportToStory = new Map();
     this.exportsToCSFFile = new Map();
@@ -83,7 +83,7 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
 
     stories.forEach((story) => {
       this.nameToStoryId.set(story.name, story.id);
-      this.componentStoriesValue.add(story);
+      this.componentStoriesValue.push(story);
       if (!this.primaryStory) this.primaryStory = story;
     });
   }
@@ -207,7 +207,7 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
   };
 
   componentStories = () => {
-    return Array.from(this.componentStoriesValue);
+    return this.componentStoriesValue;
   };
 
   componentStoriesFromCSFFile = (csfFile: CSFFile<TRenderer>) => {

--- a/code/lib/preview-api/src/modules/preview-web/docs-context/test-utils.ts
+++ b/code/lib/preview-api/src/modules/preview-web/docs-context/test-utils.ts
@@ -1,6 +1,6 @@
 import type { CSFFile, PreparedStory } from '@storybook/types';
 
-export function csfFileParts() {
+export function csfFileParts(storyId = 'meta--story', metaId = 'meta') {
   // These compose the raw exports of the CSF file
   const component = {};
   const metaExport = { component };
@@ -9,13 +9,13 @@ export function csfFileParts() {
 
   // This is the prepared story + CSF file after SB has processed them
   const storyAnnotations = {
-    id: 'meta--story',
+    id: storyId,
     moduleExport: storyExport,
   } as CSFFile['stories'][string];
-  const story = { id: 'meta--story', moduleExport: storyExport } as PreparedStory;
-  const meta = { id: 'meta', title: 'Meta', component, moduleExports } as CSFFile['meta'];
+  const story = { id: storyId, moduleExport: storyExport } as PreparedStory;
+  const meta = { id: metaId, title: 'Meta', component, moduleExports } as CSFFile['meta'];
   const csfFile = {
-    stories: { 'meta--story': storyAnnotations },
+    stories: { [storyId]: storyAnnotations },
     meta,
     moduleExports,
   } as CSFFile;

--- a/code/renderers/svelte/template/components/Html.svelte
+++ b/code/renderers/svelte/template/components/Html.svelte
@@ -5,4 +5,4 @@
   export let content = '';
 </script>
 
-<div>{@html content}></div>
+<div>{@html content}</div>


### PR DESCRIPTION
Closes #24751

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR refactors `DocsContext` so it's more resilient in scenarios where multiple CSF files are being attached.

The cause of the linked issue was that rendering `<Meta />` would call `attachCSFFile`, and changing a global causes the whole docs view to re-render. This meant that `attachCSFFile` would be called again with the same CSF file, which would just append the stories to the existing array in `DocsContext` again and again.

Upon investigating this I concluded that `DocsContext` wasn't completely implemented in a way that handled multiple CSF files being attached at the same time. This _could theoretically_ result in the `primaryStory` being the primary of the _first attached_ CSF file, however a resolved `meta` or `component` would return the one from the _last attached_ CSF file. This has now been fixed in this PR - the first attached CSF file will always be considered the "primary" one to resolve from.

However I haven't figured out how to test this in practice, I can't set up a scenario where multiple _different_ CSF files are being attached to the same context. Based on the comment here, it suggest that this is a valid scenario though in non-manual-MDX files:

https://github.com/storybookjs/storybook/blob/332c593f8fb44fe62dabad1377da0517b42543f8/code/lib/preview-api/src/modules/preview-web/render/CsfDocsRender.ts#L106-L108

I tried having two different CSF files with the same title, and while that did collect all stories under the same component in the sidebar, it didn't make a difference in autodocs. @tmeasday any ideas on how I can test this out in a real Storybook?

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Open these docs, which is an MDX doc with `<Stories />`: https://630511d655df72125520f051-tprruuakio.chromatic.com/?path=/docs/addons-docs-docs2-button--metaof
2. Toggle any of the globals multiple times and see that the amount of stories stay the same.
3. Compare that with what's on `next`, where it duplicates the stories when globals are changed: https://next--630511d655df72125520f051.chromatic.com/?path=/docs/addons-docs-docs2-button--metaof

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
