### PR TITLE
A11y: Improved toolbar a11y by fixing semantics

### DIFF
--- a/code/core/src/manager/components/preview/Toolbar.tsx
+++ b/code/core/src/manager/components/preview/Toolbar.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useId } from 'react';
 
 import { IconButton, Separator, TabBar, TabButton } from 'storybook/internal/components';
 import { type Addon_BaseType, Addon_TypesEnum } from 'storybook/internal/types';
@@ -137,8 +137,18 @@ export const ToolbarComp = React.memo<ToolData>(function ToolbarComp({
   tabId,
   api,
 }) {
+  const id = useId();
   return tabs || tools || toolsExtra ? (
-    <Toolbar className="sb-bar" key="toolbar" shown={isShown} data-test-id="sb-preview-toolbar">
+    <Toolbar
+      className="sb-bar"
+      key="toolbar"
+      shown={isShown}
+      data-test-id="sb-preview-toolbar"
+      aria-labelledby={id}
+    >
+      <span className="sb-sr-only" id={id}>
+        Toolbar
+      </span>
       <ToolbarInner>
         <ToolbarLeft>
           {tabs.length > 1 ? (
@@ -222,7 +232,7 @@ export function filterToolsSide(
   return tools.filter(filter);
 }
 
-const Toolbar = styled.div<{ shown: boolean }>(({ theme, shown }) => ({
+const Toolbar = styled.section<{ shown: boolean }>(({ theme, shown }) => ({
   position: 'relative',
   color: theme.barTextColor,
   width: '100%',


### PR DESCRIPTION
Closes #25918

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Grouped toolbar with labelled section.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access http://localhost:6006/?path=/story/example-button--primary
4. Check that toolbar is correctly rendered and readed by screen reader as unordered list and the section named as 'Toolbar'.


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  0 B | 77.8 MB | 77.8 MB | - | 100% |
| initSize |  0 B | 143 MB | 143 MB | - | 100% |
| diffSize |  0 B | 65.6 MB | 65.6 MB | - | 100% |
| buildSize |  0 B | 7.19 MB | 7.19 MB | - | 100% |
| buildSbAddonsSize |  0 B | 1.85 MB | 1.85 MB | - | 100% |
| buildSbCommonSize |  0 B | 195 kB | 195 kB | - | 100% |
| buildSbManagerSize |  0 B | 1.87 MB | 1.87 MB | - | 100% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  0 B | 3.92 MB | 3.92 MB | - | 100% |
| buildPreviewSize |  0 B | 3.28 MB | 3.28 MB | - | 100% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  0ms | 8.4s | 8.4s | - | 100% |
| generateTime |  0ms | 25.3s | 25.3s | - | 100% |
| initTime |  0ms | 20s | 20s | - | 100% |
| buildTime |  0ms | 9.1s | 9.1s | - | 100% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  0ms | 6s | 6s | - | 100% |
| devManagerResponsive |  0ms | 4.3s | 4.3s | - | 100% |
| devManagerHeaderVisible |  0ms | 761ms | 761ms | - | 100% |
| devManagerIndexVisible |  0ms | 790ms | 790ms | - | 100% |
| devStoryVisibleUncached |  0ms | 2s | 2s | - | 100% |
| devStoryVisible |  0ms | 788ms | 788ms | - | 100% |
| devAutodocsVisible |  0ms | 636ms | 636ms | - | 100% |
| devMDXVisible |  0ms | 702ms | 702ms | - | 100% |
| buildManagerHeaderVisible |  0ms | 744ms | 744ms | - | 100% |
| buildManagerIndexVisible |  0ms | 881ms | 881ms | - | 100% |
| buildStoryVisible |  0ms | 717ms | 717ms | - | 100% |
| buildAutodocsVisible |  0ms | 478ms | 478ms | - | 100% |
| buildMDXVisible |  0ms | 584ms | 584ms | - | 100% |

<!-- BENCHMARK_SECTION -->