### PR TITLE
Nextjs: Fix default annotations for portable stories

### DIFF
--- a/code/frameworks/nextjs/src/portable-stories.ts
+++ b/code/frameworks/nextjs/src/portable-stories.ts
@@ -2,6 +2,7 @@ import {
   composeStory as originalComposeStory,
   composeStories as originalComposeStories,
   setProjectAnnotations as originalSetProjectAnnotations,
+  setDefaultProjectAnnotations,
   composeConfigs,
 } from 'storybook/internal/preview-api';
 import type {
@@ -41,11 +42,12 @@ export function setProjectAnnotations(
     | NamedOrDefaultProjectAnnotations<ReactRenderer>
     | NamedOrDefaultProjectAnnotations<ReactRenderer>[]
 ): ProjectAnnotations<ReactRenderer> {
+  setDefaultProjectAnnotations(INTERNAL_DEFAULT_PROJECT_ANNOTATIONS);
   return originalSetProjectAnnotations<ReactRenderer>(projectAnnotations);
 }
 
 // This will not be necessary once we have auto preset loading
-const defaultProjectAnnotations: ProjectAnnotations<ReactRenderer> = composeConfigs([
+const INTERNAL_DEFAULT_PROJECT_ANNOTATIONS: ProjectAnnotations<ReactRenderer> = composeConfigs([
   reactAnnotations,
   // we only provide the RSC decorator, but not the feature flag. Should be set by the user
   { decorators: rscAnnotations.decorators },
@@ -89,7 +91,7 @@ export function composeStory<TArgs extends Args = Args>(
     story as StoryAnnotationsOrFn<ReactRenderer, Args>,
     componentAnnotations,
     projectAnnotations,
-    defaultProjectAnnotations,
+    INTERNAL_DEFAULT_PROJECT_ANNOTATIONS,
     exportsName
   );
 }

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -410,7 +410,9 @@ export async function setupVitest(details: TemplateDetails) {
       ${!isNextjs ? 'viteConfig' : '{}'},
       defineConfig({
         plugins: [
-          storybookTest(),
+          storybookTest({
+            storybookScript: 'yarn storybook --ci',
+          }),
           ${isSvelte ? 'svelteTesting(),' : ''}
           ${isNextjs ? "vitePluginNext({ dir: path.join(__dirname, '..') })," : ''}
         ],


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 20 B | -0.02 | 0% |
| initSize |  171 MB | 171 MB | 20 B | **-1.73** | 0% |
| diffSize |  94.6 MB | 94.6 MB | 0 B | **-1.73** | 0% |
| buildSize |  7.43 MB | 7.43 MB | 0 B | **-1.73** | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | **-1.66** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | **-1.38** | 0% |
| buildSbPreviewSize |  350 kB | 350 kB | 0 B | 0.72 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | **-1.59** | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | **-1.73** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  17.3s | 8s | -9s -306ms | -0.62 | -115.7% |
| generateTime |  23.7s | 25.5s | 1.8s | 0.74 | 7.1% |
| initTime |  19.7s | 22.5s | 2.7s | -0.26 | 12.4% |
| buildTime |  12.9s | 11.8s | -1s -136ms | **-2.77** | 🔰-9.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8s | 8.2s | 192ms | -0.52 | 2.3% |
| devManagerResponsive |  5.2s | 4.7s | -428ms | **-1.57** | 🔰-8.9% |
| devManagerHeaderVisible |  821ms | 831ms | 10ms | -0.17 | 1.2% |
| devManagerIndexVisible |  857ms | 857ms | 0ms | -0.25 | 0% |
| devStoryVisibleUncached |  1.4s | 1.3s | -80ms | -0.1 | -5.9% |
| devStoryVisible |  877ms | 879ms | 2ms | -0.28 | 0.2% |
| devAutodocsVisible |  759ms | 785ms | 26ms | -0.02 | 3.3% |
| devMDXVisible |  728ms | 799ms | 71ms | -0.1 | 8.9% |
| buildManagerHeaderVisible |  733ms | 861ms | 128ms | 0.7 | 14.9% |
| buildManagerIndexVisible |  741ms | 863ms | 122ms | 0.67 | 14.1% |
| buildStoryVisible |  788ms | 914ms | 126ms | 0.71 | 13.8% |
| buildAutodocsVisible |  692ms | 717ms | 25ms | -0.06 | 3.5% |
| buildMDXVisible |  786ms | 724ms | -62ms | -0.2 | -8.6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

The pull request introduces improvements to the handling of default project annotations for Next.js setups and enhances the Vitest setup for Storybook sandboxes.

- **`code/frameworks/nextjs/src/portable-stories.ts`**:
  - Introduced `setDefaultProjectAnnotations` function.
  - Utilized `setDefaultProjectAnnotations` in `setProjectAnnotations` and `composeStory`.
  - Defined `INTERNAL_DEFAULT_PROJECT_ANNOTATIONS` to include React, RSC, and Next.js annotations.

- **`scripts/tasks/sandbox-parts.ts`**:
  - Added `storybookScript` option to `storybookTest` plugin configuration in `setupVitest`.
  - Ensured Storybook runs in CI mode during Vitest tests.

<!-- /greptile_comment -->