### PR TITLE
Docs: Fix various docs issues

### DIFF
--- a/docs/api/portable-stories-jest.md
+++ b/docs/api/portable-stories-jest.md
@@ -22,7 +22,7 @@ Portable stories in Jest are currently only supported in [React](?renderer=react
 
 Portable stories are Storybook [stories](../writing-stories/index.md) which can be used in external environments, such as [Jest](https://jestjs.io).
 
-Normally, Storybok composes a story and its [annotations](#annotations) automatically, as part of the [story pipeline](#story-pipeline). When using stories in Jest tests, you must handle the story pipeline yourself, which is what the [`composeStories`](#composestories) and [`composeStory`](#composestory) functions enable.
+Normally, Storybook composes a story and its [annotations](#annotations) automatically, as part of the [story pipeline](#story-pipeline). When using stories in Jest tests, you must handle the story pipeline yourself, which is what the [`composeStories`](#composestories) and [`composeStory`](#composestory) functions enable.
 
 <If renderer="react">
 

--- a/docs/api/portable-stories-playwright.md
+++ b/docs/api/portable-stories-playwright.md
@@ -28,13 +28,15 @@ The portable stories API for Playwright CT is experimental. Playwright CT itself
 
 Portable stories are Storybook [stories](../writing-stories/index.md) which can be used in external environments, such as [Playwright Component Tests (CT)](https://playwright.dev/docs/test-components).
 
-Normally, Storybok composes a story and its [annotations](#annotations) automatically, as part of the [story pipeline](#story-pipeline). When using stories in Playwright CT, you can use the [`createTest`](#createtest) function, which extends Playwright's test functionality to add a custom `mount` mechanism, to take care of the story pipeline for you.
+Normally, Storybook composes a story and its [annotations](#annotations) automatically, as part of the [story pipeline](#story-pipeline). When using stories in Playwright CT, you can use the [`createTest`](#createtest) function, which extends Playwright's test functionality to add a custom `mount` mechanism, to take care of the story pipeline for you.
 
 <If renderer="react">
 
 <Callout variant="warning">
 
-**Using `Next.js`?** Next.js requires specific configuration that is only available in [Jest](./portable-stories-jest.md). The portable stories API is not supported in Next.js with Playwright CT.
+**Using `Next.js`?** The portable stories API is not yet supported in Next.js with Playwright CT.
+
+<!-- **Using `Next.js`?** Next.js requires specific configuration that is only available in [Jest](./portable-stories-jest.md). The portable stories API is not supported in Next.js with Playwright CT. -->
 
 </Callout>
 
@@ -87,9 +89,25 @@ Instead of using Playwright's own `test` function, you can use Storybook's speci
 
 <!-- prettier-ignore-end -->
 
-<Callout variant="warning">
+<Callout icon="ℹ️">
 
-Please note the [limitations of importing stories in Playwright CT](#importing-stories-in-playwright-ct).
+The code which you write in your Playwright test file is transformed and orchestrated by Playwright, where part of the code executes in Node, while other parts execute in the browser.
+
+Because of this, you have to compose the stories _in a separate file than your own test file_:
+
+```ts
+// Button.stories.portable.ts
+// Replace <your-renderer> with your renderer, e.g. react, vue3
+import { composeStories } from '@storybook/<your-renderer>';
+
+import * as stories from './Button.stories';
+
+// This function will be executed in the browser
+// and compose all stories, exporting them in a single object
+export default composeStories(stories);
+```
+
+You can then import the composed stories in your Playwright test file, as in the example above.
 
 </Callout>
 
@@ -126,7 +144,7 @@ This API should be called once, before the tests run, in [`playwright/index.ts`]
 // Replace <your-renderer> with your renderer, e.g. react, vue3
 import { setProjectAnnotations } from '@storybook/<your-renderer>';
 import * as addonAnnotations from 'my-addon/preview';
-import * as previewAnnotations from './.storybook/preview';
+import * as previewAnnotations from '../.storybook/preview';
 
 setProjectAnnotations([previewAnnotations, addonAnnotations]);
 ```
@@ -158,26 +176,6 @@ A set of project [annotations](#annotations) (those defined in `.storybook/previ
 ## Annotations
 
 Annotations are the metadata applied to a story, like [args](../writing-stories/args.md), [decorators](../writing-stories/decorators.md), [loaders](../writing-stories/loaders.md), and [play functions](../writing-stories/play-function.md). They can be defined for a specific story, all stories for a component, or all stories in the project.
-
-## Importing stories in Playwright CT
-
-The code which you write in your Playwright test file is transformed and orchestrated by Playwright, where part of the code executes in Node, while other parts execute in the browser.
-
-Because of this, you have to compose the stories _in a separate file than your own test file_:
-
-```ts
-// Button.stories.portable.ts
-// Replace <your-renderer> with your renderer, e.g. react, vue3
-import { composeStories } from '@storybook/<your-renderer>';
-
-import * as stories from './Button.stories';
-
-// This function will be executed in the browser
-// and compose all stories, exporting them in a single object
-export default composeStories(stories);
-```
-
-You can then import the composed stories in your Playwright test file, as in the [example above](#createtest).
 
 <Callout variant="info">
 

--- a/docs/get-started/nextjs.md
+++ b/docs/get-started/nextjs.md
@@ -322,7 +322,7 @@ To override these defaults, you can use [parameters](../writing-stories/paramete
 ```ts
 // .storybook/preview.ts
 import { Preview } from '@storybook/react';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { getRouter } from '@storybook/nextjs/router.mock';
 
 const preview: Preview = {
@@ -483,7 +483,7 @@ To override these defaults, you can use [parameters](../writing-stories/paramete
 ```ts
 // .storybook/preview.ts
 import { Preview } from '@storybook/react';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { getRouter } from '@storybook/nextjs/navigation.mock';
 
 const preview: Preview = {
@@ -885,11 +885,11 @@ If your server components access data via the network, we recommend using the [M
 
 In the future we will provide better mocking support in Storybook and support for [Server Actions](https://nextjs.org/docs/app/api-reference/functions/server-actions).
 
-## Portable stories
+<!-- ## Portable stories
 
 You can test your stories in a Jest environment by using the [portable stories](../api/portable-stories-jest.md) API.
 
-When using portable stories with Next.js, you need to mock the Next.js modules on which your components depend. You can use the [`@storybook/nextjs/export-mocks` module](#storybooknextjsexport-mocks) to generate the aliases needed to set up portable stories in a Jest environment. This is needed because, to replicate Next.js configuration, Storybook sets up aliases in Webpack to make testing and developing your components easier. If you make use of the advanced functionality like the built-in mocks for common Next.js modules, you need to set up this aliasing in your Jest environment as well.
+When using portable stories with Next.js, you need to mock the Next.js modules on which your components depend. You can use the [`@storybook/nextjs/export-mocks` module](#storybooknextjsexport-mocks) to generate the aliases needed to set up portable stories in a Jest environment. This is needed because, to replicate Next.js configuration, Storybook sets up aliases in Webpack to make testing and developing your components easier. If you make use of the advanced functionality like the built-in mocks for common Next.js modules, you need to set up this aliasing in your Jest environment as well. -->
 
 ## Notes for Yarn v2 and v3 users
 

--- a/docs/snippets/angular/before-each-in-meta-mock-date.ts.mdx
+++ b/docs/snippets/angular/before-each-in-meta-mock-date.ts.mdx
@@ -3,8 +3,8 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import MockDate from 'mockdate';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { getUserFromSession } from '#api/session.mock';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { getUserFromSession } from '../../api/session.mock';
 import { Page } from './Page';
 
 const meta: Meta<Page> = {

--- a/docs/snippets/angular/storybook-test-fn-mock-spy.ts.mdx
+++ b/docs/snippets/angular/storybook-test-fn-mock-spy.ts.mdx
@@ -3,9 +3,9 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import { expect, userEvent, within } from '@storybook/test';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { saveNote } from '#app/actions.mock';
-import { createNotes } from '#mocks/notes';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { saveNote } from '../../app/actions.mock';
+import { createNotes } from '../../mocks/notes';
 import NoteUI from './note-ui';
 
 const meta: Meta<NoteUI> = {

--- a/docs/snippets/angular/storybook-test-mock-return-value.ts.mdx
+++ b/docs/snippets/angular/storybook-test-mock-return-value.ts.mdx
@@ -2,8 +2,8 @@
 // Page.stories.ts
 import type { Meta, StoryObj } from '@storybook/angular';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { getUserFromSession } from '#api/session.mock';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { getUserFromSession } from '../../api/session.mock';
 import { Page } from './Page';
 
 const meta: Meta<Page> = {

--- a/docs/snippets/common/before-each-in-meta-mock-date.js.mdx
+++ b/docs/snippets/common/before-each-in-meta-mock-date.js.mdx
@@ -2,7 +2,7 @@
 // Page.stories.js
 import MockDate from 'mockdate';
 
-import { getUserFromSession } from '#api/session.mock';
+import { getUserFromSession } from '../../api/session.mock';
 import { Page } from './Page';
 
 export default {

--- a/docs/snippets/common/before-each-in-meta-mock-date.ts-4-9.mdx
+++ b/docs/snippets/common/before-each-in-meta-mock-date.ts-4-9.mdx
@@ -4,8 +4,8 @@
 import type { Meta, StoryObj } from '@storybook/your-renderer';
 import MockDate from 'mockdate';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { getUserFromSession } from '#api/session.mock';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { getUserFromSession } from '../../api/session.mock';
 import { Page } from './Page';
 
 const meta = {

--- a/docs/snippets/common/before-each-in-meta-mock-date.ts.mdx
+++ b/docs/snippets/common/before-each-in-meta-mock-date.ts.mdx
@@ -4,8 +4,8 @@
 import type { Meta, StoryObj } from '@storybook/your-renderer';
 import MockDate from 'mockdate';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { getUserFromSession } from '#api/session.mock';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { getUserFromSession } from '../../api/session.mock';
 import { Page } from './Page';
 
 const meta: Meta<typeof Page> = {

--- a/docs/snippets/common/storybook-test-fn-mock-spy.js.mdx
+++ b/docs/snippets/common/storybook-test-fn-mock-spy.js.mdx
@@ -2,8 +2,8 @@
 // NoteUI.stories.js
 import { expect, userEvent, within } from '@storybook/test';
 
-import { saveNote } from '#app/actions.mock';
-import { createNotes } from '#mocks/notes';
+import { saveNote } from '../../app/actions.mock';
+import { createNotes } from '../../mocks/notes';
 import NoteUI from './note-ui';
 
 export default {

--- a/docs/snippets/common/storybook-test-fn-mock-spy.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-test-fn-mock-spy.ts-4-9.mdx
@@ -4,9 +4,9 @@
 import type { Meta, StoryObj } from '@storybook/your-renderer';
 import { expect, userEvent, within } from '@storybook/test';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { saveNote } from '#app/actions.mock';
-import { createNotes } from '#mocks/notes';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { saveNote } from '../../app/actions.mock';
+import { createNotes } from '../../mocks/notes';
 import NoteUI from './note-ui';
 
 const meta = {

--- a/docs/snippets/common/storybook-test-fn-mock-spy.ts.mdx
+++ b/docs/snippets/common/storybook-test-fn-mock-spy.ts.mdx
@@ -4,9 +4,9 @@
 import type { Meta, StoryObj } from '@storybook/your-renderer';
 import { expect, userEvent, within } from '@storybook/test';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { saveNote } from '#app/actions.mock';
-import { createNotes } from '#mocks/notes';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { saveNote } from '../../app/actions.mock';
+import { createNotes } from '../../mocks/notes';
 import NoteUI from './note-ui';
 
 const meta: Meta<typeof NoteUI> = {

--- a/docs/snippets/common/storybook-test-mock-return-value.js.mdx
+++ b/docs/snippets/common/storybook-test-mock-return-value.js.mdx
@@ -1,8 +1,6 @@
 ```js
 // Page.stories.js
-import { fn } from '@storybook/test';
-
-import { getUserFromSession } from '#api/session.mock';
+import { getUserFromSession } from '../../api/session.mock';
 import { Page } from './Page';
 
 export default {

--- a/docs/snippets/common/storybook-test-mock-return-value.ts-4-9.mdx
+++ b/docs/snippets/common/storybook-test-mock-return-value.ts-4-9.mdx
@@ -2,10 +2,9 @@
 // Page.stories.ts
 // Replace your-renderer with the name of your renderer (e.g. react, vue3)
 import type { Meta, StoryObj } from '@storybook/your-renderer';
-import { fn } from '@storybook/test';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { getUserFromSession } from '#api/session.mock';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { getUserFromSession } from '../../api/session.mock';
 import { Page } from './Page';
 
 const meta = {

--- a/docs/snippets/common/storybook-test-mock-return-value.ts.mdx
+++ b/docs/snippets/common/storybook-test-mock-return-value.ts.mdx
@@ -2,10 +2,9 @@
 // Page.stories.ts
 // Replace your-renderer with the name of your renderer (e.g. react, vue3)
 import type { Meta, StoryObj } from '@storybook/your-renderer';
-import { fn } from '@storybook/test';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { getUserFromSession } from '#api/session.mock';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { getUserFromSession } from '../../api/session.mock';
 import { Page } from './Page';
 
 const meta: Meta<typeof Page> = {

--- a/docs/snippets/react/nextjs-cache-mock.ts-4-9.mdx
+++ b/docs/snippets/react/nextjs-cache-mock.ts-4-9.mdx
@@ -2,7 +2,7 @@
 // MyForm.stories.ts
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, within } from '@storybook/test';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { revalidatePath } from '@storybook/nextjs/cache.mock';
 
 import MyForm from './my-form';

--- a/docs/snippets/react/nextjs-cache-mock.ts.mdx
+++ b/docs/snippets/react/nextjs-cache-mock.ts.mdx
@@ -2,7 +2,7 @@
 // MyForm.stories.ts
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, within } from '@storybook/test';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { revalidatePath } from '@storybook/nextjs/cache.mock';
 
 import MyForm from './my-form';

--- a/docs/snippets/react/nextjs-headers-mock.ts-4-9.mdx
+++ b/docs/snippets/react/nextjs-headers-mock.ts-4-9.mdx
@@ -2,7 +2,7 @@
 // MyForm.stories.ts
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fireEvent, userEvent, within } from '@storybook/test';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { cookies, headers } from '@storybook/nextjs/headers.mock';
 
 import MyForm from './my-form';

--- a/docs/snippets/react/nextjs-headers-mock.ts.mdx
+++ b/docs/snippets/react/nextjs-headers-mock.ts.mdx
@@ -2,7 +2,7 @@
 // MyForm.stories.ts
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fireEvent, userEvent, within } from '@storybook/test';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { cookies, headers } from '@storybook/nextjs/headers.mock';
 
 import MyForm from './my-form';

--- a/docs/snippets/react/nextjs-navigation-mock.ts-4-9.mdx
+++ b/docs/snippets/react/nextjs-navigation-mock.ts-4-9.mdx
@@ -2,7 +2,7 @@
 // MyForm.stories.ts
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fireEvent, userEvent, within } from '@storybook/test';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { redirect, getRouter } from '@storybook/nextjs/navigation.mock';
 
 import MyForm from './my-form';

--- a/docs/snippets/react/nextjs-navigation-mock.ts.mdx
+++ b/docs/snippets/react/nextjs-navigation-mock.ts.mdx
@@ -2,7 +2,7 @@
 // MyForm.stories.ts
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fireEvent, userEvent, within } from '@storybook/test';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { redirect, getRouter } from '@storybook/nextjs/navigation.mock';
 
 import MyForm from './my-form';

--- a/docs/snippets/react/nextjs-router-mock.js.mdx
+++ b/docs/snippets/react/nextjs-router-mock.js.mdx
@@ -1,7 +1,7 @@
 ```js
 // MyForm.stories.js
 import { expect, fireEvent, userEvent, within } from '@storybook/test';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { getRouter } from '@storybook/nextjs/router.mock';
 
 import MyForm from './my-form';

--- a/docs/snippets/react/nextjs-router-mock.ts-4-9.mdx
+++ b/docs/snippets/react/nextjs-router-mock.ts-4-9.mdx
@@ -2,7 +2,7 @@
 // MyForm.stories.ts
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fireEvent, userEvent, within } from '@storybook/test';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { getRouter } from '@storybook/nextjs/router.mock';
 
 import MyForm from './my-form';

--- a/docs/snippets/react/nextjs-router-mock.ts.mdx
+++ b/docs/snippets/react/nextjs-router-mock.ts.mdx
@@ -2,7 +2,7 @@
 // MyForm.stories.ts
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fireEvent, userEvent, within } from '@storybook/test';
-// 👇 Must use this import path to have mocks typed correctly
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { getRouter } from '@storybook/nextjs/router.mock';
 
 import MyForm from './my-form';

--- a/docs/snippets/react/portable-stories-playwright-ct.ts.mdx
+++ b/docs/snippets/react/portable-stories-playwright-ct.ts.mdx
@@ -3,6 +3,7 @@
 import { createTest } from '@storybook/react/experimental-playwright';
 import { test as base } from '@playwright/experimental-ct-react';
 
+// See explanation below for `.portable` stories file
 import stories from './Button.stories.portable';
 
 const test = createTest(base);

--- a/docs/snippets/vue/portable-stories-playwright-ct.ts.mdx
+++ b/docs/snippets/vue/portable-stories-playwright-ct.ts.mdx
@@ -3,6 +3,7 @@
 import { createTest } from '@storybook/vue3/experimental-playwright';
 import { test as base } from '@playwright/experimental-ct-vue';
 
+// See explanation below for `.portable` stories file
 import stories from './Button.stories.portable';
 
 const test = createTest(base);

--- a/docs/snippets/web-components/before-each-in-meta-mock-date.js.mdx
+++ b/docs/snippets/web-components/before-each-in-meta-mock-date.js.mdx
@@ -2,7 +2,7 @@
 // Page.stories.js
 import MockDate from 'mockdate';
 
-import { getUserFromSession } from '#api/session.mock';
+import { getUserFromSession } from '../../api/session.mock';
 
 export default {
   component: 'my-page',

--- a/docs/snippets/web-components/before-each-in-meta-mock-date.ts.mdx
+++ b/docs/snippets/web-components/before-each-in-meta-mock-date.ts.mdx
@@ -3,8 +3,8 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
 import MockDate from 'mockdate';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { getUserFromSession } from '#api/session.mock';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { getUserFromSession } from '../../api/session.mock';
 
 const meta: Meta = {
   component: 'my-page',

--- a/docs/snippets/web-components/storybook-test-fn-mock-spy.js.mdx
+++ b/docs/snippets/web-components/storybook-test-fn-mock-spy.js.mdx
@@ -2,8 +2,8 @@
 // NoteUI.stories.js
 import { expect, userEvent, within } from '@storybook/test';
 
-import { saveNote } from '#app/actions.mock';
-import { createNotes } from '#mocks/notes';
+import { saveNote } from '../../app/actions.mock';
+import { createNotes } from '../../mocks/notes';
 
 export default {
   title: 'Mocked/NoteUI',

--- a/docs/snippets/web-components/storybook-test-fn-mock-spy.ts.mdx
+++ b/docs/snippets/web-components/storybook-test-fn-mock-spy.ts.mdx
@@ -3,9 +3,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, within } from '@storybook/test';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { saveNote } from '#app/actions.mock';
-import { createNotes } from '#mocks/notes';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { saveNote } from '../../app/actions.mock';
+import { createNotes } from '../../mocks/notes';
 
 const meta: Meta = {
   title: 'Mocked/NoteUI',

--- a/docs/snippets/web-components/storybook-test-mock-return-value.js.mdx
+++ b/docs/snippets/web-components/storybook-test-mock-return-value.js.mdx
@@ -1,6 +1,6 @@
 ```js
 // Page.stories.js
-import { getUserFromSession } from '#api/session.mock';
+import { getUserFromSession } from '../../api/session.mock';
 
 export default {
   component: 'my-page',

--- a/docs/snippets/web-components/storybook-test-mock-return-value.ts.mdx
+++ b/docs/snippets/web-components/storybook-test-mock-return-value.ts.mdx
@@ -2,8 +2,8 @@
 // Page.stories.ts
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-// 👇 Must use this import path to have mocks typed correctly
-import { getUserFromSession } from '#api/session.mock';
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { getUserFromSession } from '../../api/session.mock';
 
 const meta: Meta = {
   component: 'my-page',

--- a/docs/writing-stories/tags.md
+++ b/docs/writing-stories/tags.md
@@ -2,7 +2,7 @@
 title: 'Tags'
 ---
 
-Tags allow you to control which stories are included in your Storybook, enabling many different uses of the same total set of stories. For example, you can use tags to include/exclude tests from the [test runner](../writing-tests/test-runner.md#run-tests-for-a-subset-of-stories) or display [badges](https://storybook.js.org/addons/@geometricpanda/storybook-addon-badges/). For more complex use cases, see the [recipes](#recipes) section, below.
+Tags allow you to control which stories are included in your Storybook, enabling many different uses of the same total set of stories. For example, you can use tags to include/exclude tests from the [test runner](../writing-tests/test-runner.md#run-tests-for-a-subset-of-stories). For more complex use cases, see the [recipes](#recipes) section, below.
 
 ## Built-in tags
 
@@ -51,7 +51,7 @@ Within a component stories file, you apply tags like so:
 
 ## Removing tags
 
-To remove a tag from a story, prefix it with `!`. For example, we can apply the `stable` tag to all stories in a file except one, which has the `experimental` tag:
+To remove a tag from a story, prefix it with `!`. For example:
 
 <!-- prettier-ignore-start -->
 
@@ -66,12 +66,6 @@ To remove a tag from a story, prefix it with `!`. For example, we can apply the 
 />
 
 <!-- prettier-ignore-end -->
-
-<Callout variant="info">
-
-Tags like `stable` and `experimental` work very well with an addon like [badges](https://storybook.js.org/addons/@geometricpanda/storybook-addon-badges/).
-
-</Callout>
 
 Tags can be removed for all stories in your project (in `.storybook/preview.js|ts`), all stories for a component (in the CSF file meta), or a single story (as above).
 


### PR DESCRIPTION
## What I did

- Remove mentions of portable stories for jest
- Restructure portables stories for playwright ct docs to clarify `*.stories.portable` files
- Update all subpath imports in stories file examples to relative imports
- Typos
- Remove mentions of badges addon in tags docs

## Checklist for Contributors

### Testing

#### Manual testing

1. Follow the steps in the [contributing instructions](https://storybook.js.org/docs/react/contribute/new-snippets#preview-your-work) for this branch, `8-1-docs-fixes`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
