### PR TITLE
Docs: Fix MDX Stories block tag-filtering behavior

### DIFF
--- a/code/addons/docs/src/preview.ts
+++ b/code/addons/docs/src/preview.ts
@@ -22,9 +22,7 @@ export const parameters: any = {
       filter: (story: PreparedStory) => {
         const tags = story.tags || [];
         return (
-          tags.includes('autodocs') &&
-          tags.filter((tag) => excludeTags[tag]).length === 0 &&
-          !story.parameters.docs?.disable
+          tags.filter((tag) => excludeTags[tag]).length === 0 && !story.parameters.docs?.disable
         );
       },
     },

--- a/code/ui/blocks/src/blocks/Stories.stories.tsx
+++ b/code/ui/blocks/src/blocks/Stories.stories.tsx
@@ -26,3 +26,13 @@ export const DifferentToolbars: Story = {
     relativeCsfPaths: ['../examples/StoriesParameters.stories'],
   },
 };
+export const NoAutodocs: Story = {
+  parameters: {
+    relativeCsfPaths: ['../examples/ButtonNoAutodocs.stories'],
+  },
+};
+export const SomeAutodocs: Story = {
+  parameters: {
+    relativeCsfPaths: ['../examples/ButtonSomeAutodocs.stories'],
+  },
+};

--- a/code/ui/blocks/src/blocks/Stories.tsx
+++ b/code/ui/blocks/src/blocks/Stories.tsx
@@ -34,6 +34,17 @@ export const Stories: FC<StoriesProps> = ({ title = 'Stories', includePrimary = 
   if (filter) {
     stories = stories.filter((story) => filter(story, getStoryContext(story)));
   }
+  // NOTE: this should be part of the default filter function. However, there is currently
+  // no way to distinguish a Stories block in an autodocs page from Stories in an MDX file
+  // making https://github.com/storybookjs/storybook/pull/26634 an unintentional breaking change.
+  //
+  // The new behavior here is that if NONE of the stories in the autodocs page are tagged
+  // with 'autodocs', we show all stories. If ANY of the stories have autodocs then we use
+  // the new behavior.
+  const hasAutodocsTaggedStory = stories.some((story) => story.tags?.includes('autodocs'));
+  if (hasAutodocsTaggedStory) {
+    stories = stories.filter((story) => story.tags?.includes('autodocs'));
+  }
 
   if (!includePrimary) stories = stories.slice(1);
 

--- a/code/ui/blocks/src/examples/ButtonNoAutodocs.stories.tsx
+++ b/code/ui/blocks/src/examples/ButtonNoAutodocs.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta = {
+  title: 'examples/ButtonNoAutodocs',
+  component: Button,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+  parameters: {
+    chromatic: { disable: true },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    label: 'Button',
+  },
+};

--- a/code/ui/blocks/src/examples/ButtonSomeAutodocs.stories.tsx
+++ b/code/ui/blocks/src/examples/ButtonSomeAutodocs.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta = {
+  title: 'examples/ButtonSomeAutodocs',
+  component: Button,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+  parameters: {
+    chromatic: { disable: true },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+
+export const Secondary: Story = {
+  tags: ['autodocs'],
+  args: {
+    label: 'Button',
+  },
+};


### PR DESCRIPTION
Closes #27143

## What I did

Made a sneaky change to the tag-based filtering of `autodocs` introduced in 8.1, which was an unintentional breaking change for users who used the `Stories` doc block in MDX pages.

Now if NONE of the stories have the autodocs tag (which is only possible in an MDX page), it will show ALL of the stories in the `Stories` block.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

You can check the added stories:
- [No Autodocs](https://635781f3500dd2c49e189caf-tcwklekktz.chromatic.com/?path=/story/blocks-blocks-stories--no-autodocs)
- [Some Autodocs](https://635781f3500dd2c49e189caf-tcwklekktz.chromatic.com/?path=/story/blocks-blocks-stories--some-autodocs)

You can also reproduce this in a sandbox by adding `Button.mdx` and playing around with the tags in `Button.stories.ts`:

```mdx
import { Meta, Stories } from '@storybook/blocks'
import * as ButtonStories from './Button.stories'

<Meta of={ButtonStories} />

# Button stories

<Stories />
```

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
