### PR TITLE
Builder-Vite: Fix 'condition node never be used' warning

### DIFF
--- a/code/addons/a11y/package.json
+++ b/code/addons/a11y/package.json
@@ -29,8 +29,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preview": {
       "types": "./dist/preview.d.ts",

--- a/code/addons/actions/package.json
+++ b/code/addons/actions/package.json
@@ -25,8 +25,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./decorator": {
       "types": "./dist/decorator.d.ts",

--- a/code/addons/backgrounds/package.json
+++ b/code/addons/backgrounds/package.json
@@ -29,8 +29,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preview": {
       "types": "./dist/preview.d.ts",

--- a/code/addons/controls/package.json
+++ b/code/addons/controls/package.json
@@ -29,8 +29,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./manager": "./dist/manager.js",
     "./register": "./dist/manager.js",

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -28,8 +28,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preview": {
       "types": "./dist/preview.d.ts",

--- a/code/addons/essentials/package.json
+++ b/code/addons/essentials/package.json
@@ -25,8 +25,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./actions/preview": {
       "types": "./dist/actions/preview.d.ts",

--- a/code/addons/highlight/package.json
+++ b/code/addons/highlight/package.json
@@ -27,8 +27,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preview": {
       "types": "./dist/preview.d.ts",

--- a/code/addons/interactions/package.json
+++ b/code/addons/interactions/package.json
@@ -25,8 +25,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preview": {
       "types": "./dist/preview.d.ts",

--- a/code/addons/jest/package.json
+++ b/code/addons/jest/package.json
@@ -31,8 +31,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./manager": "./dist/manager.js",
     "./register": "./dist/manager.js",

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -25,8 +25,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./react": {
       "types": "./dist/react/index.d.ts",

--- a/code/addons/measure/package.json
+++ b/code/addons/measure/package.json
@@ -28,8 +28,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preview": {
       "types": "./dist/preview.d.ts",

--- a/code/addons/onboarding/package.json
+++ b/code/addons/onboarding/package.json
@@ -24,8 +24,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./manager": "./dist/manager.js",
     "./preset": "./dist/preset.js",

--- a/code/addons/outline/package.json
+++ b/code/addons/outline/package.json
@@ -31,8 +31,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preview": {
       "types": "./dist/preview.d.ts",

--- a/code/addons/storysource/package.json
+++ b/code/addons/storysource/package.json
@@ -25,8 +25,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preset": "./dist/preset.js",
     "./manager": "./dist/manager.js",

--- a/code/addons/themes/package.json
+++ b/code/addons/themes/package.json
@@ -30,8 +30,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preview": {
       "types": "./dist/preview.d.ts",

--- a/code/addons/toolbars/package.json
+++ b/code/addons/toolbars/package.json
@@ -29,8 +29,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./manager": "./dist/manager.js",
     "./register": "./dist/manager.js",

--- a/code/addons/viewport/package.json
+++ b/code/addons/viewport/package.json
@@ -26,8 +26,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preview": {
       "types": "./dist/preview.d.ts",

--- a/code/addons/vitest/package.json
+++ b/code/addons/vitest/package.json
@@ -27,8 +27,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "node": "./dist/index.cjs"
+      "require": "./dist/index.cjs"
     },
     "./plugin": {
       "types": "./dist/plugin/index.d.ts",

--- a/code/deprecated/csf-tools/package.json
+++ b/code/deprecated/csf-tools/package.json
@@ -24,8 +24,7 @@
     ".": {
       "types": "./shim.d.ts",
       "import": "./shim.mjs",
-      "require": "./shim.js",
-      "node": "./shim.js"
+      "require": "./shim.js"
     },
     "./package.json": "./package.json"
   },

--- a/code/deprecated/router/package.json
+++ b/code/deprecated/router/package.json
@@ -24,8 +24,7 @@
     ".": {
       "types": "./shim.d.ts",
       "import": "./shim.mjs",
-      "require": "./shim.js",
-      "node": "./shim.js"
+      "require": "./shim.js"
     },
     "./utils": {
       "types": "./utils.d.ts",

--- a/code/deprecated/theming/package.json
+++ b/code/deprecated/theming/package.json
@@ -24,8 +24,7 @@
     ".": {
       "types": "./shim.d.ts",
       "import": "./shim.mjs",
-      "require": "./shim.js",
-      "node": "./shim.js"
+      "require": "./shim.js"
     },
     "./create": {
       "types": "./create.d.ts",

--- a/code/lib/blocks/package.json
+++ b/code/lib/blocks/package.json
@@ -24,8 +24,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/code/lib/instrumenter/package.json
+++ b/code/lib/instrumenter/package.json
@@ -24,8 +24,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -25,8 +25,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/code/renderers/html/package.json
+++ b/code/renderers/html/package.json
@@ -23,8 +23,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preset": "./preset.js",
     "./dist/entry-preview.mjs": "./dist/entry-preview.mjs",

--- a/code/renderers/preact/package.json
+++ b/code/renderers/preact/package.json
@@ -23,8 +23,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preset": "./preset.js",
     "./dist/entry-preview.mjs": "./dist/entry-preview.mjs",

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -23,14 +23,12 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./experimental-playwright": {
       "types": "./dist/playwright.d.ts",
       "import": "./dist/playwright.mjs",
-      "require": "./dist/playwright.js",
-      "node": "./dist/playwright.js"
+      "require": "./dist/playwright.js"
     },
     "./preset": "./preset.js",
     "./dist/entry-preview.mjs": "./dist/entry-preview.mjs",

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -23,8 +23,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preset": "./preset.js",
     "./dist/entry-preview.mjs": "./dist/entry-preview.mjs",

--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -23,14 +23,12 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./experimental-playwright": {
       "types": "./dist/playwright.d.ts",
       "import": "./dist/playwright.mjs",
-      "require": "./dist/playwright.js",
-      "node": "./dist/playwright.js"
+      "require": "./dist/playwright.js"
     },
     "./preset": "./preset.js",
     "./dist/entry-preview.mjs": "./dist/entry-preview.mjs",

--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -23,14 +23,12 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./experimental-playwright": {
       "types": "./dist/playwright.d.ts",
       "import": "./dist/playwright.mjs",
-      "require": "./dist/playwright.js",
-      "node": "./dist/playwright.js"
+      "require": "./dist/playwright.js"
     },
     "./preset": "./preset.js",
     "./dist/entry-preview.mjs": "./dist/entry-preview.mjs",

--- a/code/renderers/web-components/package.json
+++ b/code/renderers/web-components/package.json
@@ -26,8 +26,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "node": "./dist/index.js"
+      "require": "./dist/index.js"
     },
     "./preset": "./preset.js",
     "./dist/entry-preview.mjs": "./dist/entry-preview.mjs",


### PR DESCRIPTION
Closes n/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have removed the `node` export in some of our Storybook packages in the case, where an `import` and a `require` export statement exists beforehand. That avoids warnings from Vite saying: "The condition 'node' here will never be used as it comes after both 'import' and 'require'" [package.json]

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a Vite-based sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Take a look at your terminal. The warning "The condition 'node' here will never be used as it comes after both 'import' and 'require'" shouldn't appear.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | 0.5 | 0% |
| initSize |  161 MB | 161 MB | 57.8 kB | -0.88 | 0% |
| diffSize |  84.8 MB | 84.8 MB | 57.8 kB | -0.89 | 0.1% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | **3** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 0.72 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | **3** | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | 0.73 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **3** | 0% |
| buildPreviewSize |  3.01 MB | 3.01 MB | 0 B | **2.99** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7s | 7.7s | 720ms | -1.19 | 9.3% |
| generateTime |  19.7s | 22.7s | 2.9s | 0.45 | 13% |
| initTime |  16s | 18s | 1.9s | 0.62 | 10.8% |
| buildTime |  11.5s | 10.4s | -1s -132ms | **-2.19** | 🔰-10.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.9s | 7.2s | 277ms | -0.17 | 3.8% |
| devManagerResponsive |  4.5s | 4.6s | 72ms | -0.31 | 1.5% |
| devManagerHeaderVisible |  793ms | 767ms | -26ms | -0.46 | -3.4% |
| devManagerIndexVisible |  830ms | 805ms | -25ms | -0.44 | -3.1% |
| devStoryVisibleUncached |  1.4s | 1.4s | 91ms | 0.57 | 6.1% |
| devStoryVisible |  829ms | 813ms | -16ms | -0.36 | -2% |
| devAutodocsVisible |  745ms | 652ms | -93ms | -0.99 | -14.3% |
| devMDXVisible |  677ms | 661ms | -16ms | -0.63 | -2.4% |
| buildManagerHeaderVisible |  791ms | 684ms | -107ms | -0.89 | -15.6% |
| buildManagerIndexVisible |  793ms | 692ms | -101ms | -0.87 | -14.6% |
| buildStoryVisible |  868ms | 772ms | -96ms | -0.5 | -12.4% |
| buildAutodocsVisible |  760ms | 624ms | -136ms | **-1.4** | 🔰-21.8% |
| buildMDXVisible |  952ms | 638ms | -314ms | -0.59 | -49.2% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR removes the 'node' export condition from package.json files across multiple Storybook packages to address Vite warnings about unused conditions.

- Removed 'node' export condition from 28 package.json files in various Storybook addons and renderers
- Simplifies export configurations to improve compatibility with Vite-based projects
- Retains 'import' and 'require' conditions to maintain functionality for different module systems
- Changes affect core addons like a11y, actions, controls, and renderers for React, Vue3, and Svelte
- No functional changes expected; modifications aim to resolve Vite warnings only

<!-- /greptile_comment -->