### PR TITLE
Build: Use `jiti` for building `core`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ orbs:
   browser-tools: circleci/browser-tools@1.4.1
   discord: antonioned/discord@0.1.0
   codecov: codecov/codecov@3.2.4
-  bun-orb: cmgriffing/bun-orb@0.0.29
   node: circleci/node@5.2.0
   nx: nrwl/nx@1.6.2
 
@@ -139,8 +138,6 @@ jobs:
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
-      - bun-orb/setup:
-          version: 1.1.1
       - restore_cache:
           name: Restore Yarn cache
           keys:
@@ -202,8 +199,6 @@ jobs:
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
-      - bun-orb/setup:
-          version: 1.1.1
       - attach_workspace:
           at: .
       - nx/set-shas:
@@ -353,8 +348,6 @@ jobs:
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"
-      - bun-orb/setup:
-          version: 1.1.1
       - attach_workspace:
           at: .
       - run:

--- a/.github/workflows/canary-release-pr.yml
+++ b/.github/workflows/canary-release-pr.yml
@@ -60,10 +60,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: 1.1.1
-
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/generate-sandboxes.yml
+++ b/.github/workflows/generate-sandboxes.yml
@@ -29,10 +29,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: next
-
-      - uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: 1.1.1
   
       - uses: actions/setup-node@v4
         with:
@@ -85,10 +81,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
-
-      - uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: 1.1.1
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/prepare-non-patch-release.yml
+++ b/.github/workflows/prepare-non-patch-release.yml
@@ -56,10 +56,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: 1.1.1
-
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -35,10 +35,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: 1.1.1
-
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,10 +47,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: 1.1.1
-
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -17,9 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: 1.1.1
       - name: Set node version
         uses: actions/setup-node@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,6 @@ You will need to have the following installed:
 - git
 - node
 - yarn
-- [bun](https://bun.sh/)
 
 ## Using fnm as a Node version manager
 

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -265,8 +265,8 @@
     "!src/**/*"
   ],
   "scripts": {
-    "check": "bun ./scripts/check.ts",
-    "prep": "bun ./scripts/prep.ts"
+    "check": "jiti ./scripts/check.ts",
+    "prep": "jiti ./scripts/prep.ts"
   },
   "dependencies": {
     "@storybook/csf": "^0.1.11",

--- a/code/core/scripts/dts.ts
+++ b/code/core/scripts/dts.ts
@@ -49,6 +49,6 @@ async function run() {
 }
 
 run().catch((e) => {
-  process.stderr.write(e.stack);
+  process.stderr.write(e.toString());
   process.exit(1);
 });

--- a/code/core/scripts/dts.ts
+++ b/code/core/scripts/dts.ts
@@ -3,47 +3,50 @@ import { process, dts, nodeInternals } from '../../../scripts/prepare/tools';
 import { getEntries } from './entries';
 import pkg from '../package.json';
 
-const cwd = process.cwd();
+async function run() {
+  const cwd = process.cwd();
 
-const flags = process.argv.slice(2);
+  const flags = process.argv.slice(2);
 
-const selection = flags[0] || 'all';
+  const selection = flags[0] || 'all';
 
-const entries = getEntries(cwd);
-const external = [
-  ...Object.keys((pkg as any).dependencies || {}),
-  ...Object.keys((pkg as any).peerDependencies || {}),
-  ...nodeInternals,
-  'typescript',
-  '@storybook/core',
+  const entries = getEntries(cwd);
+  const external = [
+    ...Object.keys((pkg as any).dependencies || {}),
+    ...Object.keys((pkg as any).peerDependencies || {}),
+    ...nodeInternals,
+    'typescript',
+    '@storybook/core',
 
-  '@storybook/core/builder-manager',
-  '@storybook/core/channels',
-  '@storybook/core/client-logger',
-  '@storybook/core/common',
-  '@storybook/core/components',
-  '@storybook/core/core-events',
-  '@storybook/core/core-server',
-  '@storybook/core/csf-tools',
-  '@storybook/core/docs-tools',
-  '@storybook/core/manager-api',
-  '@storybook/core/node-logger',
-  '@storybook/core/preview-api',
-  '@storybook/core/router',
-  '@storybook/core/telemetry',
-  '@storybook/core/theming',
-  '@storybook/core/types',
-];
+    '@storybook/core/builder-manager',
+    '@storybook/core/channels',
+    '@storybook/core/client-logger',
+    '@storybook/core/common',
+    '@storybook/core/components',
+    '@storybook/core/core-events',
+    '@storybook/core/core-server',
+    '@storybook/core/csf-tools',
+    '@storybook/core/docs-tools',
+    '@storybook/core/manager-api',
+    '@storybook/core/node-logger',
+    '@storybook/core/preview-api',
+    '@storybook/core/router',
+    '@storybook/core/telemetry',
+    '@storybook/core/theming',
+    '@storybook/core/types',
+  ];
 
-const all = entries.filter((e) => e.dts);
-const list = selection === 'all' ? all : [all[Number(selection)]];
+  const all = entries.filter((e) => e.dts);
+  const list = selection === 'all' ? all : [all[Number(selection)]];
 
-await Promise.all(
-  list.map(async (i) => {
-    await dts(
-      i.file,
-      [...external, ...i.externals],
-      join(import.meta.dirname, '..', 'tsconfig.json')
-    );
-  })
-);
+  await Promise.all(
+    list.map(async (i) => {
+      await dts(i.file, [...external, ...i.externals], join(__dirname, '..', 'tsconfig.json'));
+    })
+  );
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/code/core/scripts/dts.ts
+++ b/code/core/scripts/dts.ts
@@ -39,6 +39,8 @@ async function run() {
   const all = entries.filter((e) => e.dts);
   const list = selection === 'all' ? all : [all[Number(selection)]];
 
+  console.log('Generating d.ts files for', list.map((i) => i.file).join(', '));
+
   await Promise.all(
     list.map(async (i) => {
       await dts(i.file, [...external, ...i.externals], join(__dirname, '..', 'tsconfig.json'));
@@ -47,6 +49,6 @@ async function run() {
 }
 
 run().catch((e) => {
-  console.error(e);
+  process.stderr.write(e.stack);
   process.exit(1);
 });

--- a/code/core/scripts/helpers/dependencies.ts
+++ b/code/core/scripts/helpers/dependencies.ts
@@ -1,3 +1,4 @@
+import { readJson } from 'fs-extra';
 import { join } from 'node:path';
 
 export async function flattenDependencies(
@@ -16,7 +17,7 @@ export async function flattenDependencies(
         console.log(dep + ' not found');
         return;
       }
-      const { dependencies = {}, peerDependencies = {} } = await Bun.file(path).json();
+      const { dependencies = {}, peerDependencies = {} } = await readJson(path);
       const all: string[] = [
         ...new Set([...Object.keys(dependencies), ...Object.keys(peerDependencies)]),
       ]

--- a/code/core/scripts/helpers/generatePackageJsonFile.ts
+++ b/code/core/scripts/helpers/generatePackageJsonFile.ts
@@ -1,13 +1,15 @@
 import { join, relative } from 'node:path';
 import slash from 'slash';
-import { sortPackageJson, Bun } from '../../../../scripts/prepare/tools';
+import { sortPackageJson } from '../../../../scripts/prepare/tools';
 import type { getEntries } from '../entries';
+import { readJSON } from 'fs-extra';
+import { writeFile } from 'node:fs/promises';
 
 const cwd = process.cwd();
 
 export async function generatePackageJsonFile(entries: ReturnType<typeof getEntries>) {
   const location = join(cwd, 'package.json');
-  const pkgJson = await Bun.file(location).json();
+  const pkgJson = await readJSON(location);
 
   /** Re-create the `exports` field in `code/core/package.json`
    * This way we only need to update the `./scripts/entries.ts` file to ensure all things we create actually exist and are mapped to the correct path.
@@ -67,5 +69,5 @@ export async function generatePackageJsonFile(entries: ReturnType<typeof getEntr
     },
   };
 
-  await Bun.write(location, `${sortPackageJson(JSON.stringify(pkgJson, null, 2))}\n`, {});
+  await writeFile(location, `${sortPackageJson(JSON.stringify(pkgJson, null, 2))}\n`, {});
 }

--- a/code/core/scripts/helpers/generateTypesMapperFiles.ts
+++ b/code/core/scripts/helpers/generateTypesMapperFiles.ts
@@ -31,7 +31,7 @@ export async function generateTypesMapperFiles(entries: ReturnType<typeof getEnt
     all.map(async (filePath) => {
       const location = filePath.replace('src', 'dist').replace(/\.tsx?/, '.d.ts');
       await ensureFile(location);
-      await writeFile(location, await generateTypesMapperContent(filePath), {});
+      await writeFile(location, await generateTypesMapperContent(filePath));
     })
   );
 }

--- a/code/core/scripts/helpers/generateTypesMapperFiles.ts
+++ b/code/core/scripts/helpers/generateTypesMapperFiles.ts
@@ -2,6 +2,7 @@ import type { getEntries } from '../entries';
 import { join, relative } from 'node:path';
 import { dedent } from '../../../../scripts/prepare/tools';
 import { writeFile } from 'node:fs/promises';
+import { ensureFile } from 'fs-extra';
 
 const cwd = process.cwd();
 
@@ -27,11 +28,10 @@ export async function generateTypesMapperFiles(entries: ReturnType<typeof getEnt
   const all = entries.filter((e) => e.dts).map((e) => e.file);
 
   await Promise.all(
-    all.map(async (filePath) =>
-      writeFile(
-        filePath.replace('src', 'dist').replace(/\.tsx?/, '.d.ts'),
-        await generateTypesMapperContent(filePath)
-      )
-    )
+    all.map(async (filePath) => {
+      const location = filePath.replace('src', 'dist').replace(/\.tsx?/, '.d.ts');
+      await ensureFile(location);
+      await writeFile(location, await generateTypesMapperContent(filePath), {});
+    })
   );
 }

--- a/code/core/scripts/helpers/generateTypesMapperFiles.ts
+++ b/code/core/scripts/helpers/generateTypesMapperFiles.ts
@@ -1,7 +1,7 @@
-import { Bun } from '../../../../scripts/prepare/tools';
 import type { getEntries } from '../entries';
 import { join, relative } from 'node:path';
 import { dedent } from '../../../../scripts/prepare/tools';
+import { writeFile } from 'node:fs/promises';
 
 const cwd = process.cwd();
 
@@ -10,7 +10,7 @@ async function generateTypesMapperContent(filePath: string) {
   const downwards = relative(cwd, filePath);
 
   return dedent`
-    // auto generated file from ${import.meta.filename}, do not edit
+    // auto generated file from ${__filename}, do not edit
     export * from '${join(upwards, downwards)}';
     export type * from '${join(upwards, downwards)}';
   `;
@@ -28,7 +28,7 @@ export async function generateTypesMapperFiles(entries: ReturnType<typeof getEnt
 
   await Promise.all(
     all.map(async (filePath) =>
-      Bun.write(
+      writeFile(
         filePath.replace('src', 'dist').replace(/\.tsx?/, '.d.ts'),
         await generateTypesMapperContent(filePath)
       )

--- a/code/core/scripts/helpers/modifyThemeTypes.ts
+++ b/code/core/scripts/helpers/modifyThemeTypes.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
-import { dedent, Bun } from '../../../../scripts/prepare/tools';
+import { dedent } from '../../../../scripts/prepare/tools';
+import { readFile, writeFile } from 'node:fs/promises';
 
 export async function modifyThemeTypes() {
   /**
@@ -7,8 +8,8 @@ export async function modifyThemeTypes() {
    * This is not an option for us, because we pre-bundle emotion in.
    * The little hack work to ensure the `Theme` export is overloaded with our `StorybookTheme` interface. (in both development and production builds)
    */
-  const target = join(import.meta.dirname, '..', '..', 'dist', 'theming', 'index.d.ts');
-  const contents = await Bun.file(target).text();
+  const target = join(__dirname, '..', '..', 'dist', 'theming', 'index.d.ts');
+  const contents = await readFile(target, 'utf-8');
 
   const footer = contents.includes('// auto generated file')
     ? `export { StorybookTheme as Theme } from '../src/index';`
@@ -22,5 +23,5 @@ export async function modifyThemeTypes() {
     ${footer}
   `;
 
-  await Bun.write(target, newContents);
+  await writeFile(target, newContents);
 }

--- a/code/core/scripts/helpers/sourcefiles.ts
+++ b/code/core/scripts/helpers/sourcefiles.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { readdir } from 'node:fs/promises';
+import { readdir, writeFile } from 'node:fs/promises';
 import { dedent, prettier, getWorkspace, esbuild } from '../../../../scripts/prepare/tools';
 import { temporaryFile } from '../../src/common/utils/cli';
 
@@ -11,7 +11,7 @@ GlobalRegistrator.register({ url: 'http://localhost:3000', width: 1920, height: 
 // save this list into ./code/core/src/types/frameworks.ts and export it as a union type.
 // The name of the type is `SupportedFrameworks`. Add additionally 'qwik' and `solid` to that list.
 export const generateSourceFiles = async () => {
-  const location = join(import.meta.dirname, '..', '..', 'src');
+  const location = join(__dirname, '..', '..', 'src');
   const prettierConfig = await prettier.resolveConfig(location);
 
   await Promise.all([
@@ -23,7 +23,7 @@ export const generateSourceFiles = async () => {
 };
 
 async function generateVersionsFile(prettierConfig: prettier.Options | null): Promise<void> {
-  const location = join(import.meta.dirname, '..', '..', 'src', 'common', 'versions.ts');
+  const location = join(__dirname, '..', '..', 'src', 'common', 'versions.ts');
 
   const workspace = await getWorkspace();
 
@@ -38,7 +38,7 @@ async function generateVersionsFile(prettierConfig: prettier.Options | null): Pr
       }, {})
   );
 
-  await Bun.write(
+  await writeFile(
     location,
     await prettier.format(
       dedent`
@@ -55,23 +55,15 @@ async function generateVersionsFile(prettierConfig: prettier.Options | null): Pr
 
 async function generateFrameworksFile(prettierConfig: prettier.Options | null): Promise<void> {
   const thirdPartyFrameworks = ['qwik', 'solid'];
-  const location = join(
-    import.meta.dirname,
-    '..',
-    '..',
-    'src',
-    'types',
-    'modules',
-    'frameworks.ts'
-  );
-  const frameworksDirectory = join(import.meta.dirname, '..', '..', '..', 'frameworks');
+  const location = join(__dirname, '..', '..', 'src', 'types', 'modules', 'frameworks.ts');
+  const frameworksDirectory = join(__dirname, '..', '..', '..', 'frameworks');
 
   const readFrameworks = await readdir(frameworksDirectory);
   const frameworks = [...readFrameworks.sort(), ...thirdPartyFrameworks]
     .map((framework) => `'${framework}'`)
     .join(' | ');
 
-  await Bun.write(
+  await writeFile(
     location,
     await prettier.format(
       dedent`
@@ -87,25 +79,17 @@ async function generateFrameworksFile(prettierConfig: prettier.Options | null): 
 }
 
 const localAlias = {
-  '@storybook/core': join(import.meta.dirname, '..', '..', 'src'),
-  storybook: join(import.meta.dirname, '..', '..', 'src'),
+  '@storybook/core': join(__dirname, '..', '..', 'src'),
+  storybook: join(__dirname, '..', '..', 'src'),
 };
 async function generateExportsFile(prettierConfig: prettier.Options | null): Promise<void> {
   function removeDefault(input: string) {
     return input !== 'default';
   }
 
-  const location = join(import.meta.dirname, '..', '..', 'src', 'manager', 'globals', 'exports.ts');
+  const location = join(__dirname, '..', '..', 'src', 'manager', 'globals', 'exports.ts');
 
-  const entryFile = join(
-    import.meta.dirname,
-    '..',
-    '..',
-    'src',
-    'manager',
-    'globals',
-    'runtime.ts'
-  );
+  const entryFile = join(__dirname, '..', '..', 'src', 'manager', 'globals', 'runtime.ts');
   const outFile = await temporaryFile({ extension: 'js' });
 
   await esbuild.build({
@@ -133,7 +117,7 @@ async function generateExportsFile(prettierConfig: prettier.Options | null): Pro
     }
   }
 
-  await Bun.write(
+  await writeFile(
     location,
     await prettier.format(
       dedent`

--- a/code/core/scripts/prep.ts
+++ b/code/core/scripts/prep.ts
@@ -26,136 +26,137 @@ import { generateTypesMapperFiles } from './helpers/generateTypesMapperFiles';
 import { generateTypesFiles } from './helpers/generateTypesFiles';
 import { isNode, noExternals, isBrowser } from './helpers/isEntryType';
 
-const flags = process.argv.slice(2);
-const cwd = process.cwd();
+async function run() {
+  const flags = process.argv.slice(2);
+  const cwd = process.cwd();
 
-const isOptimized = flags.includes('--optimized');
-const isWatch = flags.includes('--watch');
-const isReset = flags.includes('--reset');
+  const isOptimized = flags.includes('--optimized');
+  const isWatch = flags.includes('--watch');
+  const isReset = flags.includes('--reset');
 
-const external = [
-  ...new Set([
-    ...Object.keys(pkg.dependencies),
-    ...Object.keys((pkg as any).peerDependencies || {}),
-  ]),
-];
+  const external = [
+    ...new Set([
+      ...Object.keys(pkg.dependencies),
+      ...Object.keys((pkg as any).peerDependencies || {}),
+    ]),
+  ];
 
-if (isOptimized && isWatch) {
-  throw new Error('Cannot watch and optimize at the same time');
-}
+  if (isOptimized && isWatch) {
+    throw new Error('Cannot watch and optimize at the same time');
+  }
 
-if (isReset) {
-  await rmdir(join(cwd, 'dist'), { recursive: true });
-}
+  if (isReset) {
+    await rmdir(join(cwd, 'dist'), { recursive: true });
+  }
 
-const entries = getEntries(cwd);
-const bundles = getBundles(cwd);
-const finals = getFinals(cwd);
+  const entries = getEntries(cwd);
+  const bundles = getBundles(cwd);
+  const finals = getFinals(cwd);
 
-type EsbuildContextOptions = Parameters<(typeof esbuild)['context']>[0];
+  type EsbuildContextOptions = Parameters<(typeof esbuild)['context']>[0];
 
-console.log(isWatch ? 'Watching...' : 'Bundling...');
+  console.log(isWatch ? 'Watching...' : 'Bundling...');
 
-const files = measure(generateSourceFiles);
-const packageJson = measure(() => generatePackageJsonFile(entries));
-const dist = files.then(() => measure(generateDistFiles));
-const types = measure(async () => {
-  await generateTypesMapperFiles(entries);
-  await modifyThemeTypes();
-  await generateTypesFiles(entries, isOptimized, cwd);
-  await modifyThemeTypes();
-});
+  const files = measure(generateSourceFiles);
+  const packageJson = measure(() => generatePackageJsonFile(entries));
+  const dist = files.then(() => measure(generateDistFiles));
+  const types = measure(async () => {
+    await generateTypesMapperFiles(entries);
+    await modifyThemeTypes();
+    await generateTypesFiles(entries, isOptimized, cwd);
+    await modifyThemeTypes();
+  });
 
-const [filesTime, packageJsonTime, distTime, typesTime] = await Promise.all([
-  files,
-  packageJson,
-  dist,
-  types,
-]);
+  const [filesTime, packageJsonTime, distTime, typesTime] = await Promise.all([
+    files,
+    packageJson,
+    dist,
+    types,
+  ]);
 
-console.log('Files generated in', chalk.yellow(prettyTime(filesTime)));
-console.log('Package.json generated in', chalk.yellow(prettyTime(packageJsonTime)));
-console.log(isWatch ? 'Watcher started in' : 'Bundled in', chalk.yellow(prettyTime(distTime)));
-console.log(
-  isOptimized ? 'Generated types in' : 'Generated type mappers in',
-  chalk.yellow(prettyTime(typesTime))
-);
+  console.log('Files generated in', chalk.yellow(prettyTime(filesTime)));
+  console.log('Package.json generated in', chalk.yellow(prettyTime(packageJsonTime)));
+  console.log(isWatch ? 'Watcher started in' : 'Bundled in', chalk.yellow(prettyTime(distTime)));
+  console.log(
+    isOptimized ? 'Generated types in' : 'Generated type mappers in',
+    chalk.yellow(prettyTime(typesTime))
+  );
 
-async function generateDistFiles() {
-  const esbuildDefaultOptions = {
-    absWorkingDir: cwd,
-    allowOverwrite: false,
-    assetNames: 'assets/[name]-[hash]',
-    bundle: true,
-    chunkNames: 'chunks/[name]-[hash]',
-    external: ['@storybook/core', ...external],
-    keepNames: true,
-    legalComments: 'none',
-    lineLimit: 140,
-    metafile: true,
-    minifyIdentifiers: isOptimized,
-    minifySyntax: isOptimized,
-    minifyWhitespace: false,
-    outdir: 'dist',
-    sourcemap: false,
-    treeShaking: true,
-  } satisfies EsbuildContextOptions;
+  async function generateDistFiles() {
+    const esbuildDefaultOptions = {
+      absWorkingDir: cwd,
+      allowOverwrite: false,
+      assetNames: 'assets/[name]-[hash]',
+      bundle: true,
+      chunkNames: 'chunks/[name]-[hash]',
+      external: ['@storybook/core', ...external],
+      keepNames: true,
+      legalComments: 'none',
+      lineLimit: 140,
+      metafile: true,
+      minifyIdentifiers: isOptimized,
+      minifySyntax: isOptimized,
+      minifyWhitespace: false,
+      outdir: 'dist',
+      sourcemap: false,
+      treeShaking: true,
+    } satisfies EsbuildContextOptions;
 
-  const browserEsbuildOptions = {
-    ...esbuildDefaultOptions,
-    format: 'esm',
-    target: ['chrome100', 'safari15', 'firefox91'],
-    splitting: false,
-    platform: 'browser',
+    const browserEsbuildOptions = {
+      ...esbuildDefaultOptions,
+      format: 'esm',
+      target: ['chrome100', 'safari15', 'firefox91'],
+      splitting: false,
+      platform: 'browser',
 
-    conditions: ['browser', 'module', 'import', 'default'],
-  } satisfies EsbuildContextOptions;
+      conditions: ['browser', 'module', 'import', 'default'],
+    } satisfies EsbuildContextOptions;
 
-  const nodeEsbuildOptions = {
-    ...esbuildDefaultOptions,
-    target: 'node18',
-    splitting: false,
-    platform: 'neutral',
-    mainFields: ['main', 'module', 'node'],
-    conditions: ['node', 'module', 'import', 'require'],
-  } satisfies EsbuildContextOptions;
+    const nodeEsbuildOptions = {
+      ...esbuildDefaultOptions,
+      target: 'node18',
+      splitting: false,
+      platform: 'neutral',
+      mainFields: ['main', 'module', 'node'],
+      conditions: ['node', 'module', 'import', 'require'],
+    } satisfies EsbuildContextOptions;
 
-  const browserAliases = {
-    assert: require.resolve('browser-assert'),
-    process: require.resolve('process/browser.js'),
-    util: require.resolve('util/util.js'),
-  };
+    const browserAliases = {
+      assert: require.resolve('browser-assert'),
+      process: require.resolve('process/browser.js'),
+      util: require.resolve('util/util.js'),
+    };
 
-  const compile = await Promise.all([
-    esbuild.context(
-      merge<EsbuildContextOptions>(nodeEsbuildOptions, {
-        entryPoints: entries
-          .filter(isNode)
-          .filter(noExternals)
-          .map((e) => e.file),
-        external: [...nodeInternals, ...esbuildDefaultOptions.external],
-        format: 'cjs',
-        outExtension: {
-          '.js': '.cjs',
-        },
-      })
-    ),
-    esbuild.context(
-      merge<EsbuildContextOptions>(browserEsbuildOptions, {
-        alias: browserAliases,
-        entryPoints: entries
-          .filter(isBrowser)
-          .filter(noExternals)
-          .map((entry) => entry.file),
-        outExtension: {
-          '.js': '.js',
-        },
-      })
-    ),
-    esbuild.context(
-      merge<EsbuildContextOptions>(nodeEsbuildOptions, {
-        banner: {
-          js: dedent`
+    const compile = await Promise.all([
+      esbuild.context(
+        merge<EsbuildContextOptions>(nodeEsbuildOptions, {
+          entryPoints: entries
+            .filter(isNode)
+            .filter(noExternals)
+            .map((e) => e.file),
+          external: [...nodeInternals, ...esbuildDefaultOptions.external],
+          format: 'cjs',
+          outExtension: {
+            '.js': '.cjs',
+          },
+        })
+      ),
+      esbuild.context(
+        merge<EsbuildContextOptions>(browserEsbuildOptions, {
+          alias: browserAliases,
+          entryPoints: entries
+            .filter(isBrowser)
+            .filter(noExternals)
+            .map((entry) => entry.file),
+          outExtension: {
+            '.js': '.js',
+          },
+        })
+      ),
+      esbuild.context(
+        merge<EsbuildContextOptions>(nodeEsbuildOptions, {
+          banner: {
+            js: dedent`
             import ESM_COMPAT_Module from "node:module";
             import { fileURLToPath as ESM_COMPAT_fileURLToPath } from 'node:url';
             import { dirname as ESM_COMPAT_dirname } from 'node:path';
@@ -163,167 +164,173 @@ async function generateDistFiles() {
             const __dirname = ESM_COMPAT_dirname(__filename);
             const require = ESM_COMPAT_Module.createRequire(import.meta.url);
           `,
-        },
-        entryPoints: entries
-          .filter(isNode)
-          .filter(noExternals)
-          .filter((i) => !isBrowser(i))
-          .map((entry) => entry.file),
-        external: [...nodeInternals, ...esbuildDefaultOptions.external],
-        format: 'esm',
-        outExtension: {
-          '.js': '.js',
-        },
-      })
-    ),
-    ...bundles.flatMap((entry) => {
-      const results = [];
-      results.push(
-        esbuild.context(
-          merge<EsbuildContextOptions>(browserEsbuildOptions, {
-            outdir: dirname(entry.file).replace('src', 'dist'),
-            entryPoints: [entry.file],
-            outExtension: { '.js': '.js' },
-            alias: {
-              ...browserAliases,
-              '@storybook/core': join(cwd, 'src'),
-              react: dirname(require.resolve('react/package.json')),
-              'react-dom': dirname(require.resolve('react-dom/package.json')),
-            },
-            external: [],
-          })
-        )
-      );
-
-      return results;
-    }),
-    ...finals.flatMap((entry) => {
-      const results = [];
-      results.push(
-        esbuild.context(
-          merge<EsbuildContextOptions>(browserEsbuildOptions, {
-            alias: {
-              '@storybook/core': join(cwd, 'src'),
-              react: dirname(require.resolve('react/package.json')),
-              'react-dom': dirname(require.resolve('react-dom/package.json')),
-              'react-dom/client': join(
-                dirname(require.resolve('react-dom/package.json')),
-                'client'
-              ),
-            },
-            define: {
-              // This should set react in prod mode for the manager
-              'process.env.NODE_ENV': JSON.stringify('production'),
-            },
-            entryPoints: [entry.file],
-            external: [],
-            outdir: dirname(entry.file).replace('src', 'dist'),
-            outExtension: {
-              '.js': '.js',
-            },
-            plugins: [globalExternals(globalsModuleInfoMap)],
-          })
-        )
-      );
-
-      return results;
-    }),
-    ...entries
-      .filter((entry) => !noExternals(entry))
-      .flatMap((entry) => {
+          },
+          entryPoints: entries
+            .filter(isNode)
+            .filter(noExternals)
+            .filter((i) => !isBrowser(i))
+            .map((entry) => entry.file),
+          external: [...nodeInternals, ...esbuildDefaultOptions.external],
+          format: 'esm',
+          outExtension: {
+            '.js': '.js',
+          },
+        })
+      ),
+      ...bundles.flatMap((entry) => {
         const results = [];
-        if (entry.node) {
-          results.push(
-            esbuild.context(
-              merge<EsbuildContextOptions>(nodeEsbuildOptions, {
-                entryPoints: [entry.file],
-                external: [
-                  ...nodeInternals,
-                  ...esbuildDefaultOptions.external,
-                  ...entry.externals,
-                ].filter((e) => !entry.internals.includes(e)),
-                format: 'cjs',
-                outdir: dirname(entry.file).replace('src', 'dist'),
-                outExtension: {
-                  '.js': '.cjs',
-                },
-              })
-            )
-          );
-        }
-        if (entry.browser) {
-          results.push(
-            esbuild.context(
-              merge<EsbuildContextOptions>(browserEsbuildOptions, {
-                entryPoints: [entry.file],
-                external: [
-                  ...nodeInternals,
-                  ...esbuildDefaultOptions.external,
-                  ...entry.externals,
-                ].filter((e) => !entry.internals.includes(e)),
-                outdir: dirname(entry.file).replace('src', 'dist'),
-                outExtension: {
-                  '.js': '.js',
-                },
-              })
-            )
-          );
-        } else if (entry.node) {
-          results.push(
-            esbuild.context(
-              merge<EsbuildContextOptions>(nodeEsbuildOptions, {
-                entryPoints: [entry.file],
-                external: [
-                  ...nodeInternals,
-                  ...esbuildDefaultOptions.external,
-                  ...entry.externals,
-                ].filter((e) => !entry.internals.includes(e)),
-                format: 'esm',
-                outdir: dirname(entry.file).replace('src', 'dist'),
-                outExtension: {
-                  '.js': '.js',
-                },
-              })
-            )
-          );
-        }
+        results.push(
+          esbuild.context(
+            merge<EsbuildContextOptions>(browserEsbuildOptions, {
+              outdir: dirname(entry.file).replace('src', 'dist'),
+              entryPoints: [entry.file],
+              outExtension: { '.js': '.js' },
+              alias: {
+                ...browserAliases,
+                '@storybook/core': join(cwd, 'src'),
+                react: dirname(require.resolve('react/package.json')),
+                'react-dom': dirname(require.resolve('react-dom/package.json')),
+              },
+              external: [],
+            })
+          )
+        );
 
         return results;
       }),
-  ]);
+      ...finals.flatMap((entry) => {
+        const results = [];
+        results.push(
+          esbuild.context(
+            merge<EsbuildContextOptions>(browserEsbuildOptions, {
+              alias: {
+                '@storybook/core': join(cwd, 'src'),
+                react: dirname(require.resolve('react/package.json')),
+                'react-dom': dirname(require.resolve('react-dom/package.json')),
+                'react-dom/client': join(
+                  dirname(require.resolve('react-dom/package.json')),
+                  'client'
+                ),
+              },
+              define: {
+                // This should set react in prod mode for the manager
+                'process.env.NODE_ENV': JSON.stringify('production'),
+              },
+              entryPoints: [entry.file],
+              external: [],
+              outdir: dirname(entry.file).replace('src', 'dist'),
+              outExtension: {
+                '.js': '.js',
+              },
+              plugins: [globalExternals(globalsModuleInfoMap)],
+            })
+          )
+        );
 
-  if (isWatch) {
-    await Promise.all(
-      compile.map(async (context) => {
-        await context.watch();
-      })
-    );
+        return results;
+      }),
+      ...entries
+        .filter((entry) => !noExternals(entry))
+        .flatMap((entry) => {
+          const results = [];
+          if (entry.node) {
+            results.push(
+              esbuild.context(
+                merge<EsbuildContextOptions>(nodeEsbuildOptions, {
+                  entryPoints: [entry.file],
+                  external: [
+                    ...nodeInternals,
+                    ...esbuildDefaultOptions.external,
+                    ...entry.externals,
+                  ].filter((e) => !entry.internals.includes(e)),
+                  format: 'cjs',
+                  outdir: dirname(entry.file).replace('src', 'dist'),
+                  outExtension: {
+                    '.js': '.cjs',
+                  },
+                })
+              )
+            );
+          }
+          if (entry.browser) {
+            results.push(
+              esbuild.context(
+                merge<EsbuildContextOptions>(browserEsbuildOptions, {
+                  entryPoints: [entry.file],
+                  external: [
+                    ...nodeInternals,
+                    ...esbuildDefaultOptions.external,
+                    ...entry.externals,
+                  ].filter((e) => !entry.internals.includes(e)),
+                  outdir: dirname(entry.file).replace('src', 'dist'),
+                  outExtension: {
+                    '.js': '.js',
+                  },
+                })
+              )
+            );
+          } else if (entry.node) {
+            results.push(
+              esbuild.context(
+                merge<EsbuildContextOptions>(nodeEsbuildOptions, {
+                  entryPoints: [entry.file],
+                  external: [
+                    ...nodeInternals,
+                    ...esbuildDefaultOptions.external,
+                    ...entry.externals,
+                  ].filter((e) => !entry.internals.includes(e)),
+                  format: 'esm',
+                  outdir: dirname(entry.file).replace('src', 'dist'),
+                  outExtension: {
+                    '.js': '.js',
+                  },
+                })
+              )
+            );
+          }
 
-    // show a log message when a file is compiled
-    watch(join(cwd, 'dist'), { recursive: true }, (event, filename) => {
-      console.log(`compiled ${chalk.cyan(filename)}`);
-    });
-  } else {
-    await Promise.all(
-      compile.map(async (context) => {
-        const out = await context.rebuild();
-        await context.dispose();
+          return results;
+        }),
+    ]);
 
-        /**
-         * I'm leaving this in place, because I want to start utilizing it in the future.
-         * I'm imagining a github action that shows the bundle analysis in the PR.
-         * I didn't have the project-scope to make that happen now, but I want expose this very rich useful data accessible, for the next person investigating bundle size issues.
-         */
+    if (isWatch) {
+      await Promise.all(
+        compile.map(async (context) => {
+          await context.watch();
+        })
+      );
 
-        // if (out.metafile) {
-        //   await Bun.write('report/meta.json', JSON.stringify(out.metafile, null, 2));
-        //   await Bun.write(
-        //     'report/meta.txt',
-        //     await esbuild.analyzeMetafile(out.metafile, { color: false, verbose: false })
-        //   );
-        //   console.log(await esbuild.analyzeMetafile(out.metafile, { color: true }));
-        // }
-      })
-    );
+      // show a log message when a file is compiled
+      watch(join(cwd, 'dist'), { recursive: true }, (event, filename) => {
+        console.log(`compiled ${chalk.cyan(filename)}`);
+      });
+    } else {
+      await Promise.all(
+        compile.map(async (context) => {
+          const out = await context.rebuild();
+          await context.dispose();
+
+          /**
+           * I'm leaving this in place, because I want to start utilizing it in the future.
+           * I'm imagining a github action that shows the bundle analysis in the PR.
+           * I didn't have the project-scope to make that happen now, but I want expose this very rich useful data accessible, for the next person investigating bundle size issues.
+           */
+
+          // if (out.metafile) {
+          //   await Bun.write('report/meta.json', JSON.stringify(out.metafile, null, 2));
+          //   await Bun.write(
+          //     'report/meta.txt',
+          //     await esbuild.analyzeMetafile(out.metafile, { color: false, verbose: false })
+          //   );
+          //   console.log(await esbuild.analyzeMetafile(out.metafile, { color: true }));
+          // }
+        })
+      );
+    }
   }
 }
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/code/core/scripts/prep.ts
+++ b/code/core/scripts/prep.ts
@@ -320,8 +320,8 @@ async function run() {
            */
 
           // if (out.metafile) {
-          //   await Bun.write('report/meta.json', JSON.stringify(out.metafile, null, 2));
-          //   await Bun.write(
+          //   await writeFile('report/meta.json', JSON.stringify(out.metafile, null, 2));
+          //   await writeFile(
           //     'report/meta.txt',
           //     await esbuild.analyzeMetafile(out.metafile, { color: false, verbose: false })
           //   );

--- a/code/core/scripts/prep.ts
+++ b/code/core/scripts/prep.ts
@@ -61,12 +61,14 @@ async function run() {
   const files = measure(generateSourceFiles);
   const packageJson = measure(() => generatePackageJsonFile(entries));
   const dist = files.then(() => measure(generateDistFiles));
-  const types = measure(async () => {
-    await generateTypesMapperFiles(entries);
-    await modifyThemeTypes();
-    await generateTypesFiles(entries, isOptimized, cwd);
-    await modifyThemeTypes();
-  });
+  const types = files.then(() =>
+    measure(async () => {
+      await generateTypesMapperFiles(entries);
+      await modifyThemeTypes();
+      await generateTypesFiles(entries, isOptimized, cwd);
+      await modifyThemeTypes();
+    })
+  );
 
   const [filesTime, packageJsonTime, distTime, typesTime] = await Promise.all([
     files,

--- a/code/core/scripts/prep.ts
+++ b/code/core/scripts/prep.ts
@@ -1,7 +1,7 @@
 /* eslint-disable local-rules/no-uncategorized-errors */
 
 import { watch } from 'node:fs';
-import { rmdir } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import {
   esbuild,
@@ -46,7 +46,8 @@ async function run() {
   }
 
   if (isReset) {
-    await rmdir(join(cwd, 'dist'), { recursive: true });
+    await rm(join(cwd, 'dist'), { recursive: true }).catch(() => {});
+    await mkdir(join(cwd, 'dist'));
   }
 
   const entries = getEntries(cwd);

--- a/code/core/src/manager/globals-runtime.ts
+++ b/code/core/src/manager/globals-runtime.ts
@@ -20,12 +20,10 @@ global.sendTelemetryError = (error) => {
 
 // handle all uncaught errors at the root of the application and log to telemetry
 global.addEventListener('error', (args) => {
-  // @ts-expect-error (not Event)
   const error = args.error || args;
   global.sendTelemetryError(error);
 });
 
-// @ts-expect-error (not Event)
 global.addEventListener('unhandledrejection', ({ reason }) => {
   global.sendTelemetryError(reason);
 });

--- a/code/core/src/typings.d.ts
+++ b/code/core/src/typings.d.ts
@@ -27,23 +27,6 @@ declare module 'lazy-universal-dotenv';
 declare module 'open';
 declare module 'pnp-webpack-plugin';
 declare module 'react-inspector';
-// declare module 'detect-package-manager' {
-//   // copied from https://www.npmjs.com/package/detect-package-manager?activeTab=code
-//   // because
-//   declare type PM = 'npm' | 'yarn' | 'pnpm' | 'bun';
-//   declare const detect: ({
-//     cwd,
-//     includeGlobalBun,
-//   }?: {
-//     cwd?: string | undefined;
-//     includeGlobalBun?: boolean | undefined;
-//   }) => Promise<PM>;
-
-//   declare function getNpmVersion(pm: PM): Promise<string>;
-//   declare function clearCache(): void;
-
-//   export { PM, clearCache, detect, getNpmVersion };
-// }
 
 declare var STORIES: any;
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -70,7 +70,6 @@
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
-    "@types/bun": "^1.1.6",
     "@types/cross-spawn": "^6.0.6",
     "@types/detect-port": "^1.3.5",
     "@types/ejs": "^3.1.5",
@@ -181,7 +180,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "bun": "^1.1.21",
     "jiti": "^1.21.6"
   },
   "optionalDependencies": {

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -1173,62 +1173,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oven/bun-darwin-aarch64@npm:1.1.21":
-  version: 1.1.21
-  resolution: "@oven/bun-darwin-aarch64@npm:1.1.21"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-darwin-x64-baseline@npm:1.1.21":
-  version: 1.1.21
-  resolution: "@oven/bun-darwin-x64-baseline@npm:1.1.21"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-darwin-x64@npm:1.1.21":
-  version: 1.1.21
-  resolution: "@oven/bun-darwin-x64@npm:1.1.21"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-linux-aarch64@npm:1.1.21":
-  version: 1.1.21
-  resolution: "@oven/bun-linux-aarch64@npm:1.1.21"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-linux-x64-baseline@npm:1.1.21":
-  version: 1.1.21
-  resolution: "@oven/bun-linux-x64-baseline@npm:1.1.21"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-linux-x64@npm:1.1.21":
-  version: 1.1.21
-  resolution: "@oven/bun-linux-x64@npm:1.1.21"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-windows-x64-baseline@npm:1.1.21":
-  version: 1.1.21
-  resolution: "@oven/bun-windows-x64-baseline@npm:1.1.21"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oven/bun-windows-x64@npm:1.1.21":
-  version: 1.1.21
-  resolution: "@oven/bun-windows-x64@npm:1.1.21"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -1462,7 +1406,6 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.4.8"
     "@testing-library/react": "npm:^16.0.0"
     "@testing-library/user-event": "npm:^14.5.2"
-    "@types/bun": "npm:^1.1.6"
     "@types/cross-spawn": "npm:^6.0.6"
     "@types/detect-port": "npm:^1.3.5"
     "@types/ejs": "npm:^3.1.5"
@@ -1490,7 +1433,6 @@ __metadata:
     "@vitest/coverage-v8": "npm:^2.0.5"
     ansi-regex: "npm:^6.0.1"
     browser-assert: "npm:^1.2.1"
-    bun: "npm:^1.1.21"
     chalk: "npm:^4.1.0"
     chromatic: "npm:^11.5.5"
     codecov: "npm:^3.8.1"
@@ -1682,15 +1624,6 @@ __metadata:
     "@types/connect": "npm:*"
     "@types/node": "npm:*"
   checksum: 10c0/bec2b8a97861a960ee415f7ab3c2aeb7f4d779fd364d27ddee46057897ea571735f1f854f5ee41682964315d4e3699f62427998b9c21851d773398ef535f0612
-  languageName: node
-  linkType: hard
-
-"@types/bun@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "@types/bun@npm:1.1.6"
-  dependencies:
-    bun-types: "npm:1.1.17"
-  checksum: 10c0/bbee1e56e03d9323f9476ba88ab78d98a7aa49e1996b36e18fc1529959666b21a264e61ff26a6584d0cb0702ee29df1a70354a83ad0113849727b7ec10ad91b7
   languageName: node
   linkType: hard
 
@@ -1947,7 +1880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>= 8, @types/node@npm:^20.0.0, @types/node@npm:~20.12.8":
+"@types/node@npm:*, @types/node@npm:>= 8, @types/node@npm:^20.0.0":
   version: 20.12.14
   resolution: "@types/node@npm:20.12.14"
   dependencies:
@@ -2137,15 +2070,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/f81a4378e6c40d593c19e0c5cbde27d635f226198613972d634f968c2df2c3902353144593a0b6f34bf8072bc09fb3328fb713484cda92b5e2732b061b51ed8f
-  languageName: node
-  linkType: hard
-
-"@types/ws@npm:~8.5.10":
-  version: 8.5.10
-  resolution: "@types/ws@npm:8.5.10"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/e9af279b984c4a04ab53295a40aa95c3e9685f04888df5c6920860d1dd073fcc57c7bd33578a04b285b2c655a0b52258d34bee0a20569dca8defb8393e1e5d29
   languageName: node
   linkType: hard
 
@@ -3670,53 +3594,6 @@ __metadata:
     base64-js: "npm:^1.3.1"
     ieee754: "npm:^1.2.1"
   checksum: 10c0/2a905fbbcde73cc5d8bd18d1caa23715d5f83a5935867c2329f0ac06104204ba7947be098fe1317fbd8830e26090ff8e764f08cd14fefc977bb248c3487bcbd0
-  languageName: node
-  linkType: hard
-
-"bun-types@npm:1.1.17":
-  version: 1.1.17
-  resolution: "bun-types@npm:1.1.17"
-  dependencies:
-    "@types/node": "npm:~20.12.8"
-    "@types/ws": "npm:~8.5.10"
-  checksum: 10c0/d7fe81d3ffd23d90b111084c97d0fd89de5934ba2c1158d52ffcf087f7daab44b3c664823867e4154db62b94e498ec3a6fb9204ea8666d37235589faf8456716
-  languageName: node
-  linkType: hard
-
-"bun@npm:^1.1.21":
-  version: 1.1.21
-  resolution: "bun@npm:1.1.21"
-  dependencies:
-    "@oven/bun-darwin-aarch64": "npm:1.1.21"
-    "@oven/bun-darwin-x64": "npm:1.1.21"
-    "@oven/bun-darwin-x64-baseline": "npm:1.1.21"
-    "@oven/bun-linux-aarch64": "npm:1.1.21"
-    "@oven/bun-linux-x64": "npm:1.1.21"
-    "@oven/bun-linux-x64-baseline": "npm:1.1.21"
-    "@oven/bun-windows-x64": "npm:1.1.21"
-    "@oven/bun-windows-x64-baseline": "npm:1.1.21"
-  dependenciesMeta:
-    "@oven/bun-darwin-aarch64":
-      optional: true
-    "@oven/bun-darwin-x64":
-      optional: true
-    "@oven/bun-darwin-x64-baseline":
-      optional: true
-    "@oven/bun-linux-aarch64":
-      optional: true
-    "@oven/bun-linux-x64":
-      optional: true
-    "@oven/bun-linux-x64-baseline":
-      optional: true
-    "@oven/bun-windows-x64":
-      optional: true
-    "@oven/bun-windows-x64-baseline":
-      optional: true
-  bin:
-    bun: bin/bun.exe
-    bunx: bin/bun.exe
-  checksum: 10c0/768260211b6c082cfa486d55976ff82e0c0928f83bd6ce5bb3e94bffbb382c1ecd666de2befe824d4a8f3e44cc026e817ae5228d86b6148344976b08f929f98c
-  conditions: (os=darwin | os=linux | os=win32) & (cpu=arm64 | cpu=x64)
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did

Removal final usage of `bun`, and replace it for `jiti`.

I'm sad I had to revert back to `__dirname` and such, which official do not exist in ESM context.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 8.79 kB | **1.67** | 0% |
| initSize |  171 MB | 171 MB | 8.79 kB | -0.65 | 0% |
| diffSize |  95 MB | 95 MB | 2 B | -0.65 | 0% |
| buildSize |  7.42 MB | 7.42 MB | 0 B | -1.1 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | -1.11 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.29 MB | 2.29 MB | 0 B | -0.58 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.45 MB | 4.45 MB | 0 B | -1.05 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | -1.11 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.6s | 6.9s | -16s -768ms | **-1.46** | 🔰-242.7% |
| generateTime |  22.3s | 21.9s | -393ms | -0.21 | -1.8% |
| initTime |  20.7s | 19.6s | -1s -95ms | -0.55 | -5.6% |
| buildTime |  13.2s | 12.2s | -977ms | **-1.39** | 🔰-8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  9.1s | 9.5s | 450ms | 0.71 | 4.7% |
| devManagerResponsive |  5.3s | 5.3s | -8ms | -0.15 | -0.2% |
| devManagerHeaderVisible |  874ms | 956ms | 82ms | 0.53 | 8.6% |
| devManagerIndexVisible |  906ms | 980ms | 74ms | 0.45 | 7.6% |
| devStoryVisibleUncached |  1.4s | 1.7s | 280ms | **2.53** | 🔺16.1% |
| devStoryVisible |  924ms | 991ms | 67ms | 0.34 | 6.8% |
| devAutodocsVisible |  781ms | 770ms | -11ms | -0.03 | -1.4% |
| devMDXVisible |  702ms | 745ms | 43ms | 0.04 | 5.8% |
| buildManagerHeaderVisible |  884ms | 1s | 187ms | **2.35** | 🔺17.5% |
| buildManagerIndexVisible |  886ms | 1s | 187ms | **2.26** | 🔺17.4% |
| buildStoryVisible |  922ms | 1.1s | 193ms | **2.15** | 🔺17.3% |
| buildAutodocsVisible |  808ms | 688ms | -120ms | -0.55 | -17.4% |
| buildMDXVisible |  750ms | 712ms | -38ms | 0.14 | -5.3% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

The PR replaces the usage of `bun` with `jiti` for building the core of the Storybook project, affecting various build scripts and configurations.

- Updated `.circleci/config.yml` to remove `bun` orb and setup steps.
- Modified `CONTRIBUTING.md` to remove `bun` as a required system utility.
- Refactored `code/core/package.json` to replace `bun` with `jiti`.
- Adjusted `code/core/scripts/dts.ts` to use `jiti` and reintroduced `__dirname`.
- Updated `code/core/scripts/helpers/generatePackageJsonFile.ts` to use `fs-extra` and `node:fs/promises`.
- Modified `code/core/scripts/helpers/generateTypesFiles.ts` to use `jiti` for process spawning.
- Replaced `bun` with `jiti` in `code/core/scripts/helpers/generateTypesMapperFiles.ts`.
- Updated `code/core/scripts/helpers/modifyThemeTypes.ts` to use Node.js file system methods.
- Adjusted `code/core/scripts/helpers/sourcefiles.ts` to use `writeFile` and `__dirname`.
- Refactored `code/core/scripts/prep.ts` to use `jiti` and improved error handling.

<!-- /greptile_comment -->