### PR TITLE
UI: Fix theming of elements inside bars

### DIFF
--- a/code/lib/theming/src/themes/dark.ts
+++ b/code/lib/theming/src/themes/dark.ts
@@ -25,7 +25,7 @@ const theme: ThemeVars = {
   textMutedColor: '#798186',
 
   // Toolbar default and active colors
-  barTextColor: '#798186',
+  barTextColor: color.mediumdark,
   barHoverColor: color.secondary,
   barSelectedColor: color.secondary,
   barBg: '#292C2E',

--- a/code/ui/blocks/src/components/ArgsTable/ArgsTable.tsx
+++ b/code/ui/blocks/src/components/ArgsTable/ArgsTable.tsx
@@ -166,7 +166,6 @@ export const TableWrapper = styled.table<{
 }));
 
 const StyledIconButton = styled(IconButton as any)(({ theme }) => ({
-  color: theme.barTextColor,
   margin: '-4px -12px -4px 0',
 }));
 

--- a/code/ui/components/src/components/Button/Button.tsx
+++ b/code/ui/components/src/components/Button/Button.tsx
@@ -172,6 +172,8 @@ const StyledButton = styled('button', {
   })(),
   ...(variant === 'ghost'
     ? {
+        // This is a hack to apply bar styles to the button as soon as it is part of a bar
+        // It is a temporary solution until we have implemented Theming 2.0.
         '.sb-bar &': {
           background: (() => {
             if (active) return transparentize(0.9, theme.barTextColor);

--- a/code/ui/components/src/components/Button/Button.tsx
+++ b/code/ui/components/src/components/Button/Button.tsx
@@ -170,6 +170,34 @@ const StyledButton = styled('button', {
     if (variant === 'ghost' && active) return theme.background.hoverable;
     return 'transparent';
   })(),
+  ...(variant === 'ghost'
+    ? {
+        '.sb-bar &': {
+          background: (() => {
+            if (active) return transparentize(0.9, theme.barTextColor);
+            return 'transparent';
+          })(),
+          color: (() => {
+            if (active) return theme.barSelectedColor;
+            return theme.barTextColor;
+          })(),
+          '&:hover': {
+            color: theme.barHoverColor,
+            background: transparentize(0.86, theme.barHoverColor),
+          },
+
+          '&:active': {
+            color: theme.barSelectedColor,
+            background: transparentize(0.9, theme.barSelectedColor),
+          },
+
+          '&:focus': {
+            boxShadow: `${rgba(theme.barHoverColor, 1)} 0 0 0 1px inset`,
+            outline: 'none',
+          },
+        },
+      }
+    : {}),
   color: (() => {
     if (variant === 'solid') return theme.color.lightest;
     if (variant === 'outline') return theme.input.color;

--- a/code/ui/components/src/components/bar/bar.tsx
+++ b/code/ui/components/src/components/bar/bar.tsx
@@ -93,10 +93,10 @@ export interface FlexBarProps extends ComponentProps<typeof Bar> {
   backgroundColor?: string;
 }
 
-export const FlexBar = ({ children, backgroundColor, ...rest }: FlexBarProps) => {
+export const FlexBar = ({ children, backgroundColor, className, ...rest }: FlexBarProps) => {
   const [left, right] = Children.toArray(children);
   return (
-    <Bar {...rest}>
+    <Bar className={`sb-bar ${className}`} {...rest}>
       <BarInner bgColor={backgroundColor}>
         <Side scrollable={rest.scrollable} left>
           {left}

--- a/code/ui/components/src/components/bar/button.tsx
+++ b/code/ui/components/src/components/bar/button.tsx
@@ -108,7 +108,7 @@ export const TabButton = styled(ButtonOrLink, { shouldForwardProp: isPropValid }
 
     '&:focus': {
       outline: '0 none',
-      borderBottomColor: theme.color.secondary,
+      borderBottomColor: theme.barSelectedColor,
     },
   }),
   ({ active, textColor, theme }) =>
@@ -120,6 +120,9 @@ export const TabButton = styled(ButtonOrLink, { shouldForwardProp: isPropValid }
       : {
           color: textColor || theme.barTextColor,
           borderBottomColor: 'transparent',
+          '&:hover': {
+            color: theme.barHoverColor,
+          },
         }
 );
 TabButton.displayName = 'TabButton';

--- a/code/ui/components/src/components/tabs/tabs.hooks.tsx
+++ b/code/ui/components/src/components/tabs/tabs.hooks.tsx
@@ -22,11 +22,14 @@ const CollapseIcon = styled.span<{ isActive: boolean }>(({ theme, isActive }) =>
 
 const AddonButton = styled(TabButton)<{ preActive: boolean }>(({ active, theme, preActive }) => {
   return `
-    color: ${preActive || active ? theme.color.secondary : theme.color.mediumdark};
+    color: ${preActive || active ? theme.barSelectedColor : theme.barTextColor};
+    .addon-collapsible-icon {
+      color: ${preActive || active ? theme.barSelectedColor : theme.barTextColor};
+    }
     &:hover {
-      color: ${theme.color.secondary};
+      color: ${theme.barHoverColor};
       .addon-collapsible-icon {
-        color: ${theme.color.secondary};
+        color: ${theme.barHoverColor};
       }
     }
   `;

--- a/code/ui/manager/src/components/mobile/navigation/MobileNavigation.tsx
+++ b/code/ui/manager/src/components/mobile/navigation/MobileNavigation.tsx
@@ -45,7 +45,7 @@ export const MobileNavigation: FC<MobileNavigationProps> = ({ menu, panel, showP
       {isMobilePanelOpen ? (
         <MobileAddonsDrawer>{panel}</MobileAddonsDrawer>
       ) : (
-        <Nav>
+        <Nav className="sb-bar">
           <Button onClick={() => setMobileMenuOpen(!isMobileMenuOpen)} title="Open navigation menu">
             <MenuIcon />
             <Text>{fullStoryName}</Text>
@@ -84,7 +84,7 @@ const Button = styled.button(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   gap: 10,
-  color: theme.color.mediumdark,
+  color: theme.barTextColor,
   fontSize: `${theme.typography.size.s2 - 1}px`,
   padding: '0 7px',
   fontWeight: theme.typography.weight.bold,

--- a/code/ui/manager/src/components/preview/Toolbar.tsx
+++ b/code/ui/manager/src/components/preview/Toolbar.tsx
@@ -135,7 +135,7 @@ export const ToolbarComp = React.memo<ToolData>(function ToolbarComp({
   api,
 }) {
   return tabs || tools || toolsExtra ? (
-    <Toolbar key="toolbar" shown={isShown} data-test-id="sb-preview-toolbar">
+    <Toolbar className="sb-bar" key="toolbar" shown={isShown} data-test-id="sb-preview-toolbar">
       <ToolbarInner>
         <ToolbarLeft>
           {tabs.length > 1 ? (

--- a/code/ui/manager/src/components/sidebar/Sidebar.tsx
+++ b/code/ui/manager/src/components/sidebar/Sidebar.tsx
@@ -183,7 +183,7 @@ export const Sidebar = React.memo(function Sidebar({
         </Top>
       </ScrollArea>
       {isLoading ? null : (
-        <Bottom>
+        <Bottom className="sb-bar">
           {bottom.map(({ id, render: Render }) => (
             <Render key={id} />
           ))}

--- a/code/ui/manager/src/settings/index.tsx
+++ b/code/ui/manager/src/settings/index.tsx
@@ -80,7 +80,7 @@ const Pages: FC<{
 
   return (
     <Fragment>
-      <Header>
+      <Header className="sb-bar">
         <TabBar role="tablist">
           <TabBarButton id="about" title="About" changeTab={changeTab} />
           {enableWhatsNew && (


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/26448

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

In Storybook 8.0, we have broken theming for elements inside bars. The theming variables "barTextColor", "barHoverColor" and "barSelectedColor" were mostly ignored and mainly other variable colors were applied.

This commit mainly ensures, that the default dark and light theming doesn't change. If "barTextColor", "barHoverColor" or "barSelectedColor" are set by the user, they get normally applied to the icon and text elements inside the bar areas, like the topbar, bottom-bar or the tab area in the addons panel.

Additionally, I have introduced a hover effect on the Tabs inside the TabsPanel. Until now, a hover didn't change the color at all.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `yarn task` -> Compile all packages
2. Go to `code/ui/.storybook` and create a new file `MyTheme.js` and put the following content in:

```js
import { create } from '@storybook/theming/create';

export default create({
  base: 'light',

  // Toolbar default and active colors
  barTextColor: 'violet',
  barSelectedColor: 'yellow',
  barHoverColor: 'green',
  barBg: 'red',
});
```
3. Import the theme in `code/ui/.storybook/manager.tsx`:

```diff
import React from 'react';
import { addons, types } from '@storybook/manager-api';
import startCase from 'lodash/startCase.js';
+ import MyTheme from './MyTheme.js';

addons.setConfig({
  sidebar: {
    renderLabel: ({ name, type }) => (type === 'story' ? name : startCase(name)),
  },
+  theme: MyTheme,
});
```

4. Make sure that the bar styles are properly applied in the TopBar:

<img width="505" alt="Bildschirmfoto 2024-03-15 um 21 35 32" src="https://github.com/storybookjs/storybook/assets/5889929/7bfc6991-5fef-49ef-924c-3912e1d9f081">

5. Make sure that the bar styles are properly applied in the Addon Panel:

<img width="593" alt="Bildschirmfoto 2024-03-15 um 21 32 44" src="https://github.com/storybookjs/storybook/assets/5889929/04bd68a6-1c30-4c82-99c7-efa8a7051f0a">

6. Make sure the bottom bar in mobile mode is properly styled:

<img width="379" alt="Bildschirmfoto 2024-03-15 um 21 34 09" src="https://github.com/storybookjs/storybook/assets/5889929/088fd1b9-fc04-43b0-b9cd-adb5fdfba08d">

7. Adjust the theming so that it applies to dark mode, and repeat the testing instructions.
8. Remove the custom theming and ensure the default dark and light modes haven't changed.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26527-sha-db4e08ae`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26527-sha-db4e08ae sandbox` or in an existing project with `npx storybook@0.0.0-pr-26527-sha-db4e08ae upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26527-sha-db4e08ae`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26527-sha-db4e08ae) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-theming-for-bar-areas`](https://github.com/storybookjs/storybook/tree/valentin/fix-theming-for-bar-areas) |
| **Commit** | [`db4e08ae`](https://github.com/storybookjs/storybook/commit/db4e08ae8b2aaeb840a8a9f06e68878357e40ee9) |
| **Datetime** | Fri Mar 15 20:41:38 UTC 2024 (`1710535298`) |
| **Workflow run** | [8302078089](https://github.com/storybookjs/storybook/actions/runs/8302078089) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26527`_
</details>
<!-- CANARY_RELEASE_SECTION -->
