### PR TITLE
Controls: Add disableSave parameter

### DIFF
--- a/code/addons/controls/src/ControlsPanel.tsx
+++ b/code/addons/controls/src/ControlsPanel.tsx
@@ -34,6 +34,7 @@ interface ControlsParameters {
   sort?: SortType;
   expanded?: boolean;
   presetColors?: PresetColor[];
+  disableSave?: boolean;
 }
 
 interface ControlsPanelProps {
@@ -46,7 +47,12 @@ export const ControlsPanel = ({ saveStory, createStory }: ControlsPanelProps) =>
   const [args, updateArgs, resetArgs, initialArgs] = useArgs();
   const [globals] = useGlobals();
   const rows = useArgTypes();
-  const { expanded, sort, presetColors } = useParameter<ControlsParameters>(PARAM_KEY, {});
+  const {
+    expanded,
+    sort,
+    presetColors,
+    disableSave = false,
+  } = useParameter<ControlsParameters>(PARAM_KEY, {});
   const { path, previewInitialized } = useStorybookState();
 
   // If the story is prepared, then show the args table
@@ -84,9 +90,10 @@ export const ControlsPanel = ({ saveStory, createStory }: ControlsPanelProps) =>
         sort={sort}
         isLoading={isLoading}
       />
-      {hasControls && hasUpdatedArgs && global.CONFIG_TYPE === 'DEVELOPMENT' && (
-        <SaveStory {...{ resetArgs, saveStory, createStory }} />
-      )}
+      {hasControls &&
+        hasUpdatedArgs &&
+        global.CONFIG_TYPE === 'DEVELOPMENT' &&
+        disableSave !== true && <SaveStory {...{ resetArgs, saveStory, createStory }} />}
     </AddonWrapper>
   );
 };

--- a/code/addons/controls/src/ControlsPanel.tsx
+++ b/code/addons/controls/src/ControlsPanel.tsx
@@ -34,7 +34,7 @@ interface ControlsParameters {
   sort?: SortType;
   expanded?: boolean;
   presetColors?: PresetColor[];
-  disableSave?: boolean;
+  disableSaveFromUI?: boolean;
 }
 
 interface ControlsPanelProps {
@@ -51,7 +51,7 @@ export const ControlsPanel = ({ saveStory, createStory }: ControlsPanelProps) =>
     expanded,
     sort,
     presetColors,
-    disableSave = false,
+    disableSaveFromUI = false,
   } = useParameter<ControlsParameters>(PARAM_KEY, {});
   const { path, previewInitialized } = useStorybookState();
 
@@ -93,7 +93,7 @@ export const ControlsPanel = ({ saveStory, createStory }: ControlsPanelProps) =>
       {hasControls &&
         hasUpdatedArgs &&
         global.CONFIG_TYPE === 'DEVELOPMENT' &&
-        disableSave !== true && <SaveStory {...{ resetArgs, saveStory, createStory }} />}
+        disableSaveFromUI !== true && <SaveStory {...{ resetArgs, saveStory, createStory }} />}
     </AddonWrapper>
   );
 };

--- a/docs/essentials/controls.mdx
+++ b/docs/essentials/controls.mdx
@@ -260,6 +260,10 @@ You can also update a control's value, then save the changes to the story. The s
 
 <Video src="../_assets/get-started/edit-story-from-controls-optimized.mp4" />
 
+### Disable creating and editing of stories
+
+If you don't want to allow the creation or editing of stories from the Controls panel, you can disable this feature by setting the `disableSave` parameter to `true` in the `parameters.controls` parameter in your `.storybook/preview.js` file.
+
 ## Configuration
 
 The Controls addon can be configured in two ways:
@@ -484,3 +488,11 @@ Specifies how the controls are sorted.
 * **none**: Unsorted, displayed in the same order the arg types are processed in
 * **alpha**: Sorted alphabetically, by the arg type's name
 * **requiredFirst**: Same as `alpha`, with any required arg types displayed first
+
+#### `disableSave`
+
+Type: `boolean`
+
+Default: `false`
+
+Disable the ability to create or edit stories from the Controls panel.

--- a/docs/essentials/controls.mdx
+++ b/docs/essentials/controls.mdx
@@ -262,7 +262,7 @@ You can also update a control's value, then save the changes to the story. The s
 
 ### Disable creating and editing of stories
 
-If you don't want to allow the creation or editing of stories from the Controls panel, you can disable this feature by setting the `disableSave` parameter to `true` in the `parameters.controls` parameter in your `.storybook/preview.js` file.
+If you don't want to allow the creation or editing of stories from the Controls panel, you can disable this feature by setting the `disableSaveFromUI` parameter to `true` in the `parameters.controls` parameter in your `.storybook/preview.js` file.
 
 ## Configuration
 
@@ -489,7 +489,7 @@ Specifies how the controls are sorted.
 * **alpha**: Sorted alphabetically, by the arg type's name
 * **requiredFirst**: Same as `alpha`, with any required arg types displayed first
 
-#### `disableSave`
+#### `disableSaveFromUI`
 
 Type: `boolean`
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28377

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added a `disableSave` parameter to `parameters.controls` to be able to disable the "save toolbar" when adjusting controls.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a Next.js sandbox for template
2. Open Storybook in your browser
3. Access a story and change controls: The save toolbar should appear
4. Shutdown Storybook
5. Go to `.storybook/preview.ts` and set `parameters.controls.disableSave: true`
6. Open Storybook
7. Access a story and change controls: The save toolbar should not appear.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | -0.66 | 0% |
| initSize |  198 MB | 198 MB | 45 B | **2.82** | 0% |
| diffSize |  122 MB | 122 MB | 45 B | **3.65** | 0% |
| buildSize |  7.6 MB | 7.6 MB | 31 B | **Infinity** | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 31 B | **Infinity** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 31 B | **Infinity** | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | - | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.7s | 25.1s | 18.3s | **1.64** | 🔺73.1% |
| generateTime |  20.3s | 21.7s | 1.3s | -0.17 | 6.3% |
| initTime |  21s | 22.2s | 1.2s | -0.21 | 5.4% |
| buildTime |  14.2s | 14.6s | 452ms | -0.2 | 3.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  11.9s | 8.4s | -3s -458ms | -0.27 | -40.7% |
| devManagerResponsive |  7.4s | 5.4s | -2s -27ms | -0.65 | -37.2% |
| devManagerHeaderVisible |  1s | 792ms | -255ms | -0.58 | -32.2% |
| devManagerIndexVisible |  1s | 826ms | -248ms | -0.52 | -30% |
| devStoryVisibleUncached |  1.6s | 1.3s | -240ms | -0.12 | -17.3% |
| devStoryVisible |  1.1s | 852ms | -250ms | -0.54 | -29.3% |
| devAutodocsVisible |  1s | 780ms | -243ms | -0.14 | -31.2% |
| devMDXVisible |  875ms | 710ms | -165ms | -0.48 | -23.2% |
| buildManagerHeaderVisible |  1s | 727ms | -283ms | -0.76 | -38.9% |
| buildManagerIndexVisible |  1s | 734ms | -295ms | -0.75 | -40.2% |
| buildStoryVisible |  1s | 777ms | -315ms | -0.77 | -40.5% |
| buildAutodocsVisible |  939ms | 659ms | -280ms | -0.88 | -42.5% |
| buildMDXVisible |  1s | 673ms | -343ms | -0.49 | -51% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Introduced a `disableSave` parameter to the Storybook Controls addon, allowing users to disable the "save toolbar" when adjusting controls.

- Updated `code/addons/controls/src/ControlsPanel.tsx` to include `disableSave` in `parameters.controls` and conditionally render the `SaveStory` component.
- Modified `docs/essentials/controls.mdx` to document the new `disableSave` parameter, providing clear usage instructions.

<!-- /greptile_comment -->