### PR TITLE
Manager: fix message when title of story ends with "/" and render all components in story that were correctly created.

### DIFF
--- a/code/lib/manager-api/src/lib/stories.ts
+++ b/code/lib/manager-api/src/lib/stories.ts
@@ -196,9 +196,7 @@ export const transformStoryIndexToStoriesHash = (
       if (parent === id) {
         throw new Error(
           dedent`
-          Invalid part '${name}', leading to id === parentId ('${id}'), inside title '${title}'
-          
-          Did you create a path that uses the separator char accidentally, such as 'Vue <docs/>' where '/' is a separator char? See https://github.com/storybookjs/storybook/issues/6128
+          Invalid title "${title}" ending in slash: ${id}
           `
         );
       }

--- a/code/ui/manager/src/components/sidebar/Refs.tsx
+++ b/code/ui/manager/src/components/sidebar/Refs.tsx
@@ -17,6 +17,8 @@ import type { Highlight, RefType } from './types';
 import { getStateType } from '../../utils/tree';
 import { CollapseIcon } from './components/CollapseIcon';
 
+import type { API_IndexHash } from '@storybook/types';
+
 export interface RefProps {
   isLoading: boolean;
   isBrowsing: boolean;
@@ -128,6 +130,28 @@ export const Ref: FC<RefType & RefProps & { status?: State['status'] }> = React.
       [api, isMain, refId]
     );
 
+    const filteredIndex = {} as API_IndexHash;
+
+    function getLastWord(str: string) {
+      const words = str.split(' ');
+      return words[words.length - 1];
+    }
+
+    // Iterate through the index data
+    for (const key in index) {
+      // Check if the key starts with id of the error message
+      if (
+        indexError &&
+        indexError.hasOwnProperty('message') &&
+        key.startsWith(getLastWord(indexError.message))
+      ) {
+        // Do not include this item in the filtered index
+        continue;
+      }
+      // Otherwise, include it in the filtered index
+      filteredIndex[key] = index[key];
+    }
+
     return (
       <>
         {isMain || (
@@ -145,7 +169,23 @@ export const Ref: FC<RefType & RefProps & { status?: State['status'] }> = React.
         {isExpanded && (
           <Wrapper data-title={title} isMain={isMain}>
             {state === 'auth' && <AuthBlock id={refId} loginUrl={loginUrl} />}
-            {state === 'error' && <ErrorBlock error={indexError} />}
+            {state === 'error' && (
+              <>
+                <ErrorBlock error={indexError} />
+                <Tree
+                  status={props.status}
+                  isBrowsing={isBrowsing}
+                  isMain={isMain}
+                  refId={refId}
+                  data={filteredIndex}
+                  docsMode={docsOptions.docsMode}
+                  selectedStoryId={selectedStoryId}
+                  onSelectStoryId={onSelectStoryId}
+                  highlightedRef={highlightedRef}
+                  setHighlightedItemId={setHighlightedItemId}
+                />
+              </>
+            )}
             {state === 'loading' && <LoaderBlock isMain={isMain} />}
             {state === 'empty' && <EmptyBlock isMain={isMain} />}
             {state === 'ready' && (


### PR DESCRIPTION
Closes #26642 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When creating a story with a title that ended with a "/", the explorer would catch that error and display the error with a message hard to parse.
Now, instead of displaying the message: "Invalid part '${name}', leading to id === parentId ('${id}'), inside title '${title}'", we have a better message that clarifies the error: "Invalid title "${title}" ending in slash: ${id}" and additionaly all other components created correctly will be displayed along side the error message.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access the Button story or create a new story
4. Add a "/" to the end of the title, e.g 'Example/Button/'
5. Check if the error to that story is displayed with a more clear message for the error and if only the correct stories are rendered

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
