### PR TITLE
Tags: Fix missing default tags if no `preview.js`

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -159,7 +159,7 @@ export class StoryIndexGenerator {
     );
 
     const previewCode = await this.getPreviewCode();
-    const projectTags = previewCode ? this.getProjectTags(previewCode) : [];
+    const projectTags = this.getProjectTags(previewCode);
 
     // Extract stories for each file
     await this.ensureExtracted({ projectTags });
@@ -556,7 +556,7 @@ export class StoryIndexGenerator {
     if (this.lastError) throw this.lastError;
 
     const previewCode = await this.getPreviewCode();
-    const projectTags = previewCode ? this.getProjectTags(previewCode) : [];
+    const projectTags = this.getProjectTags(previewCode);
 
     // Extract any entries that are currently missing
     // Pull out each file's stories into a list of stories, to be composed and sorted
@@ -665,11 +665,14 @@ export class StoryIndexGenerator {
     return previewFile && (await fs.readFile(previewFile, 'utf-8')).toString();
   }
 
-  getProjectTags(previewCode: string) {
-    const projectAnnotations = loadConfig(previewCode).parse();
+  getProjectTags(previewCode?: string) {
+    let projectTags = [];
     const defaultTags = ['dev', 'test'];
     const extraTags = this.options.docs.autodocs === true ? [AUTODOCS_TAG] : [];
-    const projectTags = projectAnnotations.getFieldValue(['tags']) ?? [];
+    if (previewCode) {
+      const projectAnnotations = loadConfig(previewCode).parse();
+      projectTags = projectAnnotations.getFieldValue(['tags']) ?? [];
+    }
     return [...defaultTags, ...projectTags, ...extraTags];
   }
 


### PR DESCRIPTION
Closes N/A

## What I did

If there is no `preview.js` config, the default tags will not get applied, making the stories disappear from the sidebar

## Checklist for Contributors

### Testing

#### Manual testing

Delete `preview.js` in a sandbox and watch the stories disappear. Verify that this doesn't happen with this fixx.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
