### PR TITLE
CLI: Throw an error when running upgrade command in incorrect cwd

### DIFF
--- a/code/lib/cli/src/helpers.test.ts
+++ b/code/lib/cli/src/helpers.test.ts
@@ -210,4 +210,20 @@ describe('Helpers', () => {
       }).toThrowError(`Could not coerce ${invalidSemverString} into a semver.`);
     });
   });
+
+  describe('hasStorybookDependencies', () => {
+    it(`should return true when any storybook dependency exists`, async () => {
+      const result = await helpers.hasStorybookDependencies({
+        getAllDependencies: async () => ({ storybook: 'x.y.z' }),
+      } as unknown as JsPackageManager);
+      expect(result).toEqual(true);
+    });
+
+    it(`should return false when no storybook dependency exists`, async () => {
+      const result = await helpers.hasStorybookDependencies({
+        getAllDependencies: async () => ({ axios: 'x.y.z' }),
+      } as unknown as JsPackageManager);
+      expect(result).toEqual(false);
+    });
+  });
 });

--- a/code/lib/cli/src/helpers.ts
+++ b/code/lib/cli/src/helpers.ts
@@ -296,3 +296,9 @@ export function coerceSemver(version: string) {
   invariant(coercedSemver != null, `Could not coerce ${version} into a semver.`);
   return coercedSemver;
 }
+
+export async function hasStorybookDependencies(packageManager: JsPackageManager) {
+  const currentPackageDeps = await packageManager.getAllDependencies();
+
+  return Object.keys(currentPackageDeps).some((dep) => dep.includes('storybook'));
+}

--- a/code/lib/cli/src/upgrade.test.ts
+++ b/code/lib/cli/src/upgrade.test.ts
@@ -16,6 +16,7 @@ vi.mock('@storybook/core-common', async (importOriginal) => {
     JsPackageManagerFactory: {
       getPackageManager: () => ({
         findInstallations: findInstallationsMock,
+        getAllDependencies: async () => ({ storybook: '8.0.0' }),
       }),
     },
     versions: Object.keys(originalModule.versions).reduce(

--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -4,6 +4,7 @@ import semver, { eq, lt, prerelease } from 'semver';
 import { logger } from '@storybook/node-logger';
 import { withTelemetry } from '@storybook/core-server';
 import {
+  UpgradeStorybookInWrongWorkingDirectory,
   UpgradeStorybookToLowerVersionError,
   UpgradeStorybookToSameVersionError,
   UpgradeStorybookUnknownCurrentVersionError,
@@ -22,6 +23,7 @@ import {
 } from '@storybook/core-common';
 import { automigrate } from './automigrate/index';
 import { autoblock } from './autoblock/index';
+import { hasStorybookDependencies } from './helpers';
 
 type Package = {
   package: string;
@@ -134,6 +136,9 @@ export const doUpgrade = async ({
     beforeVersion.startsWith('portal:') ||
     beforeVersion.startsWith('workspace:');
 
+  if (!(await hasStorybookDependencies(packageManager))) {
+    throw new UpgradeStorybookInWrongWorkingDirectory();
+  }
   if (!isCanary && lt(currentVersion, beforeVersion)) {
     throw new UpgradeStorybookToLowerVersionError({ beforeVersion, currentVersion });
   }

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -577,6 +577,20 @@ export class UpgradeStorybookUnknownCurrentVersionError extends StorybookError {
   }
 }
 
+export class UpgradeStorybookInWrongWorkingDirectory extends StorybookError {
+  readonly category = Category.CLI_UPGRADE;
+
+  readonly code = 6;
+
+  template() {
+    return dedent`
+      You are running the upgrade command in a CWD that does not contain Storybook dependencies.
+
+      Did you mean to run it in a different directory? Make sure the directory you run this command in contains a package.json with your Storybook dependencies.
+    `;
+  }
+}
+
 export class NoStatsForViteDevError extends StorybookError {
   readonly category = Category.BUILDER_VITE;
 


### PR DESCRIPTION
Closes #26421

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

In order to prevent confusion, the CLI's upgrade command will now throw an error as soon as it detects that there are no storybook dependencies in the cwd's package.json

<img width="688" alt="image" src="https://github.com/storybookjs/storybook/assets/1671563/db128d50-7e24-4d89-b19c-e93a65086f32">


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
