### PR TITLE
API: Add API access to sidebar renderLabel

### DIFF
--- a/code/lib/types/src/modules/api-stories.ts
+++ b/code/lib/types/src/modules/api-stories.ts
@@ -8,7 +8,7 @@ export interface API_BaseEntry {
   depth: number;
   name: string;
   refId?: string;
-  renderLabel?: (item: API_BaseEntry) => any;
+  renderLabel?: (item: API_BaseEntry, api: any) => any;
 }
 
 export interface API_RootEntry extends API_BaseEntry {

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -45,7 +45,7 @@ export interface API_Provider<API> {
   renderPreview?: API_IframeRenderer;
   handleAPI(api: API): void;
   getConfig(): {
-    sidebar?: API_SidebarOptions;
+    sidebar?: API_SidebarOptions<API>;
     theme?: ThemeVars;
     StoryMapper?: API_StoryMapper;
     [k: string]: any;
@@ -106,11 +106,11 @@ export interface API_UI {
 export type API_PanelPositions = 'bottom' | 'right';
 export type API_ActiveTabsType = 'sidebar' | 'canvas' | 'addons';
 
-export interface API_SidebarOptions {
+export interface API_SidebarOptions<API = any> {
   showRoots?: boolean;
   filters?: Record<string, API_FilterFunction>;
   collapsedRoots?: string[];
-  renderLabel?: (item: API_HashEntry) => any;
+  renderLabel?: (item: API_HashEntry, api: API) => any;
 }
 
 interface OnClearOptions {

--- a/code/ui/manager/src/components/mobile/navigation/MobileNavigation.tsx
+++ b/code/ui/manager/src/components/mobile/navigation/MobileNavigation.tsx
@@ -19,16 +19,17 @@ interface MobileNavigationProps {
  */
 const useFullStoryName = () => {
   const { index } = useStorybookState();
-  const currentStory = useStorybookApi().getCurrentStoryData();
+  const api = useStorybookApi();
+  const currentStory = api.getCurrentStoryData();
 
   if (!currentStory) return '';
 
-  let fullStoryName = currentStory.renderLabel?.(currentStory) || currentStory.name;
+  let fullStoryName = currentStory.renderLabel?.(currentStory, api) || currentStory.name;
   let node = index[currentStory.id];
 
   while ('parent' in node && node.parent && index[node.parent] && fullStoryName.length < 24) {
     node = index[node.parent];
-    const parentName = node.renderLabel?.(node) || node.name;
+    const parentName = node.renderLabel?.(node, api) || node.name;
     fullStoryName = `${parentName}/${fullStoryName}`;
   }
   return fullStoryName;

--- a/code/ui/manager/src/components/sidebar/Tree.tsx
+++ b/code/ui/manager/src/components/sidebar/Tree.tsx
@@ -220,7 +220,8 @@ const Node = React.memo<NodeProps>(function Node({
           }}
           {...(item.type === 'docs' && { docsMode })}
         >
-          {(item.renderLabel as (i: typeof item) => React.ReactNode)?.(item) || item.name}
+          {(item.renderLabel as (i: typeof item, api: API) => React.ReactNode)?.(item, api) ||
+            item.name}
         </LeafNode>
         {isSelected && (
           <SkipToContentLink asChild>
@@ -272,7 +273,7 @@ const Node = React.memo<NodeProps>(function Node({
           aria-expanded={isExpanded}
         >
           <CollapseIcon isExpanded={isExpanded} />
-          {item.renderLabel?.(item) || item.name}
+          {item.renderLabel?.(item, api) || item.name}
         </CollapseButton>
         {isExpanded && (
           <IconButton
@@ -325,7 +326,8 @@ const Node = React.memo<NodeProps>(function Node({
           }
         }}
       >
-        {(item.renderLabel as (i: typeof item) => React.ReactNode)?.(item) || item.name}
+        {(item.renderLabel as (i: typeof item, api: API) => React.ReactNode)?.(item, api) ||
+          item.name}
       </BranchNode>
     );
   }

--- a/docs/addons/addons-api.md
+++ b/docs/addons/addons-api.md
@@ -260,11 +260,11 @@ The following table details how to use the API values:
 
 The following options are configurable under the `sidebar` namespace:
 
-| Name               | Type     | Description                                                   | Example Value                                    |
-| ------------------ | -------- | ------------------------------------------------------------- | ------------------------------------------------ |
-| **showRoots**      | Boolean  | Display the top-level nodes as a "root" in the sidebar        | `false`                                          |
-| **collapsedRoots** | Array    | Set of root node IDs to visually collapse by default          | `['misc', 'other']`                              |
-| **renderLabel**    | Function | Create a custom label for tree nodes; must return a ReactNode | `(item) => <abbr title="...">{item.name}</abbr>` |
+| Name               | Type     | Description                                                   | Example Value                                         |
+| ------------------ | -------- | ------------------------------------------------------------- | ----------------------------------------------------- |
+| **showRoots**      | Boolean  | Display the top-level nodes as a "root" in the sidebar        | `false`                                               |
+| **collapsedRoots** | Array    | Set of root node IDs to visually collapse by default          | `['misc', 'other']`                                   |
+| **renderLabel**    | Function | Create a custom label for tree nodes; must return a ReactNode | `(item, api) => <abbr title="...">{item.name}</abbr>` |
 
 The following options are configurable under the `toolbar` namespace:
 

--- a/docs/configure/features-and-behavior.md
+++ b/docs/configure/features-and-behavior.md
@@ -32,11 +32,11 @@ The following table details how to use the API values:
 
 The following options are configurable under the `sidebar` namespace:
 
-| Name               | Type     | Description                                                   | Example Value                                    |
-| ------------------ | -------- | ------------------------------------------------------------- | ------------------------------------------------ |
-| **showRoots**      | Boolean  | Display the top-level nodes as a "root" in the sidebar        | `false`                                          |
-| **collapsedRoots** | Array    | Set of root node IDs to visually collapse by default          | `['misc', 'other']`                              |
-| **renderLabel**    | Function | Create a custom label for tree nodes; must return a ReactNode | `(item) => <abbr title="...">{item.name}</abbr>` |
+| Name               | Type     | Description                                                   | Example Value                                         |
+| ------------------ | -------- | ------------------------------------------------------------- | ----------------------------------------------------- |
+| **showRoots**      | Boolean  | Display the top-level nodes as a "root" in the sidebar        | `false`                                               |
+| **collapsedRoots** | Array    | Set of root node IDs to visually collapse by default          | `['misc', 'other']`                                   |
+| **renderLabel**    | Function | Create a custom label for tree nodes; must return a ReactNode | `(item, api) => <abbr title="...">{item.name}</abbr>` |
 
 The following options are configurable under the `toolbar` namespace:
 


### PR DESCRIPTION
Closes N/A

## What I did

Added a way to access parent/child node story metadata from the `renderLabel` function.

Here's an example of how the new API can be used to propagate story tags up to their wrapping components (the use case I had in mind for this feature):

```ts
// manager.ts
import { addons } from '@storybook/manager-api';
import type { API, LeafEntry, HashEntry } from '@storybook/manager-api';

const SYSTEM_TAGS = ['dev', 'autodocs', 'test'];

const findComponentTags = (stories: LeafEntry[]) => {
  const allTags = stories.flatMap((story) => story.tags);
  const tagToCount = allTags.reduce(
    (acc, tag) => {
      acc[tag] = (acc[tag] || 0) + 1;
      return acc;
    },
    {} as Record<string, number>
  );
  return Object.entries(tagToCount)
    .filter(([tag, count]) => count === stories.length && !SYSTEM_TAGS.includes(tag))
    .map(([tag]) => tag);
};

addons.setConfig({
  sidebar: {
    renderLabel: (item: HashEntry, api: API) => {
      if (item.type !== 'component') return item.name;
      const tags = findComponentTags(item.children.map((childId) => api.getData(childId)));
      const tagsLabel = tags.length > 0 ? ` [${tags.join(', ')}]` : '';
      return `${item.name}${tagsLabel}`;
    },
  },
});
```

## Checklist for Contributors

### Testing


#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing



### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
