### PR TITLE
Webpack: Fix sourceMap generation in csf-tools

### DIFF
--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { dedent } from 'ts-dedent';
 
 import * as t from '@babel/types';
-import bg from '@babel/generator';
+import bg, { type GeneratorOptions } from '@babel/generator';
 import bt from '@babel/traverse';
 
 import * as recast from 'recast';
@@ -599,15 +599,9 @@ export const loadCsf = (code: string, options: CsfOptions) => {
   return new CsfFile(ast, options);
 };
 
-interface FormatOptions {
-  sourceMaps?: boolean;
-  preserveStyle?: boolean;
-  inputSourceMap?: any;
-}
-
 export const formatCsf = (
   csf: CsfFile,
-  options: FormatOptions = { sourceMaps: false },
+  options: GeneratorOptions & { inputSourceMap?: string } = { sourceMaps: false },
   code?: string
 ) => {
   const result = generate(csf._ast, options, code);

--- a/code/lib/csf-plugin/src/webpack-loader.ts
+++ b/code/lib/csf-plugin/src/webpack-loader.ts
@@ -20,7 +20,11 @@ async function loader(this: LoaderContext, content: string, map: any) {
     const csf = loadCsf(content, { makeTitle }).parse();
     const csfSource = loadCsf(sourceCode, { makeTitle }).parse();
     enrichCsf(csf, csfSource, options);
-    const formattedCsf = formatCsf(csf, { sourceMaps: true, inputSourceMap: map }, content);
+    const formattedCsf = formatCsf(
+      csf,
+      { sourceMaps: true, inputSourceMap: map, sourceFileName: id },
+      content
+    );
 
     if (typeof formattedCsf === 'string') {
       return callback(null, formattedCsf, map);


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28576

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have added `babel.generate` enough information to produce a source map file to correctly define the `sources` property instead of setting it to `[undefined]`

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Use the `@storybook/addon-storysource` addon
3. Start Storybook. Storybook shouldn't fail to start

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28585-sha-af48f0d6`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28585-sha-af48f0d6 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28585-sha-af48f0d6 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28585-sha-af48f0d6`](https://npmjs.com/package/storybook/v/0.0.0-pr-28585-sha-af48f0d6) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-source-maps-for-webpack`](https://github.com/storybookjs/storybook/tree/valentin/fix-source-maps-for-webpack) |
| **Commit** | [`af48f0d6`](https://github.com/storybookjs/storybook/commit/af48f0d6af7c1879d2eca7b5c74663ffc0d5880b) |
| **Datetime** | Fri Jul 12 21:37:13 UTC 2024 (`1720820233`) |
| **Workflow run** | [9914441500](https://github.com/storybookjs/storybook/actions/runs/9914441500) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28585`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | % |
| ---- | ------ | ----- | ---- | - |
| createTime |  8.2s | 7s | -1s -240ms | 🔰-17.7% |
| generateTime |  23.2s | 22s | -1s -171ms | 🔰-5.3% |
| initTime |  22.9s | 22.2s | -614ms | -2.8% |
| createSize |  0 B | 0 B | 0 B | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 0% |
| initSize |  198 MB | 198 MB | 6.97 kB | 0% |
| diffSize |  122 MB | 122 MB | 6.97 kB | 0% |
| buildTime |  14.3s | 13s | -1s -313ms | 🔰-10% |
| buildSize |  7.59 MB | 7.59 MB | 0 B | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0% |
| testBuildTime |  0ms | 0ms | 0ms | - |
| testBuildSize |  0 B | 0 B | 0 B | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - |
| devPreviewResponsive |  10.4s | 8.3s | -2s -83ms | 🔰-24.8% |
| devManagerResponsive |  6.4s | 5.4s | -1s -32ms | 🔰-19% |
| devManagerHeaderVisible |  965ms | 847ms | -118ms | 🔰-13.9% |
| devManagerIndexVisible |  998ms | 850ms | -148ms | 🔰-17.4% |
| devStoryVisibleUncached |  2s | 1.2s | -739ms | 🔰-57.6% |
| devStoryVisible |  1s | 894ms | -125ms | 🔰-14% |
| devAutodocsVisible |  714ms | 745ms | 31ms | 4.2% |
| devMDXVisible |  876ms | 772ms | -104ms | 🔰-13.5% |
| buildManagerHeaderVisible |  883ms | 748ms | -135ms | 🔰-18% |
| buildManagerIndexVisible |  891ms | 750ms | -141ms | 🔰-18.8% |
| buildStoryVisible |  944ms | 799ms | -145ms | 🔰-18.1% |
| buildAutodocsVisible |  754ms | 713ms | -41ms | 🔰-5.8% |
| buildMDXVisible |  714ms | 725ms | 11ms | 1.5% |

<!-- BENCHMARK_SECTION -->