### PR TITLE
Types: Adjust beforeAll to be non-nullable in NormalizedProjectAnnotations

### DIFF
--- a/code/core/src/types/modules/story.ts
+++ b/code/core/src/types/modules/story.ts
@@ -6,6 +6,7 @@ import type {
   CleanupCallback,
   StepRunner,
   Canvas,
+  BeforeAll,
 } from '@storybook/csf';
 
 import type {
@@ -57,13 +58,14 @@ export type NamedOrDefaultProjectAnnotations<TRenderer extends Renderer = Render
 
 export type NormalizedProjectAnnotations<TRenderer extends Renderer = Renderer> = Omit<
   ProjectAnnotations<TRenderer>,
-  'decorators' | 'loaders' | 'runStep'
+  'decorators' | 'loaders' | 'runStep' | 'beforeAll'
 > & {
   argTypes?: StrictArgTypes;
   globalTypes?: StrictGlobalTypes;
   decorators?: DecoratorFunction<TRenderer>[];
   loaders?: LoaderFunction<TRenderer>[];
   runStep: StepRunner<TRenderer>;
+  beforeAll: BeforeAll;
 };
 
 export type NormalizedComponentAnnotations<TRenderer extends Renderer = Renderer> = Omit<


### PR DESCRIPTION
Closes #28513

## What I did

Adjust beforeAll to be non-nullable in NormalizedProjectAnnotations

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | **-1.98** | 0% |
| initSize |  198 MB | 198 MB | 51 B | **-1.67** | 0% |
| diffSize |  121 MB | 121 MB | 51 B | 0.99 | 0% |
| buildSize |  7.6 MB | 7.6 MB | 0 B | 0.82 | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | 0.71 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0.82 | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | 0.65 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0.82 | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0.58 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  24.2s | 23.2s | -1s -27ms | 1.23 | -4.4% |
| generateTime |  21.6s | 20.7s | -833ms | **-1.25** | -4% |
| initTime |  21.9s | 20.6s | -1s -318ms | **-1.71** | 🔰-6.4% |
| buildTime |  16.7s | 12.7s | -4s -7ms | **-1.69** | 🔰-31.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  12.1s | 8.1s | -4s -2ms | -0.74 | -48.9% |
| devManagerResponsive |  7s | 5.2s | -1s -829ms | -1.15 | -35% |
| devManagerHeaderVisible |  1.3s | 805ms | -497ms | -0.39 | -61.7% |
| devManagerIndexVisible |  1.3s | 841ms | -514ms | -0.36 | -61.1% |
| devStoryVisibleUncached |  2s | 1.3s | -687ms | -0.08 | -51.2% |
| devStoryVisible |  1.3s | 862ms | -521ms | -0.38 | -60.4% |
| devAutodocsVisible |  1.1s | 718ms | -441ms | -0.65 | -61.4% |
| devMDXVisible |  1s | 761ms | -318ms | -0.24 | -41.8% |
| buildManagerHeaderVisible |  1.2s | 747ms | -490ms | -0.75 | -65.6% |
| buildManagerIndexVisible |  1.2s | 750ms | -489ms | -0.76 | -65.2% |
| buildStoryVisible |  1.3s | 799ms | -521ms | -0.75 | -65.2% |
| buildAutodocsVisible |  1s | 727ms | -292ms | -0.57 | -40.2% |
| buildMDXVisible |  1.1s | 729ms | -388ms | -0.21 | -53.2% |

<!-- BENCHMARK_SECTION -->