### PR TITLE
Next.js: Make RSC portable-stories compatible

### DIFF
--- a/code/frameworks/nextjs/src/portable-stories.ts
+++ b/code/frameworks/nextjs/src/portable-stories.ts
@@ -16,6 +16,7 @@ import type {
 
 // ! ATTENTION: This needs to be a relative import so it gets prebundled. This is to avoid ESM issues in Nextjs + Jest setups
 import { INTERNAL_DEFAULT_PROJECT_ANNOTATIONS as reactAnnotations } from '../../../renderers/react/src/portable-stories';
+import * as rscAnnotations from '../../../renderers/react/src/entry-preview-rsc';
 import * as nextJsAnnotations from './preview';
 
 import type { ReactRenderer, Meta } from '@storybook/react';
@@ -46,6 +47,7 @@ export function setProjectAnnotations(
 // This will not be necessary once we have auto preset loading
 const defaultProjectAnnotations: ProjectAnnotations<ReactRenderer> = composeConfigs([
   reactAnnotations,
+  rscAnnotations,
   nextJsAnnotations,
 ]);
 

--- a/code/renderers/react/src/preset.ts
+++ b/code/renderers/react/src/preset.ts
@@ -11,6 +11,7 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   options
 ) => {
   const docsConfig = await options.presets.apply('docs', {}, options);
+  const features = await options.presets.apply('features', {}, options);
   const docsEnabled = Object.keys(docsConfig).length > 0;
   const result: string[] = [];
 
@@ -18,7 +19,7 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
     .concat(input)
     .concat([join(__dirname, 'entry-preview.mjs')])
     .concat(docsEnabled ? [join(__dirname, 'entry-preview-docs.mjs')] : [])
-    .concat(FEATURES?.experimentalRSC ? [join(__dirname, 'entry-preview-rsc.mjs')] : []);
+    .concat(features?.experimentalRSC ? [join(__dirname, 'entry-preview-rsc.mjs')] : []);
 };
 
 /**


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Made RSC portable-stories compatible.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Manual testing is not necessary. Automated tests cover this bugfix.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28756-sha-d271575c`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28756-sha-d271575c sandbox` or in an existing project with `npx storybook@0.0.0-pr-28756-sha-d271575c upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28756-sha-d271575c`](https://npmjs.com/package/storybook/v/0.0.0-pr-28756-sha-d271575c) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/rsc-portable-stories-compat`](https://github.com/storybookjs/storybook/tree/valentin/rsc-portable-stories-compat) |
| **Commit** | [`d271575c`](https://github.com/storybookjs/storybook/commit/d271575cc2c53fdd3155e2779be496ab078ba484) |
| **Datetime** | Wed Jul 31 05:29:41 UTC 2024 (`1722403781`) |
| **Workflow run** | [10174630999](https://github.com/storybookjs/storybook/actions/runs/10174630999) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28756`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 4.87 kB | **1.28** | 0% |
| initSize |  198 MB | 198 MB | -1.66 kB | 1.22 | 0% |
| diffSize |  122 MB | 122 MB | -6.52 kB | 1.15 | 0% |
| buildSize |  7.6 MB | 7.6 MB | 0 B | **1.53** | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | **1.36** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **1.36** | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | **1.53** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.8s | 6.9s | -1s -866ms | -1.06 | -26.9% |
| generateTime |  23.1s | 20s | -3s -134ms | **-1.27** | 🔰-15.7% |
| initTime |  23.5s | 20s | -3s -472ms | **-1.66** | 🔰-17.3% |
| buildTime |  15.7s | 13.9s | -1s -835ms | -0.66 | -13.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  18s | 10.9s | -7s -82ms | 0.63 | -64.5% |
| devManagerResponsive |  10.4s | 6.7s | -3s -669ms | 0.52 | -54.2% |
| devManagerHeaderVisible |  861ms | 1s | 204ms | 0.88 | 19.2% |
| devManagerIndexVisible |  896ms | 1s | 202ms | 0.85 | 18.4% |
| devStoryVisibleUncached |  2.1s | 1.6s | -571ms | 0.49 | -35.1% |
| devStoryVisible |  916ms | 1.1s | 212ms | 0.86 | 18.8% |
| devAutodocsVisible |  798ms | 958ms | 160ms | 1.09 | 16.7% |
| devMDXVisible |  781ms | 897ms | 116ms | **1.66** | 🔺12.9% |
| buildManagerHeaderVisible |  746ms | 848ms | 102ms | -0.09 | 12% |
| buildManagerIndexVisible |  753ms | 851ms | 98ms | -0.13 | 11.5% |
| buildStoryVisible |  805ms | 896ms | 91ms | -0.18 | 10.2% |
| buildAutodocsVisible |  673ms | 711ms | 38ms | -0.69 | 5.3% |
| buildMDXVisible |  856ms | 645ms | -211ms | -1.23 | -32.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated `preset.ts` to enhance feature flag management for RSC portable-stories compatibility.

- Modified `code/renderers/react/src/preset.ts` to replace global `FEATURES` with locally scoped `features` object.
- Applied `experimentalRSC` feature flag based on current preset configuration using `options.presets.apply('features', {}, options)`.
- Ensured modularity and alignment with best practices for feature flag management.

Thorough testing is recommended to ensure no regressions.

<!-- /greptile_comment -->