### PR TITLE
Next.js-Vite: Update next and vite-plugin-storybook-nextjs dependencies

### DIFF
--- a/code/frameworks/experimental-nextjs-vite/package.json
+++ b/code/frameworks/experimental-nextjs-vite/package.json
@@ -102,12 +102,12 @@
     "vite-plugin-storybook-nextjs": "^1.0.0"
   },
   "peerDependencies": {
-    "next": "^14.2.5",
+    "next": "^14.1.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
     "storybook": "workspace:^",
     "vite": "^5.0.0",
-    "vite-plugin-storybook-nextjs": "^1.0.0"
+    "vite-plugin-storybook-nextjs": "^1.0.8"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6157,12 +6157,12 @@ __metadata:
     typescript: "npm:^5.3.2"
     vite-plugin-storybook-nextjs: "npm:^1.0.0"
   peerDependencies:
-    next: ^14.2.5
+    next: ^14.1.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     storybook: "workspace:^"
     vite: ^5.0.0
-    vite-plugin-storybook-nextjs: ^1.0.0
+    vite-plugin-storybook-nextjs: ^1.0.8
   dependenciesMeta:
     sharp:
       optional: true


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Next.js peer dependency requirement was widened to also support v14.1.0 and up.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | 0.42 | 0% |
| initSize |  161 MB | 161 MB | 0 B | -0.81 | 0% |
| diffSize |  84.8 MB | 84.8 MB | 0 B | -0.81 | 0% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | **2.38** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 0.64 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | **2.38** | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | 0.65 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **2.38** | 0% |
| buildPreviewSize |  3.01 MB | 3.01 MB | 0 B | **2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  18.7s | 23.6s | 4.8s | 1.07 | 20.7% |
| generateTime |  22.2s | 25.8s | 3.5s | **1.41** | 🔺13.8% |
| initTime |  17.9s | 22.1s | 4.1s | **4.01** | 🔺19% |
| buildTime |  14.1s | 10.7s | -3s -414ms | **-1.72** | 🔰-31.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.6s | 7.4s | 804ms | 0.15 | 10.8% |
| devManagerResponsive |  4.2s | 4.8s | 649ms | 0.25 | 13.3% |
| devManagerHeaderVisible |  733ms | 899ms | 166ms | 1.2 | 18.5% |
| devManagerIndexVisible |  768ms | 941ms | 173ms | 1.22 | 18.4% |
| devStoryVisibleUncached |  1.3s | 1.7s | 416ms | **1.55** | 🔺24.2% |
| devStoryVisible |  767ms | 935ms | 168ms | 1.09 | 18% |
| devAutodocsVisible |  680ms | 741ms | 61ms | 0.3 | 8.2% |
| devMDXVisible |  652ms | 848ms | 196ms | **1.38** | 🔺23.1% |
| buildManagerHeaderVisible |  707ms | 813ms | 106ms | 0.75 | 13% |
| buildManagerIndexVisible |  709ms | 820ms | 111ms | 0.64 | 13.5% |
| buildStoryVisible |  760ms | 859ms | 99ms | 0.58 | 11.5% |
| buildAutodocsVisible |  630ms | 829ms | 199ms | **2.45** | 🔺24% |
| buildMDXVisible |  627ms | 701ms | 74ms | 0.1 | 10.6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR updates peer dependencies for the experimental Next.js-Vite framework in Storybook, widening compatibility and ensuring support for newer versions.

- Updated Next.js peer dependency to support versions from 14.1.0 onwards in `code/frameworks/experimental-nextjs-vite/package.json`
- Upgraded vite-plugin-storybook-nextjs peer dependency to version 1.0.8 or higher
- Removed specific Next.js version (14.2.5) from devDependencies, allowing for more flexible development environments

<!-- /greptile_comment -->