### PR TITLE
Docs: Fix MSW snippets

### DIFF
--- a/docs/snippets/angular/msw-addon-configure-handlers-graphql.ts.mdx
+++ b/docs/snippets/angular/msw-addon-configure-handlers-graphql.ts.mdx
@@ -57,7 +57,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         graphql.query('AllInfoQuery', () => {
-          return new HttpResponse.json({
+          return HttpResponse.json({
             data: {
               allInfo: {
                 ...TestData,
@@ -76,7 +76,7 @@ export const MockedError: Story = {
       handlers: [
         graphql.query('AllInfoQuery', async () => {
           await delay(800);
-          return new HttpResponse.json({
+          return HttpResponse.json({
             errors: [
               {
                 message: 'Access denied',

--- a/docs/snippets/angular/msw-addon-configure-handlers-http.ts.mdx
+++ b/docs/snippets/angular/msw-addon-configure-handlers-http.ts.mdx
@@ -43,7 +43,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         http.get('https://your-restful-endpoint/', () => {
-          return new HttpResponse.json(TestData);
+          return HttpResponse.json(TestData);
         }),
       ],
     },

--- a/docs/snippets/common/msw-addon-configure-handlers-http.js.mdx
+++ b/docs/snippets/common/msw-addon-configure-handlers-http.js.mdx
@@ -38,7 +38,7 @@ export const MockedSuccess = {
     msw: {
       handlers: [
         http.get('https://your-restful-endpoint/', () => {
-          return new HttpResponse.json(TestData);
+          return HttpResponse.json(TestData);
         }),
       ],
     },

--- a/docs/snippets/common/msw-addon-configure-handlers-http.ts-4-9.mdx
+++ b/docs/snippets/common/msw-addon-configure-handlers-http.ts-4-9.mdx
@@ -44,7 +44,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         http.get('https://your-restful-endpoint/', () => {
-          return new HttpResponse.json(TestData);
+          return HttpResponse.json(TestData);
         }),
       ],
     },

--- a/docs/snippets/common/msw-addon-configure-handlers-http.ts.mdx
+++ b/docs/snippets/common/msw-addon-configure-handlers-http.ts.mdx
@@ -44,7 +44,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         http.get('https://your-restful-endpoint/', () => {
-          return new HttpResponse.json(TestData);
+          return HttpResponse.json(TestData);
         }),
       ],
     },

--- a/docs/snippets/react/msw-addon-configure-handlers-graphql.js.mdx
+++ b/docs/snippets/react/msw-addon-configure-handlers-graphql.js.mdx
@@ -61,7 +61,7 @@ export const MockedSuccess = {
     msw: {
       handlers: [
         graphql.query('AllInfoQuery', () => {
-          return new HttpResponse.json({
+          return HttpResponse.json({
             data: {
               allInfo: {
                 ...TestData,
@@ -80,7 +80,7 @@ export const MockedError = {
       handlers: [
         graphql.query('AllInfoQuery', async () => {
           await delay(800);
-          return new HttpResponse.json({
+          return HttpResponse.json({
             errors: [
               {
                 message: 'Access denied',

--- a/docs/snippets/react/msw-addon-configure-handlers-graphql.ts-4-9.mdx
+++ b/docs/snippets/react/msw-addon-configure-handlers-graphql.ts-4-9.mdx
@@ -65,7 +65,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         graphql.query('AllInfoQuery', () => {
-          return new HttpResponse.json({
+          return HttpResponse.json({
             data: {
               allInfo: {
                 ...TestData,
@@ -84,7 +84,7 @@ export const MockedError: Story = {
       handlers: [
         graphql.query('AllInfoQuery', async () => {
           await delay(800);
-          return new HttpResponse.json({
+          return HttpResponse.json({
             errors: [
               {
                 message: 'Access denied',

--- a/docs/snippets/react/msw-addon-configure-handlers-graphql.ts.mdx
+++ b/docs/snippets/react/msw-addon-configure-handlers-graphql.ts.mdx
@@ -65,7 +65,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         graphql.query('AllInfoQuery', () => {
-          return new HttpResponse.json({
+          return HttpResponse.json({
             data: {
               allInfo: {
                 ...TestData,
@@ -84,7 +84,7 @@ export const MockedError: Story = {
       handlers: [
         graphql.query('AllInfoQuery', async () => {
           await delay(800);
-          return new HttpResponse.json({
+          return HttpResponse.json({
             errors: [
               {
                 message: 'Access denied',

--- a/docs/snippets/svelte/msw-addon-configure-handlers-graphql.js.mdx
+++ b/docs/snippets/svelte/msw-addon-configure-handlers-graphql.js.mdx
@@ -40,7 +40,7 @@ export const MockedSuccess = {
     msw: {
       handlers: [
         graphql.query('AllInfoQuery', () => {
-          return new HttpResponse.json({
+          return HttpResponse.json({
             data: {
               allInfo: {
                 ...TestData,
@@ -59,7 +59,7 @@ export const MockedError = {
       handlers: [
         graphql.query('AllInfoQuery', async () => {
           await delay(800);
-          return new HttpResponse.json({
+          return HttpResponse.json({
             errors: [
               {
                 message: 'Access denied',

--- a/docs/snippets/svelte/msw-addon-configure-handlers-graphql.ts-4-9.mdx
+++ b/docs/snippets/svelte/msw-addon-configure-handlers-graphql.ts-4-9.mdx
@@ -45,7 +45,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         graphql.query('AllInfoQuery', () => {
-          return new HttpResponse.json({
+          return HttpResponse.json({
             data: {
               allInfo: {
                 ...TestData,
@@ -64,7 +64,7 @@ export const MockedError: Story = {
       handlers: [
         graphql.query('AllInfoQuery', async () => {
           await delay(800);
-          return new HttpResponse.json({
+          return HttpResponse.json({
             errors: [
               {
                 message: 'Access denied',

--- a/docs/snippets/svelte/msw-addon-configure-handlers-graphql.ts.mdx
+++ b/docs/snippets/svelte/msw-addon-configure-handlers-graphql.ts.mdx
@@ -45,7 +45,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         graphql.query('AllInfoQuery', () => {
-          return new HttpResponse.json({
+          return HttpResponse.json({
             data: {
               allInfo: {
                 ...TestData,
@@ -64,7 +64,7 @@ export const MockedError: Story = {
       handlers: [
         graphql.query('AllInfoQuery', async () => {
           await delay(800);
-          return new HttpResponse.json({
+          return HttpResponse.json({
             errors: [
               {
                 message: 'Access denied',

--- a/docs/snippets/vue/msw-addon-configure-handlers-graphql.js.mdx
+++ b/docs/snippets/vue/msw-addon-configure-handlers-graphql.js.mdx
@@ -43,7 +43,7 @@ export const MockedSuccess = {
     msw: {
       handlers: [
         graphql.query('AllInfoQuery', () => {
-          return new HttpResponse.json({
+          return HttpResponse.json({
             data: {
               allInfo: {
                 ...TestData,
@@ -62,7 +62,7 @@ export const MockedError = {
       handlers: [
         graphql.query('AllInfoQuery', async () => {
           await delay(800);
-          return new HttpResponse.json({
+          return HttpResponse.json({
             errors: [
               {
                 message: 'Access denied',

--- a/docs/snippets/vue/msw-addon-configure-handlers-graphql.ts-4-9.mdx
+++ b/docs/snippets/vue/msw-addon-configure-handlers-graphql.ts-4-9.mdx
@@ -48,7 +48,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         graphql.query('AllInfoQuery', () => {
-          return new HttpResponse.json({
+          return HttpResponse.json({
             data: {
               allInfo: {
                 ...TestData,
@@ -67,7 +67,7 @@ export const MockedError: Story = {
       handlers: [
         graphql.query('AllInfoQuery', async () => {
           await delay(800);
-          return new HttpResponse.json({
+          return HttpResponse.json({
             errors: [
               {
                 message: 'Access denied',

--- a/docs/snippets/vue/msw-addon-configure-handlers-graphql.ts.mdx
+++ b/docs/snippets/vue/msw-addon-configure-handlers-graphql.ts.mdx
@@ -48,7 +48,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         graphql.query('AllInfoQuery', () => {
-          return new HttpResponse.json({
+          return HttpResponse.json({
             data: {
               allInfo: {
                 ...TestData,
@@ -67,7 +67,7 @@ export const MockedError: Story = {
       handlers: [
         graphql.query('AllInfoQuery', async () => {
           await delay(800);
-          return new HttpResponse.json({
+          return HttpResponse.json({
             errors: [
               {
                 message: 'Access denied',

--- a/docs/snippets/vue/storybook-preview-use-global-type.3.js.mdx
+++ b/docs/snippets/vue/storybook-preview-use-global-type.3.js.mdx
@@ -1,11 +1,11 @@
 ```js
 // .storybook/preview.js
 
-import { setup } from "@storybook/vue3";
+import { setup } from '@storybook/vue3';
 
-import { VApp } from "vuetify/components";
+import { VApp } from 'vuetify/components';
 
-import { registerPlugins } from "../src/plugins";
+import { registerPlugins } from '../src/plugins';
 
 setup((app) => {
   // Registers your app's plugins including Vuetify into Storybook

--- a/docs/snippets/vue/storybook-preview-use-global-type.3.ts.mdx
+++ b/docs/snippets/vue/storybook-preview-use-global-type.3.ts.mdx
@@ -1,12 +1,12 @@
 ```ts
 // .storybook/preview.ts
 
-import type { Preview } from "@storybook/vue3";
-import { setup } from "@storybook/vue3";
+import type { Preview } from '@storybook/vue3';
+import { setup } from '@storybook/vue3';
 
-import { VApp } from "vuetify/components";
+import { VApp } from 'vuetify/components';
 
-import { registerPlugins } from "../src/plugins";
+import { registerPlugins } from '../src/plugins';
 
 setup((app) => {
   // Registers your app's plugins including Vuetify into Storybook

--- a/docs/snippets/vue/storybook-preview-use-global-type.ts-4-9.mdx
+++ b/docs/snippets/vue/storybook-preview-use-global-type.ts-4-9.mdx
@@ -1,12 +1,12 @@
 ```ts
 // .storybook/preview.ts
 
-import type { Preview } from "@storybook/vue3";
-import { setup } from "@storybook/vue3";
+import type { Preview } from '@storybook/vue3';
+import { setup } from '@storybook/vue3';
 
-import { VApp } from "vuetify/components";
+import { VApp } from 'vuetify/components';
 
-import { registerPlugins } from "../src/plugins";
+import { registerPlugins } from '../src/plugins';
 
 setup((app) => {
   // Registers your app's plugins including Vuetify into Storybook

--- a/docs/snippets/web-components/msw-addon-configure-handlers-http.js.mdx
+++ b/docs/snippets/web-components/msw-addon-configure-handlers-http.js.mdx
@@ -36,7 +36,7 @@ export const MockedSuccess = {
     msw: {
       handlers: [
         http.get('https://your-restful-endpoint/', () => {
-          return new HttpResponse.json(TestData);
+          return HttpResponse.json(TestData);
         }),
       ],
     },

--- a/docs/snippets/web-components/msw-addon-configure-handlers-http.ts.mdx
+++ b/docs/snippets/web-components/msw-addon-configure-handlers-http.ts.mdx
@@ -41,7 +41,7 @@ export const MockedSuccess: Story = {
     msw: {
       handlers: [
         http.get('https://your-restful-endpoint/', () => {
-          return new HttpResponse.json(TestData);
+          return HttpResponse.json(TestData);
         }),
       ],
     },


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

With this pull request, the snippets used in the Mocking Network requests were updated to prevent misconceptions when a user tries to use them with either Rest requests or GraphQL requests, and both the MSW and the Storybook addon effectively throw errors. For example, with a Rest request, the addon throws the following error in the IDE, and when a user tries to boot up Storybook

![msw-storybook-8-rest-mocked-sucess-error](https://github.com/storybookjs/storybook/assets/22988955/ed058571-d6e1-4be3-8d66-23bcc89683fe)

![msw-storybook-8-rest-sucess-error-devtools](https://github.com/storybookjs/storybook/assets/22988955/57cdfe08-c445-4846-9d07-f5f8f296e45f)


When a GraphQL request is set up the following happens:

![msw-storybook-8-graphql-error](https://github.com/storybookjs/storybook/assets/22988955/622cc952-527c-446f-8a6b-28d46e8c61cc)


Would appreciate it when a change to the examples, I would be consulted and asked for a review,  so that I have time to vet the examples and avoid this type of scenario. More even as we have them already in place [here](https://github.com/mswjs/msw-storybook-addon/blob/main/packages/docs/src/demos/apollo/App.stories.tsx) and [here](https://github.com/mswjs/msw-storybook-addon/blob/main/packages/docs/src/demos/fetch/App.stories.tsx).

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
