### PR TITLE
React: Avoid 'Dynamic require of react is not possible' issue

### DIFF
--- a/code/addons/docs/src/DocsRenderer.tsx
+++ b/code/addons/docs/src/DocsRenderer.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import React, { Component } from 'react';
-import { renderElement, unmountElement } from '@storybook/react-dom-shim';
+import ReactDomShim from '@storybook/react-dom-shim';
 import type {
   Renderer,
   Parameters,
@@ -62,7 +62,7 @@ export class DocsRenderer<TRenderer extends Renderer> {
         import('@mdx-js/react')
           .then(({ MDXProvider }) =>
             // We use a `key={}` here to reset the `hasError` state each time we render ErrorBoundary
-            renderElement(
+            ReactDomShim.renderElement(
               <ErrorBoundary showException={reject} key={Math.random()}>
                 <MDXProvider components={components}>
                   <TDocs context={context} docsParameter={docsParameter} />
@@ -76,7 +76,7 @@ export class DocsRenderer<TRenderer extends Renderer> {
     };
 
     this.unmount = (element: HTMLElement) => {
-      unmountElement(element);
+      ReactDomShim.unmountElement(element);
     };
   }
 }

--- a/code/addons/docs/src/DocsRenderer.tsx
+++ b/code/addons/docs/src/DocsRenderer.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import React, { Component } from 'react';
-import ReactDomShim from '@storybook/react-dom-shim';
+import { renderElement, unmountElement } from '@storybook/react-dom-shim';
 import type {
   Renderer,
   Parameters,
@@ -62,7 +62,7 @@ export class DocsRenderer<TRenderer extends Renderer> {
         import('@mdx-js/react')
           .then(({ MDXProvider }) =>
             // We use a `key={}` here to reset the `hasError` state each time we render ErrorBoundary
-            ReactDomShim.renderElement(
+            renderElement(
               <ErrorBoundary showException={reject} key={Math.random()}>
                 <MDXProvider components={components}>
                   <TDocs context={context} docsParameter={docsParameter} />
@@ -76,7 +76,7 @@ export class DocsRenderer<TRenderer extends Renderer> {
     };
 
     this.unmount = (element: HTMLElement) => {
-      ReactDomShim.unmountElement(element);
+      unmountElement(element);
     };
   }
 }

--- a/code/lib/react-dom-shim/src/react-16.tsx
+++ b/code/lib/react-dom-shim/src/react-16.tsx
@@ -1,13 +1,15 @@
 /* eslint-disable react/no-deprecated */
 import type { ReactElement } from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 
-export const renderElement = async (node: ReactElement, el: Element) => {
+const renderElement = async (node: ReactElement, el: Element) => {
   return new Promise<null>((resolve) => {
     ReactDOM.render(node, el, () => resolve(null));
   });
 };
 
-export const unmountElement = (el: Element) => {
+const unmountElement = (el: Element) => {
   ReactDOM.unmountComponentAtNode(el);
 };
+
+export default { renderElement, unmountElement };

--- a/code/lib/react-dom-shim/src/react-16.tsx
+++ b/code/lib/react-dom-shim/src/react-16.tsx
@@ -2,14 +2,12 @@
 import type { ReactElement } from 'react';
 import * as ReactDOM from 'react-dom';
 
-const renderElement = async (node: ReactElement, el: Element) => {
+export const renderElement = async (node: ReactElement, el: Element) => {
   return new Promise<null>((resolve) => {
     ReactDOM.render(node, el, () => resolve(null));
   });
 };
 
-const unmountElement = (el: Element) => {
+export const unmountElement = (el: Element) => {
   ReactDOM.unmountComponentAtNode(el);
 };
-
-export default { renderElement, unmountElement };

--- a/code/lib/react-dom-shim/src/react-18.tsx
+++ b/code/lib/react-dom-shim/src/react-18.tsx
@@ -1,7 +1,7 @@
 import type { FC, ReactElement } from 'react';
-import React, { useLayoutEffect, useRef } from 'react';
+import * as React from 'react';
 import type { Root as ReactRoot, RootOptions } from 'react-dom/client';
-import ReactDOM from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 
 // A map of all rendered React 18 nodes
 const nodes = new Map<Element, ReactRoot>();
@@ -11,8 +11,8 @@ const WithCallback: FC<{ callback: () => void; children: ReactElement }> = ({
   children,
 }) => {
   // See https://github.com/reactwg/react-18/discussions/5#discussioncomment-2276079
-  const once = useRef<() => void>();
-  useLayoutEffect(() => {
+  const once = React.useRef<() => void>();
+  React.useLayoutEffect(() => {
     if (once.current === callback) return;
     once.current = callback;
     callback();
@@ -21,7 +21,7 @@ const WithCallback: FC<{ callback: () => void; children: ReactElement }> = ({
   return children;
 };
 
-export const renderElement = async (node: ReactElement, el: Element, rootOptions?: RootOptions) => {
+const renderElement = async (node: ReactElement, el: Element, rootOptions?: RootOptions) => {
   // Create Root Element conditionally for new React 18 Root Api
   const root = await getReactRoot(el, rootOptions);
 
@@ -30,7 +30,7 @@ export const renderElement = async (node: ReactElement, el: Element, rootOptions
   });
 };
 
-export const unmountElement = (el: Element, shouldUseNewRootApi?: boolean) => {
+const unmountElement = (el: Element, shouldUseNewRootApi?: boolean) => {
   const root = nodes.get(el);
 
   if (root) {
@@ -49,3 +49,5 @@ const getReactRoot = async (el: Element, rootOptions?: RootOptions): Promise<Rea
 
   return root;
 };
+
+export default { renderElement, unmountElement };

--- a/code/lib/react-dom-shim/src/react-18.tsx
+++ b/code/lib/react-dom-shim/src/react-18.tsx
@@ -21,7 +21,7 @@ const WithCallback: FC<{ callback: () => void; children: ReactElement }> = ({
   return children;
 };
 
-const renderElement = async (node: ReactElement, el: Element, rootOptions?: RootOptions) => {
+export const renderElement = async (node: ReactElement, el: Element, rootOptions?: RootOptions) => {
   // Create Root Element conditionally for new React 18 Root Api
   const root = await getReactRoot(el, rootOptions);
 
@@ -30,7 +30,7 @@ const renderElement = async (node: ReactElement, el: Element, rootOptions?: Root
   });
 };
 
-const unmountElement = (el: Element, shouldUseNewRootApi?: boolean) => {
+export const unmountElement = (el: Element, shouldUseNewRootApi?: boolean) => {
   const root = nodes.get(el);
 
   if (root) {
@@ -49,5 +49,3 @@ const getReactRoot = async (el: Element, rootOptions?: RootOptions): Promise<Rea
 
   return root;
 };
-
-export default { renderElement, unmountElement };

--- a/code/renderers/react/src/renderToCanvas.tsx
+++ b/code/renderers/react/src/renderToCanvas.tsx
@@ -53,7 +53,7 @@ export async function renderToCanvas(
   }: RenderContext<ReactRenderer>,
   canvasElement: ReactRenderer['canvasElement']
 ) {
-  const { renderElement, unmountElement } = (await import('@storybook/react-dom-shim')).default;
+  const { renderElement, unmountElement } = await import('@storybook/react-dom-shim');
   const Story = unboundStoryFn as FC<StoryContext<ReactRenderer>>;
 
   const content = (

--- a/code/renderers/react/src/renderToCanvas.tsx
+++ b/code/renderers/react/src/renderToCanvas.tsx
@@ -1,7 +1,6 @@
 import { global } from '@storybook/global';
 import type { FC } from 'react';
 import React, { Component as ReactComponent, StrictMode, Fragment } from 'react';
-import { renderElement, unmountElement } from '@storybook/react-dom-shim';
 
 import type { RenderContext } from 'storybook/internal/types';
 
@@ -54,6 +53,7 @@ export async function renderToCanvas(
   }: RenderContext<ReactRenderer>,
   canvasElement: ReactRenderer['canvasElement']
 ) {
+  const { renderElement, unmountElement } = (await import('@storybook/react-dom-shim')).default;
   const Story = unboundStoryFn as FC<StoryContext<ReactRenderer>>;
 
   const content = (


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

It closes an issue when Vitest runs portable stories. The following error occurs:
```
Error: Dynamic require of "react" is not supported
 ❯ ../../lib/react-dom-shim/dist/react-18.js ../node_modules/.vite/deps/@storybook_nextjs.js:6298:33
 ❯ ../node_modules/.vite/deps/@storybook_nextjs.js:6103:50
 ❯ ../node_modules/.vite/deps/@storybook_nextjs.js:6327:38
```

This issue at `tsup` seems to be related:
https://github.com/egoist/tsup/issues/927

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Manual testing is not necessary. Automated tests cover it.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28730-sha-8f30c5c8`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28730-sha-8f30c5c8 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28730-sha-8f30c5c8 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28730-sha-8f30c5c8`](https://npmjs.com/package/storybook/v/0.0.0-pr-28730-sha-8f30c5c8) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-dynamic-require-react-issue-in-vitest`](https://github.com/storybookjs/storybook/tree/valentin/fix-dynamic-require-react-issue-in-vitest) |
| **Commit** | [`8f30c5c8`](https://github.com/storybookjs/storybook/commit/8f30c5c8bfe2e09d7738b10923f6de4ae0279069) |
| **Datetime** | Mon Jul 29 09:00:49 UTC 2024 (`1722243649`) |
| **Workflow run** | [10141272720](https://github.com/storybookjs/storybook/actions/runs/10141272720) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28730`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | -0.59 | 0% |
| initSize |  198 MB | 198 MB | -279 B | **2.33** | 0% |
| diffSize |  122 MB | 122 MB | -279 B | **2.71** | 0% |
| buildSize |  7.6 MB | 7.6 MB | 207 B | **35** | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | -31 B | -0.23 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | -31 B | -0.23 | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 238 B | **Infinity** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.8s | 8.4s | 621ms | -0.73 | 7.3% |
| generateTime |  23.3s | 23.8s | 559ms | 0.49 | 2.3% |
| initTime |  22.1s | 23.2s | 1s | 0.27 | 4.7% |
| buildTime |  14.3s | 16s | 1.6s | 1.22 | 10.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.4s | 7.5s | -926ms | -0.97 | -12.3% |
| devManagerResponsive |  5.6s | 5.1s | -487ms | -1.13 | -9.5% |
| devManagerHeaderVisible |  899ms | 773ms | -126ms | -0.77 | -16.3% |
| devManagerIndexVisible |  939ms | 799ms | -140ms | -0.76 | -17.5% |
| devStoryVisibleUncached |  1.4s | 1s | -372ms | **-1.35** | 🔰-34.3% |
| devStoryVisible |  973ms | 817ms | -156ms | -0.84 | -19.1% |
| devAutodocsVisible |  796ms | 655ms | -141ms | -1.13 | -21.5% |
| devMDXVisible |  786ms | 647ms | -139ms | -1.13 | -21.5% |
| buildManagerHeaderVisible |  855ms | 698ms | -157ms | -1.02 | -22.5% |
| buildManagerIndexVisible |  905ms | 704ms | -201ms | -1.02 | -28.6% |
| buildStoryVisible |  915ms | 745ms | -170ms | -1.03 | -22.8% |
| buildAutodocsVisible |  888ms | 665ms | -223ms | -0.87 | -33.5% |
| buildMDXVisible |  725ms | 645ms | -80ms | -0.73 | -12.4% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request addresses the issue of dynamic require errors for React in Vitest by modifying import statements and dynamic imports.

- Updated `code/lib/react-dom-shim/src/react-16.tsx` to use namespace imports for `react-dom`.
- Modified `code/lib/react-dom-shim/src/react-18.tsx` to use namespace imports for both React and ReactDOM, ensuring compatibility with Vitest.
- Adjusted `code/renderers/react/src/renderToCanvas.tsx` to dynamically import `renderElement` and `unmountElement` from `@storybook/react-dom-shim` within the `renderToCanvas` function, preventing dynamic require errors.

<!-- /greptile_comment -->