### PR TITLE
Vue3: Fix OOM issue in docgen handling

### DIFF
--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -2,6 +2,7 @@ import findPackageJson from 'find-package-json';
 import fs from 'fs/promises';
 import MagicString from 'magic-string';
 import path from 'path';
+import ts from 'typescript';
 import type { PluginOption } from 'vite';
 import {
   TypeMeta,
@@ -133,6 +134,20 @@ async function createVueComponentMetaChecker(tsconfigPath = 'tsconfig.json') {
   const checkerOptions: MetaCheckerOptions = {
     forceUseTs: true,
     noDeclarations: true,
+    schema: {
+      ignore: [
+        (name, type, typeChecker) => {
+          // Omit all schemas whose declaration paths are in node_modules and are objects.
+          const isInNodeModules = type
+            .getSymbol()
+            ?.getDeclarations()
+            ?.some((declaration) => declaration.getSourceFile().fileName.includes('node_modules'));
+          const isObject = type.getFlags() === ts.TypeFlags.Object;
+
+          return isInNodeModules && isObject;
+        },
+      ],
+    },
     printer: { newLine: 1 },
   };
 


### PR DESCRIPTION
Closes #26647 
Closes #26935

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

I fixed an Out of Memory (OOM) issue in the Vue3-Vite setup, specifically related to the vue-component-meta plugin. The root cause of the problem was that vue-component-meta was including too much unnecessary meta information when encountering native types (lib.dom.ts), which Storybook doesn't require.
To resolve this, I utilized the ignore option in vue-component-meta. The solution identifies meta information in node_modules with object types and ignores them, effectively addressing the OOM issue.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

Due to some issues encountered in setting up the Storybook development environment, I've created an MVP project to demonstrate the problem and solution. To test these changes:

1. Visit the MVP project at: https://stackblitz.com/edit/stackblitz-starters-nqxfag
2. Run `pnpm tsx script/gen-meta.ts HelloWorld` to generate meta information for `HelloWorld.vue`.
3. Observe the generated meta information and verify that unnecessary object types from `node_modules` are excluded.
4. To reproduce the original issue, try commenting out parts of Props or Events, or the ignore function in `gen-meta.ts`.
5. Compare the results to see how the solution prevents the OOM issue while maintaining necessary meta information.

Note: If there's a strong need for automated tests in the Storybook repository itself, please let me know, and I'll work on implementing them. Given the complexity of the Storybook setup, it might take some additional time to create a proper testing environment.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

### Additional Notes
This solution assumes that for typical project requirements, external type information is not necessary. Developers can refer to the documentation of the packages they're using for relevant definitions.

For Storybook specifically, Object type schemas don't significantly contribute to generating better argsTypes. Therefore, ignoring them seems to be a suitable approach that balances functionality and performance.

While the MVP project demonstrates the fix, it's important to note that integrating this solution into the main Storybook repository may require additional considerations and testing. If the core team feels that more comprehensive testing within the Storybook environment is necessary, I'm open to working on that to ensure the solution is robust across different scenarios.
