### PR TITLE
CLI: Remove duplicated dependency warning

### DIFF
--- a/code/lib/cli/src/automigrate/helpers/getMigrationSummary.test.ts
+++ b/code/lib/cli/src/automigrate/helpers/getMigrationSummary.test.ts
@@ -129,35 +129,7 @@ describe('getMigrationSummary', () => {
       The automigrations try to migrate common patterns in your project, but might not contain everything needed to migrate to the latest version of Storybook.
 
       Please check the changelog and migration guide for manual migrations and more information: https://storybook.js.org/docs/8.0/migration-guide
-      And reach out on Discord if you need help: https://discord.gg/storybook
-
-      ─────────────────────────────────────────────────
-
-      Critical: The following dependencies are duplicated and WILL cause unexpected behavior:
-
-      @storybook/instrumenter:
-      6.0.0, 7.1.0
-
-      @storybook/core-common:
-      6.0.0, 7.1.0
-
-
-
-
-      Attention: The following dependencies are duplicated which might cause unexpected behavior:
-
-      @storybook/addon-essentials:
-      7.0.0, 7.1.0
-
-
-
-
-      Please try de-duplicating these dependencies by running yarn dedupe
-
-
-
-
-      You can find more information for a given dependency by running yarn why <package-name>"
+      And reach out on Discord if you need help: https://discord.gg/storybook"
     `);
   });
 

--- a/code/lib/cli/src/automigrate/helpers/getMigrationSummary.ts
+++ b/code/lib/cli/src/automigrate/helpers/getMigrationSummary.ts
@@ -4,7 +4,6 @@ import dedent from 'ts-dedent';
 import type { InstallationMetadata } from '@storybook/core-common';
 import type { FixSummary } from '../types';
 import { FixStatus } from '../types';
-import { getDuplicatedDepsWarnings } from '../../doctor/getDuplicatedDepsWarnings';
 
 export const messageDivider = '\n\n';
 const segmentDivider = '\n\n─────────────────────────────────────────────────\n\n';
@@ -74,14 +73,6 @@ export function getMigrationSummary({
     )}
     And reach out on Discord if you need help: ${chalk.yellow('https://discord.gg/storybook')}
   `);
-
-  const duplicatedDepsMessage = installationMetadata
-    ? getDuplicatedDepsWarnings(installationMetadata)
-    : getDuplicatedDepsWarnings();
-
-  if (duplicatedDepsMessage) {
-    messages.push(duplicatedDepsMessage.join(messageDivider));
-  }
 
   const hasNoFixes = Object.values(fixResults).every((r) => r === FixStatus.UNNECESSARY);
   const hasFailures = Object.values(fixResults).some(


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Storybook CLI was providing the "duplicated dependency warning" twice, once coming from the automigrate summary, and another coming from Storybook doctor.

![image](https://github.com/storybookjs/storybook/assets/1671563/dad886b7-57a4-4d84-8946-459cebeeb545)

This PR fixes that so now only Storybook doctor has output.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
