### PR TITLE
Angular: Fix filtering of workspace config styles

### DIFF
--- a/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -2,6 +2,7 @@ import { dirname, join, resolve } from 'path';
 import { DefinePlugin, HotModuleReplacementPlugin, ProgressPlugin, ProvidePlugin } from 'webpack';
 import type { Configuration } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+
 // @ts-expect-error (I removed this on purpose, because it's incorrect)
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
@@ -53,7 +54,11 @@ const storybookPaths: Record<string, string> = {
 };
 
 export default async (
-  options: Options & { typescriptOptions: TypescriptOptions }
+  options: Options & {
+    typescriptOptions: TypescriptOptions;
+    /* Build entries, which should not be linked in the iframe HTML file */
+    excludeChunks?: string[];
+  }
 ): Promise<Configuration> => {
   const {
     outputDir = join('.', 'public'),
@@ -64,6 +69,7 @@ export default async (
     previewUrl,
     typescriptOptions,
     features,
+    excludeChunks = [],
   } = options;
 
   const isProd = configType === 'PRODUCTION';
@@ -172,6 +178,7 @@ export default async (
         alwaysWriteToDisk: true,
         inject: false,
         template,
+        excludeChunks,
         templateParameters: {
           version: packageJson.version,
           globals: {

--- a/code/frameworks/angular/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.ts
@@ -1,18 +1,8 @@
-import {
-  BuilderContext,
-  BuilderHandlerFn,
-  BuilderOutput,
-  BuilderOutputLike,
-  Target,
-  createBuilder,
-  targetFromTargetString,
-} from '@angular-devkit/architect';
+import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { JsonObject } from '@angular-devkit/core';
-import { from, of, throwError } from 'rxjs';
-import { catchError, map, mapTo, switchMap } from 'rxjs/operators';
 import { sync as findUpSync } from 'find-up';
 import { sync as readUpSync } from 'read-pkg-up';
-import { BrowserBuilderOptions, StylePreprocessorOptions } from '@angular-devkit/build-angular';
+import { StylePreprocessorOptions } from '@angular-devkit/build-angular';
 
 import { CLIOptions } from '@storybook/types';
 import { getEnvConfig, versions } from '@storybook/core-common';
@@ -22,11 +12,13 @@ import { buildStaticStandalone, withTelemetry } from '@storybook/core-server';
 import {
   AssetPattern,
   SourceMapUnion,
+  StyleClass,
   StyleElement,
 } from '@angular-devkit/build-angular/src/builders/browser/schema';
 import { StandaloneOptions } from '../utils/standalone-options';
 import { runCompodoc } from '../utils/run-compodoc';
 import { errorSummary, printErrorDetails } from '../utils/error-handler';
+import { setup } from '../utils/setup';
 
 addToGlobalContext('cliVersion', versions.storybook);
 
@@ -59,112 +51,77 @@ export type StorybookBuilderOptions = JsonObject & {
 
 export type StorybookBuilderOutput = JsonObject & BuilderOutput & { [key: string]: any };
 
-type StandaloneBuildOptions = StandaloneOptions & { outputDir: string };
+type StandaloneBuildOptions = StandaloneOptions & { outputDir: string; excludeChunks: string[] };
 
-const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (
-  options,
-  context
-): BuilderOutputLike => {
-  const builder = from(setup(options, context)).pipe(
-    switchMap(({ tsConfig }) => {
-      const docTSConfig = findUpSync('tsconfig.doc.json', { cwd: options.configDir });
-      const runCompodoc$ = options.compodoc
-        ? runCompodoc(
-            { compodocArgs: options.compodocArgs, tsconfig: docTSConfig ?? tsConfig },
-            context
-          ).pipe(mapTo({ tsConfig }))
-        : of({});
+const commandBuilder = async (
+  options: StorybookBuilderOptions,
+  context: BuilderContext
+): Promise<BuilderOutput> => {
+  const { tsConfig, angularBuilderContext, angularBuilderOptions } = await setup(options, context);
 
-      return runCompodoc$.pipe(mapTo({ tsConfig }));
-    }),
-    map(({ tsConfig }) => {
-      getEnvConfig(options, {
-        staticDir: 'SBCONFIG_STATIC_DIR',
-        outputDir: 'SBCONFIG_OUTPUT_DIR',
-        configDir: 'SBCONFIG_CONFIG_DIR',
-      });
+  const docTSConfig = findUpSync('tsconfig.doc.json', { cwd: options.configDir });
 
-      const {
-        browserTarget,
-        stylePreprocessorOptions,
-        styles,
-        configDir,
-        docs,
-        loglevel,
-        test,
-        outputDir,
-        quiet,
-        enableProdMode = true,
-        webpackStatsJson,
-        statsJson,
-        debugWebpack,
-        disableTelemetry,
-        assets,
-        previewUrl,
-        sourceMap = false,
-      } = options;
+  if (options.compodoc) {
+    await runCompodoc(
+      { compodocArgs: options.compodocArgs, tsconfig: docTSConfig ?? tsConfig },
+      context
+    );
+  }
 
-      const standaloneOptions: StandaloneBuildOptions = {
-        packageJson: readUpSync({ cwd: __dirname }).packageJson,
-        configDir,
-        ...(docs ? { docs } : {}),
-        loglevel,
-        outputDir,
-        test,
-        quiet,
-        enableProdMode,
-        disableTelemetry,
-        angularBrowserTarget: browserTarget,
-        angularBuilderContext: context,
-        angularBuilderOptions: {
-          ...(stylePreprocessorOptions ? { stylePreprocessorOptions } : {}),
-          ...(styles ? { styles } : {}),
-          ...(assets ? { assets } : {}),
-          sourceMap,
-        },
-        tsConfig,
-        webpackStatsJson,
-        statsJson,
-        debugWebpack,
-        previewUrl,
-      };
+  getEnvConfig(options, {
+    staticDir: 'SBCONFIG_STATIC_DIR',
+    outputDir: 'SBCONFIG_OUTPUT_DIR',
+    configDir: 'SBCONFIG_CONFIG_DIR',
+  });
 
-      return standaloneOptions;
-    }),
-    switchMap((standaloneOptions) => runInstance({ ...standaloneOptions, mode: 'static' })),
-    map(() => {
-      return { success: true };
-    })
-  );
+  const {
+    configDir,
+    docs,
+    loglevel,
+    test,
+    outputDir,
+    quiet,
+    enableProdMode = true,
+    webpackStatsJson,
+    statsJson,
+    debugWebpack,
+    disableTelemetry,
+    previewUrl,
+  } = options;
 
-  return builder as any as BuilderOutput;
+  const standaloneOptions: StandaloneBuildOptions = {
+    packageJson: readUpSync({ cwd: __dirname }).packageJson,
+    configDir,
+    ...(docs ? { docs } : {}),
+    excludeChunks: angularBuilderOptions.styles
+      ?.filter((style) => typeof style !== 'string' && style.inject === false)
+      .map((s: StyleClass) => s.bundleName),
+    loglevel,
+    outputDir,
+    test,
+    quiet,
+    enableProdMode,
+    disableTelemetry,
+    angularBrowserTarget: options.browserTarget,
+    angularBuilderContext,
+    angularBuilderOptions,
+    tsConfig,
+    webpackStatsJson,
+    statsJson,
+    debugWebpack,
+    previewUrl,
+  };
+
+  await runInstance({ ...standaloneOptions, mode: 'static' });
+
+  return { success: true };
 };
 
 export default createBuilder(commandBuilder);
 
-async function setup(options: StorybookBuilderOptions, context: BuilderContext) {
-  let browserOptions: (JsonObject & BrowserBuilderOptions) | undefined;
-  let browserTarget: Target | undefined;
-
-  if (options.browserTarget) {
-    browserTarget = targetFromTargetString(options.browserTarget);
-    browserOptions = await context.validateOptions<JsonObject & BrowserBuilderOptions>(
-      await context.getTargetOptions(browserTarget),
-      await context.getBuilderNameForTarget(browserTarget)
-    );
-  }
-
-  return {
-    tsConfig:
-      options.tsConfig ??
-      findUpSync('tsconfig.json', { cwd: options.configDir }) ??
-      browserOptions.tsConfig,
-  };
-}
-
-function runInstance(options: StandaloneBuildOptions) {
-  return from(
-    withTelemetry(
+async function runInstance(options: StandaloneBuildOptions) {
+  try {
+    await withTelemetry(
       'build',
       {
         cliOptions: options,
@@ -172,6 +129,8 @@ function runInstance(options: StandaloneBuildOptions) {
         printError: printErrorDetails,
       },
       () => buildStaticStandalone(options)
-    )
-  ).pipe(catchError((error: any) => throwError(errorSummary(error))));
+    );
+  } catch (error) {
+    throw new Error(errorSummary(error));
+  }
 }

--- a/code/frameworks/angular/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.ts
@@ -1,15 +1,6 @@
-import {
-  BuilderContext,
-  BuilderHandlerFn,
-  BuilderOutput,
-  Target,
-  createBuilder,
-  targetFromTargetString,
-} from '@angular-devkit/architect';
+import { BuilderHandlerFn, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { JsonObject } from '@angular-devkit/core';
-import { BrowserBuilderOptions, StylePreprocessorOptions } from '@angular-devkit/build-angular';
-import { from, Observable, of } from 'rxjs';
-import { map, switchMap, mapTo } from 'rxjs/operators';
+import { StylePreprocessorOptions } from '@angular-devkit/build-angular';
 import { sync as findUpSync } from 'find-up';
 import { sync as readUpSync } from 'read-pkg-up';
 
@@ -20,11 +11,13 @@ import { buildDevStandalone, withTelemetry } from '@storybook/core-server';
 import {
   AssetPattern,
   SourceMapUnion,
+  StyleClass,
   StyleElement,
 } from '@angular-devkit/build-angular/src/builders/browser/schema';
 import { StandaloneOptions } from '../utils/standalone-options';
 import { runCompodoc } from '../utils/run-compodoc';
 import { printErrorDetails, errorSummary } from '../utils/error-handler';
+import { setup } from '../utils/setup';
 
 addToGlobalContext('cliVersion', versions.storybook);
 
@@ -64,131 +57,96 @@ export type StorybookBuilderOptions = JsonObject & {
 
 export type StorybookBuilderOutput = JsonObject & BuilderOutput & {};
 
-const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (options, context) => {
-  const builder = from(setup(options, context)).pipe(
-    switchMap(({ tsConfig }) => {
-      const docTSConfig = findUpSync('tsconfig.doc.json', { cwd: options.configDir });
+const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = async (options, context) => {
+  const { tsConfig, angularBuilderContext, angularBuilderOptions } = await setup(options, context);
 
-      const runCompodoc$ = options.compodoc
-        ? runCompodoc(
-            {
-              compodocArgs: [...options.compodocArgs, ...(options.quiet ? ['--silent'] : [])],
-              tsconfig: docTSConfig ?? tsConfig,
-            },
-            context
-          ).pipe(mapTo({ tsConfig }))
-        : of({});
+  const docTSConfig = findUpSync('tsconfig.doc.json', { cwd: options.configDir });
 
-      return runCompodoc$.pipe(mapTo({ tsConfig }));
-    }),
-    map(({ tsConfig }) => {
-      getEnvConfig(options, {
-        port: 'SBCONFIG_PORT',
-        host: 'SBCONFIG_HOSTNAME',
-        staticDir: 'SBCONFIG_STATIC_DIR',
-        configDir: 'SBCONFIG_CONFIG_DIR',
-        ci: 'CI',
-      });
+  if (options.compodoc) {
+    await runCompodoc(
+      {
+        compodocArgs: [...options.compodocArgs, ...(options.quiet ? ['--silent'] : [])],
+        tsconfig: docTSConfig ?? tsConfig,
+      },
+      context
+    );
+  }
 
-      options.port = parseInt(`${options.port}`, 10);
+  getEnvConfig(options, {
+    port: 'SBCONFIG_PORT',
+    host: 'SBCONFIG_HOSTNAME',
+    staticDir: 'SBCONFIG_STATIC_DIR',
+    configDir: 'SBCONFIG_CONFIG_DIR',
+    ci: 'CI',
+  });
 
-      const {
-        browserTarget,
-        stylePreprocessorOptions,
-        styles,
-        ci,
-        configDir,
-        docs,
-        host,
-        https,
-        port,
-        quiet,
-        enableProdMode = false,
-        smokeTest,
-        sslCa,
-        sslCert,
-        sslKey,
-        disableTelemetry,
-        assets,
-        initialPath,
-        open,
-        debugWebpack,
-        loglevel,
-        webpackStatsJson,
-        statsJson,
-        previewUrl,
-        sourceMap = false,
-      } = options;
+  options.port = parseInt(`${options.port}`, 10);
 
-      const standaloneOptions: StandaloneOptions = {
-        packageJson: readUpSync({ cwd: __dirname }).packageJson,
-        ci,
-        configDir,
-        ...(docs ? { docs } : {}),
-        host,
-        https,
-        port,
-        quiet,
-        enableProdMode,
-        smokeTest,
-        sslCa,
-        sslCert,
-        sslKey,
-        disableTelemetry,
-        angularBrowserTarget: browserTarget,
-        angularBuilderContext: context,
-        angularBuilderOptions: {
-          ...(stylePreprocessorOptions ? { stylePreprocessorOptions } : {}),
-          ...(styles ? { styles } : {}),
-          ...(assets ? { assets } : {}),
-          sourceMap,
-        },
-        tsConfig,
-        initialPath,
-        open,
-        debugWebpack,
-        webpackStatsJson,
-        statsJson,
-        loglevel,
-        previewUrl,
-      };
+  const {
+    browserTarget,
+    ci,
+    configDir,
+    docs,
+    host,
+    https,
+    port,
+    quiet,
+    enableProdMode = false,
+    smokeTest,
+    sslCa,
+    sslCert,
+    sslKey,
+    disableTelemetry,
+    initialPath,
+    open,
+    debugWebpack,
+    loglevel,
+    webpackStatsJson,
+    statsJson,
+    previewUrl,
+  } = options;
 
-      return standaloneOptions;
-    }),
-    switchMap((standaloneOptions) => runInstance(standaloneOptions)),
-    map((port: number) => {
-      return { success: true, info: { port } };
-    })
-  );
+  const standaloneOptions: StandaloneOptions = {
+    packageJson: readUpSync({ cwd: __dirname }).packageJson,
+    ci,
+    configDir,
+    ...(docs ? { docs } : {}),
+    excludeChunks: angularBuilderOptions.styles
+      ?.filter((style) => typeof style !== 'string' && style.inject === false)
+      .map((s: StyleClass) => s.bundleName),
+    host,
+    https,
+    port,
+    quiet,
+    enableProdMode,
+    smokeTest,
+    sslCa,
+    sslCert,
+    sslKey,
+    disableTelemetry,
+    angularBrowserTarget: browserTarget,
+    angularBuilderContext,
+    angularBuilderOptions,
+    tsConfig,
+    initialPath,
+    open,
+    debugWebpack,
+    webpackStatsJson,
+    statsJson,
+    loglevel,
+    previewUrl,
+  };
 
-  return builder as any as BuilderOutput;
+  const devPort = await runInstance(standaloneOptions);
+
+  return { success: true, info: { port: devPort } };
 };
 
 export default createBuilder(commandBuilder);
 
-async function setup(options: StorybookBuilderOptions, context: BuilderContext) {
-  let browserOptions: (JsonObject & BrowserBuilderOptions) | undefined;
-  let browserTarget: Target | undefined;
-
-  if (options.browserTarget) {
-    browserTarget = targetFromTargetString(options.browserTarget);
-    browserOptions = await context.validateOptions<JsonObject & BrowserBuilderOptions>(
-      await context.getTargetOptions(browserTarget),
-      await context.getBuilderNameForTarget(browserTarget)
-    );
-  }
-
-  return {
-    tsConfig:
-      options.tsConfig ??
-      findUpSync('tsconfig.json', { cwd: options.configDir }) ??
-      browserOptions.tsConfig,
-  };
-}
-function runInstance(options: StandaloneOptions) {
-  return new Observable<number>((observer) => {
-    // This Observable intentionally never complete, leaving the process running ;)
-    withTelemetry(
+async function runInstance(options: StandaloneOptions): Promise<number> {
+  try {
+    const { port } = await withTelemetry(
       'dev',
       {
         cliOptions: options,
@@ -196,10 +154,9 @@ function runInstance(options: StandaloneOptions) {
         printError: printErrorDetails,
       },
       () => buildDevStandalone(options)
-    )
-      .then(({ port }) => observer.next(port))
-      .catch((error) => {
-        observer.error(errorSummary(error));
-      });
-  });
+    );
+    return port;
+  } catch (error) {
+    throw new Error(errorSummary(error));
+  }
 }

--- a/code/frameworks/angular/src/builders/utils/run-compodoc.spec.ts
+++ b/code/frameworks/angular/src/builders/utils/run-compodoc.spec.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { vi, describe, afterEach, it, expect } from 'vitest';
 import { LoggerApi } from '@angular-devkit/core/src/logger';
-import { take } from 'rxjs/operators';
 import { BuilderContext } from '@angular-devkit/architect';
 
 import { runCompodoc } from './run-compodoc';
@@ -37,15 +36,13 @@ describe('runCompodoc', () => {
   } as BuilderContext;
 
   it('should run compodoc with tsconfig from context', async () => {
-    runCompodoc(
+    await runCompodoc(
       {
         compodocArgs: [],
         tsconfig: 'path/to/tsconfig.json',
       },
       builderContextMock
-    )
-      .pipe(take(1))
-      .subscribe();
+    );
 
     expect(mockRunScript).toHaveBeenCalledWith(
       'compodoc',
@@ -56,15 +53,13 @@ describe('runCompodoc', () => {
   });
 
   it('should run compodoc with tsconfig from compodocArgs', async () => {
-    runCompodoc(
+    await runCompodoc(
       {
         compodocArgs: ['-p', 'path/to/tsconfig.stories.json'],
         tsconfig: 'path/to/tsconfig.json',
       },
       builderContextMock
-    )
-      .pipe(take(1))
-      .subscribe();
+    );
 
     expect(mockRunScript).toHaveBeenCalledWith(
       'compodoc',
@@ -75,15 +70,13 @@ describe('runCompodoc', () => {
   });
 
   it('should run compodoc with default output folder.', async () => {
-    runCompodoc(
+    await runCompodoc(
       {
         compodocArgs: [],
         tsconfig: 'path/to/tsconfig.json',
       },
       builderContextMock
-    )
-      .pipe(take(1))
-      .subscribe();
+    );
 
     expect(mockRunScript).toHaveBeenCalledWith(
       'compodoc',
@@ -94,15 +87,13 @@ describe('runCompodoc', () => {
   });
 
   it('should run with custom output folder specified with --output compodocArgs', async () => {
-    runCompodoc(
+    await runCompodoc(
       {
         compodocArgs: ['--output', 'path/to/customFolder'],
         tsconfig: 'path/to/tsconfig.json',
       },
       builderContextMock
-    )
-      .pipe(take(1))
-      .subscribe();
+    );
 
     expect(mockRunScript).toHaveBeenCalledWith(
       'compodoc',
@@ -113,15 +104,13 @@ describe('runCompodoc', () => {
   });
 
   it('should run with custom output folder specified with -d compodocArgs', async () => {
-    runCompodoc(
+    await runCompodoc(
       {
         compodocArgs: ['-d', 'path/to/customFolder'],
         tsconfig: 'path/to/tsconfig.json',
       },
       builderContextMock
-    )
-      .pipe(take(1))
-      .subscribe();
+    );
 
     expect(mockRunScript).toHaveBeenCalledWith(
       'compodoc',

--- a/code/frameworks/angular/src/builders/utils/run-compodoc.ts
+++ b/code/frameworks/angular/src/builders/utils/run-compodoc.ts
@@ -13,34 +13,30 @@ const toRelativePath = (pathToTsConfig: string) => {
   return path.isAbsolute(pathToTsConfig) ? path.relative('.', pathToTsConfig) : pathToTsConfig;
 };
 
-export const runCompodoc = (
+export const runCompodoc = async (
   { compodocArgs, tsconfig }: { compodocArgs: string[]; tsconfig: string },
   context: BuilderContext
-): Observable<void> => {
-  return new Observable<void>((observer) => {
-    const tsConfigPath = toRelativePath(tsconfig);
-    const finalCompodocArgs = [
-      ...(hasTsConfigArg(compodocArgs) ? [] : ['-p', tsConfigPath]),
-      ...(hasOutputArg(compodocArgs) ? [] : ['-d', `${context.workspaceRoot || '.'}`]),
-      ...compodocArgs,
-    ];
+): Promise<void> => {
+  const tsConfigPath = toRelativePath(tsconfig);
+  const finalCompodocArgs = [
+    ...(hasTsConfigArg(compodocArgs) ? [] : ['-p', tsConfigPath]),
+    ...(hasOutputArg(compodocArgs) ? [] : ['-d', `${context.workspaceRoot || '.'}`]),
+    ...compodocArgs,
+  ];
 
-    const packageManager = JsPackageManagerFactory.getPackageManager();
+  const packageManager = JsPackageManagerFactory.getPackageManager();
 
-    try {
-      const stdout = packageManager.runPackageCommandSync(
-        'compodoc',
-        finalCompodocArgs,
-        context.workspaceRoot,
-        'inherit'
-      );
+  try {
+    const stdout = packageManager.runPackageCommandSync(
+      'compodoc',
+      finalCompodocArgs,
+      context.workspaceRoot,
+      'inherit'
+    );
 
-      context.logger.info(stdout);
-      observer.next();
-      observer.complete();
-    } catch (e) {
-      context.logger.error(e);
-      observer.error();
-    }
-  });
+    context.logger.info(stdout);
+  } catch (e) {
+    context.logger.error(e);
+    throw e;
+  }
 };

--- a/code/frameworks/angular/src/builders/utils/setup.ts
+++ b/code/frameworks/angular/src/builders/utils/setup.ts
@@ -1,0 +1,118 @@
+import { Target, targetFromTargetString } from '@angular-devkit/architect';
+import { BuilderContext } from '@angular-devkit/architect';
+import { JsonObject, logging } from '@angular-devkit/core';
+import { sync as findUpSync } from 'find-up';
+import { BrowserBuilderOptions, StylePreprocessorOptions } from '@angular-devkit/build-angular';
+import { logger } from '@storybook/node-logger';
+import {
+  AssetPattern,
+  SourceMapUnion,
+  StyleElement,
+} from '@angular-devkit/build-angular/src/builders/browser/schema';
+
+type AngularBuilderOptions = {
+  stylePreprocessorOptions?: StylePreprocessorOptions;
+  styles?: StyleElement[];
+  assets?: AssetPattern[];
+  sourceMap?: SourceMapUnion;
+};
+
+type Options = AngularBuilderOptions & {
+  browserTarget?: string | null;
+  tsConfig?: string;
+  configDir?: string;
+};
+
+export async function setup(options: Options, context: BuilderContext) {
+  let browserOptions: (JsonObject & BrowserBuilderOptions) | undefined;
+  let browserTarget: Target | undefined;
+
+  if (options.browserTarget) {
+    browserTarget = targetFromTargetString(options.browserTarget);
+    browserOptions = await context.validateOptions<JsonObject & BrowserBuilderOptions>(
+      await context.getTargetOptions(browserTarget),
+      await context.getBuilderNameForTarget(browserTarget)
+    );
+  }
+
+  const tsConfig =
+    options.tsConfig ??
+    findUpSync('tsconfig.json', { cwd: options.configDir }) ??
+    browserOptions.tsConfig;
+
+  const angularBuilderContext = getBuilderContext(context);
+
+  const angularBuilderOptions = await getBuilderOptions(
+    options.browserTarget,
+    {
+      ...(options.stylePreprocessorOptions
+        ? { stylePreprocessorOptions: options.stylePreprocessorOptions }
+        : {}),
+      ...(options.styles ? { styles: options.styles } : {}),
+      ...(options.assets ? { assets: options.assets } : {}),
+      sourceMap: options.sourceMap ?? false,
+    },
+    tsConfig,
+    options.configDir,
+    angularBuilderContext
+  );
+
+  return {
+    tsConfig,
+    angularBuilderContext,
+    angularBuilderOptions,
+  };
+}
+
+/**
+ * Get Builder Context
+ * If storybook is not start by angular builder create dumb BuilderContext
+ */
+function getBuilderContext(builderContext: BuilderContext): BuilderContext {
+  return (
+    builderContext ??
+    ({
+      target: { project: 'noop-project', builder: '', options: {} },
+      workspaceRoot: process.cwd(),
+      getProjectMetadata: () => ({}),
+      getTargetOptions: () => ({}),
+      logger: new logging.Logger('Storybook'),
+    } as unknown as BuilderContext)
+  );
+}
+
+/**
+ * Get builder options
+ * Merge target options from browser target and from storybook options
+ */
+async function getBuilderOptions(
+  angularBrowserTarget: string,
+  angularBuilderOptions: AngularBuilderOptions,
+  tsConfig: string,
+  configDir: string,
+  builderContext: BuilderContext
+) {
+  /**
+   * Get Browser Target options
+   */
+  let browserTargetOptions: JsonObject = {};
+
+  if (angularBrowserTarget) {
+    const browserTarget = targetFromTargetString(angularBrowserTarget);
+
+    browserTargetOptions = await builderContext.getTargetOptions(browserTarget);
+  }
+
+  /**
+   * Merge target options from browser target options and from storybook options
+   */
+  const builderOptions = {
+    ...browserTargetOptions,
+    ...angularBuilderOptions,
+    tsConfig:
+      tsConfig ?? findUpSync('tsconfig.json', { cwd: configDir }) ?? browserTargetOptions.tsConfig,
+  };
+  logger.info(`=> Using angular project with "tsConfig:${builderOptions.tsConfig}"`);
+
+  return builderOptions;
+}

--- a/code/frameworks/angular/src/builders/utils/standalone-options.ts
+++ b/code/frameworks/angular/src/builders/utils/standalone-options.ts
@@ -1,11 +1,7 @@
 import { BuilderContext } from '@angular-devkit/architect';
-import {
-  AssetPattern,
-  SourceMapUnion,
-  StyleElement,
-  StylePreprocessorOptions,
-} from '@angular-devkit/build-angular/src/builders/browser/schema';
+
 import { LoadOptions, CLIOptions, BuilderOptions } from '@storybook/types';
+import { AngularBuilderOptions } from '../../server/framework-preset-angular-cli';
 
 export type StandaloneOptions = CLIOptions &
   LoadOptions &
@@ -13,12 +9,8 @@ export type StandaloneOptions = CLIOptions &
     mode?: 'static' | 'dev';
     enableProdMode: boolean;
     angularBrowserTarget?: string | null;
-    angularBuilderOptions?: Record<string, any> & {
-      styles?: StyleElement[];
-      stylePreprocessorOptions?: StylePreprocessorOptions;
-      assets?: AssetPattern[];
-      sourceMap?: SourceMapUnion;
-    };
+    angularBuilderOptions?: AngularBuilderOptions;
     angularBuilderContext?: BuilderContext | null;
     tsConfig?: string;
+    excludeChunks?: string[];
   };

--- a/code/frameworks/angular/src/server/angular-cli-webpack.js
+++ b/code/frameworks/angular/src/server/angular-cli-webpack.js
@@ -56,6 +56,7 @@ exports.getWebpackConfig = async (baseConfig, { builderOptions, builderContext }
    */
   const { getCommonConfig, getStylesConfig, getDevServerConfig, getTypeScriptConfig } =
     getAngularWebpackUtils();
+
   const { config: cliConfig } = await generateI18nBrowserWebpackConfigFromContext(
     {
       // Default options
@@ -65,10 +66,15 @@ exports.getWebpackConfig = async (baseConfig, { builderOptions, builderContext }
 
       // Options provided by user
       ...builderOptions,
-      styles: builderOptions.styles
-        ?.map((style) => (typeof style === 'string' ? style : style.input))
-        .filter((style) => typeof style === 'string' || style.inject !== false),
-
+      styles: builderOptions.styles?.map((style) =>
+        typeof style === 'string'
+          ? {
+              input: style,
+              inject: true,
+              bundleName: style.split('/').pop(),
+            }
+          : style
+      ),
       // Fixed options
       optimization: false,
       namedChunks: false,

--- a/code/frameworks/angular/src/server/preset-options.ts
+++ b/code/frameworks/angular/src/server/preset-options.ts
@@ -1,17 +1,13 @@
 import { Options as CoreOptions } from '@storybook/types';
 
 import { BuilderContext } from '@angular-devkit/architect';
-import { StylePreprocessorOptions } from '@angular-devkit/build-angular';
-import { StyleElement } from '@angular-devkit/build-angular/src/builders/browser/schema';
+import { JsonObject } from '@angular-devkit/core';
 
 export type PresetOptions = CoreOptions & {
   /* Allow to get the options of a targeted "browser builder"  */
   angularBrowserTarget?: string | null;
   /* Defined set of options. These will take over priority from angularBrowserTarget options  */
-  angularBuilderOptions?: {
-    styles?: StyleElement[];
-    stylePreprocessorOptions?: StylePreprocessorOptions;
-  };
+  angularBuilderOptions?: JsonObject;
   /* Angular context from builder */
   angularBuilderContext?: BuilderContext | null;
   tsConfig?: string;


### PR DESCRIPTION
Relates https://github.com/storybookjs/storybook/pull/24768

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Currently, every kind of style is injected into the iframe HTML, although some of them are marked with inject:false to not inject them, but rather to leave it to the user to dynamically load them if required.

So, let's say a user defines two different styles via workspace configuration:

```json
{
  ...
  "projects": {
    "angular-latest": {
     ...
      "architect": {
        "build": {
          "builder": "@angular-devkit/build-angular:application",
          "options": {
            ...
            "styles": [
              "src/styles.scss",
              {
                "input": "src/design.tokens.css",
                "inject": false,
                "bundleName": "design-tokens"
              }
            ],
```

Then `styles.scss` should be injected into the `iframe.html`, whereas the `design-tokens` one shouldn't be.

Huge shoutout to @andriy-statsenko-lightit to figuring out this bug and has helped with the solution!

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run an Angular sandbox in no-link mode`
2. Adjust the workspace configuration in `angular.json` to use two different styles, where one is injected (string or object notation with inject=true) and the other one is not injected (inject=false)
3. Make sure, that only injected styles are put into the iframe.html

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-27108-sha-2470133a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-27108-sha-2470133a sandbox` or in an existing project with `npx storybook@0.0.0-pr-27108-sha-2470133a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-27108-sha-2470133a`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-27108-sha-2470133a) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-angular-styles-options-filtering`](https://github.com/storybookjs/storybook/tree/valentin/fix-angular-styles-options-filtering) |
| **Commit** | [`2470133a`](https://github.com/storybookjs/storybook/commit/2470133a27cd6165d00c365065ad0f655ff964b0) |
| **Datetime** | Wed May 15 11:50:01 UTC 2024 (`1715773801`) |
| **Workflow run** | [9095112714](https://github.com/storybookjs/storybook/actions/runs/9095112714) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=27108`_
</details>
<!-- CANARY_RELEASE_SECTION -->
