### PR TITLE
Next.js: Set `env.bugfixes` in SWC so destructuring is never transpiled

### DIFF
--- a/code/frameworks/nextjs/src/swc/next-swc-loader-patch.ts
+++ b/code/frameworks/nextjs/src/swc/next-swc-loader-patch.ts
@@ -114,6 +114,10 @@ async function loaderTransform(this: any, parentTrace: any, source?: string, inp
     // modules.
     sourceFileName: filename,
   };
+  // Transpiles the broken syntax to the closest non-broken modern syntax.
+  // E.g. it won't transpile parameter destructuring in Safari
+  // which would break how we detect if the mount context property is used in the play function.
+  programmaticOptions.env.bugfixes = true;
 
   if (!programmaticOptions.inputSourceMap) {
     delete programmaticOptions.inputSourceMap;

--- a/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
+++ b/code/lib/preview-api/src/modules/preview-web/PreviewWeb.test.ts
@@ -942,7 +942,7 @@ describe('PreviewWeb', () => {
         openBlockLoadersGate({ l: 8 });
         await waitForRender();
 
-        // Assert - renderToCanvas to be called the first time with initial args
+        // Assert - renderToCanvas to be called the first time with initial args and returned `loaded` value.
         expect(projectAnnotations.renderToCanvas).toHaveBeenCalledOnce();
         expect(projectAnnotations.renderToCanvas).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/code/lib/test/template/stories/before-each.stories.ts
+++ b/code/lib/test/template/stories/before-each.stories.ts
@@ -14,9 +14,7 @@ const meta = {
 export default meta;
 
 export const BeforeEachOrder = {
-  parameters: {
-    chromatic: { disable: true },
-  },
+  parameters: { chromatic: { disable: true } },
   beforeEach() {
     console.log('3 - [from story beforeEach]');
   },

--- a/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
+++ b/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
@@ -10,9 +10,11 @@ export default {
 // See: https://github.com/storybookjs/storybook/discussions/27389
 export const DestructureNotTranspiled = {
   async play() {
-    async function a({ b }) {
-      console.log(b);
+    async function fn({ destructured }: { destructured: unknown }) {
+      console.log(destructured);
     }
-    await expect(a.toString().replace(/\s+/g, ' ')).toContain('async function a({ b })');
+    const match = fn.toString().match(/[^(]*\(([^)]*)/);
+    const params = match?.[0];
+    await expect(params).toContain('destructured');
   },
 };

--- a/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
+++ b/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
@@ -6,14 +6,13 @@ export default {
   args: { label: 'Button' },
 };
 
-async function fn({ destructure }) {
-  console.log(destructure);
-}
-
 // We must not transpile destructuring, to make sure that we can analyze the context properties that are used in play.
 // See: https://github.com/storybookjs/storybook/discussions/27389
 export const DestructureNotTranspiled = {
   async play() {
-    await expect(fn.toString()).toBe('async function fn({ destructure }) {}');
+    async function a({ b }) {
+      console.log(b);
+    }
+    await expect(a.toString().replace(/\s+/g, ' ')).toContain('async function a({ b })');
   },
 };

--- a/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
+++ b/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
@@ -9,6 +9,7 @@ export default {
 // We must not transpile destructuring, to make sure that we can analyze the context properties that are used in play.
 // See: https://github.com/storybookjs/storybook/discussions/27389
 export const DestructureNotTranspiled = {
+  parameters: { chromatic: { disable: true } },
   async play() {
     async function fn({ destructured }: { destructured: unknown }) {
       console.log(destructured);

--- a/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
+++ b/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
@@ -1,8 +1,11 @@
 import { expect } from '@storybook/test';
+import { global as globalThis } from '@storybook/global';
 
-export default {};
+export default {
+  component: globalThis.Components.Button,
+};
 
-async function bla({ destructure }) {
+async function fn({ destructure }) {
   console.log(destructure);
 }
 
@@ -10,6 +13,6 @@ async function bla({ destructure }) {
 // See: https://github.com/storybookjs/storybook/discussions/27389
 export const DestructureNotTranspiled = {
   async play() {
-    await expect(bla.toString()).toBe('async function bla({ destructure }) {}');
+    await expect(fn.toString()).toBe('async function fn({ destructure }) {}');
   },
 };

--- a/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
+++ b/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
@@ -1,0 +1,15 @@
+import { expect } from '@storybook/test';
+
+export default {};
+
+async function bla({ destructure }) {
+  console.log(destructure);
+}
+
+// We must not transpile destructuring, to make sure that we can analyze the context properties that are used in play.
+// See: https://github.com/storybookjs/storybook/discussions/27389
+export const DestructureNotTranspiled = {
+  async play() {
+    await expect(bla.toString()).toBe('async function bla({ destructure }) {}');
+  },
+};

--- a/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
+++ b/code/lib/test/template/stories/destructuring-not-transpiled.stories.ts
@@ -3,6 +3,7 @@ import { global as globalThis } from '@storybook/global';
 
 export default {
   component: globalThis.Components.Button,
+  args: { label: 'Button' },
 };
 
 async function fn({ destructure }) {

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -205,7 +205,7 @@ function addEsbuildLoaderToStories(mainConfig: ConfigFile) {
           loader: '${esbuildLoaderPath}',
           options: {
             loader: 'tsx',
-            target: 'es2015',
+            target: 'es2022',
           },
         },
         // Handle MDX files per the addon-docs presets (ish)


### PR DESCRIPTION

## What I did

Set the env.bugfixes option in SWC by default.

env. bugfixes transpiles the broken syntax to the closest non-broken modern syntax.

E.g. it won't transpile parameter destructuring in Safari,
which would break how we detect if the mount context property is used in the play function.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
