### PR TITLE
Automigrations: Create addon-postcss automigration

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/addon-postcss.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/addon-postcss.test.ts
@@ -1,0 +1,42 @@
+import { addonPostCSS } from './addon-postcss';
+import type { StorybookConfig } from '@storybook/types';
+import type { JsPackageManager } from '@storybook/core-common';
+import { expect, describe, it } from 'vitest';
+
+const checkAddonPostCSS = async ({
+  packageManager,
+  mainConfig = {},
+  storybookVersion = '7.0.0',
+}: {
+  packageManager?: Partial<JsPackageManager>;
+  mainConfig?: Partial<StorybookConfig>;
+  storybookVersion?: string;
+}) => {
+  return addonPostCSS.check({
+    packageManager: packageManager as any,
+    storybookVersion,
+    mainConfig: mainConfig as any,
+  });
+};
+
+describe('check function', () => {
+  it('should return { hasAddonPostcss: true } if @storybook/addon-postcss is found', async () => {
+    await expect(
+      checkAddonPostCSS({
+        mainConfig: {
+          addons: ['@storybook/addon-postcss'],
+        },
+      })
+    ).resolves.toEqual({ hasAddonPostcss: true });
+  });
+
+  it('should return null if @storybook/addon-postcss is not found', async () => {
+    await expect(
+      checkAddonPostCSS({
+        mainConfig: {
+          addons: [],
+        },
+      })
+    ).resolves.toBeNull();
+  });
+});

--- a/code/lib/cli/src/automigrate/fixes/addon-postcss.ts
+++ b/code/lib/cli/src/automigrate/fixes/addon-postcss.ts
@@ -1,0 +1,41 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+import type { Fix } from '../types';
+import { getAddonNames } from '../helpers/mainConfigFile';
+
+interface AddonPostcssRunOptions {
+  hasAddonPostcss: boolean;
+}
+
+export const addonPostCSS: Fix<AddonPostcssRunOptions> = {
+  id: 'addon-postcss',
+
+  versionRange: ['<7', '>=7'],
+
+  promptType: 'notification',
+
+  async check({ mainConfig }) {
+    const addons = getAddonNames(mainConfig);
+    const hasAddonPostcss = !!addons.find((addon) => addon.includes('@storybook/addon-postcss'));
+
+    if (!hasAddonPostcss) {
+      return null;
+    }
+
+    return { hasAddonPostcss: true };
+  },
+
+  prompt() {
+    return dedent`
+      ${chalk.bold(
+        'Attention'
+      )}: We've detected that you're using the following package which might be incompatible since Storybook 8:
+
+      - ${chalk.cyan(`@storybook/addon-postcss`)}
+      
+      Please migrate to ${chalk.cyan(
+        `@storybook/addon-styling-webpack`
+      )} once the migration is complete.
+    `;
+  },
+};

--- a/code/lib/cli/src/automigrate/fixes/addon-postcss.ts
+++ b/code/lib/cli/src/automigrate/fixes/addon-postcss.ts
@@ -29,7 +29,7 @@ export const addonPostCSS: Fix<AddonPostcssRunOptions> = {
     return dedent`
       ${chalk.bold(
         'Attention'
-      )}: We've detected that you're using the following package which might be incompatible since Storybook 8:
+      )}: We've detected that you're using the following package which are incompatible with Storybook 8 and beyond:
 
       - ${chalk.cyan(`@storybook/addon-postcss`)}
       

--- a/code/lib/cli/src/automigrate/fixes/addon-postcss.ts
+++ b/code/lib/cli/src/automigrate/fixes/addon-postcss.ts
@@ -35,7 +35,7 @@ export const addonPostCSS: Fix<AddonPostcssRunOptions> = {
       
       Please migrate to ${chalk.cyan(
         `@storybook/addon-styling-webpack`
-      )} once the migration is complete.
+      )} once you're done upgrading.
     `;
   },
 };

--- a/code/lib/cli/src/automigrate/fixes/index.ts
+++ b/code/lib/cli/src/automigrate/fixes/index.ts
@@ -24,6 +24,7 @@ import { removeArgtypesRegex } from './remove-argtypes-regex';
 import { webpack5CompilerSetup } from './webpack5-compiler-setup';
 import { removeJestTestingLibrary } from './remove-jest-testing-library';
 import { mdx1to3 } from './mdx-1-to-3';
+import { addonPostCSS } from './addon-postcss';
 
 export * from '../types';
 
@@ -32,6 +33,7 @@ export const allFixes: Fix[] = [
   cra5,
   webpack5,
   vue3,
+  addonPostCSS,
   viteConfigFile,
   eslintPlugin,
   builderVite,


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/26129

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have added an automigration to detect whether @storybook/addon-postcss is installed. If so, the user should be warned and notified to rather install another addon.

## Checklist for Contributors

### Testing

- Checkout a Storybook 6 project
- Run 

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Checkout a Storybook 6 project
2. Run `storybook upgrade`
3. If it has the `@storybook/addon-postcss` setup as an addon in `.storybook/main.js`, the automigration message should appear.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26228-sha-c671ac97`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26228-sha-c671ac97 sandbox` or in an existing project with `npx storybook@0.0.0-pr-26228-sha-c671ac97 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26228-sha-c671ac97`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26228-sha-c671ac97) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/create-automigration-for-postcss-addon`](https://github.com/storybookjs/storybook/tree/valentin/create-automigration-for-postcss-addon) |
| **Commit** | [`c671ac97`](https://github.com/storybookjs/storybook/commit/c671ac976738a23cf0059d8f42f195f41bb6a5e8) |
| **Datetime** | Wed Feb 28 10:28:42 UTC 2024 (`1709116122`) |
| **Workflow run** | [8078902825](https://github.com/storybookjs/storybook/actions/runs/8078902825) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26228`_
</details>
<!-- CANARY_RELEASE_SECTION -->
