### PR TITLE
Test: Fix support for TS < 4.7

### DIFF
--- a/code/lib/test/src/index.ts
+++ b/code/lib/test/src/index.ts
@@ -1,3 +1,5 @@
+import type { BoundFunctions } from '@testing-library/dom';
+
 import type { LoaderFunction } from '@storybook/csf';
 import { global } from '@storybook/global';
 import { instrument } from '@storybook/instrumenter';
@@ -17,7 +19,7 @@ import { type queries, within } from './testing-library';
 
 export * from './spy';
 
-type Queries = ReturnType<typeof within<typeof queries>>;
+type Queries = BoundFunctions<typeof queries>;
 
 declare module '@storybook/csf' {
   interface Canvas extends Queries {}


### PR DESCRIPTION
Closes #28883

## What I did

Fix the issue by changing how we expose the `canvas` proprty's type.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

As per recommendation from @kasperpeulen :

- I went into a random story
- Changed `canvasElement` to `canvas`
- checked if there's autocompletion available (it was)

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | 1 | 0% |
| initSize |  169 MB | 169 MB | 24 B | **2.44** | 0% |
| diffSize |  92.6 MB | 92.6 MB | 24 B | **2.44** | 0% |
| buildSize |  7.46 MB | 7.46 MB | 0 B | **2.34** | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | **2.56** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | **2.27** | 0% |
| buildSbPreviewSize |  350 kB | 350 kB | 0 B | **-2.38** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | **2.27** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  26.3s | 11.4s | -14s -826ms | -0.46 | -129% |
| generateTime |  22.4s | 24s | 1.6s | **2.3** | 🔺6.8% |
| initTime |  19.5s | 21.2s | 1.7s | **1.56** | 🔺8.3% |
| buildTime |  12.7s | 11.3s | -1s -392ms | -0.55 | -12.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.5s | 8.8s | 2.3s | 0.8 | 26.9% |
| devManagerResponsive |  4.3s | 5.8s | 1.5s | **1.75** | 🔺26.2% |
| devManagerHeaderVisible |  767ms | 978ms | 211ms | **1.7** | 🔺21.6% |
| devManagerIndexVisible |  810ms | 1s | 225ms | **1.83** | 🔺21.7% |
| devStoryVisibleUncached |  1.2s | 1.5s | 382ms | **1.51** | 🔺24.1% |
| devStoryVisible |  809ms | 1s | 227ms | **1.69** | 🔺21.9% |
| devAutodocsVisible |  642ms | 890ms | 248ms | **1.32** | 🔺27.9% |
| devMDXVisible |  650ms | 865ms | 215ms | 0.94 | 24.9% |
| buildManagerHeaderVisible |  650ms | 815ms | 165ms | 0.7 | 20.2% |
| buildManagerIndexVisible |  657ms | 823ms | 166ms | 0.74 | 20.2% |
| buildStoryVisible |  712ms | 864ms | 152ms | 0.75 | 17.6% |
| buildAutodocsVisible |  714ms | 799ms | 85ms | **1.24** | 🔺10.6% |
| buildMDXVisible |  586ms | 730ms | 144ms | 0.93 | 19.7% |

<!-- BENCHMARK_SECTION -->