### PR TITLE
Fix : Add remove trailing slash in transformStoryIndexToStoriesHash function

### DIFF
--- a/code/lib/manager-api/src/lib/stories.test.ts
+++ b/code/lib/manager-api/src/lib/stories.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { StoryIndexV2, StoryIndexV3 } from '@storybook/types';
-import { transformStoryIndexV2toV3, transformStoryIndexV3toV4 } from './stories';
+import {
+  transformStoryIndexV2toV3,
+  transformStoryIndexV3toV4,
+  transformStoryIndexToStoriesHash,
+} from './stories';
 
 const baseV2: StoryIndexV2['stories'][0] = {
   id: '1',
@@ -149,5 +153,45 @@ describe('transformStoryIndexV3toV4', () => {
         "v": 4,
       }
     `);
+  });
+});
+
+describe('transformStoryIndexToStoriesHash', () => {
+  it('should correctly remove trailing slash from story titles without throwing errors', () => {
+    const indexV3: StoryIndexV3 = {
+      v: 3,
+      stories: {
+        '1': {
+          ...baseV3,
+          id: '1',
+          kind: 'story',
+          title: 'scenes/MessageComposition/shared/ComposerImageLibraryPanel/',
+          parameters: {
+            docsOnly: true,
+          },
+        },
+        '2': {
+          ...baseV3,
+          id: '2',
+          kind: 'story',
+          title: 'scenes/MessageComposition/shared/ComposerImageLibraryPanel',
+          parameters: {
+            docsOnly: true,
+          },
+        },
+      },
+    };
+
+    const options = {
+      provider: { getConfig: () => ({}), handleAPI: () => {} },
+      docsOptions: { docsMode: false },
+      filters: {},
+      status: {},
+    };
+
+    const result = transformStoryIndexToStoriesHash(indexV3, options);
+
+    expect(() => transformStoryIndexToStoriesHash(indexV3, options)).not.toThrow();
+    expect(result['1']).toBeDefined();
   });
 });

--- a/code/lib/manager-api/src/lib/stories.ts
+++ b/code/lib/manager-api/src/lib/stories.ts
@@ -184,7 +184,7 @@ export const transformStoryIndexToStoriesHash = (
 
     // First, split the title into a set of names, separated by '/' and trimmed.
     const { title } = item;
-    const groups = title.trim().split(TITLE_PATH_SEPARATOR);
+    const groups = title.replace(/\/$/, '').trim().split(TITLE_PATH_SEPARATOR);
     const root = (!setShowRoots || showRoots) && groups.length > 1 ? [groups.shift()] : [];
     const names = [...root, ...groups];
 

--- a/code/lib/manager-api/src/lib/stories.ts
+++ b/code/lib/manager-api/src/lib/stories.ts
@@ -27,6 +27,7 @@ import { type API, combineParameters, type State } from '../index';
 import merge from './merge';
 
 const TITLE_PATH_SEPARATOR = /\s*\/\s*/;
+const FIND_TRAILING_SLASH = /\/$/;
 
 export const denormalizeStoryParameters = ({
   globalParameters,
@@ -184,7 +185,7 @@ export const transformStoryIndexToStoriesHash = (
 
     // First, split the title into a set of names, separated by '/' and trimmed.
     const { title } = item;
-    const groups = title.replace(/\/$/, '').trim().split(TITLE_PATH_SEPARATOR);
+    const groups = title.replace(FIND_TRAILING_SLASH, '').trim().split(TITLE_PATH_SEPARATOR);
     const root = (!setShowRoots || showRoots) && groups.length > 1 ? [groups.shift()] : [];
     const names = [...root, ...groups];
 


### PR DESCRIPTION
Closes #26642 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

There was a bug where the Explorer component crashed due to an exception being caught when the title of a story file ended with a slash.

If the last character of the title is a slash, logic has been added to remove it.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [X] stories
- [X] unit tests
- [X] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->