### PR TITLE
Revert: "Angular: Reduce the warnings from `ts-loader` via stricter list of `includes`"

### DIFF
--- a/code/lib/cli/templates/angular/application/template-csf/.storybook/tsconfig.json
+++ b/code/lib/cli/templates/angular/application/template-csf/.storybook/tsconfig.json
@@ -6,6 +6,6 @@
     "resolveJsonModule": true
   },
   "exclude": ["../src/test.ts", "../src/**/*.spec.ts"],
-  "include": ["../src/**/*.stories.*", "./preview.ts"],
+  "include": ["../src/**/*", "./preview.ts"],
   "files": ["./typings.d.ts"]
 }

--- a/code/lib/cli/templates/angular/library/template-csf/.storybook/tsconfig.json
+++ b/code/lib/cli/templates/angular/library/template-csf/.storybook/tsconfig.json
@@ -6,6 +6,6 @@
     "resolveJsonModule": true
   },
   "exclude": ["../src/test.ts", "../src/**/*.spec.ts"],
-  "include": ["../src/**/*.stories.*", "./preview.ts"],
+  "include": ["../src/**/*", "./preview.ts"],
   "files": ["./typings.d.ts"]
 }

--- a/code/lib/preview-api/template/stories/component-play.stories.ts
+++ b/code/lib/preview-api/template/stories/component-play.stories.ts
@@ -6,9 +6,7 @@ import { expect } from '@storybook/test';
 export default {
   component: globalThis.Components.Pre,
   play: async ({ canvasElement, name }: PlayFunctionContext) => {
-    await expect(
-      JSON.parse(within(canvasElement as HTMLPreElement).getByTestId('pre').innerText)
-    ).toEqual({
+    await expect(JSON.parse(within(canvasElement).getByTestId('pre').innerText)).toEqual({
       name,
     });
   },

--- a/code/lib/preview-api/template/stories/component-play.stories.ts
+++ b/code/lib/preview-api/template/stories/component-play.stories.ts
@@ -6,7 +6,9 @@ import { expect } from '@storybook/test';
 export default {
   component: globalThis.Components.Pre,
   play: async ({ canvasElement, name }: PlayFunctionContext) => {
-    await expect(JSON.parse(within(canvasElement).getByTestId('pre').innerText)).toEqual({
+    await expect(
+      JSON.parse(within(canvasElement as HTMLPreElement).getByTestId('pre').innerText)
+    ).toEqual({
       name,
     });
   },

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -597,6 +597,8 @@ async function prepareAngularSandbox(cwd: string, templateName: string) {
   tsConfigJson.compilerOptions.noImplicitAny = false;
   tsConfigJson.compilerOptions.strict = false;
 
+  tsConfigJson.include = [...tsConfigJson.include, '../template-stories/**/*.stories.ts'];
+
   if (templateName === 'Angular CLI (Version 15)') {
     tsConfigJson.compilerOptions.paths = {
       '@angular-devkit/*': ['node_modules/@angular-devkit/*'],

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -585,7 +585,7 @@ async function prepareAngularSandbox(cwd: string, templateName: string) {
 
   // Set tsConfig compilerOptions
 
-  const tsConfigPath = join(cwd, 'tsconfig.json');
+  const tsConfigPath = join(cwd, '.storybook', 'tsconfig.json');
   const tsConfigContent = readFileSync(tsConfigPath, { encoding: 'utf-8' });
   // This does not preserve comments, but that shouldn't be an issue for sandboxes
   const tsConfigJson = JSON5.parse(tsConfigContent);
@@ -594,6 +594,8 @@ async function prepareAngularSandbox(cwd: string, templateName: string) {
   tsConfigJson.compilerOptions.noPropertyAccessFromIndexSignature = false;
   tsConfigJson.compilerOptions.jsx = 'react';
   tsConfigJson.compilerOptions.skipLibCheck = true;
+  tsConfigJson.compilerOptions.noImplicitAny = false;
+  tsConfigJson.compilerOptions.strict = false;
 
   if (templateName === 'Angular CLI (Version 15)') {
     tsConfigJson.compilerOptions.paths = {

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -585,7 +585,7 @@ async function prepareAngularSandbox(cwd: string, templateName: string) {
 
   // Set tsConfig compilerOptions
 
-  const tsConfigPath = join(cwd, '.storybook', 'tsconfig.json');
+  const tsConfigPath = join(cwd, 'tsconfig.json');
   const tsConfigContent = readFileSync(tsConfigPath, { encoding: 'utf-8' });
   // This does not preserve comments, but that shouldn't be an issue for sandboxes
   const tsConfigJson = JSON5.parse(tsConfigContent);
@@ -594,14 +594,6 @@ async function prepareAngularSandbox(cwd: string, templateName: string) {
   tsConfigJson.compilerOptions.noPropertyAccessFromIndexSignature = false;
   tsConfigJson.compilerOptions.jsx = 'react';
   tsConfigJson.compilerOptions.skipLibCheck = true;
-  tsConfigJson.compilerOptions.noImplicitAny = false;
-  tsConfigJson.compilerOptions.strict = false;
-  tsConfigJson.include = [
-    ...tsConfigJson.include,
-    '../template-stories/**/*.stories.ts',
-    // This is necessary since template stories depend on globalThis.components, which Typescript can't look up automatically
-    '../src/stories/**/*',
-  ];
 
   if (templateName === 'Angular CLI (Version 15)') {
     tsConfigJson.compilerOptions.paths = {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/26158

### What I did:

Reverting storybookjs/storybook#24531, as it broke compodocs for new projects, except in our sandboxes where we override the default settings.

