### PR TITLE
Docs: Fix typo for `autodocs` tag

### DIFF
--- a/docs/snippets/angular/tags-combo-example.ts.mdx
+++ b/docs/snippets/angular/tags-combo-example.ts.mdx
@@ -13,13 +13,13 @@ type Story = StoryObj<Button>;
 
 export const Variant1: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/react/tags-combo-example.js.mdx
+++ b/docs/snippets/react/tags-combo-example.js.mdx
@@ -8,13 +8,13 @@ export default {
 
 export const Variant1 = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2 = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/react/tags-combo-example.ts-4-9.mdx
+++ b/docs/snippets/react/tags-combo-example.ts-4-9.mdx
@@ -13,13 +13,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Variant1: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/react/tags-combo-example.ts.mdx
+++ b/docs/snippets/react/tags-combo-example.ts.mdx
@@ -13,13 +13,13 @@ type Story = StoryObj<typeof Button>;
 
 export const Variant1: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/solid/tags-combo-example.js.mdx
+++ b/docs/snippets/solid/tags-combo-example.js.mdx
@@ -8,13 +8,13 @@ export default {
 
 export const Variant1 = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2 = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/solid/tags-combo-example.ts-4-9.mdx
+++ b/docs/snippets/solid/tags-combo-example.ts-4-9.mdx
@@ -13,13 +13,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Variant1: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/solid/tags-combo-example.ts.mdx
+++ b/docs/snippets/solid/tags-combo-example.ts.mdx
@@ -13,13 +13,13 @@ type Story = StoryObj<typeof Button>;
 
 export const Variant1: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/vue/tags-combo-example.js.mdx
+++ b/docs/snippets/vue/tags-combo-example.js.mdx
@@ -8,13 +8,13 @@ export default {
 
 export const Variant1 = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2 = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/vue/tags-combo-example.ts-4-9.mdx
+++ b/docs/snippets/vue/tags-combo-example.ts-4-9.mdx
@@ -13,13 +13,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Variant1: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/vue/tags-combo-example.ts.mdx
+++ b/docs/snippets/vue/tags-combo-example.ts.mdx
@@ -13,13 +13,13 @@ type Story = StoryObj<typeof Button>;
 
 export const Variant1: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/web-components/tags-combo-example.js.mdx
+++ b/docs/snippets/web-components/tags-combo-example.js.mdx
@@ -9,13 +9,13 @@ export default {
 
 export const Variant1 = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2 = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 

--- a/docs/snippets/web-components/tags-combo-example.ts.mdx
+++ b/docs/snippets/web-components/tags-combo-example.ts.mdx
@@ -13,13 +13,13 @@ type Story = StoryObj;
 
 export const Variant1: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 1 },
 };
 
 export const Variant2: Story = {
   // 👇 This story will not appear in Storybook's sidebar or docs page
-  tags: ['!dev', '!docs'],
+  tags: ['!dev', '!autodocs'],
   args: { variant: 2 },
 };
 


### PR DESCRIPTION
## What I did

Fixed the incorrect use of the tag `docs` instead of `autodocs` in the [Tags](https://storybook.js.org/docs/writing-stories/tags) documentation.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Sorry, I did not know how to test the documentation.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
