### PR TITLE
Types: Fix type implementation for `CompatibleString`

### DIFF
--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -582,4 +582,4 @@ export interface CoreCommon_StorybookInfo {
  * const framework: Framework = '@storybook/nextjs'; // valid and will be autocompleted
  * const framework: Framework = path.dirname(require.resolve(path.join("@storybook/nextjs", "package.json"))) // valid
  */
-export type CompatibleString<T extends string> = T | (string & Record<string, never>);
+export type CompatibleString<T extends string> = T | (string & {});


### PR DESCRIPTION
Fix issue from #27088 (which closed #23232)

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Thanks to @valentinpalkovic, previous issue(#23232) is resolved in latest release [8.1.1](https://github.com/storybookjs/storybook/releases/tag/v8.1.1), 
but sadly issue didn't resolved.

> Type 'string' is not assignable to type 'FrameworkName'

https://github.com/storybookjs/storybook/blob/ba69532715f162567cc17aa3a0de8ca918dfdd2c/code/lib/types/src/modules/core-common.ts#L575-L585

Looks like `T | (string & Record<string, never>)` instead of `T | (string & {})` does not correctly do the trick, so checked code below on TS Playground with TS 5.4.5.

```ts
const emptyObjectTest: "bar" | (string & {}) = "foo";

// Type '"foo"' is not assignable to type '(string & Record<string, never>) | "bar"'.
const recordNeverTest: "bar" | (string & Record<string, never>) = "foo";

// ---

type EmptyObjectTest = "foo" extends ("bar" | (string & {})) ? "true" : "false"; // "true"
type RecordNeverTest = "foo" extends ("bar" | (string & Record<string, never>)) ? "true" : "false"; // "false"
```

Since current implementation cannot solve problem, I updated `CompatibleString` to `T | (string & {})`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Run a sandbox `yarn start`
2. Define the framework field or framework.name field as a random string. This should be valid.
3. Make sure that `@storybook/react-vite` (or specific framework that sandbox is based on) gets autocompleted or suggested by the IDE

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
