### PR TITLE
Addon Vitest: Improve transformation logic to avoid duplicate tests

### DIFF
--- a/code/addons/vitest/src/plugin/test-utils.ts
+++ b/code/addons/vitest/src/plugin/test-utils.ts
@@ -3,33 +3,29 @@
 /* eslint-disable no-underscore-dangle */
 import { type RunnerTask, type TaskContext, type TaskMeta, type TestContext } from 'vitest';
 
-import type { ComposedStoryFn } from 'storybook/internal/types';
+import { composeStory } from 'storybook/internal/preview-api';
+import type { ComponentAnnotations, ComposedStoryFn } from 'storybook/internal/types';
 
-import type { UserOptions } from './types';
 import { setViewport } from './viewports';
 
-type TagsFilter = Required<UserOptions['tags']>;
-
-export const isValidTest = (storyTags: string[], tagsFilter: TagsFilter) => {
-  const isIncluded =
-    tagsFilter?.include.length === 0 || tagsFilter?.include.some((tag) => storyTags.includes(tag));
-  const isNotExcluded = tagsFilter?.exclude.every((tag) => !storyTags.includes(tag));
-
-  return isIncluded && isNotExcluded;
-};
-
-export const testStory = (Story: ComposedStoryFn, tagsFilter: TagsFilter) => {
+export const testStory = (
+  exportName: string,
+  story: ComposedStoryFn,
+  meta: ComponentAnnotations,
+  skipTags: string[]
+) => {
+  const composedStory = composeStory(story, meta, undefined, undefined, exportName);
   return async (context: TestContext & TaskContext & { story: ComposedStoryFn }) => {
-    if (Story === undefined || tagsFilter?.skip.some((tag) => Story.tags.includes(tag))) {
+    if (composedStory === undefined || skipTags?.some((tag) => composedStory.tags.includes(tag))) {
       context.skip();
     }
 
-    context.story = Story;
+    context.story = composedStory;
 
     const _task = context.task as RunnerTask & { meta: TaskMeta & { storyId: string } };
-    _task.meta.storyId = Story.id;
+    _task.meta.storyId = composedStory.id;
 
-    await setViewport(Story.parameters.viewport);
-    await Story.run();
+    await setViewport(composedStory.parameters.viewport);
+    await composedStory.run();
   };
 };

--- a/code/addons/vitest/src/plugin/viewports.test.ts
+++ b/code/addons/vitest/src/plugin/viewports.test.ts
@@ -34,7 +34,10 @@ describe('setViewport', () => {
     };
 
     await setViewport(viewportsParam);
-    expect(page.viewport).toHaveBeenCalledWith(1200, 900);
+    expect(page.viewport).toHaveBeenCalledWith(
+      DEFAULT_VIEWPORT_DIMENSIONS.width,
+      DEFAULT_VIEWPORT_DIMENSIONS.height
+    );
   });
 
   it('should set the dimensions of viewport from INITIAL_VIEWPORTS', async () => {

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -2,7 +2,8 @@
 
 /* eslint-disable no-underscore-dangle */
 import { getStoryTitle } from '@storybook/core/common';
-import type { StoriesEntry } from '@storybook/core/types';
+import type { StoriesEntry, Tag } from '@storybook/core/types';
+import { combineTags } from '@storybook/csf';
 
 import * as t from '@babel/types';
 import { dedent } from 'ts-dedent';
@@ -11,22 +12,34 @@ import { formatCsf, loadCsf } from '../CsfFile';
 
 const logger = console;
 
+type TagsFilter = {
+  include: string[];
+  exclude: string[];
+  skip: string[];
+};
+
+const isValidTest = (storyTags: string[], tagsFilter: TagsFilter) => {
+  const isIncluded =
+    tagsFilter?.include.length === 0 || tagsFilter?.include.some((tag) => storyTags.includes(tag));
+  const isNotExcluded = tagsFilter?.exclude.every((tag) => !storyTags.includes(tag));
+
+  return isIncluded && isNotExcluded;
+};
+
 export async function vitestTransform({
   code,
   fileName,
   configDir,
   stories,
   tagsFilter,
+  previewLevelTags = [],
 }: {
   code: string;
   fileName: string;
   configDir: string;
-  tagsFilter: {
-    include: string[];
-    exclude: string[];
-    skip: string[];
-  };
+  tagsFilter: TagsFilter;
   stories: StoriesEntry[];
+  previewLevelTags: Tag[];
 }) {
   const isStoryFile = /\.stor(y|ies)\./.test(fileName);
   if (!isStoryFile) {
@@ -81,90 +94,173 @@ export async function vitestTransform({
     );
   }
 
-  const vitestTestId = parsed._file.path.scope.generateUidIdentifier('test');
-  const composeStoryId = parsed._file.path.scope.generateUidIdentifier('composeStory');
-  const testStoryId = parsed._file.path.scope.generateUidIdentifier('testStory');
-  const isValidTestId = parsed._file.path.scope.generateUidIdentifier('isValidTest');
-
-  const tagsFilterId = t.identifier(JSON.stringify(tagsFilter));
-
-  const getTestStatementForStory = ({ exportName, node }: { exportName: string; node: t.Node }) => {
-    const composedStoryId = parsed._file.path.scope.generateUidIdentifier(`composed${exportName}`);
-
-    const composeStoryCall = t.variableDeclaration('const', [
-      t.variableDeclarator(
-        composedStoryId,
-        t.callExpression(composeStoryId, [
-          t.identifier(exportName),
-          t.identifier(metaExportName),
-          t.identifier('undefined'),
-          t.identifier('undefined'),
-          t.stringLiteral(exportName),
-        ])
-      ),
-    ]);
-
-    // Preserve sourcemaps location
-    composeStoryCall.loc = node.loc;
-
-    const isValidTestCall = t.ifStatement(
-      t.callExpression(isValidTestId, [
-        t.memberExpression(composedStoryId, t.identifier('tags')),
-        tagsFilterId,
-      ]),
-      t.blockStatement([
-        t.expressionStatement(
-          t.callExpression(vitestTestId, [
-            t.stringLiteral(exportName),
-            t.callExpression(testStoryId, [composedStoryId, tagsFilterId]),
-          ])
-        ),
-      ])
+  // Filter out stories based on the passed tags filter
+  let validStories: (typeof parsed)['_storyStatements'] = {};
+  Object.keys(parsed._stories).map((key) => {
+    const finalTags = combineTags(
+      'test',
+      'dev',
+      ...previewLevelTags,
+      ...(parsed.meta?.tags || []),
+      ...(parsed._stories[key].tags || [])
     );
-    // Preserve sourcemaps location
-    isValidTestCall.loc = node.loc;
 
-    return [composeStoryCall, isValidTestCall];
-  };
-
-  Object.entries(parsed._storyStatements).forEach(([exportName, node]) => {
-    if (node === null) {
-      logger.warn(
-        dedent`
-          [Storybook]: Could not transform "${exportName}" story into test at "${fileName}".
-          Please make sure to define stories in the same file and not re-export stories coming from other files".
-        `
-      );
-      return;
+    if (isValidTest(finalTags, tagsFilter)) {
+      validStories[key] = parsed._storyStatements[key];
     }
-
-    ast.program.body.push(
-      ...getTestStatementForStory({
-        exportName,
-        node,
-      })
-    );
   });
 
-  const imports = [
-    t.importDeclaration(
-      [t.importSpecifier(vitestTestId, t.identifier('test'))],
-      t.stringLiteral('vitest')
-    ),
-    t.importDeclaration(
-      [t.importSpecifier(composeStoryId, t.identifier('composeStory'))],
-      t.stringLiteral('storybook/internal/preview-api')
-    ),
-    t.importDeclaration(
-      [
-        t.importSpecifier(testStoryId, t.identifier('testStory')),
-        t.importSpecifier(isValidTestId, t.identifier('isValidTest')),
-      ],
-      t.stringLiteral('@storybook/experimental-addon-vitest/internal/test-utils')
-    ),
-  ];
+  const vitestTestId = parsed._file.path.scope.generateUidIdentifier('test');
+  const vitestDescribeId = parsed._file.path.scope.generateUidIdentifier('describe');
 
-  ast.program.body.unshift(...imports);
+  // if no valid stories are found, we just add describe.skip() to the file to avoid empty test files
+  if (Object.keys(validStories).length === 0) {
+    const describeSkipBlock = t.expressionStatement(
+      t.callExpression(t.memberExpression(vitestDescribeId, t.identifier('skip')), [
+        t.stringLiteral('No valid tests found'),
+      ])
+    );
+
+    ast.program.body.push(describeSkipBlock);
+    const imports = [
+      t.importDeclaration(
+        [
+          t.importSpecifier(vitestTestId, t.identifier('test')),
+          t.importSpecifier(vitestDescribeId, t.identifier('describe')),
+        ],
+        t.stringLiteral('vitest')
+      ),
+    ];
+
+    ast.program.body.unshift(...imports);
+  } else {
+    const vitestExpectId = parsed._file.path.scope.generateUidIdentifier('expect');
+    const composeStoryId = parsed._file.path.scope.generateUidIdentifier('composeStory');
+    const testStoryId = parsed._file.path.scope.generateUidIdentifier('testStory');
+    const skipTagsId = t.identifier(JSON.stringify(tagsFilter.skip));
+
+    /**
+     * In Storybook users might be importing stories from other story files. As a side effect, tests
+     * can get re-triggered. To avoid this, we add a guard to only run tests if the current file is
+     * the one running the test.
+     *
+     * Const isRunningFromThisFile = import.meta.url.includes(expect.getState().testPath ??
+     * globalThis.**vitest_worker**.filepath) if(isRunningFromThisFile) { ... }
+     */
+    function getTestGuardDeclaration(vitestExpectId: t.Identifier) {
+      const isRunningFromThisFileId =
+        parsed._file.path.scope.generateUidIdentifier('isRunningFromThisFile');
+
+      // expect.getState().testPath
+      const testPathProperty = t.memberExpression(
+        t.callExpression(t.memberExpression(vitestExpectId, t.identifier('getState')), []),
+        t.identifier('testPath')
+      );
+
+      // There is a bug in Vitest where expect.getState().testPath is undefined when called outside of a test function so we add this fallback in the meantime
+      // https://github.com/vitest-dev/vitest/issues/6367
+      // globalThis.__vitest_worker__.filepath
+      const filePathProperty = t.memberExpression(
+        t.memberExpression(t.identifier('globalThis'), t.identifier('__vitest_worker__')),
+        t.identifier('filepath')
+      );
+
+      // Combine testPath and filepath using the ?? operator
+      const nullishCoalescingExpression = t.logicalExpression(
+        '??',
+        testPathProperty,
+        filePathProperty
+      );
+
+      // Create the final expression: import.meta.url.includes(...)
+      const includesCall = t.callExpression(
+        t.memberExpression(
+          t.memberExpression(
+            t.memberExpression(t.identifier('import'), t.identifier('meta')),
+            t.identifier('url')
+          ),
+          t.identifier('includes')
+        ),
+        [nullishCoalescingExpression]
+      );
+
+      const isRunningFromThisFileDeclaration = t.variableDeclaration('const', [
+        t.variableDeclarator(isRunningFromThisFileId, includesCall),
+      ]);
+      return { isRunningFromThisFileDeclaration, isRunningFromThisFileId };
+    }
+
+    const { isRunningFromThisFileDeclaration, isRunningFromThisFileId } =
+      getTestGuardDeclaration(vitestExpectId);
+
+    ast.program.body.push(isRunningFromThisFileDeclaration);
+
+    const getTestStatementForStory = ({
+      exportName,
+      node,
+    }: {
+      exportName: string;
+      node: t.Node;
+    }) => {
+      // Create the _test expression directly using the exportName identifier
+      const testStoryCall = t.expressionStatement(
+        t.callExpression(vitestTestId, [
+          t.stringLiteral(exportName),
+          t.callExpression(testStoryId, [
+            t.stringLiteral(exportName),
+            t.identifier(exportName),
+            t.identifier(metaExportName),
+            skipTagsId,
+          ]),
+        ])
+      );
+
+      // Preserve sourcemaps location
+      testStoryCall.loc = node.loc;
+
+      // Return just the testStoryCall as composeStoryCall is not needed
+      return testStoryCall;
+    };
+
+    const storyTestStatements = Object.entries(validStories)
+      .map(([exportName, node]) => {
+        if (node === null) {
+          logger.warn(
+            dedent`
+            [Storybook]: Could not transform "${exportName}" story into test at "${fileName}".
+            Please make sure to define stories in the same file and not re-export stories coming from other files".
+          `
+          );
+          return;
+        }
+
+        return getTestStatementForStory({
+          exportName,
+          node,
+        });
+      })
+      .filter((st) => !!st);
+
+    const testBlock = t.ifStatement(isRunningFromThisFileId, t.blockStatement(storyTestStatements));
+
+    ast.program.body.push(testBlock);
+
+    const imports = [
+      t.importDeclaration(
+        [
+          t.importSpecifier(vitestTestId, t.identifier('test')),
+          t.importSpecifier(vitestExpectId, t.identifier('expect')),
+        ],
+        t.stringLiteral('vitest')
+      ),
+      t.importDeclaration(
+        [t.importSpecifier(testStoryId, t.identifier('testStory'))],
+        t.stringLiteral('@storybook/experimental-addon-vitest/internal/test-utils')
+      ),
+    ];
+
+    ast.program.body.unshift(...imports);
+  }
 
   return formatCsf(parsed, { sourceMaps: true, sourceFileName: fileName }, code);
 }

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -189,8 +189,7 @@ export async function vitestTransform({
       return { isRunningFromThisFileDeclaration, isRunningFromThisFileId };
     }
 
-    const { isRunningFromThisFileDeclaration, isRunningFromThisFileId } =
-      getTestGuardDeclaration();
+    const { isRunningFromThisFileDeclaration, isRunningFromThisFileId } = getTestGuardDeclaration();
 
     ast.program.body.push(isRunningFromThisFileDeclaration);
 

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -95,7 +95,7 @@ export async function vitestTransform({
   }
 
   // Filter out stories based on the passed tags filter
-  let validStories: (typeof parsed)['_storyStatements'] = {};
+  const validStories: (typeof parsed)['_storyStatements'] = {};
   Object.keys(parsed._stories).map((key) => {
     const finalTags = combineTags(
       'test',
@@ -135,7 +135,6 @@ export async function vitestTransform({
     ast.program.body.unshift(...imports);
   } else {
     const vitestExpectId = parsed._file.path.scope.generateUidIdentifier('expect');
-    const composeStoryId = parsed._file.path.scope.generateUidIdentifier('composeStory');
     const testStoryId = parsed._file.path.scope.generateUidIdentifier('testStory');
     const skipTagsId = t.identifier(JSON.stringify(tagsFilter.skip));
 
@@ -147,7 +146,7 @@ export async function vitestTransform({
      * Const isRunningFromThisFile = import.meta.url.includes(expect.getState().testPath ??
      * globalThis.**vitest_worker**.filepath) if(isRunningFromThisFile) { ... }
      */
-    function getTestGuardDeclaration(vitestExpectId: t.Identifier) {
+    function getTestGuardDeclaration() {
       const isRunningFromThisFileId =
         parsed._file.path.scope.generateUidIdentifier('isRunningFromThisFile');
 

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -239,7 +239,7 @@ export async function vitestTransform({
           node,
         });
       })
-      .filter((st) => !!st);
+      .filter((st) => !!st) as t.ExpressionStatement[];
 
     const testBlock = t.ifStatement(isRunningFromThisFileId, t.blockStatement(storyTestStatements));
 

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -190,7 +190,7 @@ export async function vitestTransform({
     }
 
     const { isRunningFromThisFileDeclaration, isRunningFromThisFileId } =
-      getTestGuardDeclaration(vitestExpectId);
+      getTestGuardDeclaration();
 
     ast.program.body.push(isRunningFromThisFileDeclaration);
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28930

This work changes the transformation done in the plugin to:
- account for no tests in a file
- transform only the stories that should be included (uses tags at compile time)
- execute only tests if they are imported in the same

This fixes several bugs:

### 1 - test fails because there are no tests in the file
```ts
export default {
  tags: ['!test']
}

// ...
```

### 2 - test from another file execute when being imported from a story file
```ts
import { someConstant } from './Other.stories' // this causes unintended side effects
export default {}
export const MyStory = {}
```

Before:
![image](https://github.com/user-attachments/assets/327a1036-e473-4b2c-ae72-ebbdf21f5507)

After:
![image](https://github.com/user-attachments/assets/e409552f-b651-4ad0-b938-f1c4ad9b208b)


<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | -106 B | -0.45 | 0% |
| initSize |  169 MB | 169 MB | 3.37 kB | **1.74** | 0% |
| diffSize |  92.8 MB | 92.8 MB | 3.47 kB | **1.27** | 0% |
| buildSize |  7.46 MB | 7.46 MB | 138 B | 1.19 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 138 B | **1.33** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0.33 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | 1.09 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 138 B | 1.23 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 1.02 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.7s | 20.4s | 13.6s | 0.65 | 66.9% |
| generateTime |  20s | 18.2s | -1s -842ms | **-1.81** | 🔰-10.1% |
| initTime |  16.5s | 15.9s | -598ms | -1.18 | -3.8% |
| buildTime |  13s | 14.4s | 1.4s | **1.46** | 🔺9.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.8s | 7.8s | -30ms | 0.44 | -0.4% |
| devManagerResponsive |  5s | 5.1s | 119ms | 0.65 | 2.3% |
| devManagerHeaderVisible |  903ms | 855ms | -48ms | 0.39 | -5.6% |
| devManagerIndexVisible |  943ms | 893ms | -50ms | 0.36 | -5.6% |
| devStoryVisibleUncached |  1.2s | 1.4s | 214ms | 0.63 | 14.4% |
| devStoryVisible |  940ms | 894ms | -46ms | 0.37 | -5.1% |
| devAutodocsVisible |  695ms | 891ms | 196ms | **1.29** | 🔺22% |
| devMDXVisible |  697ms | 719ms | 22ms | -0.06 | 3.1% |
| buildManagerHeaderVisible |  733ms | 781ms | 48ms | 0.33 | 6.1% |
| buildManagerIndexVisible |  739ms | 791ms | 52ms | 0.39 | 6.6% |
| buildStoryVisible |  807ms | 879ms | 72ms | 0.58 | 8.2% |
| buildAutodocsVisible |  718ms | 810ms | 92ms | 1.13 | 11.4% |
| buildMDXVisible |  633ms | 726ms | 93ms | 1 | 12.8% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR enhances the Vitest addon for Storybook, focusing on improving the transformation logic and test execution efficiency. Key changes include:

- Implemented filtering of stories based on tags at compile time in `code/core/src/csf-tools/vitest-plugin/transformer.ts`
- Added extraction of preview-level tags in `code/addons/vitest/src/plugin/index.ts`
- Improved handling of cases with no valid tests in a file in `code/core/src/csf-tools/vitest-plugin/transformer.ts`
- Implemented a guard to prevent duplicate test executions in `code/core/src/csf-tools/vitest-plugin/transformer.ts`
- Updated `testStory` function in `code/addons/vitest/src/plugin/test-utils.ts` to use `composeStory` for more accurate story composition

<!-- /greptile_comment -->