### PR TITLE
Addon-interactions: Only mutate arg keys when writable

### DIFF
--- a/code/addons/interactions/src/preview.test.ts
+++ b/code/addons/interactions/src/preview.test.ts
@@ -1,10 +1,10 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { fn, isMockFunction } from '@storybook/test';
 import { action } from '@storybook/addon-actions';
 
 import { traverseArgs } from './preview';
 
-test('traverseArgs', () => {
+describe('traverseArgs', () => {
   const args = {
     deep: {
       deeper: {
@@ -18,17 +18,25 @@ test('traverseArgs', () => {
   expect(args.deep.deeper.fnKey.getMockName()).toEqual('spy');
 
   const traversed = traverseArgs(args) as typeof args;
-  expect(traversed).toEqual({
-    deep: {
-      deeper: {
-        fnKey: args.deep.deeper.fnKey,
-        actionKey: args.deep.deeper.actionKey,
-      },
-    },
-    arg2: args.arg2,
-  });
 
-  expect(traversed.deep.deeper.fnKey.getMockName()).toEqual('fnKey');
+  test('The same structure is maintained', () =>
+    expect(traversed).toEqual({
+      deep: {
+        deeper: {
+          fnKey: args.deep.deeper.fnKey,
+          actionKey: args.deep.deeper.actionKey,
+        },
+      },
+      // We don't mutate frozen objects, but we do insert them back in the tree
+      arg2: args.arg2,
+    }));
+
+  test('The mock name is mutated to be the arg key', () =>
+    expect(traversed.deep.deeper.fnKey.getMockName()).toEqual('fnKey'));
+
   const actionFn = traversed.deep.deeper.actionKey;
-  expect(isMockFunction(actionFn) && actionFn.getMockName()).toEqual('actionKey');
+
+  test('Actions are wrapped in a spy', () => expect(isMockFunction(actionFn)).toBeTruthy());
+  test('The spy of the action is also matching the arg key ', () =>
+    expect(isMockFunction(actionFn) && actionFn.getMockName()).toEqual('actionKey'));
 });

--- a/code/addons/interactions/src/preview.test.ts
+++ b/code/addons/interactions/src/preview.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'vitest';
+import { fn, isMockFunction } from '@storybook/test';
+import { action } from '@storybook/addon-actions';
+
+import { traverseArgs } from './preview';
+
+test('traverseArgs', () => {
+  const args = {
+    deep: {
+      deeper: {
+        fnKey: fn(),
+        actionKey: action('name'),
+      },
+    },
+    arg2: Object.freeze({ frozen: true }),
+  };
+
+  expect(args.deep.deeper.fnKey.getMockName()).toEqual('spy');
+
+  const traversed = traverseArgs(args) as typeof args;
+  expect(traversed).toEqual({
+    deep: {
+      deeper: {
+        fnKey: args.deep.deeper.fnKey,
+        actionKey: args.deep.deeper.actionKey,
+      },
+    },
+    arg2: args.arg2,
+  });
+
+  expect(traversed.deep.deeper.fnKey.getMockName()).toEqual('fnKey');
+  const actionFn = traversed.deep.deeper.actionKey;
+  expect(isMockFunction(actionFn) && actionFn.getMockName()).toEqual('actionKey');
+});

--- a/code/addons/interactions/src/preview.ts
+++ b/code/addons/interactions/src/preview.ts
@@ -16,7 +16,7 @@ export const { step: runStep } = instrument(
   { intercept: true }
 );
 
-const traverseArgs = (value: unknown, depth = 0, key?: string): any => {
+export const traverseArgs = (value: unknown, depth = 0, key?: string): unknown => {
   // Make sure to not get in infinite loops with self referencing args
   if (depth > 5) return value;
   if (value == null) return value;
@@ -45,9 +45,11 @@ const traverseArgs = (value: unknown, depth = 0, key?: string): any => {
 
   if (typeof value === 'object' && value.constructor === Object) {
     depth++;
-    // We have to mutate the original object for this to survive HMR.
     for (const [k, v] of Object.entries(value)) {
-      (value as Record<string, unknown>)[k] = traverseArgs(v, depth, k);
+      if (Object.getOwnPropertyDescriptor(value, k).writable) {
+        // We have to mutate the original object for this to survive HMR.
+        (value as Record<string, unknown>)[k] = traverseArgs(v, depth, k);
+      }
     }
     return value;
   }


### PR DESCRIPTION
## What I did

There was a bug in the traverseArgs implementation that mutated arg keys even when they are not writable.

![image](https://github.com/storybookjs/storybook/assets/1035299/bded3e8c-795e-44c6-9720-ef186c33f22a)

![image](https://github.com/storybookjs/storybook/assets/1035299/f17675ea-0e11-4c8a-aff6-6fd50e3a12a9)


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
