### PR TITLE
CLI: Improve `add` command & add tests

### DIFF
--- a/code/lib/cli/src/add.test.ts
+++ b/code/lib/cli/src/add.test.ts
@@ -19,7 +19,6 @@ const MockedPostInstall = vi.hoisted(() => {
     postinstallAddon: vi.fn(),
   };
 });
-
 const MockedConsole = {
   log: vi.fn(),
   warn: vi.fn(),
@@ -35,7 +34,6 @@ vi.mock('@storybook/csf-tools', () => {
 vi.mock('./postinstallAddon', () => {
   return MockedPostInstall;
 });
-
 vi.mock('@storybook/core-common', () => {
   return {
     getStorybookInfo: vi.fn(() => ({ mainConfig: {}, configDir: '' })),

--- a/code/lib/cli/src/add.test.ts
+++ b/code/lib/cli/src/add.test.ts
@@ -43,7 +43,7 @@ vi.mock('@storybook/core-common', () => {
     },
     getCoercedStorybookVersion: vi.fn(() => '8.0.0'),
     versions: {
-      'storybook/addon-docs': '^8.0.0',
+      '@storybook/addon-docs': '^8.0.0',
     },
   };
 });
@@ -79,12 +79,12 @@ describe('add', () => {
     { input: '@org/aa@4.1.0-alpha.1', expected: '@org/aa@^4.1.0-alpha.1' },
     { input: '@org/aa@next', expected: '@org/aa@next' },
 
-    { input: 'storybook/addon-docs@~4', expected: 'storybook/addon-docs@~4' },
-    { input: 'storybook/addon-docs@next', expected: 'storybook/addon-docs@next' },
-    { input: 'storybook/addon-docs', expected: 'storybook/addon-docs@^8.0.0' }, // takes it from the versions file
+    { input: '@storybook/addon-docs@~4', expected: '@storybook/addon-docs@~4' },
+    { input: '@storybook/addon-docs@next', expected: '@storybook/addon-docs@next' },
+    { input: '@storybook/addon-docs', expected: '@storybook/addon-docs@^8.0.0' }, // takes it from the versions file
   ];
 
-  test.each(testData)('$full', async ({ input, expected }) => {
+  test.each(testData)('$input', async ({ input, expected }) => {
     const [packageName] = getVersionSpecifier(input);
 
     await add(input, { packageManager: 'npm', skipPostinstall: true }, MockedConsole);
@@ -104,7 +104,18 @@ describe('add', () => {
 describe('add (extra)', () => {
   test('not warning when installing the correct version of storybook', async () => {
     await add(
-      'storybook/addon-docs',
+      '@storybook/addon-docs',
+      { packageManager: 'npm', skipPostinstall: true },
+      MockedConsole
+    );
+
+    expect(MockedConsole.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining(`is not the same as the version of Storybook you are using.`)
+    );
+  });
+  test('not warning when installing unrelated package', async () => {
+    await add(
+      '@storybook/addon-docs',
       { packageManager: 'npm', skipPostinstall: true },
       MockedConsole
     );
@@ -115,26 +126,26 @@ describe('add (extra)', () => {
   });
   test('warning when installing a core addon mismatching version of storybook', async () => {
     await add(
-      'storybook/addon-docs@2.0.0',
+      '@storybook/addon-docs@2.0.0',
       { packageManager: 'npm', skipPostinstall: true },
       MockedConsole
     );
 
     expect(MockedConsole.warn).toHaveBeenCalledWith(
       expect.stringContaining(
-        `The version of storybook/addon-docs you are installing is not the same as the version of Storybook you are using. This may lead to unexpected behavior.`
+        `The version of @storybook/addon-docs you are installing is not the same as the version of Storybook you are using. This may lead to unexpected behavior.`
       )
     );
   });
 
   test('postInstall', async () => {
     await add(
-      'storybook/addon-docs',
+      '@storybook/addon-docs',
       { packageManager: 'npm', skipPostinstall: false },
       MockedConsole
     );
 
-    expect(MockedPostInstall.postinstallAddon).toHaveBeenCalledWith('storybook/addon-docs', {
+    expect(MockedPostInstall.postinstallAddon).toHaveBeenCalledWith('@storybook/addon-docs', {
       packageManager: 'npm',
     });
   });

--- a/code/lib/cli/src/add.test.ts
+++ b/code/lib/cli/src/add.test.ts
@@ -67,33 +67,33 @@ describe('getVersionSpecifier', (it) => {
 
 describe('add', () => {
   const testData = [
-    { full: 'aa', expected: 'aa@^1.0.0' }, // resolves to the latest version
-    { full: 'aa@4', expected: 'aa@^4' },
-    { full: 'aa@4.1.0', expected: 'aa@^4.1.0' },
-    { full: 'aa@^4', expected: 'aa@^4' },
-    { full: 'aa@~4', expected: 'aa@~4' },
-    { full: 'aa@4.1.0-alpha.1', expected: 'aa@^4.1.0-alpha.1' },
-    { full: 'aa@next', expected: 'aa@next' },
+    { input: 'aa', expected: 'aa@^1.0.0' }, // resolves to the latest version
+    { input: 'aa@4', expected: 'aa@^4' },
+    { input: 'aa@4.1.0', expected: 'aa@^4.1.0' },
+    { input: 'aa@^4', expected: 'aa@^4' },
+    { input: 'aa@~4', expected: 'aa@~4' },
+    { input: 'aa@4.1.0-alpha.1', expected: 'aa@^4.1.0-alpha.1' },
+    { input: 'aa@next', expected: 'aa@next' },
 
-    { full: '@org/aa', expected: '@org/aa@^1.0.0' },
-    { full: '@org/aa@4', expected: '@org/aa@^4' },
-    { full: '@org/aa@4.1.0', expected: '@org/aa@^4.1.0' },
-    { full: '@org/aa@4.1.0-alpha.1', expected: '@org/aa@^4.1.0-alpha.1' },
-    { full: '@org/aa@next', expected: '@org/aa@next' },
+    { input: '@org/aa', expected: '@org/aa@^1.0.0' },
+    { input: '@org/aa@4', expected: '@org/aa@^4' },
+    { input: '@org/aa@4.1.0', expected: '@org/aa@^4.1.0' },
+    { input: '@org/aa@4.1.0-alpha.1', expected: '@org/aa@^4.1.0-alpha.1' },
+    { input: '@org/aa@next', expected: '@org/aa@next' },
 
-    { full: 'storybook/addon-docs@~4', expected: 'storybook/addon-docs@~4' },
-    { full: 'storybook/addon-docs@next', expected: 'storybook/addon-docs@next' },
-    { full: 'storybook/addon-docs', expected: 'storybook/addon-docs@^8.0.0' }, // takes it from the versions file
+    { input: 'storybook/addon-docs@~4', expected: 'storybook/addon-docs@~4' },
+    { input: 'storybook/addon-docs@next', expected: 'storybook/addon-docs@next' },
+    { input: 'storybook/addon-docs', expected: 'storybook/addon-docs@^8.0.0' }, // takes it from the versions file
   ];
 
-  test.each(testData)('$full', async ({ full, expected }) => {
-    const [input] = getVersionSpecifier(full);
+  test.each(testData)('$full', async ({ input, expected }) => {
+    const [packageName] = getVersionSpecifier(input);
 
-    await add(full, { packageManager: 'npm', skipPostinstall: true }, MockedConsole);
+    await add(input, { packageManager: 'npm', skipPostinstall: true }, MockedConsole);
 
     expect(MockedConfig.appendValueToArray).toHaveBeenCalledWith(
       expect.arrayContaining(['addons']),
-      input
+      packageName
     );
 
     expect(MockedPackageManager.addDependencies).toHaveBeenCalledWith(

--- a/code/lib/cli/src/add.test.ts
+++ b/code/lib/cli/src/add.test.ts
@@ -43,8 +43,9 @@ vi.mock('@storybook/core-common', () => {
     JsPackageManagerFactory: {
       getPackageManager: vi.fn(() => MockedPackageManager),
     },
+    getCoercedStorybookVersion: vi.fn(() => '8.0.0'),
     versions: {
-      '@storybook/addon-onboarding': '8.0.0',
+      'storybook/addon-docs': '^8.0.0',
     },
   };
 });
@@ -80,9 +81,9 @@ describe('add', () => {
     { full: '@org/aa@4.1.0-alpha.1', expected: '@org/aa@^4.1.0-alpha.1' },
     { full: '@org/aa@next', expected: '@org/aa@next' },
 
-    { full: '@storybook/addon-onboarding@~4', expected: '@storybook/addon-onboarding@~4' },
-    { full: '@storybook/addon-onboarding@next', expected: '@storybook/addon-onboarding@next' },
-    { full: '@storybook/addon-onboarding', expected: '@storybook/addon-onboarding@^8.0.0' }, // takes it from the versions file
+    { full: 'storybook/addon-docs@~4', expected: 'storybook/addon-docs@~4' },
+    { full: 'storybook/addon-docs@next', expected: 'storybook/addon-docs@next' },
+    { full: 'storybook/addon-docs', expected: 'storybook/addon-docs@^8.0.0' }, // takes it from the versions file
   ];
 
   test.each(testData)('$full', async ({ full, expected }) => {
@@ -105,35 +106,37 @@ describe('add', () => {
 describe('add (extra)', () => {
   test('not warning when installing the correct version of storybook', async () => {
     await add(
-      '@storybook/addon-onboarding',
+      'storybook/addon-docs',
       { packageManager: 'npm', skipPostinstall: true },
       MockedConsole
     );
 
     expect(MockedConsole.warn).not.toHaveBeenCalledWith(
-      `The version of @storybook/addon-onboarding you are installing is not the same as the version of Storybook you are using. This may lead to unexpected behavior.`
+      expect.stringContaining(`is not the same as the version of Storybook you are using.`)
     );
   });
-  test('warning when installing a specific version of storybook', async () => {
+  test('warning when installing a core addon mismatching version of storybook', async () => {
     await add(
-      '@storybook/addon-onboarding@2.0.0',
+      'storybook/addon-docs@2.0.0',
       { packageManager: 'npm', skipPostinstall: true },
       MockedConsole
     );
 
     expect(MockedConsole.warn).toHaveBeenCalledWith(
-      `The version of @storybook/addon-onboarding you are installing is not the same as the version of Storybook you are using. This may lead to unexpected behavior.`
+      expect.stringContaining(
+        `The version of storybook/addon-docs you are installing is not the same as the version of Storybook you are using. This may lead to unexpected behavior.`
+      )
     );
   });
 
   test('postInstall', async () => {
     await add(
-      '@storybook/addon-onboarding',
+      'storybook/addon-docs',
       { packageManager: 'npm', skipPostinstall: false },
       MockedConsole
     );
 
-    expect(MockedPostInstall.postinstallAddon).toHaveBeenCalledWith('@storybook/addon-onboarding', {
+    expect(MockedPostInstall.postinstallAddon).toHaveBeenCalledWith('storybook/addon-docs', {
       packageManager: 'npm',
     });
   });

--- a/code/lib/cli/src/add.test.ts
+++ b/code/lib/cli/src/add.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test, vi } from 'vitest';
+import { add, getVersionSpecifier } from './add';
+
+const MockedConfig = vi.hoisted(() => {
+  return {
+    appendValueToArray: vi.fn(),
+  };
+});
+const MockedPackageManager = vi.hoisted(() => {
+  return {
+    retrievePackageJson: vi.fn(() => ({})),
+    latestVersion: vi.fn(() => '1.0.0'),
+    addDependencies: vi.fn(() => {}),
+    type: 'npm',
+  };
+});
+const MockedPostInstall = vi.hoisted(() => {
+  return {
+    postinstallAddon: vi.fn(),
+  };
+});
+
+const MockedConsole = {
+  log: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as any as Console;
+
+vi.mock('@storybook/csf-tools', () => {
+  return {
+    readConfig: vi.fn(() => MockedConfig),
+    writeConfig: vi.fn(),
+  };
+});
+vi.mock('./postinstallAddon', () => {
+  return MockedPostInstall;
+});
+
+vi.mock('@storybook/core-common', () => {
+  return {
+    getStorybookInfo: vi.fn(() => ({ mainConfig: {}, configDir: '' })),
+    serverRequire: vi.fn(() => ({})),
+    JsPackageManagerFactory: {
+      getPackageManager: vi.fn(() => MockedPackageManager),
+    },
+    versions: {
+      '@storybook/addon-onboarding': '8.0.0',
+    },
+  };
+});
+
+describe('getVersionSpecifier', (it) => {
+  test.each([
+    ['@storybook/addon-docs', ['@storybook/addon-docs', undefined]],
+    ['@storybook/addon-docs@7.0.1', ['@storybook/addon-docs', '7.0.1']],
+    ['@storybook/addon-docs@7.0.1-beta.1', ['@storybook/addon-docs', '7.0.1-beta.1']],
+    ['@storybook/addon-docs@~7.0.1-beta.1', ['@storybook/addon-docs', '~7.0.1-beta.1']],
+    ['@storybook/addon-docs@^7.0.1-beta.1', ['@storybook/addon-docs', '^7.0.1-beta.1']],
+    ['@storybook/addon-docs@next', ['@storybook/addon-docs', 'next']],
+  ])('%s => %s', (input, expected) => {
+    const result = getVersionSpecifier(input);
+    expect(result[0]).toEqual(expected[0]);
+    expect(result[1]).toEqual(expected[1]);
+  });
+});
+
+describe('add', () => {
+  const testData = [
+    { full: 'aa', expected: 'aa@^1.0.0' }, // resolves to the latest version
+    { full: 'aa@4', expected: 'aa@^4' },
+    { full: 'aa@4.1.0', expected: 'aa@^4.1.0' },
+    { full: 'aa@^4', expected: 'aa@^4' },
+    { full: 'aa@~4', expected: 'aa@~4' },
+    { full: 'aa@4.1.0-alpha.1', expected: 'aa@^4.1.0-alpha.1' },
+    { full: 'aa@next', expected: 'aa@next' },
+
+    { full: '@org/aa', expected: '@org/aa@^1.0.0' },
+    { full: '@org/aa@4', expected: '@org/aa@^4' },
+    { full: '@org/aa@4.1.0', expected: '@org/aa@^4.1.0' },
+    { full: '@org/aa@4.1.0-alpha.1', expected: '@org/aa@^4.1.0-alpha.1' },
+    { full: '@org/aa@next', expected: '@org/aa@next' },
+
+    { full: '@storybook/addon-onboarding@~4', expected: '@storybook/addon-onboarding@~4' },
+    { full: '@storybook/addon-onboarding@next', expected: '@storybook/addon-onboarding@next' },
+    { full: '@storybook/addon-onboarding', expected: '@storybook/addon-onboarding@^8.0.0' }, // takes it from the versions file
+  ];
+
+  test.each(testData)('$full', async ({ full, expected }) => {
+    const [input] = getVersionSpecifier(full);
+
+    await add(full, { packageManager: 'npm', skipPostinstall: true }, MockedConsole);
+
+    expect(MockedConfig.appendValueToArray).toHaveBeenCalledWith(
+      expect.arrayContaining(['addons']),
+      input
+    );
+
+    expect(MockedPackageManager.addDependencies).toHaveBeenCalledWith(
+      { installAsDevDependencies: true },
+      [expected]
+    );
+  });
+});
+
+describe('add (extra)', () => {
+  test('not warning when installing the correct version of storybook', async () => {
+    await add(
+      '@storybook/addon-onboarding',
+      { packageManager: 'npm', skipPostinstall: true },
+      MockedConsole
+    );
+
+    expect(MockedConsole.warn).not.toHaveBeenCalledWith(
+      `The version of @storybook/addon-onboarding you are installing is not the same as the version of Storybook you are using. This may lead to unexpected behavior.`
+    );
+  });
+  test('warning when installing a specific version of storybook', async () => {
+    await add(
+      '@storybook/addon-onboarding@2.0.0',
+      { packageManager: 'npm', skipPostinstall: true },
+      MockedConsole
+    );
+
+    expect(MockedConsole.warn).toHaveBeenCalledWith(
+      `The version of @storybook/addon-onboarding you are installing is not the same as the version of Storybook you are using. This may lead to unexpected behavior.`
+    );
+  });
+
+  test('postInstall', async () => {
+    await add(
+      '@storybook/addon-onboarding',
+      { packageManager: 'npm', skipPostinstall: false },
+      MockedConsole
+    );
+
+    expect(MockedPostInstall.postinstallAddon).toHaveBeenCalledWith('@storybook/addon-onboarding', {
+      packageManager: 'npm',
+    });
+  });
+});

--- a/code/lib/cli/src/add.test.ts
+++ b/code/lib/cli/src/add.test.ts
@@ -114,11 +114,7 @@ describe('add (extra)', () => {
     );
   });
   test('not warning when installing unrelated package', async () => {
-    await add(
-      '@storybook/addon-docs',
-      { packageManager: 'npm', skipPostinstall: true },
-      MockedConsole
-    );
+    await add('aa', { packageManager: 'npm', skipPostinstall: true }, MockedConsole);
 
     expect(MockedConsole.warn).not.toHaveBeenCalledWith(
       expect.stringContaining(`is not the same as the version of Storybook you are using.`)

--- a/code/lib/cli/src/add.ts
+++ b/code/lib/cli/src/add.ts
@@ -102,7 +102,7 @@ export async function add(
     version = await packageManager.latestVersion(addonName);
   }
 
-  if (storybookVersion && version !== storybookVersion) {
+  if (isCoreAddon(addonName) && version !== storybookVersion) {
     logger.warn(
       `The version of ${addonName} you are installing is not the same as the version of Storybook you are using. This may lead to unexpected behavior.`
     );

--- a/code/lib/cli/src/add.ts
+++ b/code/lib/cli/src/add.ts
@@ -46,7 +46,7 @@ const checkInstalled = (addonName: string, main: any) => {
   return !!existingAddon;
 };
 
-const isCoreAddon = (addonName: string) => !!versions[addonName as keyof typeof versions];
+const isCoreAddon = (addonName: string) => Object.hasOwn(versions, addonName);
 
 /**
  * Install the given addon package and add it to main.js

--- a/code/lib/cli/src/add.ts
+++ b/code/lib/cli/src/add.ts
@@ -1,44 +1,31 @@
 import {
   getStorybookInfo,
   serverRequire,
-  getCoercedStorybookVersion,
-  isCorePackage,
   JsPackageManagerFactory,
+  versions,
   type PackageManagerName,
 } from '@storybook/core-common';
 import { readConfig, writeConfig } from '@storybook/csf-tools';
 import { isAbsolute, join } from 'path';
 import SemVer from 'semver';
 import dedent from 'ts-dedent';
+import { postinstallAddon } from './postinstallAddon';
 
-const logger = console;
-
-interface PostinstallOptions {
+export interface PostinstallOptions {
   packageManager: PackageManagerName;
 }
 
-const postinstallAddon = async (addonName: string, options: PostinstallOptions) => {
-  try {
-    const modulePath = require.resolve(`${addonName}/postinstall`, { paths: [process.cwd()] });
-
-    const postinstall = require(modulePath);
-
-    try {
-      logger.log(`Running postinstall script for ${addonName}`);
-      await postinstall(options);
-    } catch (e) {
-      logger.error(`Error running postinstall script for ${addonName}`);
-      logger.error(e);
-    }
-  } catch (e) {
-    // no postinstall script
-  }
-};
-
-const getVersionSpecifier = (addon: string) => {
-  const groups = /^(...*)@(.*)$/.exec(addon);
+/**
+ * Extract the addon name and version specifier from the input string
+ * @param addon - the input string
+ * @returns [addonName, versionSpecifier]
+ * @example
+ * getVersionSpecifier('@storybook/addon-docs@7.0.1') => ['@storybook/addon-docs', '7.0.1']
+ */
+export const getVersionSpecifier = (addon: string) => {
+  const groups = /^(@{0,1}[^@]+)(?:@(.+))?$/.exec(addon);
   if (groups) {
-    return [groups[0], groups[2]] as const;
+    return [groups[1], groups[2]] as const;
   }
   return [addon, undefined] as const;
 };
@@ -71,9 +58,11 @@ const checkInstalled = (addonName: string, main: any) => {
  */
 export async function add(
   addon: string,
-  options: { packageManager: PackageManagerName; skipPostinstall: boolean }
+  options: { packageManager: PackageManagerName; skipPostinstall: boolean },
+  logger = console
 ) {
   const { packageManager: pkgMgr } = options;
+  const [addonName, inputVersion] = getVersionSpecifier(addon);
 
   const packageManager = JsPackageManagerFactory.getPackageManager({ force: pkgMgr });
   const packageJson = await packageManager.retrievePackageJson();
@@ -85,38 +74,38 @@ export async function add(
     `);
   }
 
-  if (checkInstalled(addon, requireMain(configDir))) {
-    throw new Error(dedent`
-      Addon ${addon} is already installed; we skipped adding it to your ${mainConfig}.
-    `);
-  }
-
-  const [addonName, versionSpecifier] = getVersionSpecifier(addon);
-
   if (!mainConfig) {
     logger.error('Unable to find storybook main.js config');
     return;
   }
-  const main = await readConfig(mainConfig);
-  logger.log(`Verifying ${addonName}`);
-  const latestVersion = await packageManager.latestVersion(addonName);
-  if (!latestVersion) {
-    logger.error(`Unknown addon ${addonName}`);
+
+  if (checkInstalled(addonName, requireMain(configDir))) {
+    throw new Error(dedent`
+      Addon ${addonName} is already installed; we skipped adding it to your ${mainConfig}.
+    `);
   }
 
-  // add to package.json
-  const isStorybookAddon = addonName.startsWith('@storybook/');
-  const isAddonFromCore = isCorePackage(addonName);
-  const storybookVersion = await getCoercedStorybookVersion(packageManager);
-  const version = versionSpecifier || (isAddonFromCore ? storybookVersion : latestVersion);
+  const main = await readConfig(mainConfig);
+  logger.log(`Verifying ${addonName}`);
 
-  const addonWithVersion = SemVer.valid(version)
+  const storybookVersion = versions[addonName as keyof typeof versions] as string | undefined;
+  const isStorybookAddon = addonName.startsWith('@storybook/');
+  const version =
+    inputVersion || storybookVersion || (await packageManager.latestVersion(addonName));
+
+  if (storybookVersion && version !== storybookVersion) {
+    logger.warn(
+      `The version of ${addonName} you are installing is not the same as the version of Storybook you are using. This may lead to unexpected behavior.`
+    );
+  }
+
+  const addonWithVersion = isValidVersion(version)
     ? `${addonName}@^${version}`
     : `${addonName}@${version}`;
+
   logger.log(`Installing ${addonWithVersion}`);
   await packageManager.addDependencies({ installAsDevDependencies: true }, [addonWithVersion]);
 
-  // add to main.js
   logger.log(`Adding '${addon}' to main.js addons field.`);
   main.appendValueToArray(['addons'], addonName);
   await writeConfig(main);
@@ -124,4 +113,7 @@ export async function add(
   if (!options.skipPostinstall && isStorybookAddon) {
     await postinstallAddon(addonName, { packageManager: packageManager.type });
   }
+}
+function isValidVersion(version: string) {
+  return SemVer.valid(version) || version.match(/^\d+$/);
 }

--- a/code/lib/cli/src/postinstallAddon.ts
+++ b/code/lib/cli/src/postinstallAddon.ts
@@ -1,0 +1,19 @@
+import type { PostinstallOptions } from './add';
+
+export const postinstallAddon = async (addonName: string, options: PostinstallOptions) => {
+  try {
+    const modulePath = require.resolve(`${addonName}/postinstall`, { paths: [process.cwd()] });
+
+    const postinstall = require(modulePath);
+
+    try {
+      console.log(`Running postinstall script for ${addonName}`);
+      await postinstall(options);
+    } catch (e) {
+      console.error(`Error running postinstall script for ${addonName}`);
+      console.error(e);
+    }
+  } catch (e) {
+    // no postinstall script
+  }
+};


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25871

## What I did

I found that the add command contained a few quicks and bugs that I fixed.

- when adding a single digit version such as this: `sb add package@1` it would install the latest version instead
- when adding a storybook package it wouldn't warn you when installing a specific version that isn't the current
- the logic to split a package+version specifier into a packageName & versionSpecifier wasn't setup to deal with scope packages

I added tests for the functionality of the `add` command.
The `getVersionSpecifier` function is tested separately, because regexes can be tricky, and it's faster to iterate on it this way if there is ever another bug with in.

I can remove the warning functionality if it isn't desired.
I figured i'd be nice to have because it would prevent it from later becoming an issue the user would have to fix with the doctor command.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I've tested this manually in a sandbox via running the CLI directly from dist:

```
(next)⚡ [7] % node ../../code/lib/cli/bin/index.js add @chromatic-com/storybook@1.0.0
/Users/me/Projects/Storybook/mono/storybook/code/lib/cli/bin/index.js:23
  throw error;
  ^

Error: Addon @chromatic-com/storybook is already installed; we skipped adding it to your .storybook/main.ts.
    at add (/Users/me/Projects/Storybook/mono/storybook/code/lib/cli/dist/generate.js:3699:11)

Node.js v18.19.1
(next)⚡ [7] % node ../../code/lib/cli/bin/index.js add @storybook/addon-onboarding@1.0.0
/Users/me/Projects/Storybook/mono/storybook/code/lib/cli/bin/index.js:23
  throw error;
  ^

Error: Addon @storybook/addon-onboarding is already installed; we skipped adding it to your .storybook/main.ts.
    at add (/Users/me/Projects/Storybook/mono/storybook/code/lib/cli/dist/generate.js:3699:11)

Node.js v18.19.1
(next)⚡ [7] % node ../../code/lib/cli/bin/index.js add @storybook/addon-measure@1.0.0   
Verifying @storybook/addon-measure
Installing @storybook/addon-measure@^1.0.0
Adding '@storybook/addon-measure@1.0.0' to main.js addons field.
(next)⚡ % node ../../code/lib/cli/bin/index.js add @storybook/addon-measure      
Verifying @storybook/addon-measure
Installing @storybook/addon-measure@^8.0.0-rc.1
Adding '@storybook/addon-measure' to main.js addons field.
(next)⚡ %        
```

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
