### PR TITLE
Core: Fix addon bundling script

### DIFF
--- a/scripts/prepare/addon-bundle.ts
+++ b/scripts/prepare/addon-bundle.ts
@@ -120,7 +120,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
         ...(optimized ? dtsConfig : {}),
         entry: exportEntries,
         format: ['cjs'],
-        target: 'chrome100',
+        target: browserOptions.target,
         platform: 'neutral',
         external: [...commonExternals, ...globalManagerPackages, ...globalPreviewPackages],
         esbuildOptions: (options) => {

--- a/scripts/prepare/addon-bundle.ts
+++ b/scripts/prepare/addon-bundle.ts
@@ -120,13 +120,12 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
         ...(optimized ? dtsConfig : {}),
         entry: exportEntries,
         format: ['cjs'],
-        target: 'node18',
-        platform: 'node',
-        external: commonExternals,
+        target: 'chrome100',
+        platform: 'neutral',
+        external: [...commonExternals, ...globalManagerPackages, ...globalPreviewPackages],
         esbuildOptions: (options) => {
           /* eslint-disable no-param-reassign */
-          options.conditions = ['module'];
-          options.platform = 'node';
+          options.platform = 'neutral';
           Object.assign(options, getESBuildOptions(optimized));
           /* eslint-enable no-param-reassign */
         },


### PR DESCRIPTION
Closes: https://github.com/storybookjs/storybook/issues/26126
Closes: https://github.com/Jakob-em/storybook-addon-angular-router/issues/26
Closes: https://github.com/storybookjs/storybook/issues/26030

## What I did

I researched the problem and discovered:
- this is only a problem when using webpack
- our `addons/actions/dist/index.js` (which is an export-type-entry for the addon is compiled in ESM and CJS, however the CJS is compiled for NODE.
- our `addons/actions/dist/index.js` (which is an import-type-entry for the addon is compiled in ESM and CJS, however the CJS is compiling in all preview related packages (package consolidation would fix this).
- The user's config is compiling stories to CJS, which then causes the CJS version of the export-type-entry to be chosen by webpack.

These factors cause code designed to be run in NODE (unbundled), to be bundled again and then ran in a browser.

It seems webpack just can't really work with the output from esbuild when esbuild compiled for NODE, and webpack compiles for the browser. It creates an empty context, which then causes the issue.

## How I fixed it:

I changed the bundling script that bundles our addons, so that it now does:
- always externalizes all the storybook packages, including `preview-api`.
- it compiles for a platform of `neutral`.
- it choses whatever entry it deems best, no longer forcing it to use `module`.

The result is that:
- 7.x repro works with this change applied
- after upgrading the 7.x repro to sb8 beta, and applying this fix, it works
- The dist output of `addons/actions/dist/index.js` has 7800 lines of code removed.

## What is next?

I am pretty confident in this change, however it does change the dynamics with NODE.

I'd like to ask @yannbf 's help to verify if this did not change/break  portable stories or the test-runner in some way.

I'd also like @shilman 's position on how safe they feel this change is.

This change would need to be patched back to 7.x.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I published a canary, so testing this with any sandbox or repro should be easy.

Check if:
- upgrade works, storybook starts
- if all expected addon panels show up
- if addon-a11y functionality works
- if addon-actions functionality

Also check:
- does the test-runner still works.
- does portable stories work as expected

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26145-sha-32b8346f`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26145-sha-32b8346f sandbox` or in an existing project with `npx storybook@0.0.0-pr-26145-sha-32b8346f upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26145-sha-32b8346f`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26145-sha-32b8346f) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/fix-addon-bundling`](https://github.com/storybookjs/storybook/tree/norbert/fix-addon-bundling) |
| **Commit** | [`32b8346f`](https://github.com/storybookjs/storybook/commit/32b8346fc2be9e3b9130ed9999b0450ec1e3e441) |
| **Datetime** | Thu Feb 22 12:30:52 UTC 2024 (`1708605052`) |
| **Workflow run** | [8004494946](https://github.com/storybookjs/storybook/actions/runs/8004494946) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26145`_
</details>
<!-- CANARY_RELEASE_SECTION -->
