### PR TITLE
UI: Replace the icon prop in the Manager API

### DIFF
--- a/code/lib/manager-api/package.json
+++ b/code/lib/manager-api/package.json
@@ -49,6 +49,7 @@
     "@storybook/core-events": "workspace:*",
     "@storybook/csf": "^0.1.2",
     "@storybook/global": "^5.0.0",
+    "@storybook/icons": "workspace:*",
     "@storybook/router": "workspace:*",
     "@storybook/theming": "workspace:*",
     "@storybook/types": "workspace:*",

--- a/code/lib/manager-api/package.json
+++ b/code/lib/manager-api/package.json
@@ -49,7 +49,7 @@
     "@storybook/core-events": "workspace:*",
     "@storybook/csf": "^0.1.2",
     "@storybook/global": "^5.0.0",
-    "@storybook/icons": "workspace:*",
+    "@storybook/icons": "^1.2.5",
     "@storybook/router": "workspace:*",
     "@storybook/theming": "workspace:*",
     "@storybook/types": "workspace:*",

--- a/code/lib/manager-api/src/modules/whatsnew.tsx
+++ b/code/lib/manager-api/src/modules/whatsnew.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { global } from '@storybook/global';
 import type { WhatsNewCache, WhatsNewData } from '@storybook/core-events';
 import {
@@ -7,6 +8,7 @@ import {
   TOGGLE_WHATS_NEW_NOTIFICATIONS,
 } from '@storybook/core-events';
 import type { ModuleFn } from '../lib/types';
+import { StorybookIcon } from '@storybook/icons';
 
 export type SubState = {
   whatsNewData?: WhatsNewData;
@@ -95,7 +97,7 @@ export const init: ModuleFn = ({ fullAPI, store, provider }) => {
           headline: whatsNewData.title,
           subHeadline: "Learn what's new in Storybook",
         },
-        icon: { name: 'storybook' },
+        icon: <StorybookIcon />,
         onClear({ dismissed }: any) {
           if (dismissed) {
             setWhatsNewCache({ lastDismissedPost: whatsNewData.url });

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -127,7 +127,12 @@ export interface API_Notification {
     headline: string;
     subHeadline?: string | any;
   };
-  icon?: ReactNode;
+  icon?:
+    | ReactNode
+    | {
+        name: string;
+        color?: string;
+      };
   onClear?: (options: OnClearOptions) => void;
 }
 

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import type { RenderData } from '../../../router/src/types';
 import type { Channel } from '../../../channels/src';
 import type { ThemeVars } from '../../../theming/src/types';
@@ -127,10 +127,7 @@ export interface API_Notification {
     headline: string;
     subHeadline?: string | any;
   };
-  icon?: {
-    name: string;
-    color?: string;
-  };
+  icon?: ReactNode;
   onClear?: (options: OnClearOptions) => void;
 }
 

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import type { RenderData } from '../../../router/src/types';
 import type { Channel } from '../../../channels/src';
 import type { ThemeVars } from '../../../theming/src/types';

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -120,6 +120,13 @@ interface OnClearOptions {
   dismissed: boolean;
 }
 
+/**
+ * @deprecated Use ReactNode for the icon instead.
+ */
+interface OldIconType {
+  name: string;
+  color?: string;
+}
 export interface API_Notification {
   id: string;
   link: string;
@@ -127,12 +134,7 @@ export interface API_Notification {
     headline: string;
     subHeadline?: string | any;
   };
-  icon?:
-    | ReactNode
-    | {
-        name: string;
-        color?: string;
-      };
+  icon?: OldIconType | React.ReactNode;
   onClear?: (options: OnClearOptions) => void;
 }
 

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -135,6 +135,7 @@ export interface API_Notification {
     headline: string;
     subHeadline?: string | any;
   };
+  // TODO: Remove DeprecatedIconType in 9.0
   icon?: React.ReactNode | DeprecatedIconType;
   onClear?: (options: OnClearOptions) => void;
 }

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -122,6 +122,7 @@ interface OnClearOptions {
 
 /**
  * @deprecated Use ReactNode for the icon instead.
+ * @see https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#icons-is-deprecated
  */
 interface DeprecatedIconType {
   name: string;

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -123,7 +123,7 @@ interface OnClearOptions {
 /**
  * @deprecated Use ReactNode for the icon instead.
  */
-interface OldIconType {
+interface DeprecatedIconType {
   name: string;
   color?: string;
 }
@@ -134,7 +134,7 @@ export interface API_Notification {
     headline: string;
     subHeadline?: string | any;
   };
-  icon?: OldIconType | React.ReactNode;
+  icon?: React.ReactNode | DeprecatedIconType;
   onClear?: (options: OnClearOptions) => void;
 }
 

--- a/code/ui/manager/src/components/notifications/NotificationItem.stories.tsx
+++ b/code/ui/manager/src/components/notifications/NotificationItem.stories.tsx
@@ -235,3 +235,21 @@ export const AccessibilityGoldIconLongHeadLineNoSubHeadline: Story = {
     },
   },
 };
+
+export const WithOldIconFormat: Story = {
+  args: {
+    ...Simple.args,
+    notification: {
+      id: '13',
+      onClear,
+      content: {
+        headline: 'Storybook notifications has a accessibility icon it can be any color!',
+      },
+      icon: {
+        name: 'accessibility',
+        color: 'gold',
+      },
+      link: '/some/path',
+    },
+  },
+};

--- a/code/ui/manager/src/components/notifications/NotificationItem.stories.tsx
+++ b/code/ui/manager/src/components/notifications/NotificationItem.stories.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { LocationProvider } from '@storybook/router';
 import type { Meta, StoryObj } from '@storybook/react';
 import NotificationItem from './NotificationItem';
+import {
+  AccessibilityIcon as AccessibilityIconIcon,
+  BookIcon as BookIconIcon,
+  FaceHappyIcon,
+} from '@storybook/icons';
 
 const meta = {
   component: NotificationItem,
@@ -78,10 +83,7 @@ export const LinkIconWithColor: Story = {
       content: {
         headline: 'Storybook with a smile!',
       },
-      icon: {
-        name: 'facehappy',
-        color: 'hotpink',
-      },
+      icon: <FaceHappyIcon color="hotpink" />,
       link: '/some/path',
     },
   },
@@ -97,10 +99,7 @@ export const LinkIconWithColorSubHeadline: Story = {
         headline: 'Storybook X.X is available with a smile! Download now »',
         subHeadline: 'This link also has a sub headline',
       },
-      icon: {
-        name: 'facehappy',
-        color: 'tomato',
-      },
+      icon: <FaceHappyIcon color="tomato" />,
       link: '/some/path',
     },
   },
@@ -115,9 +114,7 @@ export const BookIcon: Story = {
       content: {
         headline: 'Storybook has a book icon!',
       },
-      icon: {
-        name: 'book',
-      },
+      icon: <BookIconIcon />,
       link: '/some/path',
     },
   },
@@ -133,9 +130,7 @@ export const StrongSubHeadline: Story = {
         headline: 'Storybook has a book icon!',
         subHeadline: <strong>Strong subHeadline</strong>,
       },
-      icon: {
-        name: 'book',
-      },
+      icon: <BookIconIcon />,
       link: '/some/path',
     },
   },
@@ -155,9 +150,7 @@ export const StrongEmphasizedSubHeadline: Story = {
           </span>
         ),
       },
-      icon: {
-        name: 'book',
-      },
+      icon: <BookIconIcon />,
       link: '/some/path',
     },
   },
@@ -173,9 +166,7 @@ export const BookIconSubHeadline: Story = {
         headline: 'Storybook has a book icon!',
         subHeadline: 'Find out more!',
       },
-      icon: {
-        name: 'book',
-      },
+      icon: <BookIconIcon />,
       link: '/some/path',
     },
   },
@@ -192,9 +183,7 @@ export const BookIconLongSubHeadline: Story = {
         subHeadline:
           'Find out more! by clicking on on buttons and downloading some applications. Find out more! by clicking on buttons and downloading some applications',
       },
-      icon: {
-        name: 'book',
-      },
+      icon: <BookIconIcon />,
       link: '/some/path',
     },
   },
@@ -210,9 +199,7 @@ export const AccessibilityIcon: Story = {
         headline: 'Storybook has a accessibility icon!',
         subHeadline: 'It is here!',
       },
-      icon: {
-        name: 'accessibility',
-      },
+      icon: <AccessibilityIconIcon />,
       link: '/some/path',
     },
   },
@@ -228,10 +215,7 @@ export const AccessibilityGoldIcon: Story = {
         headline: 'Accessibility icon!',
         subHeadline: 'It is gold!',
       },
-      icon: {
-        name: 'accessibility',
-        color: 'gold',
-      },
+      icon: <AccessibilityIconIcon color="gold" />,
       link: '/some/path',
     },
   },
@@ -246,10 +230,7 @@ export const AccessibilityGoldIconLongHeadLineNoSubHeadline: Story = {
       content: {
         headline: 'Storybook notifications has a accessibility icon it can be any color!',
       },
-      icon: {
-        name: 'accessibility',
-        color: 'gold',
-      },
+      icon: <AccessibilityIconIcon color="gold" />,
       link: '/some/path',
     },
   },

--- a/code/ui/manager/src/components/notifications/NotificationItem.tsx
+++ b/code/ui/manager/src/components/notifications/NotificationItem.tsx
@@ -2,8 +2,8 @@ import type { FC, SyntheticEvent } from 'react';
 import React from 'react';
 import { type State } from '@storybook/manager-api';
 import { Link } from '@storybook/router';
-import { styled, useTheme } from '@storybook/theming';
-import { Icons, IconButton, type IconsProps } from '@storybook/components';
+import { styled } from '@storybook/theming';
+import { IconButton } from '@storybook/components';
 import { transparentize } from 'polished';
 import { CloseAltIcon } from '@storybook/icons';
 
@@ -47,10 +47,11 @@ const NotificationIconWrapper = styled.div(() => ({
   alignItems: 'center',
 }));
 
-const NotificationTextWrapper = styled.div(() => ({
+const NotificationTextWrapper = styled.div(({ theme }) => ({
   width: '100%',
   display: 'flex',
   flexDirection: 'column',
+  color: theme.base === 'dark' ? theme.color.mediumdark : theme.color.mediumlight,
 }));
 
 const Headline = styled.div<{ hasIcon: boolean }>(({ theme, hasIcon }) => ({
@@ -76,20 +77,9 @@ const ItemContent: FC<Pick<State['notifications'][0], 'icon' | 'content'>> = ({
   icon,
   content: { headline, subHeadline },
 }) => {
-  const theme = useTheme();
-  const defaultColor = theme.base === 'dark' ? theme.color.mediumdark : theme.color.mediumlight;
   return (
     <>
-      {!icon || (
-        <NotificationIconWrapper>
-          <Icons
-            icon={icon.name as IconsProps['icon']}
-            width={16}
-            height={16}
-            color={icon.color || defaultColor}
-          />
-        </NotificationIconWrapper>
-      )}
+      {!icon || <NotificationIconWrapper>{icon}</NotificationIconWrapper>}
       <NotificationTextWrapper>
         <Headline title={headline} hasIcon={!!icon}>
           {headline}

--- a/code/ui/manager/src/components/notifications/NotificationItem.tsx
+++ b/code/ui/manager/src/components/notifications/NotificationItem.tsx
@@ -79,7 +79,7 @@ const ItemContent: FC<Pick<State['notifications'][0], 'icon' | 'content'>> = ({
 }) => {
   return (
     <>
-      {!icon || <NotificationIconWrapper>{icon}</NotificationIconWrapper>}
+      {React.isValidElement(icon) && <NotificationIconWrapper>{icon}</NotificationIconWrapper>}
       <NotificationTextWrapper>
         <Headline title={headline} hasIcon={!!icon}>
           {headline}

--- a/code/ui/manager/src/components/notifications/NotificationItem.tsx
+++ b/code/ui/manager/src/components/notifications/NotificationItem.tsx
@@ -2,8 +2,9 @@ import type { FC, SyntheticEvent } from 'react';
 import React from 'react';
 import { type State } from '@storybook/manager-api';
 import { Link } from '@storybook/router';
-import { styled } from '@storybook/theming';
-import { IconButton } from '@storybook/components';
+import { styled, useTheme } from '@storybook/theming';
+import type { IconsProps } from '@storybook/components';
+import { IconButton, Icons } from '@storybook/components';
 import { transparentize } from 'polished';
 import { CloseAltIcon } from '@storybook/icons';
 
@@ -45,6 +46,11 @@ const NotificationIconWrapper = styled.div(() => ({
   display: 'flex',
   marginRight: 10,
   alignItems: 'center',
+
+  svg: {
+    width: 16,
+    height: 16,
+  },
 }));
 
 const NotificationTextWrapper = styled.div(({ theme }) => ({
@@ -77,9 +83,21 @@ const ItemContent: FC<Pick<State['notifications'][0], 'icon' | 'content'>> = ({
   icon,
   content: { headline, subHeadline },
 }) => {
+  const theme = useTheme();
+  const defaultColor = theme.base === 'dark' ? theme.color.mediumdark : theme.color.mediumlight;
+
   return (
     <>
-      {React.isValidElement(icon) && <NotificationIconWrapper>{icon}</NotificationIconWrapper>}
+      {!icon || (
+        <NotificationIconWrapper>
+          {React.isValidElement(icon)
+            ? icon
+            : typeof icon === 'object' &&
+              'name' in icon && (
+                <Icons icon={icon.name as IconsProps['icon']} color={icon.color || defaultColor} />
+              )}
+        </NotificationIconWrapper>
+      )}
       <NotificationTextWrapper>
         <Headline title={headline} hasIcon={!!icon}>
           {headline}

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5970,6 +5970,7 @@ __metadata:
     "@storybook/core-events": "workspace:*"
     "@storybook/csf": "npm:^0.1.2"
     "@storybook/global": "npm:^5.0.0"
+    "@storybook/icons": "npm:^1.2.5"
     "@storybook/router": "workspace:*"
     "@storybook/theming": "workspace:*"
     "@storybook/types": "workspace:*"


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/26436

## What I did

In this PR I'm updating the manager API to use a `ReactNode` instead of an object with `name` and `color` for the notification component. This removes the use of the deprecated icons.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
