### PR TITLE
Extend DocsContainer to accept custom DocsPage.

### DIFF
--- a/code/ui/blocks/src/blocks/DocsContainer.tsx
+++ b/code/ui/blocks/src/blocks/DocsContainer.tsx
@@ -16,11 +16,13 @@ const { document, window: globalWindow } = global;
 export interface DocsContainerProps<TFramework extends Renderer = Renderer> {
   context: DocsContextProps<TFramework>;
   theme?: ThemeVars;
+  DocsPage?: typeof DocsPageWrapper;
 }
 
 export const DocsContainer: FC<PropsWithChildren<DocsContainerProps>> = ({
   context,
   theme,
+  DocsPage = DocsPageWrapper,
   children,
 }) => {
   let toc;
@@ -55,11 +57,11 @@ export const DocsContainer: FC<PropsWithChildren<DocsContainerProps>> = ({
     <DocsContext.Provider value={context}>
       <SourceContainer channel={context.channel}>
         <ThemeProvider theme={ensureTheme(theme)}>
-          <DocsPageWrapper
+          <DocsPage
             toc={toc ? <TableOfContents className="sbdocs sbdocs-toc--custom" {...toc} /> : null}
           >
             {children}
-          </DocsPageWrapper>
+          </DocsPage>
         </ThemeProvider>
       </SourceContainer>
     </DocsContext.Provider>

--- a/docs/snippets/common/storybook-preview-auto-docs-custom-docs-container-with-custom-page.js.mdx
+++ b/docs/snippets/common/storybook-preview-auto-docs-custom-docs-container-with-custom-page.js.mdx
@@ -1,0 +1,37 @@
+```js
+// .storybook/preview.js
+
+import * as React from 'react';
+
+import { DocsContainer } from '@storybook/blocks';
+
+const ExampleContainer = ({ children, ...props }) => {
+  return (
+    <DocsContainer
+      {...props}
+      DocsPage={({ toc, children }) => (
+        <div className="container">
+          <main>{children}</main>
+          <aside>{toc}</aside>
+        </div>
+      )}
+    >
+      {children}
+    </DocsContainer>
+  );
+};
+
+export default {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
+    },
+    docs: {
+      container: ExampleContainer,
+    },
+  },
+};
+```

--- a/docs/snippets/common/storybook-preview-auto-docs-custom-docs-container-with-custom-page.ts.mdx
+++ b/docs/snippets/common/storybook-preview-auto-docs-custom-docs-container-with-custom-page.ts.mdx
@@ -1,0 +1,42 @@
+```ts
+// .storybook/preview.ts
+
+import * as React from 'react';
+
+// Replace your-framework with the framework you are using (e.g., react, vue3)
+import { Preview } from '@storybook/your-framework';
+
+import { DocsContainer } from '@storybook/blocks';
+
+const ExampleContainer = ({ children, ...props }) => {
+  return (
+    <DocsContainer
+      {...props}
+      DocsPage={({ toc, children }) => (
+        <div className="container">
+          <main>{children}</main>
+          <aside>{toc}</aside>
+        </div>
+      )}
+    >
+      {children}
+    </DocsContainer>
+  );
+};
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
+    },
+    docs: {
+      container: ExampleContainer,
+    },
+  },
+};
+
+export default preview;
+```

--- a/docs/writing-docs/autodocs.md
+++ b/docs/writing-docs/autodocs.md
@@ -134,7 +134,7 @@ Storybook's auto-generated documentation pages can be quite long and difficult t
 By default, the table of contents on the documentation page will only show the `h3` headings that are automatically generated. However, if you want to customize the table of contents, you can add more parameters to the `toc` property. The following options and examples of how to use them are available.
 
 | Option                | Description                                                                                                                                                                                                     |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `contentsSelector`    | Defines the container's CSS selector for search for the headings <br/> `toc: { contentsSelector: '.sbdocs-content' }`                                                                                           |
 | `disable`             | Hides the table of contents for the documentation pages <br/> `toc: { disable: true }`                                                                                                                          |
 | `headingSelector`     | Defines the list of headings to feature in the table of contents <br/> `toc: { headingSelector: 'h1, h2, h3' }`                                                                                                 |
@@ -223,6 +223,25 @@ The Docs Container is the component that wraps up the documentation page. It's r
   paths={[
     'common/storybook-preview-auto-docs-custom-docs-container.js.mdx',
     'common/storybook-preview-auto-docs-custom-docs-container.ts.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+#### Custom Docs Page
+
+The Docs Container accepts `DocsPage` render prop, where you can pass a custom component to render your page.
+Your custom page will no longer have the storybook's theme styles.
+Use this prop, when you want to style your docs pages globally with custom css.
+
+Your custom `DocsPage` component will receive `toc` and `children` props, containing the table of contents (if enabled) and page contents respectivelly.
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-preview-auto-docs-custom-docs-container-with-custom-page.js.mdx',
+    'common/storybook-preview-auto-docs-custom-docs-container-with-custom-page.ts.mdx',
   ]}
 />
 


### PR DESCRIPTION
Closes #10054


## What I did

Added `DocsPage` prop to the `DocsContainer` which defaults to the current `DocsPageWrapper`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing



with the following `preview.tsx`:

```tsx
import React from 'react';
import type { Preview } from '@storybook/react';

import {DocsContainer} from "../../../code/ui/blocks/dist"

const ExampleContainer = ({ children, ...props }) => {
  return (
    <DocsContainer
      {...props}
      DocsPage={({ toc, children }) => (
        <div className="container">
          <main>{children}</main>
          <aside>{toc}</aside>
        </div>
      )}
    >
      {children}
    </DocsContainer>
  );
};


const preview: Preview = {
  parameters: {
    controls: {
      matchers: {
        color: /(background|color)$/i,
        date: /Date$/i,
      },
    },
    docs: {
      container: ExampleContainer
    }
  },
};

export default preview;
```

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
3. Open Storybook in your browser
4. Access docs page `Configure your project`
5. see the markup changed
6. see that page is not using the default styles

You should see:
<img width="1712" alt="Screenshot 2024-02-23 141829" src="https://github.com/storybookjs/storybook/assets/38855190/eae67db5-c82b-4871-b65f-c5c278cb0ebc">


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
