### PR TITLE
Maintenance: Add `node:`-prefix to node core-modules

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -1,11 +1,12 @@
-import path from 'path';
+import { join } from 'node:path';
+
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { mergeConfig } from 'vite';
 
 import type { StorybookConfig } from '../frameworks/react-vite';
 
-const componentsPath = path.join(__dirname, '../core/src/components');
-const managerApiPath = path.join(__dirname, '../core/src/manager-api');
+const componentsPath = join(__dirname, '../core/src/components');
+const managerApiPath = join(__dirname, '../core/src/manager-api');
 
 const config: StorybookConfig = {
   stories: [

--- a/code/addons/controls/src/preset/checkDocsLoaded.ts
+++ b/code/addons/controls/src/preset/checkDocsLoaded.ts
@@ -1,6 +1,6 @@
-import { checkAddonOrder, serverRequire } from 'storybook/internal/common';
+import { isAbsolute, join } from 'node:path';
 
-import path from 'path';
+import { checkAddonOrder, serverRequire } from 'storybook/internal/common';
 
 export const checkDocsLoaded = (configDir: string) => {
   checkAddonOrder({
@@ -12,9 +12,9 @@ export const checkDocsLoaded = (configDir: string) => {
       name: '@storybook/addon-controls',
       inEssentials: true,
     },
-    configFile: path.isAbsolute(configDir)
-      ? path.join(configDir, 'main')
-      : path.join(process.cwd(), configDir, 'main'),
+    configFile: isAbsolute(configDir)
+      ? join(configDir, 'main')
+      : join(process.cwd(), configDir, 'main'),
     getConfig: (configFile) => serverRequire(configFile),
   });
 };

--- a/code/addons/docs/src/plugins/mdx-plugin.ts
+++ b/code/addons/docs/src/plugins/mdx-plugin.ts
@@ -1,7 +1,8 @@
+import { dirname, join } from 'node:path';
+
 import type { Options } from 'storybook/internal/types';
 
 import { createFilter } from '@rollup/pluginutils';
-import { dirname, join } from 'path';
 import rehypeExternalLinks from 'rehype-external-links';
 import rehypeSlug from 'rehype-slug';
 import type { Plugin } from 'vite';

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -1,9 +1,10 @@
+import { dirname, isAbsolute, join } from 'node:path';
+
 import { logger } from 'storybook/internal/node-logger';
 import type { DocsOptions, Options, PresetProperty } from 'storybook/internal/types';
 
 import type { CsfPluginOptions } from '@storybook/csf-plugin';
 
-import { dirname, isAbsolute, join } from 'path';
 import rehypeExternalLinks from 'rehype-external-links';
 import rehypeSlug from 'rehype-slug';
 

--- a/code/addons/essentials/src/docs/preset.ts
+++ b/code/addons/essentials/src/docs/preset.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'path';
+import { dirname, join } from 'node:path';
 
 export * from '@storybook/addon-docs/dist/preset';
 

--- a/code/addons/essentials/src/index.ts
+++ b/code/addons/essentials/src/index.ts
@@ -1,7 +1,7 @@
+import { isAbsolute, join } from 'node:path';
+
 import { serverRequire } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
-
-import path from 'path';
 
 interface PresetOptions {
   /**
@@ -57,10 +57,8 @@ interface PresetOptions {
 }
 
 const requireMain = (configDir: string) => {
-  const absoluteConfigDir = path.isAbsolute(configDir)
-    ? configDir
-    : path.join(process.cwd(), configDir);
-  const mainFile = path.join(absoluteConfigDir, 'main');
+  const absoluteConfigDir = isAbsolute(configDir) ? configDir : join(process.cwd(), configDir);
+  const mainFile = join(absoluteConfigDir, 'main');
 
   return serverRequire(mainFile) ?? {};
 };

--- a/code/addons/interactions/src/preset.ts
+++ b/code/addons/interactions/src/preset.ts
@@ -1,6 +1,6 @@
-import { checkAddonOrder, serverRequire } from 'storybook/internal/common';
+import { isAbsolute, join } from 'node:path';
 
-import path from 'path';
+import { checkAddonOrder, serverRequire } from 'storybook/internal/common';
 
 export const checkActionsLoaded = (configDir: string) => {
   checkAddonOrder({
@@ -12,9 +12,9 @@ export const checkActionsLoaded = (configDir: string) => {
       name: '@storybook/addon-interactions',
       inEssentials: false,
     },
-    configFile: path.isAbsolute(configDir)
-      ? path.join(configDir, 'main')
-      : path.join(process.cwd(), configDir, 'main'),
+    configFile: isAbsolute(configDir)
+      ? join(configDir, 'main')
+      : join(process.cwd(), configDir, 'main'),
     getConfig: (configFile) => serverRequire(configFile),
   });
 };

--- a/code/addons/onboarding/src/preset.ts
+++ b/code/addons/onboarding/src/preset.ts
@@ -1,8 +1,8 @@
+import { readFileSync } from 'node:fs';
+
 import type { Channel } from 'storybook/internal/channels';
 import { telemetry } from 'storybook/internal/telemetry';
 import type { CoreConfig, Options } from 'storybook/internal/types';
-
-import fs from 'fs';
 
 import { STORYBOOK_ADDON_ONBOARDING_CHANNEL } from './constants';
 
@@ -20,7 +20,7 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
     const packageJsonPath = require.resolve('@storybook/addon-onboarding/package.json');
 
     const { version: addonVersion } = JSON.parse(
-      fs.readFileSync(packageJsonPath, { encoding: 'utf-8' })
+      readFileSync(packageJsonPath, { encoding: 'utf-8' })
     );
 
     channel.on(STORYBOOK_ADDON_ONBOARDING_CHANNEL, ({ type, ...event }: Event) => {

--- a/code/builders/builder-vite/src/codegen-importfn-script.ts
+++ b/code/builders/builder-vite/src/codegen-importfn-script.ts
@@ -1,6 +1,6 @@
-import type { Options } from 'storybook/internal/types';
+import { relative } from 'node:path';
 
-import * as path from 'path';
+import type { Options } from 'storybook/internal/types';
 
 import { listStories } from './list-stories';
 
@@ -27,7 +27,7 @@ function toImportPath(relativePath: string) {
 async function toImportFn(stories: string[]) {
   const { normalizePath } = await import('vite');
   const objectEntries = stories.map((file) => {
-    const relativePath = normalizePath(path.relative(process.cwd(), file));
+    const relativePath = normalizePath(relative(process.cwd(), file));
 
     return `  '${toImportPath(relativePath)}': async () => import('/@fs/${file}')`;
   });

--- a/code/builders/builder-vite/src/index.ts
+++ b/code/builders/builder-vite/src/index.ts
@@ -1,11 +1,12 @@
 // noinspection JSUnusedGlobalSymbols
+import { join, parse } from 'node:path';
+
 import { NoStatsForViteDevError } from 'storybook/internal/server-errors';
 import type { Options } from 'storybook/internal/types';
 
 import type { RequestHandler } from 'express';
 import express from 'express';
 import * as fs from 'fs-extra';
-import { join, parse } from 'path';
 import { corePath } from 'storybook/core-path';
 import type { ViteDevServer } from 'vite';
 

--- a/code/builders/builder-vite/src/list-stories.ts
+++ b/code/builders/builder-vite/src/list-stories.ts
@@ -1,8 +1,9 @@
+import { isAbsolute, join } from 'node:path';
+
 import { commonGlobOptions, normalizeStories } from 'storybook/internal/common';
 import type { Options } from 'storybook/internal/types';
 
 import { glob } from 'glob';
-import * as path from 'path';
 import slash from 'slash';
 
 export async function listStories(options: Options) {
@@ -15,10 +16,8 @@ export async function listStories(options: Options) {
           configDir: options.configDir,
           workingDir: options.configDir,
         }).map(({ directory, files }) => {
-          const pattern = path.join(directory, files);
-          const absolutePattern = path.isAbsolute(pattern)
-            ? pattern
-            : path.join(options.configDir, pattern);
+          const pattern = join(directory, files);
+          const absolutePattern = isAbsolute(pattern) ? pattern : join(options.configDir, pattern);
 
           return glob(slash(absolutePattern), {
             ...commonGlobOptions(absolutePattern),

--- a/code/builders/builder-vite/src/optimizeDeps.ts
+++ b/code/builders/builder-vite/src/optimizeDeps.ts
@@ -1,6 +1,7 @@
+import { relative } from 'node:path';
+
 import type { Options } from 'storybook/internal/types';
 
-import * as path from 'path';
 import type { UserConfig, InlineConfig as ViteInlineConfig } from 'vite';
 
 import { listStories } from './list-stories';
@@ -121,7 +122,7 @@ export async function getOptimizeDeps(config: ViteInlineConfig, options: Options
   const { root = process.cwd() } = config;
   const { normalizePath, resolveConfig } = await import('vite');
   const absoluteStories = await listStories(options);
-  const stories = absoluteStories.map((storyPath) => normalizePath(path.relative(root, storyPath)));
+  const stories = absoluteStories.map((storyPath) => normalizePath(relative(root, storyPath)));
   // TODO: check if resolveConfig takes a lot of time, possible optimizations here
   const resolvedConfig = await resolveConfig(config, 'serve', 'development');
 

--- a/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
@@ -1,6 +1,7 @@
+import { readFileSync } from 'node:fs';
+
 import type { Options } from 'storybook/internal/types';
 
-import * as fs from 'fs';
 import type { Plugin } from 'vite';
 
 import { generateImportFnScriptCode } from '../codegen-importfn-script';
@@ -100,10 +101,7 @@ export function codeGeneratorPlugin(options: Options): Plugin {
       }
 
       if (id === iframeId) {
-        return fs.readFileSync(
-          require.resolve('@storybook/builder-vite/input/iframe.html'),
-          'utf-8'
-        );
+        return readFileSync(require.resolve('@storybook/builder-vite/input/iframe.html'), 'utf-8');
       }
 
       return undefined;

--- a/code/builders/builder-vite/src/plugins/webpack-stats-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/webpack-stats-plugin.ts
@@ -1,7 +1,8 @@
 // This plugin is a direct port of https://github.com/IanVS/vite-plugin-turbosnap
+import { relative } from 'node:path';
+
 import type { BuilderStats } from 'storybook/internal/types';
 
-import path from 'path';
 import slash from 'slash';
 import type { Plugin } from 'vite';
 
@@ -57,7 +58,7 @@ export function pluginWebpackStats({ workingDir }: WebpackStatsPluginOptions): W
     }
     // Otherwise, we need them in the format `./path/to/file.js`.
     else {
-      const relativePath = path.relative(workingDir, stripQueryParams(filename));
+      const relativePath = relative(workingDir, stripQueryParams(filename));
       // This seems hacky, got to be a better way to add a `./` to the start of a path.
       return `./${slash(relativePath)}`;
     }

--- a/code/builders/builder-vite/src/utils/process-preview-annotation.ts
+++ b/code/builders/builder-vite/src/utils/process-preview-annotation.ts
@@ -1,7 +1,8 @@
+import { isAbsolute, relative, resolve } from 'node:path';
+
 import { stripAbsNodeModulesPath } from 'storybook/internal/common';
 import type { PreviewAnnotation } from 'storybook/internal/types';
 
-import { isAbsolute, relative, resolve } from 'path';
 import slash from 'slash';
 
 /**

--- a/code/builders/builder-vite/src/vite-config.ts
+++ b/code/builders/builder-vite/src/vite-config.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import {
   getBuilderOptions,
   getFrameworkName,
@@ -7,7 +9,6 @@ import {
 import { globalsNameReferenceMap } from 'storybook/internal/preview/globals';
 import type { Options } from 'storybook/internal/types';
 
-import * as path from 'path';
 import type {
   ConfigEnv,
   InlineConfig,
@@ -50,7 +51,7 @@ export async function commonConfig(
 
   const { viteConfigPath } = await getBuilderOptions<BuilderOptions>(options);
 
-  const projectRoot = path.resolve(options.configDir, '..');
+  const projectRoot = resolve(options.configDir, '..');
 
   // I destructure away the `build` property from the user's config object
   // I do this because I can contain config that breaks storybook, such as we had in a lit project.

--- a/code/builders/builder-webpack5/src/index.ts
+++ b/code/builders/builder-webpack5/src/index.ts
@@ -1,3 +1,5 @@
+import { join, parse } from 'node:path';
+
 import { PREVIEW_BUILDER_PROGRESS } from 'storybook/internal/core-events';
 import { logger } from 'storybook/internal/node-logger';
 import {
@@ -11,7 +13,6 @@ import { checkWebpackVersion } from '@storybook/core-webpack';
 
 import express from 'express';
 import fs from 'fs-extra';
-import { join, parse } from 'path';
 import prettyTime from 'pretty-hrtime';
 import { corePath } from 'storybook/core-path';
 import type { Configuration, Stats, StatsOptions } from 'webpack';

--- a/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -1,3 +1,5 @@
+import { dirname, join, resolve } from 'node:path';
+
 import {
   getBuilderOptions,
   isPreservingSymlinks,
@@ -14,7 +16,6 @@ import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import type { TransformOptions as EsbuildOptions } from 'esbuild';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import { dirname, join, resolve } from 'path';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
 import { dedent } from 'ts-dedent';
 import { DefinePlugin, HotModuleReplacementPlugin, ProgressPlugin, ProvidePlugin } from 'webpack';

--- a/code/builders/builder-webpack5/src/preview/virtual-module-mapping.ts
+++ b/code/builders/builder-webpack5/src/preview/virtual-module-mapping.ts
@@ -1,3 +1,5 @@
+import { join, resolve } from 'node:path';
+
 import {
   getBuilderOptions,
   handlebars,
@@ -9,7 +11,6 @@ import type { Options, PreviewAnnotation } from 'storybook/internal/types';
 
 import { toImportFn } from '@storybook/core-webpack';
 
-import { join, resolve } from 'path';
 import slash from 'slash';
 
 import type { BuilderOptions } from '../types';

--- a/code/core/src/builder-manager/utils/framework.test.ts
+++ b/code/core/src/builder-manager/utils/framework.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -25,24 +25,24 @@ describe('UTILITIES: Framework information', () => {
 
   describe('UTILITY: pluckStorybookPackageFromPath', () => {
     it('should return the package name if the path is a storybook package', () => {
-      const packagePath = path.join(process.cwd(), 'node_modules', '@storybook', 'foo');
+      const packagePath = join(process.cwd(), 'node_modules', '@storybook', 'foo');
       expect(pluckStorybookPackageFromPath(packagePath)).toBe('@storybook/foo');
     });
 
     it('should return undefined if the path is not a storybook package', () => {
-      const packagePath = path.join(process.cwd(), 'foo');
+      const packagePath = join(process.cwd(), 'foo');
       expect(pluckStorybookPackageFromPath(packagePath)).toBe(undefined);
     });
   });
 
   describe('UTILITY: pluckThirdPartyPackageFromPath', () => {
     it('should return the package name if the path is a third party package', () => {
-      const packagePath = path.join(process.cwd(), 'node_modules', 'bar');
+      const packagePath = join(process.cwd(), 'node_modules', 'bar');
       expect(pluckThirdPartyPackageFromPath(packagePath)).toBe('bar');
     });
 
     it('should return the given path if the path is not a third party package', () => {
-      const packagePath = path.join(process.cwd(), 'foo', 'bar', 'baz');
+      const packagePath = join(process.cwd(), 'foo', 'bar', 'baz');
       expect(pluckThirdPartyPackageFromPath(packagePath)).toBe(packagePath);
     });
   });

--- a/code/core/src/builder-manager/utils/framework.ts
+++ b/code/core/src/builder-manager/utils/framework.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { sep } from 'node:path';
 
 import { extractProperRendererNameFromFramework, getFrameworkName } from '@storybook/core/common';
 import type { Options } from '@storybook/core/types';
@@ -19,7 +19,7 @@ export const pluckNameFromConfigProperty = (property: Property) => {
 };
 
 // For replacing Windows backslashes with forward slashes
-const normalizePath = (packagePath: string) => packagePath.replaceAll(path.sep, '/');
+const normalizePath = (packagePath: string) => packagePath.replaceAll(sep, '/');
 
 export const pluckStorybookPackageFromPath = (packagePath: string) =>
   normalizePath(packagePath).match(/(@storybook\/.*)$/)?.[1];

--- a/code/core/src/cli/angular/helpers.ts
+++ b/code/core/src/cli/angular/helpers.ts
@@ -1,9 +1,10 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { logger } from '@storybook/core/node-logger';
 import { MissingAngularJsonError } from '@storybook/core/server-errors';
 
 import boxen from 'boxen';
-import fs from 'fs';
-import { join } from 'path';
 import prompts from 'prompts';
 import { dedent } from 'ts-dedent';
 
@@ -43,11 +44,11 @@ export class AngularJSON {
   };
 
   constructor() {
-    if (!fs.existsSync(ANGULAR_JSON_PATH)) {
+    if (!existsSync(ANGULAR_JSON_PATH)) {
       throw new MissingAngularJsonError({ path: join(process.cwd(), ANGULAR_JSON_PATH) });
     }
 
-    const jsonContent = fs.readFileSync(ANGULAR_JSON_PATH, 'utf8');
+    const jsonContent = readFileSync(ANGULAR_JSON_PATH, 'utf8');
     this.json = JSON.parse(jsonContent);
   }
 
@@ -149,6 +150,6 @@ export class AngularJSON {
   }
 
   write() {
-    fs.writeFileSync(ANGULAR_JSON_PATH, JSON.stringify(this.json, null, 2));
+    writeFileSync(ANGULAR_JSON_PATH, JSON.stringify(this.json, null, 2));
   }
 }

--- a/code/core/src/cli/detect.test.ts
+++ b/code/core/src/cli/detect.test.ts
@@ -1,10 +1,10 @@
+import { existsSync } from 'node:fs';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { JsPackageManager, PackageJsonWithMaybeDeps } from '@storybook/core/common';
 
 import { logger } from '@storybook/core/node-logger';
-
-import * as fs from 'fs';
 
 import { detect, detectFrameworkPreset, detectLanguage } from './detect';
 import { ProjectType, SupportedLanguage } from './project_types';
@@ -421,7 +421,7 @@ describe('Detect', () => {
 
     MOCK_FRAMEWORK_FILES.forEach((structure) => {
       it(`${structure.name}`, () => {
-        vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+        vi.mocked(existsSync).mockImplementation((filePath) => {
           return typeof filePath === 'string' && Object.keys(structure.files).includes(filePath);
         });
 
@@ -454,7 +454,7 @@ describe('Detect', () => {
         '/node_modules/.bin/react-scripts': 'file content',
       };
 
-      vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+      vi.mocked(existsSync).mockImplementation((filePath) => {
         return (
           typeof filePath === 'string' && Object.keys(forkedReactScriptsConfig).includes(filePath)
         );

--- a/code/core/src/cli/detect.ts
+++ b/code/core/src/cli/detect.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import type { JsPackageManager, PackageJsonWithMaybeDeps } from '@storybook/core/common';
@@ -6,7 +7,6 @@ import { HandledError, commandLog } from '@storybook/core/common';
 import { logger } from '@storybook/core/node-logger';
 
 import { findUpSync } from 'find-up';
-import * as fs from 'fs';
 import prompts from 'prompts';
 import semver from 'semver';
 
@@ -90,7 +90,7 @@ const getFrameworkPreset = (
   }
 
   if (Array.isArray(files) && files.length > 0) {
-    matcher.files = files.map((name) => fs.existsSync(name));
+    matcher.files = files.map((name) => existsSync(name));
   }
 
   return matcherFunction(matcher) ? preset : null;
@@ -160,7 +160,7 @@ export async function detectBuilder(packageManager: JsPackageManager, projectTyp
 }
 
 export function isStorybookInstantiated(configDir = resolve(process.cwd(), '.storybook')) {
-  return fs.existsSync(configDir);
+  return existsSync(configDir);
 }
 
 export async function detectPnp() {
@@ -170,7 +170,7 @@ export async function detectPnp() {
 export async function detectLanguage(packageManager: JsPackageManager) {
   let language = SupportedLanguage.JAVASCRIPT;
 
-  if (fs.existsSync('jsconfig.json')) {
+  if (existsSync('jsconfig.json')) {
     return language;
   }
 

--- a/code/core/src/cli/eslintPlugin.ts
+++ b/code/core/src/cli/eslintPlugin.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import { existsSync } from 'node:fs';
 
 import type { JsPackageManager } from '@storybook/core/common';
 import { paddedLog } from '@storybook/core/common';
@@ -17,7 +17,7 @@ const UNSUPPORTED_ESLINT_EXTENSIONS = ['yaml', 'yml'];
 export const findEslintFile = () => {
   const filePrefix = '.eslintrc';
   const unsupportedExtension = UNSUPPORTED_ESLINT_EXTENSIONS.find((ext: string) =>
-    fs.existsSync(`${filePrefix}.${ext}`)
+    existsSync(`${filePrefix}.${ext}`)
   );
 
   if (unsupportedExtension) {
@@ -25,7 +25,7 @@ export const findEslintFile = () => {
   }
 
   const extension = SUPPORTED_ESLINT_EXTENSIONS.find((ext: string) =>
-    fs.existsSync(`${filePrefix}.${ext}`)
+    existsSync(`${filePrefix}.${ext}`)
   );
   return extension ? `${filePrefix}.${extension}` : null;
 };

--- a/code/core/src/cli/helpers.test.ts
+++ b/code/core/src/cli/helpers.test.ts
@@ -78,7 +78,7 @@ describe('Helpers', () => {
 
   describe('copyTemplate', () => {
     it(`should copy template files when directory is present`, () => {
-      const csfDirectory = /template-csf$/;
+      const csfDirectory = /template-csf\/$/;
       fsMocks.existsSync.mockReturnValue(true);
 
       helpers.copyTemplate('');

--- a/code/core/src/cli/helpers.ts
+++ b/code/core/src/cli/helpers.ts
@@ -1,3 +1,6 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
 import {
   frameworkToRenderer as CoreFrameworkToRenderer,
   type JsPackageManager,
@@ -9,9 +12,7 @@ import type { SupportedFrameworks, SupportedRenderers } from '@storybook/core/ty
 
 import chalk from 'chalk';
 import { findUpSync } from 'find-up';
-import fs from 'fs';
-import fse from 'fs-extra';
-import path, { join } from 'path';
+import { copy, copySync, pathExists, readFile, writeFile } from 'fs-extra';
 import { coerce, satisfies } from 'semver';
 import stripJsonComments from 'strip-json-comments';
 import invariant from 'tiny-invariant';
@@ -22,12 +23,12 @@ import { CoreBuilder, SupportedLanguage } from './project_types';
 const logger = console;
 
 export function readFileAsJson(jsonPath: string, allowComments?: boolean) {
-  const filePath = path.resolve(jsonPath);
-  if (!fs.existsSync(filePath)) {
+  const filePath = resolve(jsonPath);
+  if (!existsSync(filePath)) {
     return false;
   }
 
-  const fileContent = fs.readFileSync(filePath, 'utf8');
+  const fileContent = readFileSync(filePath, 'utf8');
   const jsonContent = allowComments ? stripJsonComments(fileContent) : fileContent;
 
   try {
@@ -39,12 +40,12 @@ export function readFileAsJson(jsonPath: string, allowComments?: boolean) {
 }
 
 export const writeFileAsJson = (jsonPath: string, content: unknown) => {
-  const filePath = path.resolve(jsonPath);
-  if (!fs.existsSync(filePath)) {
+  const filePath = resolve(jsonPath);
+  if (!existsSync(filePath)) {
     return false;
   }
 
-  fs.writeFileSync(filePath, `${JSON.stringify(content, null, 2)}\n`);
+  writeFileSync(filePath, `${JSON.stringify(content, null, 2)}\n`);
   return true;
 };
 
@@ -115,13 +116,13 @@ export function addToDevDependenciesIfNotPresent(
 }
 
 export function copyTemplate(templateRoot: string, destination = '.') {
-  const templateDir = path.resolve(templateRoot, `template-csf/`);
+  const templateDir = resolve(templateRoot, `template-csf/`);
 
-  if (!fs.existsSync(templateDir)) {
+  if (!existsSync(templateDir)) {
     throw new Error(`Couldn't find template dir`);
   }
 
-  fse.copySync(templateDir, destination, { overwrite: true });
+  copySync(templateDir, destination, { overwrite: true });
 }
 
 type CopyTemplateFilesOptions = {
@@ -183,30 +184,30 @@ export async function copyTemplateFiles({
     const assetsTS38 = join(assetsDir, languageFolderMapping[SupportedLanguage.TYPESCRIPT_3_8]);
 
     // Ideally use the assets that match the language & version.
-    if (await fse.pathExists(assetsLanguage)) {
+    if (await pathExists(assetsLanguage)) {
       return assetsLanguage;
     }
     // Use fallback typescript 3.8 assets if new ones aren't available
-    if (language === SupportedLanguage.TYPESCRIPT_4_9 && (await fse.pathExists(assetsTS38))) {
+    if (language === SupportedLanguage.TYPESCRIPT_4_9 && (await pathExists(assetsTS38))) {
       return assetsTS38;
     }
     // Fallback further to TS (for backwards compatibility purposes)
-    if (await fse.pathExists(assetsTS)) {
+    if (await pathExists(assetsTS)) {
       return assetsTS;
     }
     // Fallback further to JS
-    if (await fse.pathExists(assetsJS)) {
+    if (await pathExists(assetsJS)) {
       return assetsJS;
     }
     // As a last resort, look for the root of the asset directory
-    if (await fse.pathExists(assetsDir)) {
+    if (await pathExists(assetsDir)) {
       return assetsDir;
     }
     throw new Error(`Unsupported renderer: ${renderer} (${baseDir})`);
   };
 
   const targetPath = async () => {
-    if (await fse.pathExists('./src')) {
+    if (await pathExists('./src')) {
       return './src/stories';
     }
     return './stories';
@@ -214,11 +215,11 @@ export async function copyTemplateFiles({
 
   const destinationPath = destination ?? (await targetPath());
   if (commonAssetsDir) {
-    await fse.copy(commonAssetsDir, destinationPath, {
+    await copy(commonAssetsDir, destinationPath, {
       overwrite: true,
     });
   }
-  await fse.copy(await templatePath(), destinationPath, { overwrite: true });
+  await copy(await templatePath(), destinationPath, { overwrite: true });
 
   if (commonAssetsDir) {
     let rendererType = frameworkToRenderer[renderer] || 'react';
@@ -231,13 +232,13 @@ export async function copyTemplateFiles({
 export async function adjustTemplate(templatePath: string, templateData: Record<string, any>) {
   // for now, we're just doing a simple string replace
   // in the future we might replace this with a proper templating engine
-  let template = await fse.readFile(templatePath, 'utf8');
+  let template = await readFile(templatePath, 'utf8');
 
   Object.keys(templateData).forEach((key) => {
     template = template.replaceAll(`{{${key}}}`, `${templateData[key]}`);
   });
 
-  await fse.writeFile(templatePath, template);
+  await writeFile(templatePath, template);
 }
 
 // Given a package.json, finds any official storybook package within it

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
-import path from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 import chalk from 'chalk';
 import type { CommonOptions } from 'execa';
@@ -99,7 +99,7 @@ export abstract class JsPackageManager {
       }
 
       // Move up to the parent directory
-      const parentDir = path.dirname(cwd);
+      const parentDir = dirname(cwd);
 
       // Check if we have reached the root of the filesystem
       if (parentDir === cwd) {
@@ -132,7 +132,7 @@ export abstract class JsPackageManager {
     if (!this.cwd) {
       throw new Error('Missing cwd');
     }
-    return path.resolve(this.cwd, 'package.json');
+    return resolve(this.cwd, 'package.json');
   }
 
   async readPackageJson(): Promise<PackageJson> {

--- a/code/core/src/common/js-package-manager/JsPackageManagerFactory.test.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManagerFactory.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -153,7 +153,7 @@ describe('CLASS: JsPackageManagerFactory', () => {
             status: 1,
           } as any;
         });
-        const fixture = path.join(__dirname, 'fixtures', 'pnpm-workspace', 'package');
+        const fixture = join(__dirname, 'fixtures', 'pnpm-workspace', 'package');
         expect(JsPackageManagerFactory.getPackageManager({}, fixture)).toBeInstanceOf(PNPMProxy);
       });
     });
@@ -271,7 +271,7 @@ describe('CLASS: JsPackageManagerFactory', () => {
             status: 1,
           } as any;
         });
-        const fixture = path.join(__dirname, 'fixtures', 'multiple-lockfiles');
+        const fixture = join(__dirname, 'fixtures', 'multiple-lockfiles');
         expect(JsPackageManagerFactory.getPackageManager({}, fixture)).toBeInstanceOf(Yarn1Proxy);
       });
     });

--- a/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
@@ -1,4 +1,4 @@
-import path, { parse, relative } from 'node:path';
+import { basename, parse, relative } from 'node:path';
 
 import { sync as spawnSync } from 'cross-spawn';
 import { findUpSync } from 'find-up';
@@ -55,7 +55,7 @@ export class JsPackageManagerFactory {
     // Option 2: We try to infer the package manager from the closest lockfile
     const closestLockfilePath = lockFiles[0];
 
-    const closestLockfile = closestLockfilePath && path.basename(closestLockfilePath);
+    const closestLockfile = closestLockfilePath && basename(closestLockfilePath);
 
     const hasNPMCommand = hasNPM(cwd);
     const hasPNPMCommand = hasPNPM(cwd);

--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -1,10 +1,10 @@
 import { existsSync, readFileSync } from 'node:fs';
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { logger } from '@storybook/core/node-logger';
 import { FindPackageVersionsError } from '@storybook/core/server-errors';
 
-import { findUpSync } from 'find-up';
+import { findUp } from 'find-up';
 import { platform } from 'os';
 import sort from 'semver/functions/sort.js';
 import dedent from 'ts-dedent';
@@ -89,9 +89,9 @@ export class NPMProxy extends JsPackageManager {
     packageName: string,
     basePath = this.cwd
   ): Promise<PackageJson | null> {
-    const packageJsonPath = await findUpSync(
+    const packageJsonPath = await findUp(
       (dir) => {
-        const possiblePath = path.join(dir, 'node_modules', packageName, 'package.json');
+        const possiblePath = join(dir, 'node_modules', packageName, 'package.json');
         return existsSync(possiblePath) ? possiblePath : undefined;
       },
       { cwd: basePath }

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { FindPackageVersionsError } from '@storybook/core/server-errors';
 
@@ -144,7 +144,7 @@ export class PNPMProxy extends JsPackageManager {
         const pkg = pnpApi.getPackageInformation(pkgLocator);
 
         const packageJSON = JSON.parse(
-          readFileSync(path.join(pkg.packageLocation, 'package.json'), 'utf-8')
+          readFileSync(join(pkg.packageLocation, 'package.json'), 'utf-8')
         );
 
         return packageJSON;
@@ -158,7 +158,7 @@ export class PNPMProxy extends JsPackageManager {
 
     const packageJsonPath = await findUpSync(
       (dir) => {
-        const possiblePath = path.join(dir, 'node_modules', packageName, 'package.json');
+        const possiblePath = join(dir, 'node_modules', packageName, 'package.json');
         return existsSync(possiblePath) ? possiblePath : undefined;
       },
       { cwd: basePath }

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.ts
@@ -1,9 +1,9 @@
 import { existsSync, readFileSync } from 'node:fs';
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { FindPackageVersionsError } from '@storybook/core/server-errors';
 
-import { findUpSync } from 'find-up';
+import { findUp } from 'find-up';
 import dedent from 'ts-dedent';
 
 import { createLogStream } from '../utils/cli';
@@ -70,9 +70,9 @@ export class Yarn1Proxy extends JsPackageManager {
     packageName: string,
     basePath = this.cwd
   ): Promise<PackageJson | null> {
-    const packageJsonPath = await findUpSync(
+    const packageJsonPath = await findUp(
       (dir) => {
-        const possiblePath = path.join(dir, 'node_modules', packageName, 'package.json');
+        const possiblePath = join(dir, 'node_modules', packageName, 'package.json');
         return existsSync(possiblePath) ? possiblePath : undefined;
       },
       { cwd: basePath }

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.ts
@@ -1,11 +1,11 @@
 import { existsSync, readFileSync } from 'node:fs';
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { FindPackageVersionsError } from '@storybook/core/server-errors';
 
 import { PosixFS, VirtualFS, ZipOpenFS } from '@yarnpkg/fslib';
 import { getLibzipSync } from '@yarnpkg/libzip';
-import { findUpSync } from 'find-up';
+import { findUp, findUpSync } from 'find-up';
 import { dedent } from 'ts-dedent';
 
 import { createLogStream } from '../utils/cli';
@@ -152,7 +152,7 @@ export class Yarn2Proxy extends JsPackageManager {
         const virtualFs = new VirtualFS({ baseFs: zipOpenFs });
         const crossFs = new PosixFS(virtualFs);
 
-        const virtualPath = path.join(pkg.packageLocation, 'package.json');
+        const virtualPath = join(pkg.packageLocation, 'package.json');
 
         return crossFs.readJsonSync(virtualPath);
       } catch (error: any) {
@@ -163,9 +163,9 @@ export class Yarn2Proxy extends JsPackageManager {
       }
     }
 
-    const packageJsonPath = await findUpSync(
+    const packageJsonPath = await findUp(
       (dir) => {
-        const possiblePath = path.join(dir, 'node_modules', packageName, 'package.json');
+        const possiblePath = join(dir, 'node_modules', packageName, 'package.json');
         return existsSync(possiblePath) ? possiblePath : undefined;
       },
       { cwd: basePath }

--- a/code/core/src/common/presets.test.ts
+++ b/code/core/src/common/presets.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { normalize } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -414,7 +414,7 @@ describe('resolveAddonName', () => {
   it('should resolve managerEntries', () => {
     expect(resolveAddonName({} as any, '@storybook/addon-actions/register.js', {})).toEqual({
       name: '@storybook/addon-actions/register.js',
-      managerEntries: [path.normalize('@storybook/addon-actions/register')],
+      managerEntries: [normalize('@storybook/addon-actions/register')],
       type: 'virtual',
     });
   });
@@ -422,7 +422,7 @@ describe('resolveAddonName', () => {
   it('should resolve managerEntries from new /manager path', () => {
     expect(resolveAddonName({} as any, '@storybook/addon-actions/manager', {})).toEqual({
       name: '@storybook/addon-actions/manager',
-      managerEntries: [path.normalize('@storybook/addon-actions/manager')],
+      managerEntries: [normalize('@storybook/addon-actions/manager')],
       type: 'virtual',
     });
   });
@@ -549,14 +549,14 @@ describe('loadPreset', () => {
         name: '@storybook/addon-actions/register.js',
         options: {},
         preset: {
-          managerEntries: [path.normalize('@storybook/addon-actions/register')],
+          managerEntries: [normalize('@storybook/addon-actions/register')],
         },
       },
       {
         name: 'addon-foo/register.js',
         options: {},
         preset: {
-          managerEntries: [path.normalize('addon-foo/register')],
+          managerEntries: [normalize('addon-foo/register')],
         },
       },
       {
@@ -578,14 +578,14 @@ describe('loadPreset', () => {
         name: 'addon-baz/register.js',
         options: {},
         preset: {
-          managerEntries: [path.normalize('addon-baz/register')],
+          managerEntries: [normalize('addon-baz/register')],
         },
       },
       {
         name: '@storybook/addon-notes/register-panel',
         options: {},
         preset: {
-          managerEntries: [path.normalize('@storybook/addon-notes/register-panel')],
+          managerEntries: [normalize('@storybook/addon-notes/register-panel')],
         },
       },
       {

--- a/code/core/src/common/utils/__tests__/paths.test.ts
+++ b/code/core/src/common/utils/__tests__/paths.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join, sep } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -11,12 +11,12 @@ vi.mock('find-up');
 
 describe('paths - normalizeStoryPath()', () => {
   it('returns a path starting with "./" unchanged', () => {
-    const filename = `.${path.sep}${path.join('src', 'Comp.story.js')}`;
+    const filename = `.${sep}${join('src', 'Comp.story.js')}`;
     expect(normalizeStoryPath(filename)).toEqual(filename);
   });
 
   it('returns a path starting with "../" unchanged', () => {
-    const filename = path.join('..', 'src', 'Comp.story.js');
+    const filename = join('..', 'src', 'Comp.story.js');
     expect(normalizeStoryPath(filename)).toEqual(filename);
   });
 
@@ -31,18 +31,18 @@ describe('paths - normalizeStoryPath()', () => {
   });
 
   it('adds "./" to a normalized relative path', () => {
-    const filename = path.join('src', 'Comp.story.js');
-    expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+    const filename = join('src', 'Comp.story.js');
+    expect(normalizeStoryPath(filename)).toEqual(`.${sep}${filename}`);
   });
 
   it('adds "./" to a hidden folder', () => {
-    const filename = path.join('.storybook', 'Comp.story.js');
-    expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+    const filename = join('.storybook', 'Comp.story.js');
+    expect(normalizeStoryPath(filename)).toEqual(`.${sep}${filename}`);
   });
 
   it('adds "./" to a hidden file', () => {
     const filename = `.Comp.story.js`;
-    expect(normalizeStoryPath(filename)).toEqual(`.${path.sep}${filename}`);
+    expect(normalizeStoryPath(filename)).toEqual(`.${sep}${filename}`);
   });
 });
 

--- a/code/core/src/common/utils/formatter.test.ts
+++ b/code/core/src/common/utils/formatter.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { resolve } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof meta>;
 
 describe('formatter', () => {
   describe('withPrettierConfig', () => {
-    const testPath = path.resolve(__dirname, '__tests-formatter__', 'withPrettierConfig');
+    const testPath = resolve(__dirname, '__tests-formatter__', 'withPrettierConfig');
 
     describe('prettier', async () => {
       const prettierV3 = await import('prettier');
@@ -44,7 +44,7 @@ describe('formatter', () => {
         mockPrettier.version.mockReturnValue(prettierV3.version);
         mockPrettier.resolveConfig.mockImplementation(prettierV3.resolveConfig);
 
-        const filePath = path.resolve(testPath, 'testFile.ts');
+        const filePath = resolve(testPath, 'testFile.ts');
 
         const result = await formatFileContent(filePath, dummyContent);
 
@@ -54,7 +54,7 @@ describe('formatter', () => {
   });
 
   describe('withoutPrettierConfigAndWithEditorConfig', () => {
-    const testPath = path.resolve(__dirname, '__tests-formatter__', 'withoutPrettierConfig');
+    const testPath = resolve(__dirname, '__tests-formatter__', 'withoutPrettierConfig');
 
     describe('prettier-v3', async () => {
       const prettierV3 = await import('prettier');
@@ -64,7 +64,7 @@ describe('formatter', () => {
         mockPrettier.version.mockReturnValue(prettierV3.version);
         mockPrettier.resolveConfig.mockImplementation(prettierV3.resolveConfig);
 
-        const filePath = path.resolve(testPath, 'testFile.ts');
+        const filePath = resolve(testPath, 'testFile.ts');
 
         const result = await formatFileContent(filePath, dummyContent);
 
@@ -74,7 +74,7 @@ describe('formatter', () => {
   });
 
   describe('withoutPrettierConfigAndWithEditorConfig', () => {
-    const testPath = path.resolve(__dirname, '__tests-formatter__', 'withoutEditorConfig');
+    const testPath = resolve(__dirname, '__tests-formatter__', 'withoutEditorConfig');
 
     describe('prettier-v3', async () => {
       const prettierV3 = await import('prettier');
@@ -84,7 +84,7 @@ describe('formatter', () => {
         mockPrettier.version.mockReturnValue(prettierV3.version);
         mockPrettier.resolveConfig.mockResolvedValue(null);
 
-        const filePath = path.resolve(testPath, 'testFile.ts');
+        const filePath = resolve(testPath, 'testFile.ts');
 
         const result = await formatFileContent(filePath, dummyContent);
 

--- a/code/core/src/common/utils/get-storybook-info.ts
+++ b/code/core/src/common/utils/get-storybook-info.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import type { SupportedFrameworks } from '@storybook/core/types';
 import type { CoreCommon_StorybookInfo, PackageJson } from '@storybook/core/types';
@@ -91,7 +91,7 @@ const getRendererInfo = (packageJson: PackageJson) => {
 const validConfigExtensions = ['ts', 'js', 'tsx', 'jsx', 'mjs', 'cjs'];
 
 export const findConfigFile = (prefix: string, configDir: string) => {
-  const filePrefix = path.join(configDir, prefix);
+  const filePrefix = join(configDir, prefix);
   const extension = validConfigExtensions.find((ext: string) =>
     pathExistsSync(`${filePrefix}.${ext}`)
   );

--- a/code/core/src/common/utils/load-custom-presets.ts
+++ b/code/core/src/common/utils/load-custom-presets.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { resolve } from 'node:path';
 
 import type { PresetConfig } from '@storybook/core/types';
 
@@ -8,11 +8,11 @@ import { validateConfigurationFiles } from './validate-configuration-files';
 export function loadCustomPresets({ configDir }: { configDir: string }): PresetConfig[] {
   validateConfigurationFiles(configDir);
 
-  const presets = serverRequire(path.resolve(configDir, 'presets'));
-  const main = serverRequire(path.resolve(configDir, 'main'));
+  const presets = serverRequire(resolve(configDir, 'presets'));
+  const main = serverRequire(resolve(configDir, 'main'));
 
   if (main) {
-    const resolved = serverResolve(path.resolve(configDir, 'main'));
+    const resolved = serverResolve(resolve(configDir, 'main'));
     if (resolved) {
       return [resolved];
     }

--- a/code/core/src/common/utils/load-main-config.ts
+++ b/code/core/src/common/utils/load-main-config.ts
@@ -1,10 +1,9 @@
+import { readFile } from 'node:fs/promises';
 import path, { relative } from 'node:path';
 
 import type { StorybookConfig } from '@storybook/core/types';
 
 import { MainFileESMOnlyImportError, MainFileEvaluationError } from '@storybook/core/server-errors';
-
-import { readFile } from 'fs/promises';
 
 import { serverRequire, serverResolve } from './interpret-require';
 import { validateConfigurationFiles } from './validate-configuration-files';

--- a/code/core/src/common/utils/load-main-config.ts
+++ b/code/core/src/common/utils/load-main-config.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import path, { relative } from 'node:path';
+import { relative, resolve } from 'node:path';
 
 import type { StorybookConfig } from '@storybook/core/types';
 
@@ -17,7 +17,7 @@ export async function loadMainConfig({
 }): Promise<StorybookConfig> {
   await validateConfigurationFiles(configDir);
 
-  const mainJsPath = serverResolve(path.resolve(configDir, 'main')) as string;
+  const mainJsPath = serverResolve(resolve(configDir, 'main')) as string;
 
   if (noCache && mainJsPath && require.cache[mainJsPath]) {
     delete require.cache[mainJsPath];

--- a/code/core/src/common/utils/load-manager-or-addons-file.ts
+++ b/code/core/src/common/utils/load-manager-or-addons-file.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { resolve } from 'node:path';
 
 import { logger } from '@storybook/core/node-logger';
 
@@ -7,8 +7,8 @@ import { dedent } from 'ts-dedent';
 import { getInterpretedFile } from './interpret-files';
 
 export function loadManagerOrAddonsFile({ configDir }: { configDir: string }) {
-  const storybookCustomAddonsPath = getInterpretedFile(path.resolve(configDir, 'addons'));
-  const storybookCustomManagerPath = getInterpretedFile(path.resolve(configDir, 'manager'));
+  const storybookCustomAddonsPath = getInterpretedFile(resolve(configDir, 'addons'));
+  const storybookCustomManagerPath = getInterpretedFile(resolve(configDir, 'manager'));
 
   if (storybookCustomAddonsPath || storybookCustomManagerPath) {
     logger.info('=> Loading custom manager config');
@@ -16,7 +16,7 @@ export function loadManagerOrAddonsFile({ configDir }: { configDir: string }) {
 
   if (storybookCustomAddonsPath && storybookCustomManagerPath) {
     throw new Error(dedent`
-      You have both a "addons.js" and a "manager.js", remove the "addons.js" file from your configDir (${path.resolve(
+      You have both a "addons.js" and a "manager.js", remove the "addons.js" file from your configDir (${resolve(
         configDir,
         'addons'
       )})`);

--- a/code/core/src/common/utils/load-preview-or-config-file.ts
+++ b/code/core/src/common/utils/load-preview-or-config-file.ts
@@ -1,16 +1,16 @@
-import path from 'node:path';
+import { resolve } from 'node:path';
 
 import { dedent } from 'ts-dedent';
 
 import { getInterpretedFile } from './interpret-files';
 
 export function loadPreviewOrConfigFile({ configDir }: { configDir: string }) {
-  const storybookConfigPath = getInterpretedFile(path.resolve(configDir, 'config'));
-  const storybookPreviewPath = getInterpretedFile(path.resolve(configDir, 'preview'));
+  const storybookConfigPath = getInterpretedFile(resolve(configDir, 'config'));
+  const storybookPreviewPath = getInterpretedFile(resolve(configDir, 'preview'));
 
   if (storybookConfigPath && storybookPreviewPath) {
     throw new Error(dedent`
-      You have both a "config.js" and a "preview.js", remove the "config.js" file from your configDir (${path.resolve(
+      You have both a "config.js" and a "preview.js", remove the "config.js" file from your configDir (${resolve(
         configDir,
         'config'
       )})`);

--- a/code/core/src/common/utils/normalize-path.ts
+++ b/code/core/src/common/utils/normalize-path.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { posix } from 'node:path';
 
 /**
  * Normalize a path to use forward slashes and remove .. and .
@@ -10,5 +10,5 @@ import path from 'node:path';
  * normalizePath('path\\to\\file') // => 'path/to/file'
  */
 export function normalizePath(p: string) {
-  return path.posix.normalize(p.replace(/\\/g, '/'));
+  return posix.normalize(p.replace(/\\/g, '/'));
 }

--- a/code/core/src/common/utils/normalize-stories.ts
+++ b/code/core/src/common/utils/normalize-stories.ts
@@ -1,5 +1,5 @@
 import { lstatSync } from 'node:fs';
-import path from 'node:path';
+import { basename, dirname, relative, resolve } from 'node:path';
 
 import type { NormalizedStoriesSpecifier, StoriesEntry } from '@storybook/core/types';
 
@@ -16,7 +16,7 @@ const DEFAULT_FILES_PATTERN = '**/*.@(mdx|stories.@(js|jsx|mjs|ts|tsx))';
 
 const isDirectory = (configDir: string, entry: string) => {
   try {
-    return lstatSync(path.resolve(configDir, entry)).isDirectory();
+    return lstatSync(resolve(configDir, entry)).isDirectory();
   } catch (err) {
     return false;
   }
@@ -27,8 +27,8 @@ export const getDirectoryFromWorkingDir = ({
   workingDir,
   directory,
 }: NormalizeOptions & { directory: string }) => {
-  const directoryFromConfig = path.resolve(configDir, directory);
-  const directoryFromWorking = path.relative(workingDir, directoryFromConfig);
+  const directoryFromConfig = resolve(configDir, directory);
+  const directoryFromWorking = relative(workingDir, directoryFromConfig);
 
   // relative('/foo', '/foo/src') => 'src'
   // but we want `./src` to match importPaths
@@ -61,8 +61,8 @@ export const normalizeStoriesEntry = (
     } else {
       specifierWithoutMatcher = {
         titlePrefix: DEFAULT_TITLE_PREFIX,
-        directory: path.dirname(entry),
-        files: path.basename(entry),
+        directory: dirname(entry),
+        files: basename(entry),
       };
     }
   } else {

--- a/code/core/src/common/utils/paths.ts
+++ b/code/core/src/common/utils/paths.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join, resolve, sep } from 'node:path';
 
 import { findUpSync } from 'find-up';
 
@@ -12,7 +12,7 @@ export const getProjectRoot = () => {
   try {
     const found = findUpSync('.git', { type: 'directory' });
     if (found) {
-      result = path.join(found, '..');
+      result = join(found, '..');
     }
   } catch (e) {
     //
@@ -20,7 +20,7 @@ export const getProjectRoot = () => {
   try {
     const found = findUpSync('.svn', { type: 'directory' });
     if (found) {
-      result = result || path.join(found, '..');
+      result = result || join(found, '..');
     }
   } catch (e) {
     //
@@ -28,7 +28,7 @@ export const getProjectRoot = () => {
   try {
     const found = findUpSync('.hg', { type: 'directory' });
     if (found) {
-      result = result || path.join(found, '..');
+      result = result || join(found, '..');
     }
   } catch (e) {
     //
@@ -44,7 +44,7 @@ export const getProjectRoot = () => {
   try {
     const found = findUpSync('.yarn', { type: 'directory' });
     if (found) {
-      result = result || path.join(found, '..');
+      result = result || join(found, '..');
     }
   } catch (e) {
     //
@@ -57,7 +57,7 @@ export const nodePathsToArray = (nodePath: string) =>
   nodePath
     .split(process.platform === 'win32' ? ';' : ':')
     .filter(Boolean)
-    .map((p) => path.resolve('./', p));
+    .map((p) => resolve('./', p));
 
 const relativePattern = /^\.{1,2}([/\\]|$)/;
 /**
@@ -66,5 +66,5 @@ const relativePattern = /^\.{1,2}([/\\]|$)/;
 export function normalizeStoryPath(filename: string) {
   if (relativePattern.test(filename)) return filename;
 
-  return `.${path.sep}${filename}`;
+  return `.${sep}${filename}`;
 }

--- a/code/core/src/common/utils/resolve-path-in-sb-cache.ts
+++ b/code/core/src/common/utils/resolve-path-in-sb-cache.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import findCacheDirectory from 'find-cache-dir';
 
@@ -12,7 +12,7 @@ import findCacheDirectory from 'find-cache-dir';
  */
 export function resolvePathInStorybookCache(fileOrDirectoryName: string, sub = 'default'): string {
   let cacheDirectory = findCacheDirectory({ name: 'storybook' });
-  cacheDirectory ||= path.join(process.cwd(), '.cache', 'storybook');
+  cacheDirectory ||= join(process.cwd(), '.cache', 'storybook');
 
-  return path.join(cacheDirectory, sub, fileOrDirectoryName);
+  return join(cacheDirectory, sub, fileOrDirectoryName);
 }

--- a/code/core/src/common/utils/strip-abs-node-modules-path.ts
+++ b/code/core/src/common/utils/strip-abs-node-modules-path.ts
@@ -1,16 +1,16 @@
-import path from 'node:path';
+import { posix, sep } from 'node:path';
 
 import slash from 'slash';
 
 function normalizePath(id: string) {
-  return path.posix.normalize(slash(id));
+  return posix.normalize(slash(id));
 }
 
 // We need to convert from an absolute path, to a traditional node module import path,
 // so that vite can correctly pre-bundle/optimize
 export function stripAbsNodeModulesPath(absPath: string) {
   // TODO: Evaluate if searching for node_modules in a yarn pnp environment is correct
-  const splits = absPath.split(`node_modules${path.sep}`);
+  const splits = absPath.split(`node_modules${sep}`);
   // Return everything after the final "node_modules/"
   const module = normalizePath(splits[splits.length - 1]);
   return module;

--- a/code/core/src/common/utils/validate-configuration-files.ts
+++ b/code/core/src/common/utils/validate-configuration-files.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { resolve } from 'node:path';
 
 import { once } from '@storybook/core/node-logger';
 import { MainFileMissingError } from '@storybook/core/server-errors';
@@ -11,13 +11,13 @@ import { boost } from './interpret-files';
 
 export async function validateConfigurationFiles(configDir: string) {
   const extensionsPattern = `{${Array.from(boost).join(',')}}`;
-  const mainConfigMatches = await glob(slash(path.resolve(configDir, `main${extensionsPattern}`)));
+  const mainConfigMatches = await glob(slash(resolve(configDir, `main${extensionsPattern}`)));
 
   const [mainConfigPath] = mainConfigMatches;
 
   if (mainConfigMatches.length > 1) {
     once.warn(dedent`
-      Multiple main files found in your configDir (${path.resolve(configDir)}).
+      Multiple main files found in your configDir (${resolve(configDir)}).
       Storybook will use the first one found and ignore the others. Please remove the extra files.
     `);
   }

--- a/code/core/src/core-server/server-channel/create-new-story-channel.test.ts
+++ b/code/core/src/core-server/server-channel/create-new-story-channel.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -56,7 +56,7 @@ describe(
         initCreateNewStoryChannel(
           mockChannel,
           {
-            configDir: path.join(cwd, '.storybook'),
+            configDir: join(cwd, '.storybook'),
             presets: {
               apply: (val: string) => {
                 if (val === 'framework') {
@@ -89,7 +89,7 @@ describe(
           id: 'components-page--default',
           payload: {
             storyId: 'components-page--default',
-            storyFilePath: path.join('src', 'components', 'Page.stories.jsx'),
+            storyFilePath: join('src', 'components', 'Page.stories.jsx'),
             exportedStoryName: 'Default',
           },
           success: true,
@@ -107,7 +107,7 @@ describe(
         initCreateNewStoryChannel(
           mockChannel,
           {
-            configDir: path.join(cwd, '.storybook'),
+            configDir: join(cwd, '.storybook'),
             presets: {
               apply: (val: string) => {
                 if (val === 'framework') {

--- a/code/core/src/core-server/server-channel/create-new-story-channel.ts
+++ b/code/core/src/core-server/server-channel/create-new-story-channel.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
-import path from 'node:path';
+import { relative } from 'node:path';
 
 import type { Channel } from '@storybook/core/channels';
 import { telemetry } from '@storybook/core/telemetry';
@@ -38,7 +38,7 @@ export function initCreateNewStoryChannel(
           options
         );
 
-        const relativeStoryFilePath = path.relative(process.cwd(), storyFilePath);
+        const relativeStoryFilePath = relative(process.cwd(), storyFilePath);
 
         const { storyId, kind } = await getStoryId({ storyFilePath, exportedStoryName }, options);
 
@@ -70,7 +70,7 @@ export function initCreateNewStoryChannel(
           id: data.id,
           payload: {
             storyId,
-            storyFilePath: path.relative(process.cwd(), storyFilePath),
+            storyFilePath: relative(process.cwd(), storyFilePath),
             exportedStoryName,
           },
           error: null,

--- a/code/core/src/core-server/server-channel/file-search-channel.ts
+++ b/code/core/src/core-server/server-channel/file-search-channel.ts
@@ -1,4 +1,5 @@
-import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 
 import type { Channel } from '@storybook/core/channels';
 import {
@@ -19,8 +20,6 @@ import {
   FILE_COMPONENT_SEARCH_REQUEST,
   FILE_COMPONENT_SEARCH_RESPONSE,
 } from '@storybook/core/core-events';
-
-import fs from 'fs/promises';
 
 import { doesStoryFileExist, getStoryMetadata } from '../utils/get-new-story-file';
 import { getParser } from '../utils/parser';
@@ -60,14 +59,11 @@ export async function initFileSearchChannel(
           const parser = getParser(rendererName);
 
           try {
-            const content = await fs.readFile(path.join(projectRoot, file), 'utf-8');
-            const { storyFileName } = getStoryMetadata(path.join(projectRoot, file));
-            const dirname = path.dirname(file);
+            const content = await readFile(join(projectRoot, file), 'utf-8');
+            const { storyFileName } = getStoryMetadata(join(projectRoot, file));
+            const dir = dirname(file);
 
-            const storyFileExists = doesStoryFileExist(
-              path.join(projectRoot, dirname),
-              storyFileName
-            );
+            const storyFileExists = doesStoryFileExist(join(projectRoot, dir), storyFileName);
 
             const info = await parser.parse(content);
 

--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -38,8 +38,8 @@ const readCsfMock = vi.mocked(readCsf);
 const getStorySortParameterMock = vi.mocked(getStorySortParameter);
 
 const options: StoryIndexGeneratorOptions = {
-  configDir: path.join(__dirname, '__mockdata__'),
-  workingDir: path.join(__dirname, '__mockdata__'),
+  configDir: join(__dirname, '__mockdata__'),
+  workingDir: join(__dirname, '__mockdata__'),
   indexers: [csfIndexer],
   docs: { defaultName: 'docs', autodocs: false },
 };

--- a/code/core/src/core-server/utils/__tests__/index-extraction.test.ts
+++ b/code/core/src/core-server/utils/__tests__/index-extraction.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -11,8 +11,8 @@ import { AUTODOCS_TAG, StoryIndexGenerator } from '../StoryIndexGenerator';
 vi.mock('@storybook/core/node-logger');
 
 const options: StoryIndexGeneratorOptions = {
-  configDir: path.join(__dirname, '..', '__mockdata__'),
-  workingDir: path.join(__dirname, '..', '__mockdata__'),
+  configDir: join(__dirname, '..', '__mockdata__'),
+  workingDir: join(__dirname, '..', '__mockdata__'),
   indexers: [],
   docs: { defaultName: 'docs', autodocs: false },
 };
@@ -20,7 +20,7 @@ const options: StoryIndexGeneratorOptions = {
 describe('story extraction', () => {
   it('extracts stories from full indexer inputs', async () => {
     const relativePath = './src/A.stories.js';
-    const absolutePath = path.join(options.workingDir, relativePath);
+    const absolutePath = join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
 
     const generator = new StoryIndexGenerator([specifier], {
@@ -99,7 +99,7 @@ describe('story extraction', () => {
 
   it('extracts stories from minimal indexer inputs', async () => {
     const relativePath = './src/first-nested/deeply/F.stories.js';
-    const absolutePath = path.join(options.workingDir, relativePath);
+    const absolutePath = join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
 
     const generator = new StoryIndexGenerator([specifier], {
@@ -144,7 +144,7 @@ describe('story extraction', () => {
 
   it('auto-generates title from indexer inputs without title', async () => {
     const relativePath = './src/first-nested/deeply/F.stories.js';
-    const absolutePath = path.join(options.workingDir, relativePath);
+    const absolutePath = join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
 
     const generator = new StoryIndexGenerator([specifier], {
@@ -195,7 +195,7 @@ describe('story extraction', () => {
 
   it('auto-generates name from indexer inputs without name', async () => {
     const relativePath = './src/A.stories.js';
-    const absolutePath = path.join(options.workingDir, relativePath);
+    const absolutePath = join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
 
     const generator = new StoryIndexGenerator([specifier], {
@@ -246,7 +246,7 @@ describe('story extraction', () => {
 
   it('auto-generates id', async () => {
     const relativePath = './src/A.stories.js';
-    const absolutePath = path.join(options.workingDir, relativePath);
+    const absolutePath = join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
 
     const generator = new StoryIndexGenerator([specifier], {
@@ -345,7 +345,7 @@ describe('story extraction', () => {
 
   it('auto-generates id, title and name from exportName input', async () => {
     const relativePath = './src/A.stories.js';
-    const absolutePath = path.join(options.workingDir, relativePath);
+    const absolutePath = join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
 
     const generator = new StoryIndexGenerator([specifier], {
@@ -394,7 +394,7 @@ describe('story extraction', () => {
 describe('docs entries from story extraction', () => {
   it('adds docs entry when autodocs is globally enabled', async () => {
     const relativePath = './src/A.stories.js';
-    const absolutePath = path.join(options.workingDir, relativePath);
+    const absolutePath = join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
 
     const generator = new StoryIndexGenerator([specifier], {
@@ -445,7 +445,7 @@ describe('docs entries from story extraction', () => {
   });
   it(`adds docs entry when autodocs is "tag" and an entry has the "${AUTODOCS_TAG}" tag`, async () => {
     const relativePath = './src/A.stories.js';
-    const absolutePath = path.join(options.workingDir, relativePath);
+    const absolutePath = join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
 
     const generator = new StoryIndexGenerator([specifier], {
@@ -509,7 +509,7 @@ describe('docs entries from story extraction', () => {
   });
   it(`DOES NOT adds docs entry when autodocs is false and an entry has the "${AUTODOCS_TAG}" tag`, async () => {
     const relativePath = './src/A.stories.js';
-    const absolutePath = path.join(options.workingDir, relativePath);
+    const absolutePath = join(options.workingDir, relativePath);
     const specifier: NormalizedStoriesSpecifier = normalizeStoriesEntry(relativePath, options);
 
     const generator = new StoryIndexGenerator([specifier], {

--- a/code/core/src/core-server/utils/__tests__/server-statics.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-statics.test.ts
@@ -1,4 +1,4 @@
-import path, { resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/code/core/src/core-server/utils/__tests__/server-statics.test.ts
+++ b/code/core/src/core-server/utils/__tests__/server-statics.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import path, { resolve } from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -19,14 +19,14 @@ describe('parseStaticDir', () => {
   it('returns the static dir/path and default target', async () => {
     await expect(parseStaticDir('public')).resolves.toEqual({
       staticDir: './public',
-      staticPath: path.resolve('public'),
+      staticPath: resolve('public'),
       targetDir: './',
       targetEndpoint: '/',
     });
 
     await expect(parseStaticDir('foo/bar')).resolves.toEqual({
       staticDir: './foo/bar',
-      staticPath: path.resolve('foo/bar'),
+      staticPath: resolve('foo/bar'),
       targetDir: './',
       targetEndpoint: '/',
     });
@@ -35,14 +35,14 @@ describe('parseStaticDir', () => {
   it('returns the static dir/path and custom target', async () => {
     await expect(parseStaticDir('public:/custom-endpoint')).resolves.toEqual({
       staticDir: './public',
-      staticPath: path.resolve('public'),
+      staticPath: resolve('public'),
       targetDir: './custom-endpoint',
       targetEndpoint: '/custom-endpoint',
     });
 
     await expect(parseStaticDir('foo/bar:/custom-endpoint')).resolves.toEqual({
       staticDir: './foo/bar',
-      staticPath: path.resolve('foo/bar'),
+      staticPath: resolve('foo/bar'),
       targetDir: './custom-endpoint',
       targetEndpoint: '/custom-endpoint',
     });
@@ -59,7 +59,7 @@ describe('parseStaticDir', () => {
   it('checks that the path exists', async () => {
     // @ts-expect-error for some reason vitest does not match the return type with one of the overloads from pathExists
     pathExistsMock.mockResolvedValue(false);
-    await expect(parseStaticDir('nonexistent')).rejects.toThrow(path.resolve('nonexistent'));
+    await expect(parseStaticDir('nonexistent')).rejects.toThrow(resolve('nonexistent'));
   });
 
   skipWindows(() => {
@@ -85,8 +85,8 @@ describe('parseStaticDir', () => {
   onlyWindows(() => {
     it('supports absolute file paths - windows', async () => {
       await expect(parseStaticDir('C:\\foo\\bar')).resolves.toEqual({
-        staticDir: path.resolve('C:\\foo\\bar'),
-        staticPath: path.resolve('C:\\foo\\bar'),
+        staticDir: resolve('C:\\foo\\bar'),
+        staticPath: resolve('C:\\foo\\bar'),
         targetDir: './',
         targetEndpoint: '/',
       });
@@ -95,14 +95,14 @@ describe('parseStaticDir', () => {
     it('supports absolute file paths with custom endpoint - windows', async () => {
       await expect(parseStaticDir('C:\\foo\\bar:/custom-endpoint')).resolves.toEqual({
         staticDir: expect.any(String), // can't test this properly on unix
-        staticPath: path.resolve('C:\\foo\\bar'),
+        staticPath: resolve('C:\\foo\\bar'),
         targetDir: './custom-endpoint',
         targetEndpoint: '/custom-endpoint',
       });
 
       await expect(parseStaticDir('C:\\foo\\bar:\\custom-endpoint')).resolves.toEqual({
         staticDir: expect.any(String), // can't test this properly on unix
-        staticPath: path.resolve('C:\\foo\\bar'),
+        staticPath: resolve('C:\\foo\\bar'),
         targetDir: './custom-endpoint',
         targetEndpoint: '/custom-endpoint',
       });

--- a/code/core/src/core-server/utils/get-new-story-file.test.ts
+++ b/code/core/src/core-server/utils/get-new-story-file.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -48,7 +48,7 @@ describe('get-new-story-file', () => {
 
       export const Default: Story = {};"
     `);
-    expect(storyFilePath).toBe(path.join(__dirname, 'src', 'components', 'Page.stories.tsx'));
+    expect(storyFilePath).toBe(join(__dirname, 'src', 'components', 'Page.stories.tsx'));
   });
 
   it('should create a new story file (JavaScript)', async () => {
@@ -82,6 +82,6 @@ describe('get-new-story-file', () => {
 
       export const Default = {};"
     `);
-    expect(storyFilePath).toBe(path.join(__dirname, 'src', 'components', 'Page.stories.jsx'));
+    expect(storyFilePath).toBe(join(__dirname, 'src', 'components', 'Page.stories.jsx'));
   });
 });

--- a/code/core/src/core-server/utils/get-new-story-file.ts
+++ b/code/core/src/core-server/utils/get-new-story-file.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import { existsSync } from 'node:fs';
+import { basename, dirname, extname, join } from 'node:path';
 
 import {
   extractProperRendererNameFromFramework,
@@ -31,10 +31,10 @@ export async function getNewStoryFile(
     ([, value]) => value === rendererName
   )?.[0];
 
-  const basename = path.basename(componentFilePath);
-  const extension = path.extname(componentFilePath);
-  const basenameWithoutExtension = basename.replace(extension, '');
-  const dirname = path.dirname(componentFilePath);
+  const base = basename(componentFilePath);
+  const extension = extname(componentFilePath);
+  const basenameWithoutExtension = base.replace(extension, '');
+  const dir = dirname(componentFilePath);
 
   const { storyFileName, isTypescript, storyFileExtension } = getStoryMetadata(componentFilePath);
   const storyFileNameWithExtension = `${storyFileName}.${storyFileExtension}`;
@@ -59,18 +59,18 @@ export async function getNewStoryFile(
         });
 
   const storyFilePath =
-    doesStoryFileExist(path.join(cwd, dirname), storyFileName) && componentExportCount > 1
-      ? path.join(cwd, dirname, alternativeStoryFileNameWithExtension)
-      : path.join(cwd, dirname, storyFileNameWithExtension);
+    doesStoryFileExist(join(cwd, dir), storyFileName) && componentExportCount > 1
+      ? join(cwd, dir, alternativeStoryFileNameWithExtension)
+      : join(cwd, dir, storyFileNameWithExtension);
 
   return { storyFilePath, exportedStoryName, storyFileContent, dirname };
 }
 
 export const getStoryMetadata = (componentFilePath: string) => {
   const isTypescript = /\.(ts|tsx|mts|cts)$/.test(componentFilePath);
-  const basename = path.basename(componentFilePath);
-  const extension = path.extname(componentFilePath);
-  const basenameWithoutExtension = basename.replace(extension, '');
+  const base = basename(componentFilePath);
+  const extension = extname(componentFilePath);
+  const basenameWithoutExtension = base.replace(extension, '');
   const storyFileExtension = isTypescript ? 'tsx' : 'jsx';
   return {
     storyFileName: `${basenameWithoutExtension}.stories`,
@@ -81,9 +81,9 @@ export const getStoryMetadata = (componentFilePath: string) => {
 
 export const doesStoryFileExist = (parentFolder: string, storyFileName: string) => {
   return (
-    fs.existsSync(path.join(parentFolder, `${storyFileName}.ts`)) ||
-    fs.existsSync(path.join(parentFolder, `${storyFileName}.tsx`)) ||
-    fs.existsSync(path.join(parentFolder, `${storyFileName}.js`)) ||
-    fs.existsSync(path.join(parentFolder, `${storyFileName}.jsx`))
+    existsSync(join(parentFolder, `${storyFileName}.ts`)) ||
+    existsSync(join(parentFolder, `${storyFileName}.tsx`)) ||
+    existsSync(join(parentFolder, `${storyFileName}.js`)) ||
+    existsSync(join(parentFolder, `${storyFileName}.jsx`))
   );
 };

--- a/code/core/src/core-server/utils/get-story-id.test.ts
+++ b/code/core/src/core-server/utils/get-story-id.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -8,7 +8,7 @@ describe('getStoryId', () => {
   it('should return the storyId', async () => {
     const cwd = process.cwd();
     const options = {
-      configDir: path.join(cwd, '.storybook'),
+      configDir: join(cwd, '.storybook'),
       presets: {
         apply: (val: string) => {
           if (val === 'stories') {
@@ -17,7 +17,7 @@ describe('getStoryId', () => {
         },
       },
     } as any;
-    const storyFilePath = path.join(cwd, 'src', 'components', 'stories', 'Page1.stories.ts');
+    const storyFilePath = join(cwd, 'src', 'components', 'stories', 'Page1.stories.ts');
     const exportedStoryName = 'Default';
 
     const { storyId, kind } = await getStoryId({ storyFilePath, exportedStoryName }, options);
@@ -29,7 +29,7 @@ describe('getStoryId', () => {
   it('should throw an error if the storyId cannot be calculated', async () => {
     const cwd = process.cwd();
     const options = {
-      configDir: path.join(cwd, '.storybook'),
+      configDir: join(cwd, '.storybook'),
       presets: {
         apply: (val: string) => {
           if (val === 'stories') {
@@ -38,7 +38,7 @@ describe('getStoryId', () => {
         },
       },
     } as any;
-    const storyFilePath = path.join(cwd, 'not-covered-path', 'stories', 'Page1.stories.ts');
+    const storyFilePath = join(cwd, 'not-covered-path', 'stories', 'Page1.stories.ts');
     const exportedStoryName = 'Default';
 
     await expect(() =>

--- a/code/core/src/core-server/utils/get-story-id.ts
+++ b/code/core/src/core-server/utils/get-story-id.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { relative } from 'node:path';
 
 import { normalizeStories, normalizeStoryPath } from '@storybook/core/common';
 import type { Options } from '@storybook/core/types';
@@ -25,7 +25,7 @@ export async function getStoryId(data: StoryIdData, options: Options) {
     workingDir,
   });
 
-  const relativePath = path.relative(workingDir, data.storyFilePath);
+  const relativePath = relative(workingDir, data.storyFilePath);
   const importPath = posix(normalizeStoryPath(relativePath));
 
   const autoTitle = normalizedStories

--- a/code/core/src/core-server/utils/middleware.ts
+++ b/code/core/src/core-server/utils/middleware.ts
@@ -1,14 +1,14 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 const fileExists = (basename: string) =>
   ['.js', '.cjs'].reduce((found: string, ext: string) => {
     const filename = `${basename}${ext}`;
-    return !found && fs.existsSync(filename) ? filename : found;
+    return !found && existsSync(filename) ? filename : found;
   }, '');
 
 export function getMiddleware(configDir: string) {
-  const middlewarePath = fileExists(path.resolve(configDir, 'middleware'));
+  const middlewarePath = fileExists(resolve(configDir, 'middleware'));
   if (middlewarePath) {
     let middlewareModule = require(middlewarePath);
     // eslint-disable-next-line no-underscore-dangle

--- a/code/core/src/core-server/utils/output-stats.ts
+++ b/code/core/src/core-server/utils/output-stats.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import type { Stats } from '@storybook/core/types';
 
@@ -20,7 +20,7 @@ export async function outputStats(directory: string, previewStats?: any, manager
 }
 
 export const writeStats = async (directory: string, name: string, stats: Stats) => {
-  const filePath = path.join(directory, `${name}-stats.json`);
+  const filePath = join(directory, `${name}-stats.json`);
   const { chunks, ...data } = stats.toJson(); // omit chunks, which is about half of the total data
   await new Promise((resolve, reject) => {
     stringifyStream(data, null, 2)

--- a/code/core/src/core-server/utils/parser/generic-parser.test.ts
+++ b/code/core/src/core-server/utils/parser/generic-parser.test.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -7,11 +7,11 @@ import { GenericParser } from './generic-parser';
 
 const genericParser = new GenericParser();
 
-const TEST_DIR = path.join(__dirname, '..', '__search-files-tests__');
+const TEST_DIR = join(__dirname, '..', '__search-files-tests__');
 
 describe('generic-parser', () => {
   it('should correctly return exports from ES modules', async () => {
-    const content = fs.readFileSync(path.join(TEST_DIR, 'src', 'es-module.js'), 'utf-8');
+    const content = readFileSync(join(TEST_DIR, 'src', 'es-module.js'), 'utf-8');
     const { exports } = await genericParser.parse(content);
 
     expect(exports).toEqual([

--- a/code/core/src/core-server/utils/posix.ts
+++ b/code/core/src/core-server/utils/posix.ts
@@ -1,7 +1,7 @@
-import path from 'node:path';
+import { posix as posixPath, sep } from 'node:path';
 
 /**
  * Replaces the path separator with forward slashes
  */
-export const posix = (localPath: string, sep: string = path.sep) =>
-  localPath.split(sep).filter(Boolean).join(path.posix.sep);
+export const posix = (localPath: string, seperator: string = sep) =>
+  localPath.split(seperator).filter(Boolean).join(posixPath.sep);

--- a/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.test.ts
+++ b/code/core/src/core-server/utils/save-story/duplicate-story-with-new-name.test.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-underscore-dangle */
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
 import { printCsf, readCsf } from '@storybook/core/csf-tools';
 
-import { readFile } from 'fs/promises';
 import { format } from 'prettier';
 
 import { duplicateStoryWithNewName } from './duplicate-story-with-new-name';

--- a/code/core/src/core-server/utils/save-story/save-story.ts
+++ b/code/core/src/core-server/utils/save-story/save-story.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import fs from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 
 import type { Channel } from '@storybook/core/channels';
@@ -103,7 +103,7 @@ export function initializeSaveStory(channel: Channel, options: Options, coreConf
           channel.on(STORY_RENDERED, resolve);
           setTimeout(() => resolve(channel.off(STORY_RENDERED, resolve)), 3000);
         }),
-        fs.writeFile(sourceFilePath, code),
+        writeFile(sourceFilePath, code),
       ]);
 
       channel.emit(SAVE_STORY_RESPONSE, {

--- a/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
+++ b/code/core/src/core-server/utils/save-story/update-args-in-csf-file.test.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-underscore-dangle */
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
 import { printCsf, readCsf } from '@storybook/core/csf-tools';
 
-import { readFile } from 'fs/promises';
 import { format } from 'prettier';
 
 import { getDiff } from './getDiff';

--- a/code/core/src/core-server/utils/search-files.test.ts
+++ b/code/core/src/core-server/utils/search-files.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -8,7 +8,7 @@ describe('search-files', () => {
   it('should automatically convert static search to a dynamic glob search', async (t) => {
     const files = await searchFiles({
       searchQuery: 'ommonjs',
-      cwd: path.join(__dirname, '__search-files-tests__'),
+      cwd: join(__dirname, '__search-files-tests__'),
     });
 
     expect(files).toEqual(['src/commonjs-module-default.js', 'src/commonjs-module.js']);
@@ -17,7 +17,7 @@ describe('search-files', () => {
   it('should automatically convert static search to a dynamic glob search (with file extension)', async (t) => {
     const files = await searchFiles({
       searchQuery: 'module.js',
-      cwd: path.join(__dirname, '__search-files-tests__'),
+      cwd: join(__dirname, '__search-files-tests__'),
     });
 
     expect(files).toEqual(['src/commonjs-module.js', 'src/es-module.js']);
@@ -26,7 +26,7 @@ describe('search-files', () => {
   it('should return all files if the search query matches the parent folder', async (t) => {
     const files = await searchFiles({
       searchQuery: 'file-extensions',
-      cwd: path.join(__dirname, '__search-files-tests__'),
+      cwd: join(__dirname, '__search-files-tests__'),
     });
 
     expect(files).toEqual([
@@ -44,7 +44,7 @@ describe('search-files', () => {
   it('should ignore files that do not have the allowed extensions', async (t) => {
     const files = await searchFiles({
       searchQuery: 'asset',
-      cwd: path.join(__dirname, '__search-files-tests__'),
+      cwd: join(__dirname, '__search-files-tests__'),
     });
 
     expect(files).toEqual([]);
@@ -53,7 +53,7 @@ describe('search-files', () => {
   it('should ignore test files (*.spec.*, *.test.*)', async (t) => {
     const files = await searchFiles({
       searchQuery: 'tests',
-      cwd: path.join(__dirname, '__search-files-tests__'),
+      cwd: join(__dirname, '__search-files-tests__'),
     });
 
     expect(files).toEqual([]);
@@ -62,7 +62,7 @@ describe('search-files', () => {
   it('should work with glob search patterns', async (t) => {
     const files = await searchFiles({
       searchQuery: '**/commonjs-module.js',
-      cwd: path.join(__dirname, '__search-files-tests__'),
+      cwd: join(__dirname, '__search-files-tests__'),
     });
 
     expect(files).toEqual(['src/commonjs-module.js']);
@@ -71,7 +71,7 @@ describe('search-files', () => {
   it('should respect glob but also the allowed file extensions', async (t) => {
     const files = await searchFiles({
       searchQuery: '**/*',
-      cwd: path.join(__dirname, '__search-files-tests__'),
+      cwd: join(__dirname, '__search-files-tests__'),
     });
 
     expect(files).toEqual([
@@ -93,7 +93,7 @@ describe('search-files', () => {
   it('should ignore node_modules', async (t) => {
     const files = await searchFiles({
       searchQuery: 'file-in-common.js',
-      cwd: path.join(__dirname, '__search-files-tests__'),
+      cwd: join(__dirname, '__search-files-tests__'),
     });
 
     expect(files).toEqual([]);
@@ -102,7 +102,7 @@ describe('search-files', () => {
   it('should ignore story files', async (t) => {
     const files = await searchFiles({
       searchQuery: 'es-module.stories.js',
-      cwd: path.join(__dirname, '__search-files-tests__'),
+      cwd: join(__dirname, '__search-files-tests__'),
     });
 
     expect(files).toEqual([]);
@@ -112,7 +112,7 @@ describe('search-files', () => {
     await expect(() =>
       searchFiles({
         searchQuery: '../**/*',
-        cwd: path.join(__dirname, '__search-files-tests__'),
+        cwd: join(__dirname, '__search-files-tests__'),
       })
     ).rejects.toThrowError();
   });

--- a/code/core/src/core-server/utils/server-statics.ts
+++ b/code/core/src/core-server/utils/server-statics.ts
@@ -1,4 +1,4 @@
-import path, { basename, isAbsolute } from 'node:path';
+import { basename, isAbsolute, posix, resolve, sep, win32 } from 'node:path';
 
 import { getDirectoryFromWorkingDir } from '@storybook/core/common';
 import type { Options } from '@storybook/core/types';
@@ -54,16 +54,16 @@ export async function useStatics(router: Router, options: Options) {
 export const parseStaticDir = async (arg: string) => {
   // Split on last index of ':', for Windows compatibility (e.g. 'C:\some\dir:\foo')
   const lastColonIndex = arg.lastIndexOf(':');
-  const isWindowsAbsolute = path.win32.isAbsolute(arg);
+  const isWindowsAbsolute = win32.isAbsolute(arg);
   const isWindowsRawDirOnly = isWindowsAbsolute && lastColonIndex === 1; // e.g. 'C:\some\dir'
   const splitIndex = lastColonIndex !== -1 && !isWindowsRawDirOnly ? lastColonIndex : arg.length;
 
   const targetRaw = arg.substring(splitIndex + 1) || '/';
-  const target = targetRaw.split(path.sep).join(path.posix.sep); // Ensure target has forward-slash path
+  const target = targetRaw.split(sep).join(posix.sep); // Ensure target has forward-slash path
 
   const rawDir = arg.substring(0, splitIndex);
-  const staticDir = path.isAbsolute(rawDir) ? rawDir : `./${rawDir}`;
-  const staticPath = path.resolve(staticDir);
+  const staticDir = isAbsolute(rawDir) ? rawDir : `./${rawDir}`;
+  const staticPath = resolve(staticDir);
   const targetDir = target.replace(/^\/?/, './');
   const targetEndpoint = targetDir.substring(1);
 

--- a/code/core/src/core-server/utils/stories-json.test.ts
+++ b/code/core/src/core-server/utils/stories-json.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -20,7 +20,7 @@ vi.mock('watchpack');
 vi.mock('lodash/debounce');
 vi.mock('@storybook/core/node-logger');
 
-const workingDir = path.join(__dirname, '__mockdata__');
+const workingDir = join(__dirname, '__mockdata__');
 const normalizedStories = [
   normalizeStoriesEntry(
     {

--- a/code/core/src/core-server/utils/watch-story-specifiers.test.ts
+++ b/code/core/src/core-server/utils/watch-story-specifiers.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -11,12 +11,12 @@ import { watchStorySpecifiers } from './watch-story-specifiers';
 vi.mock('watchpack');
 
 describe('watchStorySpecifiers', () => {
-  const workingDir = path.join(__dirname, '__mockdata__');
+  const workingDir = join(__dirname, '__mockdata__');
   const options = {
-    configDir: path.join(workingDir, '.storybook'),
+    configDir: join(workingDir, '.storybook'),
     workingDir,
   };
-  const abspath = (filename: string) => path.join(workingDir, filename);
+  const abspath = (filename: string) => join(workingDir, filename);
 
   let close: () => void;
   afterEach(() => close?.());

--- a/code/core/src/core-server/utils/watch-story-specifiers.ts
+++ b/code/core/src/core-server/utils/watch-story-specifiers.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import { type Dirent, lstatSync, readdirSync } from 'node:fs';
+import { basename, join, relative, resolve } from 'node:path';
 
 import { commonGlobOptions } from '@storybook/core/common';
 import type { NormalizedStoriesSpecifier, Path } from '@storybook/core/types';
@@ -9,7 +9,7 @@ import Watchpack from 'watchpack';
 
 const isDirectory = (directory: Path) => {
   try {
-    return fs.lstatSync(directory).isDirectory();
+    return lstatSync(directory).isDirectory();
   } catch (err) {
     return false;
   }
@@ -25,11 +25,11 @@ function getNestedFilesAndDirectories(directories: Path[]) {
     if (traversedDirectories.has(directory)) {
       return;
     }
-    fs.readdirSync(directory, { withFileTypes: true }).forEach((ent: fs.Dirent) => {
+    readdirSync(directory, { withFileTypes: true }).forEach((ent: Dirent) => {
       if (ent.isDirectory()) {
-        traverse(path.join(directory, ent.name));
+        traverse(join(directory, ent.name));
       } else if (ent.isFile()) {
-        files.add(path.join(directory, ent.name));
+        files.add(join(directory, ent.name));
       }
     });
     traversedDirectories.add(directory);
@@ -46,7 +46,7 @@ export function watchStorySpecifiers(
   // Watch all nested files and directories up front to avoid this issue:
   // https://github.com/webpack/watchpack/issues/222
   const { files, directories } = getNestedFilesAndDirectories(
-    specifiers.map((ns) => path.resolve(options.workingDir, ns.directory))
+    specifiers.map((ns) => resolve(options.workingDir, ns.directory))
   );
 
   // See https://www.npmjs.com/package/watchpack for full options.
@@ -59,7 +59,7 @@ export function watchStorySpecifiers(
   wp.watch({ files, directories });
 
   const toImportPath = (absolutePath: Path) => {
-    const relativePath = path.relative(options.workingDir, absolutePath);
+    const relativePath = relative(options.workingDir, absolutePath);
     return slash(relativePath.startsWith('.') ? relativePath : `./${relativePath}`);
   };
 
@@ -88,12 +88,12 @@ export function watchStorySpecifiers(
           .map(async (specifier) => {
             // If `./path/to/dir` was added, check all files matching `./path/to/dir/**/*.stories.*`
             // (where the last bit depends on `files`).
-            const dirGlob = path.join(
+            const dirGlob = join(
               absolutePath,
               '**',
               // files can be e.g. '**/foo/*/*.js' so we just want the last bit,
               // because the directory could already be within the files part (e.g. './x/foo/bar')
-              path.basename(specifier.files)
+              basename(specifier.files)
             );
 
             // Dynamically import globby because it is a pure ESM module

--- a/code/core/src/docs-tools/argTypes/convert/convert.test.ts
+++ b/code/core/src/docs-tools/argTypes/convert/convert.test.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import { readFileSync } from 'node:fs';
 
 import { describe, expect, it } from 'vitest';
 
@@ -786,7 +786,7 @@ describe('storybook type system', () => {
 });
 
 const readFixture = (fixture: string) =>
-  fs.readFileSync(`${__dirname}/__testfixtures__/${fixture}`).toString();
+  readFileSync(`${__dirname}/__testfixtures__/${fixture}`).toString();
 
 const transformToModule = (inputCode: string) => {
   const options = {

--- a/code/core/src/telemetry/anonymous-id.ts
+++ b/code/core/src/telemetry/anonymous-id.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { relative } from 'node:path';
 
 import { getProjectRoot } from '@storybook/core/common';
 
@@ -29,7 +29,7 @@ export const getAnonymousProjectId = () => {
   try {
     const projectRoot = getProjectRoot();
 
-    const projectRootPath = path.relative(projectRoot, process.cwd());
+    const projectRootPath = relative(projectRoot, process.cwd());
 
     const originBuffer = execSync(`git config --local --get remote.origin.url`, {
       timeout: 1000,

--- a/code/core/src/telemetry/get-framework-info.test.ts
+++ b/code/core/src/telemetry/get-framework-info.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { sep } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -30,7 +30,7 @@ describe('getFrameworkInfo', () => {
   });
 
   it('should resolve the framework package json correctly and strip project paths in the metadata', async () => {
-    const packageName = `${process.cwd()}/@storybook/react`.split('/').join(path.sep);
+    const packageName = `${process.cwd()}/@storybook/react`.split('/').join(sep);
     const framework = { name: packageName };
     const frameworkPackageJson = {
       name: packageName,
@@ -48,7 +48,7 @@ describe('getFrameworkInfo', () => {
 
     expect(result).toEqual({
       framework: {
-        name: '$SNIP/@storybook/react'.split('/').join(path.sep),
+        name: '$SNIP/@storybook/react'.split('/').join(sep),
         options: undefined,
       },
       builder: '@storybook/builder-vite',

--- a/code/core/src/telemetry/get-framework-info.ts
+++ b/code/core/src/telemetry/get-framework-info.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { normalize } from 'node:path';
 
 import { frameworkPackages } from '@storybook/core/common';
 import type { PackageJson, StorybookConfig } from '@storybook/core/types';
@@ -36,7 +36,7 @@ function findMatchingPackage(packageJson: PackageJson, suffixes: string[]) {
 }
 
 export const getFrameworkPackageName = (packageNameOrPath: string) => {
-  const normalizedPath = path.normalize(packageNameOrPath).replace(new RegExp(/\\/, 'g'), '/');
+  const normalizedPath = normalize(packageNameOrPath).replace(new RegExp(/\\/, 'g'), '/');
 
   const knownFramework = Object.keys(frameworkPackages).find((pkg) => normalizedPath.endsWith(pkg));
 

--- a/code/core/src/telemetry/get-monorepo-type.test.ts
+++ b/code/core/src/telemetry/get-monorepo-type.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -18,11 +18,11 @@ vi.mock('@storybook/core/common', async (importOriginal) => {
 
 const checkMonorepoType = ({ monorepoConfigFile, isYarnWorkspace = false }: any) => {
   const mockFiles = {
-    [path.join('root', 'package.json')]: isYarnWorkspace ? '{ "workspaces": [] }' : '{}',
+    [join('root', 'package.json')]: isYarnWorkspace ? '{ "workspaces": [] }' : '{}',
   };
 
   if (monorepoConfigFile) {
-    mockFiles[path.join('root', monorepoConfigFile)] = '{}';
+    mockFiles[join('root', monorepoConfigFile)] = '{}';
   }
 
   vi.mocked<typeof import('../../../__mocks__/fs-extra')>(fsExtra as any).__setMockFiles(mockFiles);

--- a/code/core/src/telemetry/get-monorepo-type.ts
+++ b/code/core/src/telemetry/get-monorepo-type.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { getProjectRoot } from '@storybook/core/common';
 import type { PackageJson } from '@storybook/core/types';
@@ -21,7 +21,7 @@ export const getMonorepoType = (): MonorepoType => {
 
   const keys = Object.keys(monorepoConfigs) as (keyof typeof monorepoConfigs)[];
   const monorepoType: MonorepoType = keys.find((monorepo) => {
-    const configFile = path.join(projectRootPath, monorepoConfigs[monorepo]);
+    const configFile = join(projectRootPath, monorepoConfigs[monorepo]);
     return existsSync(configFile);
   }) as MonorepoType;
 
@@ -29,11 +29,11 @@ export const getMonorepoType = (): MonorepoType => {
     return monorepoType;
   }
 
-  if (!existsSync(path.join(projectRootPath, 'package.json'))) {
+  if (!existsSync(join(projectRootPath, 'package.json'))) {
     return undefined;
   }
 
-  const packageJson = readJsonSync(path.join(projectRootPath, 'package.json')) as PackageJson;
+  const packageJson = readJsonSync(join(projectRootPath, 'package.json')) as PackageJson;
 
   if (packageJson?.workspaces) {
     return 'Workspaces';

--- a/code/core/src/telemetry/package-json.ts
+++ b/code/core/src/telemetry/package-json.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { join } from 'node:path';
 
 import { readJson } from 'fs-extra';
 
@@ -22,7 +22,7 @@ export const getActualPackageVersion = async (packageName: string) => {
 };
 
 export const getActualPackageJson = async (packageName: string) => {
-  const resolvedPackageJson = require.resolve(path.join(packageName, 'package.json'), {
+  const resolvedPackageJson = require.resolve(join(packageName, 'package.json'), {
     paths: [process.cwd()],
   });
   const packageJson = await readJson(resolvedPackageJson);

--- a/code/frameworks/angular/src/builders/build-storybook/index.spec.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.spec.ts
@@ -1,7 +1,7 @@
 import { Architect, createBuilder } from '@angular-devkit/architect';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { schema } from '@angular-devkit/core';
-import * as path from 'path';
+import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const buildDevStandaloneMock = vi.fn();

--- a/code/frameworks/angular/src/builders/start-storybook/index.spec.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.spec.ts
@@ -1,7 +1,7 @@
 import { Architect, createBuilder } from '@angular-devkit/architect';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { schema } from '@angular-devkit/core';
-import * as path from 'path';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const buildDevStandaloneMock = vi.fn();
@@ -62,7 +62,7 @@ describe.skip('Start Storybook Builder', () => {
     );
     // This will either take a Node package name, or a path to the directory
     // for the package.json file.
-    await architectHost.addBuilderFromPackage(path.join(__dirname, '../../..'));
+    await architectHost.addBuilderFromPackage(join(__dirname, '../../..'));
   });
 
   beforeEach(() => {

--- a/code/frameworks/angular/src/builders/utils/run-compodoc.ts
+++ b/code/frameworks/angular/src/builders/utils/run-compodoc.ts
@@ -1,17 +1,18 @@
+import { isAbsolute, relative } from 'node:path';
+
 import { JsPackageManagerFactory } from 'storybook/internal/common';
 
 import { BuilderContext } from '@angular-devkit/architect';
-import * as path from 'path';
 import { Observable } from 'rxjs';
 
 const hasTsConfigArg = (args: string[]) => args.indexOf('-p') !== -1;
 const hasOutputArg = (args: string[]) =>
   args.indexOf('-d') !== -1 || args.indexOf('--output') !== -1;
 
-// path.relative is necessary to workaround a compodoc issue with
+// relative is necessary to workaround a compodoc issue with
 // absolute paths on windows machines
 const toRelativePath = (pathToTsConfig: string) => {
-  return path.isAbsolute(pathToTsConfig) ? path.relative('.', pathToTsConfig) : pathToTsConfig;
+  return isAbsolute(pathToTsConfig) ? relative('.', pathToTsConfig) : pathToTsConfig;
 };
 
 export const runCompodoc = (

--- a/code/frameworks/angular/src/client/docs/angular-properties.test.ts
+++ b/code/frameworks/angular/src/client/docs/angular-properties.test.ts
@@ -1,16 +1,17 @@
-import fs from 'fs';
-import path from 'path';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 // File hierarchy: __testfixtures__ / some-test-case / input.*
 const inputRegExp = /^input\..*$/;
 
 describe('angular component properties', () => {
-  const fixturesDir = path.join(__dirname, '__testfixtures__');
-  fs.readdirSync(fixturesDir, { withFileTypes: true }).forEach((testEntry) => {
+  const fixturesDir = join(__dirname, '__testfixtures__');
+  readdirSync(fixturesDir, { withFileTypes: true }).forEach((testEntry) => {
     if (testEntry.isDirectory()) {
-      const testDir = path.join(fixturesDir, testEntry.name);
-      const testFile = fs.readdirSync(testDir).find((fileName) => inputRegExp.test(fileName));
+      const testDir = join(fixturesDir, testEntry.name);
+      const testFile = readdirSync(testDir).find((fileName) => inputRegExp.test(fileName));
       if (testFile) {
         // TODO: Remove this as soon as the real test is fixed
         it('true', () => {
@@ -18,19 +19,19 @@ describe('angular component properties', () => {
         });
         // TODO: Fix this test
         // it(`${testEntry.name}`, () => {
-        //   const inputPath = path.join(testDir, testFile);
+        //   const inputPath = join(testDir, testFile);
 
         //   // snapshot the output of compodoc
         //   const compodocOutput = runCompodoc(inputPath);
         //   const compodocJson = JSON.parse(compodocOutput);
         //   expect(compodocJson).toMatchFileSnapshot(
-        //     path.join(testDir, `compodoc-${SNAPSHOT_OS}.snapshot`)
+        //     join(testDir, `compodoc-${SNAPSHOT_OS}.snapshot`)
         //   );
 
         //   // snapshot the output of addon-docs angular-properties
         //   const componentData = findComponentByName('InputComponent', compodocJson);
         //   const argTypes = extractArgTypesFromData(componentData);
-        //   expect(argTypes).toMatchFileSnapshot(path.join(testDir, 'argtypes.snapshot'));
+        //   expect(argTypes).toMatchFileSnapshot(join(testDir, 'argtypes.snapshot'));
         // });
       }
     }

--- a/code/frameworks/angular/src/preset.ts
+++ b/code/frameworks/angular/src/preset.ts
@@ -1,6 +1,6 @@
 import { PresetProperty } from 'storybook/internal/types';
 
-import { dirname, join } from 'path';
+import { dirname, join } from 'node:path';
 
 import { StandaloneOptions } from './builders/utils/standalone-options';
 import { StorybookConfig } from './types';

--- a/code/frameworks/angular/src/server/framework-preset-angular-ivy.ts
+++ b/code/frameworks/angular/src/server/framework-preset-angular-ivy.ts
@@ -1,7 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { Preset } from 'storybook/internal/types';
 
-import fs from 'fs';
-import * as path from 'path';
 import { Configuration } from 'webpack';
 
 import { AngularOptions } from '../types';
@@ -43,7 +44,7 @@ export const runNgcc = async () => {
     // should be async: true but does not work due to
     // https://github.com/storybookjs/storybook/pull/11157/files#r615413803
     async: false,
-    basePath: path.join(process.cwd(), 'node_modules'), // absolute path to node_modules
+    basePath: join(process.cwd(), 'node_modules'), // absolute path to node_modules
     createNewEntryPointFormats: true, // --create-ivy-entry-points
     compileAllFormats: false, // --first-only
   });
@@ -51,7 +52,7 @@ export const runNgcc = async () => {
 
 export const webpack = async (webpackConfig: Configuration, options: PresetOptions) => {
   const packageJsonPath = require.resolve('@angular/core/package.json');
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
   const VERSION = packageJson.version;
   const framework = await options.presets.apply<Preset>('framework');
   const angularOptions = (typeof framework === 'object' ? framework.options : {}) as AngularOptions;

--- a/code/frameworks/ember/src/preset.ts
+++ b/code/frameworks/ember/src/preset.ts
@@ -1,9 +1,9 @@
+import { dirname, join } from 'node:path';
+
 import { getProjectRoot, resolvePathInStorybookCache } from 'storybook/internal/common';
 import type { PresetProperty } from 'storybook/internal/types';
 
 import { getVirtualModules } from '@storybook/builder-webpack5';
-
-import { dirname, join } from 'path';
 
 import type { StorybookConfig } from './types';
 

--- a/code/frameworks/ember/src/util.ts
+++ b/code/frameworks/ember/src/util.ts
@@ -1,12 +1,13 @@
+import { dirname, join } from 'node:path';
+
 import { sync as findUpSync } from 'find-up';
-import path from 'path';
 
 export const findDistFile = (cwd: string, relativePath: string) => {
   const nearestPackageJson = findUpSync('package.json', { cwd });
   if (!nearestPackageJson) {
     throw new Error(`Could not find package.json in: ${cwd}`);
   }
-  const packageDir = path.dirname(nearestPackageJson);
+  const packageDir = dirname(nearestPackageJson);
 
-  return path.join(packageDir, 'dist', relativePath);
+  return join(packageDir, 'dist', relativePath);
 };

--- a/code/frameworks/html-vite/src/preset.ts
+++ b/code/frameworks/html-vite/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 function getAbsolutePath<I extends string>(value: I): I {
   return dirname(require.resolve(join(value, 'package.json'))) as any;

--- a/code/frameworks/html-webpack5/src/preset.ts
+++ b/code/frameworks/html-webpack5/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;

--- a/code/frameworks/nextjs/src/babel/plugins/react-loadable-plugin.ts
+++ b/code/frameworks/nextjs/src/babel/plugins/react-loadable-plugin.ts
@@ -5,8 +5,9 @@
 /**
  * Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/babel/plugins/react-loadable-plugin.ts
  */
+import { relative as relativePath } from 'node:path';
+
 import type { types as BabelTypes, NodePath, PluginObj } from '@babel/core';
-import { relative as relativePath } from 'path';
 
 export default function ({ types: t }: { types: typeof BabelTypes }): PluginObj {
   return {

--- a/code/frameworks/nextjs/src/babel/preset.ts
+++ b/code/frameworks/nextjs/src/babel/preset.ts
@@ -1,5 +1,6 @@
+import { dirname } from 'node:path';
+
 import type { PluginItem } from '@babel/core';
-import { dirname } from 'path';
 
 const isLoadIntentTest = process.env.NODE_ENV === 'test';
 const isLoadIntentDevelopment = process.env.NODE_ENV === 'development';

--- a/code/frameworks/nextjs/src/export-mocks/webpack.ts
+++ b/code/frameworks/nextjs/src/export-mocks/webpack.ts
@@ -1,4 +1,5 @@
-import { dirname, join } from 'path';
+import { dirname, join } from 'node:path';
+
 import type { Configuration as WebpackConfig } from 'webpack';
 
 import { getCompatibilityAliases } from '../compatibility/compatibility-map';

--- a/code/frameworks/nextjs/src/font/webpack/loader/local/get-font-face-declarations.ts
+++ b/code/frameworks/nextjs/src/font/webpack/loader/local/get-font-face-declarations.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { getProjectRoot } from 'storybook/internal/common';
 
@@ -20,8 +20,8 @@ export async function getFontFaceDeclarations(
 
   // Parent folder relative to the root context
   const parentFolder = swcMode
-    ? path.dirname(path.join(getProjectRoot(), options.filename)).replace(rootContext, '')
-    : path.dirname(options.filename).replace(rootContext, '');
+    ? dirname(join(getProjectRoot(), options.filename)).replace(rootContext, '')
+    : dirname(options.filename).replace(rootContext, '');
 
   const {
     weight,
@@ -43,7 +43,7 @@ export async function getFontFaceDeclarations(
 
   const getFontFaceCSS = () => {
     if (typeof localFontSrc === 'string') {
-      const localFontPath = path.join(parentFolder, localFontSrc).replaceAll('\\', '/');
+      const localFontPath = join(parentFolder, localFontSrc).replaceAll('\\', '/');
 
       return `@font-face {
           font-family: ${id};
@@ -53,7 +53,7 @@ export async function getFontFaceDeclarations(
     }
     return localFontSrc
       .map((font) => {
-        const localFontPath = path.join(parentFolder, font.path).replaceAll('\\', '/');
+        const localFontPath = join(parentFolder, font.path).replaceAll('\\', '/');
 
         return `@font-face {
           font-family: ${id};

--- a/code/frameworks/nextjs/src/font/webpack/loader/storybook-nextjs-font-loader.ts
+++ b/code/frameworks/nextjs/src/font/webpack/loader/storybook-nextjs-font-loader.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import { sep } from 'node:path';
 
 import { getFontFaceDeclarations as getGoogleFontFaceDeclarations } from './google/get-font-face-declarations';
 import { getFontFaceDeclarations as getLocalFontFaceDeclarations } from './local/get-font-face-declarations';
@@ -41,7 +41,7 @@ export default async function storybookNextjsFontLoader(this: any) {
 
   let fontFaceDeclaration: FontFaceDeclaration | undefined;
 
-  const pathSep = path.sep;
+  const pathSep = sep;
 
   if (
     options.source.endsWith(`next${pathSep}font${pathSep}google`) ||

--- a/code/frameworks/nextjs/src/images/webpack.ts
+++ b/code/frameworks/nextjs/src/images/webpack.ts
@@ -1,5 +1,6 @@
+import { resolve as resolvePath } from 'node:path';
+
 import type { NextConfig } from 'next';
-import path from 'path';
 import semver from 'semver';
 import type { RuleSetRule, Configuration as WebpackConfig } from 'webpack';
 
@@ -18,14 +19,14 @@ const configureImageDefaults = (baseConfig: WebpackConfig): void => {
   resolve.alias = {
     ...resolve.alias,
     'sb-original/next/image': require.resolve('next/image'),
-    'next/image': path.resolve(__dirname, './images/next-image'),
+    'next/image': resolvePath(__dirname, './images/next-image'),
   };
 
   if (semver.satisfies(version, '>=13.0.0')) {
     resolve.alias = {
       ...resolve.alias,
       'sb-original/next/legacy/image': require.resolve('next/legacy/image'),
-      'next/legacy/image': path.resolve(__dirname, './images/next-legacy-image'),
+      'next/legacy/image': resolvePath(__dirname, './images/next-legacy-image'),
     };
   }
 };

--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -1,12 +1,13 @@
 // https://storybook.js.org/docs/react/addons/writing-presets
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
 import { getProjectRoot } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 import type { PresetProperty } from 'storybook/internal/types';
 
 import type { ConfigItem, PluginItem, TransformOptions } from '@babel/core';
 import { loadPartialConfig } from '@babel/core';
-import fs from 'fs';
-import { dirname, join } from 'path';
 import semver from 'semver';
 
 import { configureAliases } from './aliases/webpack';
@@ -145,7 +146,7 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (baseConfig, 
 
   const babelRCPath = join(getProjectRoot(), '.babelrc');
   const babelConfigPath = join(getProjectRoot(), 'babel.config.js');
-  const hasBabelConfig = fs.existsSync(babelRCPath) || fs.existsSync(babelConfigPath);
+  const hasBabelConfig = existsSync(babelRCPath) || existsSync(babelConfigPath);
   const nextjsVersion = getNextjsVersion();
   const isDevelopment = options.configType !== 'PRODUCTION';
 

--- a/code/frameworks/nextjs/src/swc/loader.ts
+++ b/code/frameworks/nextjs/src/swc/loader.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path';
+
 import { getProjectRoot } from 'storybook/internal/common';
 import type { Options } from 'storybook/internal/types';
 
@@ -5,7 +7,6 @@ import { getVirtualModules } from '@storybook/builder-webpack5';
 
 import type { NextConfig } from 'next';
 import loadJsConfig from 'next/dist/build/load-jsconfig';
-import path from 'path';
 import type { Configuration as WebpackConfig } from 'webpack';
 
 export const configureSWCLoader = async (
@@ -49,7 +50,7 @@ export const configureSWCLoader = async (
           dir,
           isDevelopment
         ),
-        swcCacheDir: path.join(dir, nextConfig?.distDir ?? '.next', 'cache', 'swc'),
+        swcCacheDir: join(dir, nextConfig?.distDir ?? '.next', 'cache', 'swc'),
         bundleTarget: 'default',
       },
     },

--- a/code/frameworks/nextjs/src/swc/next-swc-loader-patch.ts
+++ b/code/frameworks/nextjs/src/swc/next-swc-loader-patch.ts
@@ -26,7 +26,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
-import path, { isAbsolute } from 'node:path';
+import { isAbsolute, relative } from 'node:path';
 
 import type { NextConfig } from 'next';
 import { isWasm, transform } from 'next/dist/build/swc';
@@ -72,7 +72,7 @@ async function loaderTransform(this: any, parentTrace: any, source?: string, inp
     isReactServerLayer,
   } = loaderOptions;
   const isPageFile = filename.startsWith(pagesDir);
-  const relativeFilePathFromRoot = path.relative(rootDir, filename);
+  const relativeFilePathFromRoot = relative(rootDir, filename);
 
   const swcOptions = getLoaderSWCOptions({
     pagesDir,

--- a/code/frameworks/nextjs/src/swc/next-swc-loader-patch.ts
+++ b/code/frameworks/nextjs/src/swc/next-swc-loader-patch.ts
@@ -26,10 +26,11 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
+import path, { isAbsolute } from 'node:path';
+
 import type { NextConfig } from 'next';
 import { isWasm, transform } from 'next/dist/build/swc';
 import { getLoaderSWCOptions } from 'next/dist/build/swc/options';
-import path, { isAbsolute } from 'path';
 
 export interface SWCLoaderOptions {
   rootDir: string;

--- a/code/frameworks/nextjs/src/utils.ts
+++ b/code/frameworks/nextjs/src/utils.ts
@@ -1,9 +1,10 @@
+import { dirname, resolve, sep } from 'node:path';
+
 import { getProjectRoot } from 'storybook/internal/common';
 
 import type { NextConfig } from 'next';
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
 import loadConfig from 'next/dist/server/config';
-import path from 'path';
 import { DefinePlugin } from 'webpack';
 import type { Configuration as WebpackConfig } from 'webpack';
 
@@ -22,7 +23,7 @@ export const resolveNextConfig = async ({
 }: {
   nextConfigPath?: string;
 }): Promise<NextConfig> => {
-  const dir = nextConfigPath ? path.dirname(nextConfigPath) : getProjectRoot();
+  const dir = nextConfigPath ? dirname(nextConfigPath) : getProjectRoot();
   return loadConfig(PHASE_DEVELOPMENT_SERVER, dir, undefined);
 };
 
@@ -65,13 +66,13 @@ export const scopedResolve = (id: string): string => {
 
   try {
     // TODO: Remove in next major release (SB 8.0) and use the statement in the catch block per default instead
-    scopedModulePath = require.resolve(id, { paths: [path.resolve()] });
+    scopedModulePath = require.resolve(id, { paths: [resolve()] });
   } catch (e) {
     scopedModulePath = require.resolve(id);
   }
 
   const moduleFolderStrPosition = scopedModulePath.lastIndexOf(
-    id.replace(/\//g /* all '/' occurances */, path.sep)
+    id.replace(/\//g /* all '/' occurances */, sep)
   );
   const beginningOfMainScriptPath = moduleFolderStrPosition + id.length;
   return scopedModulePath.substring(0, beginningOfMainScriptPath);

--- a/code/frameworks/preact-vite/src/preset.ts
+++ b/code/frameworks/preact-vite/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 import type { StorybookConfig } from './types';
 

--- a/code/frameworks/preact-webpack5/src/preset.ts
+++ b/code/frameworks/preact-webpack5/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;

--- a/code/frameworks/react-vite/src/plugins/docgen-resolver.ts
+++ b/code/frameworks/react-vite/src/plugins/docgen-resolver.ts
@@ -1,4 +1,5 @@
-import { extname } from 'path';
+import { extname } from 'node:path';
+
 import resolve from 'resolve';
 
 export class ReactDocgenResolveError extends Error {

--- a/code/frameworks/react-vite/src/plugins/react-docgen.ts
+++ b/code/frameworks/react-vite/src/plugins/react-docgen.ts
@@ -1,9 +1,10 @@
+import { relative } from 'node:path';
+
 import { logger } from 'storybook/internal/node-logger';
 
 import { createFilter } from '@rollup/pluginutils';
 import findUp from 'find-up';
 import MagicString from 'magic-string';
-import path from 'path';
 import type { Documentation } from 'react-docgen';
 import {
   ERROR_CODES,
@@ -59,7 +60,7 @@ export async function reactDocgen({
     name: 'storybook:react-docgen-plugin',
     enforce: 'pre',
     async transform(src: string, id: string) {
-      if (!filter(path.relative(cwd, id))) {
+      if (!filter(relative(cwd, id))) {
         return;
       }
 

--- a/code/frameworks/react-vite/src/preset.ts
+++ b/code/frameworks/react-vite/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 import type { StorybookConfig } from './types';
 

--- a/code/frameworks/react-vite/src/utils.ts
+++ b/code/frameworks/react-vite/src/utils.ts
@@ -1,12 +1,12 @@
-import fs from 'fs';
-import path from 'path';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 export function readPackageJson(): Record<string, any> | false {
-  const packageJsonPath = path.resolve('package.json');
-  if (!fs.existsSync(packageJsonPath)) {
+  const packageJsonPath = resolve('package.json');
+  if (!existsSync(packageJsonPath)) {
     return false;
   }
 
-  const jsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+  const jsonContent = readFileSync(packageJsonPath, 'utf8');
   return JSON.parse(jsonContent);
 }

--- a/code/frameworks/react-webpack5/src/preset.ts
+++ b/code/frameworks/react-webpack5/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 import type { StorybookConfig } from './types';
 

--- a/code/frameworks/server-webpack5/src/preset.ts
+++ b/code/frameworks/server-webpack5/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;

--- a/code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts
+++ b/code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts
@@ -1,8 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { basename, relative } from 'node:path';
+
 import { logger } from 'storybook/internal/node-logger';
 
-import fs from 'fs';
 import MagicString from 'magic-string';
-import path from 'path';
 import { replace, typescript } from 'svelte-preprocess';
 import { preprocess } from 'svelte/compiler';
 import svelteDoc from 'sveltedoc-parser';
@@ -97,11 +98,11 @@ export async function svelteDocgen(svelteOptions: Record<string, any> = {}): Pro
         }
       }
 
-      const resource = path.relative(cwd, id);
+      const resource = relative(cwd, id);
 
       let docOptions;
       if (docPreprocessOptions) {
-        const rawSource = fs.readFileSync(resource).toString();
+        const rawSource = readFileSync(resource).toString();
 
         const { code: fileContent } = await preprocess(rawSource, docPreprocessOptions, {
           filename: resource,
@@ -133,9 +134,9 @@ export async function svelteDocgen(svelteOptions: Record<string, any> = {}): Pro
       }
 
       // get filename for source content
-      const file = path.basename(resource);
+      const file = basename(resource);
 
-      componentDoc.name = path.basename(file);
+      componentDoc.name = basename(file);
 
       const componentName = getNameFromFilename(resource);
       s.append(`;${componentName}.__docgen = ${JSON.stringify(componentDoc)}`);

--- a/code/frameworks/svelte-vite/src/preset.ts
+++ b/code/frameworks/svelte-vite/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 import { svelteDocgen } from './plugins/svelte-docgen';
 import type { StorybookConfig } from './types';

--- a/code/frameworks/svelte-webpack5/src/preset.ts
+++ b/code/frameworks/svelte-webpack5/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;

--- a/code/frameworks/sveltekit/src/preset.ts
+++ b/code/frameworks/sveltekit/src/preset.ts
@@ -1,10 +1,10 @@
+import { dirname, join } from 'node:path';
+
 import type { PresetProperty } from 'storybook/internal/types';
 
 import { withoutVitePlugins } from '@storybook/builder-vite';
 // @ts-expect-error -- TS picks up the type from preset.js instead of dist/preset.d.ts
 import { viteFinal as svelteViteFinal } from '@storybook/svelte-vite/preset';
-
-import { dirname, join } from 'path';
 
 import { configOverrides } from './plugins/config-overrides';
 import { mockSveltekitStores } from './plugins/mock-sveltekit-stores';

--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -1,7 +1,8 @@
+import { readFile, stat } from 'node:fs/promises';
+import { dirname, join, parse, relative, resolve } from 'node:path';
+
 import findPackageJson from 'find-package-json';
-import fs from 'fs/promises';
 import MagicString from 'magic-string';
-import path from 'path';
 import type { PluginOption } from 'vite';
 import {
   type ComponentMeta,
@@ -151,7 +152,7 @@ async function createVueComponentMetaChecker(tsconfigPath = 'tsconfig.json') {
   };
 
   const projectRoot = getProjectRoot();
-  const projectTsConfigPath = path.join(projectRoot, tsconfigPath);
+  const projectTsConfigPath = join(projectRoot, tsconfigPath);
 
   const defaultChecker = createCheckerByJson(projectRoot, { include: ['**/*'] }, checkerOptions);
 
@@ -174,17 +175,17 @@ async function createVueComponentMetaChecker(tsconfigPath = 'tsconfig.json') {
 function getProjectRoot() {
   const projectRoot = findPackageJson().next().value?.path ?? '';
 
-  const currentFileDir = path.dirname(__filename);
-  const relativePathToProjectRoot = path.relative(currentFileDir, projectRoot);
+  const currentFileDir = dirname(__filename);
+  const relativePathToProjectRoot = relative(currentFileDir, projectRoot);
 
-  return path.resolve(currentFileDir, relativePathToProjectRoot);
+  return resolve(currentFileDir, relativePathToProjectRoot);
 }
 
 /**
  * Gets the filename without file extension.
  */
 function getFilenameWithoutExtension(filename: string) {
-  return path.parse(filename).name;
+  return parse(filename).name;
 }
 
 /**
@@ -199,7 +200,7 @@ function lowercaseFirstLetter(string: string) {
  */
 async function fileExists(fullPath: string) {
   try {
-    await fs.stat(fullPath);
+    await stat(fullPath);
     return true;
   } catch {
     return false;
@@ -250,13 +251,13 @@ async function applyTempFixForEventDescriptions(filename: string, componentMeta:
 }
 
 /**
- * Gets a list of tsconfig references for the given tsconfig path.
+ * Gets a list of tsconfig references for the given tsconfig
  * This is only needed for the temporary workaround/fix for:
  * https://github.com/vuejs/language-tools/issues/3896
  */
 async function getTsConfigReferences(tsConfigPath: string) {
   try {
-    const content = JSON.parse(await fs.readFile(tsConfigPath, 'utf-8'));
+    const content = JSON.parse(await readFile(tsConfigPath, 'utf-8'));
     if (!('references' in content) || !Array.isArray(content.references)) return [];
     return content.references as unknown[];
   } catch {

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -1,6 +1,7 @@
+import { dirname, join } from 'node:path';
+
 import type { PresetProperty } from 'storybook/internal/types';
 
-import { dirname, join } from 'path';
 import type { PluginOption } from 'vite';
 
 import { vueComponentMeta } from './plugins/vue-component-meta';

--- a/code/frameworks/vue3-webpack5/src/preset.ts
+++ b/code/frameworks/vue3-webpack5/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;

--- a/code/frameworks/web-components-vite/src/preset.ts
+++ b/code/frameworks/web-components-vite/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;

--- a/code/frameworks/web-components-webpack5/src/preset.ts
+++ b/code/frameworks/web-components-webpack5/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
   dirname(require.resolve(join(input, 'package.json'))) as any;

--- a/code/lib/cli-storybook/src/add.ts
+++ b/code/lib/cli-storybook/src/add.ts
@@ -1,3 +1,5 @@
+import { isAbsolute, join } from 'node:path';
+
 import {
   JsPackageManagerFactory,
   type PackageManagerName,
@@ -8,7 +10,6 @@ import {
 } from 'storybook/internal/common';
 import { readConfig, writeConfig } from 'storybook/internal/csf-tools';
 
-import { isAbsolute, join } from 'path';
 import SemVer from 'semver';
 import { dedent } from 'ts-dedent';
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/__test__/main-config-with-wrappers.js
+++ b/code/lib/cli-storybook/src/automigrate/fixes/__test__/main-config-with-wrappers.js
@@ -1,7 +1,6 @@
-import path from 'path';
+import { dirname, join } from 'node:path';
 
-const wrapForPnp = (packageName) =>
-  path.dirname(require.resolve(path.join(packageName, 'package.json')));
+const wrapForPnp = (packageName) => dirname(require.resolve(join(packageName, 'package.json')));
 
 const config = {
   stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],

--- a/code/lib/cli-storybook/src/automigrate/fixes/initial-globals.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/initial-globals.test.ts
@@ -1,14 +1,15 @@
 /* eslint-disable no-underscore-dangle */
+import { join } from 'node:path';
+
 import { expect, it, vi } from 'vitest';
 
 import * as fsExtra from 'fs-extra';
-import path from 'path';
 
 import { initialGlobals } from './initial-globals';
 
 vi.mock('fs-extra', async () => import('../../../../../__mocks__/fs-extra'));
 
-const previewConfigPath = path.join('.storybook', 'preview.js');
+const previewConfigPath = join('.storybook', 'preview.js');
 const check = async (previewContents: string) => {
   vi.mocked<typeof import('../../../../../__mocks__/fs-extra')>(fsExtra as any).__setMockFiles({
     [previewConfigPath]: previewContents,

--- a/code/lib/cli-storybook/src/automigrate/fixes/mdx-1-to-3.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/mdx-1-to-3.ts
@@ -1,6 +1,7 @@
+import { basename } from 'node:path';
+
 import chalk from 'chalk';
 import fse from 'fs-extra';
-import { basename } from 'path';
 import { dedent } from 'ts-dedent';
 
 import type { Fix } from '../types';

--- a/code/lib/cli-storybook/src/automigrate/fixes/mdx-gfm.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/mdx-gfm.ts
@@ -1,7 +1,8 @@
+import { join } from 'node:path';
+
 import { getStorybookVersionSpecifier } from 'storybook/internal/cli';
 import { commonGlobOptions } from 'storybook/internal/common';
 
-import { join } from 'path';
 import slash from 'slash';
 import { dedent } from 'ts-dedent';
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/remove-argtypes-regex.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/remove-argtypes-regex.ts
@@ -1,4 +1,4 @@
-import * as fs from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 
 import { babelParse } from 'storybook/internal/csf-tools';
 
@@ -16,7 +16,7 @@ export const removeArgtypesRegex: Fix<{ argTypesRegex: NodePath; previewConfigPa
   async check({ previewConfigPath }) {
     if (!previewConfigPath) return null;
 
-    const previewFile = await fs.readFile(previewConfigPath, { encoding: 'utf-8' });
+    const previewFile = await readFile(previewConfigPath, { encoding: 'utf-8' });
 
     // @ts-expect-error File is not yet exposed, see https://github.com/babel/babel/issues/11350#issuecomment-644118606
     const file: BabelFile = new babel.File(

--- a/code/lib/cli-storybook/src/automigrate/fixes/remove-global-client-apis.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/remove-global-client-apis.test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable no-underscore-dangle */
+import { join } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import type { JsPackageManager } from 'storybook/internal/common';
 
 import * as fsExtra from 'fs-extra';
-import path from 'path';
 
 import { RemovedAPIs, removedGlobalClientAPIs as migration } from './remove-global-client-apis';
 
@@ -13,7 +14,7 @@ vi.mock('fs-extra', async () => import('../../../../../__mocks__/fs-extra'));
 const check = async ({ contents, previewConfigPath }: any) => {
   if (contents) {
     vi.mocked<typeof import('../../../../../__mocks__/fs-extra')>(fsExtra as any).__setMockFiles({
-      [path.join('.storybook', 'preview.js')]: contents,
+      [join('.storybook', 'preview.js')]: contents,
     });
   }
   const packageManager = {
@@ -38,7 +39,7 @@ describe('removedGlobalClientAPIs fix', () => {
       export const parameters = {};
     `;
     await expect(
-      check({ contents, previewConfigPath: path.join('.storybook', 'preview.js') })
+      check({ contents, previewConfigPath: join('.storybook', 'preview.js') })
     ).resolves.toBeNull();
   });
   it('uses 1 removed API', async () => {
@@ -47,7 +48,7 @@ describe('removedGlobalClientAPIs fix', () => {
       addParameters({});
     `;
     await expect(
-      check({ contents, previewConfigPath: path.join('.storybook', 'preview.js') })
+      check({ contents, previewConfigPath: join('.storybook', 'preview.js') })
     ).resolves.toEqual(
       expect.objectContaining({
         usedAPIs: [RemovedAPIs.addParameters],
@@ -61,7 +62,7 @@ describe('removedGlobalClientAPIs fix', () => {
       addDecorator((storyFn) => storyFn());
     `;
     await expect(
-      check({ contents, previewConfigPath: path.join('.storybook', 'preview.js') })
+      check({ contents, previewConfigPath: join('.storybook', 'preview.js') })
     ).resolves.toEqual(
       expect.objectContaining({
         usedAPIs: expect.arrayContaining([RemovedAPIs.addParameters, RemovedAPIs.addDecorator]),

--- a/code/lib/cli-storybook/src/automigrate/fixes/vite-config-file.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/vite-config-file.ts
@@ -1,8 +1,9 @@
+import { join } from 'node:path';
+
 import { frameworkToRenderer } from 'storybook/internal/cli';
 import { frameworkPackages } from 'storybook/internal/common';
 
 import findUp from 'find-up';
-import path from 'path';
 import { dedent } from 'ts-dedent';
 
 import { getFrameworkPackageName } from '../helpers/mainConfigFile';
@@ -23,7 +24,7 @@ export const viteConfigFile = {
   async check({ mainConfig, packageManager, mainConfigPath }) {
     let isViteConfigFileFound = !!(await findUp(
       ['vite.config.js', 'vite.config.mjs', 'vite.config.cjs', 'vite.config.ts', 'vite.config.mts'],
-      { cwd: mainConfigPath ? path.join(mainConfigPath, '..') : process.cwd() }
+      { cwd: mainConfigPath ? join(mainConfigPath, '..') : process.cwd() }
     ));
 
     const rendererToVitePluginMap: Record<string, string> = {

--- a/code/lib/cli-storybook/src/automigrate/helpers/mainConfigFile.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/mainConfigFile.ts
@@ -1,3 +1,5 @@
+import { normalize } from 'node:path';
+
 import { frameworkToRenderer } from 'storybook/internal/cli';
 import {
   builderPackages,
@@ -14,7 +16,6 @@ import { readConfig, writeConfig as writeConfigFile } from 'storybook/internal/c
 import type { StorybookConfig, StorybookConfigRaw } from 'storybook/internal/types';
 
 import chalk from 'chalk';
-import path from 'path';
 import { dedent } from 'ts-dedent';
 
 const logger = console;
@@ -76,7 +77,7 @@ export const getBuilderPackageName = (mainConfig?: StorybookConfigRaw) => {
     return null;
   }
 
-  const normalizedPath = path.normalize(packageNameOrPath).replace(new RegExp(/\\/, 'g'), '/');
+  const normalizedPath = normalize(packageNameOrPath).replace(new RegExp(/\\/, 'g'), '/');
 
   return builderPackages.find((pkg) => normalizedPath.endsWith(pkg)) || packageNameOrPath;
 };

--- a/code/lib/cli-storybook/src/automigrate/index.ts
+++ b/code/lib/cli-storybook/src/automigrate/index.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path';
+
 import {
   type JsPackageManager,
   JsPackageManagerFactory,
@@ -9,7 +11,6 @@ import {
 import boxen from 'boxen';
 import chalk from 'chalk';
 import { createWriteStream, move, remove } from 'fs-extra';
-import { join } from 'path';
 import prompts from 'prompts';
 import semver from 'semver';
 import invariant from 'tiny-invariant';

--- a/code/lib/cli-storybook/src/doctor/index.ts
+++ b/code/lib/cli-storybook/src/doctor/index.ts
@@ -1,10 +1,11 @@
+import { join } from 'node:path';
+
 import { JsPackageManagerFactory, temporaryFile } from 'storybook/internal/common';
 import type { PackageManagerName } from 'storybook/internal/common';
 
 import boxen from 'boxen';
 import chalk from 'chalk';
 import { createWriteStream, move, remove } from 'fs-extra';
-import { join } from 'path';
 import { dedent } from 'ts-dedent';
 
 import { cleanLog } from '../automigrate/helpers/cleanLog';

--- a/code/lib/cli-storybook/src/link.ts
+++ b/code/lib/cli-storybook/src/link.ts
@@ -1,9 +1,10 @@
+import { basename, extname, join } from 'node:path';
+
 import { logger } from 'storybook/internal/node-logger';
 
 import chalk from 'chalk';
 import { spawn as spawnAsync, sync as spawnSync } from 'cross-spawn';
 import fse from 'fs-extra';
-import path from 'path';
 
 type ExecOptions = Parameters<typeof spawnAsync>[2];
 
@@ -67,21 +68,21 @@ export const link = async ({ target, local, start }: LinkOptions) => {
   }
 
   let reproDir = target;
-  let reproName = path.basename(target);
+  let reproName = basename(target);
 
   if (!local) {
-    const reprosDir = path.join(storybookDir, '../storybook-repros');
+    const reprosDir = join(storybookDir, '../storybook-repros');
     logger.info(`Ensuring directory ${reprosDir}`);
     await fse.ensureDir(reprosDir);
 
     logger.info(`Cloning ${target}`);
     await exec(`git clone ${target}`, { cwd: reprosDir });
     // Extract a repro name from url given as input (take the last part of the path and remove the extension)
-    reproName = path.basename(target, path.extname(target));
-    reproDir = path.join(reprosDir, reproName);
+    reproName = basename(target, extname(target));
+    reproDir = join(reprosDir, reproName);
   }
 
-  const reproPackageJson = await fse.readJSON(path.join(reproDir, 'package.json'));
+  const reproPackageJson = await fse.readJSON(join(reproDir, 'package.json'));
 
   const version = spawnSync('yarn', ['--version'], {
     cwd: reproDir,

--- a/code/lib/cli-storybook/src/sandbox.ts
+++ b/code/lib/cli-storybook/src/sandbox.ts
@@ -1,3 +1,5 @@
+import { isAbsolute, join } from 'node:path';
+
 import type { PackageManagerName } from 'storybook/internal/common';
 import { JsPackageManagerFactory } from 'storybook/internal/common';
 import { versions } from 'storybook/internal/common';
@@ -7,7 +9,6 @@ import chalk from 'chalk';
 import { initiate } from 'create-storybook';
 import { existsSync, readdir } from 'fs-extra';
 import { downloadTemplate } from 'giget';
-import path from 'path';
 import prompts from 'prompts';
 import { lt, prerelease } from 'semver';
 import invariant from 'tiny-invariant';
@@ -191,9 +192,9 @@ export const sandbox = async ({
   invariant(selectedDirectory);
 
   try {
-    const templateDestination = path.isAbsolute(selectedDirectory)
+    const templateDestination = isAbsolute(selectedDirectory)
       ? selectedDirectory
-      : path.join(process.cwd(), selectedDirectory);
+      : join(process.cwd(), selectedDirectory);
 
     logger.info(`🏃 Adding ${selectedConfig.name} into ${templateDestination}`);
 

--- a/code/lib/codemod/src/index.ts
+++ b/code/lib/codemod/src/index.ts
@@ -1,8 +1,9 @@
 /* eslint import/prefer-default-export: "off" */
+import { readdirSync } from 'node:fs';
+import { rename as renameAsync } from 'node:fs/promises';
+import { extname } from 'node:path';
+
 import { sync as spawnSync } from 'cross-spawn';
-import fs from 'fs';
-import path from 'path';
-import { promisify } from 'util';
 
 import { jscodeshiftToPrettierParser } from './lib/utils';
 
@@ -16,13 +17,10 @@ export { default as updateAddonInfo } from './transforms/update-addon-info';
 const TRANSFORM_DIR = `${__dirname}/transforms`;
 
 export function listCodemods() {
-  return fs
-    .readdirSync(TRANSFORM_DIR)
+  return readdirSync(TRANSFORM_DIR)
     .filter((fname) => fname.endsWith('.js'))
     .map((fname) => fname.slice(0, -3));
 }
-
-const renameAsync = promisify(fs.rename);
 
 async function renameFile(file: any, from: any, to: any, { logger }: any) {
   const newFile = file.replace(from, to);
@@ -58,7 +56,7 @@ export async function runCodemod(
   let inferredParser = parser;
 
   if (!parser) {
-    const extension = path.extname(glob).slice(1);
+    const extension = extname(glob).slice(1);
     const knownParser = jscodeshiftToPrettierParser(extension);
     if (knownParser !== 'babel') inferredParser = extension;
   }
@@ -67,7 +65,7 @@ export async function runCodemod(
   const { globby } = await import('globby');
 
   const files = await globby([glob, '!**/node_modules', '!**/dist']);
-  const extensions = new Set(files.map((file) => path.extname(file).slice(1)));
+  const extensions = new Set(files.map((file) => extname(file).slice(1)));
   const commaSeparatedExtensions = Array.from(extensions).join(',');
 
   logger.log(`=> Applying ${codemod}: ${files.length} files`);

--- a/code/lib/codemod/src/transforms/__tests__/transforms.tests.js
+++ b/code/lib/codemod/src/transforms/__tests__/transforms.tests.js
@@ -1,27 +1,28 @@
+import { readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
-import fs from 'fs';
 import { applyTransform } from 'jscodeshift/dist/testUtils';
-import path from 'path';
 
 vi.mock('@storybook/core/node-logger');
 
 const inputRegExp = /\.input\.js$/;
 
-const fixturesDir = path.resolve(__dirname, '../__testfixtures__');
-fs.readdirSync(fixturesDir).forEach((transformName) => {
+const fixturesDir = resolve(__dirname, '../__testfixtures__');
+readdirSync(fixturesDir).forEach((transformName) => {
   // FIXME: delete after https://github.com/storybookjs/storybook/issues/19497
   if (transformName === 'mdx-to-csf') return;
 
-  const transformFixturesDir = path.join(fixturesDir, transformName);
+  const transformFixturesDir = join(fixturesDir, transformName);
   describe(`${transformName}`, () => {
     fs.readdirSync(transformFixturesDir)
       .filter((fileName) => inputRegExp.test(fileName))
       .forEach((fileName) => {
-        const inputPath = path.join(transformFixturesDir, fileName);
+        const inputPath = join(transformFixturesDir, fileName);
         it(`transforms correctly using "${fileName}" data`, () =>
           expect(
-            applyTransform(require(path.join(__dirname, '..', transformName)), null, {
+            applyTransform(require(join(__dirname, '..', transformName)), null, {
               path: inputPath,
               source: fs.readFileSync(inputPath, 'utf8'),
             })

--- a/code/lib/codemod/src/transforms/mdx-to-csf.ts
+++ b/code/lib/codemod/src/transforms/mdx-to-csf.ts
@@ -1,6 +1,6 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment,@typescript-eslint/no-shadow */
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { existsSync, renameSync, writeFileSync } from 'node:fs';
+import { basename, join, parse } from 'node:path';
 
 import { babelParse, babelParseExpression } from '@storybook/core/csf-tools';
 
@@ -30,23 +30,23 @@ const renameList: { original: string; baseName: string }[] = [];
 const brokenList: { original: string; baseName: string }[] = [];
 
 export default async function jscodeshift(info: FileInfo) {
-  const parsed = path.parse(info.path);
+  const parsed = parse(info.path);
 
-  let baseName = path.join(
+  let baseName = join(
     parsed.dir,
     parsed.name.replace('.mdx', '').replace('.stories', '').replace('.story', '')
   );
 
   // make sure the new csf file we are going to create exists
-  while (fs.existsSync(`${baseName}.stories.js`)) {
+  while (existsSync(`${baseName}.stories.js`)) {
     baseName += '_';
   }
 
   try {
-    const { csf, mdx } = await transform(info, path.basename(baseName));
+    const { csf, mdx } = await transform(info, basename(baseName));
 
     if (csf != null) {
-      fs.writeFileSync(`${baseName}.stories.js`, csf);
+      writeFileSync(`${baseName}.stories.js`, csf);
     }
 
     renameList.push({ original: info.path, baseName });
@@ -62,10 +62,10 @@ export default async function jscodeshift(info: FileInfo) {
 // This is a workaround to rename the files after the transformation, which we can remove after we switch from jscodeshift to another solution.
 process.on('exit', () => {
   renameList.forEach((file) => {
-    fs.renameSync(file.original, `${file.baseName}.mdx`);
+    renameSync(file.original, `${file.baseName}.mdx`);
   });
   brokenList.forEach((file) => {
-    fs.renameSync(file.original, `${file.original}.broken`);
+    renameSync(file.original, `${file.original}.broken`);
   });
 });
 

--- a/code/lib/core-webpack/src/load-custom-webpack-config.ts
+++ b/code/lib/core-webpack/src/load-custom-webpack-config.ts
@@ -1,8 +1,8 @@
-import { serverRequire } from 'storybook/internal/common';
+import { resolve } from 'node:path';
 
-import path from 'path';
+import { serverRequire } from 'storybook/internal/common';
 
 const webpackConfigs = ['webpack.config', 'webpackfile'];
 
 export const loadCustomWebpackConfig = (configDir: string) =>
-  serverRequire(webpackConfigs.map((configName) => path.resolve(configDir, configName)));
+  serverRequire(webpackConfigs.map((configName) => resolve(configDir, configName)));

--- a/code/lib/core-webpack/src/to-require-context.test.ts
+++ b/code/lib/core-webpack/src/to-require-context.test.ts
@@ -1,8 +1,8 @@
+import { relative } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { normalizeStoriesEntry } from 'storybook/internal/common';
-
-import path from 'path';
 
 import { toRequireContext } from './to-require-context';
 
@@ -273,7 +273,7 @@ describe('toRequireContext', () => {
       const regex = new RegExp(match);
 
       function isMatched(filePath: string) {
-        const relativePath = `./${path.relative(base, filePath)}`;
+        const relativePath = `./${relative(base, filePath)}`;
 
         const baseIncluded = filePath.includes(base);
         const matched = regex.test(relativePath);

--- a/code/lib/create-storybook/src/generators/ANGULAR/index.ts
+++ b/code/lib/create-storybook/src/generators/ANGULAR/index.ts
@@ -1,9 +1,9 @@
+import { join } from 'node:path';
+
 import { CoreBuilder } from 'storybook/internal/cli';
 import { AngularJSON, compoDocPreviewPrefix, promptForCompoDocs } from 'storybook/internal/cli';
 import { copyTemplate } from 'storybook/internal/cli';
 import { commandLog } from 'storybook/internal/common';
-
-import { join } from 'path';
 
 import { baseGenerator, getCliDir } from '../baseGenerator';
 import type { Generator } from '../types';

--- a/code/lib/create-storybook/src/generators/NEXTJS/index.ts
+++ b/code/lib/create-storybook/src/generators/NEXTJS/index.ts
@@ -1,7 +1,7 @@
-import { CoreBuilder } from 'storybook/internal/cli';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
-import { existsSync } from 'fs';
-import { join } from 'path';
+import { CoreBuilder } from 'storybook/internal/cli';
 
 import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';

--- a/code/lib/create-storybook/src/generators/REACT_SCRIPTS/index.ts
+++ b/code/lib/create-storybook/src/generators/REACT_SCRIPTS/index.ts
@@ -1,7 +1,8 @@
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
 import { CoreBuilder } from 'storybook/internal/cli';
 
-import fs from 'fs';
-import path from 'path';
 import semver from 'semver';
 import { dedent } from 'ts-dedent';
 
@@ -9,7 +10,7 @@ import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  const monorepoRootPath = path.join(__dirname, '..', '..', '..', '..', '..', '..');
+  const monorepoRootPath = join(__dirname, '..', '..', '..', '..', '..', '..');
   const extraMain = options.linkable
     ? {
         webpackFinal: `%%(config) => {
@@ -58,7 +59,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
       webpackCompiler: () => undefined,
       extraAddons,
       extraPackages,
-      staticDir: fs.existsSync(path.resolve('./public')) ? 'public' : undefined,
+      staticDir: existsSync(resolve('./public')) ? 'public' : undefined,
       extraMain,
     }
   );

--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -1,3 +1,5 @@
+import path, { dirname } from 'node:path';
+
 import type { NpmOptions } from 'storybook/internal/cli';
 import type { Builder, SupportedRenderers } from 'storybook/internal/cli';
 import { SupportedLanguage, externalFrameworks } from 'storybook/internal/cli';
@@ -10,7 +12,6 @@ import type { SupportedFrameworks } from 'storybook/internal/types';
 
 import fse from 'fs-extra';
 import ora from 'ora';
-import path, { dirname } from 'path';
 import invariant from 'tiny-invariant';
 import { dedent } from 'ts-dedent';
 

--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -1,4 +1,4 @@
-import path, { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import type { NpmOptions } from 'storybook/internal/cli';
 import type { Builder, SupportedRenderers } from 'storybook/internal/cli';
@@ -362,7 +362,7 @@ export async function baseGenerator(
         : addons,
       extensions,
       language,
-      ...(staticDir ? { staticDirs: [path.join('..', staticDir)] } : null),
+      ...(staticDir ? { staticDirs: [join('..', staticDir)] } : null),
       ...extraMain,
       ...(type !== 'framework'
         ? {
@@ -397,7 +397,7 @@ export async function baseGenerator(
       packageManager,
       language,
       destination: componentsDestinationPath,
-      commonAssetsDir: path.join(getCliDir(), 'rendererAssets', 'common'),
+      commonAssetsDir: join(getCliDir(), 'rendererAssets', 'common'),
     });
   }
 }

--- a/code/lib/create-storybook/src/generators/configure.test.ts
+++ b/code/lib/create-storybook/src/generators/configure.test.ts
@@ -94,7 +94,7 @@ describe('configureMain', () => {
 
     expect(mainConfigPath).toEqual('./.storybook/main.js');
     expect(mainConfigContent).toMatchInlineSnapshot(`
-      "import path from 'path';
+      "import path from 'node:path';
 
       /** @type { import('@storybook/react-webpack5').StorybookConfig } */
       const config = {

--- a/code/lib/create-storybook/src/generators/configure.ts
+++ b/code/lib/create-storybook/src/generators/configure.ts
@@ -1,8 +1,9 @@
+import { resolve } from 'node:path';
+
 import { SupportedLanguage, externalFrameworks } from 'storybook/internal/cli';
 import { logger } from 'storybook/internal/node-logger';
 
 import fse from 'fs-extra';
-import path from 'path';
 import { dedent } from 'ts-dedent';
 
 interface ConfigureMainOptions {
@@ -58,7 +59,7 @@ export async function configureMain({
   prefixes = [],
   ...custom
 }: ConfigureMainOptions) {
-  const srcPath = path.resolve(storybookConfigFolder, '../src');
+  const srcPath = resolve(storybookConfigFolder, '../src');
   const prefix = (await fse.pathExists(srcPath)) ? '../src' : '../stories';
   const config = {
     stories: [`${prefix}/**/*.mdx`, `${prefix}/**/*.stories.@(${extensions.join('|')})`],
@@ -87,7 +88,7 @@ export async function configureMain({
   const finalPrefixes = [...prefixes];
 
   if (custom.framework?.name.includes('path.dirname(')) {
-    imports.push(`import path from 'path';`);
+    imports.push(`import path from 'node:path';`);
   }
 
   if (isTypescript) {

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -1,3 +1,5 @@
+import { appendFile, readFile } from 'node:fs/promises';
+
 import type { Builder, NpmOptions } from 'storybook/internal/cli';
 import { ProjectType, installableProjectTypes } from 'storybook/internal/cli';
 import { detect, detectLanguage, detectPnp, isStorybookInstantiated } from 'storybook/internal/cli';
@@ -17,7 +19,6 @@ import { telemetry } from 'storybook/internal/telemetry';
 import boxen from 'boxen';
 import chalk from 'chalk';
 import findUp from 'find-up';
-import { appendFile, readFile } from 'fs/promises';
 import prompts from 'prompts';
 import { lt, prerelease } from 'semver';
 import { dedent } from 'ts-dedent';

--- a/code/lib/csf-plugin/src/rollup-based-plugin.ts
+++ b/code/lib/csf-plugin/src/rollup-based-plugin.ts
@@ -1,7 +1,8 @@
+import { readFile } from 'node:fs/promises';
+
 import type { EnrichCsfOptions } from 'storybook/internal/csf-tools';
 import { enrichCsf, formatCsf, loadCsf } from 'storybook/internal/csf-tools';
 
-import fs from 'fs/promises';
 import type { RollupPlugin } from 'unplugin';
 
 import { STORIES_REGEX } from './constants';
@@ -16,7 +17,7 @@ export function rollupBasedPlugin(options: EnrichCsfOptions): Partial<RollupPlug
         return;
       }
 
-      const sourceCode = await fs.readFile(id, 'utf-8');
+      const sourceCode = await readFile(id, 'utf-8');
       try {
         const makeTitle = (userTitle: string) => userTitle || 'default';
         const csf = loadCsf(code, { makeTitle }).parse();

--- a/code/lib/csf-plugin/src/webpack-loader.ts
+++ b/code/lib/csf-plugin/src/webpack-loader.ts
@@ -1,7 +1,7 @@
+import { readFile } from 'node:fs/promises';
+
 import type { EnrichCsfOptions } from 'storybook/internal/csf-tools';
 import { enrichCsf, formatCsf, loadCsf } from 'storybook/internal/csf-tools';
-
-import fs from 'fs/promises';
 
 interface LoaderContext {
   async: () => (err: Error | null, result?: string, map?: any) => void;
@@ -14,7 +14,7 @@ async function loader(this: LoaderContext, content: string, map: any) {
   const options = this.getOptions();
   const id = this.resourcePath;
 
-  const sourceCode = await fs.readFile(id, 'utf-8');
+  const sourceCode = await readFile(id, 'utf-8');
 
   try {
     const makeTitle = (userTitle: string) => userTitle || 'default';

--- a/code/lib/react-dom-shim/src/preset.ts
+++ b/code/lib/react-dom-shim/src/preset.ts
@@ -1,7 +1,7 @@
-import type { Options } from 'storybook/internal/types';
+import { readFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join } from 'node:path';
 
-import { readFile } from 'fs/promises';
-import { dirname, isAbsolute, join } from 'path';
+import type { Options } from 'storybook/internal/types';
 
 /**
  * Get react-dom version from the resolvedReact preset, which points to either

--- a/code/lib/source-loader/src/abstract-syntax-tree/inject-decorator.csf.test.js
+++ b/code/lib/source-loader/src/abstract-syntax-tree/inject-decorator.csf.test.js
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 
-import { readFile } from 'fs/promises';
-import path from 'path';
+import { describe, expect, it } from 'vitest';
 
 import injectDecorator from './inject-decorator';
 import getParser from './parsers';
@@ -13,7 +13,7 @@ describe('inject-decorator', () => {
     it('includes storySource parameter in the default exported object', async () => {
       const mockFilePath = './__mocks__/inject-decorator.ts.csf.txt';
       const source = await readFile(mockFilePath, 'utf-8');
-      const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+      const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
         parser: 'typescript',
       });
 
@@ -25,7 +25,7 @@ describe('inject-decorator', () => {
     it('includes storySource parameter in the default exported variable', async () => {
       const mockFilePath = './__mocks__/inject-decorator.ts.csf-meta-var.txt';
       const source = await readFile(mockFilePath, 'utf-8');
-      const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+      const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
         parser: 'typescript',
       });
 
@@ -37,7 +37,7 @@ describe('inject-decorator', () => {
     it('includes storySource parameter in CSf3', async () => {
       const mockFilePath = './__mocks__/inject-decorator.ts.csf3.txt';
       const source = await readFile(mockFilePath, 'utf-8');
-      const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+      const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
         parser: 'typescript',
       });
 
@@ -51,7 +51,7 @@ describe('inject-decorator', () => {
     it('includes storySource parameter in the default exported object', async () => {
       const mockFilePath = './__mocks__/inject-parameters.ts.csf.txt';
       const source = await readFile(mockFilePath, 'utf-8');
-      const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+      const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
         injectStoryParameters: true,
         parser: 'typescript',
       });

--- a/code/lib/source-loader/src/abstract-syntax-tree/inject-decorator.test.js
+++ b/code/lib/source-loader/src/abstract-syntax-tree/inject-decorator.test.js
@@ -1,15 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-import fs from 'fs';
-import path from 'path';
+import { describe, expect, it } from 'vitest';
 
 import injectDecorator from './inject-decorator';
 
 describe('inject-decorator', () => {
   describe('positive', () => {
     const mockFilePath = './__mocks__/inject-decorator.stories.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+    const source = readFileSync(mockFilePath, 'utf-8');
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
       parser: 'javascript',
     });
 
@@ -28,8 +28,8 @@ describe('inject-decorator', () => {
 
   describe('positive - angular', () => {
     const mockFilePath = './__mocks__/inject-decorator.angular-stories.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+    const source = readFileSync(mockFilePath, 'utf-8');
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
       parser: 'typescript',
     });
 
@@ -48,8 +48,8 @@ describe('inject-decorator', () => {
 
   describe('positive - flow', () => {
     const mockFilePath = './__mocks__/inject-decorator.flow-stories.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+    const source = readFileSync(mockFilePath, 'utf-8');
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
       parser: 'flow',
     });
 
@@ -68,8 +68,8 @@ describe('inject-decorator', () => {
 
   describe('positive - ts', () => {
     const mockFilePath = './__mocks__/inject-decorator.ts.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+    const source = readFileSync(mockFilePath, 'utf-8');
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
       parser: 'typescript',
     });
 
@@ -88,8 +88,8 @@ describe('inject-decorator', () => {
 
   describe('stories with ugly comments', () => {
     const mockFilePath = './__mocks__/inject-decorator.ugly-comments-stories.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+    const source = readFileSync(mockFilePath, 'utf-8');
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
       parser: 'javascript',
     });
 
@@ -100,8 +100,8 @@ describe('inject-decorator', () => {
 
   describe('stories with ugly comments in ts', () => {
     const mockFilePath = './__mocks__/inject-decorator.ts.ugly-comments-stories.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+    const source = readFileSync(mockFilePath, 'utf-8');
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
       parser: 'typescript',
     });
 
@@ -112,9 +112,9 @@ describe('inject-decorator', () => {
 
   it('will not change the source when there are no "storiesOf" functions', () => {
     const mockFilePath = './__mocks__/inject-decorator.no-stories.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
+    const source = readFileSync(mockFilePath, 'utf-8');
 
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath));
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath));
 
     expect(result.changed).toBeFalsy();
     expect(result.addsMap).toEqual({});
@@ -123,8 +123,8 @@ describe('inject-decorator', () => {
 
   describe('injectDecorator option is false', () => {
     const mockFilePath = './__mocks__/inject-decorator.stories.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+    const source = readFileSync(mockFilePath, 'utf-8');
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
       injectDecorator: false,
       parser: 'javascript',
     });
@@ -136,8 +136,8 @@ describe('inject-decorator', () => {
 
   describe('injectDecorator option is false - angular', () => {
     const mockFilePath = './__mocks__/inject-decorator.angular-stories.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+    const source = readFileSync(mockFilePath, 'utf-8');
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
       injectDecorator: false,
       parser: 'typescript',
     });
@@ -149,8 +149,8 @@ describe('inject-decorator', () => {
 
   describe('injectDecorator option is false - flow', () => {
     const mockFilePath = './__mocks__/inject-decorator.flow-stories.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+    const source = readFileSync(mockFilePath, 'utf-8');
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
       injectDecorator: false,
       parser: 'flow',
     });
@@ -162,8 +162,8 @@ describe('inject-decorator', () => {
 
   describe('injectDecorator option is false - ts', () => {
     const mockFilePath = './__mocks__/inject-decorator.ts.txt';
-    const source = fs.readFileSync(mockFilePath, 'utf-8');
-    const result = injectDecorator(source, path.resolve(__dirname, mockFilePath), {
+    const source = readFileSync(mockFilePath, 'utf-8');
+    const result = injectDecorator(source, resolve(__dirname, mockFilePath), {
       injectDecorator: false,
       parser: 'typescript',
     });

--- a/code/lib/source-loader/src/build.js
+++ b/code/lib/source-loader/src/build.js
@@ -1,4 +1,4 @@
-import { readFile } from 'fs/promises';
+import { readFile } from 'node:fs/promises';
 
 import { sanitizeSource } from './abstract-syntax-tree/generate-helpers';
 import { readStory } from './dependencies-lookup/readAsObject';

--- a/code/presets/create-react-app/src/helpers/getModulePath.ts
+++ b/code/presets/create-react-app/src/helpers/getModulePath.ts
@@ -1,5 +1,5 @@
-import { existsSync } from 'fs';
-import { join } from 'path';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
 interface PartialTSConfig {
   compilerOptions: {

--- a/code/presets/create-react-app/src/helpers/getReactScriptsPath.ts
+++ b/code/presets/create-react-app/src/helpers/getReactScriptsPath.ts
@@ -1,5 +1,5 @@
-import { lstatSync, readFileSync, realpathSync } from 'fs';
-import { dirname, join } from 'path';
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 export const getReactScriptsPath = (): string => {
   const cwd = process.cwd();

--- a/code/presets/create-react-app/src/helpers/processCraConfig.ts
+++ b/code/presets/create-react-app/src/helpers/processCraConfig.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import { resolve } from 'node:path';
+
 import type { PluginItem, TransformOptions } from '@babel/core';
-import { resolve } from 'path';
 import semver from 'semver';
 import type { Configuration, RuleSetCondition, RuleSetRule } from 'webpack';
 

--- a/code/presets/create-react-app/src/index.ts
+++ b/code/presets/create-react-app/src/index.ts
@@ -1,6 +1,7 @@
+import { dirname, join, relative } from 'node:path';
+
 import { logger } from 'storybook/internal/node-logger';
 
-import { dirname, join, relative } from 'path';
 import PnpWebpackPlugin from 'pnp-webpack-plugin';
 import type { Configuration, RuleSetRule, WebpackPluginInstance } from 'webpack';
 

--- a/code/presets/preact-webpack/src/index.ts
+++ b/code/presets/preact-webpack/src/index.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 import type { StorybookConfig } from './types';
 

--- a/code/presets/react-webpack/src/cra-config.test.ts
+++ b/code/presets/react-webpack/src/cra-config.test.ts
@@ -1,7 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import { join, sep } from 'node:path';
 
-import fs from 'fs';
-import path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getReactScriptsPath } from './cra-config';
 
@@ -11,7 +11,7 @@ vi.mock('fs', () => ({
   existsSync: vi.fn(() => true),
 }));
 
-const SCRIPT_PATH = path.join('.bin', 'react-scripts');
+const SCRIPT_PATH = join('.bin', 'react-scripts');
 
 describe('cra-config', () => {
   describe('when used with the default react-scripts package', () => {
@@ -23,7 +23,7 @@ describe('cra-config', () => {
 
     it('should locate the react-scripts package', () => {
       expect(getReactScriptsPath({ noCache: true })).toEqual(
-        path.join(path.sep, 'test-project', 'node_modules', 'react-scripts')
+        join(sep, 'test-project', 'node_modules', 'react-scripts')
       );
     });
   });
@@ -37,7 +37,7 @@ describe('cra-config', () => {
 
     it('should locate the react-scripts package', () => {
       expect(getReactScriptsPath({ noCache: true })).toEqual(
-        path.join(path.sep, 'test-project', 'node_modules', 'custom-react-scripts')
+        join(sep, 'test-project', 'node_modules', 'custom-react-scripts')
       );
     });
   });
@@ -69,7 +69,7 @@ exit $ret`
 
     it('should locate the react-scripts package', () => {
       expect(getReactScriptsPath({ noCache: true })).toEqual(
-        path.join(path.sep, 'test-project', 'node_modules', 'custom-react-scripts')
+        join(sep, 'test-project', 'node_modules', 'custom-react-scripts')
       );
     });
   });

--- a/code/presets/react-webpack/src/loaders/docgen-resolver.ts
+++ b/code/presets/react-webpack/src/loaders/docgen-resolver.ts
@@ -1,4 +1,5 @@
-import { extname } from 'path';
+import { extname } from 'node:path';
+
 import resolve from 'resolve';
 
 export class ReactDocgenResolveError extends Error {

--- a/code/presets/server-webpack/src/lib/compiler/json-to-csf-compiler.test.ts
+++ b/code/presets/server-webpack/src/lib/compiler/json-to-csf-compiler.test.ts
@@ -1,7 +1,8 @@
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import fs from 'fs-extra';
-import path from 'path';
 import YAML from 'yaml';
 
 import { compileCsfModule } from '.';
@@ -16,12 +17,12 @@ async function generate(filePath: string) {
   const inputRegExp = new RegExp(`.${fileType}$`);
 
   describe(`${fileType}-to-csf-compiler`, () => {
-    const transformFixturesDir = path.join(__dirname, '__testfixtures__');
+    const transformFixturesDir = join(__dirname, '__testfixtures__');
     fs.readdirSync(transformFixturesDir)
       .filter((fileName: string) => inputRegExp.test(fileName))
       .forEach((fixtureFile: string) => {
         it(`${fixtureFile}`, async () => {
-          const inputPath = path.join(transformFixturesDir, fixtureFile);
+          const inputPath = join(transformFixturesDir, fixtureFile);
           const code = await generate(inputPath);
           expect(code).toMatchFileSnapshot(inputPath.replace(inputRegExp, '.snapshot'));
         });

--- a/code/presets/svelte-webpack/src/svelte-docgen-loader.ts
+++ b/code/presets/svelte-webpack/src/svelte-docgen-loader.ts
@@ -1,7 +1,8 @@
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+
 import { logger } from 'storybook/internal/node-logger';
 
-import * as fs from 'fs';
-import * as path from 'path';
 import { preprocess } from 'svelte/compiler';
 import svelteDoc from 'sveltedoc-parser';
 import { dedent } from 'ts-dedent';
@@ -72,7 +73,7 @@ export default async function svelteDocgen(this: any, source: string) {
 
   let docOptions;
   if (preprocessOptions) {
-    const src = fs.readFileSync(resource).toString();
+    const src = await readFile(resource).toString();
 
     const { code: fileContent } = await preprocess(src, preprocessOptions);
     docOptions = {
@@ -103,10 +104,10 @@ export default async function svelteDocgen(this: any, source: string) {
   }
 
   // get filename for source content
-  const file = path.basename(resource);
+  const file = basename(resource);
 
   // populate filename in docgen
-  componentDoc.name = path.basename(file);
+  componentDoc.name = basename(file);
 
   const componentName = getNameFromFilename(resource);
 

--- a/code/renderers/html/src/preset.ts
+++ b/code/renderers/html/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { join } from 'node:path';
 
-import { join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   input = [],

--- a/code/renderers/preact/src/preset.ts
+++ b/code/renderers/preact/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { join } from 'node:path';
 
-import { join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   input = [],

--- a/code/renderers/react/src/docs/extractArgTypes.test.ts
+++ b/code/renderers/react/src/docs/extractArgTypes.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { normalizeNewlines } from 'storybook/internal/docs-tools';
@@ -5,8 +8,6 @@ import { inferControls } from 'storybook/internal/preview-api';
 import type { Renderer } from 'storybook/internal/types';
 
 import { transformFileSync, transformSync } from '@babel/core';
-import fs from 'fs';
-import path from 'path';
 // @ts-expect-error (seems broken/missing)
 import requireFromString from 'require-from-string';
 
@@ -61,21 +62,21 @@ const skippedTests = [
 
 describe('react component properties', () => {
   // Fixture files are in template/stories
-  const fixturesDir = path.resolve(__dirname, '../../template/stories/docgen-components');
-  fs.readdirSync(fixturesDir, { withFileTypes: true }).forEach((testEntry) => {
+  const fixturesDir = resolve(__dirname, '../../template/stories/docgen-components');
+  readdirSync(fixturesDir, { withFileTypes: true }).forEach((testEntry) => {
     if (testEntry.isDirectory()) {
-      const testDir = path.join(fixturesDir, testEntry.name);
-      const testFile = fs.readdirSync(testDir).find((fileName) => inputRegExp.test(fileName));
+      const testDir = join(fixturesDir, testEntry.name);
+      const testFile = readdirSync(testDir).find((fileName) => inputRegExp.test(fileName));
       if (testFile) {
         if (skippedTests.includes(testEntry.name)) {
           it.skip(`${testEntry.name}`, () => {});
         } else {
           it(`${testEntry.name}`, () => {
-            const inputPath = path.join(testDir, testFile);
+            const inputPath = join(testDir, testFile);
 
             // snapshot the output of babel-plugin-react-docgen
             const docgenPretty = annotateWithDocgen(inputPath);
-            expect(docgenPretty).toMatchFileSnapshot(path.join(testDir, 'docgen.snapshot'));
+            expect(docgenPretty).toMatchFileSnapshot(join(testDir, 'docgen.snapshot'));
 
             // transform into an uglier format that's works with require-from-string
             const docgenModule = transformToModule(docgenPretty);
@@ -83,7 +84,7 @@ describe('react component properties', () => {
             // snapshot the output of component-properties/react
             const { component } = requireFromString(docgenModule, inputPath);
             const properties = extractProps(component);
-            expect(properties).toMatchFileSnapshot(path.join(testDir, 'properties.snapshot'));
+            expect(properties).toMatchFileSnapshot(join(testDir, 'properties.snapshot'));
 
             // snapshot the output of `extractArgTypes`
             const argTypes = extractArgTypes(component);
@@ -92,7 +93,7 @@ describe('react component properties', () => {
               argTypes,
               parameters,
             } as unknown as StoryContext<Renderer>);
-            expect(rows).toMatchFileSnapshot(path.join(testDir, 'argTypes.snapshot'));
+            expect(rows).toMatchFileSnapshot(join(testDir, 'argTypes.snapshot'));
           });
         }
       }

--- a/code/renderers/react/src/preset.ts
+++ b/code/renderers/react/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { dirname, join } from 'node:path';
 
-import { dirname, join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 export const addons: PresetProperty<'addons'> = [
   require.resolve('@storybook/react-dom-shim/dist/preset'),

--- a/code/renderers/server/src/preset.ts
+++ b/code/renderers/server/src/preset.ts
@@ -1,7 +1,8 @@
+import { join } from 'node:path';
+
 import type { ComponentTitle, PresetProperty, StoryName, Tag } from 'storybook/internal/types';
 
 import fs from 'fs-extra';
-import { join } from 'path';
 import yaml from 'yaml';
 
 type FileContent = {

--- a/code/renderers/svelte/src/docs/extractArgTypes.test.ts
+++ b/code/renderers/svelte/src/docs/extractArgTypes.test.ts
@@ -1,11 +1,12 @@
+import { readFileSync } from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 
-import * as fs from 'fs';
 import svelteDoc from 'sveltedoc-parser';
 
 import { createArgTypes } from './extractArgTypes';
 
-const content = fs.readFileSync(`${__dirname}/sample/MockButton.svelte`, 'utf-8');
+const content = readFileSync(`${__dirname}/sample/MockButton.svelte`, 'utf-8');
 describe('Extracting Arguments', () => {
   it('should be svelte', () => {
     expect(content).toMatchInlineSnapshot(`

--- a/code/renderers/svelte/src/preset.ts
+++ b/code/renderers/svelte/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { join } from 'node:path';
 
-import { join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   input = [],

--- a/code/renderers/vue3/src/preset.ts
+++ b/code/renderers/vue3/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { join } from 'node:path';
 
-import { join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   input = [],

--- a/code/renderers/web-components/src/preset.ts
+++ b/code/renderers/web-components/src/preset.ts
@@ -1,6 +1,6 @@
-import type { PresetProperty } from 'storybook/internal/types';
+import { join } from 'node:path';
 
-import { join } from 'path';
+import type { PresetProperty } from 'storybook/internal/types';
 
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   input = [],

--- a/scripts/create-nx-sandbox-projects.ts
+++ b/scripts/create-nx-sandbox-projects.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import * as templates from '../code/lib/cli-storybook/src/sandbox-templates';
 
@@ -31,7 +31,7 @@ const projectJson = (name: string, framework: string, tags: string[]) => ({
 });
 Object.entries(allTemplates).forEach(([key, value]) => {
   const p = key.replaceAll('/', '-');
-  const full = path.join(process.cwd(), '../code/sandbox', p, 'project.json');
+  const full = join(process.cwd(), '../code/sandbox', p, 'project.json');
 
   console.log(full);
   const framework = value.expected.framework.replace('@storybook/', '');
@@ -44,7 +44,7 @@ Object.entries(allTemplates).forEach(([key, value]) => {
   ];
   ensureDirectoryExistence(full);
   console.log(full);
-  fs.writeFileSync(
+  writeFileSync(
     full,
     '// auto-generated from scripts/create-nx-sandbox-projects.ts\n' +
       JSON.stringify(projectJson(key, framework, tags), null, 2),
@@ -55,10 +55,10 @@ Object.entries(allTemplates).forEach(([key, value]) => {
 });
 
 function ensureDirectoryExistence(filePath: string): void {
-  const dirname = path.dirname(filePath);
-  if (fs.existsSync(dirname)) {
+  const dir = dirname(filePath);
+  if (existsSync(dir)) {
     return;
   }
-  ensureDirectoryExistence(dirname);
-  fs.mkdirSync(dirname);
+  ensureDirectoryExistence(dir);
+  mkdirSync(dir);
 }

--- a/scripts/prepare/addon-bundle.ts
+++ b/scripts/prepare/addon-bundle.ts
@@ -1,7 +1,7 @@
 import aliasPlugin from 'esbuild-plugin-alias';
 import * as fs from 'fs-extra';
 import { glob } from 'glob';
-import path, { dirname, join, relative } from 'path';
+import { dirname, join, parse, posix, relative, sep } from 'path';
 import slash from 'slash';
 import { dedent } from 'ts-dedent';
 import type { Options } from 'tsup';
@@ -250,11 +250,11 @@ function getESBuildOptions(optimized: boolean) {
 }
 
 async function generateDTSMapperFile(file: string) {
-  const { name: entryName, dir } = path.parse(file);
+  const { name: entryName, dir } = parse(file);
 
   const pathName = join(process.cwd(), dir.replace('./src', 'dist'), `${entryName}.d.ts`);
   const srcName = join(process.cwd(), file);
-  const rel = relative(dirname(pathName), dirname(srcName)).split(path.sep).join(path.posix.sep);
+  const rel = relative(dirname(pathName), dirname(srcName)).split(sep).join(posix.sep);
 
   await fs.ensureFile(pathName);
   await fs.writeFile(

--- a/scripts/prepare/bundle.ts
+++ b/scripts/prepare/bundle.ts
@@ -1,7 +1,8 @@
+import { dirname, join, parse, posix, relative, resolve, sep } from 'node:path';
+
 import aliasPlugin from 'esbuild-plugin-alias';
 import * as fs from 'fs-extra';
 import { glob } from 'glob';
-import path, { dirname, join, relative } from 'path';
 import slash from 'slash';
 import { dedent } from 'ts-dedent';
 import type { Options } from 'tsup';
@@ -79,7 +80,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
    * Generating an ESM file for them anyway is problematic because they often have a reference to `require`.
    * TSUP generated code will then have a `require` polyfill/guard in the ESM files, which causes issues for webpack.
    */
-  const nonPresetEntries = allEntries.filter((f) => !path.parse(f).name.includes('preset'));
+  const nonPresetEntries = allEntries.filter((f) => !parse(f).name.includes('preset'));
 
   const noExternal = [...extraNoExternal];
 
@@ -104,8 +105,8 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
             ? []
             : [
                 aliasPlugin({
-                  process: path.resolve('../node_modules/process/browser.js'),
-                  util: path.resolve('../node_modules/util/util.js'),
+                  process: resolve('../node_modules/process/browser.js'),
+                  util: resolve('../node_modules/util/util.js'),
                 }),
               ],
         external: externals,
@@ -207,11 +208,11 @@ function getESBuildOptions(optimized: boolean) {
 }
 
 async function generateDTSMapperFile(file: string) {
-  const { name: entryName, dir } = path.parse(file);
+  const { name: entryName, dir } = parse(file);
 
   const pathName = join(process.cwd(), dir.replace('./src', 'dist'), `${entryName}.d.ts`);
   const srcName = join(process.cwd(), file);
-  const rel = relative(dirname(pathName), dirname(srcName)).split(path.sep).join(path.posix.sep);
+  const rel = relative(dirname(pathName), dirname(srcName)).split(sep).join(posix.sep);
 
   await fs.ensureFile(pathName);
   await fs.writeFile(

--- a/scripts/prepare/tsc.ts
+++ b/scripts/prepare/tsc.ts
@@ -1,4 +1,4 @@
-import fs, { move } from 'fs-extra';
+import { emptyDir, move, readJson } from 'fs-extra';
 import { globSync } from 'glob';
 import { join } from 'path';
 import * as ts from 'typescript';
@@ -10,7 +10,7 @@ const hasFlag = (flags: string[], name: string) => !!flags.find((s) => s.startsW
 const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
   const {
     bundler: { pre, post, tsConfig: tsconfigPath = 'tsconfig.json' },
-  } = await fs.readJson(join(cwd, 'package.json'));
+  } = await readJson(join(cwd, 'package.json'));
 
   if (pre) {
     await exec(`jiti ${pre}`, { cwd });
@@ -21,7 +21,7 @@ const run = async ({ cwd, flags }: { cwd: string; flags: string[] }) => {
   // const optimized = hasFlag(flags, 'optimized');
 
   if (reset) {
-    await fs.emptyDir(join(process.cwd(), 'dist'));
+    await emptyDir(join(process.cwd(), 'dist'));
   }
 
   const content = ts.readJsonConfigFile(tsconfigPath, ts.sys.readFile);

--- a/scripts/release/__tests__/is-pr-frozen.test.ts
+++ b/scripts/release/__tests__/is-pr-frozen.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-underscore-dangle */
+import { join } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import * as fsExtraImp from 'fs-extra';
-import path from 'path';
 import * as simpleGitImp from 'simple-git';
 
 import type * as MockedFSExtra from '../../../code/__mocks__/fs-extra';
@@ -18,7 +19,7 @@ vi.mock('fs-extra', async () => import('../../../code/__mocks__/fs-extra'));
 const fsExtra = fsExtraImp as unknown as typeof MockedFSExtra;
 const simpleGit = simpleGitImp as unknown as typeof MockedSimpleGit;
 
-const CODE_PACKAGE_JSON_PATH = path.join(CODE_DIRECTORY, 'package.json');
+const CODE_PACKAGE_JSON_PATH = join(CODE_DIRECTORY, 'package.json');
 
 fsExtra.__setMockFiles({
   [CODE_PACKAGE_JSON_PATH]: JSON.stringify({ version: '1.0.0' }),

--- a/scripts/release/__tests__/version.test.ts
+++ b/scripts/release/__tests__/version.test.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-underscore-dangle */
+import { join } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import { execaCommand } from 'execa';
 import * as fsExtraImp from 'fs-extra';
-import path from 'path';
 
 import type * as MockedFSToExtra from '../../../code/__mocks__/fs-extra';
 import { run as version } from '../version';
@@ -31,17 +32,11 @@ vi.spyOn(console, 'warn').mockImplementation(() => {});
 vi.spyOn(console, 'error').mockImplementation(() => {});
 
 describe('Version', () => {
-  const CODE_DIR_PATH = path.join(__dirname, '..', '..', '..', 'code');
-  const CODE_PACKAGE_JSON_PATH = path.join(CODE_DIR_PATH, 'package.json');
-  const MANAGER_API_VERSION_PATH = path.join(
-    CODE_DIR_PATH,
-    'core',
-    'src',
-    'manager-api',
-    'version.ts'
-  );
-  const VERSIONS_PATH = path.join(CODE_DIR_PATH, 'core', 'src', 'common', 'versions.ts');
-  const A11Y_PACKAGE_JSON_PATH = path.join(CODE_DIR_PATH, 'addons', 'a11y', 'package.json');
+  const CODE_DIR_PATH = join(__dirname, '..', '..', '..', 'code');
+  const CODE_PACKAGE_JSON_PATH = join(CODE_DIR_PATH, 'package.json');
+  const MANAGER_API_VERSION_PATH = join(CODE_DIR_PATH, 'core', 'src', 'manager-api', 'version.ts');
+  const VERSIONS_PATH = join(CODE_DIR_PATH, 'core', 'src', 'common', 'versions.ts');
+  const A11Y_PACKAGE_JSON_PATH = join(CODE_DIR_PATH, 'addons', 'a11y', 'package.json');
 
   it('should throw when release type is invalid', async () => {
     fsExtra.__setMockFiles({

--- a/scripts/release/__tests__/version.test.ts
+++ b/scripts/release/__tests__/version.test.ts
@@ -280,7 +280,7 @@ describe('Version', () => {
         { spaces: 2 }
       );
       expect(execaCommand).toHaveBeenCalledWith('yarn install --mode=update-lockfile', {
-        cwd: path.join(CODE_DIR_PATH),
+        cwd: join(CODE_DIR_PATH),
         cleanup: true,
         stdio: undefined,
       });

--- a/scripts/release/__tests__/write-changelog.test.ts
+++ b/scripts/release/__tests__/write-changelog.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-underscore-dangle */
+import { join } from 'node:path';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as fsExtraImp from 'fs-extra';
-import path from 'path';
 import { dedent } from 'ts-dedent';
 
 import type * as MockedFSToExtra from '../../../code/__mocks__/fs-extra';
@@ -29,18 +30,10 @@ beforeEach(() => {
   });
 });
 
-const STABLE_CHANGELOG_PATH = path.join(__dirname, '..', '..', '..', 'CHANGELOG.md');
-const PRERELEASE_CHANGELOG_PATH = path.join(__dirname, '..', '..', '..', 'CHANGELOG.prerelease.md');
-const LATEST_VERSION_PATH = path.join(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'docs',
-  'versions',
-  'latest.json'
-);
-const NEXT_VERSION_PATH = path.join(__dirname, '..', '..', '..', 'docs', 'versions', 'next.json');
+const STABLE_CHANGELOG_PATH = join(__dirname, '..', '..', '..', 'CHANGELOG.md');
+const PRERELEASE_CHANGELOG_PATH = join(__dirname, '..', '..', '..', 'CHANGELOG.prerelease.md');
+const LATEST_VERSION_PATH = join(__dirname, '..', '..', '..', 'docs', 'versions', 'latest.json');
+const NEXT_VERSION_PATH = join(__dirname, '..', '..', '..', 'docs', 'versions', 'next.json');
 
 const EXISTING_STABLE_CHANGELOG = dedent`## 7.0.0
 

--- a/scripts/release/get-changelog-from-file.ts
+++ b/scripts/release/get-changelog-from-file.ts
@@ -1,8 +1,9 @@
+import { join } from 'node:path';
+
 import { setOutput } from '@actions/core';
 import chalk from 'chalk';
 import { program } from 'commander';
 import { readFile } from 'fs-extra';
-import path from 'path';
 import semver from 'semver';
 import { dedent } from 'ts-dedent';
 
@@ -26,7 +27,7 @@ export const getChangelogFromFile = async (args: {
   const version = args.version || (await getCurrentVersion());
   const isPrerelease = semver.prerelease(version) !== null;
   const changelogFilename = isPrerelease ? 'CHANGELOG.prerelease.md' : 'CHANGELOG.md';
-  const changelogPath = path.join(__dirname, '..', '..', changelogFilename);
+  const changelogPath = join(__dirname, '..', '..', changelogFilename);
 
   console.log(`📝 Getting changelog from ${chalk.blue(changelogPath)}`);
 

--- a/scripts/release/get-current-version.ts
+++ b/scripts/release/get-current-version.ts
@@ -1,12 +1,13 @@
+import { join } from 'node:path';
+
 import { setOutput } from '@actions/core';
 import chalk from 'chalk';
 import { readJson } from 'fs-extra';
-import path from 'path';
 
 import { esMain } from '../utils/esmain';
 
-const CODE_DIR_PATH = path.join(__dirname, '..', '..', 'code');
-const CODE_PACKAGE_JSON_PATH = path.join(CODE_DIR_PATH, 'package.json');
+const CODE_DIR_PATH = join(__dirname, '..', '..', 'code');
+const CODE_PACKAGE_JSON_PATH = join(CODE_DIR_PATH, 'package.json');
 
 export const getCurrentVersion = async () => {
   console.log(`📐 Reading current version of Storybook...`);

--- a/scripts/release/is-pr-frozen.ts
+++ b/scripts/release/is-pr-frozen.ts
@@ -1,8 +1,9 @@
+import { join } from 'node:path';
+
 import { setOutput } from '@actions/core';
 import chalk from 'chalk';
 import program from 'commander';
 import { readJson } from 'fs-extra';
-import path from 'path';
 
 import { esMain } from '../utils/esmain';
 import { getPullInfoFromCommit } from './utils/get-github-info';
@@ -16,8 +17,8 @@ program
   .option('-H, --patch', 'Look for patch PR instead of next PR', false)
   .option('-V, --verbose', 'Enable verbose logging', false);
 
-const CODE_DIR_PATH = path.join(__dirname, '..', '..', 'code');
-const CODE_PACKAGE_JSON_PATH = path.join(CODE_DIR_PATH, 'package.json');
+const CODE_DIR_PATH = join(__dirname, '..', '..', 'code');
+const CODE_PACKAGE_JSON_PATH = join(CODE_DIR_PATH, 'package.json');
 
 const getCurrentVersion = async () => {
   console.log(`📐 Reading current version of Storybook...`);

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -1,9 +1,10 @@
+import { join } from 'node:path';
+
 import chalk from 'chalk';
 import program from 'commander';
 import { execaCommand } from 'execa';
 import { readJson } from 'fs-extra';
 import pRetry from 'p-retry';
-import path from 'path';
 import semver from 'semver';
 import dedent from 'ts-dedent';
 import { z } from 'zod';
@@ -37,8 +38,8 @@ type Options = {
   dryRun?: boolean;
 };
 
-const CODE_DIR_PATH = path.join(__dirname, '..', '..', 'code');
-const CODE_PACKAGE_JSON_PATH = path.join(CODE_DIR_PATH, 'package.json');
+const CODE_DIR_PATH = join(__dirname, '..', '..', 'code');
+const CODE_PACKAGE_JSON_PATH = join(CODE_DIR_PATH, 'package.json');
 
 const validateOptions = (options: { [key: string]: any }): options is Options => {
   optionsSchema.parse(options);

--- a/scripts/release/version.ts
+++ b/scripts/release/version.ts
@@ -1,9 +1,10 @@
+import { join } from 'node:path';
+
 import { setOutput } from '@actions/core';
 import chalk from 'chalk';
 import program from 'commander';
 import { execaCommand } from 'execa';
 import { readFile, readJson, writeFile, writeJson } from 'fs-extra';
-import path from 'path';
 import semver from 'semver';
 import { z } from 'zod';
 
@@ -100,8 +101,8 @@ type ApplyOptions = BaseOptions & {
 };
 type Options = BumpOptions | ExactOptions | ApplyOptions;
 
-const CODE_DIR_PATH = path.join(__dirname, '..', '..', 'code');
-const CODE_PACKAGE_JSON_PATH = path.join(CODE_DIR_PATH, 'package.json');
+const CODE_DIR_PATH = join(__dirname, '..', '..', 'code');
+const CODE_PACKAGE_JSON_PATH = join(CODE_DIR_PATH, 'package.json');
 
 const validateOptions = (options: { [key: string]: any }): options is Options => {
   optionsSchema.parse(options);
@@ -127,8 +128,8 @@ const bumpCodeVersion = async (nextVersion: string) => {
 
 const bumpVersionSources = async (currentVersion: string, nextVersion: string) => {
   const filesToUpdate = [
-    path.join(CODE_DIR_PATH, 'core', 'src', 'manager-api', 'version.ts'),
-    path.join(CODE_DIR_PATH, 'core', 'src', 'common', 'versions.ts'),
+    join(CODE_DIR_PATH, 'core', 'src', 'manager-api', 'version.ts'),
+    join(CODE_DIR_PATH, 'core', 'src', 'common', 'versions.ts'),
   ];
   console.log(`🤜 Bumping versions in...:\n  ${chalk.cyan(filesToUpdate.join('\n  '))}`);
 
@@ -161,7 +162,7 @@ const bumpAllPackageJsons = async ({
   await Promise.all(
     packages.map(async (pkg) => {
       // 2. get the package.json
-      const packageJsonPath = path.join(CODE_DIR_PATH, pkg.location, 'package.json');
+      const packageJsonPath = join(CODE_DIR_PATH, pkg.location, 'package.json');
       const packageJson: {
         version: string;
         [key: string]: any;
@@ -285,7 +286,7 @@ export const run = async (options: unknown) => {
 
     console.log(`⬆️ Updating lock file with ${chalk.blue('yarn install --mode=update-lockfile')}`);
     await execaCommand(`yarn install --mode=update-lockfile`, {
-      cwd: path.join(CODE_DIR_PATH),
+      cwd: join(CODE_DIR_PATH),
       stdio: verbose ? 'inherit' : undefined,
       cleanup: true,
     });

--- a/scripts/release/write-changelog.ts
+++ b/scripts/release/write-changelog.ts
@@ -1,7 +1,8 @@
+import { join } from 'node:path';
+
 import chalk from 'chalk';
 import program from 'commander';
 import { readFile, writeFile, writeJson } from 'fs-extra';
-import path from 'path';
 import semver from 'semver';
 import { z } from 'zod';
 
@@ -66,7 +67,7 @@ const writeToChangelogFile = async ({
 }) => {
   const isPrerelease = semver.prerelease(version) !== null;
   const changelogFilename = isPrerelease ? 'CHANGELOG.prerelease.md' : 'CHANGELOG.md';
-  const changelogPath = path.join(__dirname, '..', '..', changelogFilename);
+  const changelogPath = join(__dirname, '..', '..', changelogFilename);
 
   if (verbose) {
     console.log(`📝 Writing changelog to ${chalk.blue(changelogPath)}`);
@@ -89,10 +90,10 @@ const writeToDocsVersionFile = async ({
 }) => {
   const isPrerelease = semver.prerelease(version) !== null;
   const filename = isPrerelease ? 'next.json' : 'latest.json';
-  const filepath = path.join(__dirname, '..', '..', 'docs', 'versions', filename);
+  const filepath = join(__dirname, '..', '..', 'docs', 'versions', filename);
 
   if (verbose) {
-    console.log(`📝 Writing changelog to ${chalk.blue(path)}`);
+    console.log(`📝 Writing changelog to ${chalk.blue(filepath)}`);
   }
 
   const textWithoutHeading = changelogText.split('\n').slice(2).join('\n').replaceAll('"', '\\"');

--- a/scripts/reset.js
+++ b/scripts/reset.js
@@ -1,11 +1,12 @@
-import { spawn } from 'child_process';
-import fs from 'fs';
+import { spawn } from 'node:child_process';
+import { appendFile, writeFileSync } from 'node:fs';
+
 import { remove } from 'fs-extra';
 import trash from 'trash';
 
 const logger = console;
 
-fs.writeFileSync('reset.log', '');
+writeFileSync('reset.log', '');
 
 const cleaningProcess = spawn('git', [
   'clean',
@@ -47,7 +48,7 @@ cleaningProcess.stdout.on('data', (data) => {
         }
       });
   }
-  fs.appendFile('reset.log', data, (err) => {
+  appendFile('reset.log', data, (err) => {
     if (err) {
       throw err;
     }

--- a/scripts/strict-ts.ts
+++ b/scripts/strict-ts.ts
@@ -1,5 +1,5 @@
-import fsSync from 'node:fs';
-import path from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import glob from 'fast-glob';
 import JSON5 from 'json5';
@@ -13,16 +13,16 @@ const files = glob.sync('**/*/tsconfig.json', {
   const packages = files
     .filter((file) => !file.includes('node_modules') && !file.includes('dist'))
     .map((file) => {
-      const packageJson = path.join(path.dirname(file), 'package.json');
+      const packageJson = join(dirname(file), 'package.json');
       let packageName;
-      if (fsSync.existsSync(packageJson)) {
-        const json = fsSync.readFileSync(packageJson, { encoding: 'utf-8' });
+      if (existsSync(packageJson)) {
+        const json = readFileSync(packageJson, { encoding: 'utf-8' });
         packageName = JSON5.parse(json).name;
       }
 
       let strict;
-      if (fsSync.existsSync(file)) {
-        const tsconfig = fsSync.readFileSync(file, { encoding: 'utf-8' });
+      if (existsSync(file)) {
+        const tsconfig = readFileSync(file, { encoding: 'utf-8' });
         const tsconfigJson = JSON5.parse(tsconfig);
         strict = tsconfigJson?.compilerOptions?.strict ?? false;
       }

--- a/scripts/tasks/sync-docs.ts
+++ b/scripts/tasks/sync-docs.ts
@@ -1,5 +1,15 @@
-import fs from 'fs';
-import path from 'path';
+import {
+  closeSync,
+  copyFile,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  rmSync,
+  unlinkSync,
+  watch,
+} from 'node:fs';
+import { join } from 'node:path';
 
 import type { Task } from '../task';
 import { ask } from '../utils/ask';
@@ -13,45 +23,45 @@ export const syncDocs: Task = {
     return false;
   },
   async run() {
-    const rootDir = path.join(__dirname, '..', '..');
-    const docsDir = path.join(rootDir, 'docs');
+    const rootDir = join(__dirname, '..', '..');
+    const docsDir = join(rootDir, 'docs');
     let frontpageDocsPath = '/src/content/docs';
 
     const frontpagePath = await ask('Provide the frontpage project path:');
-    frontpageDocsPath = path.join(rootDir, frontpagePath, frontpageDocsPath);
+    frontpageDocsPath = join(rootDir, frontpagePath, frontpageDocsPath);
 
-    if (!fs.existsSync(frontpageDocsPath)) {
-      fs.mkdirSync(frontpageDocsPath);
+    if (!existsSync(frontpageDocsPath)) {
+      mkdirSync(frontpageDocsPath);
     }
 
     logger.info(`Rebuilding docs at ${frontpageDocsPath}`);
 
-    fs.rmSync(frontpageDocsPath, { recursive: true });
-    fs.cpSync(docsDir, frontpageDocsPath, { recursive: true });
+    rmSync(frontpageDocsPath, { recursive: true });
+    cpSync(docsDir, frontpageDocsPath, { recursive: true });
 
     logger.info(`Synchronizing files from: \n${docsDir} \nto: \n${frontpageDocsPath}`);
 
-    fs.watch(docsDir, { recursive: true }, (_, filename) => {
-      const srcFilePath = path.join(docsDir, filename);
-      const targetFilePath = path.join(frontpageDocsPath, filename);
+    watch(docsDir, { recursive: true }, (_, filename) => {
+      const srcFilePath = join(docsDir, filename);
+      const targetFilePath = join(frontpageDocsPath, filename);
       const targetDir = targetFilePath.split('/').slice(0, -1).join('/');
 
       // Syncs create file
-      if (!fs.existsSync(targetFilePath)) {
-        fs.mkdirSync(targetDir, { recursive: true });
-        fs.closeSync(fs.openSync(targetFilePath, 'w'));
+      if (!existsSync(targetFilePath)) {
+        mkdirSync(targetDir, { recursive: true });
+        closeSync(openSync(targetFilePath, 'w'));
         logger.info(`Created ${filename}.`);
       }
 
       // Syncs remove file
-      if (!fs.existsSync(srcFilePath)) {
-        fs.unlinkSync(targetFilePath);
+      if (!existsSync(srcFilePath)) {
+        unlinkSync(targetFilePath);
         logger.info(`Removed ${filename}.`);
         return;
       }
 
       // Syncs update file
-      fs.copyFile(srcFilePath, targetFilePath, (err) => {
+      copyFile(srcFilePath, targetFilePath, (err) => {
         logger.info(`Updated ${filename}.`);
         if (err) throw err;
       });

--- a/scripts/utils/esmain.ts
+++ b/scripts/utils/esmain.ts
@@ -1,7 +1,7 @@
-import { createRequire } from 'module';
-import path from 'path';
-import process from 'process';
-import { fileURLToPath } from 'url';
+import { createRequire } from 'node:module';
+import { extname } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Strip the extension from a filename if it has one.
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url';
  * @return {string} The filename without a path.
  */
 export function stripExt(name: string) {
-  const extension = path.extname(name);
+  const extension = extname(name);
   if (!extension) {
     return name;
   }
@@ -31,7 +31,7 @@ export function esMain(url: string) {
 
   const modulePath = fileURLToPath(url);
 
-  const extension = path.extname(scriptPath);
+  const extension = extname(scriptPath);
   if (extension) {
     return modulePath === scriptPath;
   }

--- a/scripts/utils/filterExistsInCodeDir.ts
+++ b/scripts/utils/filterExistsInCodeDir.ts
@@ -1,5 +1,6 @@
+import { join, resolve } from 'node:path';
+
 import { pathExists } from 'fs-extra';
-import path from 'path';
 
 import { CODE_DIRECTORY } from './constants';
 
@@ -9,7 +10,7 @@ export const filterExistsInCodeDir = async (packageDirs: string[], pathToCheck: 
   (
     await Promise.all(
       packageDirs.map(async (p) =>
-        (await pathExists(path.resolve(CODE_DIRECTORY, path.join(p, pathToCheck)))) ? p : null
+        (await pathExists(resolve(CODE_DIRECTORY, join(p, pathToCheck)))) ? p : null
       )
     )
   ).filter(Boolean);

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -1,5 +1,6 @@
+import { join } from 'node:path';
+
 import { pathExists, readJSON, writeJSON } from 'fs-extra';
-import path from 'path';
 
 // TODO -- should we generate this file a second time outside of CLI?
 import storybookVersions from '../../code/core/src/common/versions';
@@ -19,7 +20,7 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
   logger.info(`🔢 Adding package resolutions:`);
   if (dryRun) return;
 
-  const packageJsonPath = path.join(cwd, 'package.json');
+  const packageJsonPath = join(cwd, 'package.json');
   const packageJson = await readJSON(packageJsonPath);
   packageJson.resolutions = {
     ...packageJson.resolutions,
@@ -35,7 +36,7 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
 };
 
 export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
-  const pnpApiExists = await pathExists(path.join(cwd, '.pnp.cjs'));
+  const pnpApiExists = await pathExists(join(cwd, '.pnp.cjs'));
 
   const command = [
     touch('yarn.lock'),
@@ -67,7 +68,7 @@ export const addWorkaroundResolutions = async ({ cwd, dryRun }: YarnOptions) => 
   logger.info(`🔢 Adding resolutions for workarounds`);
   if (dryRun) return;
 
-  const packageJsonPath = path.join(cwd, 'package.json');
+  const packageJsonPath = join(cwd, 'package.json');
   const packageJson = await readJSON(packageJsonPath);
   packageJson.resolutions = {
     ...packageJson.resolutions,

--- a/scripts/vite-ecosystem-ci/before-test.js
+++ b/scripts/vite-ecosystem-ci/before-test.js
@@ -3,30 +3,28 @@
  * This is necessary because the sandbox package.json is used to run the tests and the resolutions are needed to run the tests.
  * The vite-ecosystem-ci, though, sets the resolutions in the root package.json.
  */
-import fs from 'node:fs';
-import path from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+
 import { fileURLToPath } from 'node:url';
 
 import { execa, execaCommand } from 'execa';
 
 const filename = fileURLToPath(import.meta.url);
-const dirname = path.dirname(filename);
+const dirname = dirname(filename);
 
-const rootPackageJsonPath = path.resolve(dirname, '../../package.json');
-const sandboxPackageJsonPath = path.resolve(
-  dirname,
-  '../../sandbox/react-vite-default-ts/package.json'
-);
+const rootPackageJsonPath = resolve(dirname, '../../package.json');
+const sandboxPackageJsonPath = resolve(dirname, '../../sandbox/react-vite-default-ts/package.json');
 
-const rootPackageJson = JSON.parse(await fs.promises.readFile(rootPackageJsonPath, 'utf-8'));
-const sandboxPackageJson = JSON.parse(await fs.promises.readFile(sandboxPackageJsonPath, 'utf-8'));
+const rootPackageJson = JSON.parse(await readFile(rootPackageJsonPath, 'utf-8'));
+const sandboxPackageJson = JSON.parse(await readFile(sandboxPackageJsonPath, 'utf-8'));
 
 sandboxPackageJson.resolutions = {
   ...(sandboxPackageJson.resolutions ?? {}),
   ...rootPackageJson.resolutions,
 };
 
-await fs.promises.writeFile(sandboxPackageJsonPath, JSON.stringify(sandboxPackageJson, null, 2));
-const sandboxFolder = path.dirname(sandboxPackageJsonPath);
+await writeFile(sandboxPackageJsonPath, JSON.stringify(sandboxPackageJson, null, 2));
+const sandboxFolder = dirname(sandboxPackageJsonPath);
 await execa('yarn add playwright', { cwd: sandboxFolder, shell: true });
 await execaCommand('yarn playwright install', { cwd: sandboxFolder, shell: true });


### PR DESCRIPTION
## What I did

Node core modules (`fs`, `path`, etc) should be imported with a `node:` prefix to ensure the modules isn't accidentally resolve from `node_modules`, or a local file.

Besides getting the intent clear, it also means the formatting (order of imports) is best.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [x] unit tests
- [x] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | -0.3 | 0% |
| initSize |  167 MB | 167 MB | -1.31 kB | -0.62 | 0% |
| diffSize |  91.1 MB | 91.1 MB | -1.31 kB | -0.62 | 0% |
| buildSize |  7.42 MB | 7.42 MB | 0 B | 1.01 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | **-2** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.29 MB | 2.29 MB | 0 B | **2** | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | **-2** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.45 MB | 4.45 MB | 0 B | **2** | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | -0.49 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.1s | 22.3s | 14.2s | 0.61 | 63.7% |
| generateTime |  19.6s | 18.2s | -1s -446ms | -1.1 | -7.9% |
| initTime |  16s | 16.1s | 122ms | -1.2 | 0.8% |
| buildTime |  11.8s | 11.5s | -288ms | -0.85 | -2.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.3s | 7.4s | -839ms | -0.99 | -11.2% |
| devManagerResponsive |  4.8s | 4.5s | -323ms | **-1.29** | 🔰-7.1% |
| devManagerHeaderVisible |  986ms | 803ms | -183ms | -0.19 | -22.8% |
| devManagerIndexVisible |  1s | 833ms | -186ms | -0.2 | -22.3% |
| devStoryVisibleUncached |  1.2s | 1.3s | 99ms | 0.58 | 7.2% |
| devStoryVisible |  1s | 847ms | -188ms | -0.27 | -22.2% |
| devAutodocsVisible |  865ms | 743ms | -122ms | -0.11 | -16.4% |
| devMDXVisible |  798ms | 664ms | -134ms | -0.98 | -20.2% |
| buildManagerHeaderVisible |  768ms | 853ms | 85ms | 0.67 | 10% |
| buildManagerIndexVisible |  776ms | 858ms | 82ms | 0.64 | 9.6% |
| buildStoryVisible |  820ms | 897ms | 77ms | 0.61 | 8.6% |
| buildAutodocsVisible |  748ms | 958ms | 210ms | **2.92** | 🔺21.9% |
| buildMDXVisible |  789ms | 767ms | -22ms | 1.04 | -2.9% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

The pull request updates Node.js core module imports to use the 'node:' prefix across various files, ensuring compatibility with modern Node.js versions and aligning with best practices.

- **`code/addons/controls/src/preset/checkDocsLoaded.ts`**: Updated `path` module imports to `node:path`.
- **`code/addons/docs/src/plugins/mdx-plugin.ts`**: Changed `dirname` and `join` imports to `node:path`.
- **`code/addons/essentials/src/index.ts`**: Replaced `path` module imports with `node:path`.
- **`code/builders/builder-vite/src/codegen-importfn-script.ts`**: Added `node:` prefix to `path` module import.
- **`code/core/src/cli/angular/helpers.ts`**: Updated `fs` and `path` imports to `node:fs` and `node:path`.

These changes ensure explicit recognition of core modules, avoiding potential conflicts and maintaining consistency.

<!-- /greptile_comment -->