### PR TITLE
Tags: Fix unsafe project-level tags lookup

### DIFF
--- a/code/lib/core-server/src/utils/StoryIndexGenerator.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.ts
@@ -672,8 +672,24 @@ export class StoryIndexGenerator {
     const defaultTags = ['dev', 'test'];
     const extraTags = this.options.docs.autodocs === true ? [AUTODOCS_TAG] : [];
     if (previewCode) {
-      const projectAnnotations = loadConfig(previewCode).parse();
-      projectTags = projectAnnotations.getFieldValue(['tags']) ?? [];
+      try {
+        const projectAnnotations = loadConfig(previewCode).parse();
+        projectTags = projectAnnotations.getFieldValue(['tags']) ?? [];
+      } catch (err) {
+        once.warn(dedent`
+          Unable to parse tags from project configuration. If defined, tags should be specified inline, e.g.
+      
+          export default {
+            tags: ['foo'],
+          }
+      
+          ---
+      
+          Received:
+      
+          ${previewCode}
+        `);
+      }
     }
     return [...defaultTags, ...projectTags, ...extraTags];
   }


### PR DESCRIPTION
Closes #27510

## What I did

Catch preview.js parsing errors and present a warning instead of crashing 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Create a preview that has tags that can't be parsed:

```js
const genTags = () => ['asdf'];

export default {
  tags: genTags(),
};
```

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
