### PR TITLE
CLI: Fix dedent import in package managers

### DIFF
--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -7,7 +7,7 @@ import { FindPackageVersionsError } from '@storybook/core/server-errors';
 
 import { findUp } from 'find-up';
 import sort from 'semver/functions/sort.js';
-import dedent from 'ts-dedent';
+import { dedent } from 'ts-dedent';
 
 import { createLogStream } from '../utils/cli';
 import { JsPackageManager } from './JsPackageManager';

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -5,7 +5,7 @@ import { FindPackageVersionsError } from '@storybook/core/server-errors';
 
 import { findUpSync } from 'find-up';
 import { pathExistsSync } from 'fs-extra';
-import dedent from 'ts-dedent';
+import { dedent } from 'ts-dedent';
 
 import { createLogStream } from '../utils/cli';
 import { JsPackageManager } from './JsPackageManager';

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { FindPackageVersionsError } from '@storybook/core/server-errors';
 
 import { findUp } from 'find-up';
-import dedent from 'ts-dedent';
+import { dedent } from 'ts-dedent';
 
 import { createLogStream } from '../utils/cli';
 import { JsPackageManager } from './JsPackageManager';


### PR DESCRIPTION
Closes N/A

```
$ npx storybook@next add @storybook/experimental-addon-vitest

An error occurred while installing dependencies:
Cet.default is not a function
Error running postinstall script for @storybook/experimental-addon-vitest
HandledError: TypeError: Cet.default is not a function
    at AJ.addDependencies (/Users/shilman/projects/testing/realworld/web/node_modules/@storybook/core/dist/common/index.cjs:151965:72)
    at async postInstall (/Users/shilman/projects/testing/realworld/web/node_modules/@storybook/experimental-addon-vitest/dist/postinstall.cjs:44:212)
    at async postinstallAddon (/Users/shilman/.npm/_npx/7478adc60dc49e45/node_modules/@storybook/cli/dist/bin/index.cjs:51:984)
    at async add (/Users/shilman/.npm/_npx/7478adc60dc49e45/node_modules/@storybook/cli/dist/bin/index.cjs:55:993) {
  handled: true,
```

## What I did

Fix a bad `dedent` import in some package managers

## Checklist for Contributors

### Testing

Test the canary in [Realworld](https://github.com/lifeiscontent/realworld)

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28980-sha-5147e88f`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28980-sha-5147e88f sandbox` or in an existing project with `npx storybook@0.0.0-pr-28980-sha-5147e88f upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28980-sha-5147e88f`](https://npmjs.com/package/storybook/v/0.0.0-pr-28980-sha-5147e88f) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/fix-cli-dedent-import`](https://github.com/storybookjs/storybook/tree/shilman/fix-cli-dedent-import) |
| **Commit** | [`5147e88f`](https://github.com/storybookjs/storybook/commit/5147e88f859775a311f051c6bc2d8caafb02c988) |
| **Datetime** | Tue Aug 27 12:57:12 UTC 2024 (`1724763432`) |
| **Workflow run** | [10578571208](https://github.com/storybookjs/storybook/actions/runs/10578571208) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28980`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | 0.99 | 0% |
| initSize |  169 MB | 169 MB | -6 B | 1.02 | 0% |
| diffSize |  92.8 MB | 92.8 MB | -6 B | 1.07 | 0% |
| buildSize |  7.46 MB | 7.46 MB | 0 B | **1.45** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 1.14 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | - | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | **1.36** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | 1.23 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **1.53** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.7s | 7.9s | 1.2s | -1.23 | 15.3% |
| generateTime |  19s | 22.7s | 3.7s | 0.52 | 16.3% |
| initTime |  15.7s | 20.1s | 4.3s | **2.11** | 🔺21.6% |
| buildTime |  11.9s | 10.9s | -988ms | **-1.6** | 🔰-9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.8s | 8.4s | 559ms | **1.32** | 🔺6.6% |
| devManagerResponsive |  4.7s | 5.5s | 809ms | **1.49** | 🔺14.6% |
| devManagerHeaderVisible |  735ms | 771ms | 36ms | -0.5 | 4.7% |
| devManagerIndexVisible |  767ms | 806ms | 39ms | -0.53 | 4.8% |
| devStoryVisibleUncached |  1.3s | 1.4s | 93ms | 0.47 | 6.4% |
| devStoryVisible |  766ms | 807ms | 41ms | -0.54 | 5.1% |
| devAutodocsVisible |  732ms | 723ms | -9ms | -0.2 | -1.2% |
| devMDXVisible |  630ms | 703ms | 73ms | -0.21 | 10.4% |
| buildManagerHeaderVisible |  678ms | 764ms | 86ms | 0.17 | 11.3% |
| buildManagerIndexVisible |  683ms | 765ms | 82ms | 0.02 | 10.7% |
| buildStoryVisible |  717ms | 804ms | 87ms | -0.04 | 10.8% |
| buildAutodocsVisible |  690ms | 828ms | 138ms | **2.6** | 🔺16.7% |
| buildMDXVisible |  631ms | 745ms | 114ms | 0.81 | 15.3% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR addresses an import issue with the `dedent` function from the `ts-dedent` package across multiple package manager proxy files in Storybook's core.

- Updated import statement in `NPMProxy.ts`, `PNPMProxy.ts`, and `Yarn1Proxy.ts` from `import dedent from 'ts-dedent'` to `import { dedent } from 'ts-dedent'`
- Fixes the 'Cet.default is not a function' error in the Storybook CLI
- Improves stability of package management operations across NPM, PNPM, and Yarn1
- Resolves runtime errors caused by incorrect import syntax
- Enhances compatibility with the `@storybook/experimental-addon-vitest` postinstall script

<!-- /greptile_comment -->