### PR TITLE
Addon-docs: Fix MDX compilation with `@vitejs/plugin-react-swc` and plugins

### DIFF
--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -166,7 +166,8 @@ export const viteFinal = async (config: any, options: Options) => {
   // add alias plugin early to ensure any other plugins that also add the aliases will override this
   // eg. the preact vite plugin adds its own aliases
   plugins.unshift(packageDeduplicationPlugin);
-  plugins.push(mdxPlugin(options));
+  // mdx plugin needs to be before any react plugins
+  plugins.unshift(mdxPlugin(options));
 
   return config;
 };


### PR DESCRIPTION
Closes #24857

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Moved the MDX Vite plugin to the start of the plugins-array instead of the end.

The MDX plugin _must_ run before any React plugins to work. In 99 % of the cases it is because we have `enforce: 'pre'` defined in the plugin. However when:

1. Using [`@vitejs/plugin-react-swc`](https://github.com/vitejs/vite-plugin-react-swc)
2. And have defined plugins for _that Vite plugin_ with eg. `react({ plugins: [] })`

Our MDX plugin is runned _after_ `@vitejs/plugin-react-swc`, causing build (but now dev) to crash.

This is because we get into [this case in `@vitejs/plugin-react-swc`](https://github.com/vitejs/vite-plugin-react-swc/blob/main/src/index.ts#L176-L189), where they _also_ add `enforce: 'pre'`, causing it to run before our MDX plugin. The fix is to add it to the beginning of the array instead of the end. Also see [this condition in `@vitejs/plugin-react-swc` where they explicitly check for this case](https://github.com/vitejs/vite-plugin-react-swc/blob/main/src/index.ts#L99-L110), except with the official MDX Vite plugin and not ours of course.

I can't come up with any downsides to this fix, as this shouldn't really change anything for most users AFAIK. I've tested it in basic situations with React+Vite without issues.

Side-note: I wonder if in the future we could just use [the MDX Vite plugin](https://mdxjs.com/packages/rollup/) directly instead of creating our own (extremely thin) wrapper around the low-level MDX compiler. 🤔 I can imagine it solving the problem better, ie. supporting source maps.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

I think the only way to truly test this would be to have a sandbox with this scenario, but that's definitely not worth it.

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a new Vite project with `npm create vite`
2. Choose "React" and "TypeScript + SWC"
3. Init Storybook in the project
4. Edit `vite.config.ts`, change the line `plugins: [react()],` to `plugins: [react({ plugins: [] })]`,
5. Build the Storybook
6. See it fail with the latest version
7. Install this canary of Storybook
8. Build again
9. See it succeeds
10. Serve with `npx http-serve storybook-static -c-1h`
11. See that the "Configure..." MDX page works

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
5. Open Storybook in your browser
13. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This pull request has been released as version `0.0.0-pr-26837-sha-6fdb569c`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26837-sha-6fdb569c sandbox` or in an existing project with `npx storybook@0.0.0-pr-26837-sha-6fdb569c upgrade`.
  <details>
  <summary>More information</summary>
  
  | | |
  | --- | --- |
  | **Published version** | [`0.0.0-pr-26[8](https://github.com/storybookjs/storybook/actions/runs/8680911801/job/23802522844#step:10:8)37-sha-6fdb56[9](https://github.com/storybookjs/storybook/actions/runs/8680911801/job/23802522844#step:10:9)c`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26837-sha-6fdb569c) |
  | **Triggered by** | @JReinhold |
  | **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
  | **Branch** | [`jeppe/24857-bug-mdx-compilation-breaks-when-using-vitejsplugin-react-swc-and-extending-its-plugins`](https://github.com/storybookjs/storybook/tree/jeppe/24857-bug-mdx-compilation-breaks-when-using-vitejsplugin-react-swc-and-extending-its-plugins) |
  | **Commit** | [`6fdb569c`](https://github.com/storybookjs/storybook/commit/6fdb569c02eabc595cfb48335098563e686d4857) |
  | **Datetime** | Sun Apr 14 19:39:24 UTC 2024 (`1713123564`) |
  | **Workflow run** | [86809[11](https://github.com/storybookjs/storybook/actions/runs/8680911801/job/23802522844#step:10:11)801](https://github.com/storybookjs/storybook/actions/runs/8680911801) |
  
  To request a new release of this pull request, mention the `@storybookjs/core` team.
  
  _core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26837`_
  </details>

<!-- CANARY_RELEASE_SECTION -->
