### PR TITLE
Build: Reduce `bun` usage

### DIFF
--- a/scripts/prepare/addon-bundle.ts
+++ b/scripts/prepare/addon-bundle.ts
@@ -50,7 +50,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
   } = (await fs.readJson(join(cwd, 'package.json'))) as PackageJsonWithBundlerConfig;
 
   if (pre) {
-    await exec(`bun ${pre}`, { cwd });
+    await exec(`jiti ${pre}`, { cwd });
   }
 
   const reset = hasFlag(flags, 'reset');
@@ -204,7 +204,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
   );
 
   if (post) {
-    await exec(`bun ${post}`, { cwd }, { debug: true });
+    await exec(`jiti ${post}`, { cwd }, { debug: true });
   }
 
   console.log('done');

--- a/scripts/prepare/bundle.ts
+++ b/scripts/prepare/bundle.ts
@@ -45,7 +45,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
   } = (await fs.readJson(join(cwd, 'package.json'))) as PackageJsonWithBundlerConfig;
 
   if (pre) {
-    await exec(`bun ${pre}`, { cwd });
+    await exec(`jiti ${pre}`, { cwd });
   }
 
   const reset = hasFlag(flags, 'reset');
@@ -160,7 +160,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
   );
 
   if (post) {
-    await exec(`bun ${post}`, { cwd }, { debug: true });
+    await exec(`jiti ${post}`, { cwd }, { debug: true });
   }
 
   if (process.env.CI !== 'true') {

--- a/scripts/prepare/tsc.ts
+++ b/scripts/prepare/tsc.ts
@@ -12,7 +12,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
   } = await fs.readJson(join(cwd, 'package.json'));
 
   if (pre) {
-    await exec(`bun ${pre}`, { cwd });
+    await exec(`jiti ${pre}`, { cwd });
   }
 
   const reset = hasFlag(flags, 'reset');
@@ -66,7 +66,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
   }
 
   if (post) {
-    await exec(`bun ${post}`, { cwd }, { debug: true });
+    await exec(`jiti ${post}`, { cwd }, { debug: true });
   }
 
   if (!watch) {


### PR DESCRIPTION
Follow-up of https://github.com/storybookjs/storybook/pull/28796

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | 0.66 | 0% |
| initSize |  171 MB | 171 MB | 0 B | -0.73 | 0% |
| diffSize |  95 MB | 95 MB | 0 B | -0.73 | 0% |
| buildSize |  7.42 MB | 7.42 MB | 0 B | -1.22 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | -1.22 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.29 MB | 2.29 MB | 0 B | -0.65 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.45 MB | 4.45 MB | 0 B | -1.16 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | -1.22 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  27.1s | 7.2s | -19s -880ms | **-1.27** | 🔰-272.4% |
| generateTime |  24s | 22.4s | -1s -565ms | 0.09 | -7% |
| initTime |  22.8s | 18.8s | -4s -6ms | -0.91 | -21.3% |
| buildTime |  12.5s | 12.2s | -263ms | **-1.38** | -2.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.8s | 9.7s | 1.9s | 0.84 | 19.7% |
| devManagerResponsive |  4.5s | 5.6s | 1.1s | 0.35 | 20.6% |
| devManagerHeaderVisible |  750ms | 1s | 283ms | 1.03 | 27.4% |
| devManagerIndexVisible |  784ms | 1s | 276ms | 0.95 | 26% |
| devStoryVisibleUncached |  1.3s | 1.3s | 60ms | 0.7 | 4.4% |
| devStoryVisible |  796ms | 1s | 276ms | 0.83 | 25.7% |
| devAutodocsVisible |  699ms | 828ms | 129ms | 0.54 | 15.6% |
| devMDXVisible |  653ms | 895ms | 242ms | **1.47** | 🔺27% |
| buildManagerHeaderVisible |  654ms | 823ms | 169ms | 0.26 | 20.5% |
| buildManagerIndexVisible |  656ms | 830ms | 174ms | 0.25 | 21% |
| buildStoryVisible |  695ms | 874ms | 179ms | 0.22 | 20.5% |
| buildAutodocsVisible |  663ms | 687ms | 24ms | -0.55 | 3.5% |
| buildMDXVisible |  587ms | 671ms | 84ms | -0.21 | 12.5% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

The pull request focuses on replacing `bun` with `jiti` for executing pre and post build scripts across various build scripts to standardize the process.

- Updated `scripts/prepare/addon-bundle.ts` to use `jiti` for pre and post build scripts.
- Modified `scripts/prepare/bundle.ts` to replace `bun` with `jiti` for executing pre and post build scripts.
- Changed `scripts/prepare/tsc.ts` to utilize `jiti` instead of `bun` for pre and post build script execution.

Ensure that `jiti` handles all scenarios previously managed by `bun` without issues.

<!-- /greptile_comment -->