### PR TITLE
Addon Viewport: Add default options via parameters

### DIFF
--- a/code/.storybook/preview.tsx
+++ b/code/.storybook/preview.tsx
@@ -342,9 +342,6 @@ export const parameters = {
       'slategray',
     ],
   },
-  viewport: {
-    options: MINIMAL_VIEWPORTS,
-  },
   themes: {
     disable: true,
   },

--- a/code/addons/viewport/preview.js
+++ b/code/addons/viewport/preview.js
@@ -1,1 +1,1 @@
-export { globals } from './dist/preview';
+export * from './dist/preview';

--- a/code/addons/viewport/src/preview.ts
+++ b/code/addons/viewport/src/preview.ts
@@ -1,4 +1,5 @@
 import { PARAM_KEY as KEY } from './constants';
+import { MINIMAL_VIEWPORTS } from './defaults';
 import type { GlobalState } from './types';
 
 const modern: Record<string, GlobalState> = {
@@ -9,3 +10,11 @@ const modern: Record<string, GlobalState> = {
 const legacy = { viewport: 'reset', viewportRotated: false };
 
 export const initialGlobals = FEATURES?.viewportStoryGlobals ? modern : legacy;
+
+export const parameters = FEATURES?.viewportStoryGlobals
+  ? {
+      [KEY]: {
+        options: MINIMAL_VIEWPORTS,
+      },
+    }
+  : {};


### PR DESCRIPTION
## What I did

Add `parameters.viewport.options` to have default `MINIMAL_VIEWPORTS`

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 0 B | -0.24 | 0% |
| initSize |  169 MB | 169 MB | 1.07 kB | **1.27** | 0% |
| diffSize |  92.8 MB | 92.8 MB | 1.07 kB | 0.96 | 0% |
| buildSize |  7.46 MB | 7.46 MB | 370 B | 1.17 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 41 B | 1.04 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | 0.82 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 41 B | 0.96 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 329 B | **1.71** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  20.5s | 23.7s | 3.2s | 1.15 | 13.7% |
| generateTime |  19.1s | 21.2s | 2.1s | 0.89 | 10.2% |
| initTime |  16s | 17.3s | 1.2s | -0.13 | 7.2% |
| buildTime |  11.9s | 13.3s | 1.4s | 0.62 | 10.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.4s | 8.4s | 1s | 1.05 | 12% |
| devManagerResponsive |  5s | 5.8s | 848ms | **1.96** | 🔺14.4% |
| devManagerHeaderVisible |  905ms | 999ms | 94ms | **1.55** | 🔺9.4% |
| devManagerIndexVisible |  948ms | 1s | 85ms | **1.48** | 🔺8.2% |
| devStoryVisibleUncached |  1.3s | 1.4s | 80ms | 0.6 | 5.4% |
| devStoryVisible |  950ms | 1s | 84ms | **1.49** | 🔺8.1% |
| devAutodocsVisible |  676ms | 951ms | 275ms | **1.82** | 🔺28.9% |
| devMDXVisible |  716ms | 882ms | 166ms | 1.12 | 18.8% |
| buildManagerHeaderVisible |  723ms | 701ms | -22ms | -0.49 | -3.1% |
| buildManagerIndexVisible |  725ms | 711ms | -14ms | -0.44 | -2% |
| buildStoryVisible |  792ms | 952ms | 160ms | 1.21 | 16.8% |
| buildAutodocsVisible |  682ms | 644ms | -38ms | -0.7 | -5.9% |
| buildMDXVisible |  679ms | 800ms | 121ms | **2.13** | 🔺15.1% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds default viewport options to the addon-viewport parameters when the viewportStoryGlobals feature is enabled.

- Added MINIMAL_VIEWPORTS as default options in `code/addons/viewport/src/preview.ts` when viewportStoryGlobals is enabled
- Removed default viewport options from `code/.storybook/preview.tsx`
- Modified `code/addons/viewport/preview.js` to export all named exports from './dist/preview'
- These changes provide predefined viewport sizes out of the box while allowing more flexibility in exports

<!-- /greptile_comment -->