### PR TITLE
UI: Remove 'left' property from TooltipLinkList and Link components

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1043,7 +1043,7 @@ Please file an issue if you need these APIs.
 
 #### Removals in @storybook/components
 
-The `TooltipLinkList` component accepts a `links` property where, for each link, a `left` property could be passed. The left property is now removed in Storybook 8 and beyond. Use `icon` instead. The side-effect is that the `left` property is now removed from the `Link` component. The Link component is used to define `globalTypes` in the `preview.js` file, among other places:
+The `TooltipLinkList` component accepts a `links` property where, for each link, a `left` property could be passed. The left property is now removed in Storybook 8 and beyond. Use `icon` instead. The side-effect is that the `left` property is now removed from the `Link` component. This has an effect on the `globalTypes` definition in the `preview.js` file, among other places:
 
 ```diff
 // Replace your-framework with the framework you are using (e.g., react, vue3)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -64,6 +64,7 @@
     - [Removed `passArgsFirst` option](#removed-passargsfirst-option)
     - [Methods and properties from AddonStore](#methods-and-properties-from-addonstore)
     - [Methods and properties from PreviewAPI](#methods-and-properties-from-previewapi)
+    - [Removals in @storybook/components](#removals-in-storybookcomponents)
     - [Removals in @storybook/types](#removals-in-storybooktypes)
     - [--use-npm flag in storybook CLI](#--use-npm-flag-in-storybook-cli)
     - [hideNoControlsWarning parameter from addon controls](#hidenocontrolswarning-parameter-from-addon-controls)
@@ -1039,6 +1040,45 @@ The following exports from `@storybook/preview-api` are now removed:
 - `useAddonState`
 
 Please file an issue if you need these APIs.
+
+#### Removals in @storybook/components
+
+The `TooltipLinkList` component accepts a `links` property where, for each link, a `left` property could be passed. The left property is now removed in Storybook 8 and beyond. Use `icon` instead. The side-effect is that the `left` property is now removed from the `Link` component. The Link component is used to define `globalTypes` in the `preview.js` file, among other places:
+
+```diff
+// Replace your-framework with the framework you are using (e.g., react, vue3)
+import { Preview } from '@storybook/your-framework';
+
+const preview: Preview = {
+  globalTypes: {
+    locale: {
+      description: 'Internationalization locale',
+      defaultValue: 'en',
+      toolbar: {
+        icon: 'globe',
+        items: [
+          {
+            value: 'en',
+            right: '🇺🇸',
+-            left: '＄'
++            icon: 'facehappy'
+            title: 'English'
+          },
+          { value: 'fr', right: '🇫🇷', title: 'Français' },
+          { value: 'es', right: '🇪🇸', title: 'Español' },
+          { value: 'zh', right: '🇨🇳', title: '中文' },
+          { value: 'kr', right: '🇰🇷', title: '한국어' },
+        ],
+      },
+    },
+  },
+};
+
+export default preview;
+```
+
+The icon property only supports a limited set of icons, which are defined here:
+https://storybook.js.org/docs/8.0/faq#what-icons-are-available-for-my-toolbar-or-my-addon
 
 #### Removals in @storybook/types
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1043,9 +1043,10 @@ Please file an issue if you need these APIs.
 
 #### Removals in @storybook/components
 
-The `TooltipLinkList` component accepts a `links` property where, for each link, a `left` property could be passed. The left property is now removed in Storybook 8 and beyond. Use `icon` instead. The side-effect is that the `left` property is now removed from the `Link` component. This has an effect on the `globalTypes` definition in the `preview.js` file, among other places:
+The `TooltipLinkList` UI component used to customize the Storybook toolbar has been updated to use the `icon` property instead of the `left` property to position its content. If you've enabled this property in your `globalTypes` configuration, addons, or any other place, you'll need to replace it with an `icon` property to mimic the same behavior. For example:
 
 ```diff
+// .storybook/preview.js|ts
 // Replace your-framework with the framework you are using (e.g., react, vue3)
 import { Preview } from '@storybook/your-framework';
 
@@ -1076,9 +1077,7 @@ const preview: Preview = {
 
 export default preview;
 ```
-
-The icon property only supports a limited set of icons, which are defined here:
-https://storybook.js.org/docs/8.0/faq#what-icons-are-available-for-my-toolbar-or-my-addon
+To learn more about the available icons and their names, see the [Storybook documentation](https://storybook.js.org/docs/8.0/faq#what-icons-are-available-for-my-toolbar-or-my-addon).
 
 #### Removals in @storybook/types
 

--- a/code/addons/toolbars/src/types.ts
+++ b/code/addons/toolbars/src/types.ts
@@ -15,7 +15,6 @@ export type ToolbarShortcuts = Record<ToolbarShortcutType, ToolbarShortcutConfig
 export interface ToolbarItem {
   value?: string;
   icon?: IconsProps['icon'];
-  left?: string;
   right?: string;
   title?: string;
   hideIcon?: boolean;

--- a/docs/essentials/toolbars-and-globals.md
+++ b/docs/essentials/toolbars-and-globals.md
@@ -148,7 +148,6 @@ Here's a list of the configuration options available.
 | --------- | :----: | :-------------------------------------------------------------: | :------: |
 | **value** | String |    The string value of the menu that gets set in the globals    |   Yes    |
 | **title** | String |                   The main text of the title                    |   Yes    |
-| **left**  | String |      A string that gets shown on the left side of the menu      |    No    |
 | **right** | String |   A string that gets displayed on the right side of the menu    |    No    |
 | **icon**  | String | An icon that gets shown in the toolbar if this item is selected |    No    |
 


### PR DESCRIPTION
Relates to https://github.com/storybookjs/storybook/issues/26310

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- Removed unused `left` property type from the TooltipLinkList `Link` component, which we forgot to remove in 8.0.0-alpha.x
- Adjusted documentation and added a note to the Migration guide

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Nothing to do here because only a unused type was removed.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
