### PR TITLE
Core: Upgrade docs-mdx for smaller install

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -277,7 +277,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
-    "@storybook/docs-mdx": "4.0.0--canary.19.48b6c75.0",
+    "@storybook/docs-mdx": "4.0.0--canary.19.f920eba.0",
     "@storybook/global": "^5.0.0",
     "@storybook/icons": "^1.2.5",
     "@tanstack/react-virtual": "^3.3.0",

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -277,7 +277,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
-    "@storybook/docs-mdx": "4.0.0--canary.19.f920eba.0",
+    "@storybook/docs-mdx": "4.0.0-next.0",
     "@storybook/global": "^5.0.0",
     "@storybook/icons": "^1.2.5",
     "@tanstack/react-virtual": "^3.3.0",

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -277,7 +277,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
-    "@storybook/docs-mdx": "3.1.0-next.0",
+    "@storybook/docs-mdx": "4.0.0--canary.19.48b6c75.0",
     "@storybook/global": "^5.0.0",
     "@storybook/icons": "^1.2.5",
     "@tanstack/react-virtual": "^3.3.0",

--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -23,7 +23,6 @@ import { commonGlobOptions, normalizeStoryPath } from '@storybook/core/common';
 import { logger, once } from '@storybook/core/node-logger';
 import { getStorySortParameter, loadConfig } from '@storybook/core/csf-tools';
 import { storyNameFromExport, toId, combineTags } from '@storybook/csf';
-import { analyze } from '@storybook/docs-mdx';
 import { dedent } from 'ts-dedent';
 import { autoName } from './autoName';
 import { IndexingError, MultipleIndexingError } from './IndexingError';
@@ -408,7 +407,8 @@ export class StoryIndexGenerator {
 
       const content = await fs.readFile(absolutePath, 'utf8');
 
-      const result = analyze(content);
+      const { analyze } = await import('@storybook/docs-mdx');
+      const result = await analyze(content);
 
       // Templates are not indexed
       if (result.isTemplate) return false;

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5758,7 +5758,7 @@ __metadata:
     "@radix-ui/react-scroll-area": "npm:^1.0.5"
     "@radix-ui/react-slot": "npm:^1.0.2"
     "@storybook/csf": "npm:0.1.11"
-    "@storybook/docs-mdx": "npm:3.1.0-next.0"
+    "@storybook/docs-mdx": "npm:4.0.0--canary.19.48b6c75.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.2.5"
     "@tanstack/react-virtual": "npm:^3.3.0"
@@ -5911,10 +5911,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/docs-mdx@npm:3.1.0-next.0":
-  version: 3.1.0-next.0
-  resolution: "@storybook/docs-mdx@npm:3.1.0-next.0"
-  checksum: 10c0/7622d7c6318e842c90a71c1836d68531236c31fff7081c885803eddfafb7e3f8998689f612eaa0292209ada8352a36657dcacb5d3ef4632b8e8b8a283c39602e
+"@storybook/docs-mdx@npm:4.0.0--canary.19.48b6c75.0":
+  version: 4.0.0--canary.19.48b6c75.0
+  resolution: "@storybook/docs-mdx@npm:4.0.0--canary.19.48b6c75.0"
+  dependencies:
+    acorn: "npm:^8.12.1"
+  checksum: 10c0/6229aea30fbe02b46162de9ad0871ded4a0a37d92823e379a17b657d06fb6f694d20e79ca7b107dc0c19b0a586059133482248aa2ea6f27ce14f59c076f1853b
   languageName: node
   linkType: hard
 
@@ -9241,7 +9243,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.0, acorn@npm:^8.10.0, acorn@npm:^8.11.2, acorn@npm:^8.11.3, acorn@npm:^8.4.1, acorn@npm:^8.6.0, acorn@npm:^8.7.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
+"acorn@npm:^8.0.0, acorn@npm:^8.10.0, acorn@npm:^8.11.2, acorn@npm:^8.11.3, acorn@npm:^8.12.1, acorn@npm:^8.4.1, acorn@npm:^8.6.0, acorn@npm:^8.7.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
   version: 8.12.1
   resolution: "acorn@npm:8.12.1"
   bin:

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5758,7 +5758,7 @@ __metadata:
     "@radix-ui/react-scroll-area": "npm:^1.0.5"
     "@radix-ui/react-slot": "npm:^1.0.2"
     "@storybook/csf": "npm:0.1.11"
-    "@storybook/docs-mdx": "npm:4.0.0--canary.19.f920eba.0"
+    "@storybook/docs-mdx": "npm:4.0.0-next.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.2.5"
     "@tanstack/react-virtual": "npm:^3.3.0"
@@ -5911,12 +5911,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/docs-mdx@npm:4.0.0--canary.19.f920eba.0":
-  version: 4.0.0--canary.19.f920eba.0
-  resolution: "@storybook/docs-mdx@npm:4.0.0--canary.19.f920eba.0"
+"@storybook/docs-mdx@npm:4.0.0-next.0":
+  version: 4.0.0-next.0
+  resolution: "@storybook/docs-mdx@npm:4.0.0-next.0"
   dependencies:
     acorn: "npm:^8.12.1"
-  checksum: 10c0/b25c8bb5651932d5e883c8c5441d94d33e528b84ebe35ae565abfda0804eafd635f9f6c90b8c52cd0fe3473b458cb77acceb63d7b87e10dc6a36d47b508b753f
+  checksum: 10c0/6253361e4e3c6c716c4f4c8cc30c082bcdab66b35b30183f6574d94720d875e28927916be8bda0bff4987090c3e50d348ca898160b1812a90c5afa845400414e
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5758,7 +5758,7 @@ __metadata:
     "@radix-ui/react-scroll-area": "npm:^1.0.5"
     "@radix-ui/react-slot": "npm:^1.0.2"
     "@storybook/csf": "npm:0.1.11"
-    "@storybook/docs-mdx": "npm:4.0.0--canary.19.48b6c75.0"
+    "@storybook/docs-mdx": "npm:4.0.0--canary.19.f920eba.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.2.5"
     "@tanstack/react-virtual": "npm:^3.3.0"
@@ -5911,12 +5911,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/docs-mdx@npm:4.0.0--canary.19.48b6c75.0":
-  version: 4.0.0--canary.19.48b6c75.0
-  resolution: "@storybook/docs-mdx@npm:4.0.0--canary.19.48b6c75.0"
+"@storybook/docs-mdx@npm:4.0.0--canary.19.f920eba.0":
+  version: 4.0.0--canary.19.f920eba.0
+  resolution: "@storybook/docs-mdx@npm:4.0.0--canary.19.f920eba.0"
   dependencies:
     acorn: "npm:^8.12.1"
-  checksum: 10c0/6229aea30fbe02b46162de9ad0871ded4a0a37d92823e379a17b657d06fb6f694d20e79ca7b107dc0c19b0a586059133482248aa2ea6f27ce14f59c076f1853b
+  checksum: 10c0/b25c8bb5651932d5e883c8c5441d94d33e528b84ebe35ae565abfda0804eafd635f9f6c90b8c52cd0fe3473b458cb77acceb63d7b87e10dc6a36d47b508b753f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes N/A

## What I did

Upgrade `@storybook/docs-mdx` to an ESM-only version that no longer uses babel and runs asynchronously

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Fire up a sandbox and checks the docs/mdx stories

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28552-sha-be84deb3`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28552-sha-be84deb3 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28552-sha-be84deb3 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28552-sha-be84deb3`](https://npmjs.com/package/storybook/v/0.0.0-pr-28552-sha-be84deb3) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/optimize-docs-mdx`](https://github.com/storybookjs/storybook/tree/shilman/optimize-docs-mdx) |
| **Commit** | [`be84deb3`](https://github.com/storybookjs/storybook/commit/be84deb3d77d177b0db65442e6830ffd54e52b84) |
| **Datetime** | Thu Jul 11 16:28:00 UTC 2024 (`1720715280`) |
| **Workflow run** | [9895111271](https://github.com/storybookjs/storybook/actions/runs/9895111271) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28552`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | % |
| ---- | ------ | ----- | ---- | - |
| createTime |  18.5s | 19.2s | 692ms | 3.6% |
| generateTime |  21.7s | 21.6s | -85ms | -0.4% |
| initTime |  24s | 22.9s | -1s -17ms | -4.4% |
| createSize |  0 B | 0 B | 0 B | - |
| generateSize |  76.5 MB | 76.5 MB | 104 B | 0% |
| initSize |  205 MB | 198 MB | -6.42 MB | -3.2% |
| diffSize |  128 MB | 122 MB | -6.42 MB | 🔰-5.3% |
| buildTime |  14.5s | 14s | -523ms | -3.7% |
| buildSize |  7.59 MB | 7.59 MB | 0 B | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0% |
| testBuildTime |  0ms | 0ms | 0ms | - |
| testBuildSize |  0 B | 0 B | 0 B | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - |
| devPreviewResponsive |  8.4s | 8.3s | -10ms | -0.1% |
| devManagerResponsive |  6s | 5.8s | -248ms | -4.2% |
| devManagerHeaderVisible |  744ms | 830ms | 86ms | 🔺10.4% |
| devManagerIndexVisible |  775ms | 867ms | 92ms | 🔺10.6% |
| devStoryVisibleUncached |  1.4s | 1.1s | -326ms | 🔰-27.9% |
| devStoryVisible |  795ms | 901ms | 106ms | 🔺11.8% |
| devAutodocsVisible |  678ms | 852ms | 174ms | 🔺20.4% |
| devMDXVisible |  699ms | 760ms | 61ms | 🔺8% |
| buildManagerHeaderVisible |  736ms | 853ms | 117ms | 🔺13.7% |
| buildManagerIndexVisible |  739ms | 856ms | 117ms | 🔺13.7% |
| buildStoryVisible |  789ms | 906ms | 117ms | 🔺12.9% |
| buildAutodocsVisible |  644ms | 699ms | 55ms | 🔺7.9% |
| buildMDXVisible |  637ms | 754ms | 117ms | 🔺15.5% |

<!-- BENCHMARK_SECTION -->