### PR TITLE
CLI: Handle Yarn PnP wrapper scenario when adding an addon

### DIFF
--- a/code/lib/cli-storybook/src/add.test.ts
+++ b/code/lib/cli-storybook/src/add.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { add, getVersionSpecifier } from './add';
 
 const MockedConfig = vi.hoisted(() => {
   return {
     appendValueToArray: vi.fn(),
+    getFieldNode: vi.fn(),
+    valueToNode: vi.fn(),
+    appendNodeToArray: vi.fn(),
   };
 });
 const MockedPackageManager = vi.hoisted(() => {
@@ -18,6 +21,12 @@ const MockedPackageManager = vi.hoisted(() => {
 const MockedPostInstall = vi.hoisted(() => {
   return {
     postinstallAddon: vi.fn(),
+  };
+});
+const MockWrapRequireUtils = vi.hoisted(() => {
+  return {
+    getRequireWrapperName: vi.fn(),
+    wrapValueWithRequireWrapper: vi.fn(),
   };
 });
 const MockedConsole = {
@@ -34,6 +43,9 @@ vi.mock('storybook/internal/csf-tools', () => {
 });
 vi.mock('./postinstallAddon', () => {
   return MockedPostInstall;
+});
+vi.mock('./automigrate/fixes/wrap-require-utils', () => {
+  return MockWrapRequireUtils;
 });
 vi.mock('storybook/internal/common', () => {
   return {
@@ -103,6 +115,35 @@ describe('add', () => {
 });
 
 describe('add (extra)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  test('should not add a "wrap require" to the addon when not needed', async () => {
+    MockedConfig.getFieldNode.mockReturnValue({});
+    MockWrapRequireUtils.getRequireWrapperName.mockReturnValue(null);
+    await add(
+      '@storybook/addon-docs',
+      { packageManager: 'npm', skipPostinstall: true },
+      MockedConsole
+    );
+
+    expect(MockWrapRequireUtils.wrapValueWithRequireWrapper).not.toHaveBeenCalled();
+    expect(MockedConfig.appendValueToArray).toHaveBeenCalled();
+    expect(MockedConfig.appendNodeToArray).not.toHaveBeenCalled();
+  });
+  test('should add a "wrap require" to the addon when applicable', async () => {
+    MockedConfig.getFieldNode.mockReturnValue({});
+    MockWrapRequireUtils.getRequireWrapperName.mockReturnValue('require');
+    await add(
+      '@storybook/addon-docs',
+      { packageManager: 'npm', skipPostinstall: true },
+      MockedConsole
+    );
+
+    expect(MockWrapRequireUtils.wrapValueWithRequireWrapper).toHaveBeenCalled();
+    expect(MockedConfig.appendValueToArray).not.toHaveBeenCalled();
+    expect(MockedConfig.appendNodeToArray).toHaveBeenCalled();
+  });
   test('not warning when installing the correct version of storybook', async () => {
     await add(
       '@storybook/addon-docs',

--- a/code/lib/cli-storybook/src/add.ts
+++ b/code/lib/cli-storybook/src/add.ts
@@ -15,7 +15,6 @@ import { dedent } from 'ts-dedent';
 
 import {
   getRequireWrapperName,
-  isRequireWrapperNecessary,
   wrapValueWithRequireWrapper,
 } from './automigrate/fixes/wrap-require-utils';
 import { postinstallAddon } from './postinstallAddon';
@@ -143,7 +142,6 @@ export async function add(
   logger.log(`Adding '${addon}' to main.js addons field.`);
 
   const mainConfigAddons = main.getFieldNode(['addons']);
-
   if (mainConfigAddons && getRequireWrapperName(main) !== null) {
     const addonNode = main.valueToNode(addonName);
     main.appendNodeToArray(['addons'], addonNode as any);

--- a/code/lib/cli-storybook/src/add.ts
+++ b/code/lib/cli-storybook/src/add.ts
@@ -13,6 +13,11 @@ import { readConfig, writeConfig } from 'storybook/internal/csf-tools';
 import SemVer from 'semver';
 import { dedent } from 'ts-dedent';
 
+import {
+  getRequireWrapperName,
+  isRequireWrapperNecessary,
+  wrapValueWithRequireWrapper,
+} from './automigrate/fixes/wrap-require-utils';
 import { postinstallAddon } from './postinstallAddon';
 
 export interface PostinstallOptions {
@@ -136,7 +141,17 @@ export async function add(
   await packageManager.addDependencies({ installAsDevDependencies: true }, [addonWithVersion]);
 
   logger.log(`Adding '${addon}' to main.js addons field.`);
-  main.appendValueToArray(['addons'], addonName);
+
+  const mainConfigAddons = main.getFieldNode(['addons']);
+
+  if (mainConfigAddons && getRequireWrapperName(main) !== null) {
+    const addonNode = main.valueToNode(addonName);
+    main.appendNodeToArray(['addons'], addonNode as any);
+    wrapValueWithRequireWrapper(main, addonNode as any);
+  } else {
+    main.appendValueToArray(['addons'], addonName);
+  }
+
   await writeConfig(main);
 
   if (!skipPostinstall && isCoreAddon(addonName)) {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR introduces logic in the `storybook add` command so it handles scenarios where the user has a main.js with pnp require wrappers (for monorepos) like so:

```ts
const getAbsolutePath = (path) => require('path').resolve(__dirname, path)

const config: StorybookConfig = {
  addons: [
    getAbsolutePath("foo")
  ],
}
export default config
```

1 - When there are no wrappers -> Just add `"addon-name"` to the field
2 - When there are wrappers named either `wrapForPnP` or `getAbsolutePath` -> add `wrapperName("addon-name")` to the field


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 0.82 | 0% |
| initSize |  161 MB | 161 MB | 0 B | **-1.29** | 0% |
| diffSize |  84.7 MB | 84.7 MB | 0 B | **-1.79** | 0% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | **1.36** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | 0.73 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | -0.71 | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0.73 | 0% |
| buildPreviewSize |  3.01 MB | 3.01 MB | 0 B | **1.34** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  11.6s | 24.8s | 13.2s | **1.75** | 🔺53.3% |
| generateTime |  22.8s | 19s | -3s -804ms | -0.69 | -20% |
| initTime |  18.7s | 16.2s | -2s -468ms | -0.57 | -15.1% |
| buildTime |  12.2s | 24.3s | 12.1s | **8.08** | 🔺49.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.5s | 8.9s | 1.3s | **1.81** | 🔺15.4% |
| devManagerResponsive |  4.8s | 5.6s | 855ms | **2.12** | 🔺15% |
| devManagerHeaderVisible |  925ms | 983ms | 58ms | **1.33** | 🔺5.9% |
| devManagerIndexVisible |  969ms | 1s | 64ms | **1.37** | 🔺6.2% |
| devStoryVisibleUncached |  1.6s | 1.7s | 93ms | 0.46 | 5.4% |
| devStoryVisible |  967ms | 1s | 67ms | **1.37** | 🔺6.5% |
| devAutodocsVisible |  764ms | 911ms | 147ms | **1.65** | 🔺16.1% |
| devMDXVisible |  716ms | 962ms | 246ms | **2.08** | 🔺25.6% |
| buildManagerHeaderVisible |  813ms | 986ms | 173ms | **2.86** | 🔺17.5% |
| buildManagerIndexVisible |  815ms | 1s | 217ms | **3.27** | 🔺21% |
| buildStoryVisible |  857ms | 1s | 176ms | **2.24** | 🔺17% |
| buildAutodocsVisible |  696ms | 936ms | 240ms | **3.06** | 🔺25.6% |
| buildMDXVisible |  730ms | 919ms | 189ms | **2.38** | 🔺20.6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR enhances the Storybook CLI's `add` command to handle Yarn PnP wrapper scenarios when adding addons to monorepo setups.

- Modified `add` function in `code/lib/cli-storybook/src/add.ts` to check for require wrappers in main.js
- Added logic to wrap addon names with appropriate require wrapper if present
- Imported new utility functions from './automigrate/fixes/wrap-require-utils' for wrapper detection and handling
- Improved compatibility with monorepo setups using Yarn PnP by adjusting how addons are added to main.js

<!-- /greptile_comment -->