### PR TITLE
Controls: Fix crashing when docgen extraction partially fails

### DIFF
--- a/code/lib/core-events/src/errors/preview-errors.test.ts
+++ b/code/lib/core-events/src/errors/preview-errors.test.ts
@@ -8,11 +8,22 @@ describe('UnknownFlowArgTypesError', () => {
       raw: "SomeType['someProperty']",
     };
 
-    const message = `"There was a failure when generating ArgTypes in Typescript for {"name":"signature","raw":"SomeType['someProperty']"}
-    This type is either not supported or it is a bug in Storybook.
-    If you think this is a bug, please open an issue in Github."`;
-
     const typeError = new UnknownArgTypesError({ type, language: 'Typescript' });
-    expect(typeError.message).toMatchInlineSnapshot(message);
+    expect(typeError.message).toMatchInlineSnapshot(`
+      "There was a failure when generating detailed ArgTypes in Typescript for:
+
+      {
+        "name": "signature",
+        "raw": "SomeType['someProperty']"
+      } 
+
+      Storybook will fall back to use a generic type description instead.
+
+      This type is either not supported or it is a bug in the docgen generation in Storybook.
+      If you think this is a bug, please detail it as much as possible in the Github issue.
+
+      More info: https://github.com/storybookjs/storybook/issues/26606
+      "
+    `);
   });
 });

--- a/code/lib/core-events/src/errors/preview-errors.ts
+++ b/code/lib/core-events/src/errors/preview-errors.ts
@@ -259,15 +259,22 @@ export class UnknownArgTypesError extends StorybookError {
 
   readonly code = 1;
 
+  readonly documentation = 'https://github.com/storybookjs/storybook/issues/26606';
+
   constructor(public data: { type: object; language: string }) {
     super();
   }
 
   template() {
-    return `There was a failure when generating ArgTypes in ${
+    return dedent`There was a failure when generating detailed ArgTypes in ${
       this.data.language
-    } for ${JSON.stringify(this.data.type)}
-    This type is either not supported or it is a bug in Storybook.
-    If you think this is a bug, please open an issue in Github.`;
+    } for:
+    
+    ${JSON.stringify(this.data.type, null, 2)} 
+    
+    so Storybook will fall back to a generic type description.
+
+    This type is either not supported or it is a bug in the docgen generation in Storybook.
+    If you think this is a bug, please detail it as much as possible in the Github issue.`;
   }
 }

--- a/code/lib/core-events/src/errors/preview-errors.ts
+++ b/code/lib/core-events/src/errors/preview-errors.ts
@@ -272,7 +272,7 @@ export class UnknownArgTypesError extends StorybookError {
     
     ${JSON.stringify(this.data.type, null, 2)} 
     
-    so Storybook will fall back to a generic type description.
+    Storybook will fall back to use a generic type description instead.
 
     This type is either not supported or it is a bug in the docgen generation in Storybook.
     If you think this is a bug, please detail it as much as possible in the Github issue.`;

--- a/code/lib/docs-tools/src/argTypes/convert/index.ts
+++ b/code/lib/docs-tools/src/argTypes/convert/index.ts
@@ -7,9 +7,14 @@ import { convert as propTypesConvert } from './proptypes';
 
 export const convert = (docgenInfo: DocgenInfo) => {
   const { type, tsType, flowType } = docgenInfo;
-  if (type != null) return propTypesConvert(type);
-  if (tsType != null) return tsConvert(tsType as TSType);
-  if (flowType != null) return flowConvert(flowType as FlowType);
+  try {
+    if (type != null) return propTypesConvert(type);
+    if (tsType != null) return tsConvert(tsType as TSType);
+    if (flowType != null) return flowConvert(flowType as FlowType);
+  } catch (err) {
+    // if we can't convert the type, we'll just return null to fallback to a simple summary, and provide the error to the user
+    console.error(err);
+  }
 
   return null;
 };


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Followup work for #26774, where the controls (and docs) won't crash anymore if there's a failure when extracting prop data in docgen.

The error message is also updated to be clearer and provides a link to the docgen limitations umbrella GH issue.
As a result, there will be no failure, the type will still be displayed, but in a simpler form. The error will still be displayed, but in the dev tools instead.

Before:
![image](https://github.com/storybookjs/storybook/assets/1671563/a26c29d8-a3ab-40d0-b479-e626ec9e019f)


After:
![image](https://github.com/storybookjs/storybook/assets/1671563/04bff9d4-d5c7-4095-af4f-b358852792ec)


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Use react-docgen in a project.
2. Have a button like so:
```ts
type ReproType = {
  innerProperty: { [k: string]: string };
  innerProperty2: { string: string };
  innerProperty3: Record<string, string>;
};

type ButtonProps = JSX.IntrinsicElements['button'] & {
  repro1?: ReproType['innerProperty'];
  repro2?: ReproType['innerProperty2'];
  repro3?: ReproType['innerProperty3'];
};

export function Button({ ...rest }: ButtonProps) {
  return <button {...rest} />;
}
```
3. See it not crash

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
