### PR TITLE
CPC: Add the globals export for manager

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -142,6 +142,11 @@
       "import": "./dist/manager/globals-module-info.js",
       "require": "./dist/manager/globals-module-info.cjs"
     },
+    "./manager/globals": {
+      "types": "./dist/manager/globals.d.ts",
+      "import": "./dist/manager/globals.js",
+      "require": "./dist/manager/globals.cjs"
+    },
     "./preview/globals": {
       "types": "./dist/preview/globals.d.ts",
       "import": "./dist/preview/globals.js",
@@ -228,6 +233,9 @@
       ],
       "manager/globals-module-info": [
         "./dist/manager/globals-module-info.d.ts"
+      ],
+      "manager/globals": [
+        "./dist/manager/globals.d.ts"
       ],
       "preview/globals": [
         "./dist/preview/globals.d.ts"

--- a/code/core/scripts/entries.ts
+++ b/code/core/scripts/entries.ts
@@ -34,6 +34,7 @@ export const getEntries = (cwd: string) => {
     define('src/docs-tools/index.ts', ['browser', 'node'], true),
 
     define('src/manager/globals-module-info.ts', ['node'], true),
+    define('src/manager/globals.ts', ['node'], true),
     define('src/preview/globals.ts', ['node'], true),
   ];
 };

--- a/code/deprecated/manager/globals.js
+++ b/code/deprecated/manager/globals.js
@@ -1,0 +1,1 @@
+module.exports = require('storybook/internal/manager/globals');

--- a/code/deprecated/preview/globals.js
+++ b/code/deprecated/preview/globals.js
@@ -1,0 +1,1 @@
+module.exports = require('storybook/internal/preview/globals');

--- a/code/lib/cli/core/manager/globals.cjs
+++ b/code/lib/cli/core/manager/globals.cjs
@@ -1,0 +1,1 @@
+module.exports = require('@storybook/core/manager/globals');

--- a/code/lib/cli/core/manager/globals.d.ts
+++ b/code/lib/cli/core/manager/globals.d.ts
@@ -1,0 +1,2 @@
+export * from '@storybook/core/manager/globals';
+export type * from '@storybook/core/manager/globals';

--- a/code/lib/cli/core/manager/globals.js
+++ b/code/lib/cli/core/manager/globals.js
@@ -1,0 +1,1 @@
+export * from '@storybook/core/manager/globals';

--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -167,6 +167,11 @@
       "types": "./core/preview/globals.d.ts",
       "import": "./core/preview/globals.js",
       "require": "./core/preview/globals.cjs"
+    },
+    "./internal/manager/globals": {
+      "types": "./core/manager/globals.d.ts",
+      "import": "./core/manager/globals.js",
+      "require": "./core/manager/globals.cjs"
     }
   },
   "main": "dist/index.cjs",
@@ -218,6 +223,9 @@
       ],
       "internal/manager-errors": [
         "./core/manager-errors.d.ts"
+      ],
+      "internal/manager/globals": [
+        "./core/manager/globals.d.ts"
       ],
       "internal/manager/globals-module-info": [
         "./core/manager/globals-module-info.d.ts"


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28647

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Add the globals export for manager, the addon-kit uses it

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 1.21 | 0% |
| initSize |  198 MB | 198 MB | 12.4 kB | -0.4 | 0% |
| diffSize |  121 MB | 121 MB | 12.4 kB | -0.42 | 0% |
| buildSize |  7.59 MB | 7.6 MB | 2.45 kB | **38.59** | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | **2.91** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 2.45 kB | **6117** | 0.1% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | **3** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 2.45 kB | **48.67** | 0.1% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | **2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  9.1s | 23.3s | 14.2s | **1.53** | 🔺60.7% |
| generateTime |  21.8s | 21.1s | -654ms | -0.68 | -3.1% |
| initTime |  23.5s | 20.4s | -3s -143ms | **-1.57** | 🔰-15.4% |
| buildTime |  14.6s | 12.9s | -1s -676ms | **-1.29** | 🔰-12.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8s | 8.3s | 352ms | -0.07 | 4.2% |
| devManagerResponsive |  5.5s | 5.7s | 179ms | 0.45 | 3.1% |
| devManagerHeaderVisible |  874ms | 739ms | -135ms | -1.15 | -18.3% |
| devManagerIndexVisible |  898ms | 771ms | -127ms | -1.13 | -16.5% |
| devStoryVisibleUncached |  1.1s | 1.1s | -3ms | -0.98 | -0.3% |
| devStoryVisible |  914ms | 792ms | -122ms | -1.15 | -15.4% |
| devAutodocsVisible |  809ms | 743ms | -66ms | 0.11 | -8.9% |
| devMDXVisible |  706ms | 643ms | -63ms | **-1.8** | 🔰-9.8% |
| buildManagerHeaderVisible |  1.1s | 720ms | -399ms | -0.7 | -55.4% |
| buildManagerIndexVisible |  1.1s | 722ms | -420ms | -0.7 | -58.2% |
| buildStoryVisible |  1.1s | 770ms | -428ms | -0.71 | -55.6% |
| buildAutodocsVisible |  1s | 650ms | -428ms | -0.71 | -65.8% |
| buildMDXVisible |  786ms | 682ms | -104ms | -0.07 | -15.2% |

<!-- BENCHMARK_SECTION -->