### PR TITLE
Addon Vitest: Fix error message logic in set up file

### DIFF
--- a/code/.storybook/vitest.config.ts
+++ b/code/.storybook/vitest.config.ts
@@ -33,7 +33,7 @@ export default mergeConfig(
       include: [
         // TODO: test all core and addon stories later
         // './core/**/components/**/*.{story,stories}.?(c|m)[jt]s?(x)',
-        '../addons/interactions/src/**/*.{story,stories}.?(c|m)[jt]s?(x)',
+        '../addons/**/src/**/*.{story,stories}.?(c|m)[jt]s?(x)',
       ],
       exclude: [
         ...defaultExclude,

--- a/code/addons/onboarding/src/components/HighlightElement/HighlightElement.stories.tsx
+++ b/code/addons/onboarding/src/components/HighlightElement/HighlightElement.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, within } from '@storybook/test';
+import { expect, waitFor, within } from '@storybook/test';
 
 import { HighlightElement } from './HighlightElement';
 
@@ -38,7 +38,7 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement.parentElement!);
     const button = canvas.getByRole('button');
-    await expect(button).toHaveStyle('box-shadow: rgba(2,156,253,1) 0 0 2px 1px');
+    await waitFor(() => expect(button).toHaveStyle('box-shadow: rgba(2,156,253,1) 0 0 2px 1px'));
   },
 };
 

--- a/code/addons/vitest/src/plugin/setup-file.test.ts
+++ b/code/addons/vitest/src/plugin/setup-file.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable no-underscore-dangle */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type Task, modifyErrorMessage } from './setup-file';
+
+describe('modifyErrorMessage', () => {
+  const originalUrl = import.meta.env.__STORYBOOK_URL__;
+  beforeEach(() => {
+    import.meta.env.__STORYBOOK_URL__ = 'http://localhost:6006';
+  });
+
+  afterEach(() => {
+    import.meta.env.__STORYBOOK_URL__ = originalUrl;
+  });
+
+  it('should modify the error message if the test is failing and there is a storyId in the task meta', () => {
+    const task: Task = {
+      type: 'test',
+      result: {
+        state: 'fail',
+        errors: [{ message: 'Original error message' }],
+      },
+      meta: { storyId: 'my-story' },
+    };
+
+    modifyErrorMessage({ task });
+
+    expect(task.result?.errors?.[0].message).toMatchInlineSnapshot(`
+      "
+      [34mClick to debug the error directly in Storybook: http://localhost:6006/?path=/story/my-story&addonPanel=storybook/interactions/panel[39m
+
+      Original error message"
+    `);
+    expect(task.result?.errors?.[0].message).toContain('Original error message');
+  });
+
+  it('should not modify the error message if task type is not "test"', () => {
+    const task: Task = {
+      type: 'custom',
+      result: {
+        state: 'fail',
+        errors: [{ message: 'Original error message' }],
+      },
+      meta: { storyId: 'my-story' },
+    };
+
+    modifyErrorMessage({ task });
+
+    expect(task.result?.errors?.[0].message).toBe('Original error message');
+  });
+
+  it('should not modify the error message if task result state is not "fail"', () => {
+    const task: Task = {
+      type: 'test',
+      result: {
+        state: 'pass',
+      },
+      meta: { storyId: 'my-story' },
+    };
+
+    modifyErrorMessage({ task });
+
+    expect(task.result?.errors).toBeUndefined();
+  });
+
+  it('should not modify the error message if meta.storyId is not present', () => {
+    const task: Task = {
+      type: 'test',
+      result: {
+        state: 'fail',
+        errors: [{ message: 'Non story test failure' }],
+      },
+      meta: {},
+    };
+
+    modifyErrorMessage({ task });
+
+    expect(task.result?.errors?.[0].message).toBe('Non story test failure');
+  });
+});

--- a/code/addons/vitest/src/plugin/setup-file.ts
+++ b/code/addons/vitest/src/plugin/setup-file.ts
@@ -2,7 +2,7 @@
 
 /* eslint-disable no-underscore-dangle */
 import { afterEach, vi } from 'vitest';
-import type { RunnerTask, TaskMeta } from 'vitest';
+import type { RunnerTask } from 'vitest';
 
 import { Channel } from 'storybook/internal/channels';
 
@@ -13,13 +13,15 @@ declare global {
   var __STORYBOOK_ADDONS_CHANNEL__: Channel;
 }
 
-type ExtendedMeta = TaskMeta & { storyId: string; hasPlayFunction: boolean };
+export type Task = Partial<RunnerTask> & {
+  meta: Record<string, any>;
+};
 
 const transport = { setHandler: vi.fn(), send: vi.fn() };
-globalThis.__STORYBOOK_ADDONS_CHANNEL__ = new Channel({ transport });
+globalThis.__STORYBOOK_ADDONS_CHANNEL__ ??= new Channel({ transport });
 
-const modifyErrorMessage = ({ task }: { task: RunnerTask }) => {
-  const meta = task.meta as ExtendedMeta;
+export const modifyErrorMessage = ({ task }: { task: Task }) => {
+  const meta = task.meta;
   if (
     task.type === 'test' &&
     task.result?.state === 'fail' &&

--- a/code/addons/vitest/src/plugin/setup-file.ts
+++ b/code/addons/vitest/src/plugin/setup-file.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 /* eslint-disable no-underscore-dangle */
-import { afterAll, vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import type { RunnerTask, TaskMeta } from 'vitest';
 
 import { Channel } from 'storybook/internal/channels';
@@ -18,23 +18,19 @@ type ExtendedMeta = TaskMeta & { storyId: string; hasPlayFunction: boolean };
 const transport = { setHandler: vi.fn(), send: vi.fn() };
 globalThis.__STORYBOOK_ADDONS_CHANNEL__ = new Channel({ transport });
 
-// The purpose of this set up file is to modify the error message of failed tests
-// and inject a link to the story in Storybook
-const modifyErrorMessage = (currentTask: RunnerTask) => {
-  const meta = currentTask.meta as ExtendedMeta;
+const modifyErrorMessage = ({ task }: { task: RunnerTask }) => {
+  const meta = task.meta as ExtendedMeta;
   if (
-    currentTask.type === 'test' &&
-    currentTask.result?.state === 'fail' &&
+    task.type === 'test' &&
+    task.result?.state === 'fail' &&
     meta.storyId &&
-    currentTask.result.errors?.[0]
+    task.result.errors?.[0]
   ) {
-    const currentError = currentTask.result.errors[0];
+    const currentError = task.result.errors[0];
     const storybookUrl = import.meta.env.__STORYBOOK_URL__;
     const storyUrl = `${storybookUrl}/?path=/story/${meta.storyId}&addonPanel=storybook/interactions/panel`;
     currentError.message = `\n\x1B[34mClick to debug the error directly in Storybook: ${storyUrl}\x1B[39m\n\n${currentError.message}`;
   }
 };
 
-afterAll((suite) => {
-  suite.tasks.forEach(modifyErrorMessage);
-});
+afterEach(modifyErrorMessage);

--- a/code/package.json
+++ b/code/package.json
@@ -48,7 +48,7 @@
     "storybook:ui": "NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" ./lib/cli/bin/index.cjs dev --port 6006 --config-dir ./.storybook",
     "storybook:ui:build": "NODE_OPTIONS=\"--preserve-symlinks --preserve-symlinks-main\" ./lib/cli/bin/index.cjs build --config-dir ./.storybook --webpack-stats-json",
     "storybook:ui:chromatic": "../scripts/node_modules/.bin/chromatic --build-script-name storybook:ui:build --storybook-base-dir ./ --exit-zero-on-changes --exit-once-uploaded",
-    "storybook:vitest": "yarn test --project storybook-ui",
+    "storybook:vitest": "yarn test:watch --project storybook-ui",
     "storybook:vitest:inspect": "INSPECT=true yarn test --project storybook-ui",
     "task": "yarn --cwd ../scripts task",
     "test": "NODE_OPTIONS=--max_old_space_size=4096 vitest run",


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28903

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Before, the set up file was only overwriting the error message of the last failure if multiple stories failed. Now it is attached per test run, so it works in all occasions.

I also added a small optimization on the channel mocks

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | 0.64 | 0% |
| initSize |  169 MB | 169 MB | 0 B | **1.38** | 0% |
| diffSize |  92.6 MB | 92.6 MB | 0 B | **1.38** | 0% |
| buildSize |  7.46 MB | 7.46 MB | 0 B | **1.36** | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | **1.42** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | **1.34** | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | -0.52 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | **1.37** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **1.36** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  14s | 25.1s | 11s | **1.33** | 🔺43.9% |
| generateTime |  22.1s | 18.3s | -3s -811ms | -1.03 | -20.8% |
| initTime |  20.6s | 16.1s | -4s -500ms | -0.64 | -27.9% |
| buildTime |  11.7s | 13.1s | 1.3s | 0.58 | 10.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.4s | 7.3s | -89ms | -0.36 | -1.2% |
| devManagerResponsive |  4.8s | 4.7s | -89ms | -0.21 | -1.9% |
| devManagerHeaderVisible |  783ms | 763ms | -20ms | -0.51 | -2.6% |
| devManagerIndexVisible |  832ms | 810ms | -22ms | -0.39 | -2.7% |
| devStoryVisibleUncached |  1.3s | 1.2s | -85ms | -0.27 | -6.6% |
| devStoryVisible |  834ms | 808ms | -26ms | -0.52 | -3.2% |
| devAutodocsVisible |  773ms | 677ms | -96ms | -0.61 | -14.2% |
| devMDXVisible |  743ms | 723ms | -20ms | -0.15 | -2.8% |
| buildManagerHeaderVisible |  783ms | 711ms | -72ms | -0.33 | -10.1% |
| buildManagerIndexVisible |  788ms | 712ms | -76ms | -0.37 | -10.7% |
| buildStoryVisible |  822ms | 745ms | -77ms | -0.46 | -10.3% |
| buildAutodocsVisible |  642ms | 719ms | 77ms | 0.43 | 10.7% |
| buildMDXVisible |  651ms | 603ms | -48ms | -0.7 | -8% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR improves error handling and test coverage for the Storybook Vitest addon, focusing on more accurate error reporting and expanded test inclusion for addons.

- Modified `code/addons/vitest/src/plugin/setup-file.ts` to use `afterEach` hook for more timely error reporting
- Updated `code/.storybook/vitest.config.ts` to include all addon stories in testing
- Enhanced `HighlightElement.stories.tsx` with `waitFor` function for improved test reliability
- Changed `storybook:vitest` script in `package.json` to use `yarn test:watch` for continuous testing

<!-- /greptile_comment -->