### PR TITLE
chore: remove assert dependencies

### DIFF
--- a/code/lib/docs-tools/package.json
+++ b/code/lib/docs-tools/package.json
@@ -48,7 +48,6 @@
     "@storybook/preview-api": "workspace:*",
     "@storybook/types": "workspace:*",
     "@types/doctrine": "^0.0.3",
-    "assert": "^2.1.0",
     "doctrine": "^3.0.0",
     "lodash": "^4.17.21"
   },

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5938,7 +5938,6 @@ __metadata:
     "@storybook/preview-api": "workspace:*"
     "@storybook/types": "workspace:*"
     "@types/doctrine": "npm:^0.0.3"
-    assert: "npm:^2.1.0"
     babel-plugin-react-docgen: "npm:4.2.1"
     doctrine: "npm:^3.0.0"
     lodash: "npm:^4.17.21"
@@ -10082,7 +10081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assert@npm:^2.0.0, assert@npm:^2.1.0":
+"assert@npm:^2.0.0":
   version: 2.1.0
   resolution: "assert@npm:2.1.0"
   dependencies:


### PR DESCRIPTION
This removes the `assert` dependency from docs-tools since it seems it is no longer used.

If for some reason we do actually need it, i suggest we at least replace it with a smaller alternative as `assert` is a known-to-be-bloated dependency