### PR TITLE
CSF: Add addon-themes for testing to sandboxes & main storybook

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -69,6 +69,10 @@ const config: StorybookConfig = {
       titlePrefix: 'addons/toolbars',
     },
     {
+      directory: '../addons/themes/template/stories',
+      titlePrefix: 'addons/themes',
+    },
+    {
       directory: '../addons/onboarding/src',
       titlePrefix: 'addons/onboarding',
     },
@@ -83,6 +87,7 @@ const config: StorybookConfig = {
   ],
   addons: [
     '@storybook/addon-links',
+    '@storybook/addon-themes',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
     '@storybook/addon-storysource',

--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -125,7 +125,6 @@ const config: StorybookConfig = {
   features: {
     viewportStoryGlobals: true,
     backgroundsStoryGlobals: true,
-    // themesStoryGlobals: true,
   },
   viteFinal: (viteConfig, { configType }) =>
     mergeConfig(viteConfig, {

--- a/code/.storybook/preview.tsx
+++ b/code/.storybook/preview.tsx
@@ -166,7 +166,7 @@ export const decorators = [
    * This decorator renders the stories side-by-side, stacked or default based on the theme switcher in the toolbar
    */
   (StoryFn, { globals, playFunction, args, storyGlobals, parameters }) => {
-    let theme = globals.theme;
+    let theme = globals.sb_theme;
     let showPlayFnNotice = false;
 
     // this makes the decorator be out of 'phase' with the actually selected theme in the toolbar
@@ -314,6 +314,9 @@ export const parameters = {
   },
   viewport: {
     options: MINIMAL_VIEWPORTS,
+  },
+  themes: {
+    disable: true,
   },
   backgrounds: {
     options: {

--- a/code/.storybook/preview.tsx
+++ b/code/.storybook/preview.tsx
@@ -34,7 +34,7 @@ const ThemeBlock = styled.div<{ side: 'left' | 'right'; layout: string }>(
     overflow: 'auto',
   },
   ({ layout }) => ({
-    padding: layout === 'fullscreen' ? 0 : 10,
+    padding: layout === 'fullscreen' ? 0 : '1rem',
   }),
   ({ theme }) => ({
     background: theme.background.content,
@@ -55,14 +55,15 @@ const ThemeBlock = styled.div<{ side: 'left' | 'right'; layout: string }>(
 const ThemeStack = styled.div<{ layout: string }>(
   {
     position: 'relative',
-    minHeight: 'calc(50vh - 15px)',
+    // minHeight: 'calc(50vh - 15px)',
+    flex: 1,
   },
   ({ theme }) => ({
     background: theme.background.content,
     color: theme.color.defaultText,
   }),
   ({ layout }) => ({
-    padding: layout === 'fullscreen' ? 0 : 10,
+    padding: layout === 'fullscreen' ? 0 : '1rem',
   })
 );
 
@@ -84,6 +85,25 @@ const PlayFnNotice = styled.div(
     background: '#fffbd9',
     color: theme.color.defaultText,
   })
+);
+
+const StackContainer = ({ children, layout }) => (
+  <div
+    style={{
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      // margin: layout === 'fullscreen' ? 0 : '-1rem',
+    }}
+  >
+    <style dangerouslySetInnerHTML={{ __html: 'html, body, #storybook-root { height: 100%; }' }} />
+    {layout === 'fullscreen' ? null : (
+      <style
+        dangerouslySetInnerHTML={{ __html: 'html, body { padding: 0!important; margin: 0; }' }}
+      />
+    )}
+    {children}
+  </div>
 );
 
 const ThemedSetRoot = () => {
@@ -176,7 +196,7 @@ export const decorators = [
     if (playFunction && args.autoplay !== false && !(theme === 'light' || theme === 'dark')) {
       theme = 'light';
       showPlayFnNotice = true;
-    } else if (isChromatic() && !storyGlobals.theme && !playFunction) {
+    } else if (isChromatic() && !storyGlobals.sb_theme && !playFunction) {
       theme = 'stacked';
     }
 
@@ -206,16 +226,18 @@ export const decorators = [
             <ThemeProvider theme={convert(themes.light)}>
               <Global styles={createReset} />
             </ThemeProvider>
-            <ThemeProvider theme={convert(themes.light)}>
-              <ThemeStack data-side="left" layout={parameters.layout}>
-                <StoryFn />
-              </ThemeStack>
-            </ThemeProvider>
-            <ThemeProvider theme={convert(themes.dark)}>
-              <ThemeStack data-side="right" layout={parameters.layout}>
-                <StoryFn />
-              </ThemeStack>
-            </ThemeProvider>
+            <StackContainer layout={parameters.layout}>
+              <ThemeProvider theme={convert(themes.light)}>
+                <ThemeStack data-side="left" layout={parameters.layout}>
+                  <StoryFn />
+                </ThemeStack>
+              </ThemeProvider>
+              <ThemeProvider theme={convert(themes.dark)}>
+                <ThemeStack data-side="right" layout={parameters.layout}>
+                  <StoryFn />
+                </ThemeStack>
+              </ThemeProvider>
+            </StackContainer>
           </Fragment>
         );
       }

--- a/code/.storybook/preview.tsx
+++ b/code/.storybook/preview.tsx
@@ -55,7 +55,6 @@ const ThemeBlock = styled.div<{ side: 'left' | 'right'; layout: string }>(
 const ThemeStack = styled.div<{ layout: string }>(
   {
     position: 'relative',
-    // minHeight: 'calc(50vh - 15px)',
     flex: 1,
   },
   ({ theme }) => ({

--- a/code/addons/controls/template/stories/conditional.stories.ts
+++ b/code/addons/controls/template/stories/conditional.stories.ts
@@ -54,9 +54,9 @@ export const ToggleExpandCollapse = {
 
 export const GlobalBased = {
   argTypes: {
-    ifThemeExists: { control: 'text', if: { global: 'theme' } },
-    ifThemeNotExists: { control: 'text', if: { global: 'theme', exists: false } },
-    ifLightTheme: { control: 'text', if: { global: 'theme', eq: 'light' } },
-    ifNotLightTheme: { control: 'text', if: { global: 'theme', neq: 'light' } },
+    ifThemeExists: { control: 'text', if: { global: 'sb_theme' } },
+    ifThemeNotExists: { control: 'text', if: { global: 'sb_theme', exists: false } },
+    ifLightTheme: { control: 'text', if: { global: 'sb_theme', eq: 'light' } },
+    ifNotLightTheme: { control: 'text', if: { global: 'sb_theme', neq: 'light' } },
   },
 };

--- a/code/addons/interactions/src/components/Interaction.stories.tsx
+++ b/code/addons/interactions/src/components/Interaction.stories.tsx
@@ -54,7 +54,7 @@ export const Disabled: Story = {
 
 export const Hovered: Story = {
   ...Done,
-  globals: { theme: 'light' },
+  globals: { sb_theme: 'light' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.hover(canvas.getByRole('button'));

--- a/code/addons/interactions/src/components/InteractionsPanel.stories.tsx
+++ b/code/addons/interactions/src/components/InteractionsPanel.stories.tsx
@@ -34,7 +34,6 @@ const meta = {
     ),
   ],
   parameters: { layout: 'fullscreen' },
-  globals: { sb_theme: 'light' },
   args: {
     calls: new Map(getCalls(CallStates.DONE).map((call) => [call.id, call])),
     controls: SubnavStories.args.controls,
@@ -58,35 +57,35 @@ export const Passing: Story = {
   args: {
     interactions: getInteractions(CallStates.DONE),
   },
-};
-Passing.play = async ({ args, canvasElement }) => {
-  if (isChromatic()) return;
-  const canvas = within(canvasElement);
+  play: async ({ args, canvasElement }) => {
+    if (isChromatic()) return;
+    const canvas = within(canvasElement);
 
-  await waitFor(async () => {
-    await userEvent.click(canvas.getByLabelText('Go to start'));
-    await expect(args.controls.start).toHaveBeenCalled();
-  });
+    await waitFor(async () => {
+      await userEvent.click(canvas.getByLabelText('Go to start'));
+      await expect(args.controls.start).toHaveBeenCalled();
+    });
 
-  await waitFor(async () => {
-    await userEvent.click(canvas.getByLabelText('Go back'));
-    await expect(args.controls.back).toHaveBeenCalled();
-  });
+    await waitFor(async () => {
+      await userEvent.click(canvas.getByLabelText('Go back'));
+      await expect(args.controls.back).toHaveBeenCalled();
+    });
 
-  await waitFor(async () => {
-    await userEvent.click(canvas.getByLabelText('Go forward'));
-    await expect(args.controls.next).not.toHaveBeenCalled();
-  });
+    await waitFor(async () => {
+      await userEvent.click(canvas.getByLabelText('Go forward'));
+      await expect(args.controls.next).not.toHaveBeenCalled();
+    });
 
-  await waitFor(async () => {
-    await userEvent.click(canvas.getByLabelText('Go to end'));
-    await expect(args.controls.end).not.toHaveBeenCalled();
-  });
+    await waitFor(async () => {
+      await userEvent.click(canvas.getByLabelText('Go to end'));
+      await expect(args.controls.end).not.toHaveBeenCalled();
+    });
 
-  await waitFor(async () => {
-    await userEvent.click(canvas.getByLabelText('Rerun'));
-    await expect(args.controls.rerun).toHaveBeenCalled();
-  });
+    await waitFor(async () => {
+      await userEvent.click(canvas.getByLabelText('Rerun'));
+      await expect(args.controls.rerun).toHaveBeenCalled();
+    });
+  },
 };
 
 export const Paused: Story = {

--- a/code/addons/interactions/src/components/InteractionsPanel.stories.tsx
+++ b/code/addons/interactions/src/components/InteractionsPanel.stories.tsx
@@ -34,7 +34,7 @@ const meta = {
     ),
   ],
   parameters: { layout: 'fullscreen' },
-  globals: { theme: 'light' },
+  globals: { sb_theme: 'light' },
   args: {
     calls: new Map(getCalls(CallStates.DONE).map((call) => [call.id, call])),
     controls: SubnavStories.args.controls,

--- a/code/addons/interactions/src/components/Subnav.stories.tsx
+++ b/code/addons/interactions/src/components/Subnav.stories.tsx
@@ -1,10 +1,14 @@
 import { action } from '@storybook/addon-actions';
 import { CallStates } from '@storybook/instrumenter';
 import { Subnav } from './Subnav';
+import { parameters } from '../preview';
 
 export default {
   title: 'Subnav',
   component: Subnav,
+  parameters: {
+    layout: 'fullscreen',
+  },
   args: {
     controls: {
       start: action('start'),

--- a/code/addons/interactions/template/stories/basics.stories.ts
+++ b/code/addons/interactions/template/stories/basics.stories.ts
@@ -15,7 +15,7 @@ export default {
     onSuccess: fn(),
   },
   globals: {
-    theme: 'light',
+    sb_theme: 'light',
   },
 };
 

--- a/code/addons/themes/README.md
+++ b/code/addons/themes/README.md
@@ -45,11 +45,8 @@ import { Button } from './Button';
 export default {
   title: 'Example/Button',
   component: Button,
-  parameters: {
-    themes: {
-      themeOverride: 'light', // component level override
-    },
-  },
+  // meta level override
+  globals: { theme: 'dark' },
 };
 
 export const Primary = {
@@ -64,10 +61,7 @@ export const PrimaryDark = {
     primary: true,
     label: 'Button',
   },
-  parameters: {
-    themes: {
-      themeOverride: 'dark', // Story level override
-    },
-  },
+  // story level override
+  globals: { theme: 'dark' },
 };
 ```

--- a/code/addons/themes/src/constants.ts
+++ b/code/addons/themes/src/constants.ts
@@ -15,6 +15,7 @@ export const DEFAULT_ADDON_STATE: ThemeAddonState = {
 
 export interface ThemeParameters {
   themeOverride?: string;
+  disable?: boolean;
 }
 
 export const DEFAULT_THEME_PARAMETERS: ThemeParameters = {};

--- a/code/addons/themes/src/decorators/class-name.decorator.tsx
+++ b/code/addons/themes/src/decorators/class-name.decorator.tsx
@@ -14,7 +14,7 @@ const DEFAULT_ELEMENT_SELECTOR = 'html';
 const classStringToArray = (classString: string) => classString.split(' ').filter(Boolean);
 
 // TODO check with @kasperpeulen: change the types so they can be correctly inferred from context e.g. <Story extends (...args: any[]) => any>
-export const withThemeByClassName = <TRenderer extends Renderer = any>({
+export const withThemeByClassName = <TRenderer extends Renderer = Renderer>({
   themes,
   defaultTheme,
   parentSelector = DEFAULT_ELEMENT_SELECTOR,
@@ -47,7 +47,7 @@ export const withThemeByClassName = <TRenderer extends Renderer = any>({
       if (newThemeClasses.length > 0) {
         parentElement.classList.add(...newThemeClasses);
       }
-    }, [themeOverride, selected, parentSelector]);
+    }, [themeOverride, selected]);
 
     return storyFn();
   };

--- a/code/addons/themes/src/decorators/data-attribute.decorator.tsx
+++ b/code/addons/themes/src/decorators/data-attribute.decorator.tsx
@@ -31,7 +31,7 @@ export const withThemeByDataAttribute = <TRenderer extends Renderer = any>({
       if (parentElement) {
         parentElement.setAttribute(attributeName, themes[themeKey]);
       }
-    }, [themeOverride, selected, parentSelector, attributeName]);
+    }, [themeOverride, selected]);
 
     return storyFn();
   };

--- a/code/addons/themes/src/decorators/provider.decorator.tsx
+++ b/code/addons/themes/src/decorators/provider.decorator.tsx
@@ -38,7 +38,7 @@ export const withThemeFromJSXProvider = <TRenderer extends Renderer = any>({
       const pairs = Object.entries(themes);
 
       return pairs.length === 1 ? pluckThemeFromKeyPairTuple(pairs[0]) : themes[selectedThemeName];
-    }, [themes, selected, themeOverride]);
+    }, [selected, themeOverride]);
 
     if (!Provider) {
       return (

--- a/code/addons/themes/src/preview.tsx
+++ b/code/addons/themes/src/preview.tsx
@@ -1,7 +1,6 @@
 import type { Renderer, ProjectAnnotations } from 'storybook/internal/types';
-import { GLOBAL_KEY } from './constants';
+import { GLOBAL_KEY as KEY } from './constants';
 
-export const globals: ProjectAnnotations<Renderer>['globals'] = {
-  // Required to make sure SB picks this up from URL params
-  [GLOBAL_KEY]: '',
+export const initialGlobals: ProjectAnnotations<Renderer>['initialGlobals'] = {
+  [KEY]: '',
 };

--- a/code/addons/themes/template/stories/decorators.stories.ts
+++ b/code/addons/themes/template/stories/decorators.stories.ts
@@ -43,6 +43,9 @@ export default {
   args: {
     text: 'Testing the themes',
   },
+  globals: {
+    sb_theme: 'light',
+  },
   parameters: {
     chromatic: { disable: true },
     themes: { disable: false },

--- a/code/addons/themes/template/stories/decorators.stories.ts
+++ b/code/addons/themes/template/stories/decorators.stories.ts
@@ -1,0 +1,93 @@
+import { global as globalThis } from '@storybook/global';
+import {
+  withThemeByClassName,
+  withThemeByDataAttribute,
+  withThemeFromJSXProvider,
+} from '@storybook/addon-themes';
+import { useEffect } from 'storybook/internal/preview-api';
+
+const cleanup = () => {
+  const existing = globalThis.document.querySelector('style[data-theme-css]');
+  if (existing) {
+    existing.remove();
+  }
+};
+
+const addStyleSheetDecorator = (storyFn: any) => {
+  useEffect(() => {
+    cleanup();
+
+    const sheet = globalThis.document.createElement('style');
+    sheet.setAttribute('data-theme-css', '');
+    sheet.textContent = `
+      [data-theme="theme-a"], .theme-a {
+        background-color: white;
+        color: black;
+      }
+      [data-theme="theme-b"], .theme-b {
+        background-color: black;
+        color: white;
+      }
+    `;
+
+    globalThis.document.body.appendChild(sheet);
+
+    return cleanup;
+  });
+
+  return storyFn();
+};
+
+export default {
+  component: globalThis.Components.Pre,
+  args: {
+    text: 'Testing the themes',
+  },
+  parameters: {
+    chromatic: { disable: true },
+    themes: { disable: false },
+  },
+  decorators: [addStyleSheetDecorator],
+};
+
+export const WithThemeByClassName = {
+  globals: {},
+  decorators: [
+    withThemeByClassName({
+      defaultTheme: 'a',
+      themes: { a: 'theme-a', b: 'theme-b' },
+      parentSelector: '#storybook-root > *',
+    }),
+  ],
+};
+
+export const WithThemeByDataAttribute = {
+  globals: {},
+  decorators: [
+    withThemeByDataAttribute({
+      defaultTheme: 'a',
+      themes: { a: 'theme-a', b: 'theme-b' },
+      parentSelector: '#storybook-root > *',
+    }),
+  ],
+};
+
+export const WithThemeFromJSXProvider = {
+  globals: {},
+  decorators: [
+    withThemeFromJSXProvider({
+      defaultTheme: 'a',
+      themes: { a: { custom: 'theme-a' }, b: { custom: 'theme-b' } },
+      Provider: ({ theme, children }: any) => {
+        // this is not was a normal provider looks like obviously, but this needs to work in non-react as well
+        // the timeout is to wait for the render to complete, as it's not possible to use the useEffect hook here
+        setTimeout(() => {
+          const element = globalThis.document.querySelector('#storybook-root > *');
+          element?.classList.remove('theme-a', 'theme-b');
+          element?.classList.add(theme.custom);
+        }, 16);
+        return children;
+      },
+    }),
+  ],
+};

--- a/code/addons/themes/template/stories/globals.stories.ts
+++ b/code/addons/themes/template/stories/globals.stories.ts
@@ -1,9 +1,5 @@
 import { global as globalThis } from '@storybook/global';
-import {
-  withThemeByClassName,
-  withThemeByDataAttribute,
-  withThemeFromJSXProvider,
-} from '@storybook/addon-themes';
+import { withThemeByClassName } from '@storybook/addon-themes';
 import { useEffect } from 'storybook/internal/preview-api';
 
 const cleanup = () => {
@@ -46,6 +42,9 @@ export default {
   parameters: {
     chromatic: { disable: true },
     themes: { disable: false },
+  },
+  globals: {
+    sb_theme: 'light',
   },
   decorators: [addStyleSheetDecorator],
 };

--- a/code/addons/themes/template/stories/globals.stories.ts
+++ b/code/addons/themes/template/stories/globals.stories.ts
@@ -1,0 +1,64 @@
+import { global as globalThis } from '@storybook/global';
+import {
+  withThemeByClassName,
+  withThemeByDataAttribute,
+  withThemeFromJSXProvider,
+} from '@storybook/addon-themes';
+import { useEffect } from 'storybook/internal/preview-api';
+
+const cleanup = () => {
+  const existing = globalThis.document.querySelector('style[data-theme-css]');
+  if (existing) {
+    existing.remove();
+  }
+};
+
+const addStyleSheetDecorator = (storyFn: any) => {
+  useEffect(() => {
+    cleanup();
+
+    const sheet = globalThis.document.createElement('style');
+    sheet.setAttribute('data-theme-css', '');
+    sheet.textContent = `
+      [data-theme="theme-a"], .theme-a {
+        background-color: white;
+        color: black;
+      }
+      [data-theme="theme-b"], .theme-b {
+        background-color: black;
+        color: white;
+      }
+    `;
+
+    globalThis.document.body.appendChild(sheet);
+
+    return cleanup;
+  });
+
+  return storyFn();
+};
+
+export default {
+  component: globalThis.Components.Pre,
+  args: {
+    text: 'Testing the themes',
+  },
+  parameters: {
+    chromatic: { disable: true },
+    themes: { disable: false },
+  },
+  decorators: [addStyleSheetDecorator],
+};
+
+export const SetGlobal = {
+  globals: {
+    theme: 'b',
+  },
+  decorators: [
+    withThemeByClassName({
+      defaultTheme: 'a',
+      themes: { a: 'theme-a', b: 'theme-b' },
+      parentSelector: '#storybook-root > *',
+    }),
+  ],
+};

--- a/code/addons/themes/template/stories/parameters.stories.ts
+++ b/code/addons/themes/template/stories/parameters.stories.ts
@@ -1,0 +1,81 @@
+import { global as globalThis } from '@storybook/global';
+import {
+  withThemeByClassName,
+  withThemeByDataAttribute,
+  withThemeFromJSXProvider,
+} from '@storybook/addon-themes';
+import { useEffect } from 'storybook/internal/preview-api';
+
+const cleanup = () => {
+  const existing = globalThis.document.querySelector('style[data-theme-css]');
+  if (existing) {
+    existing.remove();
+  }
+};
+
+const addStyleSheetDecorator = (storyFn: any) => {
+  useEffect(() => {
+    cleanup();
+
+    const sheet = globalThis.document.createElement('style');
+    sheet.setAttribute('data-theme-css', '');
+    sheet.textContent = `
+      [data-theme="theme-a"], .theme-a {
+        background-color: white;
+        color: black;
+      }
+      [data-theme="theme-b"], .theme-b {
+        background-color: black;
+        color: white;
+      }
+    `;
+
+    globalThis.document.body.appendChild(sheet);
+
+    return cleanup;
+  });
+
+  return storyFn();
+};
+
+export default {
+  component: globalThis.Components.Pre,
+  args: {
+    text: 'Testing the themes',
+  },
+  parameters: {
+    chromatic: { disable: true },
+    themes: { disable: false },
+  },
+  decorators: [addStyleSheetDecorator],
+};
+
+export const SetOverride = {
+  parameters: {
+    themes: {
+      themeOverride: 'b',
+    },
+  },
+  decorators: [
+    withThemeByClassName({
+      defaultTheme: 'a',
+      themes: { a: 'theme-a', b: 'theme-b' },
+      parentSelector: '#storybook-root > *',
+    }),
+  ],
+};
+
+export const Disabled = {
+  parameters: {
+    themes: {
+      disable: true,
+    },
+  },
+  decorators: [
+    withThemeByClassName({
+      defaultTheme: 'a',
+      themes: { a: 'theme-a', b: 'theme-b' },
+      parentSelector: '#storybook-root > *',
+    }),
+  ],
+};

--- a/code/addons/themes/template/stories/parameters.stories.ts
+++ b/code/addons/themes/template/stories/parameters.stories.ts
@@ -1,9 +1,5 @@
 import { global as globalThis } from '@storybook/global';
-import {
-  withThemeByClassName,
-  withThemeByDataAttribute,
-  withThemeFromJSXProvider,
-} from '@storybook/addon-themes';
+import { withThemeByClassName } from '@storybook/addon-themes';
 import { useEffect } from 'storybook/internal/preview-api';
 
 const cleanup = () => {
@@ -42,6 +38,9 @@ export default {
   component: globalThis.Components.Pre,
   args: {
     text: 'Testing the themes',
+  },
+  globals: {
+    sb_theme: 'light',
   },
   parameters: {
     chromatic: { disable: true },

--- a/code/addons/toolbars/template/stories/globals.stories.ts
+++ b/code/addons/toolbars/template/stories/globals.stories.ts
@@ -40,13 +40,13 @@ export const OverrideLocale = {
 
 export const OverrideTheme = {
   globals: {
-    theme: 'dark',
+    sb_theme: 'dark',
   },
 };
 
 export const OverrideBoth = {
   globals: {
     locale: 'kr',
-    theme: 'dark',
+    sb_theme: 'dark',
   },
 };

--- a/code/addons/toolbars/template/stories/preview.ts
+++ b/code/addons/toolbars/template/stories/preview.ts
@@ -1,5 +1,5 @@
 export const globalTypes = {
-  theme: {
+  sb_theme: {
     name: 'Theme',
     description: 'Global theme for components',
     toolbar: {
@@ -44,6 +44,6 @@ export const globalTypes = {
 };
 
 export const initialGlobals = {
-  theme: 'light',
+  sb_theme: 'light',
   locale: 'en',
 };

--- a/code/core/src/components/components/tabs/tabs.stories.tsx
+++ b/code/core/src/components/components/tabs/tabs.stories.tsx
@@ -181,7 +181,7 @@ export const StatefulDynamicWithOpenTooltip = {
     },
     chromatic: { viewports: [380] },
   },
-  globals: { theme: 'light', viewport: 'sized' },
+  globals: { sb_theme: 'light', viewport: 'sized' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 

--- a/code/core/src/manager/components/layout/Layout.stories.tsx
+++ b/code/core/src/manager/components/layout/Layout.stories.tsx
@@ -63,7 +63,7 @@ const meta = {
     setManagerLayoutState: fn(),
     hasTab: false,
   },
-  globals: { theme: 'light' },
+  globals: { sb_theme: 'light' },
   parameters: { layout: 'fullscreen' },
   decorators: [
     MobileNavigationStoriesMeta.decorators[0] as any,
@@ -95,7 +95,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
 export const Dark: Story = {
-  globals: { theme: 'dark' },
+  globals: { sb_theme: 'dark' },
 };
 export const DesktopHorizontal: Story = {
   args: {
@@ -125,7 +125,7 @@ export const Mobile = {
 };
 export const MobileDark = {
   ...Mobile,
-  globals: { theme: 'dark' },
+  globals: { sb_theme: 'dark' },
 };
 
 export const MobileDocs = {

--- a/code/core/src/manager/components/mobile/about/MobileAbout.stories.tsx
+++ b/code/core/src/manager/components/mobile/about/MobileAbout.stories.tsx
@@ -19,7 +19,7 @@ const OpenAboutHelper = ({ children }: { children: any }) => {
 const meta = {
   component: MobileAbout,
   title: 'Mobile/About',
-  globals: { theme: 'light' },
+  globals: { sb_theme: 'light' },
   parameters: {
     layout: 'fullscreen',
     viewport: {
@@ -56,7 +56,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 export const Dark: Story = {
-  globals: { theme: 'dark' },
+  globals: { sb_theme: 'dark' },
 };
 
 export const Closed: Story = {

--- a/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
@@ -86,10 +86,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  globals: { theme: 'light' },
+  globals: { sb_theme: 'light' },
 };
 export const Dark: Story = {
-  globals: { theme: 'dark' },
+  globals: { sb_theme: 'dark' },
   parameters: { chromatic: { disable: true } },
 };
 

--- a/code/core/src/manager/components/preview/Iframe.stories.tsx
+++ b/code/core/src/manager/components/preview/Iframe.stories.tsx
@@ -22,7 +22,7 @@ export default {
     },
     chromatic: { viewports: [700] },
   },
-  globals: { theme: 'light' },
+  globals: { sb_theme: 'light' },
 };
 
 const style: CSSProperties = {

--- a/code/core/src/manager/components/sidebar/Explorer.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Explorer.stories.tsx
@@ -9,7 +9,7 @@ import { IconSymbols } from './IconSymbols';
 export default {
   component: Explorer,
   title: 'Sidebar/Explorer',
-  globals: { theme: 'side-by-side' },
+  globals: { sb_theme: 'side-by-side' },
   parameters: { layout: 'fullscreen' },
   decorators: [
     RefStories.default.decorators[0],

--- a/code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx
+++ b/code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx
@@ -14,31 +14,30 @@ const meta = {
     onOpenChange: fn(),
     setFileSearchQuery: fn(),
   },
+  parameters: {
+    layout: 'fullscreen',
+  },
   // This decorator is used to show the modal in the side by side view
   decorators: [
     (Story, context) => {
       const [container, setContainer] = useState<HTMLElement | null>(null);
 
-      if (context.globals.sb_theme === 'side-by-side') {
-        return (
-          <div
-            ref={(element) => {
-              setContainer(element);
-            }}
-            style={{
-              width: '100%',
-              height: '100%',
-              minHeight: '600px',
-              transform: 'translateZ(0)',
-            }}
-          >
-            {/* @ts-expect-error (non strict) */}
-            {Story({ args: { ...context.args, container } })}
-          </div>
-        );
-      }
-
-      return Story();
+      return (
+        <div
+          ref={(element) => {
+            setContainer(element);
+          }}
+          style={{
+            width: '100%',
+            height: '100%',
+            minHeight: '600px',
+            transform: 'translateZ(0)',
+          }}
+        >
+          {/* @ts-expect-error (non strict) */}
+          {Story({ args: { ...context.args, container } })}
+        </div>
+      );
     },
   ],
 } satisfies Meta<typeof FileSearchModal>;

--- a/code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx
+++ b/code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
     (Story, context) => {
       const [container, setContainer] = useState<HTMLElement | null>(null);
 
-      if (context.globals.theme === 'side-by-side') {
+      if (context.globals.sb_theme === 'side-by-side') {
         return (
           <div
             ref={(element) => {

--- a/code/core/src/manager/components/sidebar/Heading.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Heading.stories.tsx
@@ -230,6 +230,7 @@ export const SkipToCanvasLinkFocused: StoryObj<typeof Heading> = {
     extra: [],
     isLoading: false,
   },
+  globals: { sb_theme: 'light' },
   parameters: { layout: 'padded', chromatic: { delay: 300 } },
   play: () => {
     // focus each instance for chromatic/storybook's stacked theme

--- a/code/core/src/manager/components/sidebar/Heading.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Heading.stories.tsx
@@ -15,6 +15,7 @@ export default {
   title: 'Sidebar/Heading',
   excludeStories: /.*Data$/,
   parameters: { layout: 'fullscreen' },
+  globals: { sb_theme: 'side-by-side' },
   decorators: [
     (storyFn) => <div style={{ padding: '0 20px', maxWidth: '230px' }}>{storyFn()}</div>,
   ],

--- a/code/core/src/manager/components/sidebar/Menu.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Menu.stories.tsx
@@ -22,6 +22,7 @@ const meta = {
   args: {
     menu: fakemenu,
   },
+  globals: { sb_theme: 'side-by-side' },
   decorators: [(storyFn) => <LayoutProvider>{storyFn()}</LayoutProvider>],
 } satisfies Meta<typeof SidebarMenu>;
 export default meta;

--- a/code/core/src/manager/components/sidebar/Menu.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Menu.stories.tsx
@@ -48,6 +48,7 @@ const DoubleThemeRenderingHack = styled.div({
 });
 
 export const Expanded: Story = {
+  globals: { sb_theme: 'light' },
   render: () => {
     const menu = useMenu(
       { whatsNewData: { status: 'SUCCESS', disableWhatsNewNotifications: false } } as State,

--- a/code/core/src/manager/components/sidebar/Refs.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Refs.stories.tsx
@@ -12,6 +12,7 @@ export default {
   title: 'Sidebar/Refs',
   excludeStories: /.*Data$/,
   parameters: { layout: 'fullscreen' },
+  globals: { sb_theme: 'side-by-side' },
   decorators: [
     (storyFn: any) => (
       <ManagerContext.Provider value={{ state: { docsOptions: {} } } as any}>

--- a/code/core/src/manager/components/sidebar/Search.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Search.stories.tsx
@@ -24,6 +24,7 @@ const meta = {
   component: Search,
   title: 'Sidebar/Search',
   parameters: { layout: 'fullscreen' },
+  globals: { sb_theme: 'side-by-side' },
   decorators: [
     (storyFn: any) => (
       <div style={{ padding: 20, maxWidth: '230px' }}>

--- a/code/core/src/manager/components/sidebar/SearchResults.stories.tsx
+++ b/code/core/src/manager/components/sidebar/SearchResults.stories.tsx
@@ -12,6 +12,7 @@ export default {
   title: 'Sidebar/SearchResults',
   includeStories: /^[A-Z]/,
   parameters: { layout: 'fullscreen' },
+  globals: { sb_theme: 'side-by-side' },
   decorators: [
     (storyFn: any) => (
       <div style={{ padding: '0 20px', maxWidth: '230px' }}>

--- a/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
@@ -73,6 +73,7 @@ const meta = {
       </ManagerContext.Provider>
     ),
   ],
+  globals: { sb_theme: 'side-by-side' },
 } satisfies Meta<typeof Sidebar>;
 
 export default meta;
@@ -208,6 +209,14 @@ export const StatusesOpen: Story = {
 export const Searching: Story = {
   ...StatusesOpen,
   parameters: { chromatic: { delay: 2200 } },
+  globals: { sb_theme: 'light' },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
   play: async ({ canvasElement, step }) => {
     await step('wait 2000ms', () => wait(2000));
     const canvas = await within(canvasElement);
@@ -273,12 +282,20 @@ export const Scrolled: Story = {
   args: {
     storyId: 'group-1--child-b1',
   },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+
   render: (args) => {
     const [, setState] = React.useState(0);
     return (
       <>
         <button
-          style={{ position: 'absolute', zIndex: 10 }}
+          style={{ position: 'absolute', zIndex: 10, bottom: 0, right: 0 }}
           onClick={() => setState(() => Math.random())}
         >
           Change state

--- a/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
@@ -282,6 +282,7 @@ export const Scrolled: Story = {
   args: {
     storyId: 'group-1--child-b1',
   },
+  globals: { sb_theme: 'light' },
   decorators: [
     (StoryFn) => (
       <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>

--- a/code/core/src/manager/components/sidebar/Tree.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.stories.tsx
@@ -8,27 +8,27 @@ import { within, expect } from '@storybook/test';
 import { Tree } from './Tree';
 import { index } from './mockdata.large';
 import { DEFAULT_REF_ID } from './Sidebar';
-import { viewport } from '@popperjs/core';
-
-const customViewports = {
-  sized: {
-    name: 'Sized',
-    styles: {
-      width: '380px',
-      height: '90%',
-    },
-  },
-};
 
 const meta = {
   component: Tree,
   title: 'Sidebar/Tree',
   excludeStories: /.*Data$/,
-  globals: { theme: 'light', viewport: 'sized', viewportRotated: false },
+  globals: {
+    sb_theme: 'light',
+    viewport: { value: 'sized' },
+  },
   parameters: {
     layout: 'fullscreen',
     viewport: {
-      viewports: customViewports,
+      viewports: {
+        sized: {
+          name: 'Sized',
+          styles: {
+            width: '380px',
+            height: '90%',
+          },
+        },
+      },
     },
     chromatic: { viewports: [380] },
   },
@@ -64,7 +64,7 @@ export const Full: Story = {
 };
 export const Dark: Story = {
   ...Full,
-  globals: { theme: 'dark' },
+  globals: { sb_theme: 'dark' },
 };
 
 export const SingleStoryComponents: Story = {

--- a/code/core/src/manager/components/sidebar/Tree.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
     viewport: {
-      viewports: {
+      options: {
         sized: {
           name: 'Sized',
           styles: {
@@ -206,11 +206,6 @@ export const SkipToCanvasLinkFocused: Story = {
   ...DocsOnlySingleStoryComponents,
   parameters: {
     chromatic: { disable: true },
-    viewport: {
-      defaultViewport: 'sized',
-      viewports: customViewports,
-      defaultOrientation: 'landscape',
-    },
   },
   play: async ({ canvasElement }) => {
     const screen = await within(canvasElement);

--- a/code/core/src/manager/components/sidebar/TreeNode.stories.tsx
+++ b/code/core/src/manager/components/sidebar/TreeNode.stories.tsx
@@ -7,7 +7,8 @@ import { IconSymbols } from './IconSymbols';
 
 export default {
   title: 'Sidebar/TreeNode',
-  parameters: { layout: 'fullscreen' },
+  parameters: { layout: 'padded' },
+  globals: { sb_theme: 'side-by-side' },
   component: StoryNode,
   decorators: [
     (StoryFn: any) => (

--- a/code/core/src/preview-api/Errors.stories.tsx
+++ b/code/core/src/preview-api/Errors.stories.tsx
@@ -40,7 +40,7 @@ export default {
   parameters: {
     layout: 'fullscreen',
   },
-  globals: { theme: 'light' },
+  globals: { sb_theme: 'light' },
   title: 'Errors',
   args: {
     id: 'sb-errordisplay',

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -384,10 +384,6 @@ export interface StorybookConfigRaw {
      * use globals & globalTypes for configuring the backgrounds addon
      */
     backgroundsStoryGlobals?: boolean;
-    /**
-     * use globals & globalTypes for configuring the themes addon
-     */
-    themesStoryGlobals?: boolean;
   };
 
   build?: TestBuildConfig;

--- a/code/frameworks/angular/template/stories/core/decorators/theme-decorator/decorators.stories.ts
+++ b/code/frameworks/angular/template/stories/core/decorators/theme-decorator/decorators.stories.ts
@@ -1,7 +1,7 @@
 import { Args, Meta, componentWrapperDecorator } from '@storybook/angular';
 
 export const Base = (args: Args) => ({
-  template: 'Change theme with the brush in toolbar',
+  template: 'Change sb_theme with the brush in toolbar',
   props: {
     ...args,
   },
@@ -14,7 +14,7 @@ export default {
     componentWrapperDecorator(
       (story) => `<div [class]="myTheme">${story}</div>`,
 
-      ({ globals }) => ({ myTheme: `${globals['theme']}-theme` })
+      ({ globals }) => ({ myTheme: `${globals['sb_theme']}-theme` })
     ),
   ],
 } as Meta;

--- a/code/lib/blocks/src/blocks/Anchor.stories.tsx
+++ b/code/lib/blocks/src/blocks/Anchor.stories.tsx
@@ -4,6 +4,7 @@ import { Anchor } from './Anchor';
 const meta = {
   component: Anchor,
   parameters: {
+    layout: 'fullscreen',
     docsStyles: true,
   },
 } as Meta<typeof Anchor>;

--- a/code/lib/blocks/src/blocks/ArgTypes.stories.tsx
+++ b/code/lib/blocks/src/blocks/ArgTypes.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta<typeof ArgTypes> = {
   title: 'Blocks/ArgTypes',
   component: ArgTypes,
   parameters: {
+    layout: 'fullscreen',
     relativeCsfPaths: [
       '../examples/ArgTypesParameters.stories',
       '../examples/ArgTypesWithSubcomponentsParameters.stories',

--- a/code/lib/blocks/src/blocks/Canvas.stories.tsx
+++ b/code/lib/blocks/src/blocks/Canvas.stories.tsx
@@ -10,6 +10,7 @@ import * as SourceParameterStories from '../examples/SourceParameters.stories';
 const meta: Meta<typeof Canvas> = {
   component: Canvas,
   parameters: {
+    layout: 'fullscreen',
     relativeCsfPaths: [
       '../examples/Button.stories',
       '../examples/CanvasParameters.stories',

--- a/code/lib/blocks/src/blocks/Controls.stories.tsx
+++ b/code/lib/blocks/src/blocks/Controls.stories.tsx
@@ -11,6 +11,7 @@ import * as EmptyArgTypesStories from '../examples/EmptyArgTypes.stories';
 const meta = {
   component: Controls,
   parameters: {
+    layout: 'fullscreen',
     relativeCsfPaths: [
       '../examples/ControlsParameters.stories',
       '../examples/EmptyArgTypes.stories',

--- a/code/lib/blocks/src/blocks/Description.stories.tsx
+++ b/code/lib/blocks/src/blocks/Description.stories.tsx
@@ -10,6 +10,7 @@ import * as ButtonStoriesWithMetaDescriptionAsBoth from '../examples/ButtonWithM
 const meta: Meta<typeof Description> = {
   component: Description,
   parameters: {
+    layout: 'fullscreen',
     controls: {
       include: [],
     },

--- a/code/lib/blocks/src/blocks/DocsPage.stories.tsx
+++ b/code/lib/blocks/src/blocks/DocsPage.stories.tsx
@@ -4,6 +4,7 @@ import { DocsPage } from './DocsPage';
 const meta = {
   component: DocsPage,
   parameters: {
+    layout: 'fullscreen',
     docsStyles: true,
     chromatic: {
       disableSnapshot: true,

--- a/code/lib/blocks/src/blocks/Markdown.stories.tsx
+++ b/code/lib/blocks/src/blocks/Markdown.stories.tsx
@@ -5,7 +5,10 @@ import mdContent from '../examples/Markdown-content.md?raw';
 
 export default {
   component: MarkdownComponent,
-  parameters: { docsStyles: true },
+  parameters: {
+    layout: 'fullscreen',
+    docsStyles: true,
+  },
 };
 
 export const Markdown = {

--- a/code/lib/blocks/src/blocks/Primary.stories.tsx
+++ b/code/lib/blocks/src/blocks/Primary.stories.tsx
@@ -6,6 +6,7 @@ import * as StoriesParametersStories from '../examples/StoriesParameters.stories
 const meta = {
   component: Primary,
   parameters: {
+    layout: 'fullscreen',
     // workaround for https://github.com/storybookjs/storybook/issues/20505
     docs: { source: { type: 'code' } },
     docsStyles: true,

--- a/code/lib/blocks/src/blocks/Source.stories.tsx
+++ b/code/lib/blocks/src/blocks/Source.stories.tsx
@@ -10,6 +10,7 @@ import { argsHash, SourceContext } from './SourceContainer';
 const meta: Meta<typeof Source> = {
   component: Source,
   parameters: {
+    layout: 'fullscreen',
     relativeCsfPaths: ['../examples/SourceParameters.stories'],
     snippets: {
       'storybook-blocks-examples-stories-for-the-source-block--no-parameters': {

--- a/code/lib/blocks/src/blocks/Stories.stories.tsx
+++ b/code/lib/blocks/src/blocks/Stories.stories.tsx
@@ -3,7 +3,10 @@ import { Stories } from './Stories';
 
 const meta = {
   component: Stories,
-  parameters: { docsStyles: true },
+  parameters: {
+    layout: 'fullscreen',
+    docsStyles: true,
+  },
 } satisfies Meta<typeof Stories>;
 
 export default meta;

--- a/code/lib/blocks/src/blocks/Story.stories.tsx
+++ b/code/lib/blocks/src/blocks/Story.stories.tsx
@@ -10,6 +10,7 @@ import * as StoryParametersStories from '../examples/StoryParameters.stories';
 const meta: Meta<typeof StoryBlock> = {
   component: StoryBlock,
   parameters: {
+    layout: 'fullscreen',
     relativeCsfPaths: ['../examples/Button.stories', '../examples/StoryParameters.stories'],
     docsStyles: true,
   },

--- a/code/lib/blocks/src/blocks/Subtitle.stories.tsx
+++ b/code/lib/blocks/src/blocks/Subtitle.stories.tsx
@@ -9,6 +9,7 @@ import * as ButtonStoriesWithMetaSubtitleAsDocsSubtitle from '../examples/Button
 const meta: Meta<typeof Subtitle> = {
   component: Subtitle,
   parameters: {
+    layout: 'fullscreen',
     controls: {
       include: [],
       hideNoControlsWarning: true,

--- a/code/lib/blocks/src/blocks/Title.stories.tsx
+++ b/code/lib/blocks/src/blocks/Title.stories.tsx
@@ -6,6 +6,7 @@ const meta: Meta<typeof Title> = {
   component: Title,
   title: 'Blocks/Title',
   parameters: {
+    layout: 'fullscreen',
     controls: {
       include: [],
       hideNoControlsWarning: true,

--- a/code/lib/blocks/src/components/ArgsTable/ArgRow.stories.tsx
+++ b/code/lib/blocks/src/components/ArgsTable/ArgRow.stories.tsx
@@ -6,6 +6,7 @@ import { TableWrapper } from './ArgsTable';
 export default {
   component: ArgRow,
   title: 'Components/ArgsTable/ArgRow',
+
   decorators: [
     (getStory: any) => (
       <ResetWrapper>

--- a/code/lib/blocks/src/components/Story.stories.tsx
+++ b/code/lib/blocks/src/components/Story.stories.tsx
@@ -29,8 +29,10 @@ const meta: Meta<ExtendedStoryProps> = {
   // @ts-expect-error getting too complex with props
   component: StoryComponent,
   parameters: {
+    layout: 'fullscreen',
     relativeCsfPaths: ['../examples/Button.stories'],
   },
+  globals: { sb_theme: 'light' },
   args: {
     height: '100px',
     primary: false,
@@ -48,7 +50,10 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Loading = () => <StorySkeleton />;
+export const Loading = {
+  globals: { sb_theme: 'side-by-side' },
+  render: () => <StorySkeleton />,
+};
 
 export const Inline: Story = {
   args: {

--- a/code/lib/blocks/src/examples/Button.stories.tsx
+++ b/code/lib/blocks/src/examples/Button.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
     backgroundColor: { control: 'color' },
   },
   // Stop *this* story from being stacked in Chromatic
-  globals: { theme: 'default' },
+  globals: { sb_theme: 'default' },
   parameters: {
     // these are to test the deprecated features of the Description block
     notes: 'These are notes for the Button stories',

--- a/code/lib/blocks/src/examples/ButtonWithMetaDescriptionAsBoth.stories.tsx
+++ b/code/lib/blocks/src/examples/ButtonWithMetaDescriptionAsBoth.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
     backgroundColor: { control: 'color' },
   },
   // Stop *this* story from being stacked in Chromatic
-  globals: { theme: 'default' },
+  globals: { sb_theme: 'default' },
   parameters: {
     docs: {
       description: {

--- a/code/lib/blocks/src/examples/ButtonWithMetaDescriptionAsComment.stories.tsx
+++ b/code/lib/blocks/src/examples/ButtonWithMetaDescriptionAsComment.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
     backgroundColor: { control: 'color' },
   },
   // Stop *this* story from being stacked in Chromatic
-  globals: { theme: 'default' },
+  globals: { sb_theme: 'light' },
 } satisfies Meta<typeof Button>;
 
 export default meta;

--- a/code/lib/blocks/src/examples/ButtonWithMetaDescriptionAsParameter.stories.tsx
+++ b/code/lib/blocks/src/examples/ButtonWithMetaDescriptionAsParameter.stories.tsx
@@ -7,8 +7,7 @@ const meta = {
   argTypes: {
     backgroundColor: { control: 'color' },
   },
-  // Stop *this* story from being stacked in Chromatic
-  globals: { theme: 'default' },
+  globals: { sb_theme: 'light' },
   parameters: {
     docs: {
       description: {

--- a/code/lib/blocks/src/examples/ButtonWithMetaSubtitleAsBoth.stories.tsx
+++ b/code/lib/blocks/src/examples/ButtonWithMetaSubtitleAsBoth.stories.tsx
@@ -7,8 +7,7 @@ const meta = {
   argTypes: {
     backgroundColor: { control: 'color' },
   },
-  // Stop *this* story from being stacked in Chromatic
-  globals: { theme: 'default' },
+  globals: { sb_theme: 'light' },
   parameters: {
     // this is to test the deprecated features of the Subtitle block
     componentSubtitle: 'This subtitle is set in parameters.componentSubtitle',

--- a/code/lib/blocks/src/examples/ButtonWithMetaSubtitleAsComponentSubtitle.stories.tsx
+++ b/code/lib/blocks/src/examples/ButtonWithMetaSubtitleAsComponentSubtitle.stories.tsx
@@ -7,8 +7,7 @@ const meta = {
   argTypes: {
     backgroundColor: { control: 'color' },
   },
-  // Stop *this* story from being stacked in Chromatic
-  globals: { theme: 'default' },
+  globals: { sb_theme: 'light' },
   parameters: {
     // this is to test the deprecated features of the Subtitle block
     componentSubtitle: 'This subtitle is set in parameters.componentSubtitle',

--- a/code/lib/blocks/src/examples/ButtonWithMetaSubtitleAsDocsSubtitle.stories.tsx
+++ b/code/lib/blocks/src/examples/ButtonWithMetaSubtitleAsDocsSubtitle.stories.tsx
@@ -7,8 +7,7 @@ const meta = {
   argTypes: {
     backgroundColor: { control: 'color' },
   },
-  // Stop *this* story from being stacked in Chromatic
-  globals: { theme: 'default' },
+  globals: { sb_theme: 'light' },
   parameters: {
     docs: {
       subtitle: 'This subtitle is set in parameters.docs.subtitle',

--- a/code/lib/blocks/src/examples/StoryParameters.stories.tsx
+++ b/code/lib/blocks/src/examples/StoryParameters.stories.tsx
@@ -4,8 +4,7 @@ import { SimpleSizeTest } from './SimpleSizeTest';
 const meta = {
   title: 'examples/Stories for the Story Block',
   component: SimpleSizeTest,
-  // Stop *this* story from being stacked in Chromatic (we want the caller to stack though)
-  globals: { theme: 'default' },
+  globals: { sb_theme: 'light' },
 } satisfies Meta<typeof SimpleSizeTest>;
 export default meta;
 

--- a/code/package.json
+++ b/code/package.json
@@ -108,6 +108,7 @@
     "@storybook/addon-onboarding": "workspace:*",
     "@storybook/addon-outline": "workspace:*",
     "@storybook/addon-storysource": "workspace:*",
+    "@storybook/addon-themes": "workspace:*",
     "@storybook/addon-toolbars": "workspace:*",
     "@storybook/addon-viewport": "workspace:*",
     "@storybook/angular": "workspace:*",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5382,7 +5382,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-themes@workspace:addons/themes":
+"@storybook/addon-themes@workspace:*, @storybook/addon-themes@workspace:addons/themes":
   version: 0.0.0-use.local
   resolution: "@storybook/addon-themes@workspace:addons/themes"
   dependencies:
@@ -6499,6 +6499,7 @@ __metadata:
     "@storybook/addon-onboarding": "workspace:*"
     "@storybook/addon-outline": "workspace:*"
     "@storybook/addon-storysource": "workspace:*"
+    "@storybook/addon-themes": "workspace:*"
     "@storybook/addon-toolbars": "workspace:*"
     "@storybook/addon-viewport": "workspace:*"
     "@storybook/angular": "workspace:*"


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/27525

## What I did

- rename the `theme` global we use internally to `sb_theme`.
- add addon-themes to template stories, and to main storybook.
- add a `disable` parameter to addon-themes, so we don't have to look at it in the toolbar, unless we're testing it

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | **-1.55** | 0% |
| initSize |  198 MB | 198 MB | -929 B | 0.7 | 0% |
| diffSize |  122 MB | 122 MB | -929 B | **1.32** | 0% |
| buildSize |  7.61 MB | 7.6 MB | -554 B | 0.55 | 0% |
| buildSbAddonsSize |  1.64 MB | 1.64 MB | -250 B | 0.45 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  351 kB | 350 kB | -295 B | 0.26 | -0.1% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.48 MB | 4.48 MB | -545 B | 0.45 | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | -9 B | 0.82 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  25.7s | 23.1s | -2s -668ms | 1.1 | -11.5% |
| generateTime |  22s | 21.6s | -344ms | -0.81 | -1.6% |
| initTime |  22.3s | 21.5s | -795ms | -1.05 | -3.7% |
| buildTime |  14.9s | 13.5s | -1s -423ms | -0.68 | -10.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.7s | 8.9s | 1.1s | 0.01 | 13.4% |
| devManagerResponsive |  5.3s | 5.9s | 595ms | 0.15 | 10.1% |
| devManagerHeaderVisible |  717ms | 799ms | 82ms | -0.49 | 10.3% |
| devManagerIndexVisible |  750ms | 833ms | 83ms | -0.47 | 10% |
| devStoryVisibleUncached |  1.1s | 1s | -118ms | -1.09 | -11.2% |
| devStoryVisible |  771ms | 854ms | 83ms | -0.48 | 9.7% |
| devAutodocsVisible |  654ms | 889ms | 235ms | 1.04 | 26.4% |
| devMDXVisible |  605ms | 755ms | 150ms | -0.16 | 19.9% |
| buildManagerHeaderVisible |  700ms | 843ms | 143ms | 0.32 | 17% |
| buildManagerIndexVisible |  703ms | 846ms | 143ms | 0.28 | 16.9% |
| buildStoryVisible |  751ms | 896ms | 145ms | 0.27 | 16.2% |
| buildAutodocsVisible |  687ms | 707ms | 20ms | -0.56 | 2.8% |
| buildMDXVisible |  633ms | 730ms | 97ms | -0.13 | 13.3% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request integrates the addon-themes into Storybook for testing purposes, renaming the `theme` global to `sb_theme` and adding a `disable` parameter for better control.

- **`code/.storybook/main.ts`**: Added `@storybook/addon-themes` to the `addons` array and updated the `stories` array.
- **`code/.storybook/preview.tsx`**: Renamed `theme` global to `sb_theme` and added `disable` parameter to `addon-themes`.
- **`code/addons/themes/src/constants.ts`**: Introduced `disable` parameter to `ThemeParameters` interface.
- **`code/addons/themes/src/theme-switcher.tsx`**: Added `disable` parameter and `GLOBAL_KEY` for theme switcher control.
- **`code/addons/themes/template/stories/decorators.stories.ts`**: Added new decorators for applying themes using class names, data attributes, and JSX providers.

<!-- /greptile_comment -->