### PR TITLE
Build: Enable Nextjs-Vite sandboxes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -814,22 +814,22 @@ workflows:
           requires:
             - build
       - create-sandboxes:
-          parallelism: 37
+          parallelism: 38
           requires:
             - build
       # - smoke-test-sandboxes: # disabled for now
       #     requires:
       #       - create-sandboxes
       - build-sandboxes:
-          parallelism: 37
+          parallelism: 38
           requires:
             - create-sandboxes
       - chromatic-sandboxes:
-          parallelism: 34
+          parallelism: 35
           requires:
             - build-sandboxes
       - e2e-production:
-          parallelism: 32
+          parallelism: 33
           requires:
             - build-sandboxes
       - e2e-dev:
@@ -837,7 +837,7 @@ workflows:
           requires:
             - create-sandboxes
       - test-runner-production:
-          parallelism: 32
+          parallelism: 33
           requires:
             - build-sandboxes
       - test-portable-stories:

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -208,13 +208,11 @@ const baseTemplates = {
     name: 'Next.js Latest (Vite | TypeScript)',
     script:
       'yarn create next-app {{beforeDir}} --typescript --eslint --tailwind --app --import-alias="@/*" --src-dir',
-    inDevelopment: true,
     expected: {
       framework: '@storybook/experimental-nextjs-vite',
       renderer: '@storybook/react',
       builder: '@storybook/builder-vite',
     },
-
     modifications: {
       mainConfig: {
         framework: '@storybook/experimental-nextjs-vite',

--- a/scripts/tasks/generate.ts
+++ b/scripts/tasks/generate.ts
@@ -28,8 +28,7 @@ export const generate: Task = {
     }
 
     // This uses an async import as it depends on `lib/cli` which requires `code` to be installed.
-    // @ts-expect-error Default import required for dynamic import processed by esbuild
-    const { generate: generateRepro } = (await import('../sandbox/generate.ts')).default;
+    const { generate: generateRepro } = await import('../sandbox/generate');
 
     await generateRepro({
       templates: [details.key],


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | **2.35** | 0% |
| initSize |  167 MB | 167 MB | 0 B | **2** | 0% |
| diffSize |  91.1 MB | 91.1 MB | 0 B | 0.41 | 0% |
| buildSize |  7.42 MB | 7.42 MB | 0 B | 0.73 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | -0.73 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.29 MB | 2.29 MB | 0 B | 0.73 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | -0.73 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.45 MB | 4.45 MB | 0 B | 0.73 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | -0.73 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.6s | 7.9s | 1.2s | -1.15 | 16% |
| generateTime |  19.5s | 20.2s | 711ms | -0.05 | 3.5% |
| initTime |  16.8s | 16.4s | -392ms | -0.43 | -2.4% |
| buildTime |  10.6s | 11.4s | 834ms | -0.35 | 7.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  9.2s | 7.6s | -1s -543ms | -0.74 | -20.1% |
| devManagerResponsive |  4.8s | 4.5s | -302ms | -1 | -6.6% |
| devManagerHeaderVisible |  864ms | 816ms | -48ms | -0.15 | -5.9% |
| devManagerIndexVisible |  891ms | 821ms | -70ms | -0.39 | -8.5% |
| devStoryVisibleUncached |  1.6s | 1.2s | -322ms | -0.21 | -24.9% |
| devStoryVisible |  903ms | 853ms | -50ms | -0.27 | -5.9% |
| devAutodocsVisible |  854ms | 708ms | -146ms | -0.48 | -20.6% |
| devMDXVisible |  900ms | 702ms | -198ms | -0.68 | -28.2% |
| buildManagerHeaderVisible |  811ms | 803ms | -8ms | 0.23 | -1% |
| buildManagerIndexVisible |  813ms | 808ms | -5ms | 0.24 | -0.6% |
| buildStoryVisible |  863ms | 846ms | -17ms | 0.19 | -2% |
| buildAutodocsVisible |  766ms | 740ms | -26ms | 0.32 | -3.5% |
| buildMDXVisible |  708ms | 600ms | -108ms | -1.05 | -18% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request enables Next.js Vite sandboxes in Storybook by removing the 'inDevelopment' flag from the 'experimental-nextjs-vite/default-ts' template.

- Removed 'inDevelopment' flag from 'experimental-nextjs-vite/default-ts' template in `code/lib/cli-storybook/src/sandbox-templates.ts`
- Simplified import of `generate` function in `scripts/tasks/generate.ts`
- Indicates Next.js Vite integration for Storybook is now stable for CI and production use
- Improves code clarity by removing TypeScript workaround in generate.ts

<!-- /greptile_comment -->