### PR TITLE
Addon Vitest: Set default viewport if applicable

### DIFF
--- a/code/addons/vitest/src/plugin/viewports.test.ts
+++ b/code/addons/vitest/src/plugin/viewports.test.ts
@@ -24,8 +24,7 @@ describe('setViewport', () => {
   it('should do nothing if __vitest_browser__ is false', async () => {
     globalThis.__vitest_browser__ = false;
 
-    const result = await setViewport();
-    expect(result).toBeNull();
+    await setViewport();
     expect(page.viewport).not.toHaveBeenCalled();
   });
 

--- a/code/addons/vitest/src/plugin/viewports.test.ts
+++ b/code/addons/vitest/src/plugin/viewports.test.ts
@@ -1,0 +1,111 @@
+/* eslint-disable no-underscore-dangle */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { page } from '@vitest/browser/context';
+
+import { DEFAULT_VIEWPORT_DIMENSIONS, type ViewportsParam, setViewport } from './viewports';
+import { INITIAL_VIEWPORTS } from '../../../viewport/src/defaults';
+
+vi.mock('@vitest/browser/context', () => ({
+  page: {
+    viewport: vi.fn(),
+  },
+}));
+
+describe('setViewport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.__vitest_browser__ = true;
+  });
+
+  afterEach(() => {
+    globalThis.__vitest_browser__ = false;
+  });
+
+  it('should do nothing if __vitest_browser__ is false', async () => {
+    globalThis.__vitest_browser__ = false;
+
+    const result = await setViewport();
+    expect(result).toBeNull();
+    expect(page.viewport).not.toHaveBeenCalled();
+  });
+
+  it('should set the viewport to the specified dimensions from INITIAL_VIEWPORTS', async () => {
+    const viewportsParam: any = {
+      // supported by default in addon viewports
+      defaultViewport: 'ipad',
+    };
+
+    await setViewport(viewportsParam);
+    expect(page.viewport).toHaveBeenCalledWith(768, 1024);
+  });
+
+  it('should set the viewport to the specified dimensions if defaultViewport is valid', async () => {
+    const viewportsParam: ViewportsParam = {
+      defaultViewport: 'small',
+      viewports: {
+        small: {
+          name: 'Small screen',
+          type: 'mobile',
+          styles: {
+            width: '375px',
+            height: '667px',
+          },
+        },
+      },
+    };
+
+    await setViewport(viewportsParam);
+    expect(page.viewport).toHaveBeenCalledWith(375, 667);
+  });
+
+  it('should set the viewport to DEFAULT_VIEWPORT_DIMENSIONS if defaultViewport has unparseable styles', async () => {
+    const viewportsParam: ViewportsParam = {
+      defaultViewport: 'oddSizes',
+      viewports: {
+        oddSizes: {
+          name: 'foo',
+          type: 'other',
+          styles: {
+            width: 'calc(100vw - 20px)',
+            height: '100%',
+          },
+        },
+      },
+    };
+
+    await setViewport(viewportsParam);
+    expect(page.viewport).toHaveBeenCalledWith(
+      DEFAULT_VIEWPORT_DIMENSIONS.width,
+      DEFAULT_VIEWPORT_DIMENSIONS.height
+    );
+  });
+
+  it('should merge provided viewports with initial viewports', async () => {
+    const viewportsParam: ViewportsParam = {
+      defaultViewport: 'customViewport',
+      viewports: {
+        customViewport: {
+          name: 'Custom Viewport',
+          type: 'mobile',
+          styles: {
+            width: '800px',
+            height: '600px',
+          },
+        },
+      },
+    };
+
+    await setViewport(viewportsParam);
+    expect(page.viewport).toHaveBeenCalledWith(800, 600);
+  });
+
+  it('should fallback to DEFAULT_VIEWPORT_DIMENSIONS if defaultViewport does not exist', async () => {
+    const viewportsParam: any = {
+      defaultViewport: 'nonExistentViewport',
+    };
+
+    await setViewport(viewportsParam);
+    expect(page.viewport).toHaveBeenCalledWith(1200, 900);
+  });
+});

--- a/code/addons/vitest/src/plugin/viewports.test.ts
+++ b/code/addons/vitest/src/plugin/viewports.test.ts
@@ -48,7 +48,7 @@ describe('setViewport', () => {
   });
 
   it('should set custom defined viewport dimensions', async () => {
-     const viewportsParam: ViewportsParam = {
+    const viewportsParam: ViewportsParam = {
       defaultViewport: 'customViewport',
       viewports: {
         customViewport: {

--- a/code/addons/vitest/src/plugin/viewports.test.ts
+++ b/code/addons/vitest/src/plugin/viewports.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { page } from '@vitest/browser/context';
 
 import { DEFAULT_VIEWPORT_DIMENSIONS, type ViewportsParam, setViewport } from './viewports';
-import { INITIAL_VIEWPORTS } from '../../../viewport/src/defaults';
 
 vi.mock('@vitest/browser/context', () => ({
   page: {

--- a/code/addons/vitest/src/plugin/viewports.test.ts
+++ b/code/addons/vitest/src/plugin/viewports.test.ts
@@ -144,7 +144,7 @@ describe('setViewport', () => {
       The Storybook plugin only supports values in the following units:
       - px, vh, vw, em, rem and %.
 
-      You can either change the viewport for this story or use one of the supported units.]
+      You can either change the viewport for this story to use one of the supported units or skip the test by adding '!test' to the story's tags per https://storybook.js.org/docs/writing-stories/tags]
     `);
     expect(page.viewport).not.toHaveBeenCalled();
   });

--- a/code/addons/vitest/src/plugin/viewports.ts
+++ b/code/addons/vitest/src/plugin/viewports.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-underscore-dangle */
+import { UnsupportedViewportDimensionError } from 'storybook/internal/preview-errors';
+
 import { page } from '@vitest/browser/context';
 
 import { INITIAL_VIEWPORTS } from '../../../viewport/src/defaults';
 import type { ViewportMap, ViewportStyles } from '../../../viewport/src/types';
-import { UnsupportedViewportDimensionError } from 'storybook/internal/preview-errors';
 
 declare global {
   // eslint-disable-next-line no-var, @typescript-eslint/naming-convention

--- a/code/addons/vitest/src/plugin/viewports.ts
+++ b/code/addons/vitest/src/plugin/viewports.ts
@@ -21,7 +21,10 @@ export const DEFAULT_VIEWPORT_DIMENSIONS = {
 
 export const setViewport = async (viewportsParam: ViewportsParam = {} as ViewportsParam) => {
   const defaultViewport = viewportsParam.defaultViewport;
-  if (!page || !globalThis.__vitest_browser__ || !defaultViewport) return null;
+
+  if (!page || !globalThis.__vitest_browser__ || !defaultViewport) {
+    return null;
+  }
 
   const viewports = {
     ...INITIAL_VIEWPORTS,

--- a/code/addons/vitest/src/plugin/viewports.ts
+++ b/code/addons/vitest/src/plugin/viewports.ts
@@ -23,7 +23,7 @@ export const setViewport = async (viewportsParam: ViewportsParam = {} as Viewpor
   const defaultViewport = viewportsParam.defaultViewport;
 
   if (!page || !globalThis.__vitest_browser__ || !defaultViewport) {
-    return null;
+    return;
   }
 
   const viewports = {
@@ -47,5 +47,5 @@ export const setViewport = async (viewportsParam: ViewportsParam = {} as Viewpor
     }
   }
 
-  return page.viewport(viewportWidth, viewportHeight);
+  await page.viewport(viewportWidth, viewportHeight);
 };

--- a/code/core/src/preview-errors.ts
+++ b/code/core/src/preview-errors.ts
@@ -30,6 +30,7 @@ export enum Category {
   RENDERER_VUE3 = 'RENDERER_VUE3',
   RENDERER_WEB_COMPONENTS = 'RENDERER_WEB-COMPONENTS',
   FRAMEWORK_NEXTJS = 'FRAMEWORK_NEXTJS',
+  ADDON_VITEST = 'ADDON_VITEST',
 }
 
 export class MissingStoryAfterHmrError extends StorybookError {
@@ -313,6 +314,25 @@ export class UnknownArgTypesError extends StorybookError {
 
         This type is either not supported or it is a bug in the docgen generation in Storybook.
         If you think this is a bug, please detail it as much as possible in the Github issue.
+      `,
+    });
+  }
+}
+
+export class UnsupportedViewportDimensionError extends StorybookError {
+  constructor(public data: { dimension: string; value: string; }) {
+    super({
+      category: Category.ADDON_VITEST,
+      code: 1,
+      // TODO: Add documentation about viewports support
+      // documentation: '',
+      message: dedent`
+        Encountered an unsupported value "${data.value}" when setting the viewport ${data.dimension} dimension.
+        
+        The Storybook plugin only supports values in the following units:
+        - px, vh, vw, em, rem and %.
+
+        You can either change the viewport for this story or use one of the supported units.
       `,
     });
   }

--- a/code/core/src/preview-errors.ts
+++ b/code/core/src/preview-errors.ts
@@ -320,7 +320,7 @@ export class UnknownArgTypesError extends StorybookError {
 }
 
 export class UnsupportedViewportDimensionError extends StorybookError {
-  constructor(public data: { dimension: string; value: string; }) {
+  constructor(public data: { dimension: string; value: string }) {
     super({
       category: Category.ADDON_VITEST,
       code: 1,

--- a/code/core/src/preview-errors.ts
+++ b/code/core/src/preview-errors.ts
@@ -331,8 +331,8 @@ export class UnsupportedViewportDimensionError extends StorybookError {
         
         The Storybook plugin only supports values in the following units:
         - px, vh, vw, em, rem and %.
-
-        You can either change the viewport for this story or use one of the supported units.
+        
+        You can either change the viewport for this story to use one of the supported units or skip the test by adding '!test' to the story's tags per https://storybook.js.org/docs/writing-stories/tags
       `,
     });
   }


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28901

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Vitest integration supports viewports, but it only sets them if they match the viewports object. So if you have a viewport like mobile1 which has `320px` width and `568px` height, then the plugin will use playwright to set the viewport to 320, 568. The thing is, the default viewport (responsive) is actually invalid, in the sense that it doesn’t exist in the viewports object and therefore doesn’t relate to any width and height values. This PR makes the plugin fall back to a desktop-like dimension of 1200 width and 900 height.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | 0.33 | 0% |
| initSize |  169 MB | 169 MB | 1.9 kB | 0.93 | 0% |
| diffSize |  92.7 MB | 92.7 MB | 1.9 kB | 0.93 | 0% |
| buildSize |  7.46 MB | 7.46 MB | 2.06 kB | 1.01 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.62 MB | 1.24 kB | **240.46** | 0.1% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0.89 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 823 B | **3.97** | 0.2% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 2.06 kB | 1.23 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.9 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  22.3s | 21.1s | -1s -235ms | 0.79 | -5.8% |
| generateTime |  19.5s | 18.8s | -745ms | -0.95 | -4% |
| initTime |  16.5s | 15.8s | -704ms | -0.93 | -4.4% |
| buildTime |  12.2s | 11.2s | -1s -32ms | -0.88 | -9.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  9.5s | 7.7s | -1s -848ms | -0.09 | -23.9% |
| devManagerResponsive |  5s | 5.1s | 88ms | 0.4 | 1.7% |
| devManagerHeaderVisible |  759ms | 675ms | -84ms | **-1.78** | 🔰-12.4% |
| devManagerIndexVisible |  793ms | 715ms | -78ms | **-1.74** | 🔰-10.9% |
| devStoryVisibleUncached |  1.4s | 1.5s | 156ms | **1.24** | 🔺10% |
| devStoryVisible |  792ms | 710ms | -82ms | **-1.76** | 🔰-11.5% |
| devAutodocsVisible |  770ms | 576ms | -194ms | **-1.71** | 🔰-33.7% |
| devMDXVisible |  671ms | 574ms | -97ms | **-1.45** | 🔰-16.9% |
| buildManagerHeaderVisible |  880ms | 640ms | -240ms | -1.13 | -37.5% |
| buildManagerIndexVisible |  884ms | 646ms | -238ms | -1.14 | -36.8% |
| buildStoryVisible |  991ms | 678ms | -313ms | -1.13 | -46.2% |
| buildAutodocsVisible |  766ms | 581ms | -185ms | **-1.55** | 🔰-31.8% |
| buildMDXVisible |  634ms | 593ms | -41ms | -0.98 | -6.9% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR enhances viewport handling in the Vitest integration for Storybook, introducing a default viewport size and improving edge case management.

- Added `DEFAULT_VIEWPORT_DIMENSIONS` (1200x900) in `code/addons/vitest/src/plugin/viewports.ts` for fallback
- Implemented logic to handle invalid viewport dimensions in `setViewport` function
- Added comprehensive unit tests in `code/addons/vitest/src/plugin/viewports.test.ts` to cover various scenarios
- Improved handling of percentage-based and complex CSS calculation viewport dimensions
- Ensured valid viewport setting for the default 'responsive' viewport, which previously lacked dimensions

<!-- /greptile_comment -->