### PR TITLE
Core: Enable RSC support when parameters.react is set to true

### DIFF
--- a/code/frameworks/nextjs/src/portable-stories.ts
+++ b/code/frameworks/nextjs/src/portable-stories.ts
@@ -17,7 +17,6 @@ import type {
 
 import type { Meta, ReactRenderer } from '@storybook/react';
 
-import * as rscAnnotations from '../../../renderers/react/src/entry-preview-rsc';
 // ! ATTENTION: This needs to be a relative import so it gets prebundled. This is to avoid ESM issues in Nextjs + Jest setups
 import { INTERNAL_DEFAULT_PROJECT_ANNOTATIONS as reactAnnotations } from '../../../renderers/react/src/portable-stories';
 import * as nextJsAnnotations from './preview';
@@ -49,8 +48,6 @@ export function setProjectAnnotations(
 // This will not be necessary once we have auto preset loading
 const INTERNAL_DEFAULT_PROJECT_ANNOTATIONS: ProjectAnnotations<ReactRenderer> = composeConfigs([
   reactAnnotations,
-  // we only provide the RSC decorator, but not the feature flag. Should be set by the user
-  { decorators: rscAnnotations.decorators },
   nextJsAnnotations,
 ]);
 

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -116,7 +116,7 @@
     "entries": [
       "./src/index.ts",
       "./src/preset.ts",
-      "./src/entry-preview.ts",
+      "./src/entry-preview.tsx",
       "./src/entry-preview-docs.ts",
       "./src/entry-preview-rsc.tsx",
       "./src/playwright.ts"

--- a/code/renderers/react/src/entry-preview-rsc.tsx
+++ b/code/renderers/react/src/entry-preview-rsc.tsx
@@ -1,32 +1,3 @@
-import * as React from 'react';
-
-import type { Addon_DecoratorFunction } from 'storybook/internal/types';
-
-import semver from 'semver';
-
-import type { StoryContext } from './types';
-
-export const ServerComponentDecorator = (
-  Story: React.FC,
-  { parameters }: StoryContext
-): React.ReactNode => {
-  if (!parameters?.react?.rsc) return <Story />;
-
-  const major = semver.major(React.version);
-  const minor = semver.minor(React.version);
-  if (major < 18 || (major === 18 && minor < 3)) {
-    throw new Error('React Server Components require React >= 18.3');
-  }
-
-  return (
-    <React.Suspense>
-      <Story />
-    </React.Suspense>
-  );
-};
-
-export const decorators: Addon_DecoratorFunction<any>[] = [ServerComponentDecorator];
-
 export const parameters = {
   react: {
     rsc: true,

--- a/code/renderers/react/src/entry-preview.ts
+++ b/code/renderers/react/src/entry-preview.ts
@@ -1,4 +1,0 @@
-export const parameters: {} = { renderer: 'react' };
-export { render } from './render';
-export { renderToCanvas } from './renderToCanvas';
-export { mount } from './mount';

--- a/code/renderers/react/src/entry-preview.tsx
+++ b/code/renderers/react/src/entry-preview.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+
 import semver from 'semver';
+
 import type { Decorator } from './public-types';
 
 export const parameters = { renderer: 'react' };

--- a/code/renderers/react/src/entry-preview.tsx
+++ b/code/renderers/react/src/entry-preview.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import semver from 'semver';
+import type { Decorator } from './public-types';
+
+export const parameters = { renderer: 'react' };
+export { render } from './render';
+export { renderToCanvas } from './renderToCanvas';
+export { mount } from './mount';
+
+export const decorators: Decorator[] = [
+  (Story, context) => {
+    if (!context.parameters?.react?.rsc) return <Story />;
+
+    const major = semver.major(React.version);
+    const minor = semver.minor(React.version);
+    if (major < 18 || (major === 18 && minor < 3)) {
+      throw new Error('React Server Components require React >= 18.3');
+    }
+
+    return (
+      <React.Suspense>
+        <Story />
+      </React.Suspense>
+    );
+  },
+];


### PR DESCRIPTION
## What I did

Enable RSC support when parameters.react is set to true

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | -0.33 | 0% |
| initSize |  167 MB | 167 MB | 361 B | -0.85 | 0% |
| diffSize |  91.2 MB | 91.2 MB | 361 B | -0.85 | 0% |
| buildSize |  7.43 MB | 7.46 MB | 24 kB | -0.42 | 0.3% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | -0.7 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | -0.63 | 0% |
| buildSbPreviewSize |  350 kB | 350 kB | 0 B | 0.41 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | -0.68 | 0% |
| buildPreviewSize |  2.97 MB | 3 MB | 24 kB | -0.37 | 0.8% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  16.1s | 8.9s | -7s -233ms | -0.99 | -81.1% |
| generateTime |  19.3s | 23.5s | 4.1s | 0.37 | 17.6% |
| initTime |  16.6s | 18.7s | 2.1s | -0.67 | 11.4% |
| buildTime |  12s | 13.1s | 1.1s | -0.03 | 8.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.1s | 7.5s | -629ms | -1.22 | -8.3% |
| devManagerResponsive |  4.9s | 4.6s | -238ms | **-1.48** | 🔰-5.1% |
| devManagerHeaderVisible |  810ms | 731ms | -79ms | -1.1 | -10.8% |
| devManagerIndexVisible |  840ms | 772ms | -68ms | -1.02 | -8.8% |
| devStoryVisibleUncached |  1.1s | 1.2s | 50ms | -0.7 | 4.1% |
| devStoryVisible |  853ms | 788ms | -65ms | -1.08 | -8.2% |
| devAutodocsVisible |  742ms | 774ms | 32ms | -0.29 | 4.1% |
| devMDXVisible |  701ms | 692ms | -9ms | -0.78 | -1.3% |
| buildManagerHeaderVisible |  849ms | 807ms | -42ms | -0.23 | -5.2% |
| buildManagerIndexVisible |  850ms | 809ms | -41ms | -0.31 | -5.1% |
| buildStoryVisible |  890ms | 849ms | -41ms | -0.28 | -4.8% |
| buildAutodocsVisible |  696ms | 684ms | -12ms | -0.64 | -1.8% |
| buildMDXVisible |  711ms | 701ms | -10ms | -0.53 | -1.4% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

The pull request focuses on enabling React Server Components (RSC) support when `parameters.react` is set to true. Key changes include updates to type definitions, decorators, and ensuring compatibility with React versions 18.3 and above.

- **`code/core/src/preview-api/modules/store/csf/composeConfigs.ts`**: Updated to use `NormalizedProjectAnnotations` for RSC support.
- **`code/renderers/react/src/entry-preview-rsc.tsx`**: Simplified to set `parameters.react.rsc` to true, removing previous decorator logic.
- **`code/renderers/react/src/entry-preview.tsx`**: Added decorator to check React version and wrap story in `React.Suspense` if RSC is enabled.
- **`code/renderers/react/src/portable-stories.tsx`**: Updated `setProjectAnnotations` to return `NormalizedProjectAnnotations<ReactRenderer>`.
- **`code/frameworks/nextjs/src/portable-stories.ts`**: Updated `setProjectAnnotations` to return `NormalizedProjectAnnotations`, aligning with other frameworks.

<!-- /greptile_comment -->