### PR TITLE
Docs: Clarify requirements of Next.js with Vite

### DIFF
--- a/docs/get-started/frameworks/nextjs.mdx
+++ b/docs/get-started/frameworks/nextjs.mdx
@@ -88,6 +88,10 @@ Storybook for Next.js is a [framework](../../contribute/framework.mdx) that make
 
   You can use our freshly baked, experimental `@storybook/experimental-nextjs-vite` framework, which is based on Vite and removes the need for Webpack and Babel. It supports all of the features documented here.
 
+  <Callout variant="info">
+    Using the Next.js framework with Vite requires Next.js 14.1.0 or later.
+  </Callout>
+
   {/* prettier-ignore-start */}
 
   <CodeSnippets path="nextjs-vite-install.md" />


### PR DESCRIPTION
Docs follow-up to #28994 

<!-- greptile_comment -->

## Greptile Summary

This PR adds a callout to clarify that using the Next.js framework with Vite requires Next.js 14.1.0 or later in the Storybook documentation.

- Added a callout in `docs/get-started/frameworks/nextjs.mdx` specifying Next.js 14.1.0+ requirement for Vite integration
- Provides important information for users considering or using the experimental Vite-based Next.js framework in Storybook
- Aligns documentation with recent updates to peer dependencies for the experimental Next.js-Vite framework

<!-- /greptile_comment -->