### PR TITLE
Onboarding: Fix code snippet when story name differs from export name

### DIFF
--- a/code/addons/onboarding/src/Onboarding.tsx
+++ b/code/addons/onboarding/src/Onboarding.tsx
@@ -75,6 +75,7 @@ export default function Onboarding({ api }: { api: API }) {
   const [createNewStoryForm, setCreateNewStoryForm] = useState<HTMLElement | null>();
   const [createdStory, setCreatedStory] = useState<{
     newStoryName: string;
+    newStoryExportName: string;
     sourceFileContent: string;
     sourceFileName: string;
   } | null>();
@@ -158,8 +159,8 @@ export default function Onboarding({ api }: { api: API }) {
   }
 
   const source = createdStory?.sourceFileContent;
-  const startIndex = source?.lastIndexOf(`export const ${createdStory?.newStoryName}`);
-  const snippet = source?.slice(startIndex);
+  const startIndex = source?.lastIndexOf(`export const ${createdStory?.newStoryExportName}`);
+  const snippet = source?.slice(startIndex).trim();
   const startingLineNumber = source?.slice(0, startIndex).split('\n').length;
 
   const steps: StepDefinition[] = [

--- a/code/core/src/core-events/data/save-story.ts
+++ b/code/core/src/core-events/data/save-story.ts
@@ -9,7 +9,9 @@ export interface SaveStoryResponsePayload {
   csfId: string;
   newStoryId?: string;
   newStoryName?: string;
+  newStoryExportName?: string;
   sourceFileContent?: string;
   sourceFileName?: string;
   sourceStoryName?: string;
+  sourceStoryExportName?: string;
 }

--- a/code/core/src/core-server/utils/save-story/save-story.ts
+++ b/code/core/src/core-server/utils/save-story/save-story.ts
@@ -111,9 +111,11 @@ export function initializeSaveStory(channel: Channel, options: Options, coreConf
           csfId,
           newStoryId,
           newStoryName,
+          newStoryExportName: name,
           sourceFileContent: code,
           sourceFileName,
           sourceStoryName,
+          sourceStoryExportName: storyName,
         },
         error: null,
       } satisfies ResponseData<SaveStoryResponsePayload>);


### PR DESCRIPTION
Closes #28626

## What I did

Rather than using the **story name** to lookup the source code snippet for a newly created story, this uses the **export name**.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 1.21 | 0% |
| initSize |  198 MB | 198 MB | 220 B | -0.46 | 0% |
| diffSize |  121 MB | 121 MB | 220 B | -0.47 | 0% |
| buildSize |  7.59 MB | 7.59 MB | 13 B | **3.09** | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 13 B | **3.25** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | **2** | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | **3** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 13 B | **3.2** | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | **2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  9.1s | 24.4s | 15.2s | **1.69** | 🔺62.5% |
| generateTime |  21.8s | 23.1s | 1.3s | 0.3 | 5.9% |
| initTime |  23.5s | 22.6s | -914ms | -0.43 | -4% |
| buildTime |  14.6s | 14.2s | -395ms | -0.21 | -2.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8s | 7.6s | -379ms | -1.13 | -4.9% |
| devManagerResponsive |  5.5s | 5.1s | -405ms | **-1.34** | 🔰-7.8% |
| devManagerHeaderVisible |  874ms | 803ms | -71ms | 0.17 | -8.8% |
| devManagerIndexVisible |  898ms | 845ms | -53ms | 0.43 | -6.3% |
| devStoryVisibleUncached |  1.1s | 1.3s | 180ms | 0.39 | 13.6% |
| devStoryVisible |  914ms | 869ms | -45ms | 0.43 | -5.2% |
| devAutodocsVisible |  809ms | 763ms | -46ms | 0.44 | -6% |
| devMDXVisible |  706ms | 665ms | -41ms | **-1.38** | 🔰-6.2% |
| buildManagerHeaderVisible |  1.1s | 783ms | -336ms | -0.07 | -42.9% |
| buildManagerIndexVisible |  1.1s | 785ms | -357ms | -0.09 | -45.5% |
| buildStoryVisible |  1.1s | 825ms | -373ms | -0.19 | -45.2% |
| buildAutodocsVisible |  1s | 737ms | -341ms | 0.03 | -46.3% |
| buildMDXVisible |  786ms | 704ms | -82ms | 0.26 | -11.6% |

<!-- BENCHMARK_SECTION -->