### PR TITLE
Vite: Fix HMR

### DIFF
--- a/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
@@ -70,33 +70,33 @@ export function codeGeneratorPlugin(options: Options): Plugin {
     },
     resolveId(source) {
       if (source === virtualFileId) {
-        return `\0${virtualFileId}`;
+        return `${virtualFileId}`;
       }
       if (source === iframePath) {
         return iframeId;
       }
       if (source === virtualStoriesFile) {
-        return `\0${virtualStoriesFile}`;
+        return `${virtualStoriesFile}`;
       }
       if (source === virtualPreviewFile) {
         return virtualPreviewFile;
       }
       if (source === virtualAddonSetupFile) {
-        return `\0${virtualAddonSetupFile}`;
+        return `${virtualAddonSetupFile}`;
       }
 
       return undefined;
     },
     async load(id, config) {
-      if (id === `\0${virtualStoriesFile}`) {
+      if (id === `${virtualStoriesFile}`) {
         return generateImportFnScriptCode(options);
       }
 
-      if (id === `\0${virtualAddonSetupFile}`) {
+      if (id === `${virtualAddonSetupFile}`) {
         return generateAddonSetupCode();
       }
 
-      if (id === `\0${virtualFileId}`) {
+      if (id === `${virtualFileId}`) {
         return generateModernIframeScriptCode(options, projectRoot);
       }
 

--- a/code/e2e-tests/save-from-controls.spec.ts
+++ b/code/e2e-tests/save-from-controls.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import process from 'process';
 
 import { SbPage } from './util';
@@ -68,5 +68,8 @@ test.describe('save-from-controls', () => {
     const notification2 = await sbPage.page.waitForSelector('[title="Story created"]');
     await notification2.isVisible();
     await notification2.click();
+
+    // Assert the Button components is rendered in the preview
+    await expect(sbPage.previewRoot()).toContainText('Button');
   });
 });


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28871

## What I did

- [x] Added a test to ensure the HMR works by checking if the button component is shown after save-from-controls
- [ ] Fix the HMR bug

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | **1.98** | 0% |
| initSize |  167 MB | 167 MB | -24 B | **1.74** | 0% |
| diffSize |  91.1 MB | 91.1 MB | -24 B | 0.33 | 0% |
| buildSize |  7.42 MB | 7.42 MB | 0 B | 0.65 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | -0.65 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.29 MB | 2.29 MB | 0 B | 0.65 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | -0.65 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.45 MB | 4.45 MB | 0 B | 0.65 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | -0.65 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23s | 18.8s | -4s -282ms | 0.34 | -22.8% |
| generateTime |  18.1s | 21.5s | 3.4s | 0.57 | 16.1% |
| initTime |  16.3s | 16.7s | 363ms | -0.25 | 2.2% |
| buildTime |  10.1s | 11.7s | 1.5s | 0.09 | 13.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.4s | 8.7s | 1.2s | 0.22 | 14.2% |
| devManagerResponsive |  4.7s | 5.2s | 567ms | 0.19 | 10.7% |
| devManagerHeaderVisible |  804ms | 966ms | 162ms | **1.27** | 🔺16.8% |
| devManagerIndexVisible |  841ms | 986ms | 145ms | 1.15 | 14.7% |
| devStoryVisibleUncached |  1.2s | 1.6s | 397ms | **1.69** | 🔺24.3% |
| devStoryVisible |  852ms | 1s | 196ms | **1.55** | 🔺18.7% |
| devAutodocsVisible |  673ms | 953ms | 280ms | **1.91** | 🔺29.4% |
| devMDXVisible |  664ms | 784ms | 120ms | 0.29 | 15.3% |
| buildManagerHeaderVisible |  701ms | 867ms | 166ms | 0.88 | 19.1% |
| buildManagerIndexVisible |  710ms | 869ms | 159ms | 0.85 | 18.3% |
| buildStoryVisible |  744ms | 919ms | 175ms | 0.92 | 19% |
| buildAutodocsVisible |  689ms | 763ms | 74ms | 0.58 | 9.7% |
| buildMDXVisible |  665ms | 692ms | 27ms | 0.07 | 3.9% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds an end-to-end test for the 'save-from-controls' feature, focusing on verifying Hot Module Replacement (HMR) functionality in Storybook.

- Added assertion in `code/e2e-tests/save-from-controls.spec.ts` to check if Button component renders after story updates
- Test verifies HMR by updating and creating a new story, then checking preview content
- Addresses issue #28871 where Save from Controls (SfC) feature wasn't working in a specific alpha version
- Enhances test coverage for critical HMR functionality in Storybook's control panel

<!-- /greptile_comment -->