### PR TITLE
CPC: Fix missing exports for addon-kit

### DIFF
--- a/code/deprecated/manager/globals.cjs
+++ b/code/deprecated/manager/globals.cjs
@@ -1,0 +1,1 @@
+module.exports = require('storybook/internal/manager/globals');

--- a/code/deprecated/manager/globals.d.ts
+++ b/code/deprecated/manager/globals.d.ts
@@ -1,0 +1,2 @@
+export * from 'storybook/internal/manager/globals';
+export type * from 'storybook/internal/manager/globals';

--- a/code/deprecated/manager/globals.js
+++ b/code/deprecated/manager/globals.js
@@ -1,1 +1,1 @@
-module.exports = require('storybook/internal/manager/globals');
+export * from 'storybook/internal/manager/globals';

--- a/code/deprecated/manager/package.json
+++ b/code/deprecated/manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/manager",
-  "version": "8.3.0-alpha.2",
+  "version": "8.2.5",
   "description": "Core Storybook UI",
   "keywords": [
     "storybook"
@@ -20,6 +20,14 @@
   },
   "license": "MIT",
   "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "./globals": {
+      "type": "./globals.d.ts",
+      "import": "./globals.js",
+      "require": "./globals.cjs"
+    }
+  },
   "files": [
     "README.md",
     "*.js",
@@ -28,7 +36,7 @@
     "*.d.ts"
   ],
   "peerDependencies": {
-    "storybook": "workspace:^"
+    "storybook": "^8.2.5"
   },
   "publishConfig": {
     "access": "public"

--- a/code/deprecated/manager/package.json
+++ b/code/deprecated/manager/package.json
@@ -36,7 +36,7 @@
     "*.d.ts"
   ],
   "peerDependencies": {
-    "storybook": "^8.2.5"
+    "storybook": "workspace:^"
   },
   "publishConfig": {
     "access": "public"

--- a/code/deprecated/manager/package.json
+++ b/code/deprecated/manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/manager",
-  "version": "8.2.5",
+  "version": "8.3.0-alpha.2",
   "description": "Core Storybook UI",
   "keywords": [
     "storybook"

--- a/code/deprecated/preview/globals.cjs
+++ b/code/deprecated/preview/globals.cjs
@@ -1,0 +1,1 @@
+module.exports = require('storybook/internal/preview/globals');

--- a/code/deprecated/preview/globals.d.ts
+++ b/code/deprecated/preview/globals.d.ts
@@ -1,0 +1,2 @@
+export * from 'storybook/internal/preview/globals';
+export type * from 'storybook/internal/preview/globals';

--- a/code/deprecated/preview/globals.js
+++ b/code/deprecated/preview/globals.js
@@ -1,1 +1,1 @@
-module.exports = require('storybook/internal/preview/globals');
+export * from 'storybook/internal/preview/globals';

--- a/code/deprecated/preview/package.json
+++ b/code/deprecated/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/preview",
-  "version": "8.3.0-alpha.2",
+  "version": "8.2.5",
   "description": "",
   "keywords": [
     "storybook"
@@ -20,6 +20,14 @@
   },
   "license": "MIT",
   "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "./globals": {
+      "type": "./globals.d.ts",
+      "import": "./globals.js",
+      "require": "./globals.cjs"
+    }
+  },
   "files": [
     "README.md",
     "*.js",
@@ -28,7 +36,7 @@
     "*.d.ts"
   ],
   "peerDependencies": {
-    "storybook": "workspace:^"
+    "storybook": "^8.2.5"
   },
   "publishConfig": {
     "access": "public"

--- a/code/deprecated/preview/package.json
+++ b/code/deprecated/preview/package.json
@@ -36,7 +36,7 @@
     "*.d.ts"
   ],
   "peerDependencies": {
-    "storybook": "^8.2.5"
+    "storybook": "workspace:^"
   },
   "publishConfig": {
     "access": "public"

--- a/code/deprecated/preview/package.json
+++ b/code/deprecated/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/preview",
-  "version": "8.2.5",
+  "version": "8.3.0-alpha.2",
   "description": "",
   "keywords": [
     "storybook"


### PR DESCRIPTION
Closes #28673

## What I did

the `./globals` export was there, however due to a combination of modernized tools, the legacy method of adding an file export (just adding a file) was not enough.

After some experimentation I found the only way to make it work was by making the module `type=module` and have a full set in the export map.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | **-2.78** | 0% |
| initSize |  198 MB | 198 MB | -51 B | **-2.81** | 0% |
| diffSize |  121 MB | 121 MB | -51 B | 0.68 | 0% |
| buildSize |  7.6 MB | 7.6 MB | 0 B | 0.5 | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | 0.41 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0.5 | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | 0.33 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0.5 | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0.23 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.8s | 8.9s | 1s | -0.69 | 11.7% |
| generateTime |  33.4s | 24.9s | -8s -561ms | 0.75 | -34.4% |
| initTime |  23.9s | 24s | 85ms | 0.52 | 0.4% |
| buildTime |  14.8s | 14s | -753ms | -0.63 | -5.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  9.3s | 8.1s | -1s -169ms | -0.68 | -14.3% |
| devManagerResponsive |  6.2s | 5.5s | -662ms | -0.6 | -11.9% |
| devManagerHeaderVisible |  864ms | 777ms | -87ms | -0.57 | -11.2% |
| devManagerIndexVisible |  897ms | 813ms | -84ms | -0.53 | -10.3% |
| devStoryVisibleUncached |  1.3s | 1.4s | 116ms | 0.04 | 8.2% |
| devStoryVisible |  917ms | 833ms | -84ms | -0.56 | -10.1% |
| devAutodocsVisible |  777ms | 716ms | -61ms | -0.69 | -8.5% |
| devMDXVisible |  778ms | 709ms | -69ms | -0.77 | -9.7% |
| buildManagerHeaderVisible |  833ms | 775ms | -58ms | -0.6 | -7.5% |
| buildManagerIndexVisible |  838ms | 777ms | -61ms | -0.62 | -7.9% |
| buildStoryVisible |  891ms | 828ms | -63ms | -0.59 | -7.6% |
| buildAutodocsVisible |  759ms | 708ms | -51ms | -0.74 | -7.2% |
| buildMDXVisible |  689ms | 652ms | -37ms | -0.79 | -5.7% |

<!-- BENCHMARK_SECTION -->