### PR TITLE
CPC: Fix type generation

### DIFF
--- a/scripts/prepare/addon-bundle.ts
+++ b/scripts/prepare/addon-bundle.ts
@@ -10,6 +10,7 @@ import { exec } from '../utils/exec';
 
 import { globalPackages as globalPreviewPackages } from '../../code/core/src/preview/globals/globals';
 import { globalPackages as globalManagerPackages } from '../../code/core/src/manager/globals/globals';
+import { glob } from 'glob';
 
 /* TYPES */
 
@@ -62,8 +63,9 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
 
   const tasks: Promise<any>[] = [];
 
+  const outDir = join(process.cwd(), 'dist');
   const commonOptions: Options = {
-    outDir: join(process.cwd(), 'dist'),
+    outDir,
     silent: true,
     treeshake: true,
     shims: false,
@@ -189,6 +191,17 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
   }
 
   await Promise.all(tasks);
+
+  const dtsFiles = await glob(outDir + '/**/*.d.ts');
+  await Promise.all(
+    dtsFiles.map(async (file) => {
+      const content = await fs.readFile(file, 'utf-8');
+      await fs.writeFile(
+        file,
+        content.replace(/from \'core\/dist\/(.*)\'/, `from 'storybook/internal/$1'`)
+      );
+    })
+  );
 
   if (post) {
     await exec(`bun ${post}`, { cwd }, { debug: true });

--- a/scripts/prepare/addon-bundle.ts
+++ b/scripts/prepare/addon-bundle.ts
@@ -198,7 +198,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
       const content = await fs.readFile(file, 'utf-8');
       await fs.writeFile(
         file,
-        content.replace(/from \'core\/dist\/(.*)\'/, `from 'storybook/internal/$1'`)
+        content.replace(/from \'core\/dist\/(.*)\'/g, `from 'storybook/internal/$1'`)
       );
     })
   );

--- a/scripts/prepare/bundle.ts
+++ b/scripts/prepare/bundle.ts
@@ -7,6 +7,7 @@ import aliasPlugin from 'esbuild-plugin-alias';
 import { dedent } from 'ts-dedent';
 import slash from 'slash';
 import { exec } from '../utils/exec';
+import { glob } from 'glob';
 
 /* TYPES */
 
@@ -146,6 +147,17 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
   }
 
   await Promise.all(tasks);
+
+  const dtsFiles = await glob(outDir + '/**/*.d.ts');
+  await Promise.all(
+    dtsFiles.map(async (file) => {
+      const content = await fs.readFile(file, 'utf-8');
+      await fs.writeFile(
+        file,
+        content.replace(/from \'core\/dist\/(.*)\'/, `from 'storybook/internal/$1'`)
+      );
+    })
+  );
 
   if (post) {
     await exec(`bun ${post}`, { cwd }, { debug: true });

--- a/scripts/prepare/bundle.ts
+++ b/scripts/prepare/bundle.ts
@@ -154,7 +154,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
       const content = await fs.readFile(file, 'utf-8');
       await fs.writeFile(
         file,
-        content.replace(/from \'core\/dist\/(.*)\'/, `from 'storybook/internal/$1'`)
+        content.replace(/from \'core\/dist\/(.*)\'/g, `from 'storybook/internal/$1'`)
       );
     })
   );


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28500

## What I did

I ensured the problematic `.d.ts` output import paths no longer happen, by searching for the broken pattern and replacing it with the correct path, in the script generating these files.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
