### PR TITLE
Doc Blocks: Add support for `of` prop to `Stories` block

### DIFF
--- a/code/ui/blocks/src/blocks/Stories.stories.tsx
+++ b/code/ui/blocks/src/blocks/Stories.stories.tsx
@@ -32,7 +32,7 @@ export const Default: Story = {
   },
 };
 export const WithoutPrimaryStory: Story = {
-  args: { includePrimaryStory: false },
+  args: { includePrimary: false },
   parameters: {
     relativeCsfPaths: ['../examples/Button.stories'],
   },
@@ -64,7 +64,7 @@ export const DefaultWithOf: Story = {
 export const WithoutPrimaryStoryWithOf: Story = {
   name: 'Without Primary Story with Of',
   args: {
-    includePrimaryStory: false,
+    includePrimary: false,
     of: DefaultButtonStories,
   },
   parameters: {

--- a/code/ui/blocks/src/blocks/Stories.stories.tsx
+++ b/code/ui/blocks/src/blocks/Stories.stories.tsx
@@ -1,10 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Stories } from './Stories';
+import * as DefaultButtonStories from '../examples/Button.stories';
+import * as ParameterStories from '../examples/StoriesParameters.stories';
+import * as ButtonSomeAutodocs from '../examples/ButtonSomeAutodocs.stories';
+import * as ButtonNoAutodocs from '../examples/ButtonNoAutodocs.stories';
 
-const meta = {
+const meta: Meta<typeof Stories> = {
   component: Stories,
-  parameters: { docsStyles: true },
-} satisfies Meta<typeof Stories>;
+  parameters: {
+    relativeCsfPaths: [
+      '../examples/Button.stories',
+      '../examples/StoriesParameters.stories',
+      '../examples/ButtonSomeAutodocs.stories',
+      '../examples/ButtonNoAutodocs.stories',
+    ],
+    // workaround for https://github.com/storybookjs/storybook/issues/20505
+    docs: {
+      source: { type: 'code' },
+    },
+    docsStyles: true,
+  },
+};
 
 export default meta;
 
@@ -15,8 +31,8 @@ export const Default: Story = {
     relativeCsfPaths: ['../examples/Button.stories'],
   },
 };
-export const WithoutPrimary: Story = {
-  args: { includePrimary: false },
+export const WithoutPrimaryStory: Story = {
+  args: { includePrimaryStory: false },
   parameters: {
     relativeCsfPaths: ['../examples/Button.stories'],
   },
@@ -35,4 +51,68 @@ export const SomeAutodocs: Story = {
   parameters: {
     relativeCsfPaths: ['../examples/ButtonSomeAutodocs.stories'],
   },
+};
+export const DefaultWithOf: Story = {
+  name: 'Default with Of',
+  args: {
+    of: DefaultButtonStories,
+  },
+  parameters: {
+    relativeCsfPaths: ['../examples/Button.stories'],
+  },
+};
+export const WithoutPrimaryStoryWithOf: Story = {
+  name: 'Without Primary Story with Of',
+  args: {
+    includePrimaryStory: false,
+    of: DefaultButtonStories,
+  },
+  parameters: {
+    relativeCsfPaths: ['../examples/Button.stories'],
+  },
+};
+export const DifferentToolbarsWithOf: Story = {
+  name: 'Different Toolbars with Of',
+  args: {
+    of: ParameterStories,
+  },
+  parameters: {
+    relativeCsfPaths: ['../examples/StoriesParameters.stories'],
+  },
+};
+export const DifferentTitleWithOf: Story = {
+  name: 'Different Title with Of',
+  args: {
+    title: 'Different Title',
+    of: ParameterStories,
+  },
+  parameters: {
+    relativeCsfPaths: ['../examples/StoriesParameters.stories'],
+  },
+};
+export const NoAutodocsWithOf: Story = {
+  args: {
+    of: ButtonNoAutodocs,
+  },
+  parameters: {
+    relativeCsfPaths: ['../examples/ButtonNoAutodocs.stories'],
+  },
+};
+export const SomeAutodocsWithOf: Story = {
+  args: {
+    of: ButtonSomeAutodocs,
+  },
+  parameters: {
+    relativeCsfPaths: ['../examples/ButtonSomeAutodocs.stories'],
+  },
+};
+export const DefaultAttached: Story = {
+  parameters: { relativeCsfPaths: ['../examples/Button.stories'], attached: true },
+};
+export const OfStringMetaAttached: Story = {
+  name: 'Of "meta" Attached',
+  args: {
+    of: 'meta',
+  },
+  parameters: { relativeCsfPaths: ['../examples/Button.stories'], attached: true },
 };

--- a/code/ui/blocks/src/blocks/Stories.tsx
+++ b/code/ui/blocks/src/blocks/Stories.tsx
@@ -9,7 +9,7 @@ import { useOf } from './useOf';
 
 interface StoriesProps {
   title?: ReactElement | string;
-  includePrimaryStory?: boolean;
+  includePrimary?: boolean;
   /**
    * Specify where to get the stories from.
    */
@@ -32,9 +32,7 @@ const StyledHeading: typeof Heading = styled(Heading)(({ theme }) => ({
   },
 }));
 
-export const Stories: FC<StoriesProps> = (
-  props = { title: 'Stories', includePrimaryStory: true }
-) => {
+export const Stories: FC<StoriesProps> = (props = { title: 'Stories', includePrimary: true }) => {
   const { of } = props;
 
   if ('of' in props && of === undefined) {
@@ -62,10 +60,10 @@ export const Stories: FC<StoriesProps> = (
   const { preparedMeta } = useOf(of || 'meta', ['meta']);
 
   const title = props.title ?? preparedMeta.parameters.docs?.stories?.title;
-  const includePrimaryStory =
-    props.includePrimaryStory ?? preparedMeta.parameters.docs?.stories?.includePrimaryStory;
+  const includePrimary =
+    props.includePrimary ?? preparedMeta.parameters.docs?.stories?.includePrimary;
 
-  if (!includePrimaryStory) stories = stories.slice(1);
+  if (!includePrimary) stories = stories.slice(1);
 
   if (!stories || stories.length === 0) {
     return null;

--- a/code/ui/blocks/src/blocks/Stories.tsx
+++ b/code/ui/blocks/src/blocks/Stories.tsx
@@ -4,10 +4,16 @@ import { styled } from '@storybook/theming';
 import { DocsContext } from './DocsContext';
 import { DocsStory } from './DocsStory';
 import { Heading } from './Heading';
+import type { Of } from './useOf';
+import { useOf } from './useOf';
 
 interface StoriesProps {
   title?: ReactElement | string;
-  includePrimary?: boolean;
+  includePrimaryStory?: boolean;
+  /**
+   * Specify where to get the stories from.
+   */
+  of?: Of;
 }
 
 const StyledHeading: typeof Heading = styled(Heading)(({ theme }) => ({
@@ -26,7 +32,14 @@ const StyledHeading: typeof Heading = styled(Heading)(({ theme }) => ({
   },
 }));
 
-export const Stories: FC<StoriesProps> = ({ title = 'Stories', includePrimary = true }) => {
+export const Stories: FC<StoriesProps> = (
+  props = { title: 'Stories', includePrimaryStory: true }
+) => {
+  const { of } = props;
+
+  if ('of' in props && of === undefined) {
+    throw new Error('Unexpected `of={undefined}`, did you mistype a CSF file reference?');
+  }
   const { componentStories, projectAnnotations, getStoryContext } = useContext(DocsContext);
 
   let stories = componentStories();
@@ -46,7 +59,13 @@ export const Stories: FC<StoriesProps> = ({ title = 'Stories', includePrimary = 
     stories = stories.filter((story) => story.tags?.includes('autodocs'));
   }
 
-  if (!includePrimary) stories = stories.slice(1);
+  const { preparedMeta } = useOf(of || 'meta', ['meta']);
+
+  const title = props.title ?? preparedMeta.parameters.docs?.stories?.title;
+  const includePrimaryStory =
+    props.includePrimaryStory ?? preparedMeta.parameters.docs?.stories?.includePrimaryStory;
+
+  if (!includePrimaryStory) stories = stories.slice(1);
 
   if (!stories || stories.length === 0) {
     return null;

--- a/code/ui/blocks/src/examples/Button.stories.tsx
+++ b/code/ui/blocks/src/examples/Button.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     docs: {
       stories: {
         title: 'Stories',
-        includePrimaryStory: true,
+        includePrimary: true,
       },
       subtitle: 'This is the subtitle for the Button stories',
     },

--- a/code/ui/blocks/src/examples/Button.stories.tsx
+++ b/code/ui/blocks/src/examples/Button.stories.tsx
@@ -18,6 +18,10 @@ const meta = {
     info: 'This is info for the Button stories',
     jsx: { useBooleanShorthandSyntax: false },
     docs: {
+      stories: {
+        title: 'Stories',
+        includePrimaryStory: true,
+      },
       subtitle: 'This is the subtitle for the Button stories',
     },
   },

--- a/code/ui/blocks/src/examples/ButtonNoAutodocs.stories.tsx
+++ b/code/ui/blocks/src/examples/ButtonNoAutodocs.stories.tsx
@@ -9,6 +9,12 @@ const meta = {
   },
   parameters: {
     chromatic: { disable: true },
+    docs: {
+      stories: {
+        title: 'Stories',
+        includePrimaryStory: true,
+      },
+    },
   },
 } satisfies Meta<typeof Button>;
 

--- a/code/ui/blocks/src/examples/ButtonNoAutodocs.stories.tsx
+++ b/code/ui/blocks/src/examples/ButtonNoAutodocs.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
     docs: {
       stories: {
         title: 'Stories',
-        includePrimaryStory: true,
+        includePrimary: true,
       },
     },
   },

--- a/code/ui/blocks/src/examples/ButtonSomeAutodocs.stories.tsx
+++ b/code/ui/blocks/src/examples/ButtonSomeAutodocs.stories.tsx
@@ -9,6 +9,12 @@ const meta = {
   },
   parameters: {
     chromatic: { disable: true },
+    docs: {
+      stories: {
+        title: 'Stories',
+        includePrimaryStory: true,
+      },
+    },
   },
 } satisfies Meta<typeof Button>;
 

--- a/code/ui/blocks/src/examples/ButtonSomeAutodocs.stories.tsx
+++ b/code/ui/blocks/src/examples/ButtonSomeAutodocs.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
     docs: {
       stories: {
         title: 'Stories',
-        includePrimaryStory: true,
+        includePrimary: true,
       },
     },
   },

--- a/code/ui/blocks/src/examples/StoriesParameters.stories.tsx
+++ b/code/ui/blocks/src/examples/StoriesParameters.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
     docs: {
       stories: {
         title: 'Title Parameter',
-        includePrimaryStory: true,
+        includePrimary: true,
       },
     },
   },

--- a/code/ui/blocks/src/examples/StoriesParameters.stories.tsx
+++ b/code/ui/blocks/src/examples/StoriesParameters.stories.tsx
@@ -5,6 +5,14 @@ import { EmptyExample } from './EmptyExample';
 const meta = {
   title: 'examples/Stories for the Stories and Primary Block',
   component: EmptyExample,
+  parameters: {
+    docs: {
+      stories: {
+        title: 'Title Parameter',
+        includePrimaryStory: true,
+      },
+    },
+  },
 } satisfies Meta<typeof EmptyExample>;
 export default meta;
 

--- a/docs/api/doc-block-stories.md
+++ b/docs/api/doc-block-stories.md
@@ -29,24 +29,30 @@ import { Stories } from '@storybook/blocks';
 
 `Stories` is configured with the following props:
 
-### `includePrimary`
+### `includePrimaryStory`
 
 Type: `boolean`
 
-Default: `true`
+Default: `parameters.docs.stories.includePrimaryStory`
 
 Determines if the collection of stories includes the primary (first) story.
 
 <Callout variant="info" icon="💡">
 
-If a stories file contains only one story and `includePrimary={true}`, the `Stories` block will render nothing to avoid a potentially confusing situation.
+If a stories file contains only one story and `includePrimaryStory={true}`, the `Stories` block will render nothing to avoid a potentially confusing situation.
 
 </Callout>
+
+### `of`
+
+Type: CSF file exports
+
+Specifies which meta's stories are displayed.
 
 ### `title`
 
 Type: `string`
 
-Default: `'Stories'`
+Default: `parameters.docs.stories.title`
 
 Sets the heading content preceding the collection of stories.

--- a/docs/api/doc-block-stories.md
+++ b/docs/api/doc-block-stories.md
@@ -29,17 +29,17 @@ import { Stories } from '@storybook/blocks';
 
 `Stories` is configured with the following props:
 
-### `includePrimaryStory`
+### `includePrimary`
 
 Type: `boolean`
 
-Default: `parameters.docs.stories.includePrimaryStory`
+Default: `parameters.docs.stories.includePrimary`
 
 Determines if the collection of stories includes the primary (first) story.
 
 <Callout variant="info" icon="💡">
 
-If a stories file contains only one story and `includePrimaryStory={true}`, the `Stories` block will render nothing to avoid a potentially confusing situation.
+If a stories file contains only one story and `includePrimary={true}`, the `Stories` block will render nothing to avoid a potentially confusing situation.
 
 </Callout>
 


### PR DESCRIPTION
Co-authored-by: @jiyiru 

Partially implements #22490

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

- Add support for `of` prop via useOf with "meta" as only valid type
- Added stories
- Default to get title from parameters.docs.stories.title
- Default to get includePrimaryStory from parameters.docs.stories.includePrimaryStory
- Updated documentation, using https://github.com/storybookjs/storybook/pull/22552 as an example

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->


1. Run yarn storybook:blocks
2. Open Storybook in your browser
3. Access Stories stories


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
