### PR TITLE
Build: Rename vitest addon path in scripts

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -207,7 +207,7 @@ function addEsbuildLoaderToStories(mainConfig: ConfigFile) {
           },
         },
         // Handle MDX files per the addon-docs presets (ish)
-        {        
+        {
           test: /template-stories\\/.*\\.mdx$/,
           exclude: /\\.stories\\.mdx$/,
           use: [
@@ -512,7 +512,7 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
   // This workaround is needed because Vitest seems to have issues in link mode
   // so the /setup-file and /global-setup files from the vitest addon won't work in portal protocol
   if (options.link) {
-    const vitestAddonPath = relative(sandboxDir, join(CODE_DIRECTORY, 'addons', 'vitest'));
+    const vitestAddonPath = relative(sandboxDir, join(CODE_DIRECTORY, 'addons', 'test'));
     packageJson.resolutions = {
       ...packageJson.resolutions,
       '@storybook/experimental-addon-test': `file:${vitestAddonPath}`,


### PR DESCRIPTION
<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I was following the [step-by-step on how to contribute](https://storybook.js.org/docs/contribute/code#start-developing), but when I tried to run `yarn start` it would break with the following error:

```
An error occurred while installing dependencies:
YARN2 error
YN0001: EXCEPTION
-> Error: @storybook/experimental-addon-test@file:../../code/addons/vitest::locator=before-storybook%40workspace%3A.: ENOENT: no such file or directory, lstat '/home/my-user/git/storybook/code/addons/vitest'
```

It seems it was caused because the code was searching for a `vitest` addon folder, when it was recently renamed to `test`. Changed it, and now `yarn start` runs without errors.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run `yarn start`
2. See if it finishes without error

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | **2** | 0% |
| initSize |  161 MB | 161 MB | 0 B | -0.53 | 0% |
| diffSize |  84.7 MB | 84.7 MB | 0 B | -0.98 | 0% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | **-1.85** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | **1.68** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | -0.23 | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **1.72** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **-1.87** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23s | 22.1s | -904ms | 1.18 | -4.1% |
| generateTime |  19.2s | 19.7s | 546ms | -0.57 | 2.8% |
| initTime |  15.8s | 17.9s | 2s | -0.27 | 11.6% |
| buildTime |  12.9s | 11.6s | -1s -358ms | -0.52 | -11.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.3s | 6.9s | 618ms | 0.1 | 8.8% |
| devManagerResponsive |  4.1s | 4.3s | 210ms | -0.24 | 4.8% |
| devManagerHeaderVisible |  737ms | 789ms | 52ms | 0.04 | 6.6% |
| devManagerIndexVisible |  782ms | 825ms | 43ms | -0.02 | 5.2% |
| devStoryVisibleUncached |  1.3s | 1.2s | -152ms | -0.6 | -12.5% |
| devStoryVisible |  781ms | 824ms | 43ms | -0.01 | 5.2% |
| devAutodocsVisible |  659ms | 783ms | 124ms | **1.52** | 🔺15.8% |
| devMDXVisible |  677ms | 684ms | 7ms | -0.11 | 1% |
| buildManagerHeaderVisible |  692ms | 750ms | 58ms | 0.16 | 7.7% |
| buildManagerIndexVisible |  702ms | 752ms | 50ms | 0.02 | 6.6% |
| buildStoryVisible |  769ms | 806ms | 37ms | -0.03 | 4.6% |
| buildAutodocsVisible |  599ms | 704ms | 105ms | 0.08 | 14.9% |
| buildMDXVisible |  617ms | 657ms | 40ms | -0.21 | 6.1% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Renamed 'vitest' addon import file to 'test' to fix an error when running 'yarn start' in the Storybook development environment.

- Updated `setupVitest` function in `scripts/tasks/sandbox-parts.ts` to use 'test' instead of 'vitest' for addon path
- Fixed issue where the code was searching for a non-existent 'vitest' addon folder
- Ensures correct linking of the Vitest addon in development mode
- Resolves ENOENT error during dependency installation process

<!-- /greptile_comment -->