### PR TITLE
Core: Add Rsbuild frameworks to known frameworks

### DIFF
--- a/code/core/scripts/helpers/sourcefiles.ts
+++ b/code/core/scripts/helpers/sourcefiles.ts
@@ -55,7 +55,7 @@ async function generateVersionsFile(prettierConfig: prettier.Options | null): Pr
 }
 
 async function generateFrameworksFile(prettierConfig: prettier.Options | null): Promise<void> {
-  const thirdPartyFrameworks = ['qwik', 'solid'];
+  const thirdPartyFrameworks = ['qwik', 'solid', 'react-rsbuild', 'vue3-rsbuild'];
   const location = join(__dirname, '..', '..', 'src', 'types', 'modules', 'frameworks.ts');
   const frameworksDirectory = join(__dirname, '..', '..', '..', 'frameworks');
 

--- a/code/core/src/cli/helpers.ts
+++ b/code/core/src/cli/helpers.ts
@@ -18,7 +18,7 @@ import stripJsonComments from 'strip-json-comments';
 import invariant from 'tiny-invariant';
 
 import { getRendererDir } from './dirs';
-import { CoreBuilder, SupportedLanguage } from './project_types';
+import { CommunityBuilder, CoreBuilder, SupportedLanguage } from './project_types';
 
 const logger = console;
 
@@ -144,7 +144,10 @@ type CopyTemplateFilesOptions = {
 /** @deprecated Please use `frameworkToRenderer` from `@storybook/core-common` instead */
 export const frameworkToRenderer = CoreFrameworkToRenderer;
 
-export const frameworkToDefaultBuilder: Record<SupportedFrameworks, CoreBuilder> = {
+export const frameworkToDefaultBuilder: Record<
+  SupportedFrameworks,
+  CoreBuilder | CommunityBuilder
+> = {
   angular: CoreBuilder.Webpack5,
   ember: CoreBuilder.Webpack5,
   'html-vite': CoreBuilder.Vite,
@@ -165,6 +168,9 @@ export const frameworkToDefaultBuilder: Record<SupportedFrameworks, CoreBuilder>
   'vue3-webpack5': CoreBuilder.Webpack5,
   'web-components-vite': CoreBuilder.Vite,
   'web-components-webpack5': CoreBuilder.Webpack5,
+  // Only to pass type checking, will never be used
+  'react-rsbuild': CommunityBuilder.Rsbuild,
+  'vue3-rsbuild': CommunityBuilder.Rsbuild,
 };
 
 export async function copyTemplateFiles({

--- a/code/core/src/cli/project_types.ts
+++ b/code/core/src/cli/project_types.ts
@@ -74,6 +74,10 @@ export enum CoreWebpackCompilers {
   SWC = 'swc',
 }
 
+export enum CommunityBuilder {
+  Rsbuild = 'rsbuild',
+}
+
 export const compilerNameToCoreCompiler: Record<string, CoreWebpackCompilers> = {
   '@storybook/addon-webpack5-compiler-babel': CoreWebpackCompilers.Babel,
   '@storybook/addon-webpack5-compiler-swc': CoreWebpackCompilers.SWC,

--- a/code/core/src/common/utils/framework-to-renderer.ts
+++ b/code/core/src/common/utils/framework-to-renderer.ts
@@ -26,6 +26,8 @@ export const frameworkToRenderer: Record<
   'vue3-webpack5': 'vue3',
   'web-components-vite': 'web-components',
   'web-components-webpack5': 'web-components',
+  'react-rsbuild': 'react',
+  'vue3-rsbuild': 'vue3',
   // renderers
   html: 'html',
   preact: 'preact',

--- a/code/core/src/common/utils/get-storybook-info.ts
+++ b/code/core/src/common/utils/get-storybook-info.ts
@@ -48,8 +48,8 @@ export const frameworkPackages: Record<string, SupportedFrameworks> = {
   // community (outside of monorepo)
   'storybook-framework-qwik': 'qwik',
   'storybook-solidjs-vite': 'solid',
-  'storybook-react-rsbuild': 'react',
-  'storybook-vue3-rsbuild': 'vue3',
+  'storybook-react-rsbuild': 'react-rsbuild',
+  'storybook-vue3-rsbuild': 'vue3-rsbuild',
 };
 
 export const builderPackages = ['@storybook/builder-webpack5', '@storybook/builder-vite'];

--- a/code/core/src/common/utils/get-storybook-info.ts
+++ b/code/core/src/common/utils/get-storybook-info.ts
@@ -48,6 +48,8 @@ export const frameworkPackages: Record<string, SupportedFrameworks> = {
   // community (outside of monorepo)
   'storybook-framework-qwik': 'qwik',
   'storybook-solidjs-vite': 'solid',
+  'storybook-react-rsbuild': 'react',
+  'storybook-vue3-rsbuild': 'vue3',
 };
 
 export const builderPackages = ['@storybook/builder-webpack5', '@storybook/builder-vite'];

--- a/code/core/src/types/modules/frameworks.ts
+++ b/code/core/src/types/modules/frameworks.ts
@@ -19,4 +19,6 @@ export type SupportedFrameworks =
   | 'web-components-vite'
   | 'web-components-webpack5'
   | 'qwik'
-  | 'solid';
+  | 'solid'
+  | 'react-rsbuild'
+  | 'vue3-rsbuild';


### PR DESCRIPTION
Closes https://github.com/rspack-contrib/storybook-rsbuild/issues/51.

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Add `storybook-react-rsbuild` and `storybook-vue3-rsbuild` to known frameworks, which could make the former being detected as an `react` framework.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

1. Create an Rsbuild-react project `npm create rsbuild@latest`
2. Add Storybook https://rsbuild.dev/community/releases/v0-7#support-for-storybook
3. Try to use save from controls / add new component UI

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
5. Open Storybook in your browser
6. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28694-sha-b28ec221`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28694-sha-b28ec221 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28694-sha-b28ec221 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28694-sha-b28ec221`](https://npmjs.com/package/storybook/v/0.0.0-pr-28694-sha-b28ec221) |
| **Triggered by** | @shilman |
| **Repository** | [fi3ework/storybook](https://github.com/fi3ework/storybook) |
| **Branch** | [`patch-3`](https://github.com/fi3ework/storybook/tree/patch-3) |
| **Commit** | [`b28ec221`](https://github.com/fi3ework/storybook/commit/b28ec221b8ad74f9140bc1bdf58580b28d856d9e) |
| **Datetime** | Sun Aug 11 19:42:52 UTC 2024 (`1723405372`) |
| **Workflow run** | [10342303731](https://github.com/storybookjs/storybook/actions/runs/10342303731) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28694`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | 0.57 | 0% |
| initSize |  169 MB | 169 MB | 869 B | **1.24** | 0% |
| diffSize |  92.6 MB | 92.7 MB | 869 B | **1.24** | 0% |
| buildSize |  7.46 MB | 7.46 MB | 0 B | 1.23 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | **1.28** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 1.21 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | -0.46 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | 1.23 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 1.22 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  18.7s | 15.2s | -3s -489ms | -0.04 | -22.8% |
| generateTime |  20.8s | 20.5s | -279ms | 0.15 | -1.4% |
| initTime |  19.3s | 17.2s | -2s -85ms | -0.25 | -12.1% |
| buildTime |  11.4s | 12.5s | 1s | 0.15 | 8.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.2s | 6.5s | -1s -699ms | -1.19 | -25.9% |
| devManagerResponsive |  5.4s | 4.4s | -1s -57ms | -0.99 | -24% |
| devManagerHeaderVisible |  816ms | 1s | 278ms | **3.38** | 🔺25.4% |
| devManagerIndexVisible |  863ms | 1.1s | 273ms | **3.25** | 🔺24% |
| devStoryVisibleUncached |  1.5s | 1.2s | -346ms | -0.55 | -27.6% |
| devStoryVisible |  875ms | 1.1s | 263ms | **3.03** | 🔺23.1% |
| devAutodocsVisible |  684ms | 728ms | 44ms | -0.16 | 6% |
| devMDXVisible |  695ms | 650ms | -45ms | -0.89 | -6.9% |
| buildManagerHeaderVisible |  857ms | 725ms | -132ms | -0.29 | -18.2% |
| buildManagerIndexVisible |  866ms | 726ms | -140ms | -0.34 | -19.3% |
| buildStoryVisible |  963ms | 796ms | -167ms | -0.01 | -21% |
| buildAutodocsVisible |  774ms | 635ms | -139ms | -0.83 | -21.9% |
| buildMDXVisible |  723ms | 611ms | -112ms | -0.73 | -18.3% |

<!-- BENCHMARK_SECTION -->