### PR TITLE
Docs: Add section about missing vite config file to migration guides

### DIFF
--- a/docs/migration-guide/from-older-version.md
+++ b/docs/migration-guide/from-older-version.md
@@ -79,6 +79,10 @@ If you are using the `storiesOf` API (which requires `storyStoreV7: false` in St
 
 Storybook 8 uses MDX 3. If you're coming from MDX 1 (used by Storybook 6), there were significant breaking changes in MDX 2. Please reference our [guidance on upgrading successfully](../../release-7-6/docs/migration-guide.md#upgrade-mdx1-to-mdx2).
 
+#### Missing `vite.config.js` file
+
+If you are using Vite, you may now need to create a `vite.config.js` file in your project root to allow newer versions of Vite to work with Storybook. Additionally, you may need to install and configure a Vite plugin for your framework. More information is available in the [full migration notes](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#framework-specific-vite-plugins-have-to-be-explicitly-added).
+
 ## Troubleshooting
 
 The automatic upgrade should get your Storybook into a working state. If you encounter an error running Storybook after upgrading, here’s what to do:

--- a/docs/migration-guide/from-older-version.md
+++ b/docs/migration-guide/from-older-version.md
@@ -2,11 +2,16 @@
 title: 'Migration guide from Storybook 6.x to 8.0'
 ---
 
-Storybook 8 focuses on performance and stability.
+Storybook 8 focuses on improving performance, compatibility, and stability. Key features include:
 
-- 💨 [2-4x faster test builds](/blog/optimize-storybook-7-6/#2-4x-faster-builds-with-thetest-flag), [25-50% faster React docgen](/blog/optimize-storybook-7-6/#22x-faster-react-docgen), and [SWC support for Webpack projects](/blog/optimize-storybook-7-6/#using-webpack-enable-swc)
-- ✨ Improved framework support: you no longer need to install React as a peer dependency when using a non-React renderer
-- 🌐 [Support for React Server Components (RSC)](/blog/storybook-react-server-components/): our experimental solution renders async RSC in the browser and mocks Node code
+- 🩻 A new visual testing workflow via [the Visual Tests addon](https://www.chromatic.com/docs/visual-tests-addon/)
+- 💨 [2-4x faster test builds](https://storybook.js.org/blog/optimize-storybook-7-6/#2-4x-faster-builds-with-thetest-flag), [25-50% faster React docgen](https://storybook.js.org/blog/optimize-storybook-7-6/#22x-faster-react-docgen), and [SWC support for Webpack projects](https://storybook.js.org/blog/optimize-storybook-7-6/#using-webpack-enable-swc)
+- 🧩 Improved framework support: you no longer need to install React as a peer dependency when using a non-React renderer
+- 🎛️ Strengthened control generation in [React](https://storybook.js.org/blog/storybook-8-beta/#major-performance-improvements
+) and [Vue](https://storybook.js.org/blog/first-class-vue-support-storybook-8/) projects
+- ⚡️ Improved Vite architecture, Vitest testing, and Vite 5 support 
+- 🌐 [Support for React Server Components (RSC)](https://storybook.js.org/blog/storybook-react-server-components/): our experimental solution renders async RSC in the browser and mocks Node code
+- ✨ A refreshed desktop UI & mobile UX
 - ➕ Much, much more
 
 This guide is meant to help you **upgrade from Storybook 6.x to 8.0** successfully!

--- a/docs/migration-guide/index.md
+++ b/docs/migration-guide/index.md
@@ -79,6 +79,10 @@ If you have `storyStoreV7: false` in your `.storybook/main.js`, you will need to
 
 If you are using the `storiesOf` API (which requires `storyStoreV7: false` in Storybook 7), you will need to either [migrate your stories to CSF](../../release-7-6/docs/migration-guide.md#storiesof-to-csf) or use the [new indexer API to continue creating stories dynamically](../../release-7-6/docs/migration-guide.md#storiesof-to-dynamically-created-stories).
 
+#### Missing `vite.config.js` file
+
+If you are using Vite, you may now need to create a `vite.config.js` file in your project root to allow newer versions of Vite to work with Storybook. Additionally, you may need to install and configure a Vite plugin for your framework. More information is available in the [full migration notes](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#framework-specific-vite-plugins-have-to-be-explicitly-added).
+
 ## New projects
 
 To add Storybook to a project that isn’t currently using Storybook:

--- a/docs/migration-guide/index.md
+++ b/docs/migration-guide/index.md
@@ -1,12 +1,17 @@
 ---
-title: 'Migration guide for Storybook 8.0'
+title: 'Migration guide from Storybook 6.x to 8.0'
 ---
 
-Storybook 8 focuses on performance and stability.
+Storybook 8 focuses on improving performance, compatibility, and stability. Key features include:
 
+- 🩻 A new visual testing workflow via [the Visual Tests addon](https://www.chromatic.com/docs/visual-tests-addon/)
 - 💨 [2-4x faster test builds](https://storybook.js.org/blog/optimize-storybook-7-6/#2-4x-faster-builds-with-thetest-flag), [25-50% faster React docgen](https://storybook.js.org/blog/optimize-storybook-7-6/#22x-faster-react-docgen), and [SWC support for Webpack projects](https://storybook.js.org/blog/optimize-storybook-7-6/#using-webpack-enable-swc)
-- ✨ Improved framework support: you no longer need to install React as a peer dependency when using a non-React renderer
+- 🧩 Improved framework support: you no longer need to install React as a peer dependency when using a non-React renderer
+- 🎛️ Strengthened control generation in [React](https://storybook.js.org/blog/storybook-8-beta/#major-performance-improvements
+) and [Vue](https://storybook.js.org/blog/first-class-vue-support-storybook-8/) projects
+- ⚡️ Improved Vite architecture, Vitest testing, and Vite 5 support 
 - 🌐 [Support for React Server Components (RSC)](https://storybook.js.org/blog/storybook-react-server-components/): our experimental solution renders async RSC in the browser and mocks Node code
+- ✨ A refreshed desktop UI & mobile UX
 - ➕ Much, much more
 
 This guide is meant to help you **upgrade from Storybook 7.x to 8.0** successfully!

--- a/docs/migration-guide/index.md
+++ b/docs/migration-guide/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Migration guide from Storybook 6.x to 8.0'
+title: 'Migration guide for Storybook 8.0'
 ---
 
 Storybook 8 focuses on improving performance, compatibility, and stability. Key features include:


### PR DESCRIPTION
## What I did

See title

## Checklist for Contributors

### Testing

#### Manual testing

1. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `update-migration-guide-2`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
