### PR TITLE
UI: Fix collapse/expand all functionality

### DIFF
--- a/code/core/src/manager-api/modules/shortcuts.ts
+++ b/code/core/src/manager-api/modules/shortcuts.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { global } from '@storybook/global';
-import { FORCE_REMOUNT, PREVIEW_KEYDOWN, STORIES_COLLAPSE_ALL } from '@storybook/core/core-events';
+import {
+  FORCE_REMOUNT,
+  PREVIEW_KEYDOWN,
+  STORIES_COLLAPSE_ALL,
+  STORIES_EXPAND_ALL,
+} from '@storybook/core/core-events';
 
 import type { ModuleFn } from '../lib/types';
 
@@ -360,7 +365,7 @@ export const init: ModuleFn = ({ store, fullAPI, provider }) => {
           break;
         }
         case 'expandAll': {
-          fullAPI.expandAll();
+          fullAPI.emit(STORIES_EXPAND_ALL);
           break;
         }
         case 'remount': {

--- a/code/core/src/manager-api/modules/shortcuts.ts
+++ b/code/core/src/manager-api/modules/shortcuts.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { global } from '@storybook/global';
-import { FORCE_REMOUNT, PREVIEW_KEYDOWN } from '@storybook/core/core-events';
+import { FORCE_REMOUNT, PREVIEW_KEYDOWN, STORIES_COLLAPSE_ALL } from '@storybook/core/core-events';
 
 import type { ModuleFn } from '../lib/types';
 
@@ -356,7 +356,7 @@ export const init: ModuleFn = ({ store, fullAPI, provider }) => {
           break;
         }
         case 'collapseAll': {
-          fullAPI.collapseAll();
+          fullAPI.emit(STORIES_COLLAPSE_ALL);
           break;
         }
         case 'expandAll': {

--- a/code/core/src/manager/container/Menu.tsx
+++ b/code/core/src/manager/container/Menu.tsx
@@ -6,6 +6,7 @@ import type { API, State } from '@storybook/core/manager-api';
 import { shortcutToHumanString } from '@storybook/core/manager-api';
 import { styled, useTheme } from '@storybook/core/theming';
 import { CheckIcon, InfoIcon, ShareAltIcon, WandIcon } from '@storybook/icons';
+import { STORIES_COLLAPSE_ALL } from '@storybook/core/core-events';
 
 const focusableUIElements = {
   storySearchField: 'storybook-explorer-searchfield',
@@ -222,7 +223,7 @@ export const useMenu = (
     () => ({
       id: 'collapse',
       title: 'Collapse all',
-      onClick: () => api.collapseAll(),
+      onClick: () => api.emit(STORIES_COLLAPSE_ALL),
       right: enableShortcuts ? <Shortcut keys={shortcutKeys.collapseAll} /> : null,
     }),
     [api, enableShortcuts, shortcutKeys]


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28457

Fix: Update Menu "Collapse All" option to emit STORIES_COLLAPSE_ALL 
Issue: Clicking on "Collapse All" throws an error `api.collapseAll is not a function` 

Solution: Updated the `collapse` from the Menus.tsx component so it can emit the new events instead of calling the old methods.

### Testing

1. Visit a Storybook
2. Open the main menu (cog icon)
3. Click "collapse all"
4. Verify the tabs were collapsed

References:

Related issue: [#28457](https://github.com/storybookjs/storybook/issues/28457)
Related PR: [#25486](https://github.com/storybookjs/storybook/pull/25486)