### PR TITLE
Core: Introduce setProjectAnnotations API to more renderers and frameworks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,7 +403,7 @@ jobs:
       parallelism:
         type: integer
     executor:
-      class: large
+      class: xlarge
       name: sb_playwright
     parallelism: << parameters.parallelism >>
     steps:

--- a/code/frameworks/angular/src/client/index.ts
+++ b/code/frameworks/angular/src/client/index.ts
@@ -2,6 +2,7 @@
 import './globals';
 
 export * from './public-types';
+export * from './portable-stories';
 
 export type { StoryFnAngularReturnType as IStory } from './types';
 

--- a/code/frameworks/angular/src/client/portable-stories.ts
+++ b/code/frameworks/angular/src/client/portable-stories.ts
@@ -1,0 +1,42 @@
+import {
+  setProjectAnnotations as originalSetProjectAnnotations,
+  setDefaultProjectAnnotations,
+} from 'storybook/internal/preview-api';
+import {
+  NamedOrDefaultProjectAnnotations,
+  NormalizedProjectAnnotations,
+} from 'storybook/internal/types';
+
+import * as INTERNAL_DEFAULT_PROJECT_ANNOTATIONS from './render';
+import { AngularRenderer } from './types';
+
+/**
+ * Function that sets the globalConfig of your storybook. The global config is the preview module of
+ * your .storybook folder.
+ *
+ * It should be run a single time, so that your global config (e.g. decorators) is applied to your
+ * stories when using `composeStories` or `composeStory`.
+ *
+ * Example:
+ *
+ * ```jsx
+ * // setup-file.js
+ * import { setProjectAnnotations } from '@storybook/angular';
+ *
+ * import projectAnnotations from './.storybook/preview';
+ *
+ * setProjectAnnotations(projectAnnotations);
+ * ```
+ *
+ * @param projectAnnotations - E.g. (import projectAnnotations from '../.storybook/preview')
+ */
+export function setProjectAnnotations(
+  projectAnnotations:
+    | NamedOrDefaultProjectAnnotations<any>
+    | NamedOrDefaultProjectAnnotations<any>[]
+): NormalizedProjectAnnotations<AngularRenderer> {
+  setDefaultProjectAnnotations(INTERNAL_DEFAULT_PROJECT_ANNOTATIONS);
+  return originalSetProjectAnnotations(
+    projectAnnotations
+  ) as NormalizedProjectAnnotations<AngularRenderer>;
+}

--- a/code/frameworks/experimental-nextjs-vite/src/portable-stories.ts
+++ b/code/frameworks/experimental-nextjs-vite/src/portable-stories.ts
@@ -32,7 +32,7 @@ import * as nextJsAnnotations from './preview';
  * Example:
  *
  * ```jsx
- * // setup.js (for jest)
+ * // setup-file.js
  * import { setProjectAnnotations } from '@storybook/experimental-nextjs-vite';
  * import projectAnnotations from './.storybook/preview';
  *

--- a/code/frameworks/nextjs/src/portable-stories.ts
+++ b/code/frameworks/nextjs/src/portable-stories.ts
@@ -32,7 +32,7 @@ import * as nextJsAnnotations from './preview';
  * Example:
  *
  * ```jsx
- * // setup.js (for jest)
+ * // setup-file.js
  * import { setProjectAnnotations } from '@storybook/nextjs';
  * import projectAnnotations from './.storybook/preview';
  *

--- a/code/frameworks/sveltekit/src/index.ts
+++ b/code/frameworks/sveltekit/src/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './portable-stories';

--- a/code/frameworks/sveltekit/src/portable-stories.ts
+++ b/code/frameworks/sveltekit/src/portable-stories.ts
@@ -10,9 +10,7 @@ import type {
 } from 'storybook/internal/types';
 
 import type { SvelteRenderer } from '@storybook/svelte';
-
-// TODO: investigate whether we need to prebundle this or can just import from the renderer package
-import { INTERNAL_DEFAULT_PROJECT_ANNOTATIONS as svelteAnnotations } from '../../../renderers/svelte/src/portable-stories';
+import { INTERNAL_DEFAULT_PROJECT_ANNOTATIONS as svelteAnnotations } from '@storybook/svelte';
 import * as svelteKitAnnotations from './preview';
 
 /**

--- a/code/frameworks/sveltekit/src/portable-stories.ts
+++ b/code/frameworks/sveltekit/src/portable-stories.ts
@@ -11,6 +11,7 @@ import type {
 
 import type { SvelteRenderer } from '@storybook/svelte';
 import { INTERNAL_DEFAULT_PROJECT_ANNOTATIONS as svelteAnnotations } from '@storybook/svelte';
+
 import * as svelteKitAnnotations from './preview';
 
 /**

--- a/code/frameworks/sveltekit/src/portable-stories.ts
+++ b/code/frameworks/sveltekit/src/portable-stories.ts
@@ -1,0 +1,52 @@
+import {
+  composeConfigs,
+  setProjectAnnotations as originalSetProjectAnnotations,
+  setDefaultProjectAnnotations,
+} from 'storybook/internal/preview-api';
+import type {
+  NamedOrDefaultProjectAnnotations,
+  NormalizedProjectAnnotations,
+  ProjectAnnotations,
+} from 'storybook/internal/types';
+
+import type { SvelteRenderer } from '@storybook/svelte';
+
+// TODO: investigate whether we need to prebundle this or can just import from the renderer package
+import { INTERNAL_DEFAULT_PROJECT_ANNOTATIONS as svelteAnnotations } from '../../../renderers/svelte/src/portable-stories';
+import * as svelteKitAnnotations from './preview';
+
+/**
+ * Function that sets the globalConfig of your storybook. The global config is the preview module of
+ * your .storybook folder.
+ *
+ * It should be run a single time, so that your global config (e.g. decorators) is applied to your
+ * stories when using `composeStories` or `composeStory`.
+ *
+ * Example:
+ *
+ * ```jsx
+ * // setup-file.js
+ * import { setProjectAnnotations } from '@storybook/sveltekit';
+ * import projectAnnotations from './.storybook/preview';
+ *
+ * setProjectAnnotations(projectAnnotations);
+ * ```
+ *
+ * @param projectAnnotations - E.g. (import projectAnnotations from '../.storybook/preview')
+ */
+export function setProjectAnnotations(
+  projectAnnotations:
+    | NamedOrDefaultProjectAnnotations<any>
+    | NamedOrDefaultProjectAnnotations<any>[]
+): NormalizedProjectAnnotations<SvelteRenderer> {
+  setDefaultProjectAnnotations(INTERNAL_DEFAULT_PROJECT_ANNOTATIONS);
+  return originalSetProjectAnnotations(
+    projectAnnotations
+  ) as NormalizedProjectAnnotations<SvelteRenderer>;
+}
+
+// This will not be necessary once we have auto preset loading
+const INTERNAL_DEFAULT_PROJECT_ANNOTATIONS: ProjectAnnotations<SvelteRenderer> = composeConfigs([
+  svelteAnnotations,
+  svelteKitAnnotations,
+]);

--- a/code/renderers/html/src/index.ts
+++ b/code/renderers/html/src/index.ts
@@ -2,6 +2,7 @@
 import './globals';
 
 export * from './public-types';
+export * from './portable-stories';
 
 // optimization: stop HMR propagation in webpack
 

--- a/code/renderers/html/src/portable-stories.ts
+++ b/code/renderers/html/src/portable-stories.ts
@@ -1,0 +1,41 @@
+import {
+  setProjectAnnotations as originalSetProjectAnnotations,
+  setDefaultProjectAnnotations,
+} from 'storybook/internal/preview-api';
+import type {
+  NamedOrDefaultProjectAnnotations,
+  NormalizedProjectAnnotations,
+} from 'storybook/internal/types';
+
+import * as INTERNAL_DEFAULT_PROJECT_ANNOTATIONS from './entry-preview';
+import type { HtmlRenderer } from './types';
+
+/**
+ * Function that sets the globalConfig of your storybook. The global config is the preview module of
+ * your .storybook folder.
+ *
+ * It should be run a single time, so that your global config (e.g. decorators) is applied to your
+ * stories when using `composeStories` or `composeStory`.
+ *
+ * Example:
+ *
+ * ```jsx
+ * // setup-file.js
+ * import { setProjectAnnotations } from '@storybook/preact';
+ * import projectAnnotations from './.storybook/preview';
+ *
+ * setProjectAnnotations(projectAnnotations);
+ * ```
+ *
+ * @param projectAnnotations - E.g. (import projectAnnotations from '../.storybook/preview')
+ */
+export function setProjectAnnotations(
+  projectAnnotations:
+    | NamedOrDefaultProjectAnnotations<any>
+    | NamedOrDefaultProjectAnnotations<any>[]
+): NormalizedProjectAnnotations<HtmlRenderer> {
+  setDefaultProjectAnnotations(INTERNAL_DEFAULT_PROJECT_ANNOTATIONS);
+  return originalSetProjectAnnotations(
+    projectAnnotations
+  ) as NormalizedProjectAnnotations<HtmlRenderer>;
+}

--- a/code/renderers/preact/src/index.ts
+++ b/code/renderers/preact/src/index.ts
@@ -2,6 +2,7 @@
 import './globals';
 
 export * from './public-types';
+export * from './portable-stories';
 
 // optimization: stop HMR propagation in webpack
 

--- a/code/renderers/preact/src/portable-stories.ts
+++ b/code/renderers/preact/src/portable-stories.ts
@@ -1,0 +1,41 @@
+import {
+  setProjectAnnotations as originalSetProjectAnnotations,
+  setDefaultProjectAnnotations,
+} from 'storybook/internal/preview-api';
+import type {
+  NamedOrDefaultProjectAnnotations,
+  NormalizedProjectAnnotations,
+} from 'storybook/internal/types';
+
+import * as INTERNAL_DEFAULT_PROJECT_ANNOTATIONS from './entry-preview';
+import type { PreactRenderer } from './types';
+
+/**
+ * Function that sets the globalConfig of your storybook. The global config is the preview module of
+ * your .storybook folder.
+ *
+ * It should be run a single time, so that your global config (e.g. decorators) is applied to your
+ * stories when using `composeStories` or `composeStory`.
+ *
+ * Example:
+ *
+ * ```jsx
+ * // setup-file.js
+ * import { setProjectAnnotations } from '@storybook/preact';
+ * import projectAnnotations from './.storybook/preview';
+ *
+ * setProjectAnnotations(projectAnnotations);
+ * ```
+ *
+ * @param projectAnnotations - E.g. (import projectAnnotations from '../.storybook/preview')
+ */
+export function setProjectAnnotations(
+  projectAnnotations:
+    | NamedOrDefaultProjectAnnotations<any>
+    | NamedOrDefaultProjectAnnotations<any>[]
+): NormalizedProjectAnnotations<PreactRenderer> {
+  setDefaultProjectAnnotations(INTERNAL_DEFAULT_PROJECT_ANNOTATIONS);
+  return originalSetProjectAnnotations(
+    projectAnnotations
+  ) as NormalizedProjectAnnotations<PreactRenderer>;
+}

--- a/code/renderers/react/src/portable-stories.tsx
+++ b/code/renderers/react/src/portable-stories.tsx
@@ -31,7 +31,7 @@ import type { ReactRenderer } from './types';
  * Example:
  *
  * ```jsx
- * // setup.js (for jest)
+ * // setup-file.js
  * import { setProjectAnnotations } from '@storybook/react';
  * import projectAnnotations from './.storybook/preview';
  *

--- a/code/renderers/svelte/src/portable-stories.ts
+++ b/code/renderers/svelte/src/portable-stories.ts
@@ -49,7 +49,7 @@ type MapToComposed<TModule> = {
  * Example:
  *
  * ```jsx
- * // setup.js (for jest)
+ * // setup-file.js
  * import { setProjectAnnotations } from '@storybook/svelte';
  * import projectAnnotations from './.storybook/preview';
  *

--- a/code/renderers/vue3/src/portable-stories.ts
+++ b/code/renderers/vue3/src/portable-stories.ts
@@ -39,7 +39,7 @@ type MapToJSXAble<T> = {
  * Example:
  *
  * ```jsx
- * // setup.js (for jest)
+ * // setup-file.js
  * import { setProjectAnnotations } from '@storybook/vue3';
  * import projectAnnotations from './.storybook/preview';
  *

--- a/code/renderers/web-components/src/index.ts
+++ b/code/renderers/web-components/src/index.ts
@@ -7,6 +7,7 @@ const { window, EventSource } = global;
 
 export * from './public-types';
 export * from './framework-api';
+export * from './portable-stories';
 
 // TODO: disable HMR and do full page loads because of customElements.define
 if (typeof module !== 'undefined' && module?.hot?.decline) {

--- a/code/renderers/web-components/src/portable-stories.ts
+++ b/code/renderers/web-components/src/portable-stories.ts
@@ -1,0 +1,41 @@
+import {
+  setProjectAnnotations as originalSetProjectAnnotations,
+  setDefaultProjectAnnotations,
+} from 'storybook/internal/preview-api';
+import type {
+  NamedOrDefaultProjectAnnotations,
+  NormalizedProjectAnnotations,
+} from 'storybook/internal/types';
+
+import * as webComponentsAnnotations from './entry-preview';
+import type { WebComponentsRenderer } from './types';
+
+/**
+ * Function that sets the globalConfig of your storybook. The global config is the preview module of
+ * your .storybook folder.
+ *
+ * It should be run a single time, so that your global config (e.g. decorators) is applied to your
+ * stories when using `composeStories` or `composeStory`.
+ *
+ * Example:
+ *
+ * ```jsx
+ * // setup-file.js
+ * import { setProjectAnnotations } from '@storybook/web-components';
+ * import projectAnnotations from './.storybook/preview';
+ *
+ * setProjectAnnotations(projectAnnotations);
+ * ```
+ *
+ * @param projectAnnotations - E.g. (import projectAnnotations from '../.storybook/preview')
+ */
+export function setProjectAnnotations(
+  projectAnnotations:
+    | NamedOrDefaultProjectAnnotations<any>
+    | NamedOrDefaultProjectAnnotations<any>[]
+): NormalizedProjectAnnotations<WebComponentsRenderer> {
+  setDefaultProjectAnnotations(webComponentsAnnotations);
+  return originalSetProjectAnnotations(
+    projectAnnotations
+  ) as NormalizedProjectAnnotations<WebComponentsRenderer>;
+}

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -366,7 +366,15 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
   const isVue = template.expected.renderer === '@storybook/vue3';
   const isNextjs = template.expected.framework.includes('nextjs');
   // const isAngular = template.expected.framework === '@storybook/angular';
-  const storybookPackage = isNextjs ? template.expected.framework : template.expected.renderer;
+
+  const portableStoriesFrameworks = [
+    '@storybook/nextjs',
+    '@storybook/experimental-nextjs-vite',
+    // TODO: add sveltekit and angular once we enable their sandboxes
+  ];
+  const storybookPackage = portableStoriesFrameworks.includes(template.expected.framework)
+    ? template.expected.framework
+    : template.expected.renderer;
   const viteConfigPath = template.name.includes('JavaScript') ? 'vite.config.js' : 'vite.config.ts';
 
   await writeFile(

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -488,7 +488,8 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
 
   packageJson.scripts = {
     ...packageJson.scripts,
-    vitest: 'vitest --pass-with-no-tests --reporter=default --reporter=hanging-process',
+    vitest:
+      'vitest --pass-with-no-tests --reporter=default --reporter=hanging-process --test-timeout=5000',
   };
 
   // This workaround is needed because Vitest seems to have issues in link mode


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28895

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR introduces the `setProjectAnnotations` API to the following packages:
- @storybook/preact
- @storybook/html
- @storybook/web-components
- @storybook/angular
- @storybook/sveltekit

This introduces the first step to supporting the vitest integration (portable stories based) to these renderers. In the future, these packages would also provide the other APIs such as `composeStory` and `composeStories` in case it makes sense to support `testingLibraryRender` or a portable stories in docs use case.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Proper testing will come in upcoming PRs that sets sandbox tests for each package.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | **-2** | 0% |
| initSize |  169 MB | 169 MB | -86.1 kB | 0.44 | -0.1% |
| diffSize |  92.8 MB | 92.7 MB | -86.1 kB | 0.52 | -0.1% |
| buildSize |  7.46 MB | 7.46 MB | -2.08 kB | 0.51 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.61 MB | -1.24 kB | -0.41 | -0.1% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0.49 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | -823 B | -0.36 | -0.2% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | -2.06 kB | 0.43 | 0% |
| buildPreviewSize |  3 MB | 3 MB | -20 B | 0.55 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.6s | 7.3s | -251ms | **-1.44** | -3.4% |
| generateTime |  19.8s | 21.5s | 1.7s | 0.65 | 8% |
| initTime |  16.5s | 20s | 3.5s | 0.86 | 17.6% |
| buildTime |  11.5s | 13.7s | 2.1s | **1.25** | 🔺15.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.8s | 7.3s | -1s -501ms | -0.18 | -20.4% |
| devManagerResponsive |  5.9s | 4.8s | -1s -26ms | 0.12 | -21% |
| devManagerHeaderVisible |  1.2s | 750ms | -482ms | -0.58 | -64.3% |
| devManagerIndexVisible |  1.2s | 758ms | -511ms | -0.86 | -67.4% |
| devStoryVisibleUncached |  2s | 1.2s | -714ms | -0.23 | -55% |
| devStoryVisible |  1.2s | 789ms | -481ms | -0.61 | -61% |
| devAutodocsVisible |  999ms | 733ms | -266ms | -0.04 | -36.3% |
| devMDXVisible |  1.2s | 805ms | -486ms | 0.41 | -60.4% |
| buildManagerHeaderVisible |  931ms | 716ms | -215ms | -0.32 | -30% |
| buildManagerIndexVisible |  933ms | 725ms | -208ms | -0.28 | -28.7% |
| buildStoryVisible |  1s | 796ms | -241ms | -0.1 | -30.3% |
| buildAutodocsVisible |  892ms | 637ms | -255ms | -0.79 | -40% |
| buildMDXVisible |  694ms | 692ms | -2ms | 0.4 | -0.3% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR introduces the `setProjectAnnotations` API to multiple Storybook renderers and frameworks, laying the groundwork for vitest integration and portable stories support.

- Added `setProjectAnnotations` function in new `portable-stories.ts` files for Angular, SvelteKit, HTML, Preact, and Web Components renderers
- Updated existing `portable-stories` files for React, Vue3, and Svelte renderers to include the new API
- Introduced `composeStory` and `composeStories` functions for Next.js, React, Vue3, and Svelte renderers
- Modified index files to export the new `portable-stories` modules for affected renderers and frameworks

<!-- /greptile_comment -->