### PR TITLE
Dependencies: Upgrade `ejs` to `3.1.10`

### DIFF
--- a/code/builders/builder-manager/package.json
+++ b/code/builders/builder-manager/package.json
@@ -51,7 +51,7 @@
     "@types/ejs": "^3.1.1",
     "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.10",
     "browser-assert": "^1.2.1",
-    "ejs": "^3.1.8",
+    "ejs": "^3.1.10",
     "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
     "esbuild-plugin-alias": "^0.2.1",
     "express": "^4.17.3",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5635,7 +5635,7 @@ __metadata:
     "@types/ejs": "npm:^3.1.1"
     "@yarnpkg/esbuild-plugin-pnp": "npm:^3.0.0-rc.10"
     browser-assert: "npm:^1.2.1"
-    ejs: "npm:^3.1.8"
+    ejs: "npm:^3.1.10"
     esbuild: "npm:^0.18.0 || ^0.19.0 || ^0.20.0"
     esbuild-plugin-alias: "npm:^0.2.1"
     express: "npm:^4.17.3"
@@ -13583,7 +13583,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ejs@npm:^3.1.7, ejs@npm:^3.1.8":
+"ejs@npm:^3.1.10":
+  version: 3.1.10
+  resolution: "ejs@npm:3.1.10"
+  dependencies:
+    jake: "npm:^10.8.5"
+  bin:
+    ejs: bin/cli.js
+  checksum: 10c0/52eade9e68416ed04f7f92c492183340582a36482836b11eab97b159fcdcfdedc62233a1bf0bf5e5e1851c501f2dca0e2e9afd111db2599e4e7f53ee29429ae1
+  languageName: node
+  linkType: hard
+
+"ejs@npm:^3.1.7":
   version: 3.1.9
   resolution: "ejs@npm:3.1.9"
   dependencies:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -121,7 +121,7 @@
     "danger": "^11.2.6",
     "dataloader": "^2.2.2",
     "detect-port": "^1.3.0",
-    "ejs": "^3.1.8",
+    "ejs": "^3.1.10",
     "ejs-lint": "^2.0.0",
     "esbuild": "^0.20.1",
     "esbuild-plugin-alias": "^0.2.1",

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -2769,7 +2769,7 @@ __metadata:
     danger: "npm:^11.2.6"
     dataloader: "npm:^2.2.2"
     detect-port: "npm:^1.3.0"
-    ejs: "npm:^3.1.8"
+    ejs: "npm:^3.1.10"
     ejs-lint: "npm:^2.0.0"
     esbuild: "npm:^0.20.1"
     esbuild-plugin-alias: "npm:^0.2.1"
@@ -6302,7 +6302,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ejs@npm:^3.1.7, ejs@npm:^3.1.8":
+"ejs@npm:^3.1.10":
+  version: 3.1.10
+  resolution: "ejs@npm:3.1.10"
+  dependencies:
+    jake: "npm:^10.8.5"
+  bin:
+    ejs: bin/cli.js
+  checksum: 10c0/52eade9e68416ed04f7f92c492183340582a36482836b11eab97b159fcdcfdedc62233a1bf0bf5e5e1851c501f2dca0e2e9afd111db2599e4e7f53ee29429ae1
+  languageName: node
+  linkType: hard
+
+"ejs@npm:^3.1.7":
   version: 3.1.9
   resolution: "ejs@npm:3.1.9"
   dependencies:


### PR DESCRIPTION
## What I did

I've created this PR to bump ejs to 3.1.10 in builder-manager and also in scripts, as the previous version was vulnerable.

## Why

The builder-manager, both in 7.6.19 and 8.0.10, has "ejs": "^3.1.8" as a dependency in the package.json. This results in the vulnerable ejs 3.1.9 being used as can be seen on the yarn.lock file. 

Resources:
https://security.snyk.io/package/npm/ejs
https://github.com/storybookjs/storybook/blob/v7.6.19/code/yarn.lock#L15305
https://github.com/storybookjs/storybook/blob/v8.0.10/code/yarn.lock#L13758
https://github.com/storybookjs/storybook/blob/v8.0.10/code/builders/builder-manager/package.json#L54
https://github.com/storybookjs/storybook/blob/v7.6.19/code/builders/builder-manager/package.json#L55

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
