### PR TITLE
CLI: Automigrate improve upgrade storybook related packages

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/upgrade-storybook-related-dependencies.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/upgrade-storybook-related-dependencies.test.ts
@@ -52,20 +52,26 @@ describe('upgrade-storybook-related-dependencies fix', () => {
       {
         packageName: 'storybook',
         packageVersion: '8.0.0',
-        availableUpgrade: undefined,
+        availableUpgrade: '8.0.0',
         hasIncompatibleDependencies: true,
       },
     ];
     vi.mocked(docsUtils.getIncompatibleStorybookPackages).mockResolvedValue(analyzedPackages);
+    vi.mocked(docsUtils.getInstalledVersion).mockImplementation(
+      async (pkgName) =>
+        analyzedPackages.find((pkg) => pkg.packageName === pkgName)?.packageVersion || null
+    );
     await expect(
       check({
         packageManager: {
-          getAllDependencies: async () => ({
-            '@chromatic-com/storybook': '1.2.9',
-            '@storybook/jest': '0.2.3',
-            '@storybook/preset-create-react-app': '3.2.0',
-            storybook: '8.0.0',
-          }),
+          getAllDependencies: async () =>
+            analyzedPackages.reduce(
+              (acc, { packageName, packageVersion }) => {
+                acc[packageName] = packageVersion;
+                return acc;
+              },
+              {} as Record<string, string>
+            ),
           latestVersion: async (pkgName) =>
             analyzedPackages.find((pkg) => pkg.packageName === pkgName)?.availableUpgrade || '',
         },

--- a/code/lib/cli/src/automigrate/fixes/upgrade-storybook-related-dependencies.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/upgrade-storybook-related-dependencies.test.ts
@@ -57,10 +57,6 @@ describe('upgrade-storybook-related-dependencies fix', () => {
       },
     ];
     vi.mocked(docsUtils.getIncompatibleStorybookPackages).mockResolvedValue(analyzedPackages);
-    vi.mocked(docsUtils.getInstalledVersion).mockImplementation(
-      async (pkgName) =>
-        analyzedPackages.find((pkg) => pkg.packageName === pkgName)?.packageVersion || null
-    );
     await expect(
       check({
         packageManager: {
@@ -74,6 +70,8 @@ describe('upgrade-storybook-related-dependencies fix', () => {
             ),
           latestVersion: async (pkgName) =>
             analyzedPackages.find((pkg) => pkg.packageName === pkgName)?.availableUpgrade || '',
+          getInstalledVersion: async (pkgName) =>
+            analyzedPackages.find((pkg) => pkg.packageName === pkgName)?.packageVersion || null,
         },
       })
     ).resolves.toMatchInlineSnapshot(`

--- a/code/lib/cli/src/automigrate/fixes/upgrade-storybook-related-dependencies.ts
+++ b/code/lib/cli/src/automigrate/fixes/upgrade-storybook-related-dependencies.ts
@@ -4,10 +4,7 @@ import { gt } from 'semver';
 import type { JsPackageManager } from '@storybook/core-common';
 import { isCorePackage } from '@storybook/core-common';
 import type { Fix } from '../types';
-import {
-  getIncompatibleStorybookPackages,
-  getInstalledVersion,
-} from '../../doctor/getIncompatibleStorybookPackages';
+import { getIncompatibleStorybookPackages } from '../../doctor/getIncompatibleStorybookPackages';
 
 type PackageMetadata = {
   packageName: string;
@@ -26,7 +23,7 @@ async function getLatestVersions(
   return Promise.all(
     packages.map(async ([packageName]) => ({
       packageName,
-      beforeVersion: await getInstalledVersion(packageName, packageManager).catch(() => null),
+      beforeVersion: await packageManager.getInstalledVersion(packageName).catch(() => null),
       afterVersion: await packageManager.latestVersion(packageName).catch(() => null),
     }))
   );

--- a/code/lib/cli/src/automigrate/fixes/upgrade-storybook-related-dependencies.ts
+++ b/code/lib/cli/src/automigrate/fixes/upgrade-storybook-related-dependencies.ts
@@ -4,7 +4,10 @@ import { gt } from 'semver';
 import type { JsPackageManager } from '@storybook/core-common';
 import { isCorePackage } from '@storybook/core-common';
 import type { Fix } from '../types';
-import { getIncompatibleStorybookPackages } from '../../doctor/getIncompatibleStorybookPackages';
+import {
+  getIncompatibleStorybookPackages,
+  getInstalledVersion,
+} from '../../doctor/getIncompatibleStorybookPackages';
 
 type PackageMetadata = {
   packageName: string;
@@ -16,15 +19,6 @@ interface Options {
   upgradable: PackageMetadata[];
 }
 
-const getInstalledVersion = async (packageName: string, packageManager: JsPackageManager) => {
-  const installations = await packageManager.findInstallations([packageName]);
-  if (!installations) {
-    return null;
-  }
-
-  return Object.entries(installations.dependencies)[0]?.[1]?.[0].version || null;
-};
-
 async function getLatestVersions(
   packageManager: JsPackageManager,
   packages: [string, string][]
@@ -32,7 +26,7 @@ async function getLatestVersions(
   return Promise.all(
     packages.map(async ([packageName]) => ({
       packageName,
-      beforeVersion: await getInstalledVersion(packageName, packageManager),
+      beforeVersion: await getInstalledVersion(packageName, packageManager).catch(() => null),
       afterVersion: await packageManager.latestVersion(packageName).catch(() => null),
     }))
   );

--- a/code/lib/cli/src/doctor/getIncompatibleStorybookPackages.ts
+++ b/code/lib/cli/src/doctor/getIncompatibleStorybookPackages.ts
@@ -19,6 +19,18 @@ type Context = {
   skipErrors?: boolean;
 };
 
+export const getInstalledVersion = async (
+  packageName: string,
+  packageManager: JsPackageManager
+) => {
+  const installations = await packageManager.findInstallations([packageName]);
+  if (!installations) {
+    return null;
+  }
+
+  return Object.entries(installations.dependencies)[0]?.[1]?.[0].version || null;
+};
+
 export const checkPackageCompatibility = async (dependency: string, context: Context) => {
   const { currentStorybookVersion, skipErrors, packageManager } = context;
   try {

--- a/code/lib/cli/src/doctor/getIncompatibleStorybookPackages.ts
+++ b/code/lib/cli/src/doctor/getIncompatibleStorybookPackages.ts
@@ -19,18 +19,6 @@ type Context = {
   skipErrors?: boolean;
 };
 
-export const getInstalledVersion = async (
-  packageName: string,
-  packageManager: JsPackageManager
-) => {
-  const installations = await packageManager.findInstallations([packageName]);
-  if (!installations) {
-    return null;
-  }
-
-  return Object.entries(installations.dependencies)[0]?.[1]?.[0].version || null;
-};
-
 export const checkPackageCompatibility = async (dependency: string, context: Context) => {
   const { currentStorybookVersion, skipErrors, packageManager } = context;
   try {

--- a/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
@@ -535,6 +535,23 @@ export abstract class JsPackageManager {
     }
   }
 
+  /**
+   * Returns the installed (within node_modules or pnp zip) version of a specified package
+   */
+  public async getInstalledVersion(packageName: string): Promise<string | null> {
+    const installations = await this.findInstallations([packageName]);
+    if (!installations) {
+      return null;
+    }
+
+    console.log({
+      installations,
+      version: Object.entries(installations.dependencies)[0]?.[1]?.[0].version,
+    });
+
+    return Object.entries(installations.dependencies)[0]?.[1]?.[0].version || null;
+  }
+
   public async executeCommand({
     command,
     args = [],

--- a/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
@@ -544,11 +544,6 @@ export abstract class JsPackageManager {
       return null;
     }
 
-    console.log({
-      installations,
-      version: Object.entries(installations.dependencies)[0]?.[1]?.[0].version,
-    });
-
     return Object.entries(installations.dependencies)[0]?.[1]?.[0].version || null;
   }
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/26451

## What I did

Instead of coercing the version from the `package.json`, actually retreive the version that's installed.

This allows us to properly compare with semver if the package that's latest on npm is newer.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
