### PR TITLE
CLI: Fix `init --skip-install`

### DIFF
--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -405,7 +405,7 @@ export async function doInitiate(options: CommandOptions): Promise<
   );
 
   return {
-    shouldRunDev: !!options.dev,
+    shouldRunDev: !!options.dev && !options.skipInstall,
     projectType,
     packageManager,
     storybookCommand,


### PR DESCRIPTION
Closes #27096

## What I did

We cannot run `storybook dev` as part of install if we do not actually install the packages. The bug that we were trying to do this and it was crashing before Storybook had added the packages to `package.json`.

## Checklist for Contributors

### Testing

#### Manual testing

In a fresh project (I've done this):
1. Build this branch
2. In a fresh project, run `path/to/code/lib/cli/bin/index.js init --skip-install`
3. Verify that none of the packages have been added to `node_modules`
4. Run `pnpm install`
5. Run storybook and verify that it runs correctly

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
