### PR TITLE
Core: Move `util` to regular dependency

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -286,6 +286,7 @@
     "process": "^0.11.10",
     "recast": "^0.23.5",
     "semver": "^7.6.2",
+    "util": "^0.12.5",
     "ws": "^8.2.3"
   },
   "devDependencies": {
@@ -418,7 +419,6 @@
     "typescript": "^5.3.2",
     "unique-string": "^3.0.0",
     "use-resize-observer": "^9.1.0",
-    "util": "^0.12.4",
     "watchpack": "^2.2.0"
   },
   "publishConfig": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6034,7 +6034,7 @@ __metadata:
     typescript: "npm:^5.3.2"
     unique-string: "npm:^3.0.0"
     use-resize-observer: "npm:^9.1.0"
-    util: "npm:^0.12.4"
+    util: "npm:^0.12.5"
     watchpack: "npm:^2.2.0"
     ws: "npm:^8.2.3"
   languageName: unknown


### PR DESCRIPTION
## What I did

We use this construct:
https://github.com/storybookjs/storybook/blob/5d7b05c476bde718079597f96856a2a7b84b2f60/code/core/src/builder-manager/index.ts#L87-L89

And this means that these 3 dependencies should be available to be resolved.

Therefore they must be regular dependencies!

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

In a package manager setting that is very strict, the before situation should be broken.

```
info => Starting manager..
Error: Cannot find module 'util/util.js'
Require stack:
- /Users/jeppe/dev/work/gitbutler/node_modules/.pnpm/@storybook+core@8.3.0-beta.0/node_modules/@storybook/core/dist/builder-manager/index.js
```

By having the dependency as a normal dependency, this `require.resolve` should no longer fail.

To test this manually:
- Create a sandbox with `pnpm` in it's default setting.
  (this means having all transitive dependencies in a `node_modules/.pnpm`- folder.
- Try to start or build that sandbox

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 3.89 kB | **2.07** | 0% |
| initSize |  161 MB | 161 MB | 3.89 kB | -0.29 | 0% |
| diffSize |  84.8 MB | 84.8 MB | 0 B | -0.3 | 0% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | 0.9 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | **2** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | 0.9 | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0.91 | 0% |
| buildPreviewSize |  3.01 MB | 3.01 MB | 0 B | 0.9 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23s | 22.7s | -253ms | **1.28** | -1.1% |
| generateTime |  19.2s | 17.8s | -1s -389ms | -0.98 | -7.8% |
| initTime |  15.9s | 14.8s | -1s -108ms | -0.81 | -7.4% |
| buildTime |  13.9s | 13.9s | 71ms | 1.18 | 0.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.6s | 7.6s | 1s | 0.2 | 13.7% |
| devManagerResponsive |  4.3s | 4.8s | 481ms | 0.02 | 10% |
| devManagerHeaderVisible |  784ms | 822ms | 38ms | -0.08 | 4.6% |
| devManagerIndexVisible |  819ms | 868ms | 49ms | -0.03 | 5.6% |
| devStoryVisibleUncached |  1.4s | 1.7s | 285ms | 0.33 | 16.6% |
| devStoryVisible |  818ms | 866ms | 48ms | -0.05 | 5.5% |
| devAutodocsVisible |  719ms | 768ms | 49ms | 0.23 | 6.4% |
| devMDXVisible |  686ms | 742ms | 56ms | -0.08 | 7.5% |
| buildManagerHeaderVisible |  721ms | 834ms | 113ms | 0.74 | 13.5% |
| buildManagerIndexVisible |  728ms | 838ms | 110ms | 0.62 | 13.1% |
| buildStoryVisible |  762ms | 879ms | 117ms | 0.47 | 13.3% |
| buildAutodocsVisible |  701ms | 802ms | 101ms | **1.51** | 🔺12.6% |
| buildMDXVisible |  665ms | 795ms | 130ms | 0.82 | 16.4% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR moves the 'util' package from devDependencies to regular dependencies in the @storybook/core package.json file, ensuring its availability for aliasing and dependency resolution.

- Moved 'util' package from devDependencies to dependencies in code/core/package.json
- Updated 'util' package version from 0.12.4 to 0.12.5
- Change addresses dependency resolution issues in the builder-manager module
- Ensures compatibility with specific constructs used in the codebase

<!-- /greptile_comment -->