### PR TITLE
CLI: Improve Yarn berry error parsing

### DIFF
--- a/code/lib/core-common/src/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/lib/core-common/src/js-package-manager/Yarn2Proxy.test.ts
@@ -276,35 +276,65 @@ describe('Yarn 2 Proxy', () => {
   });
 
   describe('parseErrors', () => {
-    it('should parse yarn2 errors', () => {
+    it('should single yarn2 error message', () => {
       const YARN2_ERROR_SAMPLE = `
         ➤ YN0000: ┌ Resolution step
         ➤ YN0001: │ Error: react@npm:28.2.0: No candidates found
-            at ge (/Users/yannbraga/.cache/node/corepack/yarn/3.5.1/yarn.js:439:8124)
+            at ge (/Users/xyz/.cache/node/corepack/yarn/3.5.1/yarn.js:439:8124)
             at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
             at async Promise.allSettled (index 8)
-            at async io (/Users/yannbraga/.cache/node/corepack/yarn/3.5.1/yarn.js:390:10398)
+            at async io (/Users/xyz/.cache/node/corepack/yarn/3.5.1/yarn.js:390:10398)
         ➤ YN0000: └ Completed in 2s 369ms
         ➤ YN0000: Failed with errors in 2s 372ms
         ➤ YN0032: fsevents@npm:2.3.2: Implicit dependencies on node-gyp are discouraged
         ➤ YN0061: @npmcli/move-file@npm:2.0.1 is deprecated: This functionality has been moved to @npmcli/fs
       `;
 
-      expect(yarn2Proxy.parseErrorFromLogs(YARN2_ERROR_SAMPLE)).toEqual(
-        'YARN2 error YN0001 - EXCEPTION: react@npm:28.2.0: No candidates found'
+      expect(yarn2Proxy.parseErrorFromLogs(YARN2_ERROR_SAMPLE)).toMatchInlineSnapshot(
+        `
+        "YARN2 error
+        YN0001: EXCEPTION
+        -> Error: react@npm:28.2.0: No candidates found
+        "
+      `
       );
     });
 
-    it('should show unknown yarn2 error', () => {
-      const YARN2_ERROR_SAMPLE = dedent`
+    it('shows multiple yarn2 error messages', () => {
+      const YARN2_ERROR_SAMPLE = `
+        ➤ YN0000: · Yarn 4.1.1
         ➤ YN0000: ┌ Resolution step
-        ➤ YN0000: └ Completed in 2s 369ms
-        ➤ YN0000: Failed with errors in 2s 372ms
-        ➤ YN0032: fsevents@npm:2.3.2: Implicit dependencies on node-gyp are discouraged
-        ➤ YN0061: @npmcli/move-file@npm:2.0.1 is deprecated: This functionality has been moved to @npmcli/fs
+        ➤ YN0085: │ + @chromatic-com/storybook@npm:1.2.25, and 300 more.
+        ➤ YN0000: └ Completed in 0s 763ms
+        ➤ YN0000: ┌ Post-resolution validation
+        ➤ YN0002: │ before-storybook@workspace:. doesn't provide @testing-library/dom (p1ac37), requested by @testing-library/user-event.
+        ➤ YN0002: │ before-storybook@workspace:. doesn't provide eslint (p1f657), requested by eslint-plugin-storybook.
+        ➤ YN0086: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
+        ➤ YN0000: └ Completed
+        ➤ YN0000: ┌ Fetch step
+        ➤ YN0000: └ Completed
+        ➤ YN0000: ┌ Link step
+        ➤ YN0014: │ Failed to import certain dependencies
+        ➤ YN0071: │ Cannot link @storybook/test into before-storybook@workspace:. dependency @testing-library/jest-dom@npm:6.4.2 [ae73b] conflicts with parent dependency @testing-library/jest-dom@npm:5.17.0
+        ➤ YN0071: │ Cannot link @storybook/test into before-storybook@workspace:. dependency @testing-library/user-event@npm:14.5.2 [ae73b] conflicts with parent dependency @testing-library/user-event@npm:13.5.0 [1b0ac]
+        ➤ YN0000: └ Completed in 0s 262ms
+        ➤ YN0000: · Failed with errors in 1s 301ms
       `;
 
-      expect(yarn2Proxy.parseErrorFromLogs(YARN2_ERROR_SAMPLE)).toEqual(`YARN2 error`);
+      expect(yarn2Proxy.parseErrorFromLogs(YARN2_ERROR_SAMPLE)).toMatchInlineSnapshot(
+        `
+        "YARN2 error
+        YN0014: YARN_IMPORT_FAILED
+        -> Failed to import certain dependencies
+
+        YN0071: NM_CANT_INSTALL_EXTERNAL_SOFT_LINK
+        -> Cannot link @storybook/test into before-storybook@workspace:. dependency @testing-library/jest-dom@npm:6.4.2 [ae73b] conflicts with parent dependency @testing-library/jest-dom@npm:5.17.0
+
+        YN0071: NM_CANT_INSTALL_EXTERNAL_SOFT_LINK
+        -> Cannot link @storybook/test into before-storybook@workspace:. dependency @testing-library/user-event@npm:14.5.2 [ae73b] conflicts with parent dependency @testing-library/user-event@npm:13.5.0 [1b0ac]
+        "
+      `
+      );
     });
   });
 });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When having Yarn berry errors, most of the times the CLI doesn't provide anything helpful, just saying "Yarn2 error".
This PR changes the parsing logic so that it will show as much information as it can when extracting critical yarn errors (while trying to keep noise at a minimum level).

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Please refer to the unit tests

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
