### PR TITLE
Make watchStorySpecifiers use @parcel/watcher

### DIFF
--- a/code/lib/core-server/package.json
+++ b/code/lib/core-server/package.json
@@ -59,6 +59,7 @@
     "@babel/core": "^7.24.4",
     "@babel/parser": "^7.24.4",
     "@discoveryjs/json-ext": "^0.5.3",
+    "@parcel/watcher": "^2.4.1",
     "@storybook/builder-manager": "workspace:*",
     "@storybook/channels": "workspace:*",
     "@storybook/core-common": "workspace:*",

--- a/code/lib/core-server/src/utils/getStoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/getStoryIndexGenerator.ts
@@ -31,7 +31,7 @@ export async function getStoryIndexGenerator(
 
   const initializedStoryIndexGenerator = generator.initialize().then(() => generator);
 
-  useStoriesJson({
+  await useStoriesJson({
     router,
     initializedStoryIndexGenerator,
     normalizedStories,

--- a/code/lib/core-server/src/utils/stories-json.test.ts
+++ b/code/lib/core-server/src/utils/stories-json.test.ts
@@ -303,12 +303,17 @@ describe('useStoriesJson', () => {
 
       expect(Watchpack).toHaveBeenCalledTimes(1);
       const watcher = Watchpack.mock.instances[0];
-      expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src'] });
+      expect(watcher.watch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          directories: expect.any(Array),
+          files: expect.any(Array),
+        })
+      );
 
       expect(watcher.on).toHaveBeenCalledTimes(2);
       const onChange = watcher.on.mock.calls[0][1];
 
-      await onChange('src/nested/Button.stories.ts');
+      await onChange(`${workingDir}/src/nested/Button.stories.ts`);
       expect(mockServerChannel.emit).toHaveBeenCalledTimes(1);
       expect(mockServerChannel.emit).toHaveBeenCalledWith(STORY_INDEX_INVALIDATED);
     });
@@ -336,12 +341,17 @@ describe('useStoriesJson', () => {
 
       expect(Watchpack).toHaveBeenCalledTimes(1);
       const watcher = Watchpack.mock.instances[0];
-      expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src'] });
+      expect(watcher.watch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          directories: expect.any(Array),
+          files: expect.any(Array),
+        })
+      );
 
       expect(watcher.on).toHaveBeenCalledTimes(2);
       const onChange = watcher.on.mock.calls[0][1];
 
-      await onChange('src/nested/Button.stories.ts');
+      await onChange(`${workingDir}/src/nested/Button.stories.ts`);
       expect(mockServerChannel.emit).toHaveBeenCalledTimes(1);
       expect(mockServerChannel.emit).toHaveBeenCalledWith(STORY_INDEX_INVALIDATED);
     });
@@ -370,16 +380,21 @@ describe('useStoriesJson', () => {
 
       expect(Watchpack).toHaveBeenCalledTimes(1);
       const watcher = Watchpack.mock.instances[0];
-      expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src'] });
+      expect(watcher.watch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          directories: expect.any(Array),
+          files: expect.any(Array),
+        })
+      );
 
       expect(watcher.on).toHaveBeenCalledTimes(2);
       const onChange = watcher.on.mock.calls[0][1];
 
-      await onChange('src/nested/Button.stories.ts');
-      await onChange('src/nested/Button.stories.ts');
-      await onChange('src/nested/Button.stories.ts');
-      await onChange('src/nested/Button.stories.ts');
-      await onChange('src/nested/Button.stories.ts');
+      await onChange(`${workingDir}/src/nested/Button.stories.ts`);
+      await onChange(`${workingDir}/src/nested/Button.stories.ts`);
+      await onChange(`${workingDir}/src/nested/Button.stories.ts`);
+      await onChange(`${workingDir}/src/nested/Button.stories.ts`);
+      await onChange(`${workingDir}/src/nested/Button.stories.ts`);
 
       expect(mockServerChannel.emit).toHaveBeenCalledTimes(1);
       expect(mockServerChannel.emit).toHaveBeenCalledWith(STORY_INDEX_INVALIDATED);

--- a/code/lib/core-server/src/utils/stories-json.ts
+++ b/code/lib/core-server/src/utils/stories-json.ts
@@ -37,11 +37,18 @@ export function useStoriesJson({
   const maybeInvalidate = debounce(() => serverChannel.emit(STORY_INDEX_INVALIDATED), DEBOUNCE, {
     leading: true,
   });
-  watchStorySpecifiers(normalizedStories, { workingDir }, async (specifier, path, removed) => {
-    const generator = await initializedStoryIndexGenerator;
-    generator.invalidate(specifier, path, removed);
-    maybeInvalidate();
-  });
+  watchStorySpecifiers(
+    normalizedStories,
+    { workingDir },
+    async (specifier, path, removed) => {
+      const generator = await initializedStoryIndexGenerator;
+      generator.invalidate(specifier, path, removed);
+      maybeInvalidate();
+    },
+    (err) => {
+      console.log(err);
+    }
+  );
 
   router.use('/index.json', async (req: Request, res: Response) => {
     try {

--- a/code/lib/core-server/src/utils/stories-json.ts
+++ b/code/lib/core-server/src/utils/stories-json.ts
@@ -21,7 +21,7 @@ export async function extractStoriesJson(
   await writeJSON(outputFile, transform ? transform(storyIndex) : storyIndex);
 }
 
-export function useStoriesJson({
+export async function useStoriesJson({
   router,
   initializedStoryIndexGenerator,
   workingDir = process.cwd(),
@@ -37,7 +37,7 @@ export function useStoriesJson({
   const maybeInvalidate = debounce(() => serverChannel.emit(STORY_INDEX_INVALIDATED), DEBOUNCE, {
     leading: true,
   });
-  watchStorySpecifiers(
+  await watchStorySpecifiers(
     normalizedStories,
     { workingDir },
     async (specifier, path, removed) => {

--- a/code/lib/core-server/src/utils/watch-story-specifiers.test.ts
+++ b/code/lib/core-server/src/utils/watch-story-specifiers.test.ts
@@ -13,6 +13,7 @@ describe('watchStorySpecifiers', () => {
     configDir: path.join(workingDir, '.storybook'),
     workingDir,
   };
+  const abspath = (filename: string) => path.join(workingDir, filename);
 
   let close: () => void;
   afterEach(() => close?.());
@@ -25,11 +26,18 @@ describe('watchStorySpecifiers', () => {
 
     expect(Watchpack).toHaveBeenCalledTimes(1);
     const watcher = Watchpack.mock.instances[0];
-    expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src'] });
+    expect(watcher.watch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directories: expect.any(Array),
+        files: expect.any(Array),
+      })
+    );
 
     expect(watcher.on).toHaveBeenCalledTimes(2);
-    const onChange = watcher.on.mock.calls[0][1];
-    const onRemove = watcher.on.mock.calls[1][1];
+    const baseOnChange = watcher.on.mock.calls[0][1];
+    const baseOnRemove = watcher.on.mock.calls[1][1];
+    const onChange = (filename: string, ...args: any[]) => baseOnChange(abspath(filename), ...args);
+    const onRemove = (filename: string, ...args: any[]) => baseOnRemove(abspath(filename), ...args);
 
     // File changed, matching
     onInvalidate.mockClear();
@@ -72,10 +80,16 @@ describe('watchStorySpecifiers', () => {
 
     expect(Watchpack).toHaveBeenCalledTimes(1);
     const watcher = Watchpack.mock.instances[0];
-    expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src'] });
+    expect(watcher.watch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directories: expect.any(Array),
+        files: expect.any(Array),
+      })
+    );
 
     expect(watcher.on).toHaveBeenCalledTimes(2);
-    const onChange = watcher.on.mock.calls[0][1];
+    const baseOnChange = watcher.on.mock.calls[0][1];
+    const onChange = (filename: string, ...args: any[]) => baseOnChange(abspath(filename), ...args);
 
     onInvalidate.mockClear();
     await onChange('src/nested', 1234);
@@ -90,11 +104,18 @@ describe('watchStorySpecifiers', () => {
 
     expect(Watchpack).toHaveBeenCalledTimes(1);
     const watcher = Watchpack.mock.instances[0];
-    expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src/nested'] });
+    expect(watcher.watch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directories: expect.any(Array),
+        files: expect.any(Array),
+      })
+    );
 
     expect(watcher.on).toHaveBeenCalledTimes(2);
-    const onChange = watcher.on.mock.calls[0][1];
-    const onRemove = watcher.on.mock.calls[1][1];
+    const baseOnChange = watcher.on.mock.calls[0][1];
+    const baseOnRemove = watcher.on.mock.calls[1][1];
+    const onChange = (filename: string, ...args: any[]) => baseOnChange(abspath(filename), ...args);
+    const onRemove = (filename: string, ...args: any[]) => baseOnRemove(abspath(filename), ...args);
 
     // File changed, matching
     onInvalidate.mockClear();
@@ -131,10 +152,16 @@ describe('watchStorySpecifiers', () => {
 
     expect(Watchpack).toHaveBeenCalledTimes(1);
     const watcher = Watchpack.mock.instances[0];
-    expect(watcher.watch).toHaveBeenCalledWith({ directories: ['./src', './src/nested'] });
+    expect(watcher.watch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directories: expect.any(Array),
+        files: expect.any(Array),
+      })
+    );
 
     expect(watcher.on).toHaveBeenCalledTimes(2);
-    const onChange = watcher.on.mock.calls[0][1];
+    const baseOnChange = watcher.on.mock.calls[0][1];
+    const onChange = (filename: string, ...args: any[]) => baseOnChange(abspath(filename), ...args);
 
     onInvalidate.mockClear();
     await onChange('src/nested/Button.stories.ts', 1234);

--- a/code/lib/core-server/src/utils/watch-story-specifiers.ts
+++ b/code/lib/core-server/src/utils/watch-story-specifiers.ts
@@ -44,6 +44,7 @@ export function watchStorySpecifiers(
 ) {
   // Watch all nested files and directories up front to avoid this issue:
   // https://github.com/webpack/watchpack/issues/222
+  const absDirs = specifiers.map((ns) => path.resolve(options.workingDir, ns.directory));
   const { files, directories } = getNestedFilesAndDirectories(
     specifiers.map((ns) => path.resolve(options.workingDir, ns.directory))
   );
@@ -99,9 +100,9 @@ export function watchStorySpecifiers(
             const { globby } = await import('globby');
 
             // glob only supports forward slashes
-            const files = await globby(slash(dirGlob), commonGlobOptions(dirGlob));
+            const addedFiles = await globby(slash(dirGlob), commonGlobOptions(dirGlob));
 
-            files.forEach((filePath: Path) => {
+            addedFiles.forEach((filePath: Path) => {
               const fileImportPath = toImportPath(filePath);
 
               if (specifier.importPathMatcher.exec(fileImportPath)) {

--- a/code/lib/core-server/src/utils/watch-story-specifiers.ts
+++ b/code/lib/core-server/src/utils/watch-story-specifiers.ts
@@ -44,7 +44,6 @@ export function watchStorySpecifiers(
 ) {
   // Watch all nested files and directories up front to avoid this issue:
   // https://github.com/webpack/watchpack/issues/222
-  const absDirs = specifiers.map((ns) => path.resolve(options.workingDir, ns.directory));
   const { files, directories } = getNestedFilesAndDirectories(
     specifiers.map((ns) => path.resolve(options.workingDir, ns.directory))
   );

--- a/code/lib/core-server/src/utils/watch-story-specifiers.ts
+++ b/code/lib/core-server/src/utils/watch-story-specifiers.ts
@@ -15,11 +15,27 @@ const isDirectory = (directory: Path) => {
   }
 };
 
-// Watchpack (and path.relative) passes paths either with no leading './' - e.g. `src/Foo.stories.js`,
-// or with a leading `../` (etc), e.g. `../src/Foo.stories.js`.
-// We want to deal in importPaths relative to the working dir, so we normalize
-function toImportPath(relativePath: Path) {
-  return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
+// Takes an array of absolute paths to directories and synchronously returns
+// absolute paths to all existing files and directories nested within those
+// directories (including the passed parent directories).
+function getNestedFilesAndDirectories(directories: Path[]) {
+  const traversedDirectories = new Set<Path>();
+  const files = new Set<Path>();
+  const traverse = (directory: Path) => {
+    if (traversedDirectories.has(directory)) {
+      return;
+    }
+    fs.readdirSync(directory, { withFileTypes: true}).forEach((ent: fs.Dirent) => {
+      if (ent.isDirectory) {
+        traverse(path.join(directory, ent.name));
+      } else if (ent.isFile) {
+        files.add(path.join(directory, ent.name));
+      }
+    });
+    traversedDirectories.add(directory);
+  }
+  directories.filter(isDirectory).forEach(traverse);
+  return { files: Array.from(files), directories: Array.from(traversedDirectories) }
 }
 
 export function watchStorySpecifiers(
@@ -27,6 +43,10 @@ export function watchStorySpecifiers(
   options: { workingDir: Path },
   onInvalidate: (specifier: NormalizedStoriesSpecifier, path: Path, removed: boolean) => void
 ) {
+  // Watch all nested files and directories up front to avoid this issue:
+  // https://github.com/webpack/watchpack/issues/222
+  const { files, directories } = getNestedFilesAndDirectories(specifiers.map((ns) => path.resolve(options.workingDir, ns.directory)))
+
   // See https://www.npmjs.com/package/watchpack for full options.
   // If you want less traffic, consider using aggregation with some interval
   const wp = new Watchpack({
@@ -34,15 +54,17 @@ export function watchStorySpecifiers(
     followSymlinks: false,
     ignored: ['**/.git', '**/node_modules'],
   });
-  wp.watch({
-    directories: uniq(specifiers.map((ns) => ns.directory)),
-  });
+  wp.watch({ files, directories });
 
-  async function onChangeOrRemove(watchpackPath: Path, removed: boolean) {
-    // Watchpack passes paths either with no leading './' - e.g. `src/Foo.stories.js`,
-    // or with a leading `../` (etc), e.g. `../src/Foo.stories.js`.
-    // We want to deal in importPaths relative to the working dir, or absolute paths.
-    const importPath = slash(watchpackPath.startsWith('.') ? watchpackPath : `./${watchpackPath}`);
+  const toImportPath = (absolutePath: Path) => {
+    const relativePath = path.relative(options.workingDir, absolutePath);
+    return slash(relativePath.startsWith('.') ? relativePath : `./${relativePath}`);
+  }
+
+  async function onChangeOrRemove(absolutePath: Path, removed: boolean) {
+    // Watchpack should return absolute paths, given we passed in absolute paths
+    // to watch. Convert to an import path so we can run against the specifiers.
+    const importPath = toImportPath(absolutePath);
 
     const matchingSpecifier = specifiers.find((ns) => ns.importPathMatcher.exec(importPath));
     if (matchingSpecifier) {
@@ -55,7 +77,6 @@ export function watchStorySpecifiers(
     // However, when a directory is added, it does not fire events for any files *within* the directory,
     // so we need to scan within that directory for new files. It is tricky to use a glob for this,
     // so we'll do something a bit more "dumb" for now
-    const absolutePath = path.join(options.workingDir, importPath);
     if (!removed && isDirectory(absolutePath)) {
       await Promise.all(
         specifiers
@@ -66,11 +87,10 @@ export function watchStorySpecifiers(
             // If `./path/to/dir` was added, check all files matching `./path/to/dir/**/*.stories.*`
             // (where the last bit depends on `files`).
             const dirGlob = path.join(
-              options.workingDir,
-              importPath,
+              absolutePath,
               '**',
               // files can be e.g. '**/foo/*/*.js' so we just want the last bit,
-              // because the directoru could already be within the files part (e.g. './x/foo/bar')
+              // because the directory could already be within the files part (e.g. './x/foo/bar')
               path.basename(specifier.files)
             );
 
@@ -80,11 +100,8 @@ export function watchStorySpecifiers(
             // glob only supports forward slashes
             const files = await globby(slash(dirGlob), commonGlobOptions(dirGlob));
 
-            files.forEach((filePath) => {
-              const fileImportPath = toImportPath(
-                // use posix path separators even on windows
-                path.relative(options.workingDir, filePath).replace(/\\/g, '/')
-              );
+            files.forEach((filePath: Path) => {
+              const fileImportPath = toImportPath(filePath);
 
               if (specifier.importPathMatcher.exec(fileImportPath)) {
                 onInvalidate(specifier, fileImportPath, removed);

--- a/code/lib/core-server/src/utils/watch-story-specifiers.ts
+++ b/code/lib/core-server/src/utils/watch-story-specifiers.ts
@@ -2,7 +2,6 @@ import Watchpack from 'watchpack';
 import slash from 'slash';
 import fs from 'fs';
 import path from 'path';
-import uniq from 'lodash/uniq.js';
 
 import type { NormalizedStoriesSpecifier, Path } from '@storybook/types';
 import { commonGlobOptions } from '@storybook/core-common';
@@ -25,17 +24,17 @@ function getNestedFilesAndDirectories(directories: Path[]) {
     if (traversedDirectories.has(directory)) {
       return;
     }
-    fs.readdirSync(directory, { withFileTypes: true}).forEach((ent: fs.Dirent) => {
-      if (ent.isDirectory) {
+    fs.readdirSync(directory, { withFileTypes: true }).forEach((ent: fs.Dirent) => {
+      if (ent.isDirectory()) {
         traverse(path.join(directory, ent.name));
-      } else if (ent.isFile) {
+      } else if (ent.isFile()) {
         files.add(path.join(directory, ent.name));
       }
     });
     traversedDirectories.add(directory);
-  }
+  };
   directories.filter(isDirectory).forEach(traverse);
-  return { files: Array.from(files), directories: Array.from(traversedDirectories) }
+  return { files: Array.from(files), directories: Array.from(traversedDirectories) };
 }
 
 export function watchStorySpecifiers(
@@ -45,7 +44,9 @@ export function watchStorySpecifiers(
 ) {
   // Watch all nested files and directories up front to avoid this issue:
   // https://github.com/webpack/watchpack/issues/222
-  const { files, directories } = getNestedFilesAndDirectories(specifiers.map((ns) => path.resolve(options.workingDir, ns.directory)))
+  const { files, directories } = getNestedFilesAndDirectories(
+    specifiers.map((ns) => path.resolve(options.workingDir, ns.directory))
+  );
 
   // See https://www.npmjs.com/package/watchpack for full options.
   // If you want less traffic, consider using aggregation with some interval
@@ -59,7 +60,7 @@ export function watchStorySpecifiers(
   const toImportPath = (absolutePath: Path) => {
     const relativePath = path.relative(options.workingDir, absolutePath);
     return slash(relativePath.startsWith('.') ? relativePath : `./${relativePath}`);
-  }
+  };
 
   async function onChangeOrRemove(absolutePath: Path, removed: boolean) {
     // Watchpack should return absolute paths, given we passed in absolute paths

--- a/code/lib/core-server/src/utils/watch-story-specifiers.ts
+++ b/code/lib/core-server/src/utils/watch-story-specifiers.ts
@@ -1,131 +1,67 @@
-import Watchpack from 'watchpack';
 import slash from 'slash';
-import fs from 'fs';
 import path from 'path';
+import watcher from '@parcel/watcher';
 
 import type { NormalizedStoriesSpecifier, Path } from '@storybook/types';
-import { commonGlobOptions } from '@storybook/core-common';
 
-const isDirectory = (directory: Path) => {
-  try {
-    return fs.lstatSync(directory).isDirectory();
-  } catch (err) {
-    return false;
-  }
-};
-
-// Takes an array of absolute paths to directories and synchronously returns
-// absolute paths to all existing files and directories nested within those
-// directories (including the passed parent directories).
-function getNestedFilesAndDirectories(directories: Path[]) {
-  const traversedDirectories = new Set<Path>();
-  const files = new Set<Path>();
-  const traverse = (directory: Path) => {
-    if (traversedDirectories.has(directory)) {
-      return;
-    }
-    fs.readdirSync(directory, { withFileTypes: true }).forEach((ent: fs.Dirent) => {
-      if (ent.isDirectory()) {
-        traverse(path.join(directory, ent.name));
-      } else if (ent.isFile()) {
-        files.add(path.join(directory, ent.name));
-      }
-    });
-    traversedDirectories.add(directory);
-  };
-  directories.filter(isDirectory).forEach(traverse);
-  return { files: Array.from(files), directories: Array.from(traversedDirectories) };
-}
-
-export function watchStorySpecifiers(
+export async function watchStorySpecifiers(
   specifiers: NormalizedStoriesSpecifier[],
-  options: { workingDir: Path },
-  onInvalidate: (specifier: NormalizedStoriesSpecifier, path: Path, removed: boolean) => void
+  { workingDir }: { workingDir: Path },
+  onInvalidate: (specifier: NormalizedStoriesSpecifier, path: Path, removed: boolean) => void,
+  onError?: (err: Error) => void
 ) {
-  // Watch all nested files and directories up front to avoid this issue:
-  // https://github.com/webpack/watchpack/issues/222
-  const { files, directories } = getNestedFilesAndDirectories(
-    specifiers.map((ns) => path.resolve(options.workingDir, ns.directory))
+  // Get absolute paths to all directories we want to watch, and condense them
+  // down so that we're not creating multiple watches for the same directory.
+  const directories = condenseDirectoryList(
+    specifiers.map((ns) => slash(path.join(workingDir, ns.directory)))
   );
 
-  // See https://www.npmjs.com/package/watchpack for full options.
-  // If you want less traffic, consider using aggregation with some interval
-  const wp = new Watchpack({
-    // poll: true, // Slow!!! Enable only in special cases
-    followSymlinks: false,
-    ignored: ['**/.git', '**/node_modules'],
-  });
-  wp.watch({ files, directories });
-
   const toImportPath = (absolutePath: Path) => {
-    const relativePath = path.relative(options.workingDir, absolutePath);
+    const relativePath = path.relative(workingDir, absolutePath);
     return slash(relativePath.startsWith('.') ? relativePath : `./${relativePath}`);
   };
 
-  async function onChangeOrRemove(absolutePath: Path, removed: boolean) {
-    // Watchpack should return absolute paths, given we passed in absolute paths
-    // to watch. Convert to an import path so we can run against the specifiers.
-    const importPath = toImportPath(absolutePath);
+  const watchDirectory = (directory: Path) => {
+    return watcher.subscribe(
+      directory,
+      (err, events) => {
+        if (err) {
+          if (onError) {
+            onError(err);
+          }
+          return;
+        }
+        for (const event of events) {
+          const importPath = toImportPath(event.path);
+          const matchingSpecifier = specifiers.find((ns) => ns.importPathMatcher.exec(importPath));
+          if (matchingSpecifier) {
+            onInvalidate(matchingSpecifier, importPath, event.type === 'delete');
+          }
+        }
+      },
+      {
+        // TODO: Double check these ignore rules work as expected.
+        ignore: ['**/.git', '**/node_modules'],
+      }
+    );
+  };
 
-    const matchingSpecifier = specifiers.find((ns) => ns.importPathMatcher.exec(importPath));
-    if (matchingSpecifier) {
-      onInvalidate(matchingSpecifier, importPath, removed);
-      return;
-    }
+  const subscriptions = await Promise.all(directories.map(watchDirectory));
+  return () => {
+    return Promise.all(subscriptions.map((s) => s.unsubscribe())).then(() => {});
+  };
+}
 
-    // When a directory is removed, watchpack will fire a removed event for each file also
-    // (so we don't need to do anything special).
-    // However, when a directory is added, it does not fire events for any files *within* the directory,
-    // so we need to scan within that directory for new files. It is tricky to use a glob for this,
-    // so we'll do something a bit more "dumb" for now
-    if (!removed && isDirectory(absolutePath)) {
-      await Promise.all(
-        specifiers
-          // We only receive events for files (incl. directories) that are *within* a specifier,
-          // so will match one (or more) specifiers with this simple `startsWith`
-          .filter((specifier) => importPath.startsWith(specifier.directory))
-          .map(async (specifier) => {
-            // If `./path/to/dir` was added, check all files matching `./path/to/dir/**/*.stories.*`
-            // (where the last bit depends on `files`).
-            const dirGlob = path.join(
-              absolutePath,
-              '**',
-              // files can be e.g. '**/foo/*/*.js' so we just want the last bit,
-              // because the directory could already be within the files part (e.g. './x/foo/bar')
-              path.basename(specifier.files)
-            );
-
-            // Dynamically import globby because it is a pure ESM module
-            const { globby } = await import('globby');
-
-            // glob only supports forward slashes
-            const addedFiles = await globby(slash(dirGlob), commonGlobOptions(dirGlob));
-
-            addedFiles.forEach((filePath: Path) => {
-              const fileImportPath = toImportPath(filePath);
-
-              if (specifier.importPathMatcher.exec(fileImportPath)) {
-                onInvalidate(specifier, fileImportPath, removed);
-              }
-            });
-          })
-      );
+// Takes a list of unix-style absolute paths to directories (with no trailing
+// slashes) and removes duplicates plus any children of other directories in the
+// list.
+export function condenseDirectoryList(directories: Path[]): Path[] {
+  directories.sort((a, b) => a.length - b.length);
+  const filtered: Path[] = [];
+  for (const d of directories) {
+    if (!filtered.some((prefix) => d === prefix || d.startsWith(`${prefix}/`))) {
+      filtered.push(d);
     }
   }
-
-  wp.on('change', async (filePath: Path, mtime: Date, explanation: string) => {
-    // When a file is renamed (including being moved out of the watched dir)
-    // we see first an event with explanation=rename and no mtime for the old name.
-    // then an event with explanation=rename with an mtime for the new name.
-    // In theory we could try and track both events together and move the exports
-    // but that seems dangerous (what if the contents changed?) and frankly not worth it
-    // (at this stage at least)
-    const removed = !mtime;
-    await onChangeOrRemove(filePath, removed);
-  });
-  wp.on('remove', async (filePath: Path, explanation: string) => {
-    await onChangeOrRemove(filePath, true);
-  });
-
-  return () => wp.close();
+  return filtered;
 }

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -4427,6 +4427,140 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/watcher-android-arm64@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-android-arm64@npm:2.4.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-darwin-arm64@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-darwin-arm64@npm:2.4.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-darwin-x64@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-darwin-x64@npm:2.4.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-freebsd-x64@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-freebsd-x64@npm:2.4.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-arm-glibc@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-linux-arm-glibc@npm:2.4.1"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-arm64-glibc@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-linux-arm64-glibc@npm:2.4.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-arm64-musl@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-linux-arm64-musl@npm:2.4.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-x64-glibc@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-linux-x64-glibc@npm:2.4.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-x64-musl@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-linux-x64-musl@npm:2.4.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-win32-arm64@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-win32-arm64@npm:2.4.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-win32-ia32@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-win32-ia32@npm:2.4.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-win32-x64@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher-win32-x64@npm:2.4.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "@parcel/watcher@npm:2.4.1"
+  dependencies:
+    "@parcel/watcher-android-arm64": "npm:2.4.1"
+    "@parcel/watcher-darwin-arm64": "npm:2.4.1"
+    "@parcel/watcher-darwin-x64": "npm:2.4.1"
+    "@parcel/watcher-freebsd-x64": "npm:2.4.1"
+    "@parcel/watcher-linux-arm-glibc": "npm:2.4.1"
+    "@parcel/watcher-linux-arm64-glibc": "npm:2.4.1"
+    "@parcel/watcher-linux-arm64-musl": "npm:2.4.1"
+    "@parcel/watcher-linux-x64-glibc": "npm:2.4.1"
+    "@parcel/watcher-linux-x64-musl": "npm:2.4.1"
+    "@parcel/watcher-win32-arm64": "npm:2.4.1"
+    "@parcel/watcher-win32-ia32": "npm:2.4.1"
+    "@parcel/watcher-win32-x64": "npm:2.4.1"
+    detect-libc: "npm:^1.0.3"
+    is-glob: "npm:^4.0.3"
+    micromatch: "npm:^4.0.5"
+    node-addon-api: "npm:^7.0.0"
+    node-gyp: "npm:latest"
+  dependenciesMeta:
+    "@parcel/watcher-android-arm64":
+      optional: true
+    "@parcel/watcher-darwin-arm64":
+      optional: true
+    "@parcel/watcher-darwin-x64":
+      optional: true
+    "@parcel/watcher-freebsd-x64":
+      optional: true
+    "@parcel/watcher-linux-arm-glibc":
+      optional: true
+    "@parcel/watcher-linux-arm64-glibc":
+      optional: true
+    "@parcel/watcher-linux-arm64-musl":
+      optional: true
+    "@parcel/watcher-linux-x64-glibc":
+      optional: true
+    "@parcel/watcher-linux-x64-musl":
+      optional: true
+    "@parcel/watcher-win32-arm64":
+      optional: true
+    "@parcel/watcher-win32-ia32":
+      optional: true
+    "@parcel/watcher-win32-x64":
+      optional: true
+  checksum: 10c0/33b7112094b9eb46c234d824953967435b628d3d93a0553255e9910829b84cab3da870153c3a870c31db186dc58f3b2db81382fcaee3451438aeec4d786a6211
+  languageName: node
+  linkType: hard
+
 "@phenomnomnominal/tsquery@npm:~5.0.1":
   version: 5.0.1
   resolution: "@phenomnomnominal/tsquery@npm:5.0.1"
@@ -5958,6 +6092,7 @@ __metadata:
     "@babel/core": "npm:^7.24.4"
     "@babel/parser": "npm:^7.24.4"
     "@discoveryjs/json-ext": "npm:^0.5.3"
+    "@parcel/watcher": "npm:^2.4.1"
     "@storybook/addon-docs": "workspace:*"
     "@storybook/builder-manager": "workspace:*"
     "@storybook/channels": "workspace:*"
@@ -13187,6 +13322,15 @@ __metadata:
   version: 6.1.0
   resolution: "detect-indent@npm:6.1.0"
   checksum: 10c0/dd83cdeda9af219cf77f5e9a0dc31d828c045337386cfb55ce04fad94ba872ee7957336834154f7647b89b899c3c7acc977c57a79b7c776b506240993f97acc7
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "detect-libc@npm:1.0.3"
+  bin:
+    detect-libc: ./bin/detect-libc.js
+  checksum: 10c0/4da0deae9f69e13bc37a0902d78bf7169480004b1fed3c19722d56cff578d16f0e11633b7fbf5fb6249181236c72e90024cbd68f0b9558ae06e281f47326d50d
   languageName: node
   linkType: hard
 
@@ -20805,7 +20949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:4.0.5, micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4":
+"micromatch@npm:4.0.5, micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:
@@ -21425,6 +21569,15 @@ __metadata:
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/41f21c9d12318875a2c429befd06070ce367065a3ef02952cfd4ea17ef69fa14012732f510b82b226e99c254da8d671847ea018cad785f839a5366e02dd56302
+  languageName: node
+  linkType: hard
+
+"node-addon-api@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "node-addon-api@npm:7.1.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/2e096ab079e3c46d33b0e252386e9c239c352f7cc6d75363d9a3c00bdff34c1a5da170da861917512843f213c32d024ced9dc9552b968029786480d18727ec66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Alternative to [#27016](https://github.com/storybookjs/storybook/pull/27016) that replaces watchpack with @parcel/watcher. Have not tested, and probably won't have time to continue work.

[Thread on vite repo about them adopting @parcel/watcher](https://github.com/vitejs/vite/issues/13593), just for other discussion on positives/negatives.
