### PR TITLE
Build: Fix console errors in test-runner tests

### DIFF
--- a/code/core/template/stories/shortcuts.stories.ts
+++ b/code/core/template/stories/shortcuts.stories.ts
@@ -6,6 +6,10 @@ import type { PlayFunctionContext } from '@storybook/csf';
 export default {
   component: globalThis.Components.Form,
   tags: ['autodocs'],
+  args: {
+    onSubmit: fn(),
+    onSuccess: fn(),
+  },
 };
 
 export const KeydownDuringPlay = {

--- a/code/renderers/react/template/components/Button.jsx
+++ b/code/renderers/react/template/components/Button.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const Button = ({ onClick, label }) => (
+export const Button = ({ onClick = () => {}, label = '' }) => (
   <button type="button" onClick={onClick}>
     {label}
   </button>
 );
 
 Button.propTypes = {
-  onClick: PropTypes.func.isRequired,
-  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
+  label: PropTypes.string,
 };

--- a/code/renderers/react/template/components/Pre.jsx
+++ b/code/renderers/react/template/components/Pre.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const Pre = ({ style, object, text }) => (
+export const Pre = ({ style = {}, object = null, text = '' }) => (
   <pre style={style} data-testid="pre">
     {object ? JSON.stringify(object, null, 2) : text}
   </pre>
@@ -11,10 +11,4 @@ Pre.propTypes = {
   style: PropTypes.shape({}),
   object: PropTypes.shape({}),
   text: PropTypes.string,
-};
-
-Pre.defaultProps = {
-  style: {},
-  object: null,
-  text: '',
 };


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When running the test-runner tests with `--failOnConsole` we'd have failures resulted from console.error messages coming from React. This PR fixes that.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | -27.8 kB | **-2** | 0% |
| initSize |  171 MB | 171 MB | 194 kB | -0.55 | 0.1% |
| diffSize |  95 MB | 95.2 MB | 222 kB | -0.55 | 0.2% |
| buildSize |  7.42 MB | 7.42 MB | 0 B | -1 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | -1 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.29 MB | 2.29 MB | 0 B | -0.5 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.45 MB | 4.45 MB | 0 B | -0.95 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | -1 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  17.8s | 7.4s | -10s -403ms | **-1.37** | 🔰-139.8% |
| generateTime |  20.9s | 25.4s | 4.5s | **2.14** | 🔺17.8% |
| initTime |  18s | 21s | 3s | 0.27 | 14.2% |
| buildTime |  13.2s | 12.3s | -925ms | **-1.28** | 🔰-7.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.7s | 7.6s | -1s -151ms | -0.63 | -15.1% |
| devManagerResponsive |  5.1s | 4.8s | -326ms | -0.81 | -6.7% |
| devManagerHeaderVisible |  797ms | 818ms | 21ms | -0.29 | 2.6% |
| devManagerIndexVisible |  822ms | 847ms | 25ms | -0.31 | 3% |
| devStoryVisibleUncached |  1.2s | 1.3s | 127ms | 0.55 | 9.3% |
| devStoryVisible |  838ms | 864ms | 26ms | -0.35 | 3% |
| devAutodocsVisible |  720ms | 714ms | -6ms | -0.47 | -0.8% |
| devMDXVisible |  710ms | 686ms | -24ms | -0.51 | -3.5% |
| buildManagerHeaderVisible |  753ms | 716ms | -37ms | -0.64 | -5.2% |
| buildManagerIndexVisible |  756ms | 723ms | -33ms | -0.63 | -4.6% |
| buildStoryVisible |  801ms | 756ms | -45ms | -0.73 | -6% |
| buildAutodocsVisible |  669ms | 641ms | -28ms | -1.05 | -4.4% |
| buildMDXVisible |  652ms | 629ms | -23ms | -0.65 | -3.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

The changes address console errors in test-runner tests by providing default values for props and handlers, and ensuring events are not called unnecessarily.

- Updated `/code/core/template/stories/shortcuts.stories.ts` to include default arguments for `onSubmit` and `onSuccess` handlers using `fn()`.
- Modified `/code/core/template/stories/shortcuts.stories.ts` to ensure `PREVIEW_KEYDOWN` event is not called during `KeydownDuringPlay`.
- Added default values for `onClick` and `label` props in `/code/renderers/react/template/components/Button.jsx`.
- Set default values for `style`, `object`, and `text` props directly in `/code/renderers/react/template/components/Pre.jsx`.

These changes should reduce console errors during tests and improve component robustness.

<!-- /greptile_comment -->