### PR TITLE
Build: Use !test tag to disable test-runner tests

### DIFF
--- a/code/addons/docs/template/stories/docspage/error.stories.ts
+++ b/code/addons/docs/template/stories/docspage/error.stories.ts
@@ -2,7 +2,7 @@ import { global as globalThis } from '@storybook/global';
 
 export default {
   component: globalThis.Components.Button,
-  tags: ['autodocs'],
+  tags: ['autodocs', '!test'],
   args: { label: 'Click Me!' },
   parameters: { chromatic: { disable: true } },
 };
@@ -12,10 +12,7 @@ export default {
  */
 export const ErrorStory = {
   decorators: [
-    (storyFn) => {
-      // Don't throw in the test runner; there's no easy way to skip (yet)
-      if (window?.navigator?.userAgent?.match(/StorybookTestRunner/)) return storyFn();
-
+    () => {
       throw new Error('Story did something wrong');
     },
   ],

--- a/code/addons/interactions/template/stories/unhandled-errors.stories.ts
+++ b/code/addons/interactions/template/stories/unhandled-errors.stories.ts
@@ -13,7 +13,7 @@ export default {
     actions: { argTypesRegex: '^on[A-Z].*' },
     chromatic: { disable: true },
   },
-  tags: ['test-skip'],
+  tags: ['!test'],
 };
 
 export const Default = {

--- a/code/core/template/stories/rendering.stories.ts
+++ b/code/core/template/stories/rendering.stories.ts
@@ -24,9 +24,6 @@ export const ForceRemount = {
    */
   parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvasElement, id }: PlayFunctionContext<any>) => {
-    if (window?.navigator.userAgent.match(/StorybookTestRunner/)) {
-      return;
-    }
     const channel = globalThis.__STORYBOOK_ADDONS_CHANNEL__;
     const button = await within(canvasElement).findByRole('button');
 
@@ -39,6 +36,7 @@ export const ForceRemount = {
     // By forcing the component to remount, we reset the focus state
     await channel.emit(FORCE_REMOUNT, { storyId: id });
   },
+  tags: ['!test'],
 };
 
 export const ChangeArgs = {

--- a/code/frameworks/nextjs/template/stories/RSC.stories.jsx
+++ b/code/frameworks/nextjs/template/stories/RSC.stories.jsx
@@ -9,7 +9,7 @@ export default {
 export const Default = {};
 
 export const DisableRSC = {
-  tags: ['test-skip'],
+  tags: ['!test'],
   parameters: {
     chromatic: { disable: true },
     nextjs: { rsc: false },
@@ -17,7 +17,7 @@ export const DisableRSC = {
 };
 
 export const Error = {
-  tags: ['test-skip'],
+  tags: ['!test'],
   parameters: {
     chromatic: { disable: true },
   },

--- a/code/frameworks/nextjs/template/stories_nextjs-default-ts/Redirect.stories.tsx
+++ b/code/frameworks/nextjs/template/stories_nextjs-default-ts/Redirect.stories.tsx
@@ -44,6 +44,7 @@ export default {
       },
     },
   },
+  tags: ['!test'],
 } as Meta;
 
 export const SingletonStateGetsInvalidatedAfterRedirecting: StoryObj = {

--- a/code/frameworks/nextjs/template/stories_nextjs-default-ts/ServerActions.stories.tsx
+++ b/code/frameworks/nextjs/template/stories_nextjs-default-ts/ServerActions.stories.tsx
@@ -31,7 +31,7 @@ function Component() {
 
 export default {
   component: Component,
-  tags: ['test-skip'],
+  tags: ['!test'],
   parameters: {
     nextjs: {
       appDirectory: true,

--- a/code/lib/blocks/src/blocks/ArgTypes.stories.tsx
+++ b/code/lib/blocks/src/blocks/ArgTypes.stories.tsx
@@ -49,7 +49,7 @@ export const OfUndefined: Story = {
     of: ExampleStories.NotDefined,
   },
   parameters: { chromatic: { disableSnapshot: true } },
-  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
+  tags: ['!test'],
 };
 
 export const OfStoryUnattached: Story = {

--- a/code/lib/blocks/src/blocks/Canvas.stories.tsx
+++ b/code/lib/blocks/src/blocks/Canvas.stories.tsx
@@ -61,7 +61,7 @@ export const OfUndefined: Story = {
     of: ButtonStories.NotDefined,
   },
   parameters: { chromatic: { disableSnapshot: true } },
-  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
+  tags: ['!test'],
 };
 
 export const PropWithToolbar: Story = {

--- a/code/lib/blocks/src/blocks/Controls.stories.tsx
+++ b/code/lib/blocks/src/blocks/Controls.stories.tsx
@@ -46,7 +46,7 @@ export const OfUndefined: Story = {
     of: ExampleStories.NotDefined,
   },
   parameters: { chromatic: { disableSnapshot: true } },
-  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
+  tags: ['!test'],
 };
 
 export const IncludeProp: Story = {

--- a/code/lib/blocks/src/blocks/Description.stories.tsx
+++ b/code/lib/blocks/src/blocks/Description.stories.tsx
@@ -121,7 +121,7 @@ export const OfUndefinedAttached: Story = {
     relativeCsfPaths: ['../examples/Button.stories'],
     attached: true,
   },
-  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
+  tags: ['!test'],
 };
 export const OfStringComponentAttached: Story = {
   name: 'Of "component" Attached',

--- a/code/lib/blocks/src/blocks/Source.stories.tsx
+++ b/code/lib/blocks/src/blocks/Source.stories.tsx
@@ -66,7 +66,7 @@ export const OfUndefined: Story = {
     of: ParametersStories.NotDefined,
   },
   parameters: { chromatic: { disableSnapshot: true } },
-  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
+  tags: ['!test'],
 };
 
 export const OfTypeProp: Story = {

--- a/code/lib/blocks/src/blocks/Story.stories.tsx
+++ b/code/lib/blocks/src/blocks/Story.stories.tsx
@@ -54,7 +54,7 @@ export const OfUndefined: Story = {
     of: ButtonStories.NotDefined,
   },
   parameters: { chromatic: { disableSnapshot: true } },
-  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
+  tags: ['!test'],
 };
 
 export const Inline: Story = {

--- a/code/lib/blocks/src/blocks/Subtitle.stories.tsx
+++ b/code/lib/blocks/src/blocks/Subtitle.stories.tsx
@@ -89,7 +89,7 @@ export const OfUndefinedAttached: Story = {
     relativeCsfPaths: ['../examples/Button.stories'],
     attached: true,
   },
-  decorators: [(s) => (window?.navigator.userAgent.match(/StorybookTestRunner/) ? <div /> : s())],
+  tags: ['!test'],
 };
 export const OfStringMetaAttached: Story = {
   name: 'Of "meta" Attached',

--- a/code/renderers/react/template/stories/errors.stories.tsx
+++ b/code/renderers/react/template/stories/errors.stories.tsx
@@ -8,10 +8,7 @@ export default {
   parameters: {
     chromatic: { disable: true },
   },
-  decorators: [
-    // Skip errors if we are running in the test runner
-    (storyFn: any) => window?.navigator?.userAgent?.match(/StorybookTestRunner/) || storyFn(),
-  ],
+  tags: ['!test'],
 };
 
 export const RenderThrows = {

--- a/scripts/tasks/test-runner-build.ts
+++ b/scripts/tasks/test-runner-build.ts
@@ -17,7 +17,6 @@ export const testRunnerBuild: Task & { port: number } = {
       '--junit',
       '--maxWorkers=2',
       '--failOnConsole',
-      '--skipTags="test-skip"',
       '--index-json',
     ];
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Storybook test-runner now uses `test` as default tags, so we now remove the old ways of filtering tests and use the `!test` tag instead

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | -0.51 | 0% |
| initSize |  198 MB | 198 MB | 0 B | **2.09** | 0% |
| diffSize |  122 MB | 122 MB | 0 B | **2.29** | 0% |
| buildSize |  7.6 MB | 7.6 MB | 0 B | **4.33** | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | **3** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **3** | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | **4.36** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.7s | 7s | -758ms | -0.93 | -10.8% |
| generateTime |  28.4s | 22.4s | -5s -978ms | -0.01 | -26.6% |
| initTime |  26s | 23s | -3s -21ms | 0.18 | -13.1% |
| buildTime |  14.4s | 17.7s | 3.3s | **3.04** | 🔺19% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  9.9s | 8.4s | -1s -438ms | -0.38 | -17% |
| devManagerResponsive |  6s | 5.6s | -352ms | -0.37 | -6.2% |
| devManagerHeaderVisible |  970ms | 862ms | -108ms | -0.22 | -12.5% |
| devManagerIndexVisible |  997ms | 891ms | -106ms | -0.24 | -11.9% |
| devStoryVisibleUncached |  1.4s | 1.2s | -198ms | -0.86 | -16.2% |
| devStoryVisible |  1s | 914ms | -104ms | -0.28 | -11.4% |
| devAutodocsVisible |  823ms | 772ms | -51ms | -0.29 | -6.6% |
| devMDXVisible |  880ms | 684ms | -196ms | -0.87 | -28.7% |
| buildManagerHeaderVisible |  894ms | 809ms | -85ms | -0.26 | -10.5% |
| buildManagerIndexVisible |  897ms | 814ms | -83ms | -0.28 | -10.2% |
| buildStoryVisible |  968ms | 858ms | -110ms | -0.32 | -12.8% |
| buildAutodocsVisible |  821ms | 699ms | -122ms | -0.71 | -17.5% |
| buildMDXVisible |  742ms | 678ms | -64ms | -0.54 | -9.4% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated the Storybook test-runner to use the `!test` tag for excluding tests, replacing the old filtering methods.

- Updated `code/addons/docs/template/stories/docspage/error.stories.ts` to use `!test` tag for excluding stories from test runs.
- Replaced `test-skip` with `!test` in `code/addons/interactions/template/stories/unhandled-errors.stories.ts`.
- Simplified test exclusion in `code/core/template/stories/rendering.stories.ts` using the `!test` tag.
- Modified `code/frameworks/nextjs/template/stories/RSC.stories.jsx` to align with the new tagging system.
- Removed `--skipTags="test-skip"` flag in `scripts/tasks/test-runner-build.ts` to adopt the new tagging approach.

<!-- /greptile_comment -->