### PR TITLE
Next.js: Avoid interfering with the svgr loader

### DIFF
--- a/code/frameworks/nextjs/src/swc/loader.ts
+++ b/code/frameworks/nextjs/src/swc/loader.ts
@@ -24,7 +24,7 @@ export const configureSWCLoader = async (
   );
 
   if (rawRule && typeof rawRule === 'object') {
-    rawRule.test = /^(?!__barrel_optimize__)/;
+    rawRule.exclude = /^__barrel_optimize__/;
   }
 
   baseConfig.module?.rules?.push({


### PR DESCRIPTION
Closes #27195

## What I did

This is a followup to #27093 as it causes issues for anyone who has followed the [example for adding SVGR support to Storybook](https://storybook.js.org/docs/get-started/nextjs#custom-webpack-config). Instead of adding a `test` to the raw loader, this PR uses `exclude` so the rule doesn't apply to `__barrel_optimize__` requests.

## Checklist for Contributors

### Testing

As I mentioned in #27093, if there's a good way to cover this scenario as part of an integration and/or e2e test, please let me know.

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

There is a reproduction in https://github.com/storybookjs/storybook/issues/26991 (https://github.com/11bit/next-storybook-import-raw-bag) that could be used to confirm [this story](https://github.com/11bit/next-storybook-import-raw-bag/blob/main/stories/Page.tsx) loads with these changes.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
