### PR TITLE
Add Svelte code snippet for decorators contexts

### DIFF
--- a/docs/snippets/svelte/storybook-preview-with-styled-components-decorator.js.mdx
+++ b/docs/snippets/svelte/storybook-preview-with-styled-components-decorator.js.mdx
@@ -1,0 +1,14 @@
+```js
+// .storybook/preview.js
+
+import { setContext } from 'svelte';
+
+export default {
+  decorators: [
+    (Story) => {
+      setContext("theme", "default");
+      return Story();
+    },
+  ],
+};
+```

--- a/docs/snippets/svelte/storybook-preview-with-styled-components-decorator.ts.mdx
+++ b/docs/snippets/svelte/storybook-preview-with-styled-components-decorator.ts.mdx
@@ -1,0 +1,18 @@
+```ts
+// .storybook/preview.ts
+
+import { setContext } from 'svelte';
+
+import type { Preview } from '@storybook/svelte';
+
+const preview: Preview = {
+  decorators: [
+    (Story) => {
+      setContext("theme", "default");
+      return Story();
+    },
+  ],
+};
+
+export default preview;
+```

--- a/docs/writing-stories/decorators.md
+++ b/docs/writing-stories/decorators.md
@@ -58,6 +58,8 @@ For example, if you're working with React's Styled Components and your component
     'angular/storybook-preview-with-angular-polyfills.js.mdx',
     'solid/storybook-preview-with-styled-components-decorator.js.mdx',
     'solid/storybook-preview-with-styled-components-decorator.ts.mdx',
+    'svelte/storybook-preview-with-styled-components-decorator.js.mdx',
+    'svelte/storybook-preview-with-styled-components-decorator.ts.mdx',
   ]}
 />
 


### PR DESCRIPTION
## What I did

Add code snippets for [contexts in decorators](https://storybook.js.org/docs/writing-stories/decorators#context-for-mocking) for Svelte.

The ability to use contexts in decorators was not documented/mentioned everywhere, but I found in [this PR](https://github.com/storybookjs/storybook/pull/13785) that it is possible, and I tested that it works.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Just run the frontpage site to check the snipper appears correctly.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
