### PR TITLE
Core: Export preview symbols for embedding

### DIFF
--- a/code/lib/preview-api/src/index.ts
+++ b/code/lib/preview-api/src/index.ts
@@ -68,4 +68,5 @@ export type { PropDescriptor } from './store';
  * STORIES API
  */
 export { StoryStore } from './store';
-export { Preview, PreviewWithSelection, PreviewWeb } from './preview-web';
+export { Preview, PreviewWeb, PreviewWithSelection, UrlStore, WebView } from './preview-web';
+export type { SelectionStore, View } from './preview-web';


### PR DESCRIPTION
Originally from https://github.com/storybookjs/storybook/pull/25086

Looks like these got lost in a merge conflict with https://github.com/storybookjs/storybook/pull/24658
