### PR TITLE
Docs: Use dynamic Vite imports in snippets

### DIFF
--- a/docs/snippets/common/main-config-vite-final-env.js.mdx
+++ b/docs/snippets/common/main-config-vite-final-env.js.mdx
@@ -1,14 +1,14 @@
 ```js
 // .storybook/main.js|ts
 
-import { mergeConfig } from 'vite';
-
 export default {
   stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   core: {
     builder: '@storybook/builder-vite',
   },
   async viteFinal(config, { configType }) {
+    const { mergeConfig } = await import('vite');
+
     if (configType === 'DEVELOPMENT') {
       // Your development configuration goes here
     }

--- a/docs/snippets/common/main-config-vite-final.js.mdx
+++ b/docs/snippets/common/main-config-vite-final.js.mdx
@@ -1,13 +1,13 @@
 ```js
 // .storybook/main.js
 
-import { mergeConfig } from 'vite';
-
 export default {
   // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite)
   framework: '@storybook/your-framework',
   stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   async viteFinal(config, { configType }) {
+    const { mergeConfig } = await import('vite');
+
     if (configType === 'DEVELOPMENT') {
       // Your development configuration goes here
     }

--- a/docs/snippets/common/main-config-vite-final.ts-4-9.mdx
+++ b/docs/snippets/common/main-config-vite-final.ts-4-9.mdx
@@ -4,13 +4,13 @@
 // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite)
 import type { StorybookConfig } from '@storybook/your-framework';
 
-import { mergeConfig } from 'vite';
-
 const config: StorybookConfig = {
   // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite)
   framework: '@storybook/your-framework',
   stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   async viteFinal(config, { configType }) {
+    const { mergeConfig } = await import('vite');
+
     if (configType === 'DEVELOPMENT') {
       // Your development configuration goes here
     }

--- a/docs/snippets/common/main-config-vite-final.ts.mdx
+++ b/docs/snippets/common/main-config-vite-final.ts.mdx
@@ -3,12 +3,13 @@
 
 // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite)
 import type { StorybookConfig } from '@storybook/your-framework';
-import { mergeConfig } from 'vite';
 
 const config = {
   framework: '@storybook/your-framework',
   stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   async viteFinal(config, { configType }) {
+    const { mergeConfig } = await import('vite');
+
     if (configType === 'DEVELOPMENT') {
       // Your development configuration goes here
     }

--- a/docs/snippets/common/storybook-vite-builder-aliasing.js.mdx
+++ b/docs/snippets/common/storybook-vite-builder-aliasing.js.mdx
@@ -1,8 +1,6 @@
 ```js
 // .storybook/main.js|ts
 
-import { mergeConfig } from 'vite';
-
 export default {
   stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
@@ -11,6 +9,8 @@ export default {
   },
   async viteFinal(config) {
     // Merge custom configuration into the default config
+    const { mergeConfig } = await import('vite');
+
     return mergeConfig(config, {
       // Add dependencies to pre-optimization
       optimizeDeps: {


### PR DESCRIPTION
Reacts to https://github.com/storybookjs/storybook/issues/26291#issuecomment-1978737220

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Changed all imports from of Vite in `main.ts` documentation to be dynamic imports, to minimize the risk that users get a warning about Vite CJS bundles being deprecated.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
