### PR TITLE
Core: Fix path separator issue in check-addon-order

### DIFF
--- a/code/lib/core-common/src/utils/__tests__/check-addon-order.test.ts
+++ b/code/lib/core-common/src/utils/__tests__/check-addon-order.test.ts
@@ -17,6 +17,7 @@ const essentialAddons = [
   'toolbars',
   'measure',
   'outline',
+  'highlight',
 ];
 
 const pkgName = (entry: CoreCommon_AddonEntry): string => {
@@ -42,6 +43,22 @@ afterEach(() => {
 describe.each([
   ['docs', 'controls', ['docs', 'controls']],
   ['docs', 'controls', ['docs', 'foo/node_modules/@storybook/addon-controls']],
+  [
+    'actions',
+    'interactions',
+    [
+      'foo\\node_modules\\@storybook\\addon-essentials',
+      'foo\\node_modules\\@storybook\\addon-interactions',
+    ],
+  ],
+  [
+    'actions',
+    'interactions',
+    [
+      'foo\\\\node_modules\\\\@storybook\\\\addon-essentials',
+      'foo\\\\node_modules\\\\@storybook\\\\addon-interactions',
+    ],
+  ],
   ['docs', 'controls', [{ name: '@storybook/addon-docs' }, 'controls']],
   ['docs', 'controls', ['essentials', 'controls']],
   ['docs', 'controls', ['essentials']],

--- a/code/lib/core-common/src/utils/check-addon-order.ts
+++ b/code/lib/core-common/src/utils/check-addon-order.ts
@@ -15,7 +15,7 @@ interface Options {
 
 const predicateFor = (addon: string) => (entry: CoreCommon_AddonEntry) => {
   const name = (entry as CoreCommon_OptionsEntry).name || (entry as string);
-  return name && name.includes(addon);
+  return name && name.replaceAll(/(\\){1,2}/g, '/').includes(addon);
 };
 
 const isCorrectOrder = (


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25969

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The checkAddonOrder functionality wasn't covering operating systems, where the path separator is a backslash (`\`) instead of a forward slash.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a React Vite sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Install the addon-interactions
3. Paste this main.js into yours:

```tsx
import type { StorybookConfig } from '@storybook/react-vite'
import { resolve } from 'node:path'
import { dirname, join } from 'path'
import { mergeConfig } from 'vite'

const config: StorybookConfig = {
  stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(ts|tsx)'],
  staticDirs: ['../public'],
  core: {
    disableTelemetry: true,
  },
  addons: [
    getAbsolutePath('@storybook/addon-links'),
    getAbsolutePath('@storybook/addon-essentials'),
    getAbsolutePath('@storybook/addon-interactions'),
    getAbsolutePath('@storybook/addon-a11y'),
  ],
  framework: {
    name: getAbsolutePath('@storybook/react-vite'),
    options: {},
  },
  docs: {
    autodocs: true,
  },
  async viteFinal(config) {
    return mergeConfig(config, {
      resolve: {
        alias: [
          {
            find: 'stories',
            replacement: resolve(__dirname, '../stories'),
          },
        ],
      },
    })
  },
}

export default config

function getAbsolutePath(value: string): any {
  return dirname(require.resolve(join(value, 'package.json')))
}
```

4. Start Storybook on a Windows machine. The warning

```
WARN Expected '@storybook/addon-actions' (or '@storybook/addon-essentials') to be listed before '@storybook/addon-interactions' in main Storybook config.
```

shouldn't appear

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26362-sha-ec71ddb7`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26362-sha-ec71ddb7 sandbox` or in an existing project with `npx storybook@0.0.0-pr-26362-sha-ec71ddb7 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26362-sha-ec71ddb7`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26362-sha-ec71ddb7) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-addon-ordering-detection-on-windows`](https://github.com/storybookjs/storybook/tree/valentin/fix-addon-ordering-detection-on-windows) |
| **Commit** | [`ec71ddb7`](https://github.com/storybookjs/storybook/commit/ec71ddb7b6aedf907fcbf32dbac10847044c7d69) |
| **Datetime** | Thu Mar  7 08:50:26 UTC 2024 (`1709801426`) |
| **Workflow run** | [8185350081](https://github.com/storybookjs/storybook/actions/runs/8185350081) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26362`_
</details>
<!-- CANARY_RELEASE_SECTION -->
