### PR TITLE
ReleaseTooling: Exclude links to contributors' user profiles from changelog

### DIFF
--- a/scripts/release/generate-pr-description.ts
+++ b/scripts/release/generate-pr-description.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import chalk from 'chalk';
 import program from 'commander';
 import { z } from 'zod';
@@ -65,7 +64,6 @@ export const mapToChangelist = ({
 }): string => {
   return changes
     .filter((change) => {
-      // eslint-disable-next-line no-restricted-syntax
       for (const titleToIgnore of CHANGE_TITLES_TO_IGNORE) {
         if (change.title?.match(titleToIgnore)) {
           return false;
@@ -227,7 +225,7 @@ export const generateNonReleaseDescription = (
   - Merge this PR
   - [Follow the run of the publish action](https://github.com/storybookjs/storybook/actions/workflows/publish.yml)`
       // don't mention contributors in the release PR, to avoid spamming them
-      .replaceAll('[@', '[@ ')
+      .replaceAll('@', '')
       .replaceAll('"', '\\"')
       .replaceAll('`', '\\`')
       .replaceAll("'", "\\'")

--- a/scripts/release/utils/get-changes.ts
+++ b/scripts/release/utils/get-changes.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import chalk from 'chalk';
 import semver from 'semver';
 import type { PullRequestInfo } from './get-github-info';
@@ -206,11 +205,11 @@ export const getChangelogText = ({
       return entry.labels?.some((label) => Object.keys(RELEASED_LABELS).includes(label));
     })
     .map((entry) => {
-      const { title, links } = entry;
-      const { pull, commit, user } = links;
+      const { title, user, links } = entry;
+      const { pull, commit } = links;
       return pull
-        ? `- ${title} - ${pull}, thanks ${user}!`
-        : `- ⚠️ _Direct commit_ ${title} - ${commit} by ${user}`;
+        ? `- ${title} - ${pull}, thanks @${user}!`
+        : `- ⚠️ _Direct commit_ ${title} - ${commit} by @${user}`;
     })
     .sort();
   const text = [heading, '', ...formattedEntries].join('\n');

--- a/scripts/release/utils/get-github-info.ts
+++ b/scripts/release/utils/get-github-info.ts
@@ -255,7 +255,7 @@ export async function getPullInfoFromCommit(request: {
       pull: associatedPullRequest
         ? `[#${associatedPullRequest.number}](${associatedPullRequest.url})`
         : null,
-      user: user ? `@${user.login}` : null,
+      user: user ? `[@${user.login}](${user.url})` : null,
     },
   };
 }
@@ -294,7 +294,7 @@ export async function getPullInfoFromPullRequest(request: {
     links: {
       commit: commit ? `[\`${commit.oid}\`](${commit.commitUrl})` : null,
       pull: `[#${request.pull}](https://github.com/${request.repo}/pull/${request.pull})`,
-      user: user ? `@${user.login}` : null,
+      user: user ? `[@${user.login}](${user.url})` : null,
     },
   };
 }

--- a/scripts/release/utils/get-github-info.ts
+++ b/scripts/release/utils/get-github-info.ts
@@ -73,7 +73,7 @@ function makeQuery(repos: ReposWithCommitsAndPRsToFetch) {
                       nodes {
                         name
                       }
-                    }    
+                    }
                     mergeCommit {
                       commitUrl
                       oid
@@ -255,7 +255,7 @@ export async function getPullInfoFromCommit(request: {
       pull: associatedPullRequest
         ? `[#${associatedPullRequest.number}](${associatedPullRequest.url})`
         : null,
-      user: user ? `[@${user.login}](${user.url})` : null,
+      user: user ? `@${user.login}` : null,
     },
   };
 }
@@ -294,7 +294,7 @@ export async function getPullInfoFromPullRequest(request: {
     links: {
       commit: commit ? `[\`${commit.oid}\`](${commit.commitUrl})` : null,
       pull: `[#${request.pull}](https://github.com/${request.repo}/pull/${request.pull})`,
-      user: user ? `[@${user.login}](${user.url})` : null,
+      user: user ? `@${user.login}` : null,
     },
   };
 }


### PR DESCRIPTION
## What I did

This PR removes the explicit links to user profiles in generated changelogs. 

It seems like GitHub releases now recognize GitHub handles in the changelog as contributors, and so we don't have to explicitly link to contributors' profiles anymore. In fact, doing so will cause GitHub to _not_ recognize them properly and exclude them from the `Contributors` section ([example](https://github.com/storybookjs/storybook/releases/tag/v8.0.0-beta.5)). 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
