### PR TITLE
CPC: Fix Vite builder had wrong conditions

### DIFF
--- a/code/builders/builder-vite/src/vite-config.ts
+++ b/code/builders/builder-vite/src/vite-config.ts
@@ -65,7 +65,7 @@ export async function commonConfig(
     base: './',
     plugins: await pluginConfig(options),
     resolve: {
-      conditions: ['storybook', 'stories', 'test', 'browser', 'import', 'module', 'default'],
+      conditions: ['storybook', 'stories', 'test'],
       preserveSymlinks: isPreservingSymlinks(),
       alias: {
         assert: require.resolve('browser-assert'),


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28545

## What I did

I removed the "extra conditions" added during CPC work, as it appear to be causing https://github.com/storybookjs/storybook/issues/28545

Repro:
https://stackblitz.com/edit/storybook-interoprequiredefault2-error-rvpcnf?file=src%2FComponent.stories.jsx,package.json,src%2FComponent.jsx,package-lock.json

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I downloaded the repro:
https://stackblitz.com/edit/storybook-interoprequiredefault2-error-rvpcnf?file=src%2FComponent.stories.jsx,package.json,src%2FComponent.jsx,package-lock.json

I copied the `node_modules/@storybook/builder-vite/dist` to `<monorepo>/code/builders/vite-builder/dist`

And that got things working.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28581-sha-1dc31136`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28581-sha-1dc31136 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28581-sha-1dc31136 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28581-sha-1dc31136`](https://npmjs.com/package/storybook/v/0.0.0-pr-28581-sha-1dc31136) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/cpc-remove-vite-extra`](https://github.com/storybookjs/storybook/tree/norbert/cpc-remove-vite-extra) |
| **Commit** | [`1dc31136`](https://github.com/storybookjs/storybook/commit/1dc31136e564a7387a9cdf7de8cf3c285d92d4a3) |
| **Datetime** | Fri Jul 12 17:02:14 UTC 2024 (`1720803734`) |
| **Workflow run** | [9911464747](https://github.com/storybookjs/storybook/actions/runs/9911464747) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28581`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | % |
| ---- | ------ | ----- | ---- | - |
| createTime |  17.6s | 23.7s | 6.1s | 🔺25.8% |
| generateTime |  22.2s | 23s | 787ms | 3.4% |
| initTime |  22.3s | 23.8s | 1.5s | 🔺6.4% |
| createSize |  0 B | 0 B | 0 B | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 0% |
| initSize |  198 MB | 198 MB | -76 B | 0% |
| diffSize |  122 MB | 122 MB | -76 B | 0% |
| buildTime |  13.5s | 16.4s | 2.8s | 🔺17.4% |
| buildSize |  7.59 MB | 7.59 MB | 0 B | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0% |
| testBuildTime |  0ms | 0ms | 0ms | - |
| testBuildSize |  0 B | 0 B | 0 B | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - |
| devPreviewResponsive |  10s | 8.2s | -1s -810ms | 🔰-22% |
| devManagerResponsive |  5.8s | 5.4s | -390ms | 🔰-7.1% |
| devManagerHeaderVisible |  843ms | 1s | 247ms | 🔺22.7% |
| devManagerIndexVisible |  847ms | 1.1s | 290ms | 🔺25.5% |
| devStoryVisibleUncached |  1.7s | 970ms | -744ms | 🔰-76.7% |
| devStoryVisible |  891ms | 1.1s | 272ms | 🔺23.4% |
| devAutodocsVisible |  728ms | 798ms | 70ms | 🔺8.8% |
| devMDXVisible |  731ms | 735ms | 4ms | 0.5% |
| buildManagerHeaderVisible |  715ms | 881ms | 166ms | 🔺18.8% |
| buildManagerIndexVisible |  722ms | 893ms | 171ms | 🔺19.1% |
| buildStoryVisible |  767ms | 954ms | 187ms | 🔺19.6% |
| buildAutodocsVisible |  676ms | 1s | 337ms | 🔺33.3% |
| buildMDXVisible |  658ms | 879ms | 221ms | 🔺25.1% |

<!-- BENCHMARK_SECTION -->