### PR TITLE
UI: Improve sidebar performance when switching stories

### DIFF
--- a/code/ui/manager/src/components/layout/LayoutProvider.tsx
+++ b/code/ui/manager/src/components/layout/LayoutProvider.tsx
@@ -1,5 +1,5 @@
 import type { FC, PropsWithChildren } from 'react';
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useMemo, useState } from 'react';
 import { useMediaQuery } from '../hooks/useMedia';
 import { BREAKPOINT } from '../../constants';
 
@@ -32,22 +32,29 @@ export const LayoutProvider: FC<PropsWithChildren> = ({ children }) => {
   const isDesktop = useMediaQuery(`(min-width: ${BREAKPOINT}px)`);
   const isMobile = !isDesktop;
 
-  return (
-    <LayoutContext.Provider
-      value={{
-        isMobileMenuOpen,
-        setMobileMenuOpen,
-        isMobileAboutOpen,
-        setMobileAboutOpen,
-        isMobilePanelOpen,
-        setMobilePanelOpen,
-        isDesktop,
-        isMobile,
-      }}
-    >
-      {children}
-    </LayoutContext.Provider>
+  const contextValue = useMemo(
+    () => ({
+      isMobileMenuOpen,
+      setMobileMenuOpen,
+      isMobileAboutOpen,
+      setMobileAboutOpen,
+      isMobilePanelOpen,
+      setMobilePanelOpen,
+      isDesktop,
+      isMobile,
+    }),
+    [
+      isMobileMenuOpen,
+      setMobileMenuOpen,
+      isMobileAboutOpen,
+      setMobileAboutOpen,
+      isMobilePanelOpen,
+      setMobilePanelOpen,
+      isDesktop,
+      isMobile,
+    ]
   );
+  return <LayoutContext.Provider value={contextValue}>{children}</LayoutContext.Provider>;
 };
 
 export const useLayout = () => useContext(LayoutContext);

--- a/code/ui/manager/src/components/sidebar/Search.tsx
+++ b/code/ui/manager/src/components/sidebar/Search.tsx
@@ -176,8 +176,8 @@ export const Search = React.memo<{
     [api, inputRef, showAllComponents, DEFAULT_REF_ID]
   );
 
-  const list: SearchItem[] = useMemo(() => {
-    return dataset.entries.reduce<SearchItem[]>((acc, [refId, { index, status }]) => {
+  const makeFuse = useCallback(() => {
+    const list = dataset.entries.reduce<SearchItem[]>((acc, [refId, { index, status }]) => {
       const groupStatus = getGroupStatus(index || {}, status);
 
       if (index) {
@@ -196,12 +196,12 @@ export const Search = React.memo<{
       }
       return acc;
     }, []);
+    return new Fuse(list, options);
   }, [dataset]);
-
-  const fuse = useMemo(() => new Fuse(list, options), [list]);
 
   const getResults = useCallback(
     (input: string) => {
+      const fuse = makeFuse();
       if (!input) return [];
 
       let results: DownshiftItem[] = [];
@@ -229,7 +229,7 @@ export const Search = React.memo<{
 
       return results;
     },
-    [allComponents, fuse]
+    [allComponents, makeFuse]
   );
 
   const stateReducer = useCallback(

--- a/code/ui/manager/src/components/sidebar/Search.tsx
+++ b/code/ui/manager/src/components/sidebar/Search.tsx
@@ -5,7 +5,7 @@ import Downshift from 'downshift';
 import type { FuseOptions } from 'fuse.js';
 import Fuse from 'fuse.js';
 import { global } from '@storybook/global';
-import React, { useMemo, useRef, useState, useCallback } from 'react';
+import React, { useRef, useState, useCallback } from 'react';
 import { CloseIcon, SearchIcon } from '@storybook/icons';
 import { DEFAULT_REF_ID } from './Sidebar';
 import type {

--- a/code/ui/manager/src/components/sidebar/Tree.tsx
+++ b/code/ui/manager/src/components/sidebar/Tree.tsx
@@ -481,55 +481,73 @@ export const Tree = React.memo<{
 
   const groupStatus = useMemo(() => getGroupStatus(collapsedData, status), [collapsedData, status]);
 
-  return (
-    <Container ref={containerRef} hasOrphans={isMain && orphanIds.length > 0}>
-      <IconSymbols />
-      {collapsedItems.map((itemId) => {
-        const item = collapsedData[itemId];
-        const id = createId(itemId, refId);
+  const treeItems = useMemo(() => {
+    return collapsedItems.map((itemId) => {
+      const item = collapsedData[itemId];
+      const id = createId(itemId, refId);
 
-        if (item.type === 'root') {
-          const descendants = expandableDescendants[item.id];
-          const isFullyExpanded = descendants.every((d: string) => expanded[d]);
-          return (
-            // @ts-expect-error (TODO)
-            <Root
-              key={id}
-              item={item}
-              refId={refId}
-              isOrphan={false}
-              isDisplayed
-              isSelected={selectedStoryId === itemId}
-              isExpanded={!!expanded[itemId]}
-              setExpanded={setExpanded}
-              isFullyExpanded={isFullyExpanded}
-              expandableDescendants={descendants}
-              onSelectStoryId={onSelectStoryId}
-            />
-          );
-        }
-
-        const isDisplayed = !item.parent || ancestry[itemId].every((a: string) => expanded[a]);
-        const color = groupStatus[itemId] ? statusMapping[groupStatus[itemId]][1] : null;
-
+      if (item.type === 'root') {
+        const descendants = expandableDescendants[item.id];
+        const isFullyExpanded = descendants.every((d: string) => expanded[d]);
         return (
-          <Node
-            api={api}
+          // @ts-expect-error (TODO)
+          <Root
             key={id}
             item={item}
-            status={status?.[itemId]}
             refId={refId}
-            color={color}
-            docsMode={docsMode}
-            isOrphan={orphanIds.some((oid) => itemId === oid || itemId.startsWith(`${oid}-`))}
-            isDisplayed={isDisplayed}
+            isOrphan={false}
+            isDisplayed
             isSelected={selectedStoryId === itemId}
             isExpanded={!!expanded[itemId]}
             setExpanded={setExpanded}
+            isFullyExpanded={isFullyExpanded}
+            expandableDescendants={descendants}
             onSelectStoryId={onSelectStoryId}
           />
         );
-      })}
+      }
+
+      const isDisplayed = !item.parent || ancestry[itemId].every((a: string) => expanded[a]);
+      const color = groupStatus[itemId] ? statusMapping[groupStatus[itemId]][1] : null;
+
+      return (
+        <Node
+          api={api}
+          key={id}
+          item={item}
+          status={status?.[itemId]}
+          refId={refId}
+          color={color}
+          docsMode={docsMode}
+          isOrphan={orphanIds.some((oid) => itemId === oid || itemId.startsWith(`${oid}-`))}
+          isDisplayed={isDisplayed}
+          isSelected={selectedStoryId === itemId}
+          isExpanded={!!expanded[itemId]}
+          setExpanded={setExpanded}
+          onSelectStoryId={onSelectStoryId}
+        />
+      );
+    });
+  }, [
+    ancestry,
+    api,
+    collapsedData,
+    collapsedItems,
+    docsMode,
+    expandableDescendants,
+    expanded,
+    groupStatus,
+    onSelectStoryId,
+    orphanIds,
+    refId,
+    selectedStoryId,
+    setExpanded,
+    status,
+  ]);
+  return (
+    <Container ref={containerRef} hasOrphans={isMain && orphanIds.length > 0}>
+      <IconSymbols />
+      {treeItems}
     </Container>
   );
 });


### PR DESCRIPTION
## What I did

3 changes that add up to a moderate speed-up when switching stories, especially in projects where there are many (several hundred) stories.
1. Fuse and list within the Search component are now only calculated when needed (when the value of the search input changes), not on each render.
2. The value returned by LayoutProvider is now memoized. This has a moderate impact because this hook is used in Node within the sidebar, which may have hundreds of instances. Before this change, useLayout was causing Node to rerender every time, making its React.memo useless.
3. The list of items inside Tree is now memoized. This is helpful because this list is made by mapping over a very large list
 
In sum, I saw a performance improvement of 10-40ms (12-50%) per render when changing stories. The impact will be more or less depending on how many stories you have.

<details><summary>Expand to see performance profiles 📈</summary>
Before:
<img width="1840" alt="storybook-perf-before-best" src="https://github.com/storybookjs/storybook/assets/20398475/8e2c56a8-9574-41de-a140-df25b4ed0801">
After:
<img width="1840" alt="storybook-perf-after-best" src="https://github.com/storybookjs/storybook/assets/20398475/5c1046a5-0fb0-4d0c-8af3-8444a17491eb">

[storybook-perf-profiles.zip](https://github.com/storybookjs/storybook/files/14394438/storybook-perf-profiles.zip) (unzip, then open JSON files with React Dev Tools)
</details> 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

(Unfortunately, I don't know of a good way to test this kind of performance improvements in React. )

#### Manual testing

1. To see the largest contrast in performance, choose any sandbox and create many stories. One way to do this quickly is by making a folder of tests with auto-generated names/titles and copy/paste the folder many times.
2. Open Storybook in your browser with React Dev Tools installed
3. Start a React profile, and switch between stories in the side bar


### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

(N/A)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
