### PR TITLE
CPC: Add `CJS` for `core/components`

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -119,7 +119,8 @@
     },
     "./components": {
       "types": "./dist/components/index.d.ts",
-      "import": "./dist/components/index.js"
+      "import": "./dist/components/index.js",
+      "require": "./dist/components/index.cjs"
     },
     "./theming": {
       "types": "./dist/theming/index.d.ts",

--- a/code/core/scripts/entries.ts
+++ b/code/core/scripts/entries.ts
@@ -28,7 +28,7 @@ export const getEntries = (cwd: string) => {
     define('src/preview-api/index.ts', ['browser', 'node'], true),
     define('src/manager-api/index.ts', ['browser', 'node'], true, ['react']),
     define('src/router/index.ts', ['browser', 'node'], true, ['react']),
-    define('src/components/index.ts', ['browser'], true, [
+    define('src/components/index.ts', ['browser', 'node'], true, [
       'react',
       'react-dom',
       '@storybook/csf',

--- a/code/lib/cli/core/components/index.cjs
+++ b/code/lib/cli/core/components/index.cjs
@@ -1,0 +1,1 @@
+module.exports = require('@storybook/core/components');

--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -140,7 +140,8 @@
     },
     "./internal/components": {
       "types": "./core/components/index.d.ts",
-      "import": "./core/components/index.js"
+      "import": "./core/components/index.js",
+      "require": "./core/components/index.cjs"
     },
     "./internal/theming": {
       "types": "./core/theming/index.d.ts",


### PR DESCRIPTION
## What I did

I added back the `CJS` output for `core/components`.

This package should never be used by node, but portable stories sometimes loads annotation files referencing blocks, which then includes components :(

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
