### PR TITLE
React: Support all React component types in JSX Decorator

### DIFF
--- a/code/renderers/react/src/docs/jsxDecorator.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.tsx
@@ -8,8 +8,38 @@ import { addons, useEffect } from '@storybook/preview-api';
 import type { StoryContext, ArgsStoryFn, PartialStoryFn } from '@storybook/types';
 import { SourceType, SNIPPET_RENDERED, getDocgenSection } from '@storybook/docs-tools';
 import { logger } from '@storybook/client-logger';
+import { isMemo, isForwardRef } from './lib';
 
 import type { ReactRenderer } from '../types';
+
+const toPascalCase = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
+
+/**
+ * Converts a React symbol to a React-like displayName
+ *
+ * Symbols come from here
+ * https://github.com/facebook/react/blob/338dddc089d5865761219f02b5175db85c54c489/packages/react-devtools-shared/src/backend/ReactSymbols.js
+ *
+ * E.g.
+ * Symbol(react.suspense)                    -> React.Suspense
+ * Symbol(react.strict_mode)                 -> React.StrictMode
+ * Symbol(react.server_context.defaultValue) -> React.ServerContext.DefaultValue
+ *
+ * @param {Symbol} elementType - The symbol to convert
+ * @returns {string | null} A displayName for the Symbol in case elementType is a Symbol; otherwise, null.
+ */
+export const getReactSymbolName = (elementType: any): string => {
+  const symbolDescription = elementType.toString().replace(/^Symbol\((.*)\)$/, '$1');
+
+  const reactComponentName = symbolDescription
+    .split('.')
+    .map((segment) => {
+      // Split segment by underscore to handle cases like 'strict_mode' separately, and PascalCase them
+      return segment.split('_').map(toPascalCase).join('');
+    })
+    .join('.');
+  return reactComponentName;
+};
 
 // Recursively remove "_owner" property from elements to avoid crash on docs page when passing components as an array prop (#17482)
 // Note: It may be better to use this function only in development environment.
@@ -91,10 +121,19 @@ export const renderJsx = (code: React.ReactElement, options: JSXOptions) => {
      *
      * Cannot read properties of undefined (reading '__docgenInfo').
      */
-  } else if (renderedJSX?.type && getDocgenSection(renderedJSX.type, 'displayName')) {
+  } else {
     displayNameDefaults = {
       // To get exotic component names resolving properly
-      displayName: (el: any): string => getDocgenSection(el.type, 'displayName'),
+      displayName: (el: any): string =>
+        el.type.displayName || typeof el.type === 'symbol'
+          ? getReactSymbolName(el.type)
+          : null ||
+            getDocgenSection(el.type, 'displayName') ||
+            (el.type.name !== '_default' ? el.type.name : null) ||
+            (typeof el.type === 'function' ? 'No Display Name' : null) ||
+            (isForwardRef(el.type) ? el.type.render.name : null) ||
+            (isMemo(el.type) ? el.type.type.name : null) ||
+            el.type,
     };
   }
 

--- a/code/renderers/react/src/docs/jsxDecorator.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.tsx
@@ -29,7 +29,7 @@ const toPascalCase = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
  * @returns {string | null} A displayName for the Symbol in case elementType is a Symbol; otherwise, null.
  */
 export const getReactSymbolName = (elementType: any): string => {
-  const symbolDescription = elementType.toString().replace(/^Symbol\((.*)\)$/, '$1');
+  const symbolDescription: string = elementType.toString().replace(/^Symbol\((.*)\)$/, '$1');
 
   const reactComponentName = symbolDescription
     .split('.')
@@ -74,7 +74,7 @@ type JSXOptions = Options & {
 };
 
 /** Apply the users parameters and render the jsx for a story */
-export const renderJsx = (code: React.ReactElement, options: JSXOptions) => {
+export const renderJsx = (code: React.ReactElement, options?: JSXOptions) => {
   if (typeof code === 'undefined') {
     logger.warn('Too many skip or undefined component');
     return null;


### PR DESCRIPTION
Closes #11554, Closes #26336

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR introduces a fix to support Symbol-based React component display names, e.g. `React.StrictMode`, `React.Suspense`, and brings back support for other types of components which was removed (potentially by mistake) in #19785

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
