### PR TITLE
Angular: Allow outputPath object syntax

### DIFF
--- a/code/frameworks/angular/src/server/angular-cli-webpack.js
+++ b/code/frameworks/angular/src/server/angular-cli-webpack.js
@@ -68,6 +68,10 @@ exports.getWebpackConfig = async (baseConfig, { builderOptions, builderContext }
       styles: builderOptions.styles
         ?.map((style) => (typeof style === 'string' ? style : style.input))
         .filter((style) => typeof style === 'string' || style.inject !== false),
+      outputPath:
+        typeof builderOptions.outputPath === 'string'
+          ? builderOptions.outputPath
+          : builderOptions.outputPath?.base,
 
       // Fixed options
       optimization: false,


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28143

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have fixed an issue where `outputPath` in Angular's workspace configuration might cause issues in Storybook, if it is defined as an object.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Checkout https://stackblitz.com/edit/github-uzgadq-yz5lzq?file=angular.json
2. Install the canary of this PR
3. Storybook should start as expected

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28144-sha-88097b55`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28144-sha-88097b55 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28144-sha-88097b55 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28144-sha-88097b55`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-28144-sha-88097b55) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/angular-output-path-object`](https://github.com/storybookjs/storybook/tree/valentin/angular-output-path-object) |
| **Commit** | [`88097b55`](https://github.com/storybookjs/storybook/commit/88097b55b536fe5efee46c02ef4b6703651f3bc3) |
| **Datetime** | Fri Jun  7 12:28:11 UTC 2024 (`1717763291`) |
| **Workflow run** | [9416980443](https://github.com/storybookjs/storybook/actions/runs/9416980443) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28144`_
</details>
<!-- CANARY_RELEASE_SECTION -->
