### PR TITLE
CLI: Add @storybook/addons automigration

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/addon-postcss.ts
+++ b/code/lib/cli/src/automigrate/fixes/addon-postcss.ts
@@ -29,7 +29,7 @@ export const addonPostCSS: Fix<AddonPostcssRunOptions> = {
     return dedent`
       ${chalk.bold(
         'Attention'
-      )}: We've detected that you're using the following package which are incompatible with Storybook 8 and beyond:
+      )}: We've detected that you're using the following package which is incompatible with Storybook 8 and beyond:
 
       - ${chalk.cyan(`@storybook/addon-postcss`)}
       

--- a/code/lib/cli/src/automigrate/fixes/addons-api.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/addons-api.test.ts
@@ -1,0 +1,44 @@
+import { addonsAPI } from './addons-api';
+import type { StorybookConfig } from '@storybook/types';
+import type { JsPackageManager } from '@storybook/core-common';
+import { expect, describe, it } from 'vitest';
+
+const checkAddonsAPI = async ({
+  packageManager,
+  mainConfig = {},
+  storybookVersion = '7.0.0',
+}: {
+  packageManager?: Partial<JsPackageManager>;
+  mainConfig?: Partial<StorybookConfig>;
+  storybookVersion?: string;
+}) => {
+  return addonsAPI.check({
+    packageManager: packageManager as any,
+    storybookVersion,
+    mainConfig: mainConfig as any,
+  });
+};
+
+describe('check function', () => {
+  it('should return { usesAddonsAPI: true } if @storybook/addons is installed', async () => {
+    await expect(
+      checkAddonsAPI({
+        packageManager: {
+          getAllDependencies: async () => ({
+            '@storybook/addons': '6.0.0',
+          }),
+        },
+      })
+    ).resolves.toEqual({ usesAddonsAPI: true });
+  });
+
+  it('should return null if @storybook/addons is not installed', async () => {
+    await expect(
+      checkAddonsAPI({
+        packageManager: {
+          getAllDependencies: async () => ({}),
+        },
+      })
+    ).resolves.toBeNull();
+  });
+});

--- a/code/lib/cli/src/automigrate/fixes/addons-api.ts
+++ b/code/lib/cli/src/automigrate/fixes/addons-api.ts
@@ -1,0 +1,45 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+import type { Fix } from '../types';
+
+interface AddonsAPIRunOptions {
+  usesAddonsAPI: boolean;
+}
+
+export const addonsAPI: Fix<AddonsAPIRunOptions> = {
+  id: 'addons-api',
+
+  versionRange: ['<8', '>=8'],
+
+  promptType: 'notification',
+
+  async check({ packageManager }) {
+    const allDependencies = await packageManager.getAllDependencies();
+    const usesAddonsAPI = !!allDependencies['@storybook/addons'];
+
+    if (!usesAddonsAPI) {
+      return null;
+    }
+
+    return { usesAddonsAPI: true };
+  },
+
+  prompt() {
+    return dedent`
+      ${chalk.bold(
+        'Attention'
+      )}: We've detected that you're using the following package which is removed in Storybook 8 and beyond:
+
+      - ${chalk.cyan(`@storybook/addons`)}
+      
+      This package has been deprecated and replaced with ${chalk.cyan(
+        `@storybook/preview-api`
+      )} and ${chalk.cyan(`@storybook/manager-api`)}.
+
+      You can find more information about the new addons API in the migration guide:
+      ${chalk.yellow(
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#new-addons-api'
+      )}
+    `;
+  },
+};

--- a/code/lib/cli/src/automigrate/fixes/index.ts
+++ b/code/lib/cli/src/automigrate/fixes/index.ts
@@ -23,12 +23,14 @@ import { storyshotsMigration } from './storyshots-migration';
 import { removeArgtypesRegex } from './remove-argtypes-regex';
 import { webpack5CompilerSetup } from './webpack5-compiler-setup';
 import { removeJestTestingLibrary } from './remove-jest-testing-library';
+import { addonsAPI } from './addons-api';
 import { mdx1to3 } from './mdx-1-to-3';
 import { addonPostCSS } from './addon-postcss';
 
 export * from '../types';
 
 export const allFixes: Fix[] = [
+  addonsAPI,
   newFrameworks,
   cra5,
   webpack5,


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/26252

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I've added an automigration to detect `@storybook/addons` and notify the user that the package was removed in Storybook 8.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Upgrade any storybook that themes the manager UI. Examples:
- Storyblok
- Mealdrop

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
