### PR TITLE
Build: Send benchmarking base list to bot

### DIFF
--- a/scripts/upload-bench.ts
+++ b/scripts/upload-bench.ts
@@ -89,8 +89,8 @@ const uploadBench = async () => {
       console.log('skip uploading results to github');
       return;
     }
-    const [[base]]: any[] = await appTable.query({
-      query: `SELECT * FROM \`storybook-benchmark.benchmark_results.bench2\` WHERE branch=@baseBranch AND label=@templateKey ORDER BY timestamp DESC LIMIT 1;`,
+    const [base]: any[] = await appTable.query({
+      query: `SELECT * FROM \`storybook-benchmark.benchmark_results.bench2\` WHERE branch=@baseBranch AND label=@templateKey ORDER BY timestamp DESC LIMIT 20;`,
       params: { baseBranch, templateKey },
     });
 
@@ -101,7 +101,7 @@ const uploadBench = async () => {
             owner: 'storybookjs',
             repo: 'storybook',
             issueNumber: prNumber,
-            base: { ...defaults, ...base },
+            base: base.map((b: any) => ({ ...defaults, ...b })),
             head: row,
           }),
         })


### PR DESCRIPTION
## What I did

I tweaked the data being send to the benchmark-reporter-bot.

We now send the last 20 base builds, instead of just the last one.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | NaN | - |
| generateSize |  76.5 MB | 76.5 MB | 455 B | **1.73** | 0% |
| initSize |  198 MB | 198 MB | 455 B | **-1.33** | 0% |
| diffSize |  121 MB | 121 MB | 0 B | **-1.34** | 0% |
| buildSize |  7.59 MB | 7.59 MB | 0 B | 0.5 | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | NaN | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | NaN | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | NaN | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | NaN | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | NaN | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | NaN | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0.5 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7s | 21s | 14s | -0.85 | 66.8% |
| generateTime |  21.7s | 21.3s | -443ms | -0.42 | -2.1% |
| initTime |  23.3s | 22.4s | -866ms | 0.13 | -3.9% |
| buildTime |  15.6s | 13.3s | -2s -282ms | **1.43** | 🔰-17% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.5s | 7.9s | 400ms | -1.18 | 5% |
| devManagerResponsive |  5.2s | 5.2s | -10ms | -1.01 | -0.2% |
| devManagerHeaderVisible |  753ms | 790ms | 37ms | -0.97 | 4.7% |
| devManagerIndexVisible |  787ms | 795ms | 8ms | -0.83 | 1% |
| devStoryVisibleUncached |  1s | 1.3s | 283ms | -0.93 | 21.1% |
| devStoryVisible |  803ms | 843ms | 40ms | -1.02 | 4.7% |
| devAutodocsVisible |  716ms | 856ms | 140ms | -0.28 | 16.4% |
| devMDXVisible |  667ms | 678ms | 11ms | -1.23 | 1.6% |
| buildManagerHeaderVisible |  725ms | 846ms | 121ms | -0.83 | 14.3% |
| buildManagerIndexVisible |  730ms | 849ms | 119ms | -0.82 | 14% |
| buildStoryVisible |  772ms | 907ms | 135ms | -0.87 | 14.9% |
| buildAutodocsVisible |  655ms | 783ms | 128ms | -0.65 | 16.3% |
| buildMDXVisible |  638ms | 768ms | 130ms | -0.61 | 16.9% |

<!-- BENCHMARK_SECTION -->