### PR TITLE
Addon Vitest: Fix postinstall file types

### DIFF
--- a/code/addons/vitest/postinstall.cjs
+++ b/code/addons/vitest/postinstall.cjs
@@ -1,1 +1,1 @@
-module.exports = require('./dist/postinstall.js');
+module.exports = require('./dist/postinstall.cjs');

--- a/code/addons/vitest/preset.cjs
+++ b/code/addons/vitest/preset.cjs
@@ -1,8 +1,3 @@
-function managerEntries(entry = []) {
-  return [...entry, require.resolve('./dist/manager.js')];
-}
-
 module.exports = {
-  managerEntries,
-  ...require('./dist/preset'),
+  ...require('./dist/preset.cjs'),
 };


### PR DESCRIPTION
Closes N/A

NOTE: the problem below is actually fixed by https://github.com/storybookjs/storybook/pull/28980. But this PR is still valid. CJS should not require ESM.

```
$ npx storybook@next add @storybook/experimental-addon-vitest

An error occurred while installing dependencies:
Cet.default is not a function
Error running postinstall script for @storybook/experimental-addon-vitest
HandledError: TypeError: Cet.default is not a function
    at AJ.addDependencies (/Users/shilman/projects/testing/realworld/web/node_modules/@storybook/core/dist/common/index.cjs:151965:72)
    at async postInstall (/Users/shilman/projects/testing/realworld/web/node_modules/@storybook/experimental-addon-vitest/dist/postinstall.cjs:44:212)
    at async postinstallAddon (/Users/shilman/.npm/_npx/7478adc60dc49e45/node_modules/@storybook/cli/dist/bin/index.cjs:51:984)
    at async add (/Users/shilman/.npm/_npx/7478adc60dc49e45/node_modules/@storybook/cli/dist/bin/index.cjs:55:993) {
  handled: true,
```

## What I did

Fix CJS requiring ESM. Not sure whether this will solve the problem.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Postinstall the canary (?)

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28978-sha-d1099143`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28978-sha-d1099143 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28978-sha-d1099143 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28978-sha-d1099143`](https://npmjs.com/package/storybook/v/0.0.0-pr-28978-sha-d1099143) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/fix-vitest-postinstall`](https://github.com/storybookjs/storybook/tree/shilman/fix-vitest-postinstall) |
| **Commit** | [`d1099143`](https://github.com/storybookjs/storybook/commit/d1099143dba1a1b5cd6627f415858c2420fa23c5) |
| **Datetime** | Tue Aug 27 12:26:58 UTC 2024 (`1724761618`) |
| **Workflow run** | [10578071334](https://github.com/storybookjs/storybook/actions/runs/10578071334) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28978`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | 0.99 | 0% |
| initSize |  169 MB | 169 MB | 0 B | 1.02 | 0% |
| diffSize |  92.8 MB | 92.8 MB | 0 B | 1.07 | 0% |
| buildSize |  7.46 MB | 7.46 MB | 0 B | **1.45** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 1.14 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | **1.36** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | 1.23 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **1.53** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.7s | 16.9s | 10.1s | 0 | 60.2% |
| generateTime |  19s | 21.4s | 2.4s | 0.13 | 11.5% |
| initTime |  15.7s | 20.4s | 4.7s | **2.39** | 🔺23% |
| buildTime |  11.9s | 14s | 2.1s | 1.13 | 15.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.8s | 7.2s | -690ms | -0.37 | -9.6% |
| devManagerResponsive |  4.7s | 4.7s | 67ms | -0.25 | 1.4% |
| devManagerHeaderVisible |  735ms | 841ms | 106ms | 0.39 | 12.6% |
| devManagerIndexVisible |  767ms | 849ms | 82ms | -0.01 | 9.7% |
| devStoryVisibleUncached |  1.3s | 1.3s | 24ms | 0.15 | 1.7% |
| devStoryVisible |  766ms | 881ms | 115ms | 0.35 | 13.1% |
| devAutodocsVisible |  732ms | 770ms | 38ms | 0.33 | 4.9% |
| devMDXVisible |  630ms | 718ms | 88ms | -0.03 | 12.3% |
| buildManagerHeaderVisible |  678ms | 725ms | 47ms | -0.36 | 6.5% |
| buildManagerIndexVisible |  683ms | 726ms | 43ms | -0.46 | 5.9% |
| buildStoryVisible |  717ms | 764ms | 47ms | -0.55 | 6.2% |
| buildAutodocsVisible |  690ms | 665ms | -25ms | -0.53 | -3.8% |
| buildMDXVisible |  631ms | 668ms | 37ms | -0.28 | 5.5% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request addresses an issue with the postinstall script for the @storybook/experimental-addon-vitest addon by updating file extensions to resolve CommonJS importing ESM problems.

- Updated `code/addons/vitest/postinstall.cjs` to require 'dist/postinstall.cjs' instead of '.js'
- Modified `code/addons/vitest/preset.cjs` to directly export contents from 'dist/preset.cjs'
- These changes aim to fix the "Cet.default is not a function" error during addon installation
- The modifications are minimal but crucial for resolving the reported installation error

<!-- /greptile_comment -->