### PR TITLE
Nextjs-Vite: Re-export vite-plugin-storybook-nextjs

### DIFF
--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -64,10 +64,19 @@ export default async function postInstall(options: PostinstallOptions) {
     logger.info(
       dedent`
         We detected that you're using Next.js.
-        We will configure the vite-plugin-storybook-nextjs plugin to allow you to run tests in Vitest.
+        We will configure the @storybook/experimental-nextjs-vite/vite-plugin to allow you to run tests in Vitest.
       `
     );
-    packages.push('vite-plugin-storybook-nextjs@latest');
+
+    try {
+      const storybookVersion = await packageManager.getInstalledVersion('storybook');
+
+      packages.push(`@storybook/experimental-nextjs-vite@^${storybookVersion}`);
+    } catch (e) {
+      console.error(
+        'Failed to install @storybook/experimental-nextjs-vite. Please install it manually'
+      );
+    }
   }
 
   logger.info(c.bold('Installing packages...'));
@@ -189,8 +198,9 @@ const getVitestPluginInfo = (framework: string) => {
   let frameworkPluginCall = '';
 
   if (framework === '@storybook/nextjs') {
-    frameworkPluginImport = "import vitePluginNext from 'vite-plugin-storybook-nextjs'";
-    frameworkPluginCall = 'vitePluginNext()';
+    frameworkPluginImport =
+      "import { storybookNextJsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin'";
+    frameworkPluginCall = 'storybookNextJsPlugin()';
   }
 
   if (framework === '@storybook/sveltekit') {

--- a/code/frameworks/experimental-nextjs-vite/package.json
+++ b/code/frameworks/experimental-nextjs-vite/package.json
@@ -53,6 +53,11 @@
       "import": "./dist/export-mocks/router/index.mjs",
       "require": "./dist/export-mocks/router/index.js"
     },
+    "./vite-plugin": {
+      "types": "./dist/vite-plugin/index.d.ts",
+      "import": "./dist/vite-plugin/index.js",
+      "require": "./dist/vite-plugin/index.cjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",
@@ -93,21 +98,20 @@
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/test": "workspace:*",
-    "styled-jsx": "5.1.6"
+    "styled-jsx": "5.1.6",
+    "vite-plugin-storybook-nextjs": "^1.0.10"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
     "next": "^14.2.5",
-    "typescript": "^5.3.2",
-    "vite-plugin-storybook-nextjs": "^1.0.0"
+    "typescript": "^5.3.2"
   },
   "peerDependencies": {
     "next": "^14.1.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
     "storybook": "workspace:^",
-    "vite": "^5.0.0",
-    "vite-plugin-storybook-nextjs": "^1.0.8"
+    "vite": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
@@ -126,6 +130,7 @@
   "bundler": {
     "entries": [
       "./src/index.ts",
+      "./src/vite-plugin/index.ts",
       "./src/preset.ts",
       "./src/preview.tsx",
       "./src/export-mocks/cache/index.ts",

--- a/code/frameworks/experimental-nextjs-vite/src/index.ts
+++ b/code/frameworks/experimental-nextjs-vite/src/index.ts
@@ -1,2 +1,10 @@
+import type vitePluginStorybookNextJs from 'vite-plugin-storybook-nextjs';
+
 export * from './types';
 export * from './portable-stories';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+declare module '@storybook/experimental-nextjs-vite/vite-plugin' {
+  export const storybookNextJsPlugin: typeof vitePluginStorybookNextJs;
+}

--- a/code/frameworks/experimental-nextjs-vite/src/preset.ts
+++ b/code/frameworks/experimental-nextjs-vite/src/preset.ts
@@ -6,7 +6,6 @@ import type { PresetProperty } from 'storybook/internal/types';
 import type { StorybookConfigVite } from '@storybook/builder-vite';
 
 import { dirname, join } from 'path';
-// @ts-expect-error - tsconfig settings have to be moduleResolution=Bundler and module=Preserve
 import vitePluginStorybookNextjs from 'vite-plugin-storybook-nextjs';
 
 import type { FrameworkOptions } from './types';

--- a/code/frameworks/experimental-nextjs-vite/src/vite-plugin/index.ts
+++ b/code/frameworks/experimental-nextjs-vite/src/vite-plugin/index.ts
@@ -1,0 +1,3 @@
+import vitePluginStorybookNextJs from 'vite-plugin-storybook-nextjs';
+
+export const storybookNextJsPlugin = vitePluginStorybookNextJs;

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -216,12 +216,7 @@ const baseTemplates = {
         framework: '@storybook/experimental-nextjs-vite',
         features: { experimentalRSC: true },
       },
-      extraDependencies: [
-        'server-only',
-        'vite-plugin-storybook-nextjs',
-        '@storybook/experimental-nextjs-vite',
-        'vite',
-      ],
+      extraDependencies: ['server-only', '@storybook/experimental-nextjs-vite', 'vite'],
     },
     skipTasks: ['e2e-tests-dev', 'bench'],
   },

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6155,14 +6155,13 @@ __metadata:
     sharp: "npm:^0.33.3"
     styled-jsx: "npm:5.1.6"
     typescript: "npm:^5.3.2"
-    vite-plugin-storybook-nextjs: "npm:^1.0.0"
+    vite-plugin-storybook-nextjs: "npm:^1.0.10"
   peerDependencies:
     next: ^14.1.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     storybook: "workspace:^"
     vite: ^5.0.0
-    vite-plugin-storybook-nextjs: ^1.0.8
   dependenciesMeta:
     sharp:
       optional: true
@@ -28374,9 +28373,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-storybook-nextjs@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "vite-plugin-storybook-nextjs@npm:1.0.0"
+"vite-plugin-storybook-nextjs@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "vite-plugin-storybook-nextjs@npm:1.0.10"
   dependencies:
     "@next/env": "npm:^14.2.5"
     image-size: "npm:^1.1.1"
@@ -28386,13 +28385,13 @@ __metadata:
     ts-dedent: "npm:^2.2.0"
   peerDependencies:
     "@storybook/test": ^8.3.0-alpha.3
-    next: ^14.2.5
+    next: ^14.1.0
     storybook: ^8.3.0-alpha.3
     vite: ^5.0.0
   dependenciesMeta:
     sharp:
       optional: true
-  checksum: 10c0/6ca17326e0387044d7bfa4373e6ccb64e8bb5bec1f19898ba9b8338c7817d8bea0fb01169adfb623f652fded5e6f59170129f7c8c4d4c3c54ca3764727e5a195
+  checksum: 10c0/e0e373ef94e1761b871b2cc846c205a846901d93c7e61f9d9ee3c69740681e42e6403a7d61109c59f2d98d5829476c3e6d4e9d5a329c4bd51e758b763fa8ea9e
   languageName: node
   linkType: hard
 

--- a/docs/api/portable-stories/portable-stories-vitest.mdx
+++ b/docs/api/portable-stories/portable-stories-vitest.mdx
@@ -28,7 +28,7 @@ sidebar:
 
   <If renderer="react">
     <Callout variant="warning">
-      **Using `Next.js`?** You can test your Next.js stories with Vitest by installing and setting up the [`vite-plugin-storybook-nextjs`](https://github.com/storybookjs/vite-plugin-storybook-nextjs) package. 
+      **Using `Next.js`?** You can test your Next.js stories with Vitest by installing and setting up the `@storybook/experimental-nextjs-vite` which re-exports [vite-plugin-storybook-nextjs](https://github.com/storybookjs/vite-plugin-storybook-nextjs) package. 
     </Callout>
   </If>
 

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -369,8 +369,9 @@ const getVitestPluginInfo = (details: TemplateDetails) => {
   const isSveltekit = framework.includes('sveltekit');
 
   if (isNextjs) {
-    frameworkPluginImport = "import vitePluginNext from 'vite-plugin-storybook-nextjs'";
-    frameworkPluginCall = 'vitePluginNext()';
+    frameworkPluginImport =
+      "import { storybookNextJsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin'";
+    frameworkPluginCall = 'storybookNextJsPlugin()';
   }
 
   if (isSveltekit) {

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -98,7 +98,7 @@ export const sandbox: Task = {
       );
 
       if (details.template.expected.framework.includes('nextjs')) {
-        extraDeps.push('vite-plugin-storybook-nextjs', 'jsdom');
+        extraDeps.push('@storybook/experimental-nextjs-vite', 'jsdom');
       }
 
       // if (details.template.expected.renderer === '@storybook/svelte') {


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have re-exported `vite-plugin-storybook-nextjs` from `@storybook/experimental-nextjs-vite`

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29012-sha-f9454736`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29012-sha-f9454736 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29012-sha-f9454736 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29012-sha-f9454736`](https://npmjs.com/package/storybook/v/0.0.0-pr-29012-sha-f9454736) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/re-export-next-js-vite-plugin`](https://github.com/storybookjs/storybook/tree/valentin/re-export-next-js-vite-plugin) |
| **Commit** | [`f9454736`](https://github.com/storybookjs/storybook/commit/f9454736396716177be5ff5edc2d653f85cef9bf) |
| **Datetime** | Mon Sep  2 08:17:58 UTC 2024 (`1725265078`) |
| **Workflow run** | [10663427790](https://github.com/storybookjs/storybook/actions/runs/10663427790) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29012`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 1.01 | 0% |
| initSize |  161 MB | 161 MB | 0 B | 0.31 | 0% |
| diffSize |  84.7 MB | 84.7 MB | 0 B | 0.3 | 0% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | 0.35 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 0.9 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | 0.33 | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0.34 | 0% |
| buildPreviewSize |  3.01 MB | 3.01 MB | 0 B | 0.36 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7s | 8.7s | 1.6s | -1.08 | 18.5% |
| generateTime |  19.9s | 21.5s | 1.6s | -0.1 | 7.6% |
| initTime |  21.5s | 18s | -3s -560ms | -0.07 | -19.7% |
| buildTime |  10.6s | 12.1s | 1.4s | -0.27 | 11.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.5s | 6.9s | 403ms | -0.2 | 5.8% |
| devManagerResponsive |  4s | 4.3s | 276ms | -0.44 | 6.4% |
| devManagerHeaderVisible |  752ms | 690ms | -62ms | -0.96 | -9% |
| devManagerIndexVisible |  789ms | 725ms | -64ms | -1 | -8.8% |
| devStoryVisibleUncached |  1.3s | 867ms | -491ms | -1.07 | -56.6% |
| devStoryVisible |  791ms | 726ms | -65ms | -0.98 | -9% |
| devAutodocsVisible |  683ms | 644ms | -39ms | -0.82 | -6.1% |
| devMDXVisible |  639ms | 651ms | 12ms | -0.61 | 1.8% |
| buildManagerHeaderVisible |  703ms | 670ms | -33ms | -0.76 | -4.9% |
| buildManagerIndexVisible |  709ms | 671ms | -38ms | -0.86 | -5.7% |
| buildStoryVisible |  740ms | 745ms | 5ms | -0.65 | 0.7% |
| buildAutodocsVisible |  628ms | 608ms | -20ms | -1.05 | -3.3% |
| buildMDXVisible |  694ms | 631ms | -63ms | -0.55 | -10% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR re-exports the `vite-plugin-storybook-nextjs` from `@storybook/experimental-nextjs-vite`, simplifying the setup process for Next.js users with Vite in Storybook projects.

- Added `code/frameworks/experimental-nextjs-vite/src/vite-plugin/index.ts` to re-export the plugin as `storybookNextJsPlugin`
- Updated `code/frameworks/experimental-nextjs-vite/package.json` to include the plugin as a dependency
- Modified `code/addons/vitest/src/postinstall.ts` to use the re-exported plugin for Next.js configuration
- Removed `vite-plugin-storybook-nextjs` from extra dependencies in `code/lib/cli-storybook/src/sandbox-templates.ts`
- Updated documentation in `docs/api/portable-stories/portable-stories-vitest.mdx` to reflect the new import path

<!-- /greptile_comment -->