### PR TITLE
UI: Improve empty state of addon panel

### DIFF
--- a/code/addons/a11y/src/components/Report/index.tsx
+++ b/code/addons/a11y/src/components/Report/index.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import React, { Fragment } from 'react';
-import { Placeholder } from '@storybook/components';
+import { EmptyTabContent } from '@storybook/components';
 import type { Result } from 'axe-core';
 
 import { Item } from './Item';
@@ -18,7 +18,7 @@ export const Report: FC<ReportProps> = ({ items, empty, type }) => (
     {items && items.length ? (
       items.map((item) => <Item item={item} key={`${type}:${item.id}`} type={type} />)
     ) : (
-      <Placeholder key="placeholder">{empty}</Placeholder>
+      <EmptyTabContent title={empty} />
     )}
   </Fragment>
 );

--- a/code/addons/interactions/src/components/EmptyState.tsx
+++ b/code/addons/interactions/src/components/EmptyState.tsx
@@ -1,42 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from '@storybook/components';
+import { Link, EmptyTabContent } from '@storybook/components';
 import { DocumentIcon, VideoIcon } from '@storybook/icons';
-import { Consumer, useStorybookApi } from '@storybook/manager-api';
+import { useStorybookApi } from '@storybook/manager-api';
 import { styled } from '@storybook/theming';
 
 import { DOCUMENTATION_LINK, TUTORIAL_VIDEO_LINK } from '../constants';
-
-const Wrapper = styled.div(({ theme }) => ({
-  height: '100%',
-  display: 'flex',
-  padding: 0,
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexDirection: 'column',
-  gap: 15,
-  background: theme.background.content,
-}));
-
-const Content = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 4,
-  maxWidth: 415,
-});
-
-const Title = styled.div(({ theme }) => ({
-  fontWeight: theme.typography.weight.bold,
-  fontSize: theme.typography.size.s2 - 1,
-  textAlign: 'center',
-  color: theme.textColor,
-}));
-
-const Description = styled.div(({ theme }) => ({
-  fontWeight: theme.typography.weight.regular,
-  fontSize: theme.typography.size.s2 - 1,
-  textAlign: 'center',
-  color: theme.textMutedColor,
-}));
 
 const Links = styled.div(({ theme }) => ({
   display: 'flex',
@@ -73,27 +41,25 @@ export const Empty = () => {
   if (isLoading) return null;
 
   return (
-    <Wrapper>
-      <Content>
-        <Title>Interaction testing</Title>
-        <Description>
+    <EmptyTabContent
+      title="Interaction testing"
+      description={
+        <>
           Interaction tests allow you to verify the functional aspects of UIs. Write a play function
           for your story and you&apos;ll see it run here.
-        </Description>
-      </Content>
-      <Links>
-        <Link href={TUTORIAL_VIDEO_LINK} target="_blank" withArrow>
-          <VideoIcon /> Watch 8m video
-        </Link>
-        <Divider />
-        <Consumer>
-          {({ state }) => (
-            <Link href={docsUrl} target="_blank" withArrow>
-              <DocumentIcon /> Read docs
-            </Link>
-          )}
-        </Consumer>
-      </Links>
-    </Wrapper>
+        </>
+      }
+      footer={
+        <Links>
+          <Link href={TUTORIAL_VIDEO_LINK} target="_blank" withArrow>
+            <VideoIcon /> Watch 8m video
+          </Link>
+          <Divider />
+          <Link href={docsUrl} target="_blank" withArrow>
+            <DocumentIcon /> Read docs
+          </Link>
+        </Links>
+      }
+    />
   );
 };

--- a/code/ui/.storybook/main.ts
+++ b/code/ui/.storybook/main.ts
@@ -52,6 +52,7 @@ const config: StorybookConfig = {
     '@storybook/addon-interactions',
     '@storybook/addon-storysource',
     '@storybook/addon-designs',
+    '@storybook/addon-a11y',
     '@chromatic-com/storybook',
   ],
   build: {

--- a/code/ui/blocks/src/components/ArgsTable/Empty.tsx
+++ b/code/ui/blocks/src/components/ArgsTable/Empty.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React, { useEffect, useState } from 'react';
 import { styled } from '@storybook/theming';
-import { Link } from '@storybook/components';
+import { Link, EmptyTabContent } from '@storybook/components';
 import { DocumentIcon, SupportIcon, VideoIcon } from '@storybook/icons';
 
 interface EmptyProps {
@@ -20,27 +20,6 @@ const Wrapper = styled.div<{ inAddonPanel?: boolean }>(({ inAddonPanel, theme })
   gap: 15,
   background: theme.background.content,
   boxShadow: 'rgba(0, 0, 0, 0.10) 0 1px 3px 0',
-}));
-
-const Content = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 4,
-  maxWidth: 415,
-});
-
-const Title = styled.div(({ theme }) => ({
-  fontWeight: theme.typography.weight.bold,
-  fontSize: theme.typography.size.s2 - 1,
-  textAlign: 'center',
-  color: theme.textColor,
-}));
-
-const Description = styled.div(({ theme }) => ({
-  fontWeight: theme.typography.weight.regular,
-  fontSize: theme.typography.size.s2 - 1,
-  textAlign: 'center',
-  color: theme.textMutedColor,
 }));
 
 const Links = styled.div(({ theme }) => ({
@@ -73,39 +52,47 @@ export const Empty: FC<EmptyProps> = ({ inAddonPanel }) => {
 
   return (
     <Wrapper inAddonPanel={inAddonPanel}>
-      <Content>
-        <Title>
-          {inAddonPanel
+      <EmptyTabContent
+        title={
+          inAddonPanel
             ? 'Interactive story playground'
-            : "Args table with interactive controls couldn't be auto-generated"}
-        </Title>
-        <Description>
-          Controls give you an easy to use interface to test your components. Set your story args
-          and you&apos;ll see controls appearing here automatically.
-        </Description>
-      </Content>
-      <Links>
-        {inAddonPanel && (
+            : "Args table with interactive controls couldn't be auto-generated"
+        }
+        description={
           <>
-            <Link href="https://youtu.be/0gOfS6K0x0E" target="_blank" withArrow>
-              <VideoIcon /> Watch 5m video
-            </Link>
-            <Divider />
-            <Link
-              href="https://storybook.js.org/docs/essentials/controls"
-              target="_blank"
-              withArrow
-            >
-              <DocumentIcon /> Read docs
-            </Link>
+            Controls give you an easy to use interface to test your components. Set your story args
+            and you&apos;ll see controls appearing here automatically.
           </>
-        )}
-        {!inAddonPanel && (
-          <Link href="https://storybook.js.org/docs/essentials/controls" target="_blank" withArrow>
-            <SupportIcon /> Learn how to set that up
-          </Link>
-        )}
-      </Links>
+        }
+        footer={
+          <Links>
+            {inAddonPanel && (
+              <>
+                <Link href="https://youtu.be/0gOfS6K0x0E" target="_blank" withArrow>
+                  <VideoIcon /> Watch 5m video
+                </Link>
+                <Divider />
+                <Link
+                  href="https://storybook.js.org/docs/essentials/controls"
+                  target="_blank"
+                  withArrow
+                >
+                  <DocumentIcon /> Read docs
+                </Link>
+              </>
+            )}
+            {!inAddonPanel && (
+              <Link
+                href="https://storybook.js.org/docs/essentials/controls"
+                target="_blank"
+                withArrow
+              >
+                <SupportIcon /> Learn how to set that up
+              </Link>
+            )}
+          </Links>
+        }
+      />
     </Wrapper>
   );
 };

--- a/code/ui/blocks/src/components/ArgsTable/Empty.tsx
+++ b/code/ui/blocks/src/components/ArgsTable/Empty.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import React, { useEffect, useState } from 'react';
 import { styled } from '@storybook/theming';
 import { Link, EmptyTabContent } from '@storybook/components';
-import { DocumentIcon, SupportIcon, VideoIcon } from '@storybook/icons';
+import { DocumentIcon, VideoIcon } from '@storybook/icons';
 
 interface EmptyProps {
   inAddonPanel?: boolean;
@@ -87,7 +87,7 @@ export const Empty: FC<EmptyProps> = ({ inAddonPanel }) => {
                 target="_blank"
                 withArrow
               >
-                <SupportIcon /> Learn how to set that up
+                <DocumentIcon /> Learn how to set that up
               </Link>
             )}
           </Links>

--- a/code/ui/components/src/components/tabs/EmptyTabContent.stories.tsx
+++ b/code/ui/components/src/components/tabs/EmptyTabContent.stories.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import type { EmptyTabContent } from './EmptyTabContent';
+import { DocumentIcon } from '@storybook/icons';
+import { Link } from '@storybook/components';
+import type { Meta, StoryObj } from '@storybook/react';
+const EmptyComponent = () => '';
+
+export default {
+  component: EmptyComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof EmptyTabContent>;
+
+type Story = StoryObj<typeof EmptyTabContent>;
+
+export const EmptyStuff = {
+  render: () => {
+    return <div></div>;
+  },
+};
+
+export const OnlyTitle: Story = {
+  args: {
+    title: 'Nothing found',
+  },
+};
+
+export const TitleAndDescription: Story = {
+  args: {
+    title: 'Nothing found',
+    description: 'Sorry, there is nothing to display here.',
+  },
+};
+
+export const CustomFooter: Story = {
+  args: {
+    title: 'Nothing found',
+    description: 'Sorry, there is nothing to display here.',
+    footer: (
+      <Link href="foo" withArrow>
+        <DocumentIcon /> See the docs
+      </Link>
+    ),
+  },
+};

--- a/code/ui/components/src/components/tabs/EmptyTabContent.stories.tsx
+++ b/code/ui/components/src/components/tabs/EmptyTabContent.stories.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import type { EmptyTabContent } from './EmptyTabContent';
+import { EmptyTabContent } from './EmptyTabContent';
 import { DocumentIcon } from '@storybook/icons';
 import { Link } from '@storybook/components';
 import type { Meta, StoryObj } from '@storybook/react';
-const EmptyComponent = () => '';
 
 export default {
-  component: EmptyComponent,
+  component: EmptyTabContent,
   parameters: {
     layout: 'centered',
   },

--- a/code/ui/components/src/components/tabs/EmptyTabContent.stories.tsx
+++ b/code/ui/components/src/components/tabs/EmptyTabContent.stories.tsx
@@ -28,7 +28,18 @@ export const TitleAndDescription: Story = {
   },
 };
 
-export const CustomFooter: Story = {
+export const TitleAndFooter: Story = {
+  args: {
+    title: 'Nothing found',
+    footer: (
+      <Link href="foo" withArrow>
+        <DocumentIcon /> See the docs
+      </Link>
+    ),
+  },
+};
+
+export const TitleDescriptionAndFooter: Story = {
   args: {
     title: 'Nothing found',
     description: 'Sorry, there is nothing to display here.',

--- a/code/ui/components/src/components/tabs/EmptyTabContent.stories.tsx
+++ b/code/ui/components/src/components/tabs/EmptyTabContent.stories.tsx
@@ -15,12 +15,6 @@ export default {
 
 type Story = StoryObj<typeof EmptyTabContent>;
 
-export const EmptyStuff = {
-  render: () => {
-    return <div></div>;
-  },
-};
-
 export const OnlyTitle: Story = {
   args: {
     title: 'Nothing found',

--- a/code/ui/components/src/components/tabs/EmptyTabContent.tsx
+++ b/code/ui/components/src/components/tabs/EmptyTabContent.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { styled } from '@storybook/theming';
+
+const Wrapper = styled.div(({ theme }) => ({
+  height: '100%',
+  display: 'flex',
+  padding: 30,
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  gap: 15,
+  background: theme.background.content,
+}));
+
+const Content = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  maxWidth: 415,
+});
+
+const Title = styled.div(({ theme }) => ({
+  fontWeight: theme.typography.weight.bold,
+  fontSize: theme.typography.size.s2 - 1,
+  textAlign: 'center',
+  color: theme.textColor,
+}));
+
+const Description = styled.div(({ theme }) => ({
+  fontWeight: theme.typography.weight.regular,
+  fontSize: theme.typography.size.s2 - 1,
+  textAlign: 'center',
+  color: theme.textMutedColor,
+}));
+
+interface Props {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+export const EmptyTabContent = ({ title, description, footer }: Props) => {
+  return (
+    <Wrapper>
+      <Content>
+        <Title>{title}</Title>
+        {description && <Description>{description}</Description>}
+      </Content>
+      {footer}
+    </Wrapper>
+  );
+};

--- a/code/ui/components/src/components/tabs/tabs.stories.tsx
+++ b/code/ui/components/src/components/tabs/tabs.stories.tsx
@@ -1,9 +1,9 @@
 import { expect } from '@storybook/test';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { within, fireEvent, waitFor, screen, userEvent, findByText } from '@storybook/test';
-import { CPUIcon, MemoryIcon } from '@storybook/icons';
+import { BottomBarIcon, CloseIcon } from '@storybook/icons';
 import { Tabs, TabsState, TabWrapper } from './tabs';
 import type { ChildrenList } from './tabs.helpers';
 import { IconButton } from '../IconButton/IconButton';
@@ -260,7 +260,27 @@ export const StatelessBordered = {
   ),
 } satisfies Story;
 
+const AddonTools = () => (
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 6,
+    }}
+  >
+    <IconButton title="Tool 1">
+      <BottomBarIcon />
+    </IconButton>
+    <IconButton title="Tool 2">
+      <CloseIcon />
+    </IconButton>
+  </div>
+);
+
 export const StatelessWithTools = {
+  args: {
+    tools: <AddonTools />,
+  },
   render: (args) => (
     <Tabs
       bordered
@@ -269,22 +289,12 @@ export const StatelessWithTools = {
       actions={{
         onSelect,
       }}
-      tools={
-        <Fragment>
-          <IconButton title="Tool 1">
-            <MemoryIcon />
-          </IconButton>
-          <IconButton title="Tool 2">
-            <CPUIcon />
-          </IconButton>
-        </Fragment>
-      }
       {...args}
     >
       {content}
     </Tabs>
   ),
-} satisfies Story;
+} satisfies StoryObj<typeof Tabs>;
 
 export const StatelessAbsolute = {
   parameters: {
@@ -303,7 +313,7 @@ export const StatelessAbsolute = {
       {content}
     </Tabs>
   ),
-} satisfies Story;
+} satisfies StoryObj<typeof Tabs>;
 
 export const StatelessAbsoluteBordered = {
   parameters: {
@@ -323,9 +333,13 @@ export const StatelessAbsoluteBordered = {
       {content}
     </Tabs>
   ),
-} satisfies Story;
+} satisfies StoryObj<typeof Tabs>;
 
-export const StatelessEmpty = {
+export const StatelessEmptyWithTools = {
+  args: {
+    ...StatelessWithTools.args,
+    showToolsWhenEmpty: true,
+  },
   parameters: {
     layout: 'fullscreen',
   },
@@ -340,4 +354,25 @@ export const StatelessEmpty = {
       {...args}
     />
   ),
-} satisfies Story;
+} satisfies StoryObj<typeof Tabs>;
+
+export const StatelessWithCustomEmpty = {
+  args: {
+    ...StatelessEmptyWithTools.args,
+    customEmptyState: <div>I am custom!</div>,
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: (args) => (
+    <Tabs
+      actions={{
+        onSelect,
+      }}
+      bordered
+      menuName="Addons"
+      absolute
+      {...args}
+    />
+  ),
+} satisfies StoryObj<typeof Tabs>;

--- a/code/ui/components/src/components/tabs/tabs.stories.tsx
+++ b/code/ui/components/src/components/tabs/tabs.stories.tsx
@@ -359,7 +359,7 @@ export const StatelessEmptyWithTools = {
 export const StatelessWithCustomEmpty = {
   args: {
     ...StatelessEmptyWithTools.args,
-    customEmptyState: <div>I am custom!</div>,
+    emptyState: <div>I am custom!</div>,
   },
   parameters: {
     layout: 'fullscreen',

--- a/code/ui/components/src/components/tabs/tabs.tsx
+++ b/code/ui/components/src/components/tabs/tabs.tsx
@@ -120,7 +120,7 @@ export interface TabsProps {
   id?: string;
   tools?: ReactNode;
   showToolsWhenEmpty?: boolean;
-  customEmptyState?: ReactNode;
+  emptyState?: ReactNode;
   selected?: string;
   actions?: {
     onSelect: (id: string) => void;
@@ -142,7 +142,7 @@ export const Tabs: FC<TabsProps> = memo(
     backgroundColor,
     id: htmlId,
     menuName,
-    customEmptyState,
+    emptyState,
     showToolsWhenEmpty,
   }) => {
     const idList = childrenToList(children)
@@ -161,7 +161,7 @@ export const Tabs: FC<TabsProps> = memo(
 
     const { visibleList, tabBarRef, tabRefs, AddonTab } = useList(list);
 
-    const EmptyContent = customEmptyState ?? <EmptyTabContent title="Nothing found" />;
+    const EmptyContent = emptyState ?? <EmptyTabContent title="Nothing found" />;
 
     if (!showToolsWhenEmpty && list.length === 0) {
       return EmptyContent;

--- a/code/ui/components/src/components/tabs/tabs.tsx
+++ b/code/ui/components/src/components/tabs/tabs.tsx
@@ -1,14 +1,14 @@
 import type { FC, PropsWithChildren, ReactElement, ReactNode, SyntheticEvent } from 'react';
-import React, { useMemo, Component, Fragment, memo } from 'react';
+import React, { useMemo, Component, memo } from 'react';
 import { styled } from '@storybook/theming';
 import { sanitize } from '@storybook/csf';
 
 import type { Addon_RenderOptions } from '@storybook/types';
-import { Placeholder } from '../placeholder/placeholder';
 import { TabButton } from '../bar/button';
 import { FlexBar } from '../bar/bar';
 import { childrenToList, VisuallyHidden } from './tabs.helpers';
 import { useList } from './tabs.hooks';
+import { EmptyTabContent } from './EmptyTabContent';
 
 const ignoreSsrWarning =
   '/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */';
@@ -119,6 +119,8 @@ export interface TabsProps {
   }>[];
   id?: string;
   tools?: ReactNode;
+  showToolsWhenEmpty?: boolean;
+  customEmptyState?: ReactNode;
   selected?: string;
   actions?: {
     onSelect: (id: string) => void;
@@ -140,6 +142,8 @@ export const Tabs: FC<TabsProps> = memo(
     backgroundColor,
     id: htmlId,
     menuName,
+    customEmptyState,
+    showToolsWhenEmpty,
   }) => {
     const idList = childrenToList(children)
       .map((i) => i.id)
@@ -157,7 +161,13 @@ export const Tabs: FC<TabsProps> = memo(
 
     const { visibleList, tabBarRef, tabRefs, AddonTab } = useList(list);
 
-    return list.length ? (
+    const EmptyContent = customEmptyState ?? <EmptyTabContent title="Nothing found" />;
+
+    if (!showToolsWhenEmpty && list.length === 0) {
+      return EmptyContent;
+    }
+
+    return (
       <Wrapper absolute={absolute} bordered={bordered} id={htmlId}>
         <FlexBar scrollable={false} border backgroundColor={backgroundColor}>
           <TabBar style={{ whiteSpace: 'normal' }} ref={tabBarRef} role="tablist">
@@ -190,15 +200,13 @@ export const Tabs: FC<TabsProps> = memo(
           {tools}
         </FlexBar>
         <Content id="panel-tab-content" bordered={bordered} absolute={absolute}>
-          {list.map(({ id, active, render }) => {
-            return React.createElement(render, { key: id, active }, null);
-          })}
+          {list.length
+            ? list.map(({ id, active, render }) => {
+                return React.createElement(render, { key: id, active }, null);
+              })
+            : EmptyContent}
         </Content>
       </Wrapper>
-    ) : (
-      <Placeholder>
-        <Fragment key="title">Nothing found</Fragment>
-      </Placeholder>
     );
   }
 );

--- a/code/ui/components/src/index.ts
+++ b/code/ui/components/src/index.ts
@@ -66,6 +66,7 @@ export { default as ListItem } from './components/tooltip/ListItem';
 
 // Toolbar and subcomponents
 export { Tabs, TabsState, TabBar, TabWrapper } from './components/tabs/tabs';
+export { EmptyTabContent } from './components/tabs/EmptyTabContent';
 export { IconButtonSkeleton, TabButton } from './components/bar/button';
 export { Separator, interleaveSeparators } from './components/bar/separator';
 export { Bar, FlexBar } from './components/bar/bar';

--- a/code/ui/manager/src/components/panel/Panel.tsx
+++ b/code/ui/manager/src/components/panel/Panel.tsx
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
-import { Tabs, IconButton } from '@storybook/components';
+import React, { Component, Fragment } from 'react';
+import { Tabs, IconButton, Placeholder, P, Link } from '@storybook/components';
 import type { State } from '@storybook/manager-api';
 import { shortcutToHumanString } from '@storybook/manager-api';
 import type { Addon_BaseType } from '@storybook/types';
 import { styled } from '@storybook/theming';
-import { BottomBarIcon, CloseIcon, SidebarAltIcon } from '@storybook/icons';
+import { BottomBarIcon, CloseIcon, DocumentIcon, SidebarAltIcon } from '@storybook/icons';
 import { useLayout } from '../layout/LayoutProvider';
 
 export interface SafeTabProps {
@@ -60,6 +60,23 @@ export const AddonPanel = React.memo<{
         {...(selectedPanel ? { selected: selectedPanel } : {})}
         menuName="Addons"
         actions={actions}
+        showToolsWhenEmpty
+        customEmptyContent={
+          <Placeholder>
+            <Fragment key="title">
+              <P>Storybook add-ons</P>
+            </Fragment>
+            <EmptyStateDescription key="content">
+              <P>
+                Integrate your tools with Storybook to connect workflows and unlock advanced
+                features.
+              </P>
+              <Link href={'https://storybook.js.org/integrations'} target="_blank" withArrow>
+                <DocumentIcon /> Explore integrations catalog
+              </Link>
+            </EmptyStateDescription>
+          </Placeholder>
+        }
         tools={
           <Actions>
             {isDesktop ? (
@@ -107,4 +124,10 @@ const Actions = styled.div({
   display: 'flex',
   alignItems: 'center',
   gap: 6,
+});
+
+const EmptyStateDescription = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  flexDirection: 'column',
 });

--- a/code/ui/manager/src/components/panel/Panel.tsx
+++ b/code/ui/manager/src/components/panel/Panel.tsx
@@ -61,7 +61,7 @@ export const AddonPanel = React.memo<{
         menuName="Addons"
         actions={actions}
         showToolsWhenEmpty
-        customEmptyContent={
+        customEmptyState={
           <Placeholder>
             <Fragment key="title">
               <P>Storybook add-ons</P>

--- a/code/ui/manager/src/components/panel/Panel.tsx
+++ b/code/ui/manager/src/components/panel/Panel.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Tabs, IconButton, P, Link, EmptyTabContent } from '@storybook/components';
+import { Tabs, IconButton, Link, EmptyTabContent } from '@storybook/components';
 import type { State } from '@storybook/manager-api';
 import { shortcutToHumanString } from '@storybook/manager-api';
 import type { Addon_BaseType } from '@storybook/types';

--- a/code/ui/manager/src/components/panel/Panel.tsx
+++ b/code/ui/manager/src/components/panel/Panel.tsx
@@ -1,5 +1,5 @@
-import React, { Component, Fragment } from 'react';
-import { Tabs, IconButton, Placeholder, P, Link } from '@storybook/components';
+import React, { Component } from 'react';
+import { Tabs, IconButton, P, Link, EmptyTabContent } from '@storybook/components';
 import type { State } from '@storybook/manager-api';
 import { shortcutToHumanString } from '@storybook/manager-api';
 import type { Addon_BaseType } from '@storybook/types';
@@ -61,21 +61,21 @@ export const AddonPanel = React.memo<{
         menuName="Addons"
         actions={actions}
         showToolsWhenEmpty
-        customEmptyState={
-          <Placeholder>
-            <Fragment key="title">
-              <P>Storybook add-ons</P>
-            </Fragment>
-            <EmptyStateDescription key="content">
-              <P>
+        emptyState={
+          <EmptyTabContent
+            title="Storybook add-ons"
+            description={
+              <>
                 Integrate your tools with Storybook to connect workflows and unlock advanced
                 features.
-              </P>
+              </>
+            }
+            footer={
               <Link href={'https://storybook.js.org/integrations'} target="_blank" withArrow>
                 <DocumentIcon /> Explore integrations catalog
               </Link>
-            </EmptyStateDescription>
-          </Placeholder>
+            }
+          />
         }
         tools={
           <Actions>
@@ -124,10 +124,4 @@ const Actions = styled.div({
   display: 'flex',
   alignItems: 'center',
   gap: 6,
-});
-
-const EmptyStateDescription = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  flexDirection: 'column',
 });

--- a/code/ui/manager/src/globals/exports.ts
+++ b/code/ui/manager/src/globals/exports.ts
@@ -67,6 +67,7 @@ export default {
     'DL',
     'Div',
     'DocumentWrapper',
+    'EmptyTabContent',
     'ErrorFormatter',
     'FlexBar',
     'Form',


### PR DESCRIPTION
Closes #26445

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR revamps the empty state of the addon panel (when users have zero addons) by doing a couple of things:

1 - Adds the toolbar items so that users can toggle position and close the panel
2 - Adds some copy with a link to the integrations catalog, so that users can explore Storybook addons
<img width="676" alt="image" src="https://github.com/storybookjs/storybook/assets/1671563/69c4cc83-cd59-4bbe-a0b9-e86834cece39">

3 - Creates a new EmptyTabContent component and reuses that across different addon panels

![image](https://github.com/storybookjs/storybook/assets/1671563/65d1e68a-8182-4ac8-ae16-455f0a0ae580)


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_


1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Open interactions panel in the Button stories, it should show the empty state


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
