### PR TITLE
Core: Make sure local `@storybook/cli` is used in linked mode

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -545,10 +545,11 @@ export async function addExtraDependencies({
   await packageManager.addDependencies({ installAsDevDependencies: true }, extraDevDeps);
 
   if (extraDeps) {
+    const versionedExtraDeps = await packageManager.getVersionedPackages(extraDeps);
     if (debug) {
-      logger.log('\uD83C\uDF81 Adding extra deps', extraDeps);
+      logger.log('\uD83C\uDF81 Adding extra deps', versionedExtraDeps);
     }
-    await packageManager.addDependencies({ installAsDevDependencies: true }, extraDeps);
+    await packageManager.addDependencies({ installAsDevDependencies: true }, versionedExtraDeps);
   }
   await packageManager.installDependencies();
 }

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -81,7 +81,12 @@ export const sandbox: Task = {
       await addStories(details, options);
     }
 
-    const extraDeps = details.template.modifications?.extraDependencies ?? [];
+    const extraDeps = [
+      ...(details.template.modifications?.extraDependencies ?? []),
+      // The storybook package forwards some CLI commands to @storybook/cli with npx.
+      // Adding the dep makes sure that even npx will use the linked workspace version.
+      '@storybook/cli',
+    ];
     if (!details.template.skipTasks?.includes('vitest-integration')) {
       extraDeps.push(
         'happy-dom',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Make sure local @storybook/cli packages is used in linked mode

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.4 MB | 144 kB | **5.76** | 0.2% |
| initSize |  169 MB | 169 MB | 144 kB | **5.02** | 0.1% |
| diffSize |  92.8 MB | 92.8 MB | -12 B | 0.98 | 0% |
| buildSize |  7.46 MB | 7.46 MB | 45 B | 0.94 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 0.78 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | 0.58 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | 0.7 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 45 B | **1.53** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.2s | 7.4s | -15s -836ms | **-1.46** | 🔰-213% |
| generateTime |  19.5s | 22s | 2.5s | **1.57** | 🔺11.5% |
| initTime |  17.1s | 18.9s | 1.7s | **1.41** | 🔺9.2% |
| buildTime |  11.6s | 13.6s | 1.9s | 0.87 | 14.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.5s | 6.5s | 22ms | -1.02 | 0.3% |
| devManagerResponsive |  4.3s | 4.3s | 26ms | -1.04 | 0.6% |
| devManagerHeaderVisible |  728ms | 745ms | 17ms | -0.66 | 2.3% |
| devManagerIndexVisible |  761ms | 786ms | 25ms | -0.63 | 3.2% |
| devStoryVisibleUncached |  1.1s | 1.2s | 98ms | -0.14 | 7.7% |
| devStoryVisible |  763ms | 780ms | 17ms | -0.69 | 2.2% |
| devAutodocsVisible |  651ms | 660ms | 9ms | -0.82 | 1.4% |
| devMDXVisible |  623ms | 677ms | 54ms | -0.35 | 8% |
| buildManagerHeaderVisible |  663ms | 691ms | 28ms | -0.56 | 4.1% |
| buildManagerIndexVisible |  668ms | 698ms | 30ms | -0.56 | 4.3% |
| buildStoryVisible |  697ms | 731ms | 34ms | -0.71 | 4.7% |
| buildAutodocsVisible |  664ms | 642ms | -22ms | -0.72 | -3.4% |
| buildMDXVisible |  658ms | 627ms | -31ms | -0.73 | -4.9% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR ensures that the local @storybook/cli package is used in linked mode for sandbox environments.

- Added '@storybook/cli' to extraDeps in `scripts/tasks/sandbox.ts`
- Ensures linked workspace version of @storybook/cli is used even with npx
- Improves consistency in development and testing environments
- Affects sandbox creation and CLI command execution in Storybook

<!-- /greptile_comment -->