### PR TITLE
feat: #21925 Add a All UI page that renders all stories present in the project in a docs page.

### DIFF
--- a/code/e2e-tests/addon-backgrounds.spec.ts
+++ b/code/e2e-tests/addon-backgrounds.spec.ts
@@ -51,9 +51,7 @@ test.describe('addon-backgrounds', () => {
       const sbPage = new SbPage(page);
 
       // We start on the introduction page by default.
-      await sbPage.page.waitForURL((url) =>
-        url.search.includes(`path=/docs/configure-your-project--docs`)
-      );
+      await sbPage.page.waitForURL((url) => url.search.includes(`path=/docs/all-ui--docs`));
 
       await expect(sbPage.page.locator(backgroundToolbarSelector)).toBeVisible();
     });

--- a/code/e2e-tests/all-ui.spec.ts
+++ b/code/e2e-tests/all-ui.spec.ts
@@ -1,0 +1,450 @@
+import { test, expect } from '@playwright/test';
+import process from 'process';
+import dedent from 'ts-dedent';
+import { SbPage } from './util';
+
+const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:8001';
+
+test.describe('All UI Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(storybookUrl);
+
+    await new SbPage(page).waitUntilLoaded();
+  });
+
+  test('check presence of All UI elements', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    const root = sbPage.previewRoot();
+
+    // Check the All UI page URL
+    await expect(sbPage.page).toHaveURL(`${storybookUrl}/?path=/docs/all-ui--docs`);
+
+    // Wait for the dom content to be loaded
+    await page.waitForLoadState('domcontentloaded');
+
+    // Check that the main container is visible
+    await expect(root.locator('.sb-container')).toBeVisible({ timeout: 10000 });
+
+    // Check the presence of the section title
+    await expect(root.locator('.sb-section-title')).toHaveText(
+      'Showcase all UI elements available in the Storybook UI. This is a great way to get familiar with the UI and see how different components are rendered.'
+    );
+
+    // Check that the button container is visible
+    await expect(root.locator('.button')).toBeVisible();
+
+    // Check for a specific UI element, 'Example/Button' story
+    await expect(root.getByRole('heading', { name: 'Button' })).toBeVisible();
+    await expect(root.locator('a[href*="example-button--docs"]')).toBeVisible();
+
+    // Check for a specific UI element, 'Example/Header' story
+    await expect(root.getByRole('heading', { name: 'Header' })).toBeVisible();
+    await expect(root.locator('a[href*="example-header--docs"]')).toBeVisible();
+
+    // Check for a specific UI element, 'Example/Page' story
+    await expect(root.getByRole('heading', { name: 'Page' })).toBeVisible();
+    await expect(root.locator('a[href*="example-page--docs"]')).toBeVisible();
+
+    // Check for the visibility of the Button
+    await expect(root.locator('h3.expanded', { hasText: 'Large' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Primary' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Secondary' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Small' })).not.toBeVisible();
+
+    // Check for the visibility of the Header
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' })).not.toBeVisible();
+
+    // Check for the visibility of the Page
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' })).not.toBeVisible();
+  });
+
+  test('check expand/collapse stories toggle', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    const root = sbPage.previewRoot();
+
+    // Check the All UI page URL
+    await expect(sbPage.page).toHaveURL(`${storybookUrl}/?path=/docs/all-ui--docs`);
+
+    // Wait for the dom content to be loaded
+    await page.waitForLoadState('domcontentloaded');
+
+    // Check that the main container is visible
+    await expect(root.locator('.sb-container')).toBeVisible({ timeout: 10000 });
+
+    // Check the presence of the section title
+    await expect(root.locator('.sidebar-subheading-action')).toBeVisible();
+
+    // Check for the visibility of the Button
+    await expect(root.locator('h3.expanded', { hasText: 'Large' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Primary' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Secondary' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Small' })).not.toBeVisible();
+
+    // Check for the visibility of the Header
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' }).first()).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' }).first()).not.toBeVisible();
+
+    // Check for the visibility of the Page
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' }).nth(1)).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' }).nth(1)).not.toBeVisible();
+
+    // Expand all the stories
+    await root.locator('.sidebar-subheading-action').click();
+
+    // Check for the visibility of the Button
+    await expect(root.locator('h3.expanded', { hasText: 'Large' })).toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Primary' })).toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Secondary' })).toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Small' })).toBeVisible();
+
+    // Check for the visibility of the Header
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' }).first()).toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' }).first()).toBeVisible();
+
+    // Check for the visibility of the Page
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' }).nth(1)).toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' }).nth(1)).toBeVisible();
+
+    // Collapse all the stories
+    await root.locator('.sidebar-subheading-action').click();
+
+    // Check for the visibility of the Button
+    await expect(root.locator('h3.expanded', { hasText: 'Large' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Primary' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Secondary' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Small' })).not.toBeVisible();
+
+    // Check for the visibility of the Header
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' }).first()).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' }).first()).not.toBeVisible();
+
+    // Check for the visibility of the Page
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' }).nth(1)).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' }).nth(1)).not.toBeVisible();
+  });
+
+  test('should navigate to the button documentation page', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    const root = sbPage.previewRoot();
+
+    // Navigate to the All UI page
+    await expect(sbPage.page).toHaveURL(`${storybookUrl}/?path=/docs/all-ui--docs`);
+
+    // Click on the link to navigate to the Button documentation
+    await root.locator('a[href*="example-button--docs"]').click();
+    await expect(sbPage.page).toHaveURL(`${storybookUrl}/?path=/story/example-button--docs`);
+
+    // Check the presence of the Button title and description
+    await expect(root.getByRole('heading', { name: 'Button' })).toBeVisible();
+    await expect(
+      root.locator('p', { hasText: 'Primary UI component for user interaction' })
+    ).toBeVisible();
+
+    // Check the presence of the Button Canvas
+    await expect((await root.locator('#anchor--example-button--primary').all())[0]).toBeVisible();
+
+    // Check the presence of the Button Controls
+    await expect(root.locator('.css-14m39zm')).toBeVisible();
+
+    await expect(root.locator('h2', { hasText: 'Stories' })).toBeVisible();
+
+    // Check the presence of the Primary title and Canvas
+    await expect(root.locator('h3', { hasText: 'Primary' })).toBeVisible();
+    await expect((await root.locator('#anchor--example-button--primary').all())[1]).toBeVisible();
+
+    // Check the presence of the Secondary title and Canvas
+    await expect(root.locator('h3', { hasText: 'Secondary' })).toBeVisible();
+    await expect(root.locator('#anchor--example-button--secondary')).toBeVisible();
+
+    // Check the presence of the Large title and Canvas
+    await expect(root.locator('h3', { hasText: 'Large' })).toBeVisible();
+    await expect(root.locator('#anchor--example-button--large')).toBeVisible();
+
+    // Check the presence of the Small title and Canvas
+    await expect(root.locator('h3', { hasText: 'Small' })).toBeVisible();
+    await expect(root.locator('#anchor--example-button--small')).toBeVisible();
+  });
+
+  test('check expand button stories', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    const root = sbPage.previewRoot();
+
+    // Check the All UI page URL
+    await expect(sbPage.page).toHaveURL(`${storybookUrl}/?path=/docs/all-ui--docs`);
+
+    // Wait for the dom content to be loaded
+    await page.waitForLoadState('domcontentloaded');
+
+    // Check that the button container is visible
+    await expect(root.locator('.button')).toBeVisible();
+
+    // Check for the visibility of the Button
+    await expect(root.locator('h3.expanded', { hasText: 'Large' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Primary' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Secondary' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'Small' })).not.toBeVisible();
+
+    // Expand the 'Button' story and check its elements
+    await root.locator('h3', { hasText: 'Primary' }).click();
+    await expect(root.locator('h3.expanded', { hasText: 'Primary' })).toBeVisible();
+
+    // Click on the third button which has the text "Show code"
+    (await root.locator('button', { hasText: 'Show Code' }).all())[0].click();
+    const sourceCode = root.locator('pre.prismjs');
+    const expectedSource = dedent`
+      <Button
+        label="Button"
+        onClick={() => {}}
+        primary
+      />
+    `;
+    const normalizeCode = (code: string) =>
+      code.replace(/onClick=\{function.*\(\)\{\}\}/, 'onClick={() => {}}');
+    const actualSourceCode = await sourceCode.evaluate(
+      (el) => (el as HTMLElement).textContent?.trim() || ''
+    );
+    await expect(normalizeCode(actualSourceCode)).toBe(normalizeCode(expectedSource));
+
+    // Close the 'Button' story
+    await root.locator('h3', { hasText: 'Primary' }).click();
+    await expect(root.locator('h3.expanded', { hasText: 'Primary' })).not.toBeVisible();
+
+    // Expand the 'Button' story and check its elements
+    await root.locator('h3', { hasText: 'Secondary' }).click();
+    await expect(root.locator('h3.expanded', { hasText: 'Secondary' })).toBeVisible();
+
+    // Click on the third button which has the text "Show code"
+    (await root.locator('button', { hasText: 'Show Code' }).all())[0].click();
+    const sourceCode2 = root.locator('pre.prismjs');
+    const expectedSource2 = dedent`
+      <Button
+        label="Button"
+        onClick={() => {}}
+      />
+    `;
+    const actualSourceCode2 = await sourceCode2.evaluate(
+      (el) => (el as HTMLElement).textContent?.trim() || ''
+    );
+    await expect(normalizeCode(actualSourceCode2)).toBe(normalizeCode(expectedSource2));
+
+    // Close the 'Button' story
+    await root.locator('h3', { hasText: 'Secondary' }).click();
+    await expect(root.locator('h3.expanded', { hasText: 'Secondary' })).not.toBeVisible();
+
+    // Expand the 'Button' story and check its elements
+    await root.locator('h3', { hasText: 'Large' }).click();
+    await expect(root.locator('h3.expanded', { hasText: 'Large' })).toBeVisible();
+
+    // Click on the third button which has the text "Show code"
+    (await root.locator('button', { hasText: 'Show Code' }).all())[0].click();
+    const sourceCode3 = root.locator('pre.prismjs');
+    const expectedSource3 = dedent`
+      <Button
+        label="Button"
+        onClick={() => {}}
+        size="large"
+      />
+    `;
+    const actualSourceCode3 = await sourceCode3.evaluate(
+      (el) => (el as HTMLElement).textContent?.trim() || ''
+    );
+    await expect(normalizeCode(actualSourceCode3)).toBe(normalizeCode(expectedSource3));
+
+    // Close the 'Button' story
+    await root.locator('h3', { hasText: 'Large' }).click();
+    await expect(root.locator('h3.expanded', { hasText: 'Large' })).not.toBeVisible();
+
+    // Expand the 'Button' story and check its elements
+    await root.locator('h3', { hasText: 'Small' }).click();
+    await expect(root.locator('h3.expanded', { hasText: 'Small' })).toBeVisible();
+
+    // Click on the third button which has the text "Show code"
+    (await root.locator('button', { hasText: 'Show Code' }).all())[0].click();
+    const sourceCode4 = root.locator('pre.prismjs');
+    const expectedSource4 = dedent`
+      <Button
+        label="Button"
+        onClick={() => {}}
+        size="small"
+      />
+    `;
+    const actualSourceCode4 = await sourceCode4.evaluate(
+      (el) => (el as HTMLElement).textContent?.trim() || ''
+    );
+    await expect(normalizeCode(actualSourceCode4)).toBe(normalizeCode(expectedSource4));
+
+    // Close the 'Button' story
+    await root.locator('h3', { hasText: 'Small' }).click();
+    await expect(root.locator('h3.expanded', { hasText: 'Small' })).not.toBeVisible();
+  });
+
+  test('should navigate to the header documentation page', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    const root = sbPage.previewRoot();
+
+    // Navigate to the All UI page
+    await expect(sbPage.page).toHaveURL(`${storybookUrl}/?path=/docs/all-ui--docs`);
+
+    // Click on the link to navigate to the Button documentation
+    await root.locator('a[href*="example-header--docs"]').click();
+    await expect(sbPage.page).toHaveURL(`${storybookUrl}/?path=/story/example-header--docs`);
+
+    // Check the presence of the Header title
+    await expect(root.getByRole('heading', { name: 'Header' })).toBeVisible();
+
+    // Check the presence of the Header Canvas
+    await expect((await root.locator('#anchor--example-header--logged-in').all())[0]).toBeVisible();
+
+    // Check the presence of the Header Controls
+    await expect(root.locator('.css-14m39zm')).toBeVisible();
+    await expect(root.locator('h2', { hasText: 'Stories' })).toBeVisible();
+
+    // Check the presence of the LoggedIn title and Canvas
+    await expect(root.locator('h3', { hasText: 'Logged In' })).toBeVisible();
+    await expect((await root.locator('#anchor--example-header--logged-in').all())[1]).toBeVisible();
+
+    // Check the presence of the LoggedOut title and Canvas
+    await expect(root.locator('h3', { hasText: 'Logged Out' })).toBeVisible();
+    await expect(root.locator('#anchor--example-header--logged-out')).toBeVisible();
+  });
+
+  test('check expand header stories', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    const root = sbPage.previewRoot();
+
+    // Check the All UI page URL
+    await expect(sbPage.page).toHaveURL(`${storybookUrl}/?path=/docs/all-ui--docs`);
+
+    // Wait for the dom content to be loaded
+    await page.waitForLoadState('domcontentloaded');
+
+    // Check that the header container is visible
+    await expect(root.locator('.header')).toBeVisible();
+
+    const loggedIn = (await root.locator('h3', { hasText: 'LoggedIn' }).all())[0];
+
+    // Check for the visibility of the Header
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' })).not.toBeVisible();
+
+    // Expand the 'LoggedIn' story and check its elements
+    await loggedIn.click();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' })).toBeVisible();
+
+    // Click on the third button which has the text "Show code"
+    (await root.locator('button', { hasText: 'Show Code' }).all())[0].click();
+    const sourceCode = root.locator('pre.prismjs');
+    const expectedSource = dedent`
+      <Header
+        onCreateAccount={() => {}}
+        onLogin={() => {}}
+        onLogout={() => {}}
+        user={{
+          name: 'Jane Doe'
+        }}
+      />
+    `;
+
+    const normalizeCode = (code: string) => {
+      return code
+        .replace(/onCreateAccount=\{function.*\(\)\{\}\}/, 'onCreateAccount={() => {}}')
+        .replace(/onLogin=\{function.*\(\)\{\}\}/, 'onLogin={() => {}}')
+        .replace(/onLogout=\{function.*\(\)\{\}\}/, 'onLogout={() => {}}');
+    };
+    const actualSourceCode = await sourceCode.evaluate(
+      (el) => (el as HTMLElement).textContent?.trim() || ''
+    );
+    await expect(normalizeCode(actualSourceCode)).toBe(normalizeCode(expectedSource));
+
+    // Close the 'LoggedIn' story
+    await loggedIn.click();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' })).not.toBeVisible();
+
+    const loggedOut = (await root.locator('h3', { hasText: 'LoggedOut' }).all())[0];
+
+    // Expand the 'LoggedOut' story and check its elements
+    await loggedOut.click();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' })).toBeVisible();
+
+    // Click on the third button which has the text "Show code"
+    (await root.locator('button', { hasText: 'Show Code' }).all())[0].click();
+    const sourceCode2 = root.locator('pre.prismjs');
+    const expectedSource2 = dedent`
+      <Header
+        onCreateAccount={() => {}}
+        onLogin={() => {}}
+        onLogout={() => {}}
+      />
+    `;
+    const actualSourceCode2 = await sourceCode2.evaluate(
+      (el) => (el as HTMLElement).textContent?.trim() || ''
+    );
+    await expect(normalizeCode(actualSourceCode2)).toBe(normalizeCode(expectedSource2));
+
+    // Close the 'LoggedOut' story
+    await loggedOut.click();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' })).not.toBeVisible();
+  });
+
+  test('check expand page stories', async ({ page }) => {
+    const sbPage = new SbPage(page);
+    const root = sbPage.previewRoot();
+
+    // Check the All UI page URL
+    await expect(sbPage.page).toHaveURL(`${storybookUrl}/?path=/docs/all-ui--docs`);
+
+    // Wait for the dom content to be loaded
+    await page.waitForLoadState('domcontentloaded');
+
+    // Check that the page container is visible
+    await expect(root.locator('.page')).toBeVisible();
+
+    const loggedIn = (await root.locator('h3', { hasText: 'LoggedIn' }).all())[1];
+
+    // Check for the visibility of the Header
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' })).not.toBeVisible();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' })).not.toBeVisible();
+
+    // Expand the 'LoggedIn' story and check its elements
+    await loggedIn.click();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' })).toBeVisible();
+
+    // Click on the third button which has the text "Show code"
+    (await root.locator('button', { hasText: 'Show Code' }).all())[0].click();
+    const sourceCode = root.locator('pre.prismjs');
+    const expectedSource = dedent`
+      <Page />
+    `;
+    const actualSourceCode = await sourceCode.evaluate(
+      (el) => (el as HTMLElement).textContent?.trim() || ''
+    );
+    await expect(actualSourceCode).toBe(expectedSource);
+
+    // Close the 'LoggedIn' story
+    await loggedIn.click();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedIn' })).not.toBeVisible();
+
+    const loggedOut = (await root.locator('h3', { hasText: 'LoggedOut' }).all())[1];
+
+    // Expand the 'LoggedOut' story and check its elements
+    await loggedOut.click();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' })).toBeVisible();
+
+    // Click on the third button which has the text "Show code"
+    (await root.locator('button', { hasText: 'Show Code' }).all())[0].click();
+    const sourceCode2 = root.locator('pre.prismjs');
+    const expectedSource2 = dedent`
+      <Page />
+    `;
+    const actualSourceCode2 = await sourceCode2.evaluate(
+      (el) => (el as HTMLElement).textContent?.trim() || ''
+    );
+    await expect(actualSourceCode2).toBe(expectedSource2);
+
+    // Close the 'LoggedOut' story
+    await loggedOut.click();
+    await expect(root.locator('h3.expanded', { hasText: 'LoggedOut' })).not.toBeVisible();
+  });
+});

--- a/code/e2e-tests/manager.spec.ts
+++ b/code/e2e-tests/manager.spec.ts
@@ -203,7 +203,7 @@ test.describe('Manager UI', () => {
       const mobileNavigationHeading = await sbPage.page.locator('[title="Open navigation menu"]');
 
       // navigation menu is closed
-      await expect(mobileNavigationHeading).toHaveText('Configure your project/Docs');
+      await expect(mobileNavigationHeading).toHaveText('All UI/Docs');
       await expect(sbPage.page.locator('#storybook-explorer-menu')).not.toBeVisible();
 
       // open navigation menu
@@ -214,7 +214,7 @@ test.describe('Manager UI', () => {
       // navigation menu is still open
       await expect(sbPage.page.locator('#storybook-explorer-menu')).toBeVisible();
       // story has not changed
-      await expect(sbPage.page.url()).toContain('configure-your-project');
+      await expect(sbPage.page.url()).toContain('all-ui');
 
       await sbPage.navigateToStory('Example/Button', 'Secondary');
 

--- a/code/lib/cli/rendererAssets/common/AllUI.mdx
+++ b/code/lib/cli/rendererAssets/common/AllUI.mdx
@@ -1,0 +1,406 @@
+import React, { useState, useEffect } from 'react';
+import ButtonMeta from './Button.stories';
+import HeaderMeta from './Header.stories';
+import PageMeta from './Page.stories';
+import { loadStories } from './loadStories';
+import { IconButton } from '@storybook/components';
+import { 
+  Canvas, 
+  Meta, 
+  Controls, 
+  Title, 
+  Stories 
+} from "@storybook/blocks";
+import { 
+  ExpandAltIcon, 
+  CollapseIcon as CollapseIconSvg 
+} from '@storybook/icons';
+
+import Github from "./assets/github.svg";
+import Discord from "./assets/discord.svg";
+import Youtube from "./assets/youtube.svg";
+import Tutorials from "./assets/tutorials.svg";
+import Styling from "./assets/styling.png";
+import Context from "./assets/context.png";
+import Assets from "./assets/assets.png";
+import Docs from "./assets/docs.png";
+import Share from "./assets/share.png";
+import FigmaPlugin from "./assets/figma-plugin.png";
+import Testing from "./assets/testing.png";
+import Accessibility from "./assets/accessibility.png";
+import Theming from "./assets/theming.png";
+import AddonLibrary from "./assets/addon-library.png";
+
+export const RightArrow = () => (<svg 
+    viewBox="0 0 14 14" 
+    width="8px" 
+    height="14px" 
+    style={{ 
+      marginLeft: '4px',
+      display: 'inline-block',
+      shapeRendering: 'inherit',
+      verticalAlign: 'middle',
+      fill: 'currentColor',
+      'path fill': 'currentColor'
+    }}
+>
+  <path d="m11.1 7.35-5.5 5.5a.5.5 0 0 1-.7-.7L10.04 7 4.9 1.85a.5.5 0 1 1 .7-.7l5.5 5.5c.2.2.2.5 0 .7Z" />
+</svg>);
+
+export const DownArrow = () => (<svg 
+    viewBox="0 0 14 14" 
+    width="14px" 
+    height="8px" 
+    style={{ 
+      marginLeft: '4px',
+      display: 'inline-block',
+      shapeRendering: 'inherit',
+      verticalAlign: 'middle',
+      fill: 'currentColor',
+      'path fill': 'currentColor'
+    }}
+>
+  <path d="m7.35 11.1-5.5-5.5a.5.5 0 0 1 .7-.7l5.5 5.5 5.15-5.15a.5.5 0 1 1 .7.7l-5.5 5.5c-.2.2-.5.2-.7 0Z" />
+</svg>);
+
+{ /* Generate a link to the docs page for a story */ }
+export const generateDocsLink = (title) => `?path=/story/${title.replace(/\//g, '-').toLowerCase()}--docs`;
+
+{ /* Render a story item */ }
+export const StoryItem = ({ 
+  storyKey, 
+  story, 
+  isExpanded 
+}) => {
+
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div key={storyKey}>
+      <h3 
+        onClick={() => {
+          setExpanded(!expanded)
+        }}
+        style={{ cursor: 'pointer' }}
+        className={(expanded || isExpanded) ? 'expanded' : ''}
+      >
+        {storyKey}
+        {expanded ? <DownArrow /> : <RightArrow />}
+      </h3>
+
+      {(expanded || isExpanded) && (
+        <>
+          <Canvas 
+            of={story} 
+            withToolbar={true} 
+          />
+          <Controls of={story} />
+        </>
+      )}
+    </div>
+  );
+};
+
+{ /* Render all stories */ }
+export const AllUI = () => {
+
+  const [allStories, setAllStories] = useState([]);
+
+  // Expand/collapse all stories
+  const [isExpanded, setExpanded] = useState(false);
+
+  // Load dinamically all stories on mount
+  useEffect(() => {
+
+    const fetchStories = async () => {
+      const stories = await loadStories();
+
+      setAllStories(stories);
+    };
+
+    fetchStories();
+  }, []);
+
+  // Extract title from path
+  const getTitle = (title) => title.split('/').pop();
+
+  // Generate class name from title
+  const getClassName = (title) => title.split('/').pop().toLowerCase();
+
+  return (
+    <div className="sb-sub-container">
+      <div className="sb-section-title">
+        Showcase all UI elements available in the Storybook UI. This is a great way to get familiar with the UI and see how different components are rendered.
+      </div>
+
+      <div className="expand-collapse-button-container">
+        <IconButton
+          className="sidebar-subheading-action"
+          aria-label={isExpanded ? 'Expand' : 'Collapse'}
+          data-action="expand-all"
+          data-expanded={isExpanded}
+          onClick={(event) => {
+            event.preventDefault();
+            setExpanded(!isExpanded);
+          }}
+        >
+          {isExpanded ? <CollapseIconSvg /> : <ExpandAltIcon />}
+        </IconButton>
+      </div>
+
+      {allStories.map(({ meta, stories }) => (
+        <div key={meta.title} className={getClassName(meta.title)}>
+          <h1>{getTitle(meta.title)}</h1>
+          <a href={generateDocsLink(meta.title)}>
+            Go to {meta.title} page
+          </a>
+
+          {stories.map(([storyKey, story]) => (
+            <StoryItem 
+              key={storyKey} 
+              storyKey={storyKey} 
+              story={story} 
+              isExpanded={isExpanded} 
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+<Meta title="All UI"/>
+
+# All UI
+<div className="sb-container">
+  <AllUI />
+</div>
+
+<div className='sb-addon'>
+  <div className='sb-addon-text'>
+    <h4>Addons</h4>
+    <p className="sb-section-item-paragraph">Integrate your tools with Storybook to connect workflows.</p>
+    <a
+        href="https://storybook.js.org/integrations/"
+        target="_blank"
+      >Discover all addons<RightArrow /></a>
+  </div>
+  <div className='sb-addon-img'>
+    <img src={AddonLibrary} alt="Integrate your tools with Storybook to connect workflows." />
+  </div>
+</div>
+
+<div className="sb-section sb-socials">
+    <div className="sb-section-item">
+      <img src={Github} alt="Github logo" className="sb-explore-image"/>
+      Join our contributors building the future of UI development.
+
+      <a
+        href="https://github.com/storybookjs/storybook"
+        target="_blank"
+      >Star on GitHub<RightArrow /></a>
+    </div>
+    <div className="sb-section-item">
+      <img src={Discord} alt="Discord logo" className="sb-explore-image"/>
+      <div>
+        Get support and chat with frontend developers.
+
+        <a
+          href="https://discord.gg/storybook"
+          target="_blank"
+        >Join Discord server<RightArrow /></a>
+      </div>
+    </div>
+    <div className="sb-section-item">
+      <img src={Youtube} alt="Youtube logo" className="sb-explore-image"/>
+      <div>
+        Watch tutorials, feature previews and interviews.
+
+        <a
+          href="https://www.youtube.com/@chromaticui"
+          target="_blank"
+        >Watch on YouTube<RightArrow /></a>
+      </div>
+    </div>
+    <div className="sb-section-item">
+      <img src={Tutorials} alt="A book" className="sb-explore-image"/>
+      <p>Follow guided walkthroughs on for key workflows.</p>
+
+      <a
+          href="https://storybook.js.org/tutorials/"
+          target="_blank"
+        >Discover tutorials<RightArrow /></a>
+    </div>
+</div>
+
+<style>
+  {`
+  .sb-container {
+    margin-bottom: 48px;
+  }
+
+  .sb-section {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+  }
+
+  img {
+    object-fit: cover;
+  }
+
+  .sb-section-title {
+    margin-bottom: 32px;
+  }
+
+  .sb-section a:not(h1 a, h2 a, h3 a) {
+    font-size: 14px;
+  }
+
+  .sb-section-item, .sb-grid-item {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .sb-section-item-heading {
+    padding-top: 20px !important;
+    padding-bottom: 5px !important;
+    margin: 0 !important;
+  }
+  .sb-section-item-paragraph {
+    margin: 0;
+    padding-bottom: 10px;
+  }
+
+  .sb-chevron {
+    margin-left: 5px;
+  }
+
+  .sb-features-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: 32px 20px;
+  }
+
+  .sb-socials {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .sb-socials p {
+    margin-bottom: 10px;
+  }
+
+  .sb-explore-image {
+    max-height: 32px;
+    align-self: flex-start;
+  }
+
+  .sb-addon {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    position: relative;
+    background-color: #EEF3F8;
+    border-radius: 5px;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    background: #EEF3F8;
+    height: 180px;
+    margin-bottom: 48px;
+    overflow: hidden;
+  }
+
+  .sb-addon-text {
+    padding-left: 48px;
+    max-width: 240px;
+  }
+
+  .sb-addon-text h4 {
+    padding-top: 0px;
+  }
+
+  .sb-addon-img {
+    position: absolute;
+    left: 345px;
+    top: 0;
+    height: 100%;
+    width: 200%;
+    overflow: hidden;
+  }
+
+  .sb-addon-img img {
+    width: 650px;
+    transform: rotate(-15deg);
+    margin-left: 40px;
+    margin-top: -72px;
+    box-shadow: 0 0 1px rgba(255, 255, 255, 0);
+    backface-visibility: hidden;
+  }
+
+  @media screen and (max-width: 800px) {
+    .sb-addon-img {
+      left: 300px;
+    }
+  }
+
+  @media screen and (max-width: 600px) {
+    .sb-section {
+      flex-direction: column;
+    }
+
+    .sb-features-grid {
+      grid-template-columns: repeat(1, 1fr);
+    }
+
+    .sb-socials {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    .sb-addon {
+      height: 280px;
+      align-items: flex-start;
+      padding-top: 32px;
+      overflow: hidden;
+    }
+
+    .sb-addon-text {
+      padding-left: 24px;
+    }
+
+    .sb-addon-img {
+      right: 0;
+      left: 0;
+      top: 130px;
+      bottom: 0;
+      overflow: hidden;
+      height: auto;
+      width: 124%;
+    }
+
+    .sb-addon-img img {
+      width: 1200px;
+      transform: rotate(-12deg);
+      margin-left: 0;
+      margin-top: 48px;
+      margin-bottom: -40px;
+      margin-left: -24px;
+    }
+  }
+
+  .expanded {
+    color: #1ea7fd;
+  }
+
+  .expand-collapse-button-container {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 20px;
+  }
+
+  .sidebar-subheading-action {
+    display: flex;
+  }
+  `}
+</style>

--- a/code/lib/cli/rendererAssets/common/loadStories.jsx
+++ b/code/lib/cli/rendererAssets/common/loadStories.jsx
@@ -1,0 +1,15 @@
+// src/stories/loadStories.js
+export const loadStories = () => {
+  const modules = import.meta.glob('./*.stories.ts');
+
+  const loadModule = async (modulePath) => {
+    const module = await modules[modulePath]();
+    const meta = module.default;
+    const stories = Object.entries(module).filter(
+      ([key]) => key !== 'default' && key !== '__namedExportsOrder'
+    );
+    return { meta, stories };
+  };
+
+  return Promise.all(Object.keys(modules).map(loadModule));
+};


### PR DESCRIPTION
Closes #21925

## What I did

This feature aims to create a page that will render all the present stories in the project in one page, making the process of looking through all the components easier.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
