### PR TITLE
Docs: Update badly-migrated snippet

### DIFF
--- a/docs/_snippets/angular-builder-production.md
+++ b/docs/_snippets/angular-builder-production.md
@@ -1,0 +1,14 @@
+```shell renderer="angular" tabTitle="with-builder"
+# Builds Storybook with Angular's custom builder
+# See https://storybook.js.org/docs/get-started/frameworks/angular#how-do-i-migrate-to-an-angular-storybook-builder
+# to learn how to create the custom builder
+ng run my-project:build-storybook
+```
+
+```json renderer="angular" language="js" filename="package.json" tabTitle="script-for-builder"
+{
+  "scripts": {
+    "build-storybook": "ng run my-project:build-storybook"
+  }
+}
+```

--- a/docs/_snippets/custom-build-script-production.md
+++ b/docs/_snippets/custom-build-script-production.md
@@ -1,8 +1,0 @@
-```json renderer="angular" language="js" tabTitle="script-for-builder"
-{
-  "scripts": {
-    "build-storybook": "ng run my-project:build-storybook"
-  }
-}
-```
-

--- a/docs/sharing/publish-storybook.mdx
+++ b/docs/sharing/publish-storybook.mdx
@@ -13,13 +13,25 @@ Teams publish Storybook online to review and collaborate on works in progress. T
 
 ## Build Storybook as a static web application
 
-First, we'll need to build Storybook as a static web application. The functionality is already built-in and pre-configured for most supported frameworks. Others require a bit of customization (e.g., Angular). Run the following command inside your project's root directory:
+First, we'll need to build Storybook as a static web application. The functionality is already built-in and pre-configured for most supported frameworks. Run the following command inside your project's root directory:
 
 {/* prettier-ignore-start */}
 
-<CodeSnippets path="custom-build-script-production.md" />
+<CodeSnippets path="build-storybook-production-mode.md" />
 
 {/* prettier-ignore-end */}
+
+<If renderer="angular">
+
+If you're using Angular, it's often better to use the [Angular builder](../get-started/frameworks/angular.mdx#how-do-i-migrate-to-an-angular-storybook-builder) to build Storybook: 
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="angular-builder-production.md" />
+
+{/* prettier-ignore-end */}
+
+</If>
 
 <Callout variant="info" icon="💡">
   You can provide additional flags to customize the command. Read more about the flag options [here](../api/cli-options.mdx).


### PR DESCRIPTION
## What I did

Migration script did not correctly handle snippets with paths that had different filenames. So this fixes one known instance by splitting into two snippets.

## Checklist for Contributors

### Testing

#### Manual testing

Preview this branch in locally-run docs

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

<!-- greptile_comment -->

## Greptile Summary

The pull request addresses a migration issue in the documentation by splitting a snippet into two distinct parts for better clarity.

- **`docs/_snippets/angular-builder-production.md`**: Added two separate snippets for building Storybook with Angular's custom builder.
- **`docs/_snippets/custom-build-script-production.md`**: Deleted redundant file to maintain documentation accuracy.
- **`docs/sharing/publish-storybook.mdx`**: Modified to separate Angular build instructions into a distinct section, improving clarity and accuracy for users of different frameworks.

<!-- /greptile_comment -->