### PR TITLE
Build: Fix test in core-common being ignored

### DIFF
--- a/code/lib/core-common/src/utils/get-renderer-name.test.ts
+++ b/code/lib/core-common/src/utils/get-renderer-name.test.ts
@@ -1,15 +1,14 @@
-import { it } from 'node:test';
-import { describe, expect } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { extractProperRendererNameFromFramework } from './get-renderer-name';
 
 describe('get-renderer-name', () => {
   describe('extractProperRendererNameFromFramework', () => {
-    it('should return the renderer name for a known framework', async () => {
-      const renderer = await extractProperRendererNameFromFramework('@storybook/react');
+    test('should return the renderer name for a known framework', async () => {
+      const renderer = await extractProperRendererNameFromFramework('@storybook/react-vite');
       expect(renderer).toEqual('react');
     });
 
-    it('should return null for an unknown framework', async () => {
+    test('should return null for an unknown framework', async () => {
       const renderer = await extractProperRendererNameFromFramework('@third-party/framework');
       expect(renderer).toBeNull();
     });


### PR DESCRIPTION
One of the `get-renderer-name` tests is failing, but this goes uncaught since vitest does not understand node's test runner output.

This basically moves to using `it` from vitest rather than `node:test`, thus introducing a failing test. The failing test has then been fixed.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

N/A (unit test update)

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>
