### PR TITLE
Build: Use mocks in telemetry test

### DIFF
--- a/code/core/src/__mocks__/composeStories.txt
+++ b/code/core/src/__mocks__/composeStories.txt
@@ -1,0 +1,2 @@
+// THIS IS A MOCK FILE, DO NOT TOUCH
+const Primary = composeStory(stories.Primary, stories.default)

--- a/code/core/src/__mocks__/composeStory.txt
+++ b/code/core/src/__mocks__/composeStory.txt
@@ -1,0 +1,2 @@
+// THIS IS A MOCK FILE, DO NOT TOUCH
+const { Primary } = composeStories(stories)

--- a/code/core/src/telemetry/get-portable-stories-usage.test.ts
+++ b/code/core/src/telemetry/get-portable-stories-usage.test.ts
@@ -1,11 +1,14 @@
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 
 import { getPortableStoriesFileCountUncached } from './get-portable-stories-usage';
 
+const mocksDir = join(__dirname, '..', '__mocks__');
+
 describe('getPortableStoriesFileCountUncached', () => {
   it('should ignores node_modules, non-source files', async () => {
-    const usage = await getPortableStoriesFileCountUncached();
+    const usage = await getPortableStoriesFileCountUncached(mocksDir);
     // you can verify with: `git grep -m1 -c composeStor | wc -l`
-    expect(usage).toMatchInlineSnapshot(`14`);
+    expect(usage).toMatchInlineSnapshot(`2`);
   });
 });

--- a/code/core/src/telemetry/get-portable-stories-usage.ts
+++ b/code/core/src/telemetry/get-portable-stories-usage.ts
@@ -8,8 +8,9 @@ const cache = createFileSystemCache({
   ttl: 24 * 60 * 60 * 1000, // 24h
 });
 
-export const getPortableStoriesFileCountUncached = async () => {
-  const { stdout } = await execaCommand(`git grep -m1 -c composeStor`, {
+export const getPortableStoriesFileCountUncached = async (path?: string) => {
+  const command = `git grep -m1 -c composeStor` + (path ? ` -- ${path}` : '');
+  const { stdout } = await execaCommand(command, {
     cwd: process.cwd(),
     shell: true,
   });
@@ -17,7 +18,7 @@ export const getPortableStoriesFileCountUncached = async () => {
 };
 
 const CACHE_KEY = 'portableStories';
-export const getPortableStoriesFileCount = async () => {
+export const getPortableStoriesFileCount = async (path?: string) => {
   let cached = await cache.get(CACHE_KEY);
   if (!cached) {
     try {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes a test that was running a command against the codebase which was causing "flake". The test now runs against a fixed mock so the results are always consistent.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | -27.8 kB | **-2** | 0% |
| initSize |  171 MB | 171 MB | 194 kB | -0.55 | 0.1% |
| diffSize |  95 MB | 95.2 MB | 222 kB | -0.55 | 0.2% |
| buildSize |  7.42 MB | 7.42 MB | 0 B | -1 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | -1 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.29 MB | 2.29 MB | 0 B | -0.5 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.45 MB | 4.45 MB | 0 B | -0.95 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | -1 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  17.8s | 14.6s | -3s -178ms | -0.31 | -21.7% |
| generateTime |  20.9s | 21.5s | 618ms | -0.37 | 2.9% |
| initTime |  18s | 23.4s | 5.4s | **1.43** | 🔺23.1% |
| buildTime |  13.2s | 14.5s | 1.3s | 0.82 | 9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.7s | 9.2s | 507ms | 0.58 | 5.5% |
| devManagerResponsive |  5.1s | 5.2s | 74ms | -0.15 | 1.4% |
| devManagerHeaderVisible |  797ms | 843ms | 46ms | -0.13 | 5.5% |
| devManagerIndexVisible |  822ms | 875ms | 53ms | -0.14 | 6.1% |
| devStoryVisibleUncached |  1.2s | 1.5s | 329ms | **1.62** | 🔺21% |
| devStoryVisible |  838ms | 908ms | 70ms | -0.1 | 7.7% |
| devAutodocsVisible |  720ms | 1s | 289ms | **2.24** | 🔺28.6% |
| devMDXVisible |  710ms | 923ms | 213ms | **1.75** | 🔺23.1% |
| buildManagerHeaderVisible |  753ms | 868ms | 115ms | 0.81 | 13.2% |
| buildManagerIndexVisible |  756ms | 870ms | 114ms | 0.73 | 13.1% |
| buildStoryVisible |  801ms | 912ms | 111ms | 0.67 | 12.2% |
| buildAutodocsVisible |  669ms | 819ms | 150ms | 0.97 | 18.3% |
| buildMDXVisible |  652ms | 901ms | 249ms | **1.97** | 🔺27.6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

The pull request aims to fix a flaky test by using mock files for consistent results.

- Added `code/core/src/__mocks__/composeStories.txt` and `code/core/src/__mocks__/composeStory.txt` to provide stable mock data.
- Modified `code/core/src/telemetry/get-portable-stories-usage.test.ts` to use the new mock files, ensuring consistent test outcomes.
- Updated `code/core/src/telemetry/get-portable-stories-usage.ts` to accept an optional `path` parameter, enhancing flexibility and targeting specific directories for testing.

<!-- /greptile_comment -->