### PR TITLE
Allow custom argType sorting

### DIFF
--- a/code/addons/controls/src/ControlsPanel.tsx
+++ b/code/addons/controls/src/ControlsPanel.tsx
@@ -8,7 +8,12 @@ import {
   useParameter,
   useStorybookState,
 } from 'storybook/internal/manager-api';
-import { PureArgsTable as ArgsTable, type PresetColor, type SortType } from '@storybook/blocks';
+import {
+  PureArgsTable as ArgsTable,
+  type PresetColor,
+  type SortFn,
+  type SortType,
+} from '@storybook/blocks';
 import { styled } from 'storybook/internal/theming';
 import type { ArgTypes } from 'storybook/internal/types';
 
@@ -31,7 +36,7 @@ const AddonWrapper = styled.div({
 });
 
 interface ControlsParameters {
-  sort?: SortType;
+  sort?: SortType | SortFn;
   expanded?: boolean;
   presetColors?: PresetColor[];
 }

--- a/code/addons/controls/template/stories/sorting.stories.ts
+++ b/code/addons/controls/template/stories/sorting.stories.ts
@@ -31,3 +31,14 @@ export const None = { parameters: { controls: { sort: 'none' } } };
 export const Alpha = { parameters: { controls: { sort: 'alpha' } } };
 
 export const RequiredFirst = { parameters: { controls: { sort: 'requiredFirst' } } };
+
+export const CustomSort = {
+  parameters: {
+    controls: {
+      sort: (a, b) =>
+        a.table?.category?.localeCompare(b.table?.category) ||
+        (a.type?.required === b.type?.required ? 0 : a.type?.required ? 1 : -1) ||
+        0,
+    },
+  },
+};

--- a/code/lib/blocks/src/blocks/ArgTypes.tsx
+++ b/code/lib/blocks/src/blocks/ArgTypes.tsx
@@ -7,7 +7,7 @@ import { filterArgTypes } from 'storybook/internal/preview-api';
 import type { ArgTypesExtractor } from 'storybook/internal/docs-tools';
 import React from 'react';
 
-import type { SortType } from '../components';
+import type { SortFn, SortType } from '../components';
 import { ArgsTable as PureArgsTable, ArgsTableError, TabbedArgsTable } from '../components';
 import { useOf } from './useOf';
 import { getComponentName } from './utils';
@@ -15,7 +15,7 @@ import { getComponentName } from './utils';
 type ArgTypesParameters = {
   include?: PropDescriptor;
   exclude?: PropDescriptor;
-  sort?: SortType;
+  sort?: SortType | SortFn;
 };
 
 type ArgTypesProps = ArgTypesParameters & {

--- a/code/lib/blocks/src/blocks/Controls.tsx
+++ b/code/lib/blocks/src/blocks/Controls.tsx
@@ -7,7 +7,7 @@ import { filterArgTypes } from 'storybook/internal/preview-api';
 import type { PropDescriptor } from 'storybook/internal/preview-api';
 import type { ArgTypesExtractor } from 'storybook/internal/docs-tools';
 
-import type { SortType } from '../components';
+import type { SortFn, SortType } from '../components';
 import { ArgsTable as PureArgsTable, ArgsTableError, TabbedArgsTable } from '../components';
 import { DocsContext } from './DocsContext';
 import { useGlobals } from './useGlobals';
@@ -17,7 +17,7 @@ import { getComponentName } from './utils';
 type ControlsParameters = {
   include?: PropDescriptor;
   exclude?: PropDescriptor;
-  sort?: SortType;
+  sort?: SortType | SortFn;
 };
 
 type ControlsProps = ControlsParameters & {

--- a/code/lib/blocks/src/components/ArgsTable/ArgsTable.tsx
+++ b/code/lib/blocks/src/components/ArgsTable/ArgsTable.tsx
@@ -180,7 +180,7 @@ export enum ArgsTableError {
 }
 
 export type SortType = 'alpha' | 'requiredFirst' | 'none';
-type SortFn = (a: ArgType, b: ArgType) => number;
+export type SortFn = (a: ArgType, b: ArgType) => number;
 
 const sortFns: Record<SortType, SortFn | null> = {
   alpha: (a: ArgType, b: ArgType) => a.name.localeCompare(b.name),
@@ -197,7 +197,7 @@ export interface ArgsTableOptionProps {
   inAddonPanel?: boolean;
   initialExpandedArgs?: boolean;
   isLoading?: boolean;
-  sort?: SortType;
+  sort?: SortType | SortFn;
 }
 interface ArgsTableDataProps {
   rows: ArgTypes;
@@ -228,7 +228,7 @@ type Sections = {
   sections: Record<string, Section>;
 };
 
-const groupRows = (rows: ArgType, sort: SortType) => {
+const groupRows = (rows: ArgType, sort: SortType | SortFn) => {
   const sections: Sections = { ungrouped: [], ungroupedSubsections: {}, sections: {} };
   if (!rows) return sections;
 
@@ -254,7 +254,7 @@ const groupRows = (rows: ArgType, sort: SortType) => {
   });
 
   // apply sort
-  const sortFn = sortFns[sort];
+  const sortFn = typeof sort === 'function' ? sort : sortFns[sort];
 
   const sortSubsection = (record: Record<string, Subsection>) => {
     if (!sortFn) return record;

--- a/code/lib/blocks/src/examples/ArgTypesParameters.stories.tsx
+++ b/code/lib/blocks/src/examples/ArgTypesParameters.stories.tsx
@@ -49,6 +49,20 @@ export const Sort: Story = {
   parameters: { docs: { argTypes: { sort: 'alpha' } } },
 };
 
+export const SortCustom: Story = {
+  ...NoParameters,
+  parameters: {
+    docs: {
+      argTypes: {
+        sort: (a, b) =>
+          a.table?.category?.localeCompare(b.table?.category) ||
+          (a.type?.required === b.type?.required ? 0 : a.type?.required ? 1 : -1) ||
+          0,
+      },
+    },
+  },
+};
+
 export const Categories: Story = {
   ...NoParameters,
   argTypes: {

--- a/code/lib/blocks/src/examples/ControlsParameters.stories.tsx
+++ b/code/lib/blocks/src/examples/ControlsParameters.stories.tsx
@@ -49,6 +49,20 @@ export const Sort: Story = {
   parameters: { docs: { controls: { sort: 'alpha' } } },
 };
 
+export const SortCustom: Story = {
+  ...NoParameters,
+  parameters: {
+    docs: {
+      controls: {
+        sort: (a, b) =>
+          a.table?.category?.localeCompare(b.table?.category) ||
+          (a.type?.required === b.type?.required ? 0 : a.type?.required ? 1 : -1) ||
+          0,
+      },
+    },
+  },
+};
+
 export const Categories: Story = {
   ...NoParameters,
   argTypes: {

--- a/code/lib/blocks/src/index.ts
+++ b/code/lib/blocks/src/index.ts
@@ -1,7 +1,7 @@
 // FIXME: sort this out, maybe with package.json exports map
 // https://medium.com/swlh/npm-new-package-json-exports-field-1a7d1f489ccf
 export { ArgsTable as PureArgsTable } from './components';
-export type { SortType } from './components';
+export type { SortFn, SortType } from './components';
 
 export * from './blocks';
 export * from './controls';

--- a/docs/api/doc-blocks/doc-block-argtypes.mdx
+++ b/docs/api/doc-blocks/doc-block-argtypes.mdx
@@ -86,7 +86,7 @@ Specifies which story to get the arg types from. If a CSF file exports is provid
 
 ### `sort`
 
-Type: `'none' | 'alpha' | 'requiredFirst'`
+Type: `'none' | 'alpha' | 'requiredFirst' | SortFn`
 
 Default: `parameters.docs.argTypes.sort` or `'none'`
 
@@ -95,3 +95,4 @@ Specifies how the arg types are sorted.
 * **none**: Unsorted, displayed in the same order the arg types are processed in
 * **alpha**: Sorted alphabetically, by the arg type's name
 * **requiredFirst**: Same as `alpha`, with any required arg types displayed first
+* **SortFn**: A callback to define your own sorting logic

--- a/docs/api/doc-blocks/doc-block-controls.mdx
+++ b/docs/api/doc-blocks/doc-block-controls.mdx
@@ -100,7 +100,7 @@ Specifies which story to get the controls from. If a CSF file exports is provide
 
 ### `sort`
 
-Type: `'none' | 'alpha' | 'requiredFirst'`
+Type: `'none' | 'alpha' | 'requiredFirst' | SortFn`
 
 Default: `parameters.docs.controls.sort` or `'none'`
 
@@ -109,3 +109,4 @@ Specifies how the controls are sorted.
 * **none**: Unsorted, displayed in the same order the controls are processed in
 * **alpha**: Sorted alphabetically, by the arg type's name
 * **requiredFirst**: Same as `alpha`, with any required controls displayed first
+* **SortFn**: A callback to define your own sorting logic

--- a/docs/essentials/controls.mdx
+++ b/docs/essentials/controls.mdx
@@ -475,7 +475,7 @@ Specify preset color swatches for the color picker control. The color value may 
 
 #### `sort`
 
-Type: `'none' | 'alpha' | 'requiredFirst'`
+Type: `'none' | 'alpha' | 'requiredFirst' | SortFn`
 
 Default: `'none'`
 
@@ -484,3 +484,4 @@ Specifies how the controls are sorted.
 * **none**: Unsorted, displayed in the same order the arg types are processed in
 * **alpha**: Sorted alphabetically, by the arg type's name
 * **requiredFirst**: Same as `alpha`, with any required arg types displayed first
+* **SortFn**: A callback to define your own sorting logic


### PR DESCRIPTION
closes #27520, closes #24524, related-to #25386

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Allow custom sorting of `argTypes` via a function callback

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

TODO

#### Manual testing

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

TODO

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes

TODO

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->