### PR TITLE
Docs: Add `web-components-vite` framework doc

### DIFF
--- a/code/frameworks/web-components-vite/README.md
+++ b/code/frameworks/web-components-vite/README.md
@@ -1,1 +1,3 @@
-# Storybook for Web components
+# Storybook for Web components & Vite
+
+See [documentation](https://storybook.js.org/docs/8.0/get-started/web-components-vite?renderer=web-components) for installation instructions, usage examples, APIs, and more.

--- a/docs/get-started/web-components-vite.md
+++ b/docs/get-started/web-components-vite.md
@@ -1,0 +1,128 @@
+---
+title: Storybook for Web components & Vite
+---
+
+export const SUPPORTED_RENDERER = 'web-components';
+
+Storybook for Web components & Vite is a [framework](../contribute/framework.md) that makes it easy to develop and test UI components in isolation for applications using [Web components](https://www.webcomponents.org/introduction) built with [Vite](https://vitejs.dev/).
+
+<If notRenderer={SUPPORTED_RENDERER}>
+
+<Callout variant="info">
+
+Storybook for Web components & Vite is only supported in [Web components](?renderer=web-components) projects.
+
+</Callout>
+
+<!-- End non-supported renderers -->
+
+</If>
+
+<If renderer={SUPPORTED_RENDERER}>
+
+## Requirements
+
+- Vite ≥ 4.0
+- Storybook ≥ 8.0
+
+## Getting started
+
+### In a project without Storybook
+
+Follow the prompts after running this command in your Web components project's root directory:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+   'common/init-command.npx.js.mdx',
+   'common/init-command.yarn.js.mdx',
+   'common/init-command.pnpm.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+[More on getting started with Storybook.](./install.md)
+
+### In a project with Storybook
+
+This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-upgrade.npm.js.mdx',
+    'common/storybook-upgrade.pnpm.js.mdx',
+    'common/storybook-upgrade.yarn.js.mdx'
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+#### Automatic migration
+
+When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/web-components-vite`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
+
+#### Manual migration
+
+First, install the framework:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'web-components/web-components-vite-install.npm.js.mdx',
+    'web-components/web-components-vite-install.pnpm.js.mdx',
+    'web-components/web-components-vite-install.yarn.js.mdx'
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+Then, update your `.storybook/main.js|ts` to change the framework property:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'web-components/web-components-vite-add-framework.js.mdx',
+    'web-components/web-components-vite-add-framework.ts.mdx'
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+## API
+
+### Options
+
+You can pass an options object for additional configuration if needed:
+
+```js
+// .storybook/main.js
+import * as path from 'path';
+
+export default {
+  // ...
+  framework: {
+    name: '@storybook/web-components-vite',
+    options: {
+      // ...
+    },
+  },
+};
+```
+
+The available options are:
+
+#### `builder`
+
+Type: `Record<string, any>`
+
+Configure options for the [framework's builder](../api/main-config-framework.md#optionsbuilder). For this framework, available options can be found in the [Vite builder docs](../builders/vite.md).
+
+<!-- End supported renderers -->
+
+</If>

--- a/docs/snippets/web-components/web-components-vite-add-framework.js.mdx
+++ b/docs/snippets/web-components/web-components-vite-add-framework.js.mdx
@@ -1,0 +1,7 @@
+```js
+// .storybook/main.js
+export default {
+  // ...
+  framework: '@storybook/web-components-vite', // 👈 Add this
+};
+```

--- a/docs/snippets/web-components/web-components-vite-add-framework.ts.mdx
+++ b/docs/snippets/web-components/web-components-vite-add-framework.ts.mdx
@@ -1,0 +1,11 @@
+```ts
+// .storybook/main.ts
+import { StorybookConfig } from '@storybook/web-components-vite';
+
+const config: StorybookConfig = {
+  // ...
+  framework: '@storybook/web-components-vite', // 👈 Add this
+};
+
+export default config;
+```

--- a/docs/snippets/web-components/web-components-vite-install.npm.js.mdx
+++ b/docs/snippets/web-components/web-components-vite-install.npm.js.mdx
@@ -1,0 +1,3 @@
+```shell
+npm install --save-dev @storybook/web-components-vite
+```

--- a/docs/snippets/web-components/web-components-vite-install.pnpm.js.mdx
+++ b/docs/snippets/web-components/web-components-vite-install.pnpm.js.mdx
@@ -1,0 +1,3 @@
+```shell
+pnpm install --save-dev @storybook/web-components-vite
+```

--- a/docs/snippets/web-components/web-components-vite-install.yarn.js.mdx
+++ b/docs/snippets/web-components/web-components-vite-install.yarn.js.mdx
@@ -1,0 +1,3 @@
+```shell
+yarn add --dev @storybook/web-components-vite
+```

--- a/docs/toc.js
+++ b/docs/toc.js
@@ -63,6 +63,11 @@ module.exports = {
               title: 'Vue & Webpack',
               type: 'link',
             },
+            {
+              pathSegment: 'web-components-vite',
+              title: 'Web components & Vite',
+              type: 'link',
+            },
           ],
         },
         {


### PR DESCRIPTION
## What I did

See title

![screenshot of docs page](https://github.com/storybookjs/storybook/assets/486540/f9f97c66-c35a-4a8c-b211-ec86abc69e11)

## Checklist for Contributors

### Testing

#### Manual testing

1. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `framework-doc-web-components-vite`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
