### PR TITLE
Docs: Add `svelte-webpack5` framework doc

### DIFF
--- a/code/frameworks/svelte-webpack5/README.md
+++ b/code/frameworks/svelte-webpack5/README.md
@@ -1,32 +1,3 @@
-# Storybook for Svelte
+# Storybook for Svelte & Webpack
 
-Storybook for Svelte is a UI development environment for your Svelte components.
-With it, you can visualize different states of your UI components and develop them interactively.
-
-![Storybook Screenshot](https://github.com/storybookjs/storybook/blob/main/media/storybook-intro.gif)
-
-Storybook runs outside of your app.
-So you can develop UI components in isolation without worrying about app specific dependencies and requirements.
-
-## Getting Started
-
-```sh
-cd my-svelte-app
-npx storybook@latest init
-```
-
-For more information visit: [storybook.js.org](https://storybook.js.org)
-
----
-
-Storybook also comes with a lot of [addons](https://storybook.js.org/addons) and a great API to customize as you wish.
-You can also build a [static version](https://storybook.js.org/docs/svelte/sharing/publish-storybook) of your Storybook and deploy it anywhere you want.
-
-## TODOs
-
-- Support `addon-info`
-- Support Svelte markup directly in stories
-- Add Svelte storybook generator
-- Provide stories that show advanced Svelte use cases
-- Hydratable
-- Advanced mount options
+See [documentation](https://storybook.js.org/docs/8.0/get-started/svelte-webpack5?renderer=svelte) for installation instructions, usage examples, APIs, and more.

--- a/docs/get-started/svelte-webpack5.md
+++ b/docs/get-started/svelte-webpack5.md
@@ -82,7 +82,37 @@ First, install the framework:
 
 <!-- prettier-ignore-end -->
 
-Then, update your `.storybook/main.js|ts` to change the framework property:
+Next, install and register your appropriate compiler addon, depending on whether you're using SWC (recommended) or Babel:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-addon-compiler-swc-auto-install.npm.js.mdx',
+    'common/storybook-addon-compiler-swc-auto-install.pnpm.js.mdx',
+    'common/storybook-addon-compiler-swc-auto-install.yarn.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+or
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-addon-compiler-babel-auto-install.npm.js.mdx',
+    'common/storybook-addon-compiler-babel-auto-install.pnpm.js.mdx',
+    'common/storybook-addon-compiler-babel-auto-install.yarn.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+More details can be found in the [Webpack builder docs](../builders/webpack.md#compiler-support).
+
+Finally, update your `.storybook/main.js|ts` to change the framework property:
 
 <!-- prettier-ignore-start -->
 

--- a/docs/get-started/svelte-webpack5.md
+++ b/docs/get-started/svelte-webpack5.md
@@ -22,9 +22,9 @@ Storybook for Svelte & Webpack is only supported in [Svelte](?renderer=svelte) p
 
 ## Requirements
 
-- Svelte ≥ 3.0
+- Svelte ≥ 4.0
 - Webpack ≥ 5.0
-- Storybook ≥ 7.0
+- Storybook ≥ 8.0
 
 ## Getting started
 

--- a/docs/get-started/svelte-webpack5.md
+++ b/docs/get-started/svelte-webpack5.md
@@ -1,0 +1,153 @@
+---
+title: Storybook for Svelte & Webpack
+---
+
+export const SUPPORTED_RENDERER = 'svelte';
+
+Storybook for Svelte & Webpack is a [framework](../contribute/framework.md) that makes it easy to develop and test UI components in isolation for applications using [Svelte](https://svelte.dev/) built with [Webpack](https://webpack.js.org/).
+
+<If notRenderer={SUPPORTED_RENDERER}>
+
+<Callout variant="info">
+
+Storybook for Svelte & Webpack is only supported in [Svelte](?renderer=svelte) projects.
+
+</Callout>
+
+<!-- End non-supported renderers -->
+
+</If>
+
+<If renderer={SUPPORTED_RENDERER}>
+
+## Requirements
+
+- Svelte ≥ 3.0
+- Webpack ≥ 5.0
+- Storybook ≥ 7.0
+
+## Getting started
+
+### In a project without Storybook
+
+Follow the prompts after running this command in your Svelte project's root directory:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+   'common/init-command.npx.js.mdx',
+   'common/init-command.yarn.js.mdx',
+   'common/init-command.pnpm.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+[More on getting started with Storybook.](./install.md)
+
+### In a project with Storybook
+
+This framework is designed to work with Storybook 7+. If you’re not already using v7, upgrade with this command:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'common/storybook-upgrade.npm.js.mdx',
+    'common/storybook-upgrade.pnpm.js.mdx',
+    'common/storybook-upgrade.yarn.js.mdx'
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+#### Automatic migration
+
+When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/svelte-webpack5`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
+
+#### Manual migration
+
+First, install the framework:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'svelte/svelte-webpack5-install.npm.js.mdx',
+    'svelte/svelte-webpack5-install.pnpm.js.mdx',
+    'svelte/svelte-webpack5-install.yarn.js.mdx'
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+Then, update your `.storybook/main.js|ts` to change the framework property:
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+    'svelte/svelte-webpack5-add-framework.js.mdx',
+    'svelte/svelte-webpack5-add-framework.ts.mdx'
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+## Writing native Svelte stories
+
+Storybook provides a Svelte addon maintained by the community, enabling you to write stories for your Svelte components using the template syntax. You'll need to take some additional steps to enable this feature.
+
+Run the following command to install the addon.
+
+<!-- prettier-ignore-start -->
+
+<CodeSnippets
+  paths={[
+   'svelte/svelte-csf-addon-install.yarn.js.mdx',
+   'svelte/svelte-csf-addon-install.npm.js.mdx',
+   'svelte/svelte-csf-addon-install.pnpm.js.mdx',
+  ]}
+/>
+
+<!-- prettier-ignore-end -->
+
+<Callout variant="info">
+
+The community actively maintains the Svelte CSF addon but still lacks some features currently available in the official Storybook Svelte framework support. For more information, see [addon's documentation](https://github.com/storybookjs/addon-svelte-csf).
+
+</Callout>
+
+## API
+
+### Options
+
+You can pass an options object for additional configuration if needed:
+
+```js
+// .storybook/main.js
+import * as path from 'path';
+
+export default {
+  // ...
+  framework: {
+    name: '@storybook/svelte-webpack5',
+    options: {
+      // ...
+    },
+  },
+};
+```
+
+The available options are:
+
+#### `builder`
+
+Type: `Record<string, any>`
+
+Configure options for the [framework's builder](../api/main-config-framework.md#optionsbuilder). For this framework, available options can be found in the [Webpack builder docs](../builders/webpack.md).
+
+<!-- End supported renderers -->
+
+</If>

--- a/docs/get-started/svelte-webpack5.md
+++ b/docs/get-started/svelte-webpack5.md
@@ -115,7 +115,7 @@ Run the following command to install the addon.
 
 <Callout variant="info">
 
-The community actively maintains the Svelte CSF addon but still lacks some features currently available in the official Storybook Svelte framework support. For more information, see [addon's documentation](https://github.com/storybookjs/addon-svelte-csf).
+The community actively maintains the Svelte CSF addon but still lacks some features currently available in the official Storybook Svelte framework support. For more information, see [the addon's documentation](https://github.com/storybookjs/addon-svelte-csf).
 
 </Callout>
 

--- a/docs/snippets/svelte/svelte-webpack5-add-framework.js.mdx
+++ b/docs/snippets/svelte/svelte-webpack5-add-framework.js.mdx
@@ -1,0 +1,7 @@
+```js
+// .storybook/main.js
+export default {
+  // ...
+  framework: '@storybook/svelte-webpack5', // 👈 Add this
+};
+```

--- a/docs/snippets/svelte/svelte-webpack5-add-framework.ts.mdx
+++ b/docs/snippets/svelte/svelte-webpack5-add-framework.ts.mdx
@@ -1,0 +1,11 @@
+```ts
+// .storybook/main.ts
+import { StorybookConfig } from '@storybook/svelte-webpack5';
+
+const config: StorybookConfig = {
+  // ...
+  framework: '@storybook/svelte-webpack5', // 👈 Add this
+};
+
+export default config;
+```

--- a/docs/snippets/svelte/svelte-webpack5-install.npm.js.mdx
+++ b/docs/snippets/svelte/svelte-webpack5-install.npm.js.mdx
@@ -1,0 +1,3 @@
+```shell
+npm install --save-dev @storybook/svelte-webpack5
+```

--- a/docs/snippets/svelte/svelte-webpack5-install.pnpm.js.mdx
+++ b/docs/snippets/svelte/svelte-webpack5-install.pnpm.js.mdx
@@ -1,0 +1,3 @@
+```shell
+pnpm install --save-dev @storybook/svelte-webpack5
+```

--- a/docs/snippets/svelte/svelte-webpack5-install.yarn.js.mdx
+++ b/docs/snippets/svelte/svelte-webpack5-install.yarn.js.mdx
@@ -1,0 +1,3 @@
+```shell
+yarn add --dev @storybook/svelte-webpack5
+```

--- a/docs/toc.js
+++ b/docs/toc.js
@@ -49,6 +49,11 @@ module.exports = {
               type: 'link',
             },
             {
+              pathSegment: 'svelte-webpack5',
+              title: 'Svelte & Webpack',
+              type: 'link',
+            },
+            {
               pathSegment: 'vue3-vite',
               title: 'Vue & Vite',
               type: 'link',


### PR DESCRIPTION
## What I did

See title

![screenshot of docs page](https://github.com/storybookjs/storybook/assets/486540/8b306a9d-d99e-4e98-a293-91adc54a5305)

## Checklist for Contributors

### Testing

#### Manual testing

1. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `framework-doc-svelte-webpack5`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
