### PR TITLE
CPC: Remove externalization of `memoizerific` and remove need for `util-deprecate`

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -300,7 +300,6 @@
     "@types/react-syntax-highlighter": "11.0.5",
     "@types/react-transition-group": "^4",
     "@types/semver": "^7.3.4",
-    "@types/util-deprecate": "^1.0.0",
     "@types/ws": "^8",
     "@vitest/utils": "^1.3.1",
     "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.10",
@@ -384,7 +383,6 @@
     "unique-string": "^3.0.0",
     "use-resize-observer": "^9.1.0",
     "util": "^0.12.4",
-    "util-deprecate": "^1.0.2",
     "watchpack": "^2.2.0"
   },
   "publishConfig": {

--- a/code/core/scripts/entries.ts
+++ b/code/core/scripts/entries.ts
@@ -33,8 +33,6 @@ export const getEntries = (cwd: string) => {
       'react-dom',
       '@storybook/csf',
       '@storybook/global',
-      'memoizerific',
-      'util-deprecate',
     ]),
     define('src/theming/index.ts', ['browser', 'node'], true, ['react']),
     define('src/theming/create.ts', ['browser', 'node'], true, ['react']),

--- a/code/core/src/preview-api/modules/store/csf/normalizeStory.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeStory.test.ts
@@ -3,6 +3,8 @@ import type { Renderer, StoryAnnotationsOrFn } from '@storybook/core/types';
 
 import { normalizeStory } from './normalizeStory';
 
+vi.mock('@storybook/core/client-logger');
+
 describe('normalizeStory', () => {
   describe('id generation', () => {
     it('respects component id', () => {

--- a/code/core/src/preview-api/modules/store/csf/normalizeStory.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeStory.ts
@@ -8,8 +8,7 @@ import type {
 } from '@storybook/core/types';
 import { storyNameFromExport, toId } from '@storybook/csf';
 import { dedent } from 'ts-dedent';
-import { logger } from '@storybook/core/client-logger';
-import deprecate from 'util-deprecate';
+import { logger, deprecate } from '@storybook/core/client-logger';
 import { normalizeInputTypes } from './normalizeInputTypes';
 import { normalizeArrays } from './normalizeArrays';
 import type {
@@ -24,8 +23,6 @@ CSF .story annotations deprecated; annotate story functions directly:
 See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#hoisted-csf-annotations for details and codemod.
 `;
 
-const deprecatedStoryAnnotationWarning = deprecate(() => {}, deprecatedStoryAnnotation);
-
 export function normalizeStory<TRenderer extends Renderer>(
   key: StoryId,
   storyAnnotations: LegacyStoryAnnotationsOrFn<TRenderer>,
@@ -38,7 +35,7 @@ export function normalizeStory<TRenderer extends Renderer>(
   const { story } = storyObject;
   if (story) {
     logger.debug('deprecated story', story);
-    deprecatedStoryAnnotationWarning();
+    deprecate(deprecatedStoryAnnotation);
   }
 
   const exportName = storyNameFromExport(key);

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5764,7 +5764,6 @@ __metadata:
     "@types/react-syntax-highlighter": "npm:11.0.5"
     "@types/react-transition-group": "npm:^4"
     "@types/semver": "npm:^7.3.4"
-    "@types/util-deprecate": "npm:^1.0.0"
     "@types/ws": "npm:^8"
     "@vitest/utils": "npm:^1.3.1"
     "@yarnpkg/esbuild-plugin-pnp": "npm:^3.0.0-rc.10"
@@ -5852,7 +5851,6 @@ __metadata:
     unique-string: "npm:^3.0.0"
     use-resize-observer: "npm:^9.1.0"
     util: "npm:^0.12.4"
-    util-deprecate: "npm:^1.0.2"
     watchpack: "npm:^2.2.0"
     ws: "npm:^8.2.3"
   languageName: unknown


### PR DESCRIPTION
## What I did

- I no longer externalize `memoizerific` in `component`
- I've removed the need to have `util-deprecate` and thus removed it as a dependency.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28410-sha-1e4b8fe0`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28410-sha-1e4b8fe0 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28410-sha-1e4b8fe0 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28410-sha-1e4b8fe0`](https://npmjs.com/package/storybook/v/0.0.0-pr-28410-sha-1e4b8fe0) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/cpc-followup`](https://github.com/storybookjs/storybook/tree/norbert/cpc-followup) |
| **Commit** | [`1e4b8fe0`](https://github.com/storybookjs/storybook/commit/1e4b8fe0482e925453084c02cff8cc4774bcf4f2) |
| **Datetime** | Mon Jul  1 12:51:55 UTC 2024 (`1719838315`) |
| **Workflow run** | [9744567016](https://github.com/storybookjs/storybook/actions/runs/9744567016) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28410`_
</details>
<!-- CANARY_RELEASE_SECTION -->
