### PR TITLE
Onboarding: Fix modal background and add stories to manager's Storybook

### DIFF
--- a/code/addons/onboarding/package.json
+++ b/code/addons/onboarding/package.json
@@ -45,6 +45,9 @@
     "check": "node --loader ../../../scripts/node_modules/esbuild-register/loader.js -r ../../../scripts/node_modules/esbuild-register/register.js ../../../scripts/prepare/check.ts",
     "prep": "node --loader ../../../scripts/node_modules/esbuild-register/loader.js -r ../../../scripts/node_modules/esbuild-register/register.js ../../../scripts/prepare/addon-bundle.ts"
   },
+  "dependencies": {
+    "react-confetti": "^6.1.0"
+  },
   "devDependencies": {
     "@radix-ui/react-dialog": "^1.0.5",
     "@storybook/channels": "workspace:*",
@@ -59,7 +62,6 @@
     "@storybook/types": "workspace:*",
     "framer-motion": "^11.0.3",
     "react": "^18.2.0",
-    "react-confetti": "^6.1.0",
     "react-dom": "^18.2.0",
     "react-joyride": "^2.7.2",
     "react-use-measure": "^2.1.1",

--- a/code/addons/onboarding/src/components/Confetti/Confetti.tsx
+++ b/code/addons/onboarding/src/components/Confetti/Confetti.tsx
@@ -1,4 +1,4 @@
-import { ReactConfetti } from 'react-confetti/src/ReactConfetti';
+import ReactConfetti from 'react-confetti';
 import React, { useEffect } from 'react';
 import { styled } from '@storybook/theming';
 import { createPortal } from 'react-dom';

--- a/code/addons/onboarding/src/features/WelcomeModal/WelcomeModal.stories.tsx
+++ b/code/addons/onboarding/src/features/WelcomeModal/WelcomeModal.stories.tsx
@@ -1,11 +1,38 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { WelcomeModal } from './WelcomeModal';
 
 const meta: Meta<typeof WelcomeModal> = {
   component: WelcomeModal,
-  decorators: [(storyFn) => <div style={{ width: '1200px', height: '800px' }}>{storyFn()}</div>],
+  // This decorator is used to show the modal in the side by side view
+  decorators: [
+    (Story, context) => {
+      const [container, setContainer] = useState<HTMLElement | undefined>(undefined);
+
+      if (context.globals.theme === 'side-by-side') {
+        return (
+          <div
+            ref={(element) => {
+              if (element) {
+                setContainer(element);
+              }
+            }}
+            style={{
+              width: '100%',
+              height: '100%',
+              minHeight: '600px',
+              transform: 'translateZ(0)',
+            }}
+          >
+            {Story({ args: { ...context.args, container } })}
+          </div>
+        );
+      }
+
+      return Story();
+    },
+  ],
 };
 
 export default meta;

--- a/code/addons/onboarding/src/features/WelcomeModal/WelcomeModal.styled.tsx
+++ b/code/addons/onboarding/src/features/WelcomeModal/WelcomeModal.styled.tsx
@@ -1,5 +1,10 @@
 import { ArrowRightIcon } from '@storybook/icons';
 import { keyframes, styled } from '@storybook/theming';
+import { Modal } from '@storybook/components';
+
+export const ModalWrapper = styled(Modal)`
+  background: white;
+`;
 
 export const ModalContentWrapper = styled.div`
   border-radius: 5px;

--- a/code/addons/onboarding/src/features/WelcomeModal/WelcomeModal.tsx
+++ b/code/addons/onboarding/src/features/WelcomeModal/WelcomeModal.tsx
@@ -1,4 +1,3 @@
-import { Modal } from '@storybook/components';
 import type { FC } from 'react';
 import React from 'react';
 
@@ -15,17 +14,19 @@ import {
   Circle2,
   Circle3,
   TopContent,
+  ModalWrapper,
 } from './WelcomeModal.styled';
 
 interface WelcomeModalProps {
   onProceed: () => void;
   skipOnboarding: () => void;
+  container?: HTMLElement;
 }
 
-export const WelcomeModal: FC<WelcomeModalProps> = ({ onProceed, skipOnboarding }) => {
+export const WelcomeModal: FC<WelcomeModalProps> = ({ onProceed, skipOnboarding, container }) => {
   return (
     <div style={{ zIndex: 10 }}>
-      <Modal width={540} height={430} defaultOpen>
+      <ModalWrapper width={540} height={430} defaultOpen container={container}>
         <ModalContentWrapper data-chromatic="ignore">
           <TopContent>
             <StorybookLogo />
@@ -48,7 +49,7 @@ export const WelcomeModal: FC<WelcomeModalProps> = ({ onProceed, skipOnboarding 
             <Circle3 />
           </Background>
         </ModalContentWrapper>
-      </Modal>
+      </ModalWrapper>
     </div>
   );
 };

--- a/code/addons/onboarding/src/features/WriteStoriesModal/WriteStoriesModal.stories.tsx
+++ b/code/addons/onboarding/src/features/WriteStoriesModal/WriteStoriesModal.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { waitFor, within, expect, fn } from '@storybook/test';
@@ -33,6 +33,7 @@ const meta: Meta<typeof WriteStoriesModal> = {
       }),
     },
   },
+
   decorators: [
     (storyFn, context) => {
       (context.args.api.getData as typeof getData)
@@ -41,6 +42,31 @@ const meta: Meta<typeof WriteStoriesModal> = {
         .mockReturnValueOnce(null)
         .mockReturnValueOnce({ some: 'data' });
       return <div style={{ width: '1200px', height: '800px' }}>{storyFn()}</div>;
+    },
+    (Story, context) => {
+      const [container, setContainer] = useState<HTMLElement | undefined>(undefined);
+
+      if (context.globals.theme === 'side-by-side') {
+        return (
+          <div
+            ref={(element) => {
+              if (element) {
+                setContainer(element);
+              }
+            }}
+            style={{
+              width: '100%',
+              height: '100%',
+              minHeight: '600px',
+              transform: 'translateZ(0)',
+            }}
+          >
+            {Story({ args: { ...context.args, container } })}
+          </div>
+        );
+      }
+
+      return Story();
     },
   ],
 };

--- a/code/addons/onboarding/src/features/WriteStoriesModal/WriteStoriesModal.styled.tsx
+++ b/code/addons/onboarding/src/features/WriteStoriesModal/WriteStoriesModal.styled.tsx
@@ -1,4 +1,9 @@
 import { keyframes, styled } from '@storybook/theming';
+import { Modal } from '@storybook/components';
+
+export const ModalWrapper = styled(Modal)`
+  background: white;
+`;
 
 export const ModalContent = styled.div`
   display: flex;

--- a/code/addons/onboarding/src/features/WriteStoriesModal/WriteStoriesModal.tsx
+++ b/code/addons/onboarding/src/features/WriteStoriesModal/WriteStoriesModal.tsx
@@ -12,6 +12,7 @@ import {
   Main,
   ModalContent,
   ModalTitle,
+  ModalWrapper,
   SpanHighlight,
   Step2Text,
 } from './WriteStoriesModal.styled';
@@ -41,6 +42,7 @@ interface WriteStoriesModalProps {
   addonsStore: AddonStore;
   codeSnippets: CodeSnippets;
   skipOnboarding: () => void;
+  container?: HTMLElement;
 }
 
 export const WriteStoriesModal: FC<WriteStoriesModalProps> = ({
@@ -49,6 +51,7 @@ export const WriteStoriesModal: FC<WriteStoriesModalProps> = ({
   addonsStore,
   skipOnboarding,
   codeSnippets,
+  container,
 }) => {
   const [step, setStep] = useState<'imports' | 'meta' | 'story' | 'args' | 'customStory'>(
     'imports'
@@ -91,7 +94,7 @@ export const WriteStoriesModal: FC<WriteStoriesModalProps> = ({
   }, [api, step]);
 
   return (
-    <Modal width={740} height={430} defaultOpen>
+    <ModalWrapper width={740} height={430} container={container} defaultOpen>
       <ModalContent>
         {codeSnippets ? (
           <SyntaxHighlighter
@@ -284,6 +287,6 @@ export const WriteStoriesModal: FC<WriteStoriesModalProps> = ({
           </Background>
         </Main>
       </ModalContent>
-    </Modal>
+    </ModalWrapper>
   );
 };

--- a/code/ui/.storybook/main.ts
+++ b/code/ui/.storybook/main.ts
@@ -23,6 +23,10 @@ const allStories = [
     directory: '../../addons/controls/src', // TODO other addons?
     titlePrefix: '@addons/controls',
   },
+  {
+    directory: '../../addons/onboarding/src',
+    titlePrefix: '@addons/onboarding',
+  },
 ];
 
 /**


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

After extracting the modal from onboarding for being reusable, the background was broken in dark mode. Additionally, I have added the onboarding stories to the manager so that we can track changes.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
