### PR TITLE
CLI: Fix the initialization of Storybook in workspaces

### DIFF
--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -64,16 +64,6 @@ export abstract class JsPackageManager {
     return packageJSON ? packageJSON.version ?? null : null;
   }
 
-  // NOTE: for some reason yarn prefers the npm registry in
-  // local development, so always use npm
-  async setRegistryURL(url: string) {
-    if (url) {
-      await this.executeCommand({ command: 'npm', args: ['config', 'set', 'registry', url] });
-    } else {
-      await this.executeCommand({ command: 'npm', args: ['config', 'delete', 'registry'] });
-    }
-  }
-
   async getRegistryURL() {
     const res = await this.executeCommand({ command: 'npm', args: ['config', 'get', 'registry'] });
     const url = res.trim();
@@ -486,6 +476,8 @@ export abstract class JsPackageManager {
     fetchAllVersions: T
   ): // Use generic and conditional type to force `string[]` if fetchAllVersions is true and `string` if false
   Promise<T extends true ? string[] : string>;
+
+  public abstract getRegistryURL(): Promise<string | undefined>;
 
   public abstract runPackageCommand(
     command: string,

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -64,12 +64,6 @@ export abstract class JsPackageManager {
     return packageJSON ? packageJSON.version ?? null : null;
   }
 
-  async getRegistryURL() {
-    const res = await this.executeCommand({ command: 'npm', args: ['config', 'get', 'registry'] });
-    const url = res.trim();
-    return url === 'undefined' ? undefined : url;
-  }
-
   constructor(options?: JsPackageManagerOptions) {
     this.cwd = options?.cwd || process.cwd();
   }

--- a/code/core/src/common/js-package-manager/NPMProxy.test.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.test.ts
@@ -34,21 +34,6 @@ describe('NPM Proxy', () => {
     });
   });
 
-  describe('setRegistryUrl', () => {
-    it('should run `npm config set registry https://foo.bar`', async () => {
-      const executeCommandSpy = vi.spyOn(npmProxy, 'executeCommand').mockResolvedValueOnce('');
-
-      await npmProxy.setRegistryURL('https://foo.bar');
-
-      expect(executeCommandSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'npm',
-          args: ['config', 'set', 'registry', 'https://foo.bar'],
-        })
-      );
-    });
-  });
-
   describe('installDependencies', () => {
     describe('npm6', () => {
       it('should run `npm install`', async () => {

--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -181,6 +181,17 @@ export class NPMProxy extends JsPackageManager {
     });
   }
 
+  public async getRegistryURL() {
+    const res = await this.executeCommand({
+      command: 'npm',
+      // "npm config" commands are not allowed in workspaces per default
+      // https://github.com/npm/cli/issues/6099#issuecomment-1847584792
+      args: ['config', 'get', 'registry', '-ws=false', '-iwr'],
+    });
+    const url = res.trim();
+    return url === 'undefined' ? undefined : url;
+  }
+
   protected async runAddDeps(dependencies: string[], installAsDevDependencies: boolean) {
     const { logStream, readLogFile, moveLogFile, removeLogFile } = await createLogStream();
     let args = [...dependencies];

--- a/code/core/src/common/js-package-manager/PNPMProxy.test.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.test.ts
@@ -24,21 +24,6 @@ describe('PNPM Proxy', () => {
     });
   });
 
-  describe('setRegistryUrl', () => {
-    it('should run `npm config set registry https://foo.bar`', async () => {
-      const executeCommandSpy = vi.spyOn(pnpmProxy, 'executeCommand').mockResolvedValueOnce('');
-
-      await pnpmProxy.setRegistryURL('https://foo.bar');
-
-      expect(executeCommandSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'npm',
-          args: ['config', 'set', 'registry', 'https://foo.bar'],
-        })
-      );
-    });
-  });
-
   describe('installDependencies', () => {
     it('should run `pnpm install`', async () => {
       const executeCommandSpy = vi

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -90,6 +90,15 @@ export class PNPMProxy extends JsPackageManager {
     });
   }
 
+  public async getRegistryURL() {
+    const res = await this.executeCommand({
+      command: 'pnpm',
+      args: ['config', 'get', 'registry'],
+    });
+    const url = res.trim();
+    return url === 'undefined' ? undefined : url;
+  }
+
   async runPackageCommand(command: string, args: string[], cwd?: string): Promise<string> {
     return this.executeCommand({
       command: 'pnpm',

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.test.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.test.ts
@@ -25,21 +25,6 @@ describe('Yarn 1 Proxy', () => {
     });
   });
 
-  describe('setRegistryUrl', () => {
-    it('should run `yarn config set npmRegistryServer https://foo.bar`', async () => {
-      const executeCommandSpy = vi.spyOn(yarn1Proxy, 'executeCommand').mockResolvedValueOnce('');
-
-      await yarn1Proxy.setRegistryURL('https://foo.bar');
-
-      expect(executeCommandSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'npm',
-          args: ['config', 'set', 'registry', 'https://foo.bar'],
-        })
-      );
-    });
-  });
-
   describe('installDependencies', () => {
     it('should run `yarn`', async () => {
       const executeCommandSpy = vi.spyOn(yarn1Proxy, 'executeCommand').mockResolvedValueOnce('');

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.ts
@@ -83,6 +83,15 @@ export class Yarn1Proxy extends JsPackageManager {
     return JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as Record<string, any>;
   }
 
+  public async getRegistryURL() {
+    const res = await this.executeCommand({
+      command: 'yarn',
+      args: ['config', 'get', 'registry'],
+    });
+    const url = res.trim();
+    return url === 'undefined' ? undefined : url;
+  }
+
   public async findInstallations(pattern: string[], { depth = 99 }: { depth?: number } = {}) {
     const yarnArgs = ['list', '--pattern', pattern.map((p) => `"${p}"`).join(' '), '--json'];
 

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.test.ts
@@ -53,21 +53,6 @@ describe('Yarn 2 Proxy', () => {
     });
   });
 
-  describe('setRegistryUrl', () => {
-    it('should run `yarn config set npmRegistryServer https://foo.bar`', async () => {
-      const executeCommandSpy = vi.spyOn(yarn2Proxy, 'executeCommand').mockResolvedValueOnce('');
-
-      await yarn2Proxy.setRegistryURL('https://foo.bar');
-
-      expect(executeCommandSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'npm',
-          args: ['config', 'set', 'registry', 'https://foo.bar'],
-        })
-      );
-    });
-  });
-
   describe('addDependencies', () => {
     it('with devDep it should run `yarn install -D @storybook/core`', async () => {
       const executeCommandSpy = vi.spyOn(yarn2Proxy, 'executeCommand').mockResolvedValueOnce('');

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.ts
@@ -239,6 +239,15 @@ export class Yarn2Proxy extends JsPackageManager {
     await removeLogFile();
   }
 
+  public async getRegistryURL() {
+    const res = await this.executeCommand({
+      command: 'yarn',
+      args: ['config', 'get', 'npmRegistryServer'],
+    });
+    const url = res.trim();
+    return url === 'undefined' ? undefined : url;
+  }
+
   protected async runRemoveDeps(dependencies: string[]) {
     const args = [...dependencies];
 

--- a/scripts/sandbox/generate.ts
+++ b/scripts/sandbox/generate.ts
@@ -72,7 +72,7 @@ const withLocalRegistry = async ({
     error = e;
   } finally {
     console.log(`📦 Restoring registry: ${prevUrl}`);
-    await runCommand(`npm config set registry ${LOCAL_REGISTRY_URL}`, { cwd, env }, debug);
+    await runCommand(`npm config set registry ${prevUrl}`, { cwd, env }, debug);
 
     if (error) {
       throw error;

--- a/scripts/sandbox/generate.ts
+++ b/scripts/sandbox/generate.ts
@@ -45,18 +45,34 @@ const sbInit = async (
   await runCommand(`${sbCliBinaryPath} init ${fullFlags.join(' ')}`, { cwd, env }, debug);
 };
 
-const withLocalRegistry = async (packageManager: JsPackageManager, action: () => Promise<void>) => {
+type LocalRegistryProps = {
+  packageManager: JsPackageManager;
+  action: () => Promise<void>;
+  cwd: string;
+  env: Record<string, any>;
+  debug: boolean;
+};
+
+const withLocalRegistry = async ({
+  packageManager,
+  action,
+  cwd,
+  env,
+  debug,
+}: LocalRegistryProps) => {
   const prevUrl = await packageManager.getRegistryURL();
   let error;
   try {
     console.log(`📦 Configuring local registry: ${LOCAL_REGISTRY_URL}`);
-    packageManager.setRegistryURL(LOCAL_REGISTRY_URL);
+    // NOTE: for some reason yarn prefers the npm registry in
+    // local development, so always use npm
+    await runCommand(`npm config set registry ${LOCAL_REGISTRY_URL}`, { cwd, env }, debug);
     await action();
   } catch (e) {
     error = e;
   } finally {
     console.log(`📦 Restoring registry: ${prevUrl}`);
-    await packageManager.setRegistryURL(prevUrl);
+    await runCommand(`npm config set registry ${LOCAL_REGISTRY_URL}`, { cwd, env }, debug);
 
     if (error) {
       throw error;
@@ -88,14 +104,20 @@ const addStorybook = async ({
 
     const packageManager = JsPackageManagerFactory.getPackageManager({ force: 'yarn1' }, tmpDir);
     if (localRegistry) {
-      await withLocalRegistry(packageManager, async () => {
-        await packageManager.addPackageResolutions({
-          ...storybookVersions,
-          // Yarn1 Issue: https://github.com/storybookjs/storybook/issues/22431
-          jackspeak: '2.1.1',
-        });
+      await withLocalRegistry({
+        packageManager,
+        action: async () => {
+          await packageManager.addPackageResolutions({
+            ...storybookVersions,
+            // Yarn1 Issue: https://github.com/storybookjs/storybook/issues/22431
+            jackspeak: '2.1.1',
+          });
 
-        await sbInit(tmpDir, env, [...flags, '--package-manager=yarn1'], debug);
+          await sbInit(tmpDir, env, [...flags, '--package-manager=yarn1'], debug);
+        },
+        cwd: tmpDir,
+        env,
+        debug,
       });
     } else {
       await sbInit(tmpDir, env, [...flags, '--package-manager=yarn1'], debug);
@@ -159,7 +181,7 @@ const runGenerators = async (
         const baseDir = join(REPROS_DIRECTORY, dirName);
         const beforeDir = join(baseDir, BEFORE_DIR_NAME);
         try {
-          let flags: string[] = [];
+          let flags: string[] = ['--no-dev'];
           if (expected.renderer === '@storybook/html') flags = ['--type html'];
           else if (expected.renderer === '@storybook/server') flags = ['--type server'];
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/20726

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have fixed a bug related to npm and workspaces where calling `npm config get ...` in a workspace was throwing an error.

Additionally, I have removed the `setRegistryURL` method from the JSPackageManager class since it was exclusively used by our scripts.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Manually tested with the following package managers:
- yarn berry pnp
- pnpm
- npm

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. git clone https://github.com/kinetics-dev/kinetics.git
2. cd ./packages/kinetics-core
3. npx storybook@<canary> init

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28699-sha-3cca421e`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28699-sha-3cca421e sandbox` or in an existing project with `npx storybook@0.0.0-pr-28699-sha-3cca421e upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28699-sha-3cca421e`](https://npmjs.com/package/storybook/v/0.0.0-pr-28699-sha-3cca421e) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-installing-storybook-in-workspaces`](https://github.com/storybookjs/storybook/tree/valentin/fix-installing-storybook-in-workspaces) |
| **Commit** | [`3cca421e`](https://github.com/storybookjs/storybook/commit/3cca421eb5838d5f27915b65e7964de58e2d1d71) |
| **Datetime** | Wed Jul 24 08:39:37 UTC 2024 (`1721810377`) |
| **Workflow run** | [10073385361](https://github.com/storybookjs/storybook/actions/runs/10073385361) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28699`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | **-1.48** | 0% |
| initSize |  198 MB | 198 MB | 875 B | **-1.45** | 0% |
| diffSize |  121 MB | 121 MB | 875 B | **1.98** | 0% |
| buildSize |  7.6 MB | 7.6 MB | 0 B | 0.33 | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | 0.33 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0.33 | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | - | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.6s | 7.5s | -16s -43ms | -0.91 | -211.4% |
| generateTime |  20.7s | 21.2s | 447ms | -0.47 | 2.1% |
| initTime |  21.9s | 20.7s | -1s -174ms | **-1.26** | 🔰-5.6% |
| buildTime |  14.8s | 13s | -1s -842ms | **-1.56** | 🔰-14.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.2s | 9.7s | 1.5s | 0.43 | 15.5% |
| devManagerResponsive |  5.6s | 6s | 410ms | 0.21 | 6.7% |
| devManagerHeaderVisible |  802ms | 914ms | 112ms | -0.01 | 12.3% |
| devManagerIndexVisible |  843ms | 959ms | 116ms | 0.06 | 12.1% |
| devStoryVisibleUncached |  1.1s | 1.6s | 431ms | 0.51 | 26.8% |
| devStoryVisible |  864ms | 971ms | 107ms | -0.01 | 11% |
| devAutodocsVisible |  723ms | 899ms | 176ms | 0.78 | 19.6% |
| devMDXVisible |  718ms | 748ms | 30ms | -0.34 | 4% |
| buildManagerHeaderVisible |  819ms | 973ms | 154ms | 0.86 | 15.8% |
| buildManagerIndexVisible |  825ms | 983ms | 158ms | 0.89 | 16.1% |
| buildStoryVisible |  870ms | 1s | 156ms | 0.79 | 15.2% |
| buildAutodocsVisible |  721ms | 815ms | 94ms | 0.25 | 11.5% |
| buildMDXVisible |  650ms | 897ms | 247ms | **1.26** | 🔺27.5% |

<!-- BENCHMARK_SECTION -->