### PR TITLE
Docs: Fix heading levels of `useOf` API reference

### DIFF
--- a/docs/api/doc-block-useof.md
+++ b/docs/api/doc-block-useof.md
@@ -56,18 +56,20 @@ import * as ButtonStories from './Button.stories';
 
 ## useOf
 
-## Signature
+### Type
 
+<!-- prettier-ignore-start -->
 ```ts
-useOf = (
+(
   moduleExportOrType: ModuleExport | 'story' | 'meta' | 'component',
   validTypes?: Array<'story' | 'meta' | 'component'>
-): EnhancedResolvedModuleExportType
+) => EnhancedResolvedModuleExportType
 ```
+<!-- prettier-ignore-end -->
 
-## Parameters
+### Parameters
 
-### `moduleExportOrType`
+#### `moduleExportOrType`
 
 (**Required**)
 
@@ -81,29 +83,29 @@ When the custom block is in an [attached doc](./doc-block-meta.md#attached-vs-un
 - `useOf('meta')` returns the annotated meta in attached mode; error in unattached mode
 - `useOf('component')` returns the annotated component specified in the meta in attached mode; error in unattached mode
 
-### `validTypes`
+#### `validTypes`
 
 Type: `Array<'story' | 'meta' | 'component'>`
 
 Optionally specify an array of valid types that your block accepts. Passing anything other than the valid type(s) will result in an error. For example, the [`Canvas`](./doc-block-canvas.md) block uses `useOf(of, ['story'])`, which ensures it only accepts a reference to a story, not a meta or component.
 
-## Return
+### Return
 
 The return value depends on the matched type:
 
-### `EnhancedResolvedModuleExportType['type'] === 'story'`
+#### `EnhancedResolvedModuleExportType['type'] === 'story'`
 
 Type: `{ type: 'story', story: PreparedStory }`
 
 For stories, annotated stories are returned as is. They are prepared, meaning that they are already merged with project and meta annotations.
 
-### `EnhancedResolvedModuleExportType['type'] === 'meta'`
+#### `EnhancedResolvedModuleExportType['type'] === 'meta'`
 
 Type: `{ type: 'meta', csfFile: CSFFile, preparedMeta: PreparedMeta }`
 
 For meta, the parsed CSF file is returned, along with prepared annotated meta. That is, project annotations merged with meta annotations, but no story annotations.
 
-### `EnhancedResolvedModuleExportType['type'] === 'component'`
+#### `EnhancedResolvedModuleExportType['type'] === 'component'`
 
 Type: `{ type: 'component', component: Component, projectAnnotations: NormalizedProjectAnnotations }`
 


### PR DESCRIPTION
## What I did

See title

## Checklist for Contributors

### Testing

#### Manual testing

1. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `api-ref-use-of-fix-headings`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
