### PR TITLE
Addon Vitest: Fix tests potentially not existing in non-isolate mode

### DIFF
--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -80,7 +80,7 @@ describe('transformer', () => {
         };
         export default _meta;
         export const Story = {};
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Story", _testStory("Story", Story, _meta, []));
         }
@@ -109,7 +109,7 @@ describe('transformer', () => {
         };
         export default _meta;
         export const Story = {};
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Story", _testStory("Story", Story, _meta, []));
         }
@@ -139,7 +139,7 @@ describe('transformer', () => {
         };
         export default meta;
         export const Story = {};
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Story", _testStory("Story", Story, meta, []));
         }
@@ -170,7 +170,7 @@ describe('transformer', () => {
         };
         export default meta;
         export const Story = {};
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Story", _testStory("Story", Story, meta, []));
         }
@@ -206,7 +206,7 @@ describe('transformer', () => {
             label: 'Primary Button'
           }
         };
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Primary", _testStory("Primary", Primary, _meta, []));
         }
@@ -240,7 +240,7 @@ describe('transformer', () => {
           }
         };
         export { Primary };
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Primary", _testStory("Primary", Primary, _meta, []));
         }
@@ -276,7 +276,7 @@ describe('transformer', () => {
         };
         export const Secondary = {};
         export { Primary };
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Secondary", _testStory("Secondary", Secondary, _meta, []));
           _test("Primary", _testStory("Primary", Primary, _meta, []));
@@ -308,7 +308,7 @@ describe('transformer', () => {
         export default _meta;
         export const Story = {};
         export const nonStory = 123;
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Story", _testStory("Story", Story, _meta, []));
         }
@@ -365,7 +365,7 @@ describe('transformer', () => {
           tags: ['include-me']
         };
         export const NotIncluded = {};
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Included", _testStory("Included", Included, _meta, []));
         }
@@ -396,7 +396,7 @@ describe('transformer', () => {
         export const NotIncluded = {
           tags: ['exclude-me']
         };
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Included", _testStory("Included", Included, _meta, []));
         }
@@ -424,7 +424,7 @@ describe('transformer', () => {
         export const Skipped = {
           tags: ['skip-me']
         };
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Skipped", _testStory("Skipped", Skipped, _meta, ["skip-me"]));
         }
@@ -456,7 +456,7 @@ describe('transformer', () => {
         };
         export default meta;
         export const Primary = {};
-        const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath);
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
         if (_isRunningFromThisFile) {
           _test("Primary", _testStory("Primary", Primary, meta, []));
         }

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -175,7 +175,7 @@ export async function vitestTransform({
         // TODO: switch order of testPathProperty and filePathProperty when the bug is fixed
         // https://github.com/vitest-dev/vitest/issues/6367 (or probably just use testPathProperty)
         filePathProperty,
-        testPathProperty,
+        testPathProperty
       );
 
       // Create the final expression: import.meta.url.includes(...)

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -172,8 +172,10 @@ export async function vitestTransform({
       // Combine testPath and filepath using the ?? operator
       const nullishCoalescingExpression = t.logicalExpression(
         '??',
+        // TODO: switch order of testPathProperty and filePathProperty when the bug is fixed
+        // https://github.com/vitest-dev/vitest/issues/6367 (or probably just use testPathProperty)
+        filePathProperty,
         testPathProperty,
-        filePathProperty
       );
 
       // Create the final expression: import.meta.url.includes(...)


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes an issue where there is test flake in when running vitest tests with non-isolate mode. This is related to a bug in Vitest.

The fix switches the order of the following statement from:
```ts
const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
```

to
```ts
const _isRunningFromThisFile = import.meta.url.includes(_expect.getState().testPath ?? globalThis.__vitest_worker__.filepath );
```

Once this bug is fixed in https://github.com/vitest-dev/vitest/issues/6367 we can replace the code again. There is a reminder as a code comment.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28993-sha-5e4d9ae9`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28993-sha-5e4d9ae9 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28993-sha-5e4d9ae9 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28993-sha-5e4d9ae9`](https://npmjs.com/package/storybook/v/0.0.0-pr-28993-sha-5e4d9ae9) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/fix-isolate-false-issue`](https://github.com/storybookjs/storybook/tree/yann/fix-isolate-false-issue) |
| **Commit** | [`5e4d9ae9`](https://github.com/storybookjs/storybook/commit/5e4d9ae99eed06f54014deb801ffd3d7f6510a1f) |
| **Datetime** | Wed Aug 28 11:36:49 UTC 2024 (`1724845009`) |
| **Workflow run** | [10595892999](https://github.com/storybookjs/storybook/actions/runs/10595892999) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28993`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | 0.25 | 0% |
| initSize |  161 MB | 161 MB | 961 B | -0.67 | 0% |
| diffSize |  84.8 MB | 84.8 MB | 961 B | -0.67 | 0% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | **1.73** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 0.49 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | **1.73** | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | 0.5 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **1.73** | 0% |
| buildPreviewSize |  3.01 MB | 3.01 MB | 0 B | **1.73** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  15.9s | 23.7s | 7.8s | 1.08 | 33% |
| generateTime |  21.7s | 21.2s | -558ms | -0.17 | -2.6% |
| initTime |  17.5s | 18.6s | 1s | 1.01 | 5.8% |
| buildTime |  11.4s | 10.3s | -1s -88ms | **-2.09** | 🔰-10.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  9.7s | 6.6s | -3s -90ms | -1 | -46.5% |
| devManagerResponsive |  6s | 4.4s | -1s -684ms | -0.88 | -38.2% |
| devManagerHeaderVisible |  941ms | 740ms | -201ms | -0.81 | -27.2% |
| devManagerIndexVisible |  991ms | 775ms | -216ms | -0.83 | -27.9% |
| devStoryVisibleUncached |  1.7s | 1.3s | -345ms | -0.25 | -25.1% |
| devStoryVisible |  990ms | 776ms | -214ms | -0.82 | -27.6% |
| devAutodocsVisible |  1s | 688ms | -393ms | -0.63 | -57.1% |
| devMDXVisible |  998ms | 667ms | -331ms | -0.7 | -49.6% |
| buildManagerHeaderVisible |  1s | 696ms | -346ms | -0.82 | -49.7% |
| buildManagerIndexVisible |  1s | 729ms | -315ms | -0.57 | -43.2% |
| buildStoryVisible |  1s | 731ms | -365ms | -1.06 | -49.9% |
| buildAutodocsVisible |  760ms | 705ms | -55ms | -0.02 | -7.8% |
| buildMDXVisible |  858ms | 619ms | -239ms | -0.92 | -38.6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR addresses a test flakiness issue in non-isolate mode for Vitest tests by modifying the order of properties in a nullish coalescing expression.

- Changed order in `_isRunningFromThisFile` declaration to prioritize `globalThis.__vitest_worker__.filepath`
- Added TODO comment to remind developers to revert changes once Vitest bug is fixed
- Updated `transformer.test.ts` to reflect the changes in the implementation
- Temporary fix for issue #6367 in Vitest repository

<!-- /greptile_comment -->