### PR TITLE
CLI: Fix eslint configuration for string `extends`

### DIFF
--- a/code/lib/cli/src/automigrate/helpers/eslintPlugin.test.ts
+++ b/code/lib/cli/src/automigrate/helpers/eslintPlugin.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeExtends } from './eslintPlugin';
+
+describe('normalizeExtends', () => {
+  it('returns empty array when existingExtends is falsy', () => {
+    expect(normalizeExtends(null)).toEqual([]);
+    expect(normalizeExtends(undefined)).toEqual([]);
+  });
+
+  it('returns existingExtends when it is a string', () => {
+    expect(normalizeExtends('foo')).toEqual(['foo']);
+  });
+
+  it('returns existingExtends when it is an array', () => {
+    expect(normalizeExtends(['foo'])).toEqual(['foo']);
+  });
+
+  it('throws when existingExtends is not a string or array', () => {
+    expect(() => normalizeExtends(true)).toThrowError('Invalid eslint extends true');
+  });
+});


### PR DESCRIPTION
Closes N/A

## What I did

Looks like ESlint config `.extends` can also be a string and our automigration fails in that case:

![image](https://github.com/storybookjs/storybook/assets/488689/287b2470-bb8e-45b8-b68b-4ea12816a3da)

Thanks @ShaunEvening for the bug report! 🙌

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Install SB in a project with a string value for eslint extends

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
