### PR TITLE
Vitest: Fix default viewport

### DIFF
--- a/code/addons/vitest/src/plugin/viewports.test.ts
+++ b/code/addons/vitest/src/plugin/viewports.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-underscore-dangle */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+
 import { page } from '@vitest/browser/context';
 
 import { DEFAULT_VIEWPORT_DIMENSIONS, type ViewportsParam, setViewport } from './viewports';
@@ -42,6 +44,7 @@ describe('setViewport', () => {
 
   it('should set the dimensions of viewport from INITIAL_VIEWPORTS', async () => {
     const viewportsParam: any = {
+      viewports: INITIAL_VIEWPORTS,
       // supported by default in addon viewports
       defaultViewport: 'ipad',
     };

--- a/code/addons/vitest/src/plugin/viewports.ts
+++ b/code/addons/vitest/src/plugin/viewports.ts
@@ -3,7 +3,7 @@ import { UnsupportedViewportDimensionError } from 'storybook/internal/preview-er
 
 import { page } from '@vitest/browser/context';
 
-import { INITIAL_VIEWPORTS } from '../../../viewport/src/defaults';
+import { MINIMAL_VIEWPORTS } from '../../../viewport/src/defaults';
 import type { ViewportMap, ViewportStyles } from '../../../viewport/src/types';
 
 declare global {
@@ -50,12 +50,12 @@ const parseDimension = (value: string, dimension: 'width' | 'height') => {
 export const setViewport = async (viewportsParam: ViewportsParam = {} as ViewportsParam) => {
   const defaultViewport = viewportsParam.defaultViewport;
 
-  if (!page || !globalThis.__vitest_browser__ || !defaultViewport) {
+  if (!page || !globalThis.__vitest_browser__) {
     return;
   }
 
   const viewports = {
-    ...INITIAL_VIEWPORTS,
+    ...MINIMAL_VIEWPORTS,
     ...viewportsParam.viewports,
   };
 


### PR DESCRIPTION
## What I did

The default viewport in storybook is MINIMAL_VIEWPORTS.
https://github.com/storybookjs/storybook/blob/513bb66bb9729ece57581b6eb50e5b338c47c0b9/code/addons/viewport/src/legacy/ToolLegacy.tsx#L122-L127

The addon now also uses that as default.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.4 MB | 144 kB | **5.76** | 0.2% |
| initSize |  169 MB | 169 MB | 144 kB | **5.02** | 0.1% |
| diffSize |  92.8 MB | 92.8 MB | -12 B | 0.98 | 0% |
| buildSize |  7.46 MB | 7.46 MB | 0 B | 0.91 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 0.78 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | 0.58 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | 0.7 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **1.39** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.2s | 6.9s | -16s -282ms | **-1.52** | 🔰-233% |
| generateTime |  19.5s | 20.2s | 693ms | 0.05 | 3.4% |
| initTime |  17.1s | 17.8s | 684ms | 0.51 | 3.8% |
| buildTime |  11.6s | 10.7s | -940ms | **-1.82** | 🔰-8.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.5s | 6.9s | 423ms | -0.57 | 6.1% |
| devManagerResponsive |  4.3s | 4.6s | 285ms | -0.49 | 6.2% |
| devManagerHeaderVisible |  728ms | 783ms | 55ms | -0.33 | 7% |
| devManagerIndexVisible |  761ms | 826ms | 65ms | -0.28 | 7.9% |
| devStoryVisibleUncached |  1.1s | 1.1s | -23ms | -0.66 | -2% |
| devStoryVisible |  763ms | 827ms | 64ms | -0.29 | 7.7% |
| devAutodocsVisible |  651ms | 874ms | 223ms | 1.15 | 25.5% |
| devMDXVisible |  623ms | 672ms | 49ms | -0.38 | 7.3% |
| buildManagerHeaderVisible |  663ms | 725ms | 62ms | -0.19 | 8.6% |
| buildManagerIndexVisible |  668ms | 727ms | 59ms | -0.24 | 8.1% |
| buildStoryVisible |  697ms | 804ms | 107ms | -0.02 | 13.3% |
| buildAutodocsVisible |  664ms | 699ms | 35ms | -0.04 | 5% |
| buildMDXVisible |  658ms | 604ms | -54ms | -1.12 | -8.9% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR updates the Vitest plugin for Storybook to align with the default viewport behavior, focusing on the use of MINIMAL_VIEWPORTS instead of INITIAL_VIEWPORTS.

- Modified `code/addons/vitest/src/plugin/viewports.ts` to use MINIMAL_VIEWPORTS as the default
- Removed the check for defaultViewport in the setViewport function
- Simplified viewport configuration to match Storybook's core behavior
- Ensures consistency between Vitest plugin and Storybook's default viewport settings
- Improves compatibility and reduces potential confusion for users

<!-- /greptile_comment -->