### PR TITLE
Release: Patch 7.6.19 (manual)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 7.6.18
 
+- Fix bad release in `7.6.18` thanks @jreinhold!
+
+## 7.6.18
+
 - Core: Fix addon bundling script [#26145](https://github.com/storybookjs/storybook/pull/26145), thanks @ndelangen!
 
 ## 7.6.17

--- a/code/package.json
+++ b/code/package.json
@@ -295,6 +295,7 @@
     "type": "opencollective",
     "url": "https://opencollective.com/storybook"
   },
+  "deferredNextVersion": "7.6.19",
   "pr-log": {
     "skipLabels": [
       "cleanup"


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/26932
Closes https://github.com/storybookjs/storybook/issues/26929

This is a *manual* pull request that bumps the version from `7.6.18` to `7.6.19`.

CI is failing because of a bug with our Next.js support introduced in 14.2. This has already been fixed in 8.0 by https://github.com/storybookjs/storybook/pull/26874, and I don't intend to backport that fix too. Therefore I consider CI ✅

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
<!-- CANARY_RELEASE_SECTION -->
