### PR TITLE
CLI: Fix CLI always asking all automigrations

### DIFF
--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -130,55 +130,59 @@ export const doUpgrade = async ({
   // If we can't determine the existing version fallback to v0.0.0 to not block the upgrade
   const beforeVersion = (await getInstalledStorybookVersion(packageManager)) ?? '0.0.0';
 
-  const currentVersion = versions['@storybook/cli'];
+  const currentCLIVersion = versions['@storybook/cli'];
   const isCanary =
-    currentVersion.startsWith('0.0.0') ||
+    currentCLIVersion.startsWith('0.0.0') ||
     beforeVersion.startsWith('portal:') ||
     beforeVersion.startsWith('workspace:');
 
   if (!(await hasStorybookDependencies(packageManager))) {
     throw new UpgradeStorybookInWrongWorkingDirectory();
   }
-  if (!isCanary && lt(currentVersion, beforeVersion)) {
-    throw new UpgradeStorybookToLowerVersionError({ beforeVersion, currentVersion });
+  if (!isCanary && lt(currentCLIVersion, beforeVersion)) {
+    throw new UpgradeStorybookToLowerVersionError({
+      beforeVersion,
+      currentVersion: currentCLIVersion,
+    });
   }
 
-  if (!isCanary && eq(currentVersion, beforeVersion)) {
+  if (!isCanary && eq(currentCLIVersion, beforeVersion)) {
     // Not throwing, as the beforeVersion calculation doesn't always work in monorepos.
     logger.warn(new UpgradeStorybookToSameVersionError({ beforeVersion }).message);
   }
 
-  const [latestVersion, packageJson] = await Promise.all([
-    //
+  const [latestCLIVersionOnNPM, packageJson] = await Promise.all([
     packageManager.latestVersion('@storybook/cli'),
     packageManager.retrievePackageJson(),
   ]);
 
-  const isOutdated = lt(currentVersion, latestVersion);
-  const isExactLatest = currentVersion === latestVersion;
-  const isPrerelease = prerelease(currentVersion) !== null;
+  const isCLIOutdated = lt(currentCLIVersion, latestCLIVersionOnNPM);
+  const isCLIExactLatest = currentCLIVersion === latestCLIVersionOnNPM;
+  const isCLIPrerelease = prerelease(currentCLIVersion) !== null;
 
-  const borderColor = isOutdated ? '#FC521F' : '#F1618C';
+  const isUpgrade = lt(beforeVersion, currentCLIVersion);
+
+  const borderColor = isCLIOutdated ? '#FC521F' : '#F1618C';
 
   const messages = {
     welcome: `Upgrading Storybook from version ${chalk.bold(beforeVersion)} to version ${chalk.bold(
-      currentVersion
+      currentCLIVersion
     )}..`,
     notLatest: chalk.red(dedent`
-      This version is behind the latest release, which is: ${chalk.bold(latestVersion)}!
+      This version is behind the latest release, which is: ${chalk.bold(latestCLIVersionOnNPM)}!
       You likely ran the upgrade command through npx, which can use a locally cached version, to upgrade to the latest version please run:
       ${chalk.bold('npx storybook@latest upgrade')}
       
       You may want to CTRL+C to stop, and run with the latest version instead.
     `),
-    prelease: chalk.yellow('This is a pre-release version.'),
+    prerelease: chalk.yellow('This is a pre-release version.'),
   };
 
   logger.plain(
     boxen(
       [messages.welcome]
-        .concat(isOutdated && !isPrerelease ? [messages.notLatest] : [])
-        .concat(isPrerelease ? [messages.prelease] : [])
+        .concat(isCLIOutdated && !isCLIPrerelease ? [messages.notLatest] : [])
+        .concat(isCLIPrerelease ? [messages.prerelease] : [])
         .join('\n'),
       { borderStyle: 'round', padding: 1, borderColor }
     )
@@ -227,7 +231,7 @@ export const doUpgrade = async ({
       }) as Array<keyof typeof versions>;
       return monorepoDependencies.map((dependency) => {
         let char = '^';
-        if (isOutdated) {
+        if (isCLIOutdated) {
           char = '';
         }
         if (isCanary) {
@@ -268,9 +272,9 @@ export const doUpgrade = async ({
       configDir,
       mainConfigPath,
       beforeVersion,
-      storybookVersion: currentVersion,
-      isUpgrade: isOutdated,
-      isLatest: isExactLatest,
+      storybookVersion: currentCLIVersion,
+      isUpgrade,
+      isLatest: isCLIExactLatest,
     });
   }
 
@@ -284,7 +288,7 @@ export const doUpgrade = async ({
 
     await telemetry('upgrade', {
       beforeVersion,
-      afterVersion: currentVersion,
+      afterVersion: currentCLIVersion,
       ...automigrationTelemetry,
     });
   }


### PR DESCRIPTION
## What I did

I renamed a few variables so they are clearer in their intent.
I made `isUpgrade` it's own variable, separate from `isOutdated` which has a different meaning. (which I cleared up by renaming it).

Thanks for pairing with me on this @shilman

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
