### PR TITLE
Vue3: Add vite plugin for portable stories

### DIFF
--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -198,6 +198,11 @@ const getVitestPluginInfo = (framework: string) => {
     frameworkPluginCall = 'storybookSveltekitPlugin()';
   }
 
+  if (framework === '@storybook/vue3-vite') {
+    frameworkPluginImport = "import { storybookVuePlugin } from '@storybook/vue3-vite/vite'";
+    frameworkPluginCall = 'storybookVuePlugin()';
+  }
+
   return { frameworkPluginImport, frameworkPluginCall };
 };
 

--- a/code/frameworks/vue3-vite/package.json
+++ b/code/frameworks/vue3-vite/package.json
@@ -30,6 +30,11 @@
       "types": "./dist/preset.d.ts",
       "require": "./dist/preset.js"
     },
+    "./vite": {
+      "types": "./dist/vite.d.ts",
+      "require": "./dist/vite.js",
+      "import": "./dist/vite.mjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",
@@ -74,7 +79,8 @@
   "bundler": {
     "entries": [
       "./src/index.ts",
-      "./src/preset.ts"
+      "./src/preset.ts",
+      "./src/vite.ts"
     ],
     "platform": "node"
   },

--- a/code/frameworks/vue3-vite/src/plugins/vue-template.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-template.ts
@@ -1,0 +1,14 @@
+import type { Plugin } from 'vite';
+
+export async function templateCompilation() {
+  return {
+    name: 'storybook:vue-template-compilation',
+    config: () => ({
+      resolve: {
+        alias: {
+          vue: 'vue/dist/vue.esm-bundler.js',
+        },
+      },
+    }),
+  } satisfies Plugin;
+}

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -6,6 +6,7 @@ import type { PluginOption } from 'vite';
 
 import { vueComponentMeta } from './plugins/vue-component-meta';
 import { vueDocgen } from './plugins/vue-docgen';
+import { templateCompilation } from './plugins/vue-template';
 import type { FrameworkOptions, StorybookConfig, VueDocgenPlugin } from './types';
 
 const getAbsolutePath = <I extends string>(input: I): I =>
@@ -17,7 +18,7 @@ export const core: PresetProperty<'core'> = {
 };
 
 export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) => {
-  const plugins: PluginOption[] = [];
+  const plugins: PluginOption[] = [templateCompilation()];
 
   const framework = await options.presets.apply('framework');
   const frameworkOptions: FrameworkOptions =
@@ -35,11 +36,6 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
   const { mergeConfig } = await import('vite');
   return mergeConfig(config, {
     plugins,
-    resolve: {
-      alias: {
-        vue: 'vue/dist/vue.esm-bundler.js',
-      },
-    },
   });
 };
 

--- a/code/frameworks/vue3-vite/src/vite.ts
+++ b/code/frameworks/vue3-vite/src/vite.ts
@@ -1,0 +1,5 @@
+import { templateCompilation } from './plugins/vue-template';
+
+export const storybookVuePlugin = () => {
+  return [templateCompilation()];
+};

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -30,7 +30,7 @@ import { executeCLIStep, steps } from '../utils/cli-step';
 import { CODE_DIRECTORY, REPROS_DIRECTORY } from '../utils/constants';
 import { exec } from '../utils/exec';
 import { filterExistsInCodeDir } from '../utils/filterExistsInCodeDir';
-import { addPreviewAnnotations, readMainConfig } from '../utils/main-js';
+import { addPreviewAnnotations, readConfig } from '../utils/main-js';
 import { updatePackageScripts } from '../utils/package-json';
 import { findFirstPath } from '../utils/paths';
 import { workspacePath } from '../utils/workspace';
@@ -378,6 +378,11 @@ const getVitestPluginInfo = (details: TemplateDetails) => {
     frameworkPluginCall = 'storybookSveltekitPlugin()';
   }
 
+  if (framework === '@storybook/vue3-vite') {
+    frameworkPluginImport = "import { storybookVuePlugin } from '@storybook/vue3-vite/vite'";
+    frameworkPluginCall = 'storybookVuePlugin()';
+  }
+
   return { frameworkPluginImport, frameworkPluginCall };
 };
 
@@ -414,7 +419,6 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
     ${isVue ? 'import * as vueAnnotations from "../src/stories/renderers/vue3/preview.js"' : ''}
 
     const annotations = setProjectAnnotations([
-      { tags: ['vitest'] },
       rendererDocsAnnotations,
       projectAnnotations,
       coreAnnotations,
@@ -424,7 +428,7 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
       ${isVue ? 'vueAnnotations,' : ''}
     ])
 
-    beforeAll(annotations.beforeAll!)`
+    beforeAll(annotations.beforeAll)`
   );
 
   await writeFile(
@@ -461,13 +465,11 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
           }
           resolve: {
             preserveSymlinks: true,
-            ${isVue ? "alias: { vue: 'vue/dist/vue.esm-bundler.js' }," : ''}
           },
           test: {
             name: "storybook",
             pool: "threads",
             include: [
-              // we need to set the path like this because svelte-kit overrides the root path so this makes it work in all sandboxes
               "src/**/*.{story,stories}.?(c|m)[jt]s?(x)",
               "template-stories/**/*.{story,stories}.?(c|m)[jt]s?(x)",
             ],
@@ -488,7 +490,6 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
               name: "chromium",
               provider: "playwright",
               headless: true,
-              screenshotFailures: false,
             },
             setupFiles: ["./.storybook/vitest.setup.ts"],
             environment: "happy-dom",
@@ -503,8 +504,7 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
 
   packageJson.scripts = {
     ...packageJson.scripts,
-    vitest:
-      'vitest --pass-with-no-tests --reporter=default --reporter=hanging-process --test-timeout=5000',
+    vitest: 'vitest --reporter=default --reporter=hanging-process --test-timeout=5000',
   };
 
   // This workaround is needed because Vitest seems to have issues in link mode
@@ -562,7 +562,7 @@ export const addStories: Task['run'] = async (
   const cwd = sandboxDir;
   const storiesPath = await findFirstPath([join('src', 'stories'), 'stories'], { cwd });
 
-  const mainConfig = await readMainConfig({ cwd });
+  const mainConfig = await readConfig({ cwd });
   const packageManager = JsPackageManagerFactory.getPackageManager({}, sandboxDir);
 
   // Ensure that we match the right stories in the stories directory
@@ -709,7 +709,7 @@ export const addStories: Task['run'] = async (
 
 export const extendMain: Task['run'] = async ({ template, sandboxDir, key }, { disableDocs }) => {
   logger.log('📝 Extending main.js');
-  const mainConfig = await readMainConfig({ cwd: sandboxDir });
+  const mainConfig = await readConfig({ cwd: sandboxDir });
 
   if (key === 'react-vite/default-ts') {
     addRefs(mainConfig);
@@ -785,6 +785,17 @@ export const extendMain: Task['run'] = async ({ template, sandboxDir, key }, { d
     setSandboxViteFinal(mainConfig);
   }
   await writeConfig(mainConfig);
+};
+
+export const extendPreview: Task['run'] = async ({ template, sandboxDir }) => {
+  logger.log('📝 Extending preview.js');
+  const previewConfig = await readConfig({ cwd: sandboxDir, fileName: 'preview' });
+
+  if (template.expected.builder.includes('vite')) {
+    previewConfig.setFieldValue(['tags'], ['vitest']);
+  }
+
+  await writeConfig(previewConfig);
 };
 
 export async function setImportMap(cwd: string) {

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -562,7 +562,7 @@ export const addStories: Task['run'] = async (
   const cwd = sandboxDir;
   const storiesPath = await findFirstPath([join('src', 'stories'), 'stories'], { cwd });
 
-  const mainConfig = await readConfig({ cwd });
+  const mainConfig = await readConfig({ fileName: 'main', cwd });
   const packageManager = JsPackageManagerFactory.getPackageManager({}, sandboxDir);
 
   // Ensure that we match the right stories in the stories directory
@@ -709,7 +709,7 @@ export const addStories: Task['run'] = async (
 
 export const extendMain: Task['run'] = async ({ template, sandboxDir, key }, { disableDocs }) => {
   logger.log('📝 Extending main.js');
-  const mainConfig = await readConfig({ cwd: sandboxDir });
+  const mainConfig = await readConfig({ fileName: 'main', cwd: sandboxDir });
 
   if (key === 'react-vite/default-ts') {
     addRefs(mainConfig);

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -42,6 +42,7 @@ export const sandbox: Task = {
       install,
       addStories,
       extendMain,
+      extendPreview,
       init,
       addExtraDependencies,
       setImportMap,
@@ -119,6 +120,8 @@ export const sandbox: Task = {
     });
 
     await extendMain(details, options);
+
+    await extendPreview(details, options);
 
     await setImportMap(details.sandboxDir);
 

--- a/scripts/utils/main-js.ts
+++ b/scripts/utils/main-js.ts
@@ -4,9 +4,9 @@ import slash from 'slash';
 
 import { getInterpretedFile } from '../../code/core/src/common';
 import type { ConfigFile } from '../../code/core/src/csf-tools';
-import { readConfig } from '../../code/core/src/csf-tools';
+import { readConfig as csfReadConfig } from '../../code/core/src/csf-tools';
 
-export async function readMainConfig({ cwd }: { cwd: string }) {
+export async function readConfig({ fileName = 'main', cwd }: { fileName?: string; cwd: string }) {
   const configDir = join(cwd, '.storybook');
   if (!existsSync(configDir)) {
     throw new Error(
@@ -14,8 +14,8 @@ export async function readMainConfig({ cwd }: { cwd: string }) {
     );
   }
 
-  const mainConfigPath = getInterpretedFile(resolve(configDir, 'main'));
-  return readConfig(mainConfigPath);
+  const mainConfigPath = getInterpretedFile(resolve(configDir, fileName));
+  return csfReadConfig(mainConfigPath);
 }
 
 export function addPreviewAnnotations(mainConfig: ConfigFile, paths: string[]) {

--- a/scripts/utils/main-js.ts
+++ b/scripts/utils/main-js.ts
@@ -6,7 +6,7 @@ import { getInterpretedFile } from '../../code/core/src/common';
 import type { ConfigFile } from '../../code/core/src/csf-tools';
 import { readConfig as csfReadConfig } from '../../code/core/src/csf-tools';
 
-export async function readConfig({ fileName = 'main', cwd }: { fileName?: string; cwd: string }) {
+export async function readConfig({ fileName, cwd }: { fileName: string; cwd: string }) {
   const configDir = join(cwd, '.storybook');
   if (!existsSync(configDir)) {
     throw new Error(


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR introduces a plugin in `@storybook/vue3-vite` so that users can get the necessary config to test their stories using portable stories:

```ts
import { defineWorkspace, defaultExclude } from "vitest/config";
import { storybookTest } from "@storybook/experimental-addon-vitest/plugin";
import { storybookVuePlugin } from '@storybook/vue3-vite/vite'

export default defineWorkspace([
  {
    extends: "vite.config.ts",
    plugins: [
      storybookTest(),
     storybookVuePlugin() // 👈 Add this plugin, it will allow to mount template-based Vue components
    ],
  }
])
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | **1.81** | 0% |
| initSize |  161 MB | 161 MB | 0 B | -0.23 | 0% |
| diffSize |  84.8 MB | 84.8 MB | 0 B | -0.24 | 0% |
| buildSize |  7.48 MB | 7.48 MB | 115 B | 0.83 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | **1.73** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | 0.82 | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0.82 | 0% |
| buildPreviewSize |  3.01 MB | 3.01 MB | 115 B | 0.84 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.2s | 6.3s | -16s -807ms | **-1.28** | 🔰-262.7% |
| generateTime |  19.5s | 18.2s | -1s -389ms | -0.9 | -7.6% |
| initTime |  16.8s | 15s | -1s -839ms | -0.77 | -12.3% |
| buildTime |  14.2s | 13.5s | -721ms | 0.7 | -5.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7s | 7.1s | 116ms | -0.22 | 1.6% |
| devManagerResponsive |  4.3s | 4.6s | 276ms | -0.1 | 5.9% |
| devManagerHeaderVisible |  685ms | 791ms | 106ms | -0.23 | 13.4% |
| devManagerIndexVisible |  726ms | 837ms | 111ms | -0.18 | 13.3% |
| devStoryVisibleUncached |  1.1s | 1.4s | 274ms | -0.17 | 19.4% |
| devStoryVisible |  724ms | 837ms | 113ms | -0.18 | 13.5% |
| devAutodocsVisible |  684ms | 678ms | -6ms | -0.52 | -0.9% |
| devMDXVisible |  889ms | 778ms | -111ms | 0.2 | -14.3% |
| buildManagerHeaderVisible |  713ms | 752ms | 39ms | -0.03 | 5.2% |
| buildManagerIndexVisible |  720ms | 759ms | 39ms | -0.06 | 5.1% |
| buildStoryVisible |  795ms | 799ms | 4ms | -0.24 | 0.5% |
| buildAutodocsVisible |  654ms | 735ms | 81ms | 0.58 | 11% |
| buildMDXVisible |  610ms | 670ms | 60ms | -0.19 | 9% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR introduces a new Vite plugin for Vue3 in Storybook, enabling portable story testing and improving Vue3 component support with Vite as a builder.

- Added `storybookVuePlugin` in `code/frameworks/vue3-vite/src/vite.ts` for Vue3 template compilation
- Modified `code/frameworks/vue3-vite/src/preset.ts` to include the new `templateCompilation` plugin
- Updated `code/addons/vitest/src/postinstall.ts` to support Vue3 Vite plugin in Vitest addon
- Enhanced `scripts/utils/main-js.ts` with a more flexible `readConfig` function
- Added `extendPreview` task in `scripts/tasks/sandbox.ts` for additional preview environment configuration

<!-- /greptile_comment -->