### PR TITLE
Docs: Fix `Typeset` Doc block `fontSizes` type

### DIFF
--- a/code/ui/blocks/src/components/Typeset.tsx
+++ b/code/ui/blocks/src/components/Typeset.tsx
@@ -35,7 +35,7 @@ const Wrapper = styled.div(withReset, ({ theme }) => ({
 
 export interface TypesetProps {
   fontFamily?: string;
-  fontSizes: string[];
+  fontSizes: number[];
   fontWeight?: number;
   sampleText?: string;
 }

--- a/code/ui/blocks/src/components/Typeset.tsx
+++ b/code/ui/blocks/src/components/Typeset.tsx
@@ -35,7 +35,7 @@ const Wrapper = styled.div(withReset, ({ theme }) => ({
 
 export interface TypesetProps {
   fontFamily?: string;
-  fontSizes: number[];
+  fontSizes: (string | number)[];
   fontWeight?: number;
   sampleText?: string;
 }

--- a/docs/api/doc-block-typeset.md
+++ b/docs/api/doc-block-typeset.md
@@ -84,7 +84,7 @@ Provides a font family to be displayed.
 
 ### `fontSizes`
 
-Type: `number[]`
+Type: `(string | number)[]`
 
 Provides a list of available font sizes (in `px`).
 


### PR DESCRIPTION
## What I did

Fixes the type for `fontSizes` in the `Typeset` block to match the [docs](https://storybook.js.org/docs/api/doc-block-typeset#fontsizes).

Currently, Typescript will throw an error if you try to pass in a `number[]` to this prop. You either need to typecast a `number[]` to a `string[]`, or pass in a string array with the `px` in order for it to work.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run any app or sandbox that uses Storybook, , e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`.
2. Open any editor that has Typescript support.
3. Create a component that uses the `Typeset` component and pass in an array of numbers to `fontSizes`.
4. Should not see any Typescript errors.

### Documentation

No updates to documentation needed.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

