### PR TITLE
React: Handle TypeScript path aliases in react-docgen loader

### DIFF
--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -50,10 +50,13 @@
     "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.0",
     "@rollup/pluginutils": "^5.0.2",
     "@storybook/builder-vite": "workspace:*",
+    "@storybook/node-logger": "workspace:*",
     "@storybook/react": "workspace:*",
+    "find-up": "^5.0.0",
     "magic-string": "^0.30.0",
     "react-docgen": "^7.0.0",
-    "resolve": "^1.22.8"
+    "resolve": "^1.22.8",
+    "tsconfig-paths": "^4.2.0"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/code/frameworks/react-vite/src/plugins/react-docgen.test.ts
+++ b/code/frameworks/react-vite/src/plugins/react-docgen.test.ts
@@ -1,0 +1,52 @@
+import { getReactDocgenImporter } from './react-docgen';
+import { describe, it, expect, vi } from 'vitest';
+
+const reactDocgenMock = vi.hoisted(() => {
+  return {
+    makeFsImporter: vi.fn().mockImplementation((fn) => fn),
+  };
+});
+
+const reactDocgenResolverMock = vi.hoisted(() => {
+  return {
+    defaultLookupModule: vi.fn(),
+  };
+});
+
+vi.mock('./docgen-resolver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('path')>();
+  return {
+    ...actual,
+    defaultLookupModule: reactDocgenResolverMock.defaultLookupModule,
+  };
+});
+
+vi.mock('react-docgen', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('path')>();
+  return {
+    ...actual,
+    makeFsImporter: reactDocgenMock.makeFsImporter,
+  };
+});
+
+describe('getReactDocgenImporter function', () => {
+  it('should not map the request if a tsconfig path mapping is not available', () => {
+    const filename = './src/components/Button.tsx';
+    const basedir = '/src';
+    const imported = getReactDocgenImporter(undefined);
+    reactDocgenResolverMock.defaultLookupModule.mockImplementation((filen: string) => filen);
+    const result = (imported as any)(filename, basedir);
+    expect(result).toBe(filename);
+  });
+
+  it('should map the request', () => {
+    const mappedFile = './mapped-file.tsx';
+    const matchPath = vi.fn().mockReturnValue(mappedFile);
+    const filename = './src/components/Button.tsx';
+    const basedir = '/src';
+    const imported = getReactDocgenImporter(matchPath);
+    reactDocgenResolverMock.defaultLookupModule.mockImplementation((filen: string) => filen);
+    const result = (imported as any)(filename, basedir);
+    expect(result).toBe(mappedFile);
+  });
+});

--- a/code/frameworks/react-vite/src/preset.ts
+++ b/code/frameworks/react-vite/src/preset.ts
@@ -43,7 +43,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets 
     // Needs to run before the react plugin, so add to the front
     plugins.unshift(
       // If react-docgen is specified, use it for everything, otherwise only use it for non-typescript files
-      reactDocgen({
+      await reactDocgen({
         include: reactDocgenOption === 'react-docgen' ? /\.(mjs|tsx?|jsx?)$/ : /\.(mjs|jsx?)$/,
       })
     );

--- a/code/presets/react-webpack/package.json
+++ b/code/presets/react-webpack/package.json
@@ -71,11 +71,13 @@
     "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
     "@types/node": "^18.0.0",
     "@types/semver": "^7.3.4",
+    "find-up": "^5.0.0",
     "fs-extra": "^11.1.0",
     "magic-string": "^0.30.5",
     "react-docgen": "^7.0.0",
     "resolve": "^1.22.8",
     "semver": "^7.3.7",
+    "tsconfig-paths": "^4.2.0",
     "webpack": "5"
   },
   "devDependencies": {

--- a/code/presets/react-webpack/src/loaders/react-docgen-loader.test.ts
+++ b/code/presets/react-webpack/src/loaders/react-docgen-loader.test.ts
@@ -1,0 +1,52 @@
+import { getReactDocgenImporter } from './react-docgen-loader';
+import { describe, it, expect, vi } from 'vitest';
+
+const reactDocgenMock = vi.hoisted(() => {
+  return {
+    makeFsImporter: vi.fn().mockImplementation((fn) => fn),
+  };
+});
+
+const reactDocgenResolverMock = vi.hoisted(() => {
+  return {
+    defaultLookupModule: vi.fn(),
+  };
+});
+
+vi.mock('./docgen-resolver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('path')>();
+  return {
+    ...actual,
+    defaultLookupModule: reactDocgenResolverMock.defaultLookupModule,
+  };
+});
+
+vi.mock('react-docgen', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('path')>();
+  return {
+    ...actual,
+    makeFsImporter: reactDocgenMock.makeFsImporter,
+  };
+});
+
+describe('getReactDocgenImporter function', () => {
+  it('should not map the request if a tsconfig path mapping is not available', () => {
+    const filename = './src/components/Button.tsx';
+    const basedir = '/src';
+    const imported = getReactDocgenImporter(undefined);
+    reactDocgenResolverMock.defaultLookupModule.mockImplementation((filen: string) => filen);
+    const result = (imported as any)(filename, basedir);
+    expect(result).toBe(filename);
+  });
+
+  it('should map the request', () => {
+    const mappedFile = './mapped-file.tsx';
+    const matchPath = vi.fn().mockReturnValue(mappedFile);
+    const filename = './src/components/Button.tsx';
+    const basedir = '/src';
+    const imported = getReactDocgenImporter(matchPath);
+    reactDocgenResolverMock.defaultLookupModule.mockImplementation((filen: string) => filen);
+    const result = (imported as any)(filename, basedir);
+    expect(result).toBe(mappedFile);
+  });
+});

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6340,11 +6340,13 @@ __metadata:
     "@storybook/react-docgen-typescript-plugin": "npm:1.0.6--canary.9.0c3f3b7.0"
     "@types/node": "npm:^18.0.0"
     "@types/semver": "npm:^7.3.4"
+    find-up: "npm:^5.0.0"
     fs-extra: "npm:^11.1.0"
     magic-string: "npm:^0.30.5"
     react-docgen: "npm:^7.0.0"
     resolve: "npm:^1.22.8"
     semver: "npm:^7.3.7"
+    tsconfig-paths: "npm:^4.2.0"
     typescript: "npm:^5.3.2"
     webpack: "npm:5"
   peerDependencies:
@@ -6488,11 +6490,14 @@ __metadata:
     "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.3.0"
     "@rollup/pluginutils": "npm:^5.0.2"
     "@storybook/builder-vite": "workspace:*"
+    "@storybook/node-logger": "workspace:*"
     "@storybook/react": "workspace:*"
     "@types/node": "npm:^18.0.0"
+    find-up: "npm:^5.0.0"
     magic-string: "npm:^0.30.0"
     react-docgen: "npm:^7.0.0"
     resolve: "npm:^1.22.8"
+    tsconfig-paths: "npm:^4.2.0"
     typescript: "npm:^5.3.2"
     vite: "npm:^4.0.0"
   peerDependencies:
@@ -28381,7 +28386,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:^4.0.0, tsconfig-paths@npm:^4.1.2":
+"tsconfig-paths@npm:^4.0.0, tsconfig-paths@npm:^4.1.2, tsconfig-paths@npm:^4.2.0":
   version: 4.2.0
   resolution: "tsconfig-paths@npm:4.2.0"
   dependencies:


### PR DESCRIPTION
Relates https://github.com/storybookjs/storybook/issues/25059
Relates https://github.com/reactjs/react-docgen/issues/456

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I added tsconfig path handling in both, the Webpack5 react-docgen loader and in the Vite react-docgen plugin.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

**Vite**

1. Create a react-ts-vite sandbox
2. Add the following to the sandbox's tsconfig file:

```json
{
  "compilerOptions": {
    ...
    "baseUrl": ".",
    "paths": {
      "~/*": ["./src/stories/*"]
    }
  }
}
```

3. Setup the `vite-tsconfig-paths` plugin
4. Create the following files in `src/stories`:

```tsx
// Button2.tsx
import React from 'react';

import { ButtomType, ButtonProps } from '~/Button2.types';

/**
 * Primary UI component for user interaction
 */
export const Button = ({
  size = 'medium',
  label,
  type = ButtomType.Button,
  ...props
}: ButtonProps) => {
  return (
    <button
      type={type}
      className={['storybook-button', `storybook-button--${size}`].join(' ')}
      {...props}
    >
      {label}
    </button>
  );
};
```

```tsx
// Button2.stories.ts
import type { Meta, StoryObj } from '@storybook/react';

import { Button } from '~/Button2';

// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
const meta = {
  component: Button,
  parameters: {
    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
    layout: 'centered',
  },
  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
  tags: ['autodocs'],
} satisfies Meta<typeof Button>;

export default meta;
type Story = StoryObj<typeof meta>;

// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
export const Primary: Story = {
  args: {
    label: 'Button',
  },
};
```

```tsx
// Button2.types.tsx
export enum ButtomType {
  Submit = 'submit',
  Reset = 'reset',
  Button = 'button',
}

export interface ButtonProps {
  /**
   * How large should the button be?
   */
  size?: 'small' | 'medium' | 'large';
  /**
   * Button contents
   */
  label: string;
  /**
   * Optional click handler
   */
  onClick?: () => void;
  /**
   * Optional button type
   */
  type?: ButtomType;
}
```

5. Make sure, that react-docgen can extract the types! E.g. JSDOC comments are available and all Button properties are shown in the Controls panel

**Webpack**

- 1. Setup a react-ts-webpack sandbox
- 2. Follow https://storybook.js.org/docs/builders/webpack#typescript-modules-are-not-resolved-within-storybook to setup the path aliases loader
- 3. Copy the tsconfig from the vite sandbox into the react sandbox (delete the `reference` part)
- 4. Create the same files, which were created in the testing instructions for Vite
- 5. Make sure, that react-docgen can extract the types! E.g. JSDOC comments are available and all Button properties are shown in the Controls panel


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
