### PR TITLE
CPC: Fix incorrect re-export in `core-events`

### DIFF
--- a/code/deprecated/core-events/shim.js
+++ b/code/deprecated/core-events/shim.js
@@ -1,1 +1,1 @@
-module.exports = require('storybook/internal/core-errors');
+module.exports = require('storybook/internal/core-events');


### PR DESCRIPTION
## What I did

There was an incorrect re-export in `core-events`

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | % |
| ---- | ------ | ----- | ---- | - |
| createTime |  8s | 22.8s | 14.8s | 🔺64.8% |
| generateTime |  22.7s | 23.7s | 1s | 4.3% |
| initTime |  21.2s | 26.4s | 5.1s | 🔺19.5% |
| createSize |  0 B | 0 B | 0 B | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 0% |
| initSize |  198 MB | 198 MB | 0 B | 0% |
| diffSize |  122 MB | 122 MB | 0 B | 0% |
| buildTime |  15.9s | 12.2s | -3s -716ms | 🔰-30.3% |
| buildSize |  7.59 MB | 7.59 MB | 0 B | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0% |
| testBuildTime |  0ms | 0ms | 0ms | - |
| testBuildSize |  0 B | 0 B | 0 B | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - |
| devPreviewResponsive |  9.5s | 8.5s | -998ms | 🔰-11.7% |
| devManagerResponsive |  6.1s | 5.7s | -442ms | 🔰-7.7% |
| devManagerHeaderVisible |  898ms | 772ms | -126ms | 🔰-16.3% |
| devManagerIndexVisible |  928ms | 799ms | -129ms | 🔰-16.1% |
| devStoryVisibleUncached |  1.3s | 1.1s | -160ms | 🔰-13.4% |
| devStoryVisible |  955ms | 815ms | -140ms | 🔰-17.2% |
| devAutodocsVisible |  784ms | 827ms | 43ms | 🔺5.2% |
| devMDXVisible |  812ms | 728ms | -84ms | 🔰-11.5% |
| buildManagerHeaderVisible |  845ms | 885ms | 40ms | 4.5% |
| buildManagerIndexVisible |  902ms | 893ms | -9ms | -1% |
| buildStoryVisible |  915ms | 956ms | 41ms | 4.3% |
| buildAutodocsVisible |  823ms | 755ms | -68ms | 🔰-9% |
| buildMDXVisible |  757ms | 678ms | -79ms | 🔰-11.7% |

<!-- BENCHMARK_SECTION -->