### PR TITLE
Next.js-Vite: Streamline Next.js dir option

### DIFF
--- a/code/frameworks/experimental-nextjs-vite/src/preset.ts
+++ b/code/frameworks/experimental-nextjs-vite/src/preset.ts
@@ -1,4 +1,6 @@
 // https://storybook.js.org/docs/react/addons/writing-presets
+import path from 'node:path';
+
 import type { PresetProperty } from 'storybook/internal/types';
 
 import type { StorybookConfigVite } from '@storybook/builder-vite';
@@ -7,7 +9,7 @@ import { dirname, join } from 'path';
 // @ts-expect-error - tsconfig settings have to be moduleResolution=Bundler and module=Preserve
 import vitePluginStorybookNextjs from 'vite-plugin-storybook-nextjs';
 
-import type { StorybookConfig } from './types';
+import type { FrameworkOptions } from './types';
 
 export const core: PresetProperty<'core'> = async (config, options) => {
   const framework = await options.presets.apply('framework');
@@ -34,14 +36,10 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entry =
 
 export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, options) => {
   config.plugins = config.plugins || [];
-  const framework = (await options.presets.apply(
-    'framework',
-    {},
-    options
-  )) as StorybookConfig['framework'];
+  const { nextConfigPath } = await options.presets.apply<FrameworkOptions>('frameworkOptions');
 
-  const nextAppDir = typeof framework !== 'string' ? framework.options.nextAppDir : undefined;
-  config.plugins.push(vitePluginStorybookNextjs({ dir: nextAppDir }));
+  const nextDir = nextConfigPath ? path.dirname(nextConfigPath) : undefined;
+  config.plugins.push(vitePluginStorybookNextjs({ dir: nextDir }));
 
   return config;
 };

--- a/code/frameworks/experimental-nextjs-vite/src/types.ts
+++ b/code/frameworks/experimental-nextjs-vite/src/types.ts
@@ -9,12 +9,8 @@ type FrameworkName = CompatibleString<'@storybook/experimental-nextjs-vite'>;
 type BuilderName = CompatibleString<'@storybook/builder-vite'>;
 
 export type FrameworkOptions = {
-  /**
-   * The directory where the Next.js app is located.
-   *
-   * @default process.cwd()
-   */
-  nextAppDir?: string;
+  /** The path to the Next.js configuration file. */
+  nextConfigPath?: string;
   builder?: BuilderOptions;
 };
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have streamlined the Next.js config dir configuration for the Next.js Vite framework.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 0 B | -0.01 | 0% |
| initSize |  161 MB | 161 MB | -386 B | -0.54 | 0% |
| diffSize |  84.8 MB | 84.8 MB | -386 B | -0.54 | 0% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | **1.36** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 0.33 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | **1.36** | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | 0.33 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **1.36** | 0% |
| buildPreviewSize |  3.01 MB | 3.01 MB | 0 B | **1.36** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.7s | 15.2s | 8.4s | 0.11 | 55.6% |
| generateTime |  19.2s | 23.3s | 4.1s | 0.57 | 17.7% |
| initTime |  16.1s | 19.1s | 3s | **1.53** | 🔺15.9% |
| buildTime |  11s | 11.4s | 335ms | -0.81 | 2.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6s | 8.2s | 2.1s | 0.79 | 26.3% |
| devManagerResponsive |  3.9s | 5.2s | 1.3s | 0.76 | 25.1% |
| devManagerHeaderVisible |  1s | 914ms | -162ms | 0.64 | -17.7% |
| devManagerIndexVisible |  1.1s | 956ms | -159ms | 0.64 | -16.6% |
| devStoryVisibleUncached |  1.3s | 1.8s | 521ms | 0.62 | 28.1% |
| devStoryVisible |  1.1s | 957ms | -159ms | 0.64 | -16.6% |
| devAutodocsVisible |  608ms | 856ms | 248ms | 1.05 | 29% |
| devMDXVisible |  692ms | 823ms | 131ms | 0.62 | 15.9% |
| buildManagerHeaderVisible |  656ms | 943ms | 287ms | **1.71** | 🔺30.4% |
| buildManagerIndexVisible |  662ms | 946ms | 284ms | **1.59** | 🔺30% |
| buildStoryVisible |  692ms | 986ms | 294ms | **1.34** | 🔺29.8% |
| buildAutodocsVisible |  668ms | 907ms | 239ms | **3.15** | 🔺26.4% |
| buildMDXVisible |  586ms | 730ms | 144ms | 0.22 | 19.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR streamlines the Next.js configuration for the experimental Next.js Vite framework in Storybook, simplifying the setup process and aligning it more closely with Next.js conventions.

- Replaced `nextAppDir` with `nextConfigPath` in `viteFinal` function in `code/frameworks/experimental-nextjs-vite/src/preset.ts`
- Updated `FrameworkOptions` type in `code/frameworks/experimental-nextjs-vite/src/types.ts` to include `nextConfigPath` instead of `nextAppDir`
- Modified `viteFinal` function to use `nextConfigPath` for determining the Next.js configuration directory
- Improved import statements and type usage in `preset.ts` for better code organization
- Potential backwards compatibility concerns due to the change from `nextAppDir` to `nextConfigPath`

<!-- /greptile_comment -->