### PR TITLE
Components: Remove external overrides

### DIFF
--- a/code/core/scripts/entries.ts
+++ b/code/core/scripts/entries.ts
@@ -28,12 +28,7 @@ export const getEntries = (cwd: string) => {
     define('src/preview-api/index.ts', ['browser', 'node'], true),
     define('src/manager-api/index.ts', ['browser', 'node'], true, ['react']),
     define('src/router/index.ts', ['browser', 'node'], true, ['react']),
-    define('src/components/index.ts', ['browser', 'node'], true, [
-      'react',
-      'react-dom',
-      '@storybook/csf',
-      '@storybook/global',
-    ]),
+    define('src/components/index.ts', ['browser', 'node'], true, ['react', 'react-dom']),
     define('src/theming/index.ts', ['browser', 'node'], true, ['react']),
     define('src/theming/create.ts', ['browser', 'node'], true, ['react']),
     define('src/docs-tools/index.ts', ['browser', 'node'], true),


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28619

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Remove external overrides, use package.json as source of truth

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 216 B | **1.67** | 0% |
| initSize |  198 MB | 198 MB | 1.39 kB | -0.7 | 0% |
| diffSize |  121 MB | 121 MB | 1.17 kB | -0.71 | 0% |
| buildSize |  7.59 MB | 7.59 MB | 48 B | **9.1** | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | **3** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | **4.36** | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **3.06** | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 48 B | **Infinity** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  13.4s | 13.3s | -149ms | -0.07 | -1.1% |
| generateTime |  22.3s | 21.9s | -385ms | -0.26 | -1.8% |
| initTime |  24.8s | 22.8s | -2s -30ms | -0.34 | -8.9% |
| buildTime |  15.6s | 14s | -1s -544ms | -0.17 | -11% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.9s | 9.5s | 620ms | **1.41** | 🔺6.5% |
| devManagerResponsive |  5.9s | 6.1s | 200ms | **1.39** | 3.3% |
| devManagerHeaderVisible |  888ms | 796ms | -92ms | -0.12 | -11.6% |
| devManagerIndexVisible |  916ms | 834ms | -82ms | 0.02 | -9.8% |
| devStoryVisibleUncached |  1.2s | 1.6s | 438ms | **1.74** | 🔺26% |
| devStoryVisible |  933ms | 856ms | -77ms | -0.01 | -9% |
| devAutodocsVisible |  848ms | 843ms | -5ms | **1.83** | -0.6% |
| devMDXVisible |  848ms | 772ms | -76ms | 0.46 | -9.8% |
| buildManagerHeaderVisible |  944ms | 832ms | -112ms | 0.41 | -13.5% |
| buildManagerIndexVisible |  954ms | 839ms | -115ms | 0.44 | -13.7% |
| buildStoryVisible |  1s | 900ms | -103ms | 0.57 | -11.4% |
| buildAutodocsVisible |  987ms | 706ms | -281ms | -0.19 | -39.8% |
| buildMDXVisible |  842ms | 668ms | -174ms | -0.14 | -26% |

<!-- BENCHMARK_SECTION -->