### PR TITLE
CSF: Make sure loaders/decorators can be used as array

### DIFF
--- a/code/lib/preview-api/src/modules/store/csf/composeConfigs.test.ts
+++ b/code/lib/preview-api/src/modules/store/csf/composeConfigs.test.ts
@@ -176,6 +176,34 @@ describe('composeConfigs', () => {
     });
   });
 
+  it('allows single array to be written without array', () => {
+    expect(
+      composeConfigs([
+        {
+          argsEnhancers: ['1', '2'],
+          argTypesEnhancers: ['1', '2'],
+          loaders: '1',
+        },
+        {
+          argsEnhancers: '3',
+          argTypesEnhancers: '3',
+          loaders: ['2', '3'],
+        },
+      ])
+    ).toEqual({
+      parameters: {},
+      decorators: [],
+      args: {},
+      argsEnhancers: ['1', '2', '3'],
+      argTypes: {},
+      argTypesEnhancers: ['1', '2', '3'],
+      globals: {},
+      globalTypes: {},
+      loaders: ['1', '2', '3'],
+      runStep: expect.any(Function),
+    });
+  });
+
   it('combines decorators in reverse file order', () => {
     expect(
       composeConfigs([

--- a/code/lib/preview-api/src/modules/store/csf/composeConfigs.ts
+++ b/code/lib/preview-api/src/modules/store/csf/composeConfigs.ts
@@ -3,6 +3,7 @@ import { global } from '@storybook/global';
 
 import { combineParameters } from '../parameters';
 import { composeStepRunners } from './stepRunners';
+import { normalizeArrays } from './normalizeArrays';
 
 export function getField<TFieldType = any>(
   moduleExportList: ModuleExports[],
@@ -16,10 +17,10 @@ export function getArrayField<TFieldType = any>(
   field: string,
   options: { reverseFileOrder?: boolean } = {}
 ): TFieldType[] {
-  return getField(moduleExportList, field).reduce(
-    (a: any, b: any) => (options.reverseFileOrder ? [...b, ...a] : [...a, ...b]),
-    []
-  );
+  return getField(moduleExportList, field).reduce((prev: any, cur: any) => {
+    const normalized = normalizeArrays(cur);
+    return options.reverseFileOrder ? [...normalized, ...prev] : [...prev, ...normalized];
+  }, []);
 }
 
 export function getObjectField<TFieldType = Record<string, any>>(


### PR DESCRIPTION
## What I did

Make sure loaders/decorators can be used as array.

Our type definitions allow both an array as a function to be assigned to loaders or decorators. This worked in 7.6 but regressed in 8.0.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
