### PR TITLE
CLI: Add conditional logging for manager and preview start

### DIFF
--- a/code/core/src/builder-manager/index.ts
+++ b/code/core/src/builder-manager/index.ts
@@ -126,7 +126,9 @@ const starter: StarterFunction = async function* starterGeneratorFn({
   options,
   router,
 }) {
-  logger.info('=> Starting manager..');
+  if (!options.quiet) {
+    logger.info('=> Starting manager..');
+  }
 
   const {
     config,

--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -95,7 +95,9 @@ export async function storybookDevServer(options: Options) {
   let previewStarted: Promise<any> = Promise.resolve();
 
   if (!options.ignorePreview) {
-    logger.info('=> Starting preview..');
+    if (!options.quiet) {
+      logger.info('=> Starting preview..');
+    }
     previewStarted = previewBuilder
       .start({
         startTime: process.hrtime(),


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

In quiet mode, "Starting preview/manager" are no longer printed.
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | % |
| ---- | ------ | ----- | ---- | - |
| createTime |  9.1s | 16.9s | 7.7s | 🔺45.8% |
| generateTime |  29s | 19.8s | -9s -221ms | 🔰-46.5% |
| initTime |  27.6s | 20.3s | -7s -257ms | 🔰-35.6% |
| createSize |  0 B | 0 B | 0 B | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 0% |
| initSize |  198 MB | 198 MB | 44 B | 0% |
| diffSize |  121 MB | 121 MB | 44 B | 0% |
| buildTime |  13.1s | 14.8s | 1.6s | 🔺11.3% |
| buildSize |  7.59 MB | 7.59 MB | 0 B | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0% |
| testBuildTime |  0ms | 0ms | 0ms | - |
| testBuildSize |  0 B | 0 B | 0 B | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - |
| devPreviewResponsive |  10.1s | 9.2s | -878ms | 🔰-9.4% |
| devManagerResponsive |  6.1s | 6s | -163ms | -2.7% |
| devManagerHeaderVisible |  794ms | 926ms | 132ms | 🔺14.3% |
| devManagerIndexVisible |  806ms | 961ms | 155ms | 🔺16.1% |
| devStoryVisibleUncached |  1.5s | 1.6s | 146ms | 🔺8.6% |
| devStoryVisible |  845ms | 986ms | 141ms | 🔺14.3% |
| devAutodocsVisible |  742ms | 789ms | 47ms | 🔺6% |
| devMDXVisible |  732ms | 832ms | 100ms | 🔺12% |
| buildManagerHeaderVisible |  753ms | 807ms | 54ms | 🔺6.7% |
| buildManagerIndexVisible |  754ms | 811ms | 57ms | 🔺7% |
| buildStoryVisible |  810ms | 874ms | 64ms | 🔺7.3% |
| buildAutodocsVisible |  716ms | 722ms | 6ms | 0.8% |
| buildMDXVisible |  689ms | 771ms | 82ms | 🔺10.6% |

<!-- BENCHMARK_SECTION -->