### PR TITLE
Build: Fix caching issue with Verdaccio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test-results
 /bench
 .verdaccio-cache
 .next
+/.npmrc
 
 # Yarn stuff
 /**/.yarn/*

--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -12,6 +12,7 @@ import { PACKS_DIRECTORY } from './utils/constants';
 
 import { maxConcurrentTasks } from './utils/concurrency';
 import { getWorkspaces } from './utils/workspace';
+import { execa, execaSync } from 'execa';
 
 program
   .option('-O, --open', 'keep process open')
@@ -20,6 +21,8 @@ program
 program.parse(process.argv);
 
 const logger = console;
+
+const root = path.resolve(__dirname, '..');
 
 const startVerdaccio = async () => {
   let resolved = false;
@@ -108,19 +111,6 @@ const publish = async (packages: { name: string; location: string }[], url: stri
   );
 };
 
-const addUser = (url: string) =>
-  new Promise<void>((res, rej) => {
-    logger.log(`👤 add temp user to verdaccio`);
-
-    exec(`npx npm-cli-adduser -r "${url}" -a -u user -p password -e user@example.com`, (e) => {
-      if (e) {
-        rej(e);
-      } else {
-        res();
-      }
-    });
-  });
-
 const run = async () => {
   const verdaccioUrl = `http://localhost:6001`;
 
@@ -146,18 +136,23 @@ const run = async () => {
 
   logger.log(`🌿 verdaccio running on ${verdaccioUrl}`);
 
-  // in some environments you need to add a dummy user. always try to add & catch on failure
-  try {
-    await addUser(verdaccioUrl);
-  } catch (e) {
-    //
-  }
+  logger.log(`👤 add temp user to verdaccio`);
+  await execa(
+    'npx',
+    // creates a .npmrc file in the root directory of the project
+    ['npm-auth-to-token', '-u', 'foo', '-p', 's3cret', '-e', 'test@test.com', '-r', verdaccioUrl],
+    {
+      cwd: root,
+    }
+  );
 
   logger.log(`📦 found ${packages.length} storybook packages at version ${chalk.blue(version)}`);
 
   if (program.publish) {
     await publish(packages, verdaccioUrl);
   }
+
+  await execa('npx', ['rimraf', '.npmrc'], { cwd: root });
 
   if (!program.open) {
     verdaccioServer.close();
@@ -166,5 +161,6 @@ const run = async () => {
 
 run().catch((e) => {
   logger.error(e);
+  execaSync('npx', ['rimraf', '.npmrc'], { cwd: root });
   process.exit(1);
 });


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes multiple things:

- if a user does not have an access token in place globally for Verdaccio, the `npm adduser` command will fail locally and therefore new contributors cannot run Verdaccio in linked mode.
- In the above mentioned case, it seems that Verdaccio was sometimes not publishing new assets, but keeping the cache and delivering a cached version of a package. This led to issues like this: https://cloud.nx.app/runs/jjlIC4hbiD, where a dependency of `@storybook/cli` couldn't be found because Verdaccio delivered a cached package.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a sandbox in linked mode
2. Start Storybook to verify its functionality

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
