### PR TITLE
Feat: Compact folders (smart flatten)

### DIFF
--- a/code/lib/manager-api/src/lib/stories.ts
+++ b/code/lib/manager-api/src/lib/stories.ts
@@ -300,7 +300,7 @@ export const transformStoryIndexToStoriesHash = (
 
         parent.children = [child.id];
         child.parent = parent.id;
-        child.name = `${item.name} / ${child.name}`;
+        child.name = `${item.name}/ ${child.name}`;
         if (type === 'group') {
           child.type = 'nested_group';
           child = child as API_NestedGroupEntry;

--- a/code/lib/manager-api/src/lib/stories.ts
+++ b/code/lib/manager-api/src/lib/stories.ts
@@ -277,6 +277,7 @@ export const transformStoryIndexToStoriesHash = (
     item.children.forEach((childId: any) => addItem(acc, storiesHashOutOfOrder[childId]));
   }
 
+  // This function fixes the depth of an item and its children
   function fixDepth(item: API_HashEntry | any) {
     if (item.type !== 'root') {
       const parent = storiesHashOutOfOrder[item.parent];

--- a/code/lib/manager-api/src/modules/stories.ts
+++ b/code/lib/manager-api/src/modules/stories.ts
@@ -452,7 +452,7 @@ export const init: ModuleFn<SubAPI, SubState> = ({
         } else {
           // Support legacy API with component permalinks, where kind is `x/y` but permalink is 'z'
           const entry = hash[sanitize(titleOrId)];
-          if (entry?.type === 'component') {
+          if (entry?.type === 'component' || entry?.type === 'nested_component') {
             const foundId = entry.children.find((childId: any) => hash[childId].name === name);
             if (foundId) {
               api.selectStory(foundId, undefined, options);
@@ -689,7 +689,8 @@ export const init: ModuleFn<SubAPI, SubState> = ({
         const stateHasSelection = state.viewMode && state.storyId;
         const stateSelectionDifferent = state.viewMode !== viewMode || state.storyId !== storyId;
         const { type } = state.index?.[state.storyId] || {};
-        const isStory = !(type === 'root' || type === 'component' || type === 'group');
+        const isStory = !(type === 'root' || type === 'component' || type === 'group' ||
+          type === 'nested_group' || type === 'nested_component');
 
         /**
          * When storybook starts, we want to navigate to the first story.

--- a/code/lib/manager-api/src/tests/stories.test.ts
+++ b/code/lib/manager-api/src/tests/stories.test.ts
@@ -1585,4 +1585,202 @@ describe('stories API', () => {
       `);
     });
   });
+
+  describe('nested', () => {
+    it('2 groups become nested', () => {
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
+      api.setIndex({
+        v: 4,
+        entries: {
+          'root-nested-folder-some-component--my-story': {
+            type: 'story',
+            id: 'root-nested-folder-some-component--my-story',
+            title: 'Root/Nested/Folder/some component',
+            name: 'My Story',
+            importPath: './path/to/some-component.ts',
+          },
+        },
+      });
+      const { index } = store.getState();
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(index!)).toEqual([
+        'root',
+        'root-nested-folder',
+        'root-nested-folder-some-component',
+        'root-nested-folder-some-component--my-story',
+      ]);
+      expect(index!['root']).toMatchObject({
+        type: 'root',
+        name: 'Root',
+      });
+      expect(index!['root-nested-folder']).toMatchObject({
+        type: 'nested_group',     // verify group is compacted to the same heading
+        name: 'Nested/ Folder',   // space is placed only after slash
+      });
+    });
+
+    it('one group has 2 groups as child, therefore it does not nest', () => {
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
+      api.setIndex({
+        v: 4,
+        entries: {
+          'root-folder-with-children-child-1-component--story-1': {
+            type: 'story',
+            id: 'root-folder-with-children-child-1-component--story-1',
+            title: 'Root/folder with children/child 1/component',
+            name: 'Story 1',
+            importPath: './path/to/component.ts',
+          },
+          'root-folder-with-children-child-2-component--story-2': {
+            type: 'story',
+            id: 'root-folder-with-children-child-2-component--story-2',
+            title: 'Root/folder with children/child 2/component',
+            name: 'Story 2',
+            importPath: './path/to/component.ts',
+          },
+        }
+      });
+      const { index } = store.getState();
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(index!)).toEqual([
+        'root',
+        'root-folder-with-children',
+        'root-folder-with-children-child-1',
+        'root-folder-with-children-child-1-component',
+        'root-folder-with-children-child-1-component--story-1',
+        'root-folder-with-children-child-2',
+        'root-folder-with-children-child-2-component',
+        'root-folder-with-children-child-2-component--story-2',
+      ]);
+      expect(index!['root-folder-with-children']).toMatchObject({
+        type: 'group',
+        name: 'folder with children',
+      });
+      expect(index!['root-folder-with-children-child-1']).toMatchObject({
+        type: 'group',
+        name: 'child 1',
+      });
+      expect(index!['root-folder-with-children-child-2']).toMatchObject({
+        type: 'group',
+        name: 'child 2',
+      });
+    });
+
+    it('multiple groups nested in the same heading', () => {
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
+      api.setIndex({
+        v: 4,
+        entries: {
+          'root-folders-with-one-child-component--story-3': {
+            type: 'story',
+            id: 'root-folders-with-one-child-component--story-3',
+            title: 'Root/folders/with/one child/component',
+            name: 'Story 3',
+            importPath: './path/to/component.ts',
+          },
+        }
+      });
+      const { index } = store.getState();
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(index!)).toEqual([
+        'root',
+        'root-folders-with-one-child',
+        'root-folders-with-one-child-component',
+        'root-folders-with-one-child-component--story-3',
+      ]);
+      expect(index!['root-folders-with-one-child']).toMatchObject({
+        type: 'nested_group',
+        name: 'folders/ with/ one child',
+      });
+    });
+
+    it('multiple groups nested in the same heading', () => {
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
+      api.setIndex({
+        v: 4,
+        entries: {
+          'root-lvl1-lvl2group1-lvl3group1-component1--docs-1': {
+            type: 'story',
+            id: 'root-lvl1-lvl2group1-lvl3group1-component1--docs-1',
+            title: 'root/lvl1/lvl2group1/lvl3group1/component1',
+            name: 'Docs 1',
+            importPath: './path/to/component1.ts',
+            storiesImports: [],
+          },
+          'root-lvl1-lvl2group2-fakegroup--docs-2': {
+            type: 'story',
+            id: 'root-lvl1-lvl2group2-fakegroup--docs-2',
+            title: 'root/lvl1/lvl2group2/fakegroup',
+            name: 'Docs 2',
+            importPath: './path/to/.ts',
+            storiesImports: [],
+          },
+          'root-lvl1-lvl2group3-component3--story-3': {
+            type: 'story',
+            id: 'root-lvl1-lvl2group3-component3--story-3',
+            title: 'root/lvl1/lvl2group3/component3',
+            name: 'Story 3',
+            importPath: './path/to/component3.ts',
+          },
+          'root-lvl1-lvl2group4-lvl3group4-lvl4-component4--story-4': {
+            type: 'story',
+            id: 'root-lvl1-lvl2group4-lvl3group4-lvl4-component4--story-4',
+            title: 'root/lvl1/lvl2group4/lvl3group4/lvl4/component4',
+            name: 'Story 4',
+            importPath: './path/to/component4.ts',
+          },
+        }
+      });
+      const { index } = store.getState();
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(index!)).toEqual([
+        'root',
+        'root-lvl1',
+        'root-lvl1-lvl2group1-lvl3group1',  // nested here...
+        'root-lvl1-lvl2group1-lvl3group1-component1',
+        'root-lvl1-lvl2group1-lvl3group1-component1--docs-1',
+        'root-lvl1-lvl2group2',
+        'root-lvl1-lvl2group2-fakegroup',   // is not nested beacause it is a component not a group
+        'root-lvl1-lvl2group2-fakegroup--docs-2',
+        'root-lvl1-lvl2group3',
+        'root-lvl1-lvl2group3-component3',
+        'root-lvl1-lvl2group3-component3--story-3',
+        'root-lvl1-lvl2group4-lvl3group4-lvl4', // ...and here
+        'root-lvl1-lvl2group4-lvl3group4-lvl4-component4',
+        'root-lvl1-lvl2group4-lvl3group4-lvl4-component4--story-4',
+      ]);
+      expect(index!['root-lvl1']).toMatchObject({
+        type: 'group',
+        name: 'lvl1',
+      });
+      expect(index!['root-lvl1-lvl2group1-lvl3group1']).toMatchObject({
+        type: 'nested_group',
+        name: 'lvl2group1/ lvl3group1',
+      });
+      expect(index!['root-lvl1-lvl2group2']).toMatchObject({
+        type: 'group',
+        name: 'lvl2group2',
+      });
+      expect(index!['root-lvl1-lvl2group2-fakegroup']).toMatchObject({
+        type: 'component',
+        name: 'fakegroup',
+      });
+      expect(index!['root-lvl1-lvl2group3']).toMatchObject({
+        type: 'group',
+        name: 'lvl2group3',
+      });
+      expect(index!['root-lvl1-lvl2group4-lvl3group4-lvl4']).toMatchObject({
+        type: 'nested_group',
+        name: 'lvl2group4/ lvl3group4/ lvl4',
+      });
+    });
+  });
 });

--- a/code/lib/manager-api/src/tests/stories.test.ts
+++ b/code/lib/manager-api/src/tests/stories.test.ts
@@ -1587,6 +1587,101 @@ describe('stories API', () => {
   });
 
   describe('nested', () => {
+    it('group has only a child of the same type but has also a child component (diff type)', () => {
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
+      api.setIndex({
+        v: 4,
+        entries: {
+          'root-main-folder-child-folder-component--story': {
+            type: 'story',
+            id: 'root-main-folder-child-folder-component--story',
+            title: 'root/main folder/child folder/component',
+            name: 'Story',
+            importPath: './path/to/component.ts',
+          },
+          'root-main-folder-child-component--story': {
+            type: 'story',
+            id: 'root-main-folder-child-component--story',
+            title: 'root/main folder/child component',
+            name: 'Story',
+            importPath: './path/to/child-component.ts',
+          },
+        },
+      });
+      const { index } = store.getState();
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(index!)).toEqual([
+        'root',
+        'root-main-folder',
+        'root-main-folder-child-folder',
+        'root-main-folder-child-folder-component',
+        'root-main-folder-child-folder-component--story',
+        'root-main-folder-child-component',
+        'root-main-folder-child-component--story',
+      ]);
+      expect(index!['root-main-folder']).toMatchObject({
+        type: 'group',
+        name: 'main folder',
+      });
+      expect(index!['root-main-folder-child-folder']).toMatchObject({
+        type: 'group',
+        name: 'child folder',
+      });
+      expect(index!['root-main-folder-child-component']).toMatchObject({
+        type: 'component',
+        name: 'child component',
+      });
+    });
+
+    it('group has only a child of the same type but has also a child story (diff type)', () => {
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
+      api.setIndex({
+        v: 4,
+        entries: {
+          'root-main-folder-child-folder-component--story': {
+            type: 'story',
+            id: 'root-main-folder-child-folder-component--story',
+            title: 'root/main folder/child folder/component',
+            name: 'Story',
+            importPath: './path/to/component.ts',
+          },
+          'root-main-folder--child-story': {
+            type: 'story',
+            id: 'root-main-folder--child-story',
+            title: 'root/main folder',
+            name: 'Child Story',
+            importPath: './path/to/.ts',
+          },
+        },
+      });
+      const { index } = store.getState();
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(index!)).toEqual([
+        'root',
+        'root-main-folder',
+        'root-main-folder-child-folder',
+        'root-main-folder-child-folder-component',
+        'root-main-folder-child-folder-component--story',
+        'root-main-folder--child-story',
+      ]);
+      expect(index!['root-main-folder']).toMatchObject({
+        type: 'group',
+        name: 'main folder',
+      });
+      expect(index!['root-main-folder-child-folder']).toMatchObject({
+        type: 'group',
+        name: 'child folder',
+      });
+      expect(index!['root-main-folder--child-story']).toMatchObject({
+        type: 'story',
+        name: 'Child Story',
+      });
+    });
+
     it('2 groups become nested', () => {
       const moduleArgs = createMockModuleArgs({});
       const { api } = initStories(moduleArgs as unknown as ModuleArgs);
@@ -1621,7 +1716,7 @@ describe('stories API', () => {
       });
     });
 
-    it('one group has 2 groups as child, therefore it does not nest', () => {
+    it('one group has 2 groups as children, therefore it does not nest', () => {
       const moduleArgs = createMockModuleArgs({});
       const { api } = initStories(moduleArgs as unknown as ModuleArgs);
       const { store } = moduleArgs;
@@ -1667,6 +1762,93 @@ describe('stories API', () => {
       expect(index!['root-folder-with-children-child-2']).toMatchObject({
         type: 'group',
         name: 'child 2',
+      });
+    });
+
+    it('many groups have many groups as children, therefore none nest, there are only groups', () => {
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
+      api.setIndex({
+        v: 4,
+        entries: {
+          'root-lvl1-lvl2group1-lvl3group1-component1--story-1': {
+            type: 'story',
+            id: 'root-lvl1-lvl2group1-lvl3group1-component1--story-1',
+            title: 'root/lvl1/lvl2group1/lvl3group1/component1',
+            name: 'Story 1',
+            importPath: './path/to/component1.ts',
+          },
+          'root-lvl1-lvl2group1-lvl3group2-component2--story-2': {
+            type: 'story',
+            id: 'root-lvl1-lvl2group1-lvl3group2-component2--story-2',
+            title: 'root/lvl1/lvl2group1/lvl3group2/component2',
+            name: 'Story 2',
+            importPath: './path/to/component2.ts',
+          },
+          'root-lvl1-lvl2group2-lvl3group3-component3--story-3': {
+            type: 'story',
+            id: 'root-lvl1-lvl2group2-lvl3group3-component3--story-3',
+            title: 'root/lvl1/lvl2group2/lvl3group3/component3',
+            name: 'Story 3',
+            importPath: './path/to/component3.ts',
+          },
+          'root-lvl1-lvl2group2-lvl3group4-component4--story-4': {
+            type: 'story',
+            id: 'root-lvl1-lvl2group2-lvl3group4-component4--story-4',
+            title: 'root/lvl1/lvl2group2/lvl3group4/component4',
+            name: 'Story 4',
+            importPath: './path/to/component4.ts',
+          },
+        }
+      });
+      const { index } = store.getState();
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(index!)).toEqual([
+        'root',
+        'root-lvl1',
+        'root-lvl1-lvl2group1',
+        'root-lvl1-lvl2group1-lvl3group1',
+        'root-lvl1-lvl2group1-lvl3group1-component1',
+        'root-lvl1-lvl2group1-lvl3group1-component1--story-1',
+        'root-lvl1-lvl2group1-lvl3group2',
+        'root-lvl1-lvl2group1-lvl3group2-component2',
+        'root-lvl1-lvl2group1-lvl3group2-component2--story-2',
+        'root-lvl1-lvl2group2',
+        'root-lvl1-lvl2group2-lvl3group3',
+        'root-lvl1-lvl2group2-lvl3group3-component3',
+        'root-lvl1-lvl2group2-lvl3group3-component3--story-3',
+        'root-lvl1-lvl2group2-lvl3group4',
+        'root-lvl1-lvl2group2-lvl3group4-component4',
+        'root-lvl1-lvl2group2-lvl3group4-component4--story-4',
+      ]);
+      expect(index!['root-lvl1']).toMatchObject({
+        type: 'group',
+        name: 'lvl1',
+      });
+      expect(index!['root-lvl1-lvl2group1']).toMatchObject({
+        type: 'group',
+        name: 'lvl2group1',
+      });
+      expect(index!['root-lvl1-lvl2group1-lvl3group1']).toMatchObject({
+        type: 'group',
+        name: 'lvl3group1',
+      });
+      expect(index!['root-lvl1-lvl2group1-lvl3group2']).toMatchObject({
+        type: 'group',
+        name: 'lvl3group2',
+      });
+      expect(index!['root-lvl1-lvl2group2']).toMatchObject({
+        type: 'group',
+        name: 'lvl2group2',
+      });
+      expect(index!['root-lvl1-lvl2group2-lvl3group3']).toMatchObject({
+        type: 'group',
+        name: 'lvl3group3',
+      });
+      expect(index!['root-lvl1-lvl2group2-lvl3group4']).toMatchObject({
+        type: 'group',
+        name: 'lvl3group4',
       });
     });
 

--- a/code/lib/types/src/modules/api-stories.ts
+++ b/code/lib/types/src/modules/api-stories.ts
@@ -17,8 +17,20 @@ export interface API_RootEntry extends API_BaseEntry {
   children: StoryId[];
 }
 
+export interface API_NestedGroupEntry extends API_BaseEntry {
+  type: 'nested_group';
+  parent?: StoryId;
+  children: StoryId[];
+}
+
 export interface API_GroupEntry extends API_BaseEntry {
   type: 'group';
+  parent?: StoryId;
+  children: StoryId[];
+}
+
+export interface API_NestedComponentEntry extends API_BaseEntry {
+  type: 'nested_component';
   parent?: StoryId;
   children: StoryId[];
 }
@@ -59,7 +71,9 @@ export interface API_StoryEntry extends API_BaseEntry {
 export type API_LeafEntry = API_DocsEntry | API_StoryEntry;
 export type API_HashEntry =
   | API_RootEntry
+  | API_NestedGroupEntry
   | API_GroupEntry
+  | API_NestedComponentEntry
   | API_ComponentEntry
   | API_DocsEntry
   | API_StoryEntry;

--- a/code/ui/manager/src/components/sidebar/IconSymbols.tsx
+++ b/code/ui/manager/src/components/sidebar/IconSymbols.tsx
@@ -14,20 +14,42 @@ const Svg = styled.svg`
 // We are importing the icons from @storybook/icons as we need to add symbols inside of them.
 // This will allow to set icons once and use them everywhere.
 
+const NESTED_GROUP_ID = 'icon--group';
 const GROUP_ID = 'icon--group';
+const NESTED_COMPONENT_ID = 'icon--component';
 const COMPONENT_ID = 'icon--component';
 const DOCUMENT_ID = 'icon--document';
 const STORY_ID = 'icon--story';
 
+// For now the nested groups/components remain with the same icon as the group/components themselves.
+
 export const IconSymbols: FC = () => {
   return (
     <Svg data-chromatic="ignore">
+      <symbol id={NESTED_GROUP_ID}>
+        {/* https://github.com/storybookjs/icons/blob/main/src/icons/Folder.tsx */}
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M6.586 3.504l-1.5-1.5H1v9h12v-7.5H6.586zm.414-1L5.793 1.297a1 1 0 00-.707-.293H.5a.5.5 0 00-.5.5v10a.5.5 0 00.5.5h13a.5.5 0 00.5-.5v-8.5a.5.5 0 00-.5-.5H7z"
+          fill="currentColor"
+        />
+      </symbol>
       <symbol id={GROUP_ID}>
         {/* https://github.com/storybookjs/icons/blob/main/src/icons/Folder.tsx */}
         <path
           fillRule="evenodd"
           clipRule="evenodd"
           d="M6.586 3.504l-1.5-1.5H1v9h12v-7.5H6.586zm.414-1L5.793 1.297a1 1 0 00-.707-.293H.5a.5.5 0 00-.5.5v10a.5.5 0 00.5.5h13a.5.5 0 00.5-.5v-8.5a.5.5 0 00-.5-.5H7z"
+          fill="currentColor"
+        />
+      </symbol>
+      <symbol id={NESTED_COMPONENT_ID}>
+        {/* https://github.com/storybookjs/icons/blob/main/src/icons/Component.tsx */}
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M3.5 1.004a2.5 2.5 0 00-2.5 2.5v7a2.5 2.5 0 002.5 2.5h7a2.5 2.5 0 002.5-2.5v-7a2.5 2.5 0 00-2.5-2.5h-7zm8.5 5.5H7.5v-4.5h3a1.5 1.5 0 011.5 1.5v3zm0 1v3a1.5 1.5 0 01-1.5 1.5h-3v-4.5H12zm-5.5 4.5v-4.5H2v3a1.5 1.5 0 001.5 1.5h3zM2 6.504h4.5v-4.5h-3a1.5 1.5 0 00-1.5 1.5v3z"
           fill="currentColor"
         />
       </symbol>
@@ -66,9 +88,11 @@ export const IconSymbols: FC = () => {
   );
 };
 
-export const UseSymbol: FC<{ type: 'group' | 'component' | 'document' | 'story' }> = ({ type }) => {
+export const UseSymbol: FC<{ type: 'group' | 'nested_group' | 'component' | 'nested_component' | 'document' | 'story' }> = ({ type }) => {
   if (type === 'group') return <use xlinkHref={`#${GROUP_ID}`} />;
+  if (type === 'nested_group') return <use xlinkHref={`#${NESTED_GROUP_ID}`} />;
   if (type === 'component') return <use xlinkHref={`#${COMPONENT_ID}`} />;
+  if (type === 'nested_component') return <use xlinkHref={`#${NESTED_COMPONENT_ID}`} />;
   if (type === 'document') return <use xlinkHref={`#${DOCUMENT_ID}`} />;
   if (type === 'story') return <use xlinkHref={`#${STORY_ID}`} />;
   return null;

--- a/code/ui/manager/src/components/sidebar/IconSymbols.tsx
+++ b/code/ui/manager/src/components/sidebar/IconSymbols.tsx
@@ -14,10 +14,10 @@ const Svg = styled.svg`
 // We are importing the icons from @storybook/icons as we need to add symbols inside of them.
 // This will allow to set icons once and use them everywhere.
 
-const NESTED_GROUP_ID = 'icon--group';
+const NESTED_GROUP_ID = 'icon--group--nested';
 const GROUP_ID = 'icon--group';
 const NESTED_COMPONENT_ID = 'icon--component';
-const COMPONENT_ID = 'icon--component';
+const COMPONENT_ID = 'icon--component--nested';
 const DOCUMENT_ID = 'icon--document';
 const STORY_ID = 'icon--story';
 
@@ -27,11 +27,15 @@ export const IconSymbols: FC = () => {
   return (
     <Svg data-chromatic="ignore">
       <symbol id={NESTED_GROUP_ID}>
-        {/* https://github.com/storybookjs/icons/blob/main/src/icons/Folder.tsx */}
+        {/* https://github.com/storybookjs/icons/blob/main/src/icons/Category.tsx */}
+        <path
+          d="M3 1.5a.5.5 0 01.5-.5h7a.5.5 0 010 1h-7a.5.5 0 01-.5-.5zM2 3.504a.5.5 0 01.5-.5h9a.5.5 0 010 1h-9a.5.5 0 01-.5-.5z"
+          fill="currentColor"
+        />
         <path
           fillRule="evenodd"
           clipRule="evenodd"
-          d="M6.586 3.504l-1.5-1.5H1v9h12v-7.5H6.586zm.414-1L5.793 1.297a1 1 0 00-.707-.293H.5a.5.5 0 00-.5.5v10a.5.5 0 00.5.5h13a.5.5 0 00.5-.5v-8.5a.5.5 0 00-.5-.5H7z"
+          d="M1 5.5a.5.5 0 01.5-.5h11a.5.5 0 01.5.5v7a.5.5 0 01-.5.5h-11a.5.5 0 01-.5-.5v-7zM2 12V6h10v6H2z"
           fill="currentColor"
         />
       </symbol>
@@ -49,7 +53,25 @@ export const IconSymbols: FC = () => {
         <path
           fillRule="evenodd"
           clipRule="evenodd"
-          d="M3.5 1.004a2.5 2.5 0 00-2.5 2.5v7a2.5 2.5 0 002.5 2.5h7a2.5 2.5 0 002.5-2.5v-7a2.5 2.5 0 00-2.5-2.5h-7zm8.5 5.5H7.5v-4.5h3a1.5 1.5 0 011.5 1.5v3zm0 1v3a1.5 1.5 0 01-1.5 1.5h-3v-4.5H12zm-5.5 4.5v-4.5H2v3a1.5 1.5 0 001.5 1.5h3zM2 6.504h4.5v-4.5h-3a1.5 1.5 0 00-1.5 1.5v3z"
+          d="M16.5098 5.01L14.5498 3.05C13.1498 1.65 10.8498 1.65 9.44977 3.05L7.48977 5.01C7.09977 5.4 7.09977 6.04 7.48977 6.43L11.2998 10.24C11.6898 10.63 12.3198 10.63 12.7098 10.24L16.5198 6.43C16.8998 6.04 16.8998 5.4 16.5098 5.01Z"
+          fill="currentColor"
+        />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M5.01 7.49172L3.05 9.45172C1.65 10.8517 1.65 13.1517 3.05 14.5517L5.01 16.5117C5.4 16.9017 6.03 16.9017 6.42 16.5117L10.23 12.7017C10.62 12.3117 10.62 11.6817 10.23 11.2917L6.43 7.49172C6.04 7.10172 5.4 7.10172 5.01 7.49172Z"
+          fill="currentColor"
+        />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M20.9491 9.45172L18.9891 7.49172C18.5991 7.10172 17.9691 7.10172 17.5791 7.49172L13.7691 11.3017C13.3791 11.6917 13.3791 12.3217 13.7691 12.7117L17.5791 16.5217C17.9691 16.9117 18.5991 16.9117 18.9891 16.5217L20.9491 14.5617C22.3491 13.1517 22.3491 10.8517 20.9491 9.45172Z"
+          fill="currentColor"
+        />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M7.48907 18.9891L9.44907 20.9491C10.8491 22.3491 13.1491 22.3491 14.5491 20.9491L16.5091 18.9891C16.8991 18.5991 16.8991 17.9691 16.5091 17.5791L12.6991 13.7691C12.3091 13.3791 11.6791 13.3791 11.2891 13.7691L7.47907 17.5791C7.09907 17.9591 7.09907 18.5991 7.48907 18.9891Z"
           fill="currentColor"
         />
       </symbol>

--- a/code/ui/manager/src/components/sidebar/SearchResults.tsx
+++ b/code/ui/manager/src/components/sidebar/SearchResults.tsx
@@ -173,7 +173,7 @@ const Result: FC<
 
   const api = useStorybookApi();
   useEffect(() => {
-    if (api && props.isHighlighted && item.type === 'component') {
+    if (api && props.isHighlighted && (item.type === 'component' || item.type === 'nested_component')) {
       api.emit(PRELOAD_ENTRIES, { ids: [item.children[0]] }, { options: { target: item.refId } });
     }
   }, [props.isHighlighted, item]);
@@ -191,12 +191,17 @@ const Result: FC<
             <UseSymbol type="component" />
           </TypeIcon>
         )}
+        {item.type === 'nested_component' && (
+          <TypeIcon viewBox="0 0 14 14" width="14" height="14" type="nested_component">
+            <UseSymbol type="nested_component" />
+          </TypeIcon>
+        )}
         {item.type === 'story' && (
           <TypeIcon viewBox="0 0 14 14" width="14" height="14" type="story">
             <UseSymbol type="story" />
           </TypeIcon>
         )}
-        {!(item.type === 'component' || item.type === 'story') && (
+        {!(item.type === 'component' || item.type === 'nested_component' || item.type === 'story') && (
           <TypeIcon viewBox="0 0 14 14" width="14" height="14" type="document">
             <UseSymbol type="document" />
           </TypeIcon>
@@ -267,7 +272,7 @@ export const SearchResults: FC<{
     const refId = currentTarget.getAttribute('data-refid');
     const item = api.resolveStory(storyId, refId === 'storybook_internal' ? undefined : refId);
 
-    if (item?.type === 'component') {
+    if (item?.type === 'component' || item?.type === 'nested_component') {
       api.emit(PRELOAD_ENTRIES, {
         // @ts-expect-error (TODO)
         ids: [item.isLeaf ? item.id : item.children[0]],

--- a/code/ui/manager/src/components/sidebar/SearchResults.tsx
+++ b/code/ui/manager/src/components/sidebar/SearchResults.tsx
@@ -192,7 +192,7 @@ const Result: FC<
           </TypeIcon>
         )}
         {item.type === 'nested_component' && (
-          <TypeIcon viewBox="0 0 14 14" width="14" height="14" type="nested_component">
+          <TypeIcon viewBox="0 0 22 22" width="14" height="14" type="nested_component">
             <UseSymbol type="nested_component" />
           </TypeIcon>
         )}

--- a/code/ui/manager/src/components/sidebar/Tree.tsx
+++ b/code/ui/manager/src/components/sidebar/Tree.tsx
@@ -33,7 +33,6 @@ import { statusMapping, getHighestStatus, getGroupStatus } from '../../utils/sta
 import { useLayout } from '../layout/LayoutProvider';
 import { IconSymbols } from './IconSymbols';
 import { CollapseIcon } from './components/CollapseIcon';
-import { I } from 'vitest/dist/reporters-1evA5lom';
 
 const Container = styled.div<{ hasOrphans: boolean }>((props) => ({
   marginTop: props.hasOrphans ? 20 : 0,

--- a/code/ui/manager/src/components/sidebar/Tree.tsx
+++ b/code/ui/manager/src/components/sidebar/Tree.tsx
@@ -293,8 +293,9 @@ const Node = React.memo<NodeProps>(function Node({
     );
   }
 
-  if (item.type === 'component' || item.type === 'group') {
-    const BranchNode = item.type === 'component' ? ComponentNode : GroupNode;
+  if (item.type === 'component' || item.type === 'group' || item.type === 'nested_group' || item.type === 'nested_component') {
+    const isComponent = (item.type === 'component' || item.type === 'nested_component');
+    const BranchNode = isComponent ? ComponentNode : GroupNode;
     return (
       <BranchNode
         key={id}
@@ -304,21 +305,21 @@ const Node = React.memo<NodeProps>(function Node({
         data-ref-id={refId}
         data-item-id={item.id}
         data-parent-id={item.parent}
-        data-nodetype={item.type === 'component' ? 'component' : 'group'}
+        data-nodetype={item.type}
         data-highlightable={isDisplayed}
         aria-controls={item.children && item.children[0]}
         aria-expanded={isExpanded}
         depth={isOrphan ? item.depth : item.depth - 1}
-        isComponent={item.type === 'component'}
+        isComponent={isComponent}
         isExpandable={item.children && item.children.length > 0}
         isExpanded={isExpanded}
         onClick={(event) => {
           event.preventDefault();
           setExpanded({ ids: [item.id], value: !isExpanded });
-          if (item.type === 'component' && !isExpanded && isDesktop) onSelectStoryId(item.id);
+          if (isComponent && !isExpanded && isDesktop) onSelectStoryId(item.id);
         }}
         onMouseEnter={() => {
-          if (item.type === 'component') {
+          if (isComponent) {
             api.emit(PRELOAD_ENTRIES, {
               ids: [item.children[0]],
               options: { target: refId },

--- a/code/ui/manager/src/components/sidebar/Tree.tsx
+++ b/code/ui/manager/src/components/sidebar/Tree.tsx
@@ -15,7 +15,7 @@ import React, { useCallback, useMemo, useRef } from 'react';
 
 import { PRELOAD_ENTRIES } from '@storybook/core-events';
 import { ExpandAltIcon, CollapseIcon as CollapseIconSvg } from '@storybook/icons';
-import { ComponentNode, DocumentNode, GroupNode, RootNode, StoryNode } from './TreeNode';
+import { ComponentNode, NestedComponentNode, DocumentNode, GroupNode, NestedGroupNode, RootNode, StoryNode } from './TreeNode';
 
 import type { ExpandAction, ExpandedState } from './useExpanded';
 
@@ -33,6 +33,7 @@ import { statusMapping, getHighestStatus, getGroupStatus } from '../../utils/sta
 import { useLayout } from '../layout/LayoutProvider';
 import { IconSymbols } from './IconSymbols';
 import { CollapseIcon } from './components/CollapseIcon';
+import { I } from 'vitest/dist/reporters-1evA5lom';
 
 const Container = styled.div<{ hasOrphans: boolean }>((props) => ({
   marginTop: props.hasOrphans ? 20 : 0,
@@ -293,9 +294,22 @@ const Node = React.memo<NodeProps>(function Node({
     );
   }
 
+  function getBranchNode(item: Item) {
+    switch (item.type) {
+      case 'nested_group':
+        return NestedGroupNode;
+      case 'component':
+        return ComponentNode;
+      case 'nested_component':
+        return NestedComponentNode;
+      default:
+        return GroupNode;
+    }
+  }
+
   if (item.type === 'component' || item.type === 'group' || item.type === 'nested_group' || item.type === 'nested_component') {
     const isComponent = (item.type === 'component' || item.type === 'nested_component');
-    const BranchNode = isComponent ? ComponentNode : GroupNode;
+    const BranchNode = getBranchNode(item);
     return (
       <BranchNode
         key={id}

--- a/code/ui/manager/src/components/sidebar/TreeNode.tsx
+++ b/code/ui/manager/src/components/sidebar/TreeNode.tsx
@@ -5,15 +5,15 @@ import React from 'react';
 import { UseSymbol } from './IconSymbols';
 import { CollapseIcon } from './components/CollapseIcon';
 
-export const TypeIcon = styled.svg<{ type: 'component' | 'story' | 'group' | 'document' }>(
+export const TypeIcon = styled.svg<{ type: 'component' | 'nested_component' | 'story' | 'group' | 'nested_group' | 'document' }>(
   ({ theme, type }) => ({
     width: 14,
     height: 14,
     flex: '0 0 auto',
     color: (() => {
-      if (type === 'group')
+      if (type === 'group' || type === 'nested_group')
         return theme.base === 'dark' ? theme.color.primary : theme.color.ultraviolet;
-      if (type === 'component') return theme.color.secondary;
+      if (type === 'component' || type === 'nested_component') return theme.color.secondary;
       if (type === 'document') return theme.base === 'dark' ? theme.color.gold : '#ff8300';
       if (type === 'story') return theme.color.seafoam;
       return 'currentColor';

--- a/code/ui/manager/src/components/sidebar/TreeNode.tsx
+++ b/code/ui/manager/src/components/sidebar/TreeNode.tsx
@@ -11,11 +11,33 @@ export const TypeIcon = styled.svg<{ type: 'component' | 'nested_component' | 's
     height: 14,
     flex: '0 0 auto',
     color: (() => {
-      if (type === 'group' || type === 'nested_group')
-        return theme.base === 'dark' ? theme.color.primary : theme.color.ultraviolet;
-      if (type === 'component' || type === 'nested_component') return theme.color.secondary;
-      if (type === 'document') return theme.base === 'dark' ? theme.color.gold : '#ff8300';
-      if (type === 'story') return theme.color.seafoam;
+      if (type === 'group') {
+        if (theme.base === 'dark') {
+          return theme.color.primary;
+        }
+        return theme.color.ultraviolet;
+      }
+      if (type === 'nested_group') {
+        if (theme.base === 'dark') {
+          return theme.color.purple;
+        }
+        return theme.color.ultraviolet;
+      }
+      if (type === 'component') {
+        return theme.color.secondary;
+      }
+      if (type === 'nested_component') {
+        return theme.color.green;
+      }
+      if (type === 'document') {
+        if (theme.base === 'dark') {
+          return theme.color.gold;
+        }
+        return '#ff8300';
+      }
+      if (type === 'story') {
+        return theme.color.seafoam;
+      }
       return 'currentColor';
     })(),
   })
@@ -110,6 +132,27 @@ export const GroupNode: FC<
   );
 });
 
+export const NestedGroupNode: FC<
+  ComponentProps<typeof BranchNode> & { isExpanded?: boolean; isExpandable?: boolean }
+> = React.memo(function NestedGroupNode({
+  children,
+  isExpanded = false,
+  isExpandable = false,
+  ...props
+}) {
+  return (
+    <BranchNode isExpandable={isExpandable} tabIndex={-1} {...props}>
+      <Wrapper>
+        {isExpandable && <CollapseIcon isExpanded={isExpanded} />}
+        <TypeIcon viewBox="0 0 14 14" width="14" height="14" type="nested_group">
+          <UseSymbol type="nested_group" />
+        </TypeIcon>
+      </Wrapper>
+      {children}
+    </BranchNode>
+  );
+});
+
 export const ComponentNode: FC<ComponentProps<typeof BranchNode>> = React.memo(
   function ComponentNode({ theme, children, isExpanded, isExpandable, isSelected, ...props }) {
     return (
@@ -118,6 +161,22 @@ export const ComponentNode: FC<ComponentProps<typeof BranchNode>> = React.memo(
           {isExpandable && <CollapseIcon isExpanded={isExpanded} />}
           <TypeIcon viewBox="0 0 14 14" width="12" height="12" type="component">
             <UseSymbol type="component" />
+          </TypeIcon>
+        </Wrapper>
+        {children}
+      </BranchNode>
+    );
+  }
+);
+
+export const NestedComponentNode: FC<ComponentProps<typeof BranchNode>> = React.memo(
+  function NestedComponentNode({ theme, children, isExpanded, isExpandable, isSelected, ...props }) {
+    return (
+      <BranchNode isExpandable={isExpandable} tabIndex={-1} {...props}>
+        <Wrapper>
+          {isExpandable && <CollapseIcon isExpanded={isExpanded} />}
+          <TypeIcon viewBox="0 0 22 22" width="14" height="14" type="nested_component">
+            <UseSymbol type="nested_component" />
           </TypeIcon>
         </Wrapper>
         {children}

--- a/code/ui/manager/src/utils/status.tsx
+++ b/code/ui/manager/src/utils/status.tsx
@@ -44,7 +44,7 @@ export function getGroupStatus(
   status: API_StatusState
 ): Record<string, API_StatusValue> {
   return Object.values(collapsedData).reduce<Record<string, API_StatusValue>>((acc, item) => {
-    if (item.type === 'group' || item.type === 'component') {
+    if (item.type === 'component' || item.type === 'group' || item.type === 'nested_group' || item.type === 'nested_component') {
       const leafs = getDescendantIds(collapsedData as any, item.id, false)
         .map((id) => collapsedData[id])
         .filter((i) => i.type === 'story');


### PR DESCRIPTION
Closes #25014

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What we did

<!-- Briefly describe what your PR does -->

### Feature implementation

In storybook, there is currently a route tree which can go quite deep. With this, it is necessary to click trough all of the folders to access all the files of the project. With compact folders (smart flatten) this problem can be solved.

Compact folders allow folders with just one entry of the same type (relevant for storybook, since there are many types of folders and files) to be collapsed into the same level with single headings, which improves readability and keeps the tree cleaner.

For example: a group folder with just one group folder as entry becomes
a single heading which name is composed by these 2 folders.

Here is a visual example of the feature:

![Alt text](https://i.ibb.co/dmRvGgt/image.png)

### Feature coverage with new unit tests

Since the new feature changes manager API (introduced nested folders types) we find it relevant to add some unit tests to cover this implementation.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

Example:
1. Run storybook in localhost using the command below:
```
$ yarn start
```
2. Verify in the sidebar that folders are now nested

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
