### PR TITLE
CPC: Correct path to the `@storybook/theming/create` alias

### DIFF
--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -70,7 +70,7 @@ async function webpack(
    */
   const cliPath = require.resolve('storybook/package.json');
   const themingPath = join(cliPath, '..', 'core', 'theming', 'index.js');
-  const themingCreatePath = join(cliPath, 'core', 'theming', 'create.js');
+  const themingCreatePath = join(cliPath, '..', 'core', 'theming', 'create.js');
 
   const componentsPath = join(cliPath, '..', 'core', 'components', 'index.js');
   const blocksPath = dirname(require.resolve('@storybook/blocks/package.json'));

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -68,11 +68,11 @@ async function webpack(
    *
    * In the future the `@storybook/theming` and `@storybook/components` can be removed, as they should be singletons in the future due to the peerDependency on `storybook` package.
    */
-  const cliPath = require.resolve('storybook/package.json');
-  const themingPath = join(cliPath, '..', 'core', 'theming', 'index.js');
-  const themingCreatePath = join(cliPath, '..', 'core', 'theming', 'create.js');
+  const cliPath = dirname(require.resolve('storybook/package.json'));
+  const themingPath = join(cliPath, 'core', 'theming', 'index.js');
+  const themingCreatePath = join(cliPath, 'core', 'theming', 'create.js');
 
-  const componentsPath = join(cliPath, '..', 'core', 'components', 'index.js');
+  const componentsPath = join(cliPath, 'core', 'components', 'index.js');
   const blocksPath = dirname(require.resolve('@storybook/blocks/package.json'));
   if (Array.isArray(webpackConfig.resolve?.alias)) {
     alias = [...webpackConfig.resolve?.alias];


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28566

## What I did

The path to the `@storybook/theming/create` included `package.json` which made it impossible to resolve the alias.

### Before
```
 '@storybook/theming/create': '<localPath>/node_modules/storybook/package.json/core/theming/create.js',
```

### After
```
 '@storybook/theming/create': '<localPath>/node_modules/storybook/core/theming/create.js',
```


<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->



<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- integrate storybook in a project
- create a custom theme
- it should work now

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 248 B | 1.09 | 0% |
| initSize |  198 MB | 198 MB | -13 kB | -0.3 | 0% |
| diffSize |  121 MB | 121 MB | -13.3 kB | -0.32 | 0% |
| buildSize |  7.6 MB | 7.59 MB | -2.45 kB | -0.09 | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | **1.97** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | -2.45 kB | -0.33 | -0.1% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | **2** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | -2.45 kB | -0.13 | -0.1% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | **1.73** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.2s | 23.1s | 15.8s | **1.53** | 🔺68.5% |
| generateTime |  23.1s | 21s | -2s -87ms | -0.77 | -9.9% |
| initTime |  24s | 22.3s | -1s -673ms | -0.66 | -7.5% |
| buildTime |  15.2s | 16.3s | 1.1s | **1.57** | 🔺7.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.8s | 8.7s | 907ms | 0.24 | 10.4% |
| devManagerResponsive |  5.2s | 5.6s | 433ms | -0.02 | 7.6% |
| devManagerHeaderVisible |  740ms | 926ms | 186ms | **2.34** | 🔺20.1% |
| devManagerIndexVisible |  776ms | 965ms | 189ms | **2.53** | 🔺19.6% |
| devStoryVisibleUncached |  1.3s | 1.2s | -149ms | -0.24 | -11.9% |
| devStoryVisible |  797ms | 987ms | 190ms | **2.48** | 🔺19.3% |
| devAutodocsVisible |  687ms | 832ms | 145ms | **1.3** | 🔺17.4% |
| devMDXVisible |  686ms | 750ms | 64ms | 0.24 | 8.5% |
| buildManagerHeaderVisible |  744ms | 937ms | 193ms | **1.48** | 🔺20.6% |
| buildManagerIndexVisible |  746ms | 944ms | 198ms | **1.45** | 🔺21% |
| buildStoryVisible |  793ms | 991ms | 198ms | **1.39** | 🔺20% |
| buildAutodocsVisible |  664ms | 794ms | 130ms | 0.46 | 16.4% |
| buildMDXVisible |  728ms | 1s | 347ms | **6.07** | 🔺32.3% |

<!-- BENCHMARK_SECTION -->