### PR TITLE
Addon Vitest: Set screenshotFailures to false by default

### DIFF
--- a/code/addons/vitest/src/plugin/index.ts
+++ b/code/addons/vitest/src/plugin/index.ts
@@ -81,6 +81,10 @@ export const storybookTest = (options?: UserOptions): Plugin => {
         __STORYBOOK_URL__: storybookUrl,
       };
 
+      if (config.test.browser) {
+        config.test.browser.screenshotFailures ??= false;
+      }
+
       config.resolve ??= {};
       config.resolve.conditions ??= [];
       config.resolve.conditions.push('storybook', 'stories', 'test');


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28904

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Vitest plugin will set `test.browser.screenshotFailures` to false by default if not set by the user.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | 0.57 | 0% |
| initSize |  169 MB | 169 MB | 0 B | **1.24** | 0% |
| diffSize |  92.6 MB | 92.6 MB | 0 B | **1.24** | 0% |
| buildSize |  7.46 MB | 7.46 MB | 0 B | 1.23 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | **1.28** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 1.21 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | -0.46 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | 1.23 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 1.22 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  18.7s | 6.5s | -12s -188ms | **-1.29** | 🔰-185% |
| generateTime |  20.8s | 20.4s | -438ms | 0.05 | -2.1% |
| initTime |  19.3s | 17s | -2s -273ms | -0.33 | -13.3% |
| buildTime |  11.4s | 12.4s | 983ms | 0.09 | 7.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.2s | 6.2s | -2s -42ms | **-1.5** | 🔰-32.9% |
| devManagerResponsive |  5.4s | 4.1s | -1s -280ms | **-1.41** | 🔰-30.6% |
| devManagerHeaderVisible |  816ms | 768ms | -48ms | -0.58 | -6.2% |
| devManagerIndexVisible |  863ms | 823ms | -40ms | -0.36 | -4.9% |
| devStoryVisibleUncached |  1.5s | 1s | -537ms | **-1.65** | 🔰-50.6% |
| devStoryVisible |  875ms | 824ms | -51ms | -0.47 | -6.2% |
| devAutodocsVisible |  684ms | 799ms | 115ms | 0.54 | 14.4% |
| devMDXVisible |  695ms | 662ms | -33ms | -0.77 | -5% |
| buildManagerHeaderVisible |  857ms | 629ms | -228ms | **-1.46** | 🔰-36.2% |
| buildManagerIndexVisible |  866ms | 635ms | -231ms | **-1.45** | 🔰-36.4% |
| buildStoryVisible |  963ms | 666ms | -297ms | **-1.52** | 🔰-44.6% |
| buildAutodocsVisible |  774ms | 635ms | -139ms | -0.83 | -21.9% |
| buildMDXVisible |  723ms | 558ms | -165ms | **-1.56** | 🔰-29.6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR sets the default behavior for screenshot failures in Storybook's Vitest plugin, addressing issue #28904.

- Modified `code/addons/vitest/src/plugin/index.ts` to set `screenshotFailures` to `false` by default in browser tests
- Added a conditional check to only set the default if `config.test.browser` exists
- Implemented using optional chaining (`??=`) for concise code and to preserve user-defined values

<!-- /greptile_comment -->