### PR TITLE
Addon Docs: Fix [Object object] displayName in some JSX components

### DIFF
--- a/code/renderers/react/src/docs/jsxDecorator.test.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.test.tsx
@@ -130,11 +130,22 @@ describe('renderJsx', () => {
       }
     );
 
-    expect(renderJsx(createElement(MyExoticComponentRef, {}, 'I am forwardRef!'), {}))
+    expect(renderJsx(<MyExoticComponentRef>I am forwardRef!</MyExoticComponentRef>))
       .toMatchInlineSnapshot(`
-        <MyExoticComponent>
+        <React.ForwardRef>
           I am forwardRef!
-        </MyExoticComponent>
+        </React.ForwardRef>
+      `);
+
+    // if docgenInfo is present, it should use the displayName from there
+    (MyExoticComponentRef as any).__docgenInfo = {
+      displayName: 'ExoticComponent',
+    };
+    expect(renderJsx(<MyExoticComponentRef>I am forwardRef!</MyExoticComponentRef>))
+      .toMatchInlineSnapshot(`
+        <ExoticComponent>
+          I am forwardRef!
+        </ExoticComponent>
       `);
   });
 
@@ -143,11 +154,20 @@ describe('renderJsx', () => {
       return <div>{props.children}</div>;
     });
 
-    expect(renderJsx(createElement(MyMemoComponentRef, {}, 'I am memo!'), {}))
-      .toMatchInlineSnapshot(`
-      <MyMemoComponent>
+    expect(renderJsx(<MyMemoComponentRef>I am memo!</MyMemoComponentRef>)).toMatchInlineSnapshot(`
+      <React.Memo>
         I am memo!
-      </MyMemoComponent>
+      </React.Memo>
+    `);
+
+    // if docgenInfo is present, it should use the displayName from there
+    (MyMemoComponentRef as any).__docgenInfo = {
+      displayName: 'MyMemoComponentRef',
+    };
+    expect(renderJsx(<MyMemoComponentRef>I am memo!</MyMemoComponentRef>)).toMatchInlineSnapshot(`
+      <MyMemoComponentRef>
+        I am memo!
+      </MyMemoComponentRef>
     `);
   });
 

--- a/code/renderers/react/src/docs/jsxDecorator.tsx
+++ b/code/renderers/react/src/docs/jsxDecorator.tsx
@@ -29,7 +29,8 @@ const toPascalCase = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
  * @returns {string | null} A displayName for the Symbol in case elementType is a Symbol; otherwise, null.
  */
 export const getReactSymbolName = (elementType: any): string => {
-  const symbolDescription: string = elementType.toString().replace(/^Symbol\((.*)\)$/, '$1');
+  const elementName = elementType.$$typeof || elementType;
+  const symbolDescription: string = elementName.toString().replace(/^Symbol\((.*)\)$/, '$1');
 
   const reactComponentName = symbolDescription
     .split('.')
@@ -124,16 +125,28 @@ export const renderJsx = (code: React.ReactElement, options?: JSXOptions) => {
   } else {
     displayNameDefaults = {
       // To get exotic component names resolving properly
-      displayName: (el: any): string =>
-        el.type.displayName || typeof el.type === 'symbol'
-          ? getReactSymbolName(el.type)
-          : null ||
-            getDocgenSection(el.type, 'displayName') ||
-            (el.type.name !== '_default' ? el.type.name : null) ||
-            (typeof el.type === 'function' ? 'No Display Name' : null) ||
-            (isForwardRef(el.type) ? el.type.render.name : null) ||
-            (isMemo(el.type) ? el.type.type.name : null) ||
-            el.type,
+      displayName: (el: any): string => {
+        if (el.type.displayName) {
+          return el.type.displayName;
+        } else if (getDocgenSection(el.type, 'displayName')) {
+          return getDocgenSection(el.type, 'displayName');
+        } else if (
+          typeof el.type === 'symbol' ||
+          (el.type.$$typeof && typeof el.type.$$typeof === 'symbol')
+        ) {
+          return getReactSymbolName(el.type);
+        } else if (el.type.name && el.type.name !== '_default') {
+          return el.type.name;
+        } else if (typeof el.type === 'function') {
+          return 'No Display Name';
+        } else if (isForwardRef(el.type)) {
+          return el.type.render.name;
+        } else if (isMemo(el.type)) {
+          return el.type.type.name;
+        } else {
+          return el.type;
+        }
+      },
     };
   }
 


### PR DESCRIPTION
Closes #20920, Closes #26503

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR reworks the logic in the JSX decorator to account for more use cases, fixing the [Object object] displayName issue.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

There are unit tests for this. You can also test it manually if you'd like:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Change its main.ts to use react-typescript-docgen
3. Look at the autodocs page for the Button component
4. Change the Button component to use different formats:
- Nothing, just as is in the boilerplate
- override Button.displayName
- forwardRef()
- memo()


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
