### PR TITLE
CSF-Tools: Fix export specifier bug

### DIFF
--- a/code/lib/csf-tools/src/ConfigFile.test.ts
+++ b/code/lib/csf-tools/src/ConfigFile.test.ts
@@ -216,13 +216,24 @@ describe('ConfigFile', () => {
           )
         ).toEqual([{ directory: '../src', titlePrefix: 'Demo' }]);
       });
-      it('export specfier', () => {
+      it('export specifier', () => {
         expect(
           getField(
             ['foo'],
             dedent`
               const foo = 'bar';
               export { foo };
+            `
+          )
+        ).toEqual('bar');
+      });
+      it('export aliased specifier', () => {
+        expect(
+          getField(
+            ['fooAlias'],
+            dedent`
+              const foo = 'bar';
+              export { foo as fooAlias };
             `
           )
         ).toEqual('bar');

--- a/code/lib/csf-tools/src/ConfigFile.ts
+++ b/code/lib/csf-tools/src/ConfigFile.ts
@@ -224,9 +224,14 @@ export class ConfigFile {
           } else if (node.specifiers) {
             // export { X };
             node.specifiers.forEach((spec) => {
-              if (t.isExportSpecifier(spec) && t.isIdentifier(spec.exported)) {
+              if (
+                t.isExportSpecifier(spec) &&
+                t.isIdentifier(spec.local) &&
+                t.isIdentifier(spec.exported)
+              ) {
+                const { name: localName } = spec.local;
                 const { name: exportName } = spec.exported;
-                const decl = _findVarDeclarator(exportName, parent as t.Program) as any;
+                const decl = _findVarDeclarator(localName, parent as t.Program) as any;
                 self._exports[exportName] = decl.init;
                 self._exportDecls[exportName] = decl;
               }


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

CSF-Tools was not able to analyze aliased named exports properly. An export like the following lead to an Error:

```
var preview_default = {};

export { preview_default as default };
```

The fix now makes sure that the local name of the ExportSpecifier is used to find the proper declaration

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-27418-sha-ab9c6633`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-27418-sha-ab9c6633 sandbox` or in an existing project with `npx storybook@0.0.0-pr-27418-sha-ab9c6633 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-27418-sha-ab9c6633`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-27418-sha-ab9c6633) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-aliased-named-export-analysis`](https://github.com/storybookjs/storybook/tree/valentin/fix-aliased-named-export-analysis) |
| **Commit** | [`ab9c6633`](https://github.com/storybookjs/storybook/commit/ab9c6633924263614f5724347d697bfee9042fbc) |
| **Datetime** | Wed May 29 19:51:16 UTC 2024 (`1717012276`) |
| **Workflow run** | [9292245868](https://github.com/storybookjs/storybook/actions/runs/9292245868) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=27418`_
</details>
<!-- CANARY_RELEASE_SECTION -->
