### PR TITLE
CLI: Add yarn1 package manager fallback for init in empty directory

### DIFF
--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -242,7 +242,7 @@ export async function doInitiate(
 > {
   const { packageManager: pkgMgr } = options;
 
-  const packageManager = JsPackageManagerFactory.getPackageManager({
+  let packageManager = JsPackageManagerFactory.getPackageManager({
     force: pkgMgr,
   });
 
@@ -276,6 +276,13 @@ export async function doInitiate(
 
   // Check if the current directory is empty.
   if (options.force !== true && currentDirectoryIsEmpty(packageManager.type)) {
+    // Initializing Storybook in an empty directory with yarn1
+    // will very likely fail due to different kind of hoisting issues
+    // which doesn't get fixed anymore in yarn1.
+    // We will fallback to npm in this case.
+    if (packageManager.type === 'yarn1') {
+      packageManager = JsPackageManagerFactory.getPackageManager({ force: 'npm' });
+    }
     // Prompt the user to create a new project from our list.
     await scaffoldNewProject(packageManager.type, options);
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/26480

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have introduced a package manager fallback from yarn1 to npm in cases where Storybook is initialized into an empty directory. Due to hoisting issues in yarn1, the framework's initialization already fails, and the `init` process exited with an error.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `mkdir empty-directory && cd ./empty-directory`
2. `touch yarn.lock`
3. `mkdir nested && cd ./nested`
4. `npx storybook@0.0.0-pr-26500-sha-4eef9b4c init`
5. Storybook starts and is initialized with npm instead of yarn.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26500-sha-4eef9b4c`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26500-sha-4eef9b4c sandbox` or in an existing project with `npx storybook@0.0.0-pr-26500-sha-4eef9b4c upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26500-sha-4eef9b4c`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26500-sha-4eef9b4c) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/use-npm-over-yarn1-while-init`](https://github.com/storybookjs/storybook/tree/valentin/use-npm-over-yarn1-while-init) |
| **Commit** | [`4eef9b4c`](https://github.com/storybookjs/storybook/commit/4eef9b4cf0c058baea19718d631c6f6d07a117b4) |
| **Datetime** | Thu Mar 14 14:37:16 UTC 2024 (`1710427036`) |
| **Workflow run** | [8282580419](https://github.com/storybookjs/storybook/actions/runs/8282580419) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26500`_
</details>
<!-- CANARY_RELEASE_SECTION -->
