### PR TITLE
Docs: replace `build-storybook` with `storybook build`

### DIFF
--- a/docs/api/main-config-build.md
+++ b/docs/api/main-config-build.md
@@ -25,11 +25,11 @@ Type: `TestBuildFlags`
 }
 ```
 
-Configures Storybook's production builds for performance testing purposes by disabling certain features from the build. When running `build-storybook`, this feature is enabled by setting the `--test` [flag](./cli-options.md#build).
+Configures Storybook's production builds for performance testing purposes by disabling certain features from the build. When running `storybook build`, this feature is enabled by setting the `--test` [flag](./cli-options.md#build).
 
 <Callout variant="info" icon="💡">
 
-The options documented on this page are automatically enabled when the `--test` flag is provided to the `build-storybook` command. We encourage you to override these options only if you need to disable a specific feature for your project or if you are debugging a build issue.
+The options documented on this page are automatically enabled when the `--test` flag is provided to the `storybook build` command. We encourage you to override these options only if you need to disable a specific feature for your project or if you are debugging a build issue.
 
 </Callout>
 

--- a/docs/snippets/common/build-storybook-production-mode.npm.js.mdx
+++ b/docs/snippets/common/build-storybook-production-mode.npm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-npm run build-storybook
+npm run storybook build
 ```

--- a/docs/snippets/common/build-storybook-production-mode.pnpm.js.mdx
+++ b/docs/snippets/common/build-storybook-production-mode.pnpm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-pnpm run build-storybook
+pnpm run storybook build
 ```

--- a/docs/snippets/common/build-storybook-production-mode.yarn.js.mdx
+++ b/docs/snippets/common/build-storybook-production-mode.yarn.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-yarn build-storybook
+yarn storybook build
 ```

--- a/docs/snippets/common/ghp-github-action.yml.mdx
+++ b/docs/snippets/common/ghp-github-action.yml.mdx
@@ -33,7 +33,7 @@ jobs:
       - uses: bitovi/github-actions-storybook-to-github-pages@v1.0.1
         with:
           install_command: yarn install # default: npm ci
-          build_command: yarn build-storybook # default: npm run build-storybook
+          build_command: yarn storybook build # default: npm run storybook build
           path: storybook-static # default: dist/storybook
           checkout: false # default: true
 ```

--- a/docs/snippets/common/storybook-build-test-flag.npm.js.mdx
+++ b/docs/snippets/common/storybook-build-test-flag.npm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-npm run build-storybook -- --test
+npm run storybook build -- --test
 ```

--- a/docs/snippets/common/storybook-build-test-flag.pnpm.js.mdx
+++ b/docs/snippets/common/storybook-build-test-flag.pnpm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-pnpm run build-storybook --test
+pnpm run storybook build --test
 ```

--- a/docs/snippets/common/storybook-build-test-flag.yarn.js.mdx
+++ b/docs/snippets/common/storybook-build-test-flag.yarn.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-yarn build-storybook --test
+yarn storybook build --test
 ```

--- a/docs/snippets/common/storybook-debug-webpack-prod.npm.js.mdx
+++ b/docs/snippets/common/storybook-debug-webpack-prod.npm.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-npm run build-storybook -- --debug-webpack
+npm run storybook build -- --debug-webpack
 ```

--- a/docs/snippets/common/storybook-debug-webpack-prod.yarn.js.mdx
+++ b/docs/snippets/common/storybook-debug-webpack-prod.yarn.js.mdx
@@ -1,3 +1,3 @@
 ```shell
-yarn build-storybook --debug-webpack
+yarn storybook build --debug-webpack
 ```

--- a/docs/snippets/common/test-runner-local-build-workflow.yml.mdx
+++ b/docs/snippets/common/test-runner-local-build-workflow.yml.mdx
@@ -17,7 +17,7 @@ jobs:
       - name: Install Playwright
         run: npx playwright install --with-deps
       - name: Build Storybook
-        run: yarn build-storybook --quiet
+        run: yarn storybook build --quiet
       - name: Serve Storybook and run tests
         run: |
           npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \

--- a/docs/writing-docs/build-documentation.md
+++ b/docs/writing-docs/build-documentation.md
@@ -30,7 +30,7 @@ There's some caveats to this build mode, as to the normal Storybook build:
 
 ## Publish Storybook's documentation
 
-You can also publish your documentation, the same you would [publish](../sharing/publish-storybook.md) your Storybook. You can use the `--docs` flag with `build-storybook` command. We recommend as well including it as a script in your `package.json` file:
+You can also publish your documentation, the same you would [publish](../sharing/publish-storybook.md) your Storybook. You can use the `--docs` flag with `storybook build` command. We recommend as well including it as a script in your `package.json` file:
 
 ```json
 {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

I found a couple of `build-storybook` instances in the documentation, and replaced them with `storybook build`.

The affected pages/sections are:
- https://storybook.js.org/docs/api/main-config-build#test
- https://storybook.js.org/docs/builders/webpack#configure
- https://storybook.js.org/docs/sharing/publish-storybook#build-storybook-as-a-static-web-application
- https://storybook.js.org/docs/sharing/publish-storybook#customizing-the-build-for-performance
- https://storybook.js.org/docs/sharing/publish-storybook#github-pages
- https://storybook.js.org/docs/writing-docs/build-documentation#publish-storybooks-documentation
- https://storybook.js.org/docs/writing-tests/test-runner#run-against-non-deployed-storybooks

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

The changes should be tested manually. But I'm having some issues with `yarn task` on my machine, so I am not able test locally, unfortunately.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
