### PR TITLE
Addon Onboarding: Trigger onboarding during init for Vue and Angular projects

### DIFF
--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -427,12 +427,16 @@ export async function initiate(options: CommandOptions): Promise<void> {
     logger.log('\nRunning Storybook');
 
     try {
-      const isReactWebProject =
-        projectType === ProjectType.REACT_SCRIPTS ||
-        projectType === ProjectType.REACT ||
-        projectType === ProjectType.WEBPACK_REACT ||
-        projectType === ProjectType.REACT_PROJECT ||
-        projectType === ProjectType.NEXTJS;
+      const supportsOnboarding = [
+        ProjectType.REACT_SCRIPTS,
+        ProjectType.REACT,
+        ProjectType.WEBPACK_REACT,
+        ProjectType.REACT_PROJECT,
+        ProjectType.NEXTJS,
+        ProjectType.VUE3,
+        ProjectType.NUXT,
+        ProjectType.ANGULAR,
+      ].includes(projectType);
 
       const flags = [];
 
@@ -442,7 +446,7 @@ export async function initiate(options: CommandOptions): Promise<void> {
         flags.push('--');
       }
 
-      if (isReactWebProject) {
+      if (supportsOnboarding) {
         flags.push('--initial-path=/onboarding');
       }
 

--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -434,7 +434,6 @@ export async function initiate(options: CommandOptions): Promise<void> {
         ProjectType.REACT_PROJECT,
         ProjectType.NEXTJS,
         ProjectType.VUE3,
-        ProjectType.NUXT,
         ProjectType.ANGULAR,
       ].includes(projectType);
 


### PR DESCRIPTION
## What I did

Makes `storybook init` start the onboarding flow for Vue3, Nuxt and Angular projects.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
