### PR TITLE
Tags: Refine composition behavior

### DIFF
--- a/code/lib/manager-api/src/lib/stories.ts
+++ b/code/lib/manager-api/src/lib/stories.ts
@@ -153,7 +153,7 @@ export const transformStoryIndexV4toV5 = (
       (acc, entry) => {
         acc[entry.id] = {
           ...entry,
-          tags: entry.tags ? [...entry.tags, 'dev'] : ['dev'],
+          tags: entry.tags ? ['dev', 'test', ...entry.tags] : ['dev'],
         };
 
         return acc;


### PR DESCRIPTION
Closes N/A

## What I did

In #27358 I fixed a glaring composition bug between 8.1+ storybooks and older Storybook versions that did not have the `dev` tag automatically added to all stories.

This PR improves upon that PR:
- [x] It adds the `dev` tag to the front of the list, which is the correct precedence
- [x] It also adds the `test` tag. This shouldn't really change anything right now since the Test Runner ignores composition, but could prevent future bugs if we change the `test` tag behavior in the future.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
