### PR TITLE
CLI: Improve error message when fetching CLI version

### DIFF
--- a/code/lib/core-common/src/js-package-manager/PNPMProxy.ts
+++ b/code/lib/core-common/src/js-package-manager/PNPMProxy.ts
@@ -3,6 +3,8 @@ import dedent from 'ts-dedent';
 import { sync as findUpSync } from 'find-up';
 import path from 'path';
 import fs from 'fs';
+import { FindPackageVersionsError } from '@storybook/core-events/server-errors';
+
 import { JsPackageManager } from './JsPackageManager';
 import type { PackageJson } from './PackageJson';
 import type { InstallationMetadata, PackageMetadata } from './types';
@@ -222,22 +224,26 @@ export class PNPMProxy extends JsPackageManager {
   ): Promise<T extends true ? string[] : string> {
     const args = [fetchAllVersions ? 'versions' : 'version', '--json'];
 
-    const commandResult = await this.executeCommand({
-      command: 'pnpm',
-      args: ['info', packageName, ...args],
-    });
-
     try {
+      const commandResult = await this.executeCommand({
+        command: 'pnpm',
+        args: ['info', packageName, ...args],
+      });
+
       const parsedOutput = JSON.parse(commandResult);
 
-      if (parsedOutput.error) {
-        // FIXME: improve error handling
-        throw new Error(parsedOutput.error.summary);
-      } else {
-        return parsedOutput;
+      if (parsedOutput.error?.summary) {
+        // this will be handled in the catch block below
+        throw parsedOutput.error.summary;
       }
-    } catch (e) {
-      throw new Error(`Unable to find versions of ${packageName} using pnpm`);
+
+      return parsedOutput;
+    } catch (error) {
+      throw new FindPackageVersionsError({
+        error,
+        packageManager: 'PNPM',
+        packageName,
+      });
     }
   }
 

--- a/code/lib/core-events/src/errors/server-errors.ts
+++ b/code/lib/core-events/src/errors/server-errors.ts
@@ -604,3 +604,22 @@ export class NoStatsForViteDevError extends StorybookError {
     `;
   }
 }
+
+export class FindPackageVersionsError extends StorybookError {
+  readonly category = Category.CLI;
+
+  readonly code = 1;
+
+  constructor(
+    public data: { error: Error | unknown; packageName: string; packageManager: string }
+  ) {
+    super();
+  }
+
+  template() {
+    return dedent`
+      Unable to find versions of "${this.data.packageName}" using ${this.data.packageManager}
+      ${this.data.error && `Reason: ${this.data.error}`}
+    `;
+  }
+}


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR brings a new categorized error to the CLI on an error related to #26553 and #27236. Instead of showing the user just
```
 Unable to find versions of @storybook/cli using NPM
```

Which could happen for many different reasons:
- NPM might return a non-successful code in their API
- The package might not exist
- an NPM version has a bug
- our parsing code has a bug

Now they will get a highly described issue like so (example of outdated NPM + 404 status from npm API):
![image](https://github.com/storybookjs/storybook/assets/1671563/b7ecf2a3-8409-482b-acfb-c292bd9397ab)

or an error in our parsing code:
![image](https://github.com/storybookjs/storybook/assets/1671563/e2eb319b-0aee-4d3d-aa8f-8bd2ffe9ea4b)

Additionally the error is now categorized in telemetry.

This change is applicable to:
- storybook init
- storybook add
- storybook upgrade

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_
easiest way to test it is via storybook add:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Run `sb add non-existent-package` where sb points to the CLI binary in the monorepo

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
