### PR TITLE
Build: Migrate to `happy-dom`, use `vitest` `node-environment` by default

### DIFF
--- a/code/.eslintrc.js
+++ b/code/.eslintrc.js
@@ -58,14 +58,7 @@ module.exports = {
       },
     },
     {
-      files: ['**/template/**/*'],
-      rules: {
-        'import/no-extraneous-dependencies': 'off',
-      },
-    },
-    {
-      // this package depends on a lot of peerDependencies we don't want to specify, because npm would install them
-      files: ['**/addons/docs/**/*'],
+      files: ['**/template/**/*', '**/vitest.config.ts', '**/addons/docs/**/*'],
       rules: {
         'import/no-extraneous-dependencies': 'off',
       },

--- a/code/addons/a11y/src/components/A11YPanel.test.tsx
+++ b/code/addons/a11y/src/components/A11YPanel.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render, waitFor, fireEvent, act, cleanup } from '@testing-library/react';

--- a/code/addons/a11y/src/components/A11yContext.test.tsx
+++ b/code/addons/a11y/src/components/A11yContext.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import * as React from 'react';
 import type { AxeResults } from 'axe-core';

--- a/code/addons/a11y/src/components/Report/HighlightToggle.test.tsx
+++ b/code/addons/a11y/src/components/Report/HighlightToggle.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent, cleanup } from '@testing-library/react';

--- a/code/addons/a11y/vitest.config.ts
+++ b/code/addons/a11y/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/actions/vitest.config.ts
+++ b/code/addons/actions/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/backgrounds/vitest.config.ts
+++ b/code/addons/backgrounds/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/controls/vitest.config.ts
+++ b/code/addons/controls/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/docs/vitest.config.ts
+++ b/code/addons/docs/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/essentials/vitest.config.ts
+++ b/code/addons/essentials/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/gfm/vitest.config.ts
+++ b/code/addons/gfm/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/highlight/vitest.config.ts
+++ b/code/addons/highlight/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/interactions/vitest.config.ts
+++ b/code/addons/interactions/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/jest/vitest.config.ts
+++ b/code/addons/jest/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/links/src/react/components/link.test.tsx
+++ b/code/addons/links/src/react/components/link.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 /// <reference types="@testing-library/jest-dom" />;
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import React from 'react';

--- a/code/addons/links/src/utils.test.ts
+++ b/code/addons/links/src/utils.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { describe, beforeAll, beforeEach, it, expect, vi } from 'vitest';
 import { addons } from '@storybook/preview-api';
 import { SELECT_STORY } from '@storybook/core-events';

--- a/code/addons/links/vitest.config.ts
+++ b/code/addons/links/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/measure/vitest.config.ts
+++ b/code/addons/measure/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/onboarding/vitest.config.ts
+++ b/code/addons/onboarding/vitest.config.ts
@@ -4,6 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: { environment: 'jsdom' },
+    // Add custom config here
   })
 );

--- a/code/addons/outline/vitest.config.ts
+++ b/code/addons/outline/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/storysource/vitest.config.ts
+++ b/code/addons/storysource/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/themes/vitest.config.ts
+++ b/code/addons/themes/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/toolbars/vitest.config.ts
+++ b/code/addons/toolbars/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/addons/viewport/vitest.config.ts
+++ b/code/addons/viewport/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/builders/builder-manager/vitest.config.ts
+++ b/code/builders/builder-manager/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/builders/builder-vite/vitest.config.ts
+++ b/code/builders/builder-vite/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/builders/builder-webpack5/vitest.config.ts
+++ b/code/builders/builder-webpack5/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/angular/package.json
+++ b/code/frameworks/angular/package.json
@@ -80,7 +80,6 @@
     "@types/cross-spawn": "^6.0.2",
     "@types/tmp": "^0.2.3",
     "cross-spawn": "^7.0.3",
-    "jsdom": "^23.0.1",
     "tmp": "^0.2.1",
     "typescript": "^5.3.2",
     "webpack": "5",

--- a/code/frameworks/angular/src/builders/build-storybook/index.spec.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.spec.ts
@@ -1,7 +1,3 @@
-/*
- * @vitest-environment node
- */
-
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { vi, describe, beforeEach, expect, it, afterEach } from 'vitest';
 import { Architect, createBuilder } from '@angular-devkit/architect';

--- a/code/frameworks/angular/src/builders/start-storybook/index.spec.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.spec.ts
@@ -1,7 +1,3 @@
-/*
- * @vitest-environment node
- */
-
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { vi, describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { Architect, createBuilder } from '@angular-devkit/architect';

--- a/code/frameworks/angular/src/client/angular-beta/RendererFactory.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/RendererFactory.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Component, ɵresetJitOptions } from '@angular/core';
 import { platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';

--- a/code/frameworks/angular/src/client/angular-beta/StorybookModule.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/StorybookModule.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { NgModule, Component, EventEmitter, Input, Output } from '@angular/core';
 import { describe, expect, it } from 'vitest';
 

--- a/code/frameworks/angular/src/client/angular-beta/utils/BootstrapQueue.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/BootstrapQueue.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { Subject, lastValueFrom } from 'rxjs';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 

--- a/code/frameworks/angular/src/client/angular-beta/utils/NgComponentAnalyzer.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/NgComponentAnalyzer.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import {
   Type,
   Component,

--- a/code/frameworks/angular/vitest.config.ts
+++ b/code/frameworks/angular/vitest.config.ts
@@ -1,12 +1,12 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
-export default defineConfig(({ mode }) => {
-  return mergeConfig(vitestCommonConfig, {
+export default mergeConfig(
+  vitestCommonConfig,
+  defineConfig({
+    // Add custom config here
     test: {
       setupFiles: ['src/test-setup.ts'],
-      environment: 'jsdom',
     },
-  });
-});
+  })
+);

--- a/code/frameworks/ember/vitest.config.ts
+++ b/code/frameworks/ember/vitest.config.ts
@@ -1,12 +1,9 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/html-webpack5/vitest.config.ts
+++ b/code/frameworks/html-webpack5/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/nextjs/vitest.config.ts
+++ b/code/frameworks/nextjs/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/preact-vite/vitest.config.ts
+++ b/code/frameworks/preact-vite/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/preact-webpack5/vitest.config.ts
+++ b/code/frameworks/preact-webpack5/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/react-vite/vitest.config.ts
+++ b/code/frameworks/react-vite/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/react-webpack5/vitest.config.ts
+++ b/code/frameworks/react-webpack5/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/server-webpack5/vitest.config.ts
+++ b/code/frameworks/server-webpack5/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/svelte-vite/vitest.config.ts
+++ b/code/frameworks/svelte-vite/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/svelte-webpack5/vitest.config.ts
+++ b/code/frameworks/svelte-webpack5/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/sveltekit/vitest.config.ts
+++ b/code/frameworks/sveltekit/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/vue3-vite/vitest.config.ts
+++ b/code/frameworks/vue3-vite/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/vue3-webpack5/vitest.config.ts
+++ b/code/frameworks/vue3-webpack5/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/web-components-vite/vitest.config.ts
+++ b/code/frameworks/web-components-vite/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/frameworks/web-components-webpack5/vitest.config.ts
+++ b/code/frameworks/web-components-webpack5/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/channels/vitest.config.ts
+++ b/code/lib/channels/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/cli-sb/vitest.config.ts
+++ b/code/lib/cli-sb/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/cli-storybook/vitest.config.ts
+++ b/code/lib/cli-storybook/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/cli/vitest.config.ts
+++ b/code/lib/cli/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/client-logger/vitest.config.ts
+++ b/code/lib/client-logger/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/codemod/vitest.config.ts
+++ b/code/lib/codemod/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/core-common/vitest.config.ts
+++ b/code/lib/core-common/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/core-events/vitest.config.ts
+++ b/code/lib/core-events/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
+++ b/code/lib/core-server/src/utils/StoryIndexGenerator.test.ts
@@ -1,8 +1,5 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 
-/**
- * @vitest-environment node
- */
 import { describe, beforeEach, it, expect, vi } from 'vitest';
 
 import path from 'path';

--- a/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
+++ b/code/lib/core-server/src/utils/__tests__/index-extraction.test.ts
@@ -1,6 +1,3 @@
-/**
- * @vitest-environment node
- */
 import { describe, it, expect, vi } from 'vitest';
 
 import path from 'path';

--- a/code/lib/core-server/vitest.config.ts
+++ b/code/lib/core-server/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/core-webpack/vitest.config.ts
+++ b/code/lib/core-webpack/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/csf-plugin/vitest.config.ts
+++ b/code/lib/csf-plugin/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/csf-tools/vitest.config.ts
+++ b/code/lib/csf-tools/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/docs-tools/vitest.config.ts
+++ b/code/lib/docs-tools/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/instrumenter/src/instrumenter.test.ts
+++ b/code/lib/instrumenter/src/instrumenter.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 /* eslint-disable no-underscore-dangle */
 import { addons, mockChannel } from '@storybook/preview-api';
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';

--- a/code/lib/instrumenter/vitest.config.ts
+++ b/code/lib/instrumenter/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/manager-api/src/tests/shortcut.test.js
+++ b/code/lib/manager-api/src/tests/shortcut.test.js
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest';
 
 import { global } from '@storybook/global';

--- a/code/lib/manager-api/vitest.config.ts
+++ b/code/lib/manager-api/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/node-logger/vitest.config.ts
+++ b/code/lib/node-logger/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.integration.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.integration.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment happy-dom
 import { describe, beforeEach, it, expect, vi } from 'vitest';
 
 import React from 'react';

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment happy-dom
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 
 import { global } from '@storybook/global';

--- a/code/lib/preview-api/src/modules/preview-web/render/StoryRender.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/render/StoryRender.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { describe, it, expect, vi } from 'vitest';
 import { Channel } from '@storybook/channels';
 import type { Renderer, StoryIndexEntry } from '@storybook/types';

--- a/code/lib/preview-api/src/modules/preview-web/simulate-pageload.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/simulate-pageload.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment happy-dom
 import { describe, it, expect } from 'vitest';
 
 import { global } from '@storybook/global';

--- a/code/lib/preview-api/vitest.config.ts
+++ b/code/lib/preview-api/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/preview/vitest.config.ts
+++ b/code/lib/preview/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/router/vitest.config.ts
+++ b/code/lib/router/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/source-loader/vitest.config.ts
+++ b/code/lib/source-loader/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/telemetry/vitest.config.ts
+++ b/code/lib/telemetry/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/test/src/index.test.ts
+++ b/code/lib/test/src/index.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { describe, it, test } from 'vitest';
 import { expect, fn, isMockFunction, traverseArgs } from '@storybook/test';
 import { action } from '@storybook/addon-actions';

--- a/code/lib/test/vitest.config.ts
+++ b/code/lib/test/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/theming/src/tests/util.test.js
+++ b/code/lib/theming/src/tests/util.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { describe, it, expect, vi } from 'vitest';
 import { lightenColor as lighten, darkenColor as darken, getPreferredColorScheme } from '../utils';
 

--- a/code/lib/theming/vitest.config.ts
+++ b/code/lib/theming/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/lib/types/vitest.config.ts
+++ b/code/lib/types/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/package.json
+++ b/code/package.json
@@ -202,6 +202,7 @@
     "fs-extra": "^11.1.0",
     "github-release-from-changelog": "^2.1.1",
     "glob": "^10.0.0",
+    "happy-dom": "^14.12.0",
     "http-server": "^14.1.1",
     "husky": "^4.3.7",
     "lint-staged": "^13.2.2",

--- a/code/presets/server-webpack/vitest.config.ts
+++ b/code/presets/server-webpack/vitest.config.ts
@@ -1,12 +1,9 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'node',
-    },
+    // Add custom config here
   })
 );

--- a/code/renderers/html/vitest.config.ts
+++ b/code/renderers/html/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/renderers/preact/vitest.config.ts
+++ b/code/renderers/preact/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/renderers/react/src/__test__/portable-stories.test.tsx
+++ b/code/renderers/react/src/__test__/portable-stories.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 /* eslint-disable import/namespace */
 import React from 'react';
 import { vi, it, expect, afterEach, describe } from 'vitest';

--- a/code/renderers/react/src/public-types.test.tsx
+++ b/code/renderers/react/src/public-types.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 // this file tests Typescript types that's why there are no assertions
 import { describe, it } from 'vitest';
 

--- a/code/renderers/react/vitest.config.ts
+++ b/code/renderers/react/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/renderers/server/vitest.config.ts
+++ b/code/renderers/server/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -73,7 +73,6 @@
     "@testing-library/svelte": "patch:@testing-library/svelte@npm%3A4.1.0#~/.yarn/patches/@testing-library-svelte-npm-4.1.0-34b7037bc0.patch",
     "expect-type": "^0.15.0",
     "fs-extra": "^11.1.0",
-    "jsdom": "^24.0.0",
     "svelte": "^5.0.0-next.65",
     "svelte-check": "^3.6.4",
     "typescript": "^5.3.2"

--- a/code/renderers/svelte/src/__test__/composeStories/__snapshots__/portable-stories.test.ts.snap
+++ b/code/renderers/svelte/src/__test__/composeStories/__snapshots__/portable-stories.test.ts.snap
@@ -99,6 +99,8 @@ exports[`Renders CSF3InputFieldFilled story 1`] = `
   <div>
     <input
       data-testid="input"
+      formaction="http://localhost:3000/"
+      formmethod=""
     />
     <!---->
     <!---->

--- a/code/renderers/svelte/src/__test__/composeStories/portable-stories.test.ts
+++ b/code/renderers/svelte/src/__test__/composeStories/portable-stories.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 /// <reference types="@testing-library/jest-dom" />;
 import { it, expect, vi, describe, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/svelte';

--- a/code/renderers/svelte/vitest.config.ts
+++ b/code/renderers/svelte/vitest.config.ts
@@ -5,7 +5,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default defineConfig(
   mergeConfig(vitestCommonConfig, {
     test: {
-      environment: 'jsdom',
       // setupFiles: ['./vitest-setup.ts'],
     },
     plugins: [

--- a/code/renderers/vue3/src/__tests__/composeStories/portable-stories.test.ts
+++ b/code/renderers/vue3/src/__tests__/composeStories/portable-stories.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 /// <reference types="@testing-library/jest-dom" />;
 import { it, expect, vi, describe } from 'vitest';
 import { render, screen } from '@testing-library/vue';

--- a/code/renderers/vue3/vitest.config.ts
+++ b/code/renderers/vue3/vitest.config.ts
@@ -7,9 +7,6 @@ export default mergeConfig(
   vitestCommonConfig,
   // @ts-expect-error seems like there's a type mismatch in the vue plugin
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
     // @ts-expect-error seems like there's a type mismatch in the vue plugin
     plugins: [vue()],
   })

--- a/code/renderers/web-components/src/docs/custom-elements.test.ts
+++ b/code/renderers/web-components/src/docs/custom-elements.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 /* eslint-disable no-underscore-dangle */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { global } from '@storybook/global';

--- a/code/renderers/web-components/src/docs/sourceDecorator.test.ts
+++ b/code/renderers/web-components/src/docs/sourceDecorator.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { html, render } from 'lit';
 import type { Mock } from 'vitest';
 import { describe, beforeEach, it, vi, expect } from 'vitest';

--- a/code/renderers/web-components/src/docs/web-components-properties.test.ts
+++ b/code/renderers/web-components/src/docs/web-components-properties.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import path from 'path';
 import { vi, describe, it, expect } from 'vitest';
 import fs from 'fs';

--- a/code/renderers/web-components/vitest.config.ts
+++ b/code/renderers/web-components/vitest.config.ts
@@ -1,12 +1,10 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { vitestCommonConfig } from '../../vitest.workspace';
 
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/ui/blocks/vitest.config.ts
+++ b/code/ui/blocks/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/ui/components/src/components/typography/link/link.test.tsx
+++ b/code/ui/components/src/components/typography/link/link.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { vi, describe, afterEach, it, expect } from 'vitest';
 import type { AnchorHTMLAttributes } from 'react';
 import React from 'react';

--- a/code/ui/components/vitest.config.ts
+++ b/code/ui/components/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/ui/manager/vitest.config.ts
+++ b/code/ui/manager/vitest.config.ts
@@ -4,8 +4,6 @@ import { vitestCommonConfig } from '../../vitest.workspace';
 export default mergeConfig(
   vitestCommonConfig,
   defineConfig({
-    test: {
-      environment: 'jsdom',
-    },
+    // Add custom config here
   })
 );

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5509,7 +5509,6 @@ __metadata:
     "@types/webpack-env": "npm:^1.18.0"
     cross-spawn: "npm:^7.0.3"
     find-up: "npm:^5.0.0"
-    jsdom: "npm:^23.0.1"
     read-pkg-up: "npm:^7.0.1"
     semver: "npm:^7.3.7"
     telejson: "npm:^7.2.0"
@@ -6830,6 +6829,7 @@ __metadata:
     fs-extra: "npm:^11.1.0"
     github-release-from-changelog: "npm:^2.1.1"
     glob: "npm:^10.0.0"
+    happy-dom: "npm:^14.12.0"
     http-server: "npm:^14.1.1"
     husky: "npm:^4.3.7"
     lint-staged: "npm:^13.2.2"
@@ -6988,7 +6988,6 @@ __metadata:
     "@testing-library/svelte": "patch:@testing-library/svelte@npm%3A4.1.0#~/.yarn/patches/@testing-library-svelte-npm-4.1.0-34b7037bc0.patch"
     expect-type: "npm:^0.15.0"
     fs-extra: "npm:^11.1.0"
-    jsdom: "npm:^24.0.0"
     svelte: "npm:^5.0.0-next.65"
     svelte-check: "npm:^3.6.4"
     sveltedoc-parser: "npm:^4.2.1"
@@ -12638,24 +12637,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssstyle@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "cssstyle@npm:3.0.0"
-  dependencies:
-    rrweb-cssom: "npm:^0.6.0"
-  checksum: 10c0/23acee092c1cec670fb7b8110e48abd740dc4e574d3b74848743067cb3377a86a1f64cf02606aabd7bb153785e68c2c1e09ce53295ddf7a4b470b3c7c55ec807
-  languageName: node
-  linkType: hard
-
-"cssstyle@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "cssstyle@npm:4.0.1"
-  dependencies:
-    rrweb-cssom: "npm:^0.6.0"
-  checksum: 10c0/cadf9a8b23e11f4c6d63f21291096a0b0be868bd4ab9c799daa2c5b18330e39e5281605f01da906e901b42f742df0f3b3645af6465e83377ff7d15a88ee432a0
-  languageName: node
-  linkType: hard
-
 "csstype@npm:^2.6.8":
   version: 2.6.21
   resolution: "csstype@npm:2.6.21"
@@ -12740,16 +12721,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-urls@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "data-urls@npm:5.0.0"
-  dependencies:
-    whatwg-mimetype: "npm:^4.0.0"
-    whatwg-url: "npm:^14.0.0"
-  checksum: 10c0/1b894d7d41c861f3a4ed2ae9b1c3f0909d4575ada02e36d3d3bc584bdd84278e20709070c79c3b3bff7ac98598cb191eb3e86a89a79ea4ee1ef360e1694f92ad
-  languageName: node
-  linkType: hard
-
 "de-indent@npm:^1.0.2":
   version: 1.0.2
   resolution: "de-indent@npm:1.0.2"
@@ -12798,13 +12769,6 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 10c0/85c39fe8fbf0482d4a1e224ef0119db5c1897f8503bcef8b826adff7a1b11414972f6fef2d7dec2ee0b4be3863cf64ac1439137ae9e6af23a3d8dcbe26a5b4b2
-  languageName: node
-  linkType: hard
-
-"decimal.js@npm:^10.4.3":
-  version: 10.4.3
-  resolution: "decimal.js@npm:10.4.3"
-  checksum: 10c0/6d60206689ff0911f0ce968d40f163304a6c1bc739927758e6efc7921cfa630130388966f16bf6ef6b838cb33679fbe8e7a78a2f3c478afce841fd55ac8fb8ee
   languageName: node
   linkType: hard
 
@@ -16384,6 +16348,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"happy-dom@npm:^14.12.0":
+  version: 14.12.0
+  resolution: "happy-dom@npm:14.12.0"
+  dependencies:
+    entities: "npm:^4.5.0"
+    webidl-conversions: "npm:^7.0.0"
+    whatwg-mimetype: "npm:^3.0.0"
+  checksum: 10c0/b844d7f3f16d2657a8650e0968ddd9272f152cfd9660e0dd4378215f153fc940509981d387e1e855f117baf0cf432918ff084f10c9b557192db5d7743d78302e
+  languageName: node
+  linkType: hard
+
 "has-bigints@npm:^1.0.1, has-bigints@npm:^1.0.2":
   version: 1.0.2
   resolution: "has-bigints@npm:1.0.2"
@@ -16751,15 +16726,6 @@ __metadata:
   dependencies:
     whatwg-encoding: "npm:^2.0.0"
   checksum: 10c0/b17b3b0fb5d061d8eb15121c3b0b536376c3e295ecaf09ba48dd69c6b6c957839db124fe1e2b3f11329753a4ee01aa7dedf63b7677999e86da17fbbdd82c5386
-  languageName: node
-  linkType: hard
-
-"html-encoding-sniffer@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "html-encoding-sniffer@npm:4.0.0"
-  dependencies:
-    whatwg-encoding: "npm:^3.1.1"
-  checksum: 10c0/523398055dc61ac9b34718a719cb4aa691e4166f29187e211e1607de63dc25ac7af52ca7c9aead0c4b3c0415ffecb17326396e1202e2e86ff4bca4c0ee4c6140
   languageName: node
   linkType: hard
 
@@ -17820,13 +17786,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-potential-custom-element-name@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "is-potential-custom-element-name@npm:1.0.1"
-  checksum: 10c0/b73e2f22bc863b0939941d369486d308b43d7aef1f9439705e3582bfccaa4516406865e32c968a35f97a99396dac84e2624e67b0a16b0a15086a785e16ce7db9
-  languageName: node
-  linkType: hard
-
 "is-promise@npm:^2.0.0":
   version: 2.2.2
   resolution: "is-promise@npm:2.2.2"
@@ -18330,74 +18289,6 @@ __metadata:
   version: 4.0.0
   resolution: "jsdoc-type-pratt-parser@npm:4.0.0"
   checksum: 10c0/b23ef7bbbe2f56d72630d1c5a233dc9fecaff399063d373c57bef136908c1b05e723dac107177303c03ccf8d75aa51507510b282aa567600477479c5ea0c36d1
-  languageName: node
-  linkType: hard
-
-"jsdom@npm:^23.0.1":
-  version: 23.0.1
-  resolution: "jsdom@npm:23.0.1"
-  dependencies:
-    cssstyle: "npm:^3.0.0"
-    data-urls: "npm:^5.0.0"
-    decimal.js: "npm:^10.4.3"
-    form-data: "npm:^4.0.0"
-    html-encoding-sniffer: "npm:^4.0.0"
-    http-proxy-agent: "npm:^7.0.0"
-    https-proxy-agent: "npm:^7.0.2"
-    is-potential-custom-element-name: "npm:^1.0.1"
-    nwsapi: "npm:^2.2.7"
-    parse5: "npm:^7.1.2"
-    rrweb-cssom: "npm:^0.6.0"
-    saxes: "npm:^6.0.0"
-    symbol-tree: "npm:^3.2.4"
-    tough-cookie: "npm:^4.1.3"
-    w3c-xmlserializer: "npm:^5.0.0"
-    webidl-conversions: "npm:^7.0.0"
-    whatwg-encoding: "npm:^3.1.1"
-    whatwg-mimetype: "npm:^4.0.0"
-    whatwg-url: "npm:^14.0.0"
-    ws: "npm:^8.14.2"
-    xml-name-validator: "npm:^5.0.0"
-  peerDependencies:
-    canvas: ^2.11.2
-  peerDependenciesMeta:
-    canvas:
-      optional: true
-  checksum: 10c0/13b2b3693ccb40215d1cce77bac7a295414ee4c0a06e30167f8087c9867145ba23dbd592bd95a801cadd7b3698bfd20b9c3f2c26fd8422607f22609ed2e404ef
-  languageName: node
-  linkType: hard
-
-"jsdom@npm:^24.0.0":
-  version: 24.0.0
-  resolution: "jsdom@npm:24.0.0"
-  dependencies:
-    cssstyle: "npm:^4.0.1"
-    data-urls: "npm:^5.0.0"
-    decimal.js: "npm:^10.4.3"
-    form-data: "npm:^4.0.0"
-    html-encoding-sniffer: "npm:^4.0.0"
-    http-proxy-agent: "npm:^7.0.0"
-    https-proxy-agent: "npm:^7.0.2"
-    is-potential-custom-element-name: "npm:^1.0.1"
-    nwsapi: "npm:^2.2.7"
-    parse5: "npm:^7.1.2"
-    rrweb-cssom: "npm:^0.6.0"
-    saxes: "npm:^6.0.0"
-    symbol-tree: "npm:^3.2.4"
-    tough-cookie: "npm:^4.1.3"
-    w3c-xmlserializer: "npm:^5.0.0"
-    webidl-conversions: "npm:^7.0.0"
-    whatwg-encoding: "npm:^3.1.1"
-    whatwg-mimetype: "npm:^4.0.0"
-    whatwg-url: "npm:^14.0.0"
-    ws: "npm:^8.16.0"
-    xml-name-validator: "npm:^5.0.0"
-  peerDependencies:
-    canvas: ^2.11.2
-  peerDependenciesMeta:
-    canvas:
-      optional: true
-  checksum: 10c0/7b35043d7af39ad6dcaef0fa5679d8c8a94c6c9b6cc4a79222b7c9987d57ab7150c50856684ae56b473ab28c7d82aec0fb7ca19dcbd4c3f46683c807d717a3af
   languageName: node
   linkType: hard
 
@@ -21632,13 +21523,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nwsapi@npm:^2.2.7":
-  version: 2.2.7
-  resolution: "nwsapi@npm:2.2.7"
-  checksum: 10c0/44be198adae99208487a1c886c0a3712264f7bbafa44368ad96c003512fed2753d4e22890ca1e6edb2690c3456a169f2a3c33bfacde1905cf3bf01c7722464db
-  languageName: node
-  linkType: hard
-
 "nx@npm:18.0.6":
   version: 18.0.6
   resolution: "nx@npm:18.0.6"
@@ -22383,7 +22267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:^7.0.0, parse5@npm:^7.1.2":
+"parse5@npm:^7.0.0":
   version: 7.1.2
   resolution: "parse5@npm:7.1.2"
   dependencies:
@@ -23262,13 +23146,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"psl@npm:^1.1.33":
-  version: 1.9.0
-  resolution: "psl@npm:1.9.0"
-  checksum: 10c0/6a3f805fdab9442f44de4ba23880c4eba26b20c8e8e0830eff1cb31007f6825dace61d17203c58bfe36946842140c97a1ba7f67bc63ca2d88a7ee052b65d97ab
-  languageName: node
-  linkType: hard
-
 "public-encrypt@npm:^4.0.0":
   version: 4.0.3
   resolution: "public-encrypt@npm:4.0.3"
@@ -23448,7 +23325,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.1":
+"punycode@npm:^2.1.0, punycode@npm:^2.1.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
@@ -23496,13 +23373,6 @@ __metadata:
   version: 0.2.1
   resolution: "querystring@npm:0.2.1"
   checksum: 10c0/6841b32bec4f16ffe7f5b5e4373b47ad451f079cde3a7f45e63e550f0ecfd8f8189ef81fb50079413b3fc1c59b06146e4c98192cb74ed7981aca72090466cd94
-  languageName: node
-  linkType: hard
-
-"querystringify@npm:^2.1.1":
-  version: 2.2.0
-  resolution: "querystringify@npm:2.2.0"
-  checksum: 10c0/3258bc3dbdf322ff2663619afe5947c7926a6ef5fb78ad7d384602974c467fadfc8272af44f5eb8cddd0d011aae8fabf3a929a8eee4b86edcc0a21e6bd10f9aa
   languageName: node
   linkType: hard
 
@@ -25067,13 +24937,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rrweb-cssom@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "rrweb-cssom@npm:0.6.0"
-  checksum: 10c0/3d9d90d53c2349ea9c8509c2690df5a4ef930c9cf8242aeb9425d4046f09d712bb01047e00da0e1c1dab5db35740b3d78fd45c3e7272f75d3724a563f27c30a3
-  languageName: node
-  linkType: hard
-
 "rsvp@npm:^3.0.14, rsvp@npm:^3.0.18":
   version: 3.6.2
   resolution: "rsvp@npm:3.6.2"
@@ -25269,15 +25132,6 @@ __metadata:
   version: 1.3.0
   resolution: "sax@npm:1.3.0"
   checksum: 10c0/599dbe0ba9d8bd55e92d920239b21d101823a6cedff71e542589303fa0fa8f3ece6cf608baca0c51be846a2e88365fac94a9101a9c341d94b98e30c4deea5bea
-  languageName: node
-  linkType: hard
-
-"saxes@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "saxes@npm:6.0.0"
-  dependencies:
-    xmlchars: "npm:^2.2.0"
-  checksum: 10c0/3847b839f060ef3476eb8623d099aa502ad658f5c40fd60c105ebce86d244389b0d76fcae30f4d0c728d7705ceb2f7e9b34bb54717b6a7dbedaf5dad2d9a4b74
   languageName: node
   linkType: hard
 
@@ -26751,13 +26605,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"symbol-tree@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "symbol-tree@npm:3.2.4"
-  checksum: 10c0/dfbe201ae09ac6053d163578778c53aa860a784147ecf95705de0cd23f42c851e1be7889241495e95c37cabb058edb1052f141387bef68f705afc8f9dd358509
-  languageName: node
-  linkType: hard
-
 "symlink-or-copy@npm:^1.0.0, symlink-or-copy@npm:^1.0.1, symlink-or-copy@npm:^1.1.8, symlink-or-copy@npm:^1.2.0, symlink-or-copy@npm:^1.3.1":
   version: 1.3.1
   resolution: "symlink-or-copy@npm:1.3.1"
@@ -27112,27 +26959,6 @@ __metadata:
   version: 1.0.0
   resolution: "token-stream@npm:1.0.0"
   checksum: 10c0/c1924a89686fc035d579cbe856da12306571d5fe7408eeeebe80df7c25c5cc644b8ae102d5cbc0f085d0e105f391d1a48dc0e568520434c5b444ea6c7de2b822
-  languageName: node
-  linkType: hard
-
-"tough-cookie@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "tough-cookie@npm:4.1.3"
-  dependencies:
-    psl: "npm:^1.1.33"
-    punycode: "npm:^2.1.1"
-    universalify: "npm:^0.2.0"
-    url-parse: "npm:^1.5.3"
-  checksum: 10c0/4fc0433a0cba370d57c4b240f30440c848906dee3180bb6e85033143c2726d322e7e4614abb51d42d111ebec119c4876ed8d7247d4113563033eebbc1739c831
-  languageName: node
-  linkType: hard
-
-"tr46@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "tr46@npm:5.0.0"
-  dependencies:
-    punycode: "npm:^2.3.1"
-  checksum: 10c0/1521b6e7bbc8adc825c4561480f9fe48eb2276c81335eed9fa610aa4c44a48a3221f78b10e5f18b875769eb3413e30efbf209ed556a17a42aa8d690df44b7bee
   languageName: node
   linkType: hard
 
@@ -27989,13 +27815,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"universalify@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "universalify@npm:0.2.0"
-  checksum: 10c0/cedbe4d4ca3967edf24c0800cfc161c5a15e240dac28e3ce575c689abc11f2c81ccc6532c8752af3b40f9120fb5e454abecd359e164f4f6aa44c29cd37e194fe
-  languageName: node
-  linkType: hard
-
 "universalify@npm:^2.0.0":
   version: 2.0.0
   resolution: "universalify@npm:2.0.0"
@@ -28080,16 +27899,6 @@ __metadata:
   version: 4.0.1
   resolution: "url-join@npm:4.0.1"
   checksum: 10c0/ac65e2c7c562d7b49b68edddcf55385d3e922bc1dd5d90419ea40b53b6de1607d1e45ceb71efb9d60da02c681d13c6cb3a1aa8b13fc0c989dfc219df97ee992d
-  languageName: node
-  linkType: hard
-
-"url-parse@npm:^1.5.3":
-  version: 1.5.10
-  resolution: "url-parse@npm:1.5.10"
-  dependencies:
-    querystringify: "npm:^2.1.1"
-    requires-port: "npm:^1.0.0"
-  checksum: 10c0/bd5aa9389f896974beb851c112f63b466505a04b4807cea2e5a3b7092f6fbb75316f0491ea84e44f66fed55f1b440df5195d7e3a8203f64fcefa19d182f5be87
   languageName: node
   linkType: hard
 
@@ -28764,15 +28573,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"w3c-xmlserializer@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "w3c-xmlserializer@npm:5.0.0"
-  dependencies:
-    xml-name-validator: "npm:^5.0.0"
-  checksum: 10c0/8712774c1aeb62dec22928bf1cdfd11426c2c9383a1a63f2bcae18db87ca574165a0fbe96b312b73652149167ac6c7f4cf5409f2eb101d9c805efe0e4bae798b
-  languageName: node
-  linkType: hard
-
 "wait-on@npm:^7.0.1":
   version: 7.2.0
   resolution: "wait-on@npm:7.2.0"
@@ -29124,29 +28924,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-encoding@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "whatwg-encoding@npm:3.1.1"
-  dependencies:
-    iconv-lite: "npm:0.6.3"
-  checksum: 10c0/273b5f441c2f7fda3368a496c3009edbaa5e43b71b09728f90425e7f487e5cef9eb2b846a31bd760dd8077739c26faf6b5ca43a5f24033172b003b72cf61a93e
-  languageName: node
-  linkType: hard
-
-"whatwg-mimetype@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "whatwg-mimetype@npm:4.0.0"
-  checksum: 10c0/a773cdc8126b514d790bdae7052e8bf242970cebd84af62fb2f35a33411e78e981f6c0ab9ed1fe6ec5071b09d5340ac9178e05b52d35a9c4bcf558ba1b1551df
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "whatwg-url@npm:14.0.0"
-  dependencies:
-    tr46: "npm:^5.0.0"
-    webidl-conversions: "npm:^7.0.0"
-  checksum: 10c0/ac32e9ba9d08744605519bbe9e1371174d36229689ecc099157b6ba102d4251a95e81d81f3d80271eb8da182eccfa65653f07f0ab43ea66a6934e643fd091ba9
+"whatwg-mimetype@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "whatwg-mimetype@npm:3.0.0"
+  checksum: 10c0/323895a1cda29a5fb0b9ca82831d2c316309fede0365047c4c323073e3239067a304a09a1f4b123b9532641ab604203f33a1403b5ca6a62ef405bcd7a204080f
   languageName: node
   linkType: hard
 
@@ -29392,7 +29173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.13.0, ws@npm:^8.14.2, ws@npm:^8.16.0, ws@npm:^8.2.3":
+"ws@npm:^8.13.0, ws@npm:^8.2.3":
   version: 8.16.0
   resolution: "ws@npm:8.16.0"
   peerDependencies:
@@ -29411,20 +29192,6 @@ __metadata:
   version: 2.0.1
   resolution: "xcase@npm:2.0.1"
   checksum: 10c0/11b8ae8f6734b29d442a5acf1dff3a896cabbf49e7ffa01472ff6fa687a6e6f6a25889d06c10a41950e7a90fe89239fa78d95eab0c5eb654ca75f0ccd71ba8ed
-  languageName: node
-  linkType: hard
-
-"xml-name-validator@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "xml-name-validator@npm:5.0.0"
-  checksum: 10c0/3fcf44e7b73fb18be917fdd4ccffff3639373c7cb83f8fc35df6001fecba7942f1dbead29d91ebb8315e2f2ff786b508f0c9dc0215b6353f9983c6b7d62cb1f5
-  languageName: node
-  linkType: hard
-
-"xmlchars@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "xmlchars@npm:2.2.0"
-  checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did

- Migrate to use `happy-dom` over `jsdom`
- Utilize the `environment` value for `vitest` being `node` already, we do not need to specify it.
- `vitest.config.ts` does not need it's dependencies checked by ESlint

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
