### PR TITLE
Backgrounds/Viewports: Make defaults overridable in `StoryGlobals`-mode

### DIFF
--- a/code/addons/backgrounds/src/components/Tool.tsx
+++ b/code/addons/backgrounds/src/components/Tool.tsx
@@ -6,18 +6,17 @@ import { useGlobals, useParameter } from 'storybook/internal/manager-api';
 import { CircleIcon, GridIcon, PhotoIcon, RefreshIcon } from '@storybook/icons';
 
 import { PARAM_KEY as KEY } from '../constants';
+import { DEFAULT_BACKGROUNDS } from '../defaults';
 import type { Background, BackgroundMap, Config, GlobalStateUpdate } from '../types';
 
 type Link = Parameters<typeof TooltipLinkList>['0']['links'][0];
-
-const emptyBackgroundMap: BackgroundMap = {};
 
 export const BackgroundTool = memo(function BackgroundSelector() {
   const config = useParameter<Config>(KEY);
   const [globals, updateGlobals, storyGlobals] = useGlobals();
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
-  const { options = emptyBackgroundMap, disable = true } = config || {};
+  const { options = DEFAULT_BACKGROUNDS, disable = true } = config || {};
   if (disable) {
     return null;
   }

--- a/code/addons/backgrounds/src/decorator.ts
+++ b/code/addons/backgrounds/src/decorator.ts
@@ -6,6 +6,7 @@ import type {
 } from 'storybook/internal/types';
 
 import { PARAM_KEY as KEY } from './constants';
+import { DEFAULT_BACKGROUNDS } from './defaults';
 import type { Config, GridConfig } from './types';
 import { addBackgroundStyle, addGridStyle, clearStyles, isReduceMotionEnabled } from './utils';
 
@@ -25,7 +26,11 @@ export const withBackgroundAndGrid = (
   context: StoryContext<Renderer>
 ) => {
   const { globals, parameters, viewMode, id } = context;
-  const { options = {}, disable, grid = defaultGrid } = (parameters[KEY] || {}) as Config;
+  const {
+    options = DEFAULT_BACKGROUNDS,
+    disable,
+    grid = defaultGrid,
+  } = (parameters[KEY] || {}) as Config;
   const data = globals[KEY] || {};
   const backgroundName: string | undefined = data.value;
 
@@ -35,6 +40,7 @@ export const withBackgroundAndGrid = (
   const showGrid = data.grid || false;
   const shownBackground = !!item && !disable;
 
+  console.log({ context, globals, parameters, options, data, item, value, shownBackground, KEY });
   const backgroundSelector = viewMode === 'docs' ? `#anchor--${id} .docs-story` : '.sb-show-main';
   const gridSelector = viewMode === 'docs' ? `#anchor--${id} .docs-story` : '.sb-show-main';
 

--- a/code/addons/backgrounds/src/decorator.ts
+++ b/code/addons/backgrounds/src/decorator.ts
@@ -40,7 +40,6 @@ export const withBackgroundAndGrid = (
   const showGrid = data.grid || false;
   const shownBackground = !!item && !disable;
 
-  console.log({ context, globals, parameters, options, data, item, value, shownBackground, KEY });
   const backgroundSelector = viewMode === 'docs' ? `#anchor--${id} .docs-story` : '.sb-show-main';
   const gridSelector = viewMode === 'docs' ? `#anchor--${id} .docs-story` : '.sb-show-main';
 

--- a/code/addons/backgrounds/src/defaults.ts
+++ b/code/addons/backgrounds/src/defaults.ts
@@ -1,0 +1,6 @@
+import type { BackgroundMap } from './types';
+
+export const DEFAULT_BACKGROUNDS: BackgroundMap = {
+  light: { name: 'light', value: '#F8F8F8' },
+  dark: { name: 'dark', value: '#333' },
+};

--- a/code/addons/backgrounds/src/preview.ts
+++ b/code/addons/backgrounds/src/preview.ts
@@ -2,6 +2,7 @@ import type { Addon_DecoratorFunction } from 'storybook/internal/types';
 
 import { PARAM_KEY as KEY } from './constants';
 import { withBackgroundAndGrid } from './decorator';
+import { DEFAULT_BACKGROUNDS } from './defaults';
 import { withBackground } from './legacy/withBackgroundLegacy';
 import { withGrid } from './legacy/withGridLegacy';
 import type { Config, GlobalState } from './types';
@@ -18,20 +19,10 @@ export const parameters = {
       cellAmount: 5,
     },
     disable: false,
-    ...(FEATURES?.backgroundsStoryGlobals
-      ? {
-          options: {
-            light: { name: 'light', value: '#F8F8F8' },
-            dark: { name: 'dark', value: '#333' },
-          },
-        }
-      : {
-          // TODO: remove in 9.0
-          values: [
-            { name: 'light', value: '#F8F8F8' },
-            { name: 'dark', value: '#333333' },
-          ],
-        }),
+    // TODO: remove in 9.0
+    ...(!FEATURES?.backgroundsStoryGlobals && {
+      values: Object.values(DEFAULT_BACKGROUNDS),
+    }),
   } satisfies Partial<Config>,
 };
 

--- a/code/addons/viewport/src/components/Tool.tsx
+++ b/code/addons/viewport/src/components/Tool.tsx
@@ -7,15 +7,15 @@ import { Global } from 'storybook/internal/theming';
 import { GrowIcon, RefreshIcon, TransferIcon } from '@storybook/icons';
 
 import { PARAM_KEY as KEY } from '../constants';
+import { MINIMAL_VIEWPORTS } from '../defaults';
 import { responsiveViewport } from '../responsiveViewport';
 import { registerShortcuts } from '../shortcuts';
-import type { Config, GlobalState, GlobalStateUpdate, Viewport, ViewportMap } from '../types';
+import type { Config, GlobalStateUpdate, Viewport, ViewportMap } from '../types';
 import {
   ActiveViewportLabel,
   ActiveViewportSize,
   IconButtonLabel,
   IconButtonWithLabel,
-  emptyViewportMap,
   iconsMap,
 } from '../utils';
 
@@ -39,7 +39,7 @@ export const ViewportTool: FC<{ api: API }> = ({ api }) => {
   const [globals, updateGlobals, storyGlobals] = useGlobals();
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
-  const { options = emptyViewportMap, disable } = config || {};
+  const { options = MINIMAL_VIEWPORTS, disable } = config || {};
   const data = globals?.[KEY] || {};
   const viewportName: string = data.value;
   const isRotated: boolean = data.isRotated;

--- a/code/addons/viewport/src/preview.ts
+++ b/code/addons/viewport/src/preview.ts
@@ -10,11 +10,3 @@ const modern: Record<string, GlobalState> = {
 const legacy = { viewport: 'reset', viewportRotated: false };
 
 export const initialGlobals = FEATURES?.viewportStoryGlobals ? modern : legacy;
-
-export const parameters = FEATURES?.viewportStoryGlobals
-  ? {
-      [KEY]: {
-        options: MINIMAL_VIEWPORTS,
-      },
-    }
-  : {};

--- a/code/addons/viewport/src/utils.tsx
+++ b/code/addons/viewport/src/utils.tsx
@@ -42,5 +42,3 @@ export const iconsMap: Record<Viewport['type'], React.ReactNode> = {
   tablet: <TabletIcon />,
   other: <Fragment />,
 };
-
-export const emptyViewportMap: ViewportMap = {};


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Changes the behavior of the Viewport and Backgrounds addons when in `XStoryGlobals`-mode. Previously the defaults where specified as default parameters. This meant that users couldn't override them or get rid of the default options, ever, because parameters deep merge.

Now the defaults are set internally, and only activated if the user hasn't specified the `options` parameters. Meaning that as soon as users adds their own viewports/backgrounds, the defaults disappear.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Compile
2. Start a default dev sandbox
3. See the default viewports (phone/desktop) and backgrounds (light/dark) in the toolbar
4. Add the following properties to your sandbox's preview default export:
```js
    backgrounds: {
      options: {
        twitter: { name: 'twitter', value: '#00aced' },
        facebook: { name: 'facebook', value: '#3b5998' },
      },
    },
    viewport: {
      options: {
        iphone5: {
          name: 'phone',
          styles: {
            width: '320px',
            height: '468px',
          },
        },
        ipad: {
          name: 'pad',
          styles: {
            width: '620px',
            height: '868px',
          },
        },

      },
    }

```
5. See that the viewports and backgrounds in the toolbar are now only the custom ones, with the defaults being removed.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 0.91 | 0% |
| initSize |  161 MB | 161 MB | -1.56 kB | 0.2 | 0% |
| diffSize |  84.7 MB | 84.7 MB | -1.56 kB | 0.19 | 0% |
| buildSize |  7.48 MB | 7.48 MB | -357 B | 0.16 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 21 B | **2.4** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | 0.23 | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 21 B | 0.24 | 0% |
| buildPreviewSize |  3.01 MB | 3 MB | -378 B | 0.05 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  18.2s | 18.3s | 93ms | 0.54 | 0.5% |
| generateTime |  25s | 23.5s | -1s -492ms | 0.29 | -6.3% |
| initTime |  19.9s | 18.9s | -1s -26ms | 0.11 | -5.4% |
| buildTime |  13s | 11.6s | -1s -362ms | -0.64 | -11.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.8s | 6.4s | 521ms | -0.69 | 8.1% |
| devManagerResponsive |  3.8s | 4.1s | 315ms | -0.58 | 7.5% |
| devManagerHeaderVisible |  652ms | 800ms | 148ms | 0 | 18.5% |
| devManagerIndexVisible |  682ms | 837ms | 155ms | -0.03 | 18.5% |
| devStoryVisibleUncached |  802ms | 1.2s | 441ms | -0.39 | 35.5% |
| devStoryVisible |  681ms | 836ms | 155ms | -0.03 | 18.5% |
| devAutodocsVisible |  580ms | 717ms | 137ms | -0.05 | 19.1% |
| devMDXVisible |  579ms | 677ms | 98ms | -0.28 | 14.5% |
| buildManagerHeaderVisible |  676ms | 938ms | 262ms | **2.39** | 🔺27.9% |
| buildManagerIndexVisible |  713ms | 947ms | 234ms | **2.35** | 🔺24.7% |
| buildStoryVisible |  712ms | 986ms | 274ms | **1.82** | 🔺27.8% |
| buildAutodocsVisible |  580ms | 986ms | 406ms | **3.68** | 🔺41.2% |
| buildMDXVisible |  668ms | 827ms | 159ms | **1.48** | 🔺19.2% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request modifies the Viewport and Backgrounds addons in Storybook to make their default options overridable, allowing users to completely replace or remove the default viewports and backgrounds.

- Added `DEFAULT_BACKGROUNDS` in `code/addons/backgrounds/src/defaults.ts` for customizable background options
- Modified `code/addons/viewport/src/components/Tool.tsx` to use `MINIMAL_VIEWPORTS` as default, enabling user-defined viewport options
- Updated `code/addons/backgrounds/src/preview.ts` and `code/addons/viewport/src/preview.ts` to apply defaults only when custom options are not provided
- Removed `emptyViewportMap` from `code/addons/viewport/src/utils.tsx` to align with the new customization approach
- Adjusted `code/addons/backgrounds/src/decorator.ts` to use `DEFAULT_BACKGROUNDS` as the default value for options

<!-- /greptile_comment -->