### PR TITLE
Automigrations: Add migration note about new react-docgen default

### DIFF
--- a/code/lib/cli/src/automigrate/fixes/react-docgen.test.ts
+++ b/code/lib/cli/src/automigrate/fixes/react-docgen.test.ts
@@ -25,31 +25,35 @@ describe('no-ops', () => {
       check({
         packageManager: {},
         main: {
+          framework: '@storybook/react-vite',
           typescript: {
             // @ts-expect-error assume react
             reactDocgen: 'react-docgen-typescript',
           },
         },
       })
-    ).resolves.toBeFalsy();
+    ).resolves.toBeNull();
 
     await expect(
       check({
         packageManager: {},
         main: {
+          framework: '@storybook/react-vite',
           typescript: {
             // @ts-expect-error assume react
             reactDocgen: false,
           },
         },
       })
-    ).resolves.toBeFalsy();
+    ).resolves.toBeNull();
   });
+
   it('typescript.reactDocgen and typescript.reactDocgenTypescriptOptions are both unset', async () => {
     await expect(
       check({
         packageManager: {},
         main: {
+          framework: '@storybook/react-vite',
           typescript: {
             // @ts-expect-error assume react
             reactDocgen: 'react-docgen-typescript',
@@ -57,22 +61,55 @@ describe('no-ops', () => {
           },
         },
       })
-    ).resolves.toBeFalsy();
+    ).resolves.toBeNull();
+  });
+
+  it('typescript.reactDocgen is undefined and it is not a react framework', async () => {
+    await expect(
+      check({
+        packageManager: {},
+        main: {
+          framework: '@storybook/sveltekit',
+        },
+      })
+    ).resolves.toBeNull();
   });
 });
 
 describe('continue', () => {
+  it('should resolve if the framework is using a react renderer', async () => {
+    await expect(
+      check({
+        packageManager: {},
+        main: {
+          framework: '@storybook/nextjs',
+        },
+      })
+    ).resolves.toEqual({
+      reactDocgenTypescriptOptions: undefined,
+      reactDocgen: undefined,
+    });
+  });
+
   it('typescript.reactDocgenTypescriptOptions is set', async () => {
     await expect(
       check({
         packageManager: {},
         main: {
+          framework: '@storybook/react-vite',
           typescript: {
             // @ts-expect-error assume react
-            reactDocgenTypescriptOptions: {},
+            reactDocgenTypescriptOptions: {
+              someOption: true,
+            },
           },
         },
       })
-    ).resolves.toBeTruthy();
+    ).resolves.toEqual({
+      reactDocgenTypescriptOptions: {
+        someOption: true,
+      },
+      reactDocgen: undefined,
+    });
   });
 });

--- a/code/lib/cli/src/automigrate/fixes/react-docgen.ts
+++ b/code/lib/cli/src/automigrate/fixes/react-docgen.ts
@@ -1,15 +1,15 @@
 import { dedent } from 'ts-dedent';
-import { updateMainConfig } from '../helpers/mainConfigFile';
+import { getRendererName, updateMainConfig } from '../helpers/mainConfigFile';
 import type { Fix } from '../types';
+import chalk from 'chalk';
 
 const logger = console;
 
 interface Options {
-  reactDocgenTypescriptOptions: any;
+  reactDocgenTypescriptOptions?: any;
+  reactDocgen?: 'react-docgen-typescript' | 'react-docgen' | false;
 }
 
-/**
- */
 export const reactDocgen: Fix<Options> = {
   id: 'react-docgen',
 
@@ -17,13 +17,20 @@ export const reactDocgen: Fix<Options> = {
 
   async check({ mainConfig }) {
     // @ts-expect-error assume react
-    const { reactDocgenTypescriptOptions } = mainConfig.typescript || {};
+    const { reactDocgenTypescriptOptions, reactDocgen: rDocgen } = mainConfig.typescript || {};
 
-    return reactDocgenTypescriptOptions ? { reactDocgenTypescriptOptions } : null;
+    const rendererName = getRendererName(mainConfig);
+
+    if (rendererName !== 'react' || rDocgen !== undefined) {
+      return null;
+    }
+
+    return { reactDocgenTypescriptOptions, reactDocgen: rDocgen };
   },
 
-  prompt() {
-    return dedent`
+  prompt({ reactDocgenTypescriptOptions }) {
+    if (reactDocgenTypescriptOptions) {
+      return dedent`
       You have "typescript.reactDocgenTypescriptOptions" configured in your main.js,
       but "typescript.reactDocgen" is unset.
       
@@ -37,15 +44,34 @@ export const reactDocgen: Fix<Options> = {
 
       https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-docgen-component-analysis-by-default
     `;
+    } else {
+      return dedent`
+      Since Storybook 8, ${chalk.cyan(
+        'react-docgen'
+      )} is now the default for generating component controls, replacing ${chalk.cyan(
+        'react-docgen-typescript'
+      )}. 
+      This offers better performance and suits most cases. 
+      However, for complex TypeScript types or specific type features, the generated controls might not be as precise.
+      
+      For more on this change, check the migration guide: 
+      ${chalk.yellow(
+        'https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-docgen-component-analysis-by-default'
+      )}
+      
+      For known "react-docgen" limitations, see: 
+      ${chalk.yellow('https://github.com/storybookjs/storybook/issues/26606')}
+      
+      Would you like to switch back to ${chalk.cyan('react-docgen-typescript')} in your Storybook?
+    `;
+    }
   },
 
-  async run({ dryRun, mainConfigPath }) {
+  async run({ dryRun, mainConfigPath, result }) {
     if (!dryRun) {
       await updateMainConfig({ mainConfigPath, dryRun: !!dryRun }, async (main) => {
         logger.info(`✅ Setting typescript.reactDocgen`);
-        if (!dryRun) {
-          main.setFieldValue(['typescript', 'reactDocgen'], 'react-docgen-typescript');
-        }
+        main.setFieldValue(['typescript', 'reactDocgen'], 'react-docgen-typescript');
       });
     }
   },

--- a/code/lib/cli/src/automigrate/fixes/react-docgen.ts
+++ b/code/lib/cli/src/automigrate/fixes/react-docgen.ts
@@ -46,7 +46,7 @@ export const reactDocgen: Fix<Options> = {
     `;
     } else {
       return dedent`
-      Since Storybook 8, ${chalk.cyan(
+      Since Storybook 8.0, ${chalk.cyan(
         'react-docgen'
       )} is now the default for generating component controls, replacing ${chalk.cyan(
         'react-docgen-typescript'

--- a/code/lib/cli/src/automigrate/helpers/mainConfigFile.test.ts
+++ b/code/lib/cli/src/automigrate/helpers/mainConfigFile.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   getBuilderPackageName,
   getFrameworkPackageName,
+  getRendererName,
   getRendererPackageNameFromFramework,
 } from './mainConfigFile';
 
@@ -130,6 +131,61 @@ describe('getFrameworkPackageName', () => {
 
     const packageName = getFrameworkPackageName(mainConfig as any);
     expect(packageName).toBe(packageNameOrPath);
+  });
+});
+
+describe('getRendererName', () => {
+  it('should return null when mainConfig is undefined', () => {
+    const rendererName = getRendererName(undefined);
+    expect(rendererName).toBeNull();
+  });
+
+  it('should return null when framework package name or path is not found', () => {
+    const mainConfig = {};
+
+    const rendererName = getRendererName(mainConfig as any);
+    expect(rendererName).toBeNull();
+  });
+
+  it('should return renderer name when framework is a string', () => {
+    const frameworkPackage = '@storybook/react-webpack5';
+    const mainConfig = {
+      framework: frameworkPackage,
+    };
+
+    const rendererName = getRendererName(mainConfig as any);
+    expect(rendererName).toBe('react');
+  });
+
+  it('should return renderer name when framework.name contains valid framework package name', () => {
+    const frameworkPackage = '@storybook/react-vite';
+    const packageNameOrPath = `/path/to/${frameworkPackage}`;
+    const mainConfig = {
+      framework: { name: packageNameOrPath },
+    };
+
+    const rendererName = getRendererName(mainConfig as any);
+    expect(rendererName).toBe('react');
+  });
+
+  it('should return renderer name when framework.name contains windows backslash paths', () => {
+    const packageNameOrPath = 'c:\\path\\to\\@storybook\\sveltekit';
+    const mainConfig = {
+      framework: { name: packageNameOrPath },
+    };
+
+    const rendererName = getRendererName(mainConfig as any);
+    expect(rendererName).toBe('svelte');
+  });
+
+  it(`should return undefined when framework does not contain the name of a valid framework package`, () => {
+    const packageNameOrPath = '@my-org/storybook-framework';
+    const mainConfig = {
+      framework: packageNameOrPath,
+    };
+
+    const rendererName = getRendererName(mainConfig as any);
+    expect(rendererName).toBeUndefined();
   });
 });
 

--- a/code/lib/cli/src/automigrate/helpers/mainConfigFile.ts
+++ b/code/lib/cli/src/automigrate/helpers/mainConfigFile.ts
@@ -13,6 +13,7 @@ import dedent from 'ts-dedent';
 import path from 'path';
 import type { JsPackageManager } from '@storybook/core-common';
 import { getCoercedStorybookVersion } from '@storybook/core-common';
+import { frameworkToRenderer } from '../../helpers';
 
 const logger = console;
 
@@ -34,6 +35,23 @@ export const getFrameworkPackageName = (mainConfig?: StorybookConfigRaw) => {
   return (
     Object.keys(frameworkPackages).find((pkg) => normalizedPath.endsWith(pkg)) || packageNameOrPath
   );
+};
+
+/**
+ * Given a Storybook configuration object, retrieves the inferred renderer name from the framework.
+ * @param mainConfig - The main Storybook configuration object to lookup.
+ * @returns - The renderer name. If not found, returns null.
+ */
+export const getRendererName = (mainConfig?: StorybookConfigRaw) => {
+  const frameworkPackageName = getFrameworkPackageName(mainConfig);
+
+  if (!frameworkPackageName) {
+    return null;
+  }
+
+  const frameworkName = frameworkPackages[frameworkPackageName];
+
+  return frameworkToRenderer[frameworkName as keyof typeof frameworkToRenderer];
 };
 
 /**


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/26555

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have enhanced the existing `react-docgen` automigration to give users the possibility to migrate back to the previous `typescript.reactDocgen` default `react-docgen-typescript`.

![Bildschirmfoto 2024-03-22 um 15 18 30](https://github.com/storybookjs/storybook/assets/5889929/a6c2a652-be69-4ecb-93f2-5005ba9e31ef)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Migrate a react-based project from Storybook 7 to 8.
2. If you don't have `typescript.reactDocgen` and `typescript.reactDocgenTypescriptOptions` set, the automigration should pop up.
3. For projects which are not react-based, the automigration shouldn't pop up

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
