### PR TITLE
CLI: Add diagnostic when the `storybook` package is missing

### DIFF
--- a/code/lib/cli/src/doctor/index.ts
+++ b/code/lib/cli/src/doctor/index.ts
@@ -105,6 +105,15 @@ export const doctor = async ({
 
   const allDependencies = (await packageManager.getAllDependencies()) as Record<string, string>;
 
+  if (!('storybook' in allDependencies)) {
+    logDiagnostic(
+      'Package storybook not found',
+      dedent`
+        The storybook package was not found in your package.json.
+        Installing storybook as a direct dev dependency in your package.json is required. 
+      `
+    );
+  }
   const incompatibleStorybookPackagesList = await getIncompatibleStorybookPackages({
     currentStorybookVersion: storybookVersion,
   });

--- a/code/lib/cli/src/doctor/index.ts
+++ b/code/lib/cli/src/doctor/index.ts
@@ -107,9 +107,9 @@ export const doctor = async ({
 
   if (!('storybook' in allDependencies)) {
     logDiagnostic(
-      'Package storybook not found',
+      `Package ${chalk.cyan('storybook')} not found`,
       dedent`
-        The storybook package was not found in your package.json.
+        The ${chalk.cyan('storybook')} package was not found in your package.json.
         Installing storybook as a direct dev dependency in your package.json is required. 
       `
     );

--- a/code/lib/cli/src/doctor/index.ts
+++ b/code/lib/cli/src/doctor/index.ts
@@ -110,7 +110,7 @@ export const doctor = async ({
       `Package ${chalk.cyan('storybook')} not found`,
       dedent`
         The ${chalk.cyan('storybook')} package was not found in your package.json.
-        Installing storybook as a direct dev dependency in your package.json is required. 
+        Installing ${chalk.cyan('storybook')} as a direct dev dependency in your package.json is required. 
       `
     );
   }


### PR DESCRIPTION
## What I did

Add diagnostic when the `storybook` package is missing

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | % |
| ---- | ------ | ----- | ---- | - |
| createTime |  9.1s | 23.8s | 14.6s | 🔺61.5% |
| generateTime |  29s | 23.1s | -5s -946ms | 🔰-25.7% |
| initTime |  27.6s | 23.5s | -4s -149ms | 🔰-17.7% |
| createSize |  0 B | 0 B | 0 B | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 0% |
| initSize |  198 MB | 198 MB | 684 B | 0% |
| diffSize |  121 MB | 121 MB | 684 B | 0% |
| buildTime |  13.1s | 16.5s | 3.3s | 🔺20.2% |
| buildSize |  7.59 MB | 7.59 MB | 0 B | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0% |
| testBuildTime |  0ms | 0ms | 0ms | - |
| testBuildSize |  0 B | 0 B | 0 B | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - |
| devPreviewResponsive |  10.1s | 8.4s | -1s -699ms | 🔰-20.1% |
| devManagerResponsive |  6.1s | 5.7s | -434ms | 🔰-7.5% |
| devManagerHeaderVisible |  794ms | 921ms | 127ms | 🔺13.8% |
| devManagerIndexVisible |  806ms | 956ms | 150ms | 🔺15.7% |
| devStoryVisibleUncached |  1.5s | 1.1s | -430ms | 🔰-38.3% |
| devStoryVisible |  845ms | 983ms | 138ms | 🔺14% |
| devAutodocsVisible |  742ms | 880ms | 138ms | 🔺15.7% |
| devMDXVisible |  732ms | 786ms | 54ms | 🔺6.9% |
| buildManagerHeaderVisible |  753ms | 755ms | 2ms | 0.3% |
| buildManagerIndexVisible |  754ms | 756ms | 2ms | 0.3% |
| buildStoryVisible |  810ms | 803ms | -7ms | -0.9% |
| buildAutodocsVisible |  716ms | 691ms | -25ms | -3.6% |
| buildMDXVisible |  689ms | 651ms | -38ms | 🔰-5.8% |

<!-- BENCHMARK_SECTION -->