### PR TITLE
CPC: Fix type usage in renderers

### DIFF
--- a/code/renderers/react/src/mount.ts
+++ b/code/renderers/react/src/mount.ts
@@ -1,5 +1,5 @@
 import { type StoryContext, type ReactRenderer } from './public-types';
-import type { BaseAnnotations } from '@storybook/types';
+import type { BaseAnnotations } from 'storybook/internal/types';
 
 export const mount: BaseAnnotations<ReactRenderer>['mount'] =
   (context: StoryContext) => async (ui) => {

--- a/code/renderers/svelte/src/mount.ts
+++ b/code/renderers/svelte/src/mount.ts
@@ -1,5 +1,5 @@
 import { type StoryContext, type SvelteRenderer } from './public-types';
-import { type BaseAnnotations } from '@storybook/types';
+import { type BaseAnnotations } from 'storybook/internal/types';
 
 export const mount: BaseAnnotations<SvelteRenderer>['mount'] = (context: StoryContext) => {
   return async (Component, options) => {

--- a/code/renderers/vue3/src/mount.ts
+++ b/code/renderers/vue3/src/mount.ts
@@ -1,6 +1,6 @@
 import { type StoryContext, type VueRenderer } from './public-types';
 import { h } from 'vue';
-import { type BaseAnnotations } from '@storybook/types';
+import { type BaseAnnotations } from 'storybook/internal/types';
 
 export const mount: BaseAnnotations<VueRenderer>['mount'] = (context: StoryContext) => {
   return async (Component, options) => {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28728

## What I did

As the issue describes, there are places after #27039 that still referenced consolidated packages.
This is wrong, and is addressed in this PR.

The reason this happened was due to CPC taking a long time to complete, and other PRs happened to parallel and were merged after CPC.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | -0.59 | 0% |
| initSize |  198 MB | 198 MB | 0 B | **2.34** | 0% |
| diffSize |  122 MB | 122 MB | 0 B | **2.71** | 0% |
| buildSize |  7.6 MB | 7.6 MB | 0 B | **4.36** | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | **4.36** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **4.36** | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | - | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.8s | 20.7s | 12.8s | 1.01 | 62.1% |
| generateTime |  23.3s | 21.9s | -1s -348ms | -0.14 | -6.1% |
| initTime |  22.1s | 21.1s | -1s -31ms | -0.74 | -4.9% |
| buildTime |  14.3s | 12.6s | -1s -794ms | **-2.28** | 🔰-14.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.4s | 8.9s | 455ms | 0.05 | 5.1% |
| devManagerResponsive |  5.6s | 5.6s | 87ms | -0.28 | 1.5% |
| devManagerHeaderVisible |  899ms | 837ms | -62ms | -0.3 | -7.4% |
| devManagerIndexVisible |  939ms | 871ms | -68ms | -0.26 | -7.8% |
| devStoryVisibleUncached |  1.4s | 1.4s | -53ms | -0.15 | -3.8% |
| devStoryVisible |  973ms | 898ms | -75ms | -0.28 | -8.4% |
| devAutodocsVisible |  796ms | 746ms | -50ms | -0.41 | -6.7% |
| devMDXVisible |  786ms | 744ms | -42ms | -0.18 | -5.6% |
| buildManagerHeaderVisible |  855ms | 829ms | -26ms | -0.05 | -3.1% |
| buildManagerIndexVisible |  905ms | 830ms | -75ms | -0.1 | -9% |
| buildStoryVisible |  915ms | 886ms | -29ms | -0.05 | -3.3% |
| buildAutodocsVisible |  888ms | 688ms | -200ms | -0.66 | -29.1% |
| buildMDXVisible |  725ms | 662ms | -63ms | -0.6 | -9.5% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated import paths for `BaseAnnotations` in various renderer `mount.ts` files to ensure correct internal type usage.

- **React Renderer**: Updated `code/renderers/react/src/mount.ts` to import `BaseAnnotations` from `storybook/internal/types`.
- **Svelte Renderer**: Modified `code/renderers/svelte/src/mount.ts` to use `storybook/internal/types` for `BaseAnnotations`.
- **Vue3 Renderer**: Changed `code/renderers/vue3/src/mount.ts` to import `BaseAnnotations` from `storybook/internal/types`.

Ensure the new import paths are correct and all dependencies are resolved.

<!-- /greptile_comment -->