### PR TITLE
Fix: Invariant failed: Expected package.json#version to be defined in the "undefined" package

### DIFF
--- a/code/core/src/core-server/standalone.ts
+++ b/code/core/src/core-server/standalone.ts
@@ -4,7 +4,8 @@ import { dirname } from 'node:path';
 
 async function build(options: any = {}, frameworkOptions: any = {}) {
   const { mode = 'dev' } = options;
-  const packageJson = dirname(require.resolve('@storybook/core/package.json'));
+  const packageJsonDir = dirname(require.resolve('@storybook/core/package.json'));
+  const packageJson = JSON.parse(require('fs').readFileSync(`${packageJsonDir}/package.json`));
 
   const commonOptions = {
     ...options,


### PR DESCRIPTION
Closes #28606

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

It looks like the packageJson const was getting set as the path rather than returning the json. I renamed that const and used it to read the file contents and parse the json. 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. I tested a monorepo that has the undefined version issue:

```
 NX   Invariant failed: Expected package.json#version to be defined in the "undefined" package}
```
2. I built the code then copied the built core-server code to the monorepo that was having an issue.
3. I ran storybook and saw it successfully spin up:

```
╭───────────────────────────────────────────────────╮
│                                                   │
│   Storybook 8.2.6 for react-webpack5 started      │
│   345 ms for manager and 7.73 s for preview       │
│                                                   │
│    Local:            http://localhost:4402/       │
│    On your network:  http://192.168.4.41:4402/    │
│                                                   │
╰───────────────────────────────────────────────────╯
```

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28752-sha-a65743e5`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28752-sha-a65743e5 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28752-sha-a65743e5 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28752-sha-a65743e5`](https://npmjs.com/package/storybook/v/0.0.0-pr-28752-sha-a65743e5) |
| **Triggered by** | @ndelangen |
| **Repository** | [abcdmku/storybook](https://github.com/abcdmku/storybook) |
| **Branch** | [`issue-28606-fix`](https://github.com/abcdmku/storybook/tree/issue-28606-fix) |
| **Commit** | [`a65743e5`](https://github.com/abcdmku/storybook/commit/a65743e553b85c9b42410c6e111aebe353a10329) |
| **Datetime** | Tue Jul 30 14:36:35 UTC 2024 (`1722350195`) |
| **Workflow run** | [10164438729](https://github.com/storybookjs/storybook/actions/runs/10164438729) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28752`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | **-2.93** | 0% |
| initSize |  198 MB | 198 MB | -597 B | -0.08 | 0% |
| diffSize |  122 MB | 122 MB | -597 B | 0.51 | 0% |
| buildSize |  7.6 MB | 7.6 MB | -303 B | 0.07 | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | -192 B | -0.43 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 13 B | 0.33 | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | -124 B | -0.58 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | -303 B | -0.49 | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0.73 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.5s | 25.6s | 18s | **1.75** | 🔺70.4% |
| generateTime |  24.8s | 21.1s | -3s -672ms | -0.8 | -17.3% |
| initTime |  25.6s | 21s | -4s -570ms | **-1.24** | 🔰-21.7% |
| buildTime |  16.2s | 13.8s | -2s -421ms | -0.42 | -17.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.3s | 9.1s | 797ms | -0.15 | 8.7% |
| devManagerResponsive |  5.4s | 5.9s | 500ms | -0.12 | 8.5% |
| devManagerHeaderVisible |  845ms | 915ms | 70ms | 0.19 | 7.7% |
| devManagerIndexVisible |  871ms | 926ms | 55ms | 0.07 | 5.9% |
| devStoryVisibleUncached |  1.4s | 1.4s | 49ms | 0.08 | 3.3% |
| devStoryVisible |  893ms | 971ms | 78ms | 0.17 | 8% |
| devAutodocsVisible |  784ms | 967ms | 183ms | 1.19 | 18.9% |
| devMDXVisible |  740ms | 854ms | 114ms | **1.24** | 🔺13.3% |
| buildManagerHeaderVisible |  876ms | 944ms | 68ms | 0.65 | 7.2% |
| buildManagerIndexVisible |  877ms | 946ms | 69ms | 0.6 | 7.3% |
| buildStoryVisible |  918ms | 1s | 88ms | 0.63 | 8.7% |
| buildAutodocsVisible |  794ms | 753ms | -41ms | -0.31 | -5.4% |
| buildMDXVisible |  689ms | 814ms | 125ms | 0.63 | 15.4% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

The pull request fixes an issue with the `packageJson` constant in `standalone.ts`, ensuring the correct JSON content is read and parsed.

- Modified `code/core/src/core-server/standalone.ts` to correctly read and parse `package.json`.
- Renamed the constant to `packageJsonDir` to hold the directory path.
- Ensured `packageJson` contains the actual JSON content, resolving the undefined package version error.

<!-- /greptile_comment -->