### PR TITLE
Next.js: Fix include and exclude in Babel config

### DIFF
--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -59,7 +59,7 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = (
 export const babel: PresetProperty<'babel'> = async (baseConfig: TransformOptions) => {
   const configPartial = loadPartialConfig({
     ...baseConfig,
-    filename: `${getProjectRoot()}/__fake__.js`,
+    filename: baseConfig.filename || `${getProjectRoot()}/__fake__.js`,
   });
 
   const options = configPartial?.options;


### PR DESCRIPTION
### Description

This PR addresses the issue where conditional Babel config such as `include` and `exclude` is ignored in Storybook's Next.js preset. 

**Issue:** #28467 

### Changes Made
- Updated `preset.ts` to use the original filename from `baseConfig` instead of a fake one, ensuring that `include` and `exclude` conditions are respected.

### Reproduction Steps
1. Open the button story.
2. Check the console to verify that async/await is not transpiled when babel-env is set to modern.

### References
- Issue report: [#28467](https://github.com/storybookjs/storybook/issues/28467)
- Related code: `/code/frameworks/nextjs/src/preset.ts`

### Testing
- Verified the fix locally by following the reproduction steps.
