### PR TITLE
export some types to avoid "not portable" error

### DIFF
--- a/code/renderers/react/src/public-types.ts
+++ b/code/renderers/react/src/public-types.ts
@@ -15,7 +15,15 @@ import type { ComponentProps, ComponentType } from 'react';
 import type { SetOptional, Simplify } from 'type-fest';
 import type { ReactRenderer } from './types';
 
-export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
+export type {
+  Args,
+  ArgTypes,
+  Parameters,
+  StrictArgs,
+  ComponentAnnotations as _ComponentAnnotations,
+  AnnotatedStoryFn as _AnnotatedStoryFn,
+  PartialStoryFn as _PartialStoryFn,
+} from '@storybook/types';
 export type { ReactRenderer };
 
 /**


### PR DESCRIPTION
Fixes #24656 

## What I did

When Storybook React is used in a project with tsConfig values `declaration: true` and `moduleResolution: bundler`, you can get an error like the following: 
` inferred type of default cannot be named without a reference to [etc]/node_modules/@storybook/types . This is likely not portable. A type annotation is necessary.`

To fix this error, I changed the code to export some types. I know you may not be eager to add things to the public API, so I prefixed the types with underscores.

In the attached issue, @kasperpeulen said
> I think this issue is best solved by instructing people how to exclude *.stories.tsx from emitting d.ts, but still keep it being typechecked.

I know this would be better, but in my case, adding a second tsconfig to hundreds of packages so we can avoid emitting storybook types would more difficult than this fix. I understand if you don't want to merge it though 🙇🏼 

Also note, I was unable to reproduce similar issues in other frameworks (angular and Vue). I believe this is only an issue in React because the react storybook types have some conditional types.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I was unable to reproduce this issue inside the storybook monorepo - I think because the way types are built is different from production builds. [Here is a reproduction repo](https://github.com/literalpie/sb-not-portable-types)
1. In that repo, open `src/Errors.stories.tsx`
2. TS errors should be shown in your editor
3. You can also see the errors by running `pnpm run build:types`

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
