### PR TITLE
Builder Vite: Pass on errors about not having a real stats object in smoke tests

### DIFF
--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -17,11 +17,7 @@ import { join, relative, resolve } from 'path';
 import { deprecate } from '@storybook/node-logger';
 import { dedent } from 'ts-dedent';
 import { readFile } from 'fs-extra';
-import {
-  Category,
-  MissingBuilderError,
-  NoStatsForViteDevError,
-} from '@storybook/core-events/server-errors';
+import { MissingBuilderError, NoStatsForViteDevError } from '@storybook/core-events/server-errors';
 import { storybookDevServer } from './dev-server';
 import { outputStats } from './utils/output-stats';
 import { outputStartupInformation } from './utils/output-startup-information';

--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -17,7 +17,11 @@ import { join, relative, resolve } from 'path';
 import { deprecate } from '@storybook/node-logger';
 import { dedent } from 'ts-dedent';
 import { readFile } from 'fs-extra';
-import { MissingBuilderError } from '@storybook/core-events/server-errors';
+import {
+  Category,
+  MissingBuilderError,
+  NoStatsForViteDevError,
+} from '@storybook/core-events/server-errors';
 import { storybookDevServer } from './dev-server';
 import { outputStats } from './utils/output-stats';
 import { outputStartupInformation } from './utils/output-startup-information';
@@ -192,7 +196,16 @@ export async function buildDevStandalone(
   if (options.smokeTest) {
     const warnings: Error[] = [];
     warnings.push(...(managerStats?.toJson()?.warnings || []));
-    warnings.push(...(previewStats?.toJson()?.warnings || []));
+    try {
+      warnings.push(...(previewStats?.toJson()?.warnings || []));
+    } catch (err) {
+      if (err instanceof NoStatsForViteDevError) {
+        // pass, the Vite builder has no warnings in the stats object anyway, but not stats at all
+        // in dev.
+      } else {
+        throw err;
+      }
+    }
 
     const problems = warnings
       .filter((warning) => !warning.message.includes(`export 'useInsertionEffect'`))

--- a/code/lib/core-server/src/build-dev.ts
+++ b/code/lib/core-server/src/build-dev.ts
@@ -196,8 +196,8 @@ export async function buildDevStandalone(
       warnings.push(...(previewStats?.toJson()?.warnings || []));
     } catch (err) {
       if (err instanceof NoStatsForViteDevError) {
-        // pass, the Vite builder has no warnings in the stats object anyway, but not stats at all
-        // in dev.
+        // pass, the Vite builder has no warnings in the stats object anyway,
+        // but no stats at all in dev mode
       } else {
         throw err;
       }


### PR DESCRIPTION
Closes #

## What I did

Catch errors coming from the Vite builder when we try and access its stats object in Smoke Tests

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [x] integration tests
- [ ] end-to-end tests
