### PR TITLE
Angular: Fix Angular sandbox startup errors

### DIFF
--- a/code/addons/actions/src/runtime/action.ts
+++ b/code/addons/actions/src/runtime/action.ts
@@ -21,10 +21,9 @@ const isReactSyntheticEvent = (e: unknown): e is SyntheticEvent =>
       findProto(e, (proto) => /^Synthetic(?:Base)?Event$/.test(proto.constructor.name)) &&
       typeof (e as SyntheticEvent).persist === 'function'
   );
-const serializeArg = <T>(a: T) => {
+const serializeArg = <T extends object>(a: T) => {
   if (isReactSyntheticEvent(a)) {
     const e: SyntheticEvent = Object.create(
-      // @ts-expect-error (Converted from ts-ignore)
       a.constructor.prototype,
       Object.getOwnPropertyDescriptors(a)
     );

--- a/code/addons/links/src/utils.ts
+++ b/code/addons/links/src/utils.ts
@@ -37,9 +37,7 @@ export const hrefTo = (title: ComponentTitle, name: StoryName): Promise<string> 
   return new Promise((resolve) => {
     const { location } = document;
     const query = parseQuery(location.search);
-    // @ts-expect-error (Converted from ts-ignore)
-    const existingId = [].concat(query.id)[0];
-    // @ts-expect-error (Converted from ts-ignore)
+    const existingId = query.id;
     const titleToLink = title || existingId.split('--', 2)[0];
     const id = toId(titleToLink, name);
     const path = `/story/${id}`;

--- a/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
@@ -363,7 +363,7 @@ export abstract class JsPackageManager {
    *
    * @param packageNames
    */
-  public getVersions(...packageNames: StorybookPackage[]): Promise<string[]> {
+  public getVersions(...packageNames: string[]): Promise<string[]> {
     return Promise.all(
       packageNames.map((packageName) => {
         return this.getVersion(packageName);
@@ -380,11 +380,11 @@ export abstract class JsPackageManager {
    * @param packageName The name of the package
    * @param constraint A valid semver constraint, example: '1.x || >=2.5.0 || 5.0.0 - 7.2.3'
    */
-  public async getVersion(packageName: StorybookPackage, constraint?: string): Promise<string> {
+  public async getVersion(packageName: string, constraint?: string): Promise<string> {
     let current: string | undefined;
 
-    if (/(@storybook|^sb$|^storybook$)/.test(packageName)) {
-      current = storybookPackagesVersions[packageName];
+    if (packageName in storybookPackagesVersions) {
+      current = storybookPackagesVersions[packageName as StorybookPackage];
     }
 
     let latest;

--- a/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
@@ -17,6 +17,8 @@ const logger = console;
 
 export type PackageManagerName = 'npm' | 'yarn1' | 'yarn2' | 'pnpm';
 
+type StorybookPackage = keyof typeof storybookPackagesVersions;
+
 /**
  * Extract package name and version from input
  *
@@ -361,7 +363,7 @@ export abstract class JsPackageManager {
    *
    * @param packageNames
    */
-  public getVersions(...packageNames: string[]): Promise<string[]> {
+  public getVersions(...packageNames: StorybookPackage[]): Promise<string[]> {
     return Promise.all(
       packageNames.map((packageName) => {
         return this.getVersion(packageName);
@@ -378,11 +380,10 @@ export abstract class JsPackageManager {
    * @param packageName The name of the package
    * @param constraint A valid semver constraint, example: '1.x || >=2.5.0 || 5.0.0 - 7.2.3'
    */
-  public async getVersion(packageName: string, constraint?: string): Promise<string> {
+  public async getVersion(packageName: StorybookPackage, constraint?: string): Promise<string> {
     let current: string | undefined;
 
     if (/(@storybook|^sb$|^storybook$)/.test(packageName)) {
-      // @ts-expect-error (Converted from ts-ignore)
       current = storybookPackagesVersions[packageName];
     }
 

--- a/code/lib/preview-api/src/modules/preview-web/Preview.tsx
+++ b/code/lib/preview-api/src/modules/preview-web/Preview.tsx
@@ -100,9 +100,7 @@ export class Preview<TRenderer extends Renderer> {
         get: (_, method) => {
           if (this.storyStoreValue) {
             deprecate('Accessing the Story Store is deprecated and will be removed in 9.0');
-
-            // @ts-expect-error I'm not sure if there's a way to keep TS happy here
-            return this.storyStoreValue[method];
+            return this.storyStoreValue[method as keyof StoryStore<TRenderer>];
           }
 
           throw new StoryStoreAccessedBeforeInitializationError();

--- a/code/lib/test/src/index.ts
+++ b/code/lib/test/src/index.ts
@@ -36,6 +36,6 @@ const resetAllMocksLoader: LoaderFunction = ({ parameters }) => {
   }
 };
 
-// @ts-expect-error We are using this as a default Storybook loader, when the test package is used. This avoids the need for optional peer dependency workarounds.
+// We are using this as a default Storybook loader, when the test package is used. This avoids the need for optional peer dependency workarounds.
 // eslint-disable-next-line no-underscore-dangle
-global.__STORYBOOK_TEST_LOADERS__ = [resetAllMocksLoader];
+(global as any).__STORYBOOK_TEST_LOADERS__ = [resetAllMocksLoader];


### PR DESCRIPTION
## What I did

In `main,` you cannot bootstrap a startable Angular Sandbox app. The Angular app type-checker complains that many `ts-expect-errors` are unnecessary and must be removed. Angular is wrong here, but I don't know how to tell Angular that these `@ts-expect-errors` were right. But I also think all the `ts-expect-errors` were unnecessary and solvable in non-invasive ways.

This PR aims to make the Angular Sandbox startable again without any workarounds.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Create an Angular sandbox app
2. Start it
3. It should start without errors

**Sanity check:**
1. Use `main`
2. Create an Angular sandbox app
3. Start it
4. It should fail to start because of 5 `@ts-expect-errors`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
