### PR TITLE
CLI: Fix vite config automigration to resolve from project root

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/vite-config-file.ts
+++ b/code/lib/cli/src/automigrate/fixes/vite-config-file.ts
@@ -16,6 +16,8 @@ export const viteConfigFile = {
 
   versionRange: ['<8.0.0-beta.3', '>=8.0.0-beta.3'],
 
+  promptType: 'notification',
+
   async check({ mainConfig, packageManager, mainConfigPath }) {
     let isViteConfigFileFound = !!(await findUp(
       ['vite.config.js', 'vite.config.mjs', 'vite.config.cjs', 'vite.config.ts'],

--- a/code/lib/cli/src/automigrate/fixes/vite-config-file.ts
+++ b/code/lib/cli/src/automigrate/fixes/vite-config-file.ts
@@ -4,6 +4,7 @@ import findUp from 'find-up';
 import { getFrameworkPackageName } from '../helpers/mainConfigFile';
 import { frameworkToRenderer } from '../../helpers';
 import { frameworkPackages } from '@storybook/core-common';
+import path from 'path';
 
 interface ViteConfigFileRunOptions {
   plugins: string[];
@@ -15,13 +16,11 @@ export const viteConfigFile = {
 
   versionRange: ['<8.0.0-beta.3', '>=8.0.0-beta.3'],
 
-  async check({ mainConfig, packageManager }) {
-    let isViteConfigFileFound = !!(await findUp([
-      'vite.config.js',
-      'vite.config.mjs',
-      'vite.config.cjs',
-      'vite.config.ts',
-    ]));
+  async check({ mainConfig, packageManager, mainConfigPath }) {
+    let isViteConfigFileFound = !!(await findUp(
+      ['vite.config.js', 'vite.config.mjs', 'vite.config.cjs', 'vite.config.ts'],
+      { cwd: mainConfigPath ? path.join(mainConfigPath, '..') : process.cwd() }
+    ));
 
     const rendererToVitePluginMap: Record<string, string> = {
       preact: '@preact/preset-vite',

--- a/code/lib/cli/src/automigrate/types.ts
+++ b/code/lib/cli/src/automigrate/types.ts
@@ -27,9 +27,8 @@ export interface RunOptions<ResultType> {
  */
 export type Prompt = 'auto' | 'manual' | 'notification';
 
-export interface Fix<ResultType = any> {
+type BaseFix<ResultType = any> = {
   id: string;
-  promptType?: Prompt | ((result: ResultType) => Promise<Prompt> | Prompt);
   /**
    * The from/to version range of Storybook that this fix applies to. The strings are semver ranges.
    * The versionRange will only be checked if the automigration is part of an upgrade.
@@ -38,8 +37,23 @@ export interface Fix<ResultType = any> {
   versionRange: [from: string, to: string];
   check: (options: CheckOptions) => Promise<ResultType | null>;
   prompt: (result: ResultType) => string;
-  run?: (options: RunOptions<ResultType>) => Promise<void>;
-}
+};
+
+type PromptType<ResultType = any, T = Prompt> =
+  | T
+  | ((result: ResultType) => Promise<Prompt> | Prompt);
+
+export type Fix<ResultType = any> = (
+  | {
+      promptType?: PromptType<ResultType, 'auto'>;
+      run: (options: RunOptions<ResultType>) => Promise<void>;
+    }
+  | {
+      promptType: PromptType<ResultType, 'manual' | 'notification'>;
+      run?: never;
+    }
+) &
+  BaseFix<ResultType>;
 
 export type FixId = string;
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/26260

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I try to resolve and search for the vite.config.js starting from the project root instead of `cwd` during the `vite-config-file` automigration.

Additionally, the `vite-config-file` automigrations throws an error instead of showing a prompt. This was because the `promptType` wasn't defined and a `run` function was missing. I have improved the types for the `Fix` type.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Checkout https://github.com/mandarini/storybook-upgrade-latest-nx
2. Checkout the README.md for detailed reproduction steps

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26262-sha-bb8590c9`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26262-sha-bb8590c9 sandbox` or in an existing project with `npx storybook@0.0.0-pr-26262-sha-bb8590c9 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26262-sha-bb8590c9`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26262-sha-bb8590c9) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-vite-config-automigration`](https://github.com/storybookjs/storybook/tree/valentin/fix-vite-config-automigration) |
| **Commit** | [`bb8590c9`](https://github.com/storybookjs/storybook/commit/bb8590c9b7d59cfd047be62632eb8e20ca299a9e) |
| **Datetime** | Mon Mar  4 07:30:07 UTC 2024 (`1709537407`) |
| **Workflow run** | [8136961530](https://github.com/storybookjs/storybook/actions/runs/8136961530) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26262`_
</details>
<!-- CANARY_RELEASE_SECTION -->
