### PR TITLE
Addon-interactions: Fix deprecation warnings

### DIFF
--- a/code/addons/interactions/src/components/Interaction.tsx
+++ b/code/addons/interactions/src/components/Interaction.tsx
@@ -187,7 +187,7 @@ export const Interaction = ({
               hasChrome={false}
               tooltip={<Note note={`${isCollapsed ? 'Show' : 'Hide'} interactions`} />}
             >
-              <StyledIconButton containsIcon onClick={toggleCollapsed}>
+              <StyledIconButton onClick={toggleCollapsed}>
                 <ListUnorderedIcon />
               </StyledIconButton>
             </WithTooltip>

--- a/code/addons/interactions/src/components/Subnav.tsx
+++ b/code/addons/interactions/src/components/Subnav.tsx
@@ -137,7 +137,6 @@ export const Subnav: React.FC<SubnavProps> = ({
             <WithTooltip trigger="hover" hasChrome={false} tooltip={<Note note="Go to start" />}>
               <RewindButton
                 aria-label="Go to start"
-                containsIcon
                 onClick={controls.start}
                 disabled={!controlStates.start}
               >
@@ -148,7 +147,6 @@ export const Subnav: React.FC<SubnavProps> = ({
             <WithTooltip trigger="hover" hasChrome={false} tooltip={<Note note="Go back" />}>
               <StyledIconButton
                 aria-label="Go back"
-                containsIcon
                 onClick={controls.back}
                 disabled={!controlStates.back}
               >
@@ -159,7 +157,6 @@ export const Subnav: React.FC<SubnavProps> = ({
             <WithTooltip trigger="hover" hasChrome={false} tooltip={<Note note="Go forward" />}>
               <StyledIconButton
                 aria-label="Go forward"
-                containsIcon
                 onClick={controls.next}
                 disabled={!controlStates.next}
               >
@@ -170,7 +167,6 @@ export const Subnav: React.FC<SubnavProps> = ({
             <WithTooltip trigger="hover" hasChrome={false} tooltip={<Note note="Go to end" />}>
               <StyledIconButton
                 aria-label="Go to end"
-                containsIcon
                 onClick={controls.end}
                 disabled={!controlStates.end}
               >
@@ -179,7 +175,7 @@ export const Subnav: React.FC<SubnavProps> = ({
             </WithTooltip>
 
             <WithTooltip trigger="hover" hasChrome={false} tooltip={<Note note="Rerun" />}>
-              <RerunButton aria-label="Rerun" containsIcon onClick={controls.rerun}>
+              <RerunButton aria-label="Rerun" onClick={controls.rerun}>
                 <SyncIcon />
               </RerunButton>
             </WithTooltip>


### PR DESCRIPTION
Closes #26595 

## What I did

Remove deprecated button parameters, finishing work started in https://github.com/storybookjs/storybook/pull/25822 (cc @cdedreuille )

## Checklist for Contributors

### Testing

#### Manual testing ✅ 

1. Open a sandbox & open a story that uses `addon-interactions`, such as `Header`'s `LoggedIn` story.
2. Open the `Interactions` addon panel
3. Verify that there are no deprecation warnings in the browser console

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
