### PR TITLE
CLI: Update spawn options in proxy.ts to support Windows

### DIFF
--- a/code/lib/cli/src/proxy.ts
+++ b/code/lib/cli/src/proxy.ts
@@ -12,7 +12,7 @@ if (['dev', 'build'].includes(args[0])) {
       ? [`create-storybook@${versions.storybook}`, ...args.slice(1)]
       : [`@storybook/cli@${versions.storybook}`, ...args];
   const command = ['npx', '--yes', ...proxiedArgs];
-  const child = spawn(command[0], command.slice(1), { stdio: 'inherit' });
+  const child = spawn(command[0], command.slice(1), { stdio: 'inherit', shell: true });
   child.on('exit', (code) => {
     if (code != null) {
       process.exit(code);


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixing an issue on Windows where spawning a child process executing an `npx` command fails with an `Error: spawn npx ENOENT` error. This error occurred during the upgrade to `8.3.0-alpha.4 or higher.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Run `npx storybook@<canary> upgrade` on Windows in a Storybook project. The above mentioned error shouldn't appear.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | 0.5 | 0% |
| initSize |  161 MB | 161 MB | 58.4 kB | -0.88 | 0% |
| diffSize |  84.8 MB | 84.8 MB | 58.4 kB | -0.89 | 0.1% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | **3** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 0.72 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | **3** | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | 0.73 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **3** | 0% |
| buildPreviewSize |  3.01 MB | 3.01 MB | 0 B | **2.99** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7s | 25.6s | 18.5s | **1.24** | 🔺72.6% |
| generateTime |  19.7s | 21.3s | 1.5s | 0.01 | 7.4% |
| initTime |  16s | 17.5s | 1.4s | 0.24 | 8.4% |
| buildTime |  11.5s | 12.9s | 1.3s | 0.77 | 10.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.9s | 7s | 63ms | -0.46 | 0.9% |
| devManagerResponsive |  4.5s | 4.5s | -72ms | -0.65 | -1.6% |
| devManagerHeaderVisible |  793ms | 718ms | -75ms | -1.07 | -10.4% |
| devManagerIndexVisible |  830ms | 759ms | -71ms | -1.01 | -9.4% |
| devStoryVisibleUncached |  1.4s | 1.3s | -47ms | -0.03 | -3.5% |
| devStoryVisible |  829ms | 758ms | -71ms | -1.01 | -9.4% |
| devAutodocsVisible |  745ms | 722ms | -23ms | 0.04 | -3.2% |
| devMDXVisible |  677ms | 644ms | -33ms | -0.81 | -5.1% |
| buildManagerHeaderVisible |  791ms | 683ms | -108ms | -0.91 | -15.8% |
| buildManagerIndexVisible |  793ms | 690ms | -103ms | -0.89 | -14.9% |
| buildStoryVisible |  868ms | 723ms | -145ms | -1.11 | -20.1% |
| buildAutodocsVisible |  760ms | 710ms | -50ms | 0.22 | -7% |
| buildMDXVisible |  952ms | 628ms | -324ms | -0.69 | -51.6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request updates the spawn options in the CLI's proxy.ts file to support Windows environments.

- Modified `code/lib/cli/src/proxy.ts` to add `shell: true` option to `spawn` function call
- Addresses `Error: spawn npx ENOENT` issue when executing `npx` commands on Windows
- Ensures child processes are executed in a shell environment, resolving compatibility problems
- Improves cross-platform support for Storybook CLI operations

<!-- /greptile_comment -->