### PR TITLE
CLI: Automigration fix version detection of upgrading related packages

### DIFF
--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -103,6 +103,7 @@ export const doAutomigrate = async (options: AutofixOptionsFromCLI) => {
     mainConfigPath,
     configDir,
     isUpgrade: false,
+    isLatest: false,
   });
 
   if (outcome) {
@@ -125,6 +126,7 @@ export const automigrate = async ({
   skipInstall,
   hideMigrationSummary = false,
   isUpgrade,
+  isLatest,
 }: AutofixOptions): Promise<{
   fixResults: Record<string, FixStatus>;
   preCheckFailure?: PreCheckFailure;
@@ -140,7 +142,7 @@ export const automigrate = async ({
       // we only allow this automigration when the user explicitly asks for it, or they are upgrading to the latest version of storybook
       if (
         fix.id === upgradeStorybookRelatedDependencies.id &&
-        isUpgrade !== 'latest' &&
+        isLatest === false &&
         fixId !== upgradeStorybookRelatedDependencies.id
       ) {
         return false;

--- a/code/lib/cli/src/automigrate/types.ts
+++ b/code/lib/cli/src/automigrate/types.ts
@@ -1,5 +1,5 @@
-import type { StorybookConfigRaw } from '@storybook/types';
 import type { JsPackageManager, PackageManagerName } from '@storybook/core-common';
+import type { StorybookConfigRaw } from '@storybook/types';
 
 export interface CheckOptions {
   packageManager: JsPackageManager;
@@ -75,7 +75,8 @@ export interface AutofixOptions extends Omit<AutofixOptionsFromCLI, 'packageMana
   /**
    * Whether the migration is part of an upgrade.
    */
-  isUpgrade: false | true | 'latest';
+  isUpgrade: boolean;
+  isLatest: boolean;
 }
 export interface AutofixOptionsFromCLI {
   fixId?: FixId;

--- a/code/lib/cli/src/migrate.ts
+++ b/code/lib/cli/src/migrate.ts
@@ -1,11 +1,12 @@
 import { listCodemods, runCodemod } from '@storybook/codemod';
-import { runFixes } from './automigrate';
-import { mdxToCSF } from './automigrate/fixes/mdx-to-csf';
 import {
   JsPackageManagerFactory,
-  getStorybookInfo,
   getCoercedStorybookVersion,
+  getStorybookInfo,
 } from '@storybook/core-common';
+
+import { runFixes } from './automigrate';
+import { mdxToCSF } from './automigrate/fixes/mdx-to-csf';
 import { getStorybookVersionSpecifier } from './helpers';
 
 const logger = console;

--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -148,6 +148,7 @@ export const doUpgrade = async ({
   ]);
 
   const isOutdated = lt(currentVersion, latestVersion);
+  const isExactLatest = currentVersion === latestVersion;
   const isPrerelease = prerelease(currentVersion) !== null;
 
   const borderColor = isOutdated ? '#FC521F' : '#F1618C';
@@ -261,7 +262,8 @@ export const doUpgrade = async ({
       mainConfigPath,
       beforeVersion,
       storybookVersion: currentVersion,
-      isUpgrade: isOutdated ? true : 'latest',
+      isUpgrade: isOutdated,
+      isLatest: isExactLatest,
     });
   }
 


### PR DESCRIPTION
## What I did

- add a flag for detecting is the latest version we got from npm matches the version of the CLI exactly

The flag outdated checks over preleases as well, assuming a prerelease being available means it's outdated.

For this feature , we want to know if the version on NPM is the exact same as the current CLI version.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I have a reproduction on `rc.2`, and I ran:
```
node /{path-to}/storybook/code/lib/cli/bin/index.js upgrade
```

This produced the correct result:
The automigration was NOT added.

Testing the inverse is a lot harder..
But I managed to simulate it roughly..

I changed this line:
https://github.com/storybookjs/storybook/blob/d978771b182d2a98035fa650f91fa7b949ab2089/code/lib/cli/src/upgrade.ts#L151

to:
```ts
const isExactLatest = true; //currentVersion === latestVersion;
```

I reset the repro to before the upgrade & ran the command again:
```
node /{path-to}/storybook/code/lib/cli/bin/index.js upgrade
```

This time the automigration was correctly added!

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
