### PR TITLE
Telemetry: Add globals stats

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -94,6 +94,7 @@ describe('StoryIndexGenerator', () => {
         expect(stats).toMatchInlineSnapshot(`
           {
             "beforeEach": 0,
+            "globals": 0,
             "loaders": 0,
             "moduleMock": 0,
             "mount": 0,
@@ -461,6 +462,7 @@ describe('StoryIndexGenerator', () => {
         expect(stats).toMatchInlineSnapshot(`
           {
             "beforeEach": 1,
+            "globals": 0,
             "loaders": 1,
             "moduleMock": 0,
             "mount": 1,
@@ -725,6 +727,7 @@ describe('StoryIndexGenerator', () => {
         expect(stats).toMatchInlineSnapshot(`
           {
             "beforeEach": 1,
+            "globals": 0,
             "loaders": 1,
             "moduleMock": 0,
             "mount": 1,

--- a/code/core/src/csf-tools/CsfFile.test.ts
+++ b/code/core/src/csf-tools/CsfFile.test.ts
@@ -47,6 +47,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -60,6 +61,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -90,6 +92,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -102,6 +105,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -131,6 +135,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -161,6 +166,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -189,6 +195,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -215,6 +222,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -242,6 +250,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -252,6 +261,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -279,6 +289,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -289,6 +300,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -316,6 +328,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -326,6 +339,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -354,6 +368,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -364,6 +379,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -396,6 +412,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -409,6 +426,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -441,6 +459,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -454,6 +473,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -483,6 +503,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -493,6 +514,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -522,6 +544,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -532,6 +555,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -559,6 +583,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -569,6 +594,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -600,6 +626,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -630,6 +657,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -661,6 +689,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -697,6 +726,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -728,6 +758,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -741,6 +772,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -767,6 +799,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -777,6 +810,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -808,6 +842,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -821,6 +856,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -853,6 +889,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -932,6 +969,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -942,6 +980,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -994,6 +1033,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -1004,6 +1044,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -1080,6 +1121,7 @@ describe('CsfFile', () => {
               render: true
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1111,6 +1153,7 @@ describe('CsfFile', () => {
               render: true
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1140,6 +1183,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1171,6 +1215,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1251,6 +1296,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -1283,6 +1329,7 @@ describe('CsfFile', () => {
               render: true
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1317,6 +1364,7 @@ describe('CsfFile', () => {
               render: true
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1376,6 +1424,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -1410,6 +1459,7 @@ describe('CsfFile', () => {
               render: true
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1440,6 +1490,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: true
               moduleMock: false
@@ -1469,6 +1520,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: true
               moduleMock: false
@@ -1501,6 +1553,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: true
               moduleMock: false
@@ -1533,6 +1586,7 @@ describe('CsfFile', () => {
               render: true
               loaders: true
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1564,6 +1618,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -1613,6 +1668,7 @@ describe('CsfFile', () => {
             render: false
             loaders: false
             beforeEach: false
+            globals: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1632,6 +1688,7 @@ describe('CsfFile', () => {
             render: false
             loaders: false
             beforeEach: false
+            globals: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1669,6 +1726,7 @@ describe('CsfFile', () => {
             render: false
             loaders: false
             beforeEach: false
+            globals: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1711,6 +1769,7 @@ describe('CsfFile', () => {
             render: false
             loaders: false
             beforeEach: false
+            globals: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1768,6 +1827,7 @@ describe('CsfFile', () => {
             render: true
             loaders: false
             beforeEach: false
+            globals: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1804,6 +1864,7 @@ describe('CsfFile', () => {
             render: true
             loaders: false
             beforeEach: false
+            globals: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1840,6 +1901,7 @@ describe('CsfFile', () => {
             render: true
             loaders: false
             beforeEach: false
+            globals: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1876,6 +1938,7 @@ describe('CsfFile', () => {
             render: true
             loaders: false
             beforeEach: false
+            globals: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1905,6 +1968,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: true
+              globals: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1933,6 +1997,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: true
@@ -1958,6 +2023,7 @@ describe('CsfFile', () => {
               render: false
               loaders: false
               beforeEach: false
+              globals: false
               storyFn: false
               mount: false
               moduleMock: true

--- a/code/core/src/csf-tools/CsfFile.test.ts
+++ b/code/core/src/csf-tools/CsfFile.test.ts
@@ -1976,6 +1976,36 @@ describe('CsfFile', () => {
     });
   });
 
+  describe('globals', () => {
+    it('basic', () => {
+      expect(
+        parse(
+          dedent`
+          export default { title: 'foo/bar' };
+          export const A = {
+            globals: { foo: 'bar' }
+          };
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        meta:
+          title: foo/bar
+        stories:
+          - id: foo-bar--a
+            name: A
+            __stats:
+              play: false
+              render: false
+              loaders: false
+              beforeEach: false
+              globals: true
+              storyFn: false
+              mount: false
+              moduleMock: false
+      `);
+    });
+  });
+
   describe('module mocks', () => {
     it('alias', () => {
       expect(

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -566,7 +566,7 @@ export class CsfFile {
           acc[key].tags = [...(acc[key].tags || []), 'play-fn'];
         }
         const stats = acc[key].__stats;
-        ['play', 'render', 'loaders', 'beforeEach'].forEach((annotation) => {
+        ['play', 'render', 'loaders', 'beforeEach', 'globals'].forEach((annotation) => {
           stats[annotation as keyof IndexInputStats] =
             !!storyAnnotations[annotation] || !!self._metaAnnotations[annotation];
         });

--- a/code/core/src/types/modules/indexer.ts
+++ b/code/core/src/types/modules/indexer.ts
@@ -95,6 +95,7 @@ export interface IndexInputStats {
   mount?: boolean;
   beforeEach?: boolean;
   moduleMock?: boolean;
+  globals?: boolean;
 }
 
 /**

--- a/docs/configure/telemetry.mdx
+++ b/docs/configure/telemetry.mdx
@@ -75,6 +75,16 @@ Will generate the following output:
       "onboardingStoryCount": 0,
       "onboardingDocsCount": 0,
       "version": 4
+    },
+    "storyStats": {
+      "play": 0,
+      "render": 1,
+      "loaders": 0,
+      "beforeEach": 0,
+      "globals": 0,
+      "storyFn": 5,
+      "mount": 0,
+      "moduleMock": 0
     }
   },
   "metadata": {


### PR DESCRIPTION
Part of #27210

## What I did

- [x] Track usage of the new `globals` annotation
- [x] Add test
- [x] Update telemetry docs

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Add a globals story, run with `STORYBOOK_TELEMETRY_DEBUG=1`, and verify that the story is logged in `payload.stats`. 

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | 0.35 | 0% |
| initSize |  171 MB | 171 MB | 45 B | -1.16 | 0% |
| diffSize |  94.5 MB | 94.5 MB | 45 B | -1.16 | 0% |
| buildSize |  7.42 MB | 7.42 MB | 0 B | **-2.37** | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | **-2.25** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.29 MB | 2.29 MB | 0 B | -1.11 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | 0.58 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.45 MB | 4.45 MB | 0 B | **-2.14** | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | **-2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  12.4s | 7.8s | -4s -572ms | -1 | -58% |
| generateTime |  21.8s | 22.9s | 1s | 0.25 | 4.4% |
| initTime |  18.3s | 20s | 1.6s | -0.66 | 8.3% |
| buildTime |  12.9s | 16.5s | 3.5s | **2.43** | 🔺21.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.4s | 7.8s | 491ms | -0.5 | 6.2% |
| devManagerResponsive |  4.8s | 5.1s | 333ms | -0.55 | 6.4% |
| devManagerHeaderVisible |  888ms | 809ms | -79ms | -0.35 | -9.8% |
| devManagerIndexVisible |  924ms | 846ms | -78ms | -0.33 | -9.2% |
| devStoryVisibleUncached |  1.1s | 1s | -113ms | -1.22 | -10.8% |
| devStoryVisible |  947ms | 868ms | -79ms | -0.34 | -9.1% |
| devAutodocsVisible |  742ms | 657ms | -85ms | -0.87 | -12.9% |
| devMDXVisible |  761ms | 681ms | -80ms | -0.7 | -11.7% |
| buildManagerHeaderVisible |  886ms | 669ms | -217ms | -1.18 | -32.4% |
| buildManagerIndexVisible |  920ms | 673ms | -247ms | -1.2 | -36.7% |
| buildStoryVisible |  930ms | 721ms | -209ms | -1.15 | -29% |
| buildAutodocsVisible |  668ms | 642ms | -26ms | -1.07 | -4% |
| buildMDXVisible |  655ms | 641ms | -14ms | -0.6 | -2.2% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

The pull request adds telemetry tracking for the new `globals` annotation, including updates to tests and documentation.

- **`code/core/src/core-server/utils/StoryIndexGenerator.test.ts`**: Added `globals` field to `stats` object in test cases to track `globals` annotation usage.
- **`code/core/src/csf-tools/CsfFile.test.ts`**: Updated test cases to include checks for `globals` property in story statistics.
- **`code/core/src/csf-tools/CsfFile.ts`**: Included `globals` in the list of tracked annotations in the `__stats` object.
- **`code/core/src/types/modules/indexer.ts`**: Added `globals` property to `IndexInputStats` interface for telemetry purposes.
- **`docs/configure/telemetry.mdx`**: Documented new telemetry data collection for `globals` annotation.

<!-- /greptile_comment -->