### PR TITLE
Source Block: Fix for explicitly undefined source code

### DIFF
--- a/code/ui/blocks/src/components/Preview.tsx
+++ b/code/ui/blocks/src/components/Preview.tsx
@@ -119,7 +119,7 @@ const getSource = (
   setExpanded: Function
 ): SourceItem => {
   switch (true) {
-    case !!(withSource && withSource.error): {
+    case !!(withSource && (withSource.error || withSource.code === null)): {
       return {
         source: null,
         actionItem: {


### PR DESCRIPTION
Closes #26193

## What I did

Check if `code` property is `null` in the `withSource` object, as there is no need to have an error. Could see that this file is unchanged, so I guess somewhere else in the code the logic changed between v7 and v8

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [X] stories
- [X] unit tests
- [X] integration tests
- [X] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

`yarn task --task sandbox --start-from auto --template react-vite/default-ts`

Then build the `blocks` package, and modify the `Button.stories.ts` file:

```diff
parameters: {
    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
    layout: 'centered',
+    docs: {
+     source: {
+        code: null,
+      },
+    },
  },
```

Then run the sandbox storybook and visit the button's story.

### Documentation

- [X] Add or update documentation reflecting your changes
- [X] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
