### PR TITLE
Addon-docs: Remove babel dependency

### DIFF
--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -98,7 +98,6 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@babel/core": "^7.24.4",
     "@mdx-js/react": "^3.0.0",
     "@storybook/blocks": "workspace:*",
     "@storybook/csf-plugin": "workspace:*",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5321,7 +5321,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-docs@workspace:addons/docs"
   dependencies:
-    "@babel/core": "npm:^7.24.4"
     "@mdx-js/mdx": "npm:^3.0.0"
     "@mdx-js/react": "npm:^3.0.0"
     "@rollup/pluginutils": "npm:^5.0.2"


### PR DESCRIPTION
Closes N/A

## What I did

Remove unnecessary `@babel/core` dependency

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | **-4.36** | 0% |
| initSize |  169 MB | 169 MB | -53 B | 0.69 | 0% |
| diffSize |  92.7 MB | 92.7 MB | -53 B | 0.78 | 0% |
| buildSize |  7.46 MB | 7.46 MB | 0 B | 0.77 | 0% |
| buildSbAddonsSize |  1.61 MB | 1.61 MB | 0 B | 0.77 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0.72 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | -0.18 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | 0.74 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.78 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  16.2s | 9.7s | -6s -510ms | -0.97 | -66.9% |
| generateTime |  21s | 20.4s | -586ms | 0.02 | -2.9% |
| initTime |  18.4s | 17.3s | -1s -79ms | -0.31 | -6.2% |
| buildTime |  12.1s | 11.1s | -1s -43ms | -1.02 | -9.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.8s | 8.3s | 1.5s | 0.45 | 18.1% |
| devManagerResponsive |  4.6s | 5.1s | 539ms | 0.51 | 10.4% |
| devManagerHeaderVisible |  781ms | 955ms | 174ms | **2.09** | 🔺18.2% |
| devManagerIndexVisible |  815ms | 991ms | 176ms | **1.93** | 🔺17.8% |
| devStoryVisibleUncached |  1.2s | 1.6s | 412ms | **2** | 🔺24.6% |
| devStoryVisible |  813ms | 992ms | 179ms | **1.74** | 🔺18% |
| devAutodocsVisible |  721ms | 827ms | 106ms | 0.93 | 12.8% |
| devMDXVisible |  714ms | 904ms | 190ms | **1.66** | 🔺21% |
| buildManagerHeaderVisible |  727ms | 1s | 277ms | **2.51** | 🔺27.6% |
| buildManagerIndexVisible |  733ms | 1s | 364ms | **3.44** | 🔺33.2% |
| buildStoryVisible |  810ms | 1s | 288ms | **2.67** | 🔺26.2% |
| buildAutodocsVisible |  695ms | 769ms | 74ms | 0.77 | 9.6% |
| buildMDXVisible |  701ms | 927ms | 226ms | **4.05** | 🔺24.4% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request removes the '@babel/core' dependency from the '@storybook/addon-docs' package, potentially streamlining the addon's dependencies.

- Removed '@babel/core' from dependencies in `code/addons/docs/package.json`
- Potential impact on code transformation or processing in the docs addon
- May affect build process or runtime behavior of '@storybook/addon-docs'
- Could lead to improved build times or reduced package size
- Requires thorough testing to ensure no functionality is broken by this removal

<!-- /greptile_comment -->