### PR TITLE
Vue: Fix reference error when using re-exports with "vue-component-meta"

### DIFF
--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -94,7 +94,13 @@ export async function vueComponentMeta(): Promise<PluginOption> {
           // we can only add the "__docgenInfo" to variables that are actually defined in the current file
           // so e.g. re-exports like "export { default as MyComponent } from './MyComponent.vue'" must be ignored
           // to prevent runtime errors
-          if (new RegExp(`export {.*${name}.*}`).test(src)) {
+          if (
+            new RegExp(`export {.*${name}.*}`).test(src) ||
+            new RegExp(`export \\* from ['"]\\S*${name}['"]`).test(src) ||
+            // when using re-exports, some exports might be resolved via checker.getExportNames
+            // but are not directly exported inside the current file so we need to ignore them too
+            !src.includes(name)
+          ) {
             return;
           }
 


### PR DESCRIPTION
Closes #26179

## What I did

Fix reference errors when generating docinfo with the new `vue-component-meta` docgen plugin.
The issue occurred when using re-exports in `.ts` files (example below) that is then used inside Vue components.

```ts
export * from "./some-file";
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Clone the repository mentioned in the issue report
2. Run `pnpm install`
3. Run `pnpm storybook`
4. Open http://localhost:6006/?path=/docs/%E5%85%AC%E5%85%B1%E7%BB%84%E4%BB%B6-drawer-drawer--docs

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
