### PR TITLE
Core: Remove util dependency

### DIFF
--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -71,8 +71,7 @@
     "semver": "^7.3.7",
     "tempy": "^3.1.0",
     "tiny-invariant": "^1.3.1",
-    "ts-dedent": "^2.0.0",
-    "util": "^0.12.4"
+    "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
     "@types/find-cache-dir": "^3.2.1",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5912,7 +5912,6 @@ __metadata:
     ts-dedent: "npm:^2.0.0"
     type-fest: "npm:~2.19"
     typescript: "npm:^5.3.2"
-    util: "npm:^0.12.4"
   peerDependencies:
     prettier: ^2 || ^3
   peerDependenciesMeta:


### PR DESCRIPTION
Removes the `util` dependency which seems to be redundant/unused.

We use node's built in `util` module in our `scripts`, but don't seem to use this NPM dependency in our production code.

## What I did

Removes an unused dependency

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

N/A (existing automated tests should cover)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>
