### PR TITLE
Actions: Fix attaching action after a spy is restored to original function

### DIFF
--- a/code/addons/actions/src/loaders.ts
+++ b/code/addons/actions/src/loaders.ts
@@ -17,6 +17,8 @@ const attachActionsToFunctionMocks: LoaderFunction = (context) => {
         typeof value === 'function' && '_isMockFunction' in value && value._isMockFunction
     )
     .forEach(([key, value]) => {
+      // See this discussion for context:
+      // https://github.com/vitest-dev/vitest/pull/5352
       const previous =
         value.getMockImplementation() ??
         (tinySpyInternalState in value ? value[tinySpyInternalState]?.getOriginal() : undefined);

--- a/code/addons/actions/src/loaders.ts
+++ b/code/addons/actions/src/loaders.ts
@@ -2,6 +2,8 @@
 import type { LoaderFunction } from '@storybook/types';
 import { action } from './runtime';
 
+export const tinySpyInternalState = Symbol.for('tinyspy:spy');
+
 const attachActionsToFunctionMocks: LoaderFunction = (context) => {
   const {
     args,
@@ -15,7 +17,9 @@ const attachActionsToFunctionMocks: LoaderFunction = (context) => {
         typeof value === 'function' && '_isMockFunction' in value && value._isMockFunction
     )
     .forEach(([key, value]) => {
-      const previous = value.getMockImplementation();
+      const previous =
+        value.getMockImplementation() ??
+        (tinySpyInternalState in value ? value[tinySpyInternalState]?.getOriginal() : undefined);
       if (previous?._actionAttached !== true && previous?.isAction !== true) {
         const implementation = (...params: unknown[]) => {
           action(key)(...params);


### PR DESCRIPTION
## What I did

 Fix attaching action, after a spy is restored to the original implemementation.

Before, we would override the original implementation incorrectly when addon actions is installed.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
