### PR TITLE
Addon-a11y: Workaround for Vite 5.3.0 compat

### DIFF
--- a/code/addons/a11y/src/a11yRunner.ts
+++ b/code/addons/a11y/src/a11yRunner.ts
@@ -29,7 +29,7 @@ const run = async (storyId: string, input: A11yParameters = defaultParameters) =
     if (!active) {
       active = true;
       channel.emit(EVENTS.RUNNING);
-      const axe = (await import('axe-core')).default;
+      const { default: axe } = await import('axe-core');
 
       const { element = '#storybook-root', config, options = {} } = input;
       const htmlElement = document.querySelector(element as string);


### PR DESCRIPTION
Closes N/A

## What I did

Workaround for https://github.com/vitejs/vite/pull/14221/files#diff-121079017d1fa98d6a0ea3354d5c73df45ab277078228cd7384c7a4e84c5a813R340

Thanks for the suggestion @yannbf !

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a new Vite project
2. Add addon-a11y
3. `npx storybook build`

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
