### PR TITLE
Build: Improve E2E tests with ESLint rules

### DIFF
--- a/code/.eslintrc.js
+++ b/code/.eslintrc.js
@@ -177,5 +177,28 @@ module.exports = {
         'local-rules/no-duplicated-error-codes': 'error',
       },
     },
+    {
+      files: ['./e2e-tests/*.ts'],
+      extends: ['plugin:playwright/recommended'],
+      rules: {
+        'playwright/no-skipped-test': [
+          'warn',
+          {
+            allowConditional: true,
+          },
+        ],
+        'playwright/no-raw-locators': 'off', // TODO: enable this, requires the UI to actually be accessible
+        'playwright/prefer-comparison-matcher': 'error',
+        'playwright/prefer-equality-matcher': 'error',
+        'playwright/prefer-hooks-on-top': 'error',
+        'playwright/prefer-strict-equal': 'error',
+        'playwright/prefer-to-be': 'error',
+        'playwright/prefer-to-contain': 'error',
+        'playwright/prefer-to-have-count': 'error',
+        'playwright/prefer-to-have-length': 'error',
+        'playwright/require-to-throw-message': 'error',
+        'playwright/require-top-level-describe': 'error',
+      },
+    },
   ],
 };

--- a/code/addons/test/package.json
+++ b/code/addons/test/package.json
@@ -8,14 +8,14 @@
     "vitest",
     "testing"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/vitest",
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/test",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/storybookjs/storybook.git",
-    "directory": "code/addons/vitest"
+    "directory": "code/addons/test"
   },
   "funding": {
     "type": "opencollective",

--- a/code/e2e-tests/addon-actions.spec.ts
+++ b/code/e2e-tests/addon-actions.spec.ts
@@ -18,11 +18,11 @@ test.describe('addon-actions', () => {
 
     await sbPage.navigateToStory('example/button', 'primary');
     const root = sbPage.previewRoot();
-    const button = root.locator('button', { hasText: 'Button' });
+    const button = root.getByRole('button', { name: 'Button' });
     await button.click();
 
     await sbPage.viewAddonPanel('Actions');
-    const logItem = await page.locator('#storybook-panel-root #panel-tab-content', {
+    const logItem = page.locator('#storybook-panel-root #panel-tab-content', {
       hasText: 'click',
     });
     await expect(logItem).toBeVisible();
@@ -40,11 +40,11 @@ test.describe('addon-actions', () => {
     await sbPage.navigateToStory('addons/actions/spies', 'show-spy-on-in-actions');
 
     const root = sbPage.previewRoot();
-    const button = root.locator('button', { hasText: 'Button' });
+    const button = root.getByRole('button', { name: 'Button' });
     await button.click();
 
     await sbPage.viewAddonPanel('Actions');
-    const logItem = await page.locator('#storybook-panel-root #panel-tab-content', {
+    const logItem = page.locator('#storybook-panel-root #panel-tab-content', {
       hasText: 'console.log',
     });
     await expect(logItem).toBeVisible();

--- a/code/e2e-tests/addon-controls.spec.ts
+++ b/code/e2e-tests/addon-controls.spec.ts
@@ -21,9 +21,7 @@ test.describe('addon-controls', () => {
     await expect(sbPage.previewRoot().locator('button')).toContainText('Hello world');
 
     // Args in URL
-    await page.waitForTimeout(300);
-    const url = await page.url();
-    await expect(url).toContain('args=label:Hello+world');
+    await page.waitForURL((url) => url.search.includes('args=label:Hello+world'));
 
     // Boolean toggle: Primary/secondary
     await expect(sbPage.previewRoot().locator('button')).toHaveCSS(
@@ -72,8 +70,8 @@ test.describe('addon-controls', () => {
     await expect(sbPage.previewRoot().locator('button')).toContainText('Hello world');
 
     await sbPage.viewAddonPanel('Controls');
-    const label = await sbPage.panelContent().locator('textarea[name=label]').inputValue();
-    await expect(label).toEqual('Hello world');
+    const label = sbPage.panelContent().locator('textarea[name=label]');
+    await expect(label).toHaveValue('Hello world');
   });
 
   test('should set select option when value contains double spaces', async ({ page }) => {

--- a/code/e2e-tests/addon-docs.spec.ts
+++ b/code/e2e-tests/addon-docs.spec.ts
@@ -179,7 +179,7 @@ test.describe('addon-docs', () => {
     const root = sbPage.previewRoot();
     const stories = root.locator('.sb-story button');
 
-    await expect(await stories.count()).toBe(3);
+    await expect(stories).toHaveCount(3);
     await expect(stories.first()).toHaveText('Basic');
     await expect(stories.nth(1)).toHaveText('Basic');
     await expect(stories.last()).toHaveText('Another');
@@ -265,12 +265,14 @@ test.describe('addon-docs', () => {
     const root = sbPage.previewRoot();
 
     const storyHeadings = root.locator('.sb-anchor > h3');
-    await expect(await storyHeadings.count()).toBe(6);
-    await expect(storyHeadings.nth(0)).toHaveText('Default A');
-    await expect(storyHeadings.nth(1)).toHaveText('Span Content');
-    await expect(storyHeadings.nth(2)).toHaveText('Code Content');
-    await expect(storyHeadings.nth(3)).toHaveText('Default B');
-    await expect(storyHeadings.nth(4)).toHaveText('H 1 Content');
-    await expect(storyHeadings.nth(5)).toHaveText('H 2 Content');
+    await expect(storyHeadings).toHaveCount(6);
+    await expect(storyHeadings).toHaveText([
+      'Default A',
+      'Span Content',
+      'Code Content',
+      'Default B',
+      'H 1 Content',
+      'H 2 Content',
+    ]);
   });
 });

--- a/code/e2e-tests/addon-docs.spec.ts
+++ b/code/e2e-tests/addon-docs.spec.ts
@@ -1,3 +1,6 @@
+/* eslint-disable playwright/no-conditional-expect */
+
+/* eslint-disable playwright/no-conditional-in-test */
 import { expect, test } from '@playwright/test';
 import process from 'process';
 import { dedent } from 'ts-dedent';
@@ -94,14 +97,14 @@ test.describe('addon-docs', () => {
 
     const toggleCount = await toggles.count();
     for (let i = 0; i < toggleCount; i += 1) {
-      const toggle = await toggles.nth(i);
-      await toggle.click({ force: true });
+      const toggle = toggles.nth(i);
+      await toggle.click();
     }
 
     const codes = root.locator('pre.prismjs');
     const codeCount = await codes.count();
     for (let i = 0; i < codeCount; i += 1) {
-      const code = await codes.nth(i);
+      const code = codes.nth(i);
       const text = await code.innerText();
       await expect(text).not.toMatch(/^\(args\) => /);
     }
@@ -132,13 +135,13 @@ test.describe('addon-docs', () => {
     const toggles = root.locator('.docblock-code-toggle');
 
     // Open up the first and second code toggle (i.e the "Basic" story outside and inside the Stories block)
-    await (await toggles.nth(0)).click({ force: true });
-    await (await toggles.nth(1)).click({ force: true });
+    await toggles.nth(0).click();
+    await toggles.nth(1).click();
 
     // Check they both say "Basic"
     const codes = root.locator('pre.prismjs');
-    const primaryCode = await codes.nth(0);
-    const storiesCode = await codes.nth(1);
+    const primaryCode = codes.nth(0);
+    const storiesCode = codes.nth(1);
     await expect(primaryCode).toContainText('Basic');
     await expect(storiesCode).toContainText('Basic');
 
@@ -210,12 +213,12 @@ test.describe('addon-docs', () => {
     }
 
     // Arrange - Get the actual versions
-    const mdxReactVersion = await root.getByTestId('mdx-react');
-    const mdxReactDomVersion = await root.getByTestId('mdx-react-dom');
-    const mdxReactDomServerVersion = await root.getByTestId('mdx-react-dom-server');
-    const componentReactVersion = await root.getByTestId('component-react');
-    const componentReactDomVersion = await root.getByTestId('component-react-dom');
-    const componentReactDomServerVersion = await root.getByTestId('component-react-dom-server');
+    const mdxReactVersion = root.getByTestId('mdx-react');
+    const mdxReactDomVersion = root.getByTestId('mdx-react-dom');
+    const mdxReactDomServerVersion = root.getByTestId('mdx-react-dom-server');
+    const componentReactVersion = root.getByTestId('component-react');
+    const componentReactDomVersion = root.getByTestId('component-react-dom');
+    const componentReactDomServerVersion = root.getByTestId('component-react-dom-server');
 
     // Assert - The versions are in the expected range
     await expect(mdxReactVersion).toHaveText(expectedReactVersionRange);
@@ -232,9 +235,9 @@ test.describe('addon-docs', () => {
     await sbPage.navigateToStory('addons/docs/docs2/resolvedreact', 'docs');
 
     // Arrange - Get the actual versions
-    const autodocsReactVersion = await root.getByTestId('react');
-    const autodocsReactDomVersion = await root.getByTestId('react-dom');
-    const autodocsReactDomServerVersion = await root.getByTestId('react-dom-server');
+    const autodocsReactVersion = root.getByTestId('react');
+    const autodocsReactDomVersion = root.getByTestId('react-dom');
+    const autodocsReactDomServerVersion = root.getByTestId('react-dom-server');
 
     // Assert - The versions are in the expected range
     await expect(autodocsReactVersion).toHaveText(expectedReactVersionRange);
@@ -247,9 +250,9 @@ test.describe('addon-docs', () => {
     await sbPage.navigateToStory('addons/docs/docs2/resolvedreact', 'story');
 
     // Arrange - Get the actual versions
-    const storyReactVersion = await root.getByTestId('react');
-    const storyReactDomVersion = await root.getByTestId('react-dom');
-    const storyReactDomServerVersion = await root.getByTestId('react-dom-server');
+    const storyReactVersion = root.getByTestId('react');
+    const storyReactDomVersion = root.getByTestId('react-dom');
+    const storyReactDomServerVersion = root.getByTestId('react-dom-server');
 
     // Assert - The versions are in the expected range
     await expect(storyReactVersion).toHaveText(expectedReactVersionRange);

--- a/code/e2e-tests/addon-interactions.spec.ts
+++ b/code/e2e-tests/addon-interactions.spec.ts
@@ -24,10 +24,10 @@ test.describe('addon-interactions', () => {
     await sbPage.navigateToStory('example/page', 'logged-in');
     await sbPage.viewAddonPanel('Interactions');
 
-    const welcome = await sbPage.previewRoot().locator('.welcome');
+    const welcome = sbPage.previewRoot().locator('.welcome');
     await expect(welcome).toContainText('Welcome, Jane Doe!', { timeout: 50000 });
 
-    const interactionsTab = await page.locator('#tabbutton-storybook-interactions-panel');
+    const interactionsTab = page.locator('#tabbutton-storybook-interactions-panel');
     await expect(interactionsTab).toContainText(/(\d)/);
     await expect(interactionsTab).toBeVisible();
 
@@ -36,7 +36,7 @@ test.describe('addon-interactions', () => {
     await expect(panel).toContainText(/userEvent.click/);
     await expect(panel).toBeVisible();
 
-    const done = await panel.locator('[data-testid=icon-done]').nth(0);
+    const done = panel.locator('[data-testid=icon-done]').nth(0);
     await expect(done).toBeVisible();
   });
 
@@ -57,16 +57,16 @@ test.describe('addon-interactions', () => {
     await sbPage.viewAddonPanel('Interactions');
 
     // Test initial state - Interactions have run, count is correct and values are as expected
-    const formInput = await sbPage.previewRoot().locator('#interaction-test-form input');
+    const formInput = sbPage.previewRoot().locator('#interaction-test-form input');
     await expect(formInput).toHaveValue('final value', { timeout: 50000 });
 
-    const interactionsTab = await page.locator('#tabbutton-storybook-interactions-panel');
+    const interactionsTab = page.locator('#tabbutton-storybook-interactions-panel');
     await expect(interactionsTab.getByText('3')).toBeVisible();
     await expect(interactionsTab).toBeVisible();
     await expect(interactionsTab).toBeVisible();
 
     const panel = sbPage.panelContent();
-    const runStatusBadge = await panel.locator('[aria-label="Status of the test run"]');
+    const runStatusBadge = panel.locator('[aria-label="Status of the test run"]');
     await expect(runStatusBadge).toContainText(/Pass/);
     await expect(panel).toContainText(/"initial value"/);
     await expect(panel).toContainText(/clear/);
@@ -74,18 +74,18 @@ test.describe('addon-interactions', () => {
     await expect(panel).toBeVisible();
 
     // Test interactions debugger - Stepping through works, count is correct and values are as expected
-    const interactionsRow = await panel.locator('[aria-label="Interaction step"]');
+    const interactionsRow = panel.locator('[aria-label="Interaction step"]');
 
     await interactionsRow.first().isVisible();
 
-    await expect(await interactionsRow.count()).toEqual(3);
+    await expect(interactionsRow).toHaveCount(3);
     const firstInteraction = interactionsRow.first();
     await firstInteraction.click();
 
     await expect(runStatusBadge).toContainText(/Runs/);
     await expect(formInput).toHaveValue('initial value');
 
-    const goForwardBtn = await panel.locator('[aria-label="Go forward"]');
+    const goForwardBtn = panel.locator('[aria-label="Go forward"]');
     await goForwardBtn.click();
     await expect(formInput).toHaveValue('');
     await goForwardBtn.click();
@@ -94,7 +94,7 @@ test.describe('addon-interactions', () => {
     await expect(runStatusBadge).toContainText(/Pass/);
 
     // Test rerun state (from addon panel) - Interactions have rerun, count is correct and values are as expected
-    const rerunInteractionButton = await panel.locator('[aria-label="Rerun"]');
+    const rerunInteractionButton = panel.locator('[aria-label="Rerun"]');
     await rerunInteractionButton.click();
 
     await expect(formInput).toHaveValue('final value');
@@ -107,7 +107,7 @@ test.describe('addon-interactions', () => {
     await expect(interactionsTab.getByText('3')).toBeVisible();
 
     // Test remount state (from toolbar) - Interactions have rerun, count is correct and values are as expected
-    const remountComponentButton = await page.locator('[title="Remount component"]');
+    const remountComponentButton = page.locator('[title="Remount component"]');
     await remountComponentButton.click();
 
     await interactionsRow.first().isVisible();
@@ -132,7 +132,7 @@ test.describe('addon-interactions', () => {
     await sbPage.deepLinkToStory(storybookUrl, 'addons/interactions/unhandled-errors', 'default');
     await sbPage.viewAddonPanel('Interactions');
 
-    const button = await sbPage.previewRoot().locator('button');
+    const button = sbPage.previewRoot().locator('button');
     await expect(button).toContainText('Button', { timeout: 50000 });
 
     const panel = sbPage.panelContent();

--- a/code/e2e-tests/addon-toolbars.spec.ts
+++ b/code/e2e-tests/addon-toolbars.spec.ts
@@ -30,7 +30,7 @@ test.describe('addon-toolbars', () => {
     // Click on viewport button and select spanish
     await sbPage.navigateToStory('addons/toolbars/globals', 'override-locale');
     await expect(sbPage.previewRoot()).toContainText('안녕하세요');
-    const button = await sbPage.page.locator('[title="Internationalization locale"]');
+    const button = sbPage.page.locator('[title="Internationalization locale"]');
 
     await expect(button).toHaveAttribute('disabled', '');
   });

--- a/code/e2e-tests/addon-toolbars.spec.ts
+++ b/code/e2e-tests/addon-toolbars.spec.ts
@@ -32,6 +32,6 @@ test.describe('addon-toolbars', () => {
     await expect(sbPage.previewRoot()).toContainText('안녕하세요');
     const button = await sbPage.page.locator('[title="Internationalization locale"]');
 
-    await expect(await button.getAttribute('disabled')).toBe('');
+    await expect(button).toHaveAttribute('disabled', '');
   });
 });

--- a/code/e2e-tests/composition.spec.ts
+++ b/code/e2e-tests/composition.spec.ts
@@ -3,48 +3,42 @@ import { expect, test } from '@playwright/test';
 import { SbPage } from './util';
 
 const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:6006';
-
-// This is a slow test, and (presumably) framework independent, so only run it on one sandbox
-const skipTest = process.env.STORYBOOK_TEMPLATE_NAME !== 'react-vite/default-ts';
+const templateName = process.env.STORYBOOK_TEMPLATE_NAME || '';
 
 test.describe('composition', () => {
+  test.skip(
+    templateName !== 'react-vite/default-ts',
+    'Slow, framework independent test, so only run it on in react-vite/default-ts'
+  );
+
   test.beforeEach(async ({ page }) => {
-    if (skipTest) {
-      return;
-    }
     await page.goto(storybookUrl);
     await new SbPage(page).waitUntilLoaded();
   });
 
   test('should correctly filter composed stories', async ({ page }) => {
-    if (skipTest) {
-      return;
-    }
-
     // Expect that composed Storybooks are visible
-
-    // Expect that composed Storybooks are visible
-    await expect(await page.getByTitle('Storybook 8.0.0')).toBeVisible();
-    await expect(await page.getByTitle('Storybook 7.6.18')).toBeVisible();
+    await expect(page.getByTitle('Storybook 8.0.0')).toBeVisible();
+    await expect(page.getByTitle('Storybook 7.6.18')).toBeVisible();
 
     // Expect composed stories to be available in the sidebar
     await page.locator('[id="storybook\\@8\\.0\\.0_components-badge"]').click();
     await expect(
-      await page.locator('[id="storybook\\@8\\.0\\.0_components-badge--default"]')
+      page.locator('[id="storybook\\@8\\.0\\.0_components-badge--default"]')
     ).toBeVisible();
 
     await page.locator('[id="storybook\\@7\\.6\\.18_components-badge"]').click();
     await expect(
-      await page.locator('[id="storybook\\@7\\.6\\.18_components-badge--default"]')
+      page.locator('[id="storybook\\@7\\.6\\.18_components-badge--default"]')
     ).toBeVisible();
 
     // Expect composed stories `to be available in the search
     await page.getByPlaceholder('Find components').fill('Button');
     await expect(
-      await page.getByRole('option', { name: 'Button Storybook 8.0.0 / @blocks / examples' })
+      page.getByRole('option', { name: 'Button Storybook 8.0.0 / @blocks / examples' })
     ).toBeVisible();
     await expect(
-      await page.getByRole('option', { name: 'Button Storybook 7.6.18 / @blocks / examples' })
+      page.getByRole('option', { name: 'Button Storybook 7.6.18 / @blocks / examples' })
     ).toBeVisible();
   });
 });

--- a/code/e2e-tests/framework-nextjs.spec.ts
+++ b/code/e2e-tests/framework-nextjs.spec.ts
@@ -27,7 +27,7 @@ test.describe('Next.js', () => {
       sbPage = new SbPage(page);
     });
 
-    // TODO: Test is flaky, investigate why
+    // eslint-disable-next-line playwright/no-skipped-test -- test is flaky, investigate why
     test.skip('should lazy load images by default', async () => {
       await sbPage.navigateToStory('stories/frameworks/nextjs/Image', 'lazy');
 
@@ -36,7 +36,7 @@ test.describe('Next.js', () => {
       expect(await img.evaluate<boolean, HTMLImageElement>((image) => image.complete)).toBeFalsy();
     });
 
-    // TODO: Test is flaky, investigate why
+    // eslint-disable-next-line playwright/no-skipped-test -- test is flaky, investigate why
     test.skip('should eager load images when loading parameter is set to eager', async () => {
       await sbPage.navigateToStory('stories/frameworks/nextjs/Image', 'eager');
 
@@ -50,19 +50,6 @@ test.describe('Next.js', () => {
     let root: Locator;
     let sbPage: SbPage;
 
-    function testRoutingBehaviour(buttonText: string, action: string) {
-      test(`should trigger ${action} action`, async ({ page }) => {
-        const button = root.locator('button', { hasText: buttonText });
-        await button.click();
-
-        await sbPage.viewAddonPanel('Actions');
-        const logItem = await page.locator('#storybook-panel-root #panel-tab-content', {
-          hasText: `useRouter().${action}`,
-        });
-        await expect(logItem).toBeVisible();
-      });
-    }
-
     test.beforeEach(async ({ page }) => {
       sbPage = new SbPage(page);
 
@@ -72,6 +59,19 @@ test.describe('Next.js', () => {
       );
       root = sbPage.previewRoot();
     });
+
+    function testRoutingBehaviour(buttonText: string, action: string) {
+      test(`should trigger ${action} action`, async ({ page }) => {
+        const button = root.locator('button', { hasText: buttonText });
+        await button.click();
+
+        await sbPage.viewAddonPanel('Actions');
+        const logItem = page.locator('#storybook-panel-root #panel-tab-content', {
+          hasText: `useRouter().${action}`,
+        });
+        await expect(logItem).toBeVisible();
+      });
+    }
 
     testRoutingBehaviour('Go back', 'back');
     testRoutingBehaviour('Go forward', 'forward');
@@ -85,25 +85,25 @@ test.describe('Next.js', () => {
     let root: Locator;
     let sbPage: SbPage;
 
-    function testRoutingBehaviour(buttonText: string, action: string) {
-      test(`should trigger ${action} action`, async ({ page }) => {
-        const button = root.locator('button', { hasText: buttonText });
-        await button.click();
-
-        await sbPage.viewAddonPanel('Actions');
-        const logItem = await page.locator('#storybook-panel-root #panel-tab-content', {
-          hasText: `useRouter().${action}`,
-        });
-        await expect(logItem).toBeVisible();
-      });
-    }
-
     test.beforeEach(async ({ page }) => {
       sbPage = new SbPage(page);
 
       await sbPage.navigateToStory('stories/frameworks/nextjs-nextjs-default-ts/Router', 'default');
       root = sbPage.previewRoot();
     });
+
+    function testRoutingBehaviour(buttonText: string, action: string) {
+      test(`should trigger ${action} action`, async ({ page }) => {
+        const button = root.locator('button', { hasText: buttonText });
+        await button.click();
+
+        await sbPage.viewAddonPanel('Actions');
+        const logItem = page.locator('#storybook-panel-root #panel-tab-content', {
+          hasText: `useRouter().${action}`,
+        });
+        await expect(logItem).toBeVisible();
+      });
+    }
 
     testRoutingBehaviour('Go back', 'back');
     testRoutingBehaviour('Go forward', 'forward');

--- a/code/e2e-tests/framework-svelte.spec.ts
+++ b/code/e2e-tests/framework-svelte.spec.ts
@@ -6,13 +6,13 @@ import { SbPage } from './util';
 const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:6006';
 const templateName = process.env.STORYBOOK_TEMPLATE_NAME;
 
-test.beforeEach(async ({ page }) => {
-  await page.goto(storybookUrl);
-  await new SbPage(page).waitUntilLoaded();
-});
-
 test.describe('Svelte', () => {
-  test.skip(!templateName?.includes('svelte'), 'Only run this test on Svelte');
+  test.beforeEach(async ({ page }) => {
+    await page.goto(storybookUrl);
+    await new SbPage(page).waitUntilLoaded();
+  });
+
+  test.skip(!templateName?.includes('svelte'), 'Only run these tests on Svelte');
 
   test('JS story has auto-generated args table', async ({ page }) => {
     const sbPage = new SbPage(page);
@@ -58,76 +58,76 @@ test.describe('Svelte', () => {
     await sbPage.navigateToStory('stories/renderers/svelte/decorators-runs-once', 'default');
     expect(lines).toHaveLength(1);
   });
-});
 
-test.describe('SvelteKit', () => {
-  test.skip(!templateName?.includes('svelte-kit'), 'Only run this test on SvelteKit');
+  test.describe('SvelteKit', () => {
+    test.skip(!templateName?.includes('svelte-kit'), 'Only run this test on SvelteKit');
 
-  test('Links are logged in Actions panel', async ({ page }) => {
-    const sbPage = new SbPage(page);
+    test('Links are logged in Actions panel', async ({ page }) => {
+      const sbPage = new SbPage(page);
 
-    await sbPage.navigateToStory('stories/sveltekit/modules/hrefs', 'default-actions');
-    const root = sbPage.previewRoot();
-    const link = root.locator('a', { hasText: 'Link to /basic-href' });
-    await link.click();
+      await sbPage.navigateToStory('stories/sveltekit/modules/hrefs', 'default-actions');
+      const root = sbPage.previewRoot();
+      const link = root.locator('a', { hasText: 'Link to /basic-href' });
+      await link.click();
 
-    await sbPage.viewAddonPanel('Actions');
-    const basicLogItem = await page.locator('#storybook-panel-root #panel-tab-content', {
-      hasText: `/basic-href`,
+      await sbPage.viewAddonPanel('Actions');
+      const basicLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
+        hasText: `/basic-href`,
+      });
+
+      await expect(basicLogItem).toBeVisible();
+      const complexLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
+        hasText: `/deep/nested`,
+      });
+      await expect(complexLogItem).toBeVisible();
     });
 
-    await expect(basicLogItem).toBeVisible();
-    const complexLogItem = await page.locator('#storybook-panel-root #panel-tab-content', {
-      hasText: `/deep/nested`,
+    test('goto are logged in Actions panel', async ({ page }) => {
+      const sbPage = new SbPage(page);
+
+      await sbPage.navigateToStory('stories/sveltekit/modules/navigation', 'default-actions');
+      const root = sbPage.previewRoot();
+      await sbPage.viewAddonPanel('Actions');
+
+      const goto = root.locator('button', { hasText: 'goto' });
+      await goto.click();
+
+      const gotoLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
+        hasText: `/storybook-goto`,
+      });
+      await expect(gotoLogItem).toBeVisible();
+
+      const invalidate = root.getByRole('button', { name: 'invalidate', exact: true });
+      await invalidate.click();
+
+      const invalidateLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
+        hasText: `/storybook-invalidate`,
+      });
+      await expect(invalidateLogItem).toBeVisible();
+
+      const invalidateAll = root.getByRole('button', { name: 'invalidateAll' });
+      await invalidateAll.click();
+
+      const invalidateAllLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
+        hasText: `"invalidateAll"`,
+      });
+      await expect(invalidateAllLogItem).toBeVisible();
+
+      const replaceState = root.getByRole('button', { name: 'replaceState' });
+      await replaceState.click();
+
+      const replaceStateLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
+        hasText: `/storybook-replace-state`,
+      });
+      await expect(replaceStateLogItem).toBeVisible();
+
+      const pushState = root.getByRole('button', { name: 'pushState' });
+      await pushState.click();
+
+      const pushStateLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
+        hasText: `/storybook-push-state`,
+      });
+      await expect(pushStateLogItem).toBeVisible();
     });
-    await expect(complexLogItem).toBeVisible();
-  });
-
-  test('goto are logged in Actions panel', async ({ page }) => {
-    const sbPage = new SbPage(page);
-
-    await sbPage.navigateToStory('stories/sveltekit/modules/navigation', 'default-actions');
-    const root = sbPage.previewRoot();
-    await sbPage.viewAddonPanel('Actions');
-
-    const goto = root.locator('button', { hasText: 'goto' });
-    await goto.click();
-
-    const gotoLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
-      hasText: `/storybook-goto`,
-    });
-    await expect(gotoLogItem).toBeVisible();
-
-    const invalidate = root.getByRole('button', { name: 'invalidate', exact: true });
-    await invalidate.click();
-
-    const invalidateLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
-      hasText: `/storybook-invalidate`,
-    });
-    await expect(invalidateLogItem).toBeVisible();
-
-    const invalidateAll = root.getByRole('button', { name: 'invalidateAll' });
-    await invalidateAll.click();
-
-    const invalidateAllLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
-      hasText: `"invalidateAll"`,
-    });
-    await expect(invalidateAllLogItem).toBeVisible();
-
-    const replaceState = root.getByRole('button', { name: 'replaceState' });
-    await replaceState.click();
-
-    const replaceStateLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
-      hasText: `/storybook-replace-state`,
-    });
-    await expect(replaceStateLogItem).toBeVisible();
-
-    const pushState = root.getByRole('button', { name: 'pushState' });
-    await pushState.click();
-
-    const pushStateLogItem = page.locator('#storybook-panel-root #panel-tab-content', {
-      hasText: `/storybook-push-state`,
-    });
-    await expect(pushStateLogItem).toBeVisible();
   });
 });

--- a/code/e2e-tests/json-files.spec.ts
+++ b/code/e2e-tests/json-files.spec.ts
@@ -11,7 +11,7 @@ test.describe('JSON files', () => {
   test('should have index.json', async ({ page }) => {
     const json = await page.evaluate(() => fetch('/index.json').then((res) => res.json()));
 
-    expect(json).toEqual({
+    expect(json).toStrictEqual({
       v: expect.any(Number),
       entries: expect.objectContaining({
         'example-button--primary': expect.objectContaining({

--- a/code/e2e-tests/manager.spec.ts
+++ b/code/e2e-tests/manager.spec.ts
@@ -23,14 +23,14 @@ test.describe('Manager UI', () => {
 
       // toggle with keyboard shortcut
       await sbPage.page.locator('html').press('Alt+s');
-      await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
+      await expect(sbPage.page.locator('.sidebar-container')).toBeHidden();
       await sbPage.page.locator('html').press('Alt+s');
       await expect(sbPage.page.locator('.sidebar-container')).toBeVisible();
 
       // toggle with menu item
       await sbPage.page.locator('[aria-label="Shortcuts"]').click();
       await sbPage.page.locator('#list-item-S').click();
-      await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
+      await expect(sbPage.page.locator('.sidebar-container')).toBeHidden();
 
       // toggle with "show sidebar" button
       await sbPage.page.locator('[aria-label="Show sidebar"]').click();
@@ -40,8 +40,8 @@ test.describe('Manager UI', () => {
     test('Toolbar toggling', async ({ page }) => {
       const sbPage = new SbPage(page);
       const expectToolbarVisibility = async (visible: boolean) => {
-        expect(async () => {
-          const toolbar = await sbPage.page.locator(`[data-test-id="sb-preview-toolbar"]`);
+        await expect(async () => {
+          const toolbar = sbPage.page.locator(`[data-test-id="sb-preview-toolbar"]`);
           const marginTop = await toolbar.evaluate(
             (element) => window.getComputedStyle(element).marginTop
           );
@@ -73,13 +73,13 @@ test.describe('Manager UI', () => {
         // navigate to docs to hide panel
         await sbPage.navigateToStory('example/button', 'docs');
 
-        await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
+        await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
 
         // toggle with keyboard shortcut
         await sbPage.page.locator('html').press('Alt+a');
-        await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
+        await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
         await sbPage.page.locator('html').press('Alt+a');
-        await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
+        await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
       });
 
       test('Toggling', async ({ page }) => {
@@ -92,14 +92,14 @@ test.describe('Manager UI', () => {
 
         // toggle with keyboard shortcut
         await sbPage.page.locator('html').press('Alt+a');
-        await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
+        await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
         await sbPage.page.locator('html').press('Alt+a');
         await expect(sbPage.page.locator('#storybook-panel-root')).toBeVisible();
 
         // toggle with menu item
         await sbPage.page.locator('[aria-label="Shortcuts"]').click();
         await sbPage.page.locator('#list-item-A').click();
-        await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
+        await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
 
         // toggle with "show addons" button
         await sbPage.page.locator('[aria-label="Show addons"]').click();
@@ -121,7 +121,7 @@ test.describe('Manager UI', () => {
 
         // hide with keyboard shortcut
         await sbPage.page.locator('html').press('Alt+a');
-        await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
+        await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
 
         // toggling position should also show the panel again
         await sbPage.page.locator('html').press('Alt+d');
@@ -140,8 +140,8 @@ test.describe('Manager UI', () => {
 
       // toggle with keyboard shortcut
       await sbPage.page.locator('html').press('Alt+f');
-      await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
-      await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
+      await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
+      await expect(sbPage.page.locator('.sidebar-container')).toBeHidden();
 
       await sbPage.page.locator('html').press('Alt+f');
       await expect(sbPage.page.locator('#storybook-panel-root')).toBeVisible();
@@ -150,8 +150,8 @@ test.describe('Manager UI', () => {
       // toggle with menu item
       await sbPage.page.locator('[aria-label="Shortcuts"]').click();
       await sbPage.page.locator('#list-item-F').click();
-      await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
-      await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
+      await expect(sbPage.page.locator('.sidebar-container')).toBeHidden();
+      await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
 
       // toggle with "go/exit fullscreen" button
       await sbPage.page.locator('[aria-label="Exit full screen"]').click();
@@ -159,20 +159,20 @@ test.describe('Manager UI', () => {
       await expect(sbPage.page.locator('.sidebar-container')).toBeVisible();
 
       await sbPage.page.locator('[aria-label="Go full screen"]').click();
-      await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
-      await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
+      await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
+      await expect(sbPage.page.locator('.sidebar-container')).toBeHidden();
 
       // go fullscreen when sidebar is shown but panel is hidden
       await sbPage.page.locator('[aria-label="Show sidebar"]').click();
       await sbPage.page.locator('[aria-label="Go full screen"]').click();
-      await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
-      await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
+      await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
+      await expect(sbPage.page.locator('.sidebar-container')).toBeHidden();
 
       // go fullscreen when panel is shown but sidebar is hidden
       await sbPage.page.locator('[aria-label="Show addons"]').click();
       await sbPage.page.locator('[aria-label="Go full screen"]').click();
-      await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
-      await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
+      await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
+      await expect(sbPage.page.locator('.sidebar-container')).toBeHidden();
     });
 
     test('Settings page', async ({ page }) => {
@@ -182,7 +182,7 @@ test.describe('Manager UI', () => {
 
       await expect(sbPage.page.url()).toContain('/settings/about');
 
-      await expect(sbPage.page.locator('#storybook-panel-root')).not.toBeVisible();
+      await expect(sbPage.page.locator('#storybook-panel-root')).toBeHidden();
 
       await sbPage.page.locator('[title="Close settings page"]').click();
       await expect(sbPage.page.url()).not.toContain('/settings/about');
@@ -202,12 +202,12 @@ test.describe('Manager UI', () => {
     test('Navigate to story', async ({ page }) => {
       const sbPage = new SbPage(page);
 
-      const closeNavigationButton = await sbPage.page.locator('[title="Close navigation menu"]');
-      const mobileNavigationHeading = await sbPage.page.locator('[title="Open navigation menu"]');
+      const closeNavigationButton = sbPage.page.locator('[title="Close navigation menu"]');
+      const mobileNavigationHeading = sbPage.page.locator('[title="Open navigation menu"]');
 
       // navigation menu is closed
-      await expect(closeNavigationButton).not.toBeVisible();
-      await expect(sbPage.page.locator('#storybook-explorer-menu')).not.toBeVisible();
+      await expect(closeNavigationButton).toBeHidden();
+      await expect(sbPage.page.locator('#storybook-explorer-menu')).toBeHidden();
 
       // open navigation menu
       await mobileNavigationHeading.click();
@@ -223,7 +223,7 @@ test.describe('Manager UI', () => {
 
       // navigation menu is closed
       await expect(mobileNavigationHeading).toHaveText('Example/Button/Secondary');
-      await expect(sbPage.page.locator('#storybook-explorer-menu')).not.toBeVisible();
+      await expect(sbPage.page.locator('#storybook-explorer-menu')).toBeHidden();
       // story has changed
       await expect(sbPage.page.url()).toContain('example-button--secondary');
     });
@@ -231,13 +231,13 @@ test.describe('Manager UI', () => {
     test('Open and close addon panel', async ({ page }) => {
       const sbPage = new SbPage(page);
 
-      const mobileNavigationHeading = await sbPage.page.locator('[title="Open navigation menu"]');
+      const mobileNavigationHeading = sbPage.page.locator('[title="Open navigation menu"]');
       await mobileNavigationHeading.click();
       await sbPage.navigateToStory('Example/Button', 'Secondary');
 
       // panel is closed
       await expect(mobileNavigationHeading).toHaveText('Example/Button/Secondary');
-      await expect(sbPage.page.locator('#tabbutton-addon-controls')).not.toBeVisible();
+      await expect(sbPage.page.locator('#tabbutton-addon-controls')).toBeHidden();
 
       // open panel
       await sbPage.page.locator('[title="Open addon panel"]').click();
@@ -250,7 +250,7 @@ test.describe('Manager UI', () => {
 
       // panel is closed
       await expect(mobileNavigationHeading).toHaveText('Example/Button/Secondary');
-      await expect(sbPage.page.locator('#tabbutton-addon-controls')).not.toBeVisible();
+      await expect(sbPage.page.locator('#tabbutton-addon-controls')).toBeHidden();
     });
   });
 });

--- a/code/e2e-tests/module-mocking.spec.ts
+++ b/code/e2e-tests/module-mocking.spec.ts
@@ -18,7 +18,7 @@ test.describe('module-mocking', () => {
     await sbPage.navigateToStory('lib/test/before-each', 'before-each-order');
 
     await sbPage.viewAddonPanel('Actions');
-    const logItem = await page.locator('#storybook-panel-root #panel-tab-content');
+    const logItem = page.locator('#storybook-panel-root #panel-tab-content');
     await expect(logItem).toBeVisible();
 
     const expectedTexts = [
@@ -42,7 +42,7 @@ test.describe('module-mocking', () => {
     await sbPage.navigateToStory('lib/test/module-mocking', 'basic');
 
     await sbPage.viewAddonPanel('Actions');
-    const logItem = await page.locator('#storybook-panel-root #panel-tab-content', {
+    const logItem = page.locator('#storybook-panel-root #panel-tab-content', {
       hasText: 'foo: []',
     });
     await expect(logItem).toBeVisible();

--- a/code/e2e-tests/preview-api.spec.ts
+++ b/code/e2e-tests/preview-api.spec.ts
@@ -27,16 +27,16 @@ test.describe('preview-api', () => {
 
     // wait for the play function to complete
     await sbPage.viewAddonPanel('Interactions');
-    const interactionsTab = await page.locator('#tabbutton-storybook-interactions-panel');
+    const interactionsTab = page.locator('#tabbutton-storybook-interactions-panel');
     await expect(interactionsTab).toBeVisible();
     const panel = sbPage.panelContent();
-    const runStatusBadge = await panel.locator('[aria-label="Status of the test run"]');
+    const runStatusBadge = panel.locator('[aria-label="Status of the test run"]');
     await expect(runStatusBadge).toContainText(/Pass/);
 
     // click outside, to remove focus from the input of the story, then press S to toggle sidebar
     await sbPage.previewRoot().click();
     await sbPage.previewRoot().press('Alt+s');
-    await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
+    await expect(sbPage.page.locator('.sidebar-container')).toBeHidden();
   });
 
   test('should pass over shortcuts, but not from play functions, docs', async ({ page }) => {
@@ -51,7 +51,7 @@ test.describe('preview-api', () => {
     await expect(sbPage.page.locator('.sidebar-container')).toBeVisible();
 
     await sbPage.previewRoot().getByRole('button').getByText('Submit').first().press('Alt+s');
-    await expect(sbPage.page.locator('.sidebar-container')).not.toBeVisible();
+    await expect(sbPage.page.locator('.sidebar-container')).toBeHidden();
   });
 
   // if rerenders were interleaved the button would have rendered "Error: Interleaved loaders. Changed arg"
@@ -61,7 +61,7 @@ test.describe('preview-api', () => {
 
     const root = sbPage.previewRoot();
 
-    const labelControl = await sbPage.page.locator('#control-label');
+    const labelControl = sbPage.page.locator('#control-label');
 
     await expect(root.getByText('Loaded. Click me')).toBeVisible();
     await expect(labelControl).toBeVisible();

--- a/code/e2e-tests/save-from-controls.spec.ts
+++ b/code/e2e-tests/save-from-controls.spec.ts
@@ -35,11 +35,11 @@ test.describe('save-from-controls', () => {
     await sbPage.panelContent().locator('[data-short-label="Unsaved changes"]').isVisible();
 
     // update the story
-    await sbPage.panelContent().locator('button').getByText('Update story').click({ force: true });
+    await sbPage.panelContent().locator('button').getByText('Update story').click();
 
     // Assert the file is saved
-    const notification1 = await sbPage.page.waitForSelector('[title="Story saved"]');
-    await notification1.isVisible();
+    const notification1 = sbPage.page.getByTitle('Story saved');
+    await expect(notification1).toBeVisible();
 
     // dismiss
     await notification1.click();
@@ -52,21 +52,19 @@ test.describe('save-from-controls', () => {
     // Assert the footer is shown
     await sbPage.panelContent().locator('[data-short-label="Unsaved changes"]').isVisible();
 
-    const buttons = await sbPage
+    const buttons = sbPage
       .panelContent()
       .locator('[aria-label="Create new story with these settings"]');
 
     // clone the story
-    await buttons.click({ force: true });
+    await buttons.click();
 
-    const input = await sbPage.page.waitForSelector('[placeholder="Story export name"]');
-    await input.fill('ClonedStory' + id);
-    const submit = await sbPage.page.waitForSelector('[type="submit"]');
-    await submit.click();
+    await sbPage.page.getByPlaceholder('Story export name').fill('ClonedStory' + id);
+    await sbPage.page.getByRole('button', { name: 'Create' }).click();
 
     // Assert the file is saved
-    const notification2 = await sbPage.page.waitForSelector('[title="Story created"]');
-    await notification2.isVisible();
+    const notification2 = sbPage.page.getByTitle('Story created');
+    await expect(notification2).toBeVisible();
     await notification2.click();
 
     // Assert the Button components is rendered in the preview

--- a/code/e2e-tests/storybook-hooks.spec.ts
+++ b/code/e2e-tests/storybook-hooks.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable playwright/expect-expect */
+
 /* eslint-disable no-underscore-dangle */
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';

--- a/code/e2e-tests/tags.spec.ts
+++ b/code/e2e-tests/tags.spec.ts
@@ -34,9 +34,9 @@ test.describe('tags', () => {
     await sbPage.navigateToStory('core/tags-add', 'docs');
 
     // Sidebar should include dev and exclude inheritance, autodocs, test
-    await expect(page.locator('#core-tags-add--dev-only')).toHaveCount(1);
-    await expect(page.locator('#core-tags-add--docs-only')).toHaveCount(0);
-    await expect(page.locator('#core-tags-add--test-only')).toHaveCount(0);
+    await expect(page.locator('#core-tags-add--dev')).toHaveCount(1);
+    await expect(page.locator('#core-tags-add--autodocs')).toHaveCount(0);
+    await expect(page.locator('#core-tags-add--test')).toHaveCount(0);
 
     // Autodocs should include autodocs and exclude dev, test
     const preview = sbPage.previewRoot();

--- a/code/e2e-tests/tags.spec.ts
+++ b/code/e2e-tests/tags.spec.ts
@@ -16,26 +16,16 @@ test.describe('tags', () => {
     await sbPage.navigateToStory('core/tags-config', 'docs');
 
     // Sidebar should include dev-only and exclude docs-only and test-only
-    const devOnlyEntry = await page.locator('#core-tags-config--dev-only').all();
-    expect(devOnlyEntry.length).toBe(1);
-
-    const docsOnlyEntry = await page.locator('#core-tags-config--docs-only').all();
-    expect(docsOnlyEntry.length).toBe(0);
-
-    const testOnlyEntry = await page.locator('#core-tags-config--test-only').all();
-    expect(testOnlyEntry.length).toBe(0);
+    await expect(page.locator('#core-tags-config--dev-only')).toHaveCount(1);
+    await expect(page.locator('#core-tags-config--docs-only')).toHaveCount(0);
+    await expect(page.locator('#core-tags-config--test-only')).toHaveCount(0);
 
     // Autodocs should include docs-only and exclude dev-only and test-only
-    const root = sbPage.previewRoot();
+    const preview = sbPage.previewRoot();
 
-    const devOnlyAnchor = await root.locator('#anchor--core-tags-config--dev-only').all();
-    expect(devOnlyAnchor.length).toBe(0);
-
-    const docsOnlyAnchor = await root.locator('#anchor--core-tags-config--docs-only').all();
-    expect(docsOnlyAnchor.length).toBe(1);
-
-    const testOnlyAnchor = await root.locator('#anchor--core-tags-config--test-only').all();
-    expect(testOnlyAnchor.length).toBe(0);
+    await expect(preview.locator('#anchor--core-tags-config--dev-only')).toHaveCount(0);
+    await expect(preview.locator('#anchor--core-tags-config--docs-only')).toHaveCount(1);
+    await expect(preview.locator('#anchor--core-tags-config--test-only')).toHaveCount(0);
   });
 
   test('should correctly add dev, autodocs, test stories', async ({ page }) => {
@@ -44,27 +34,17 @@ test.describe('tags', () => {
     await sbPage.navigateToStory('core/tags-add', 'docs');
 
     // Sidebar should include dev and exclude inheritance, autodocs, test
-    const devEntry = await page.locator('#core-tags-add--dev').all();
-    expect(devEntry.length).toBe(1);
-
-    const autodocsEntry = await page.locator('#core-tags-add--autodocs').all();
-    expect(autodocsEntry.length).toBe(0);
-
-    const testOnlyEntry = await page.locator('#core-tags-add--test').all();
-    expect(testOnlyEntry.length).toBe(0);
+    await expect(page.locator('#core-tags-add--dev-only')).toHaveCount(1);
+    await expect(page.locator('#core-tags-add--docs-only')).toHaveCount(0);
+    await expect(page.locator('#core-tags-add--test-only')).toHaveCount(0);
 
     // Autodocs should include autodocs and exclude dev, test
-    const root = sbPage.previewRoot();
+    const preview = sbPage.previewRoot();
 
-    const devAnchor = await root.locator('#anchor--core-tags-add--dev').all();
-    expect(devAnchor.length).toBe(0);
-
+    await expect(preview.locator('#anchor--core-tags-add--dev')).toHaveCount(0);
     // FIXME: shows as primary story and also in stories, inconsistent btw dev/CI?
-    const autodocsAnchor = await root.locator('#anchor--core-tags-add--autodocs').all();
-    expect(autodocsAnchor.length).not.toBe(0);
-
-    const testAnchor = await root.locator('#anchor--core-tags-add--test').all();
-    expect(testAnchor.length).toBe(0);
+    await expect(preview.locator('#anchor--core-tags-add--autodocs')).not.toHaveCount(0);
+    await expect(preview.locator('#anchor--core-tags-add--test')).toHaveCount(0);
   });
 
   test('should correctly remove dev, autodocs, test stories', async ({ page }) => {
@@ -73,25 +53,15 @@ test.describe('tags', () => {
     await sbPage.navigateToStory('core/tags-remove', 'docs');
 
     // Sidebar should include inheritance, no-autodocs, no-test. and exclude no-dev
-    const noDevEntry = await page.locator('#core-tags-remove--no-dev').all();
-    expect(noDevEntry.length).toBe(0);
+    await expect(page.locator('#core-tags-remove--no-dev')).toHaveCount(0);
+    await expect(page.locator('#core-tags-remove--no-autodocs')).toHaveCount(1);
+    await expect(page.locator('#core-tags-remove--no-test')).toHaveCount(1);
 
-    const noAutodocsEntry = await page.locator('#core-tags-remove--no-autodocs').all();
-    expect(noAutodocsEntry.length).toBe(1);
+    // Autodocs should include autodocs and exclude dev, test
+    const preview = sbPage.previewRoot();
 
-    const noTestEntry = await page.locator('#core-tags-remove--no-test').all();
-    expect(noTestEntry.length).toBe(1);
-
-    // Autodocs should include inheritance, no-dev, no-test. and exclude no-autodocs
-    const root = sbPage.previewRoot();
-
-    const noDevAnchor = await root.locator('#anchor--core-tags-remove--no-dev').all();
-    expect(noDevAnchor.length).toBe(1);
-
-    const noAutodocsAnchor = await root.locator('#anchor--core-tags-remove--no-autodocs').all();
-    expect(noAutodocsAnchor.length).toBe(0);
-
-    const noTestAnchor = await root.locator('#anchor--core-tags-remove--no-test').all();
-    expect(noTestAnchor.length).toBe(1);
+    await expect(preview.locator('#anchor--core-tags-remove--no-dev')).toHaveCount(1);
+    await expect(preview.locator('#anchor--core-tags-remove--no-autodocs')).toHaveCount(0);
+    await expect(preview.locator('#anchor--core-tags-remove--no-test')).toHaveCount(1);
   });
 });

--- a/code/e2e-tests/util.ts
+++ b/code/e2e-tests/util.ts
@@ -43,9 +43,9 @@ export class SbPage {
     const titleId = toId(title);
     const storyId = toId(name);
     const storyLinkId = `#${titleId}--${storyId}`;
-    await this.page.waitForSelector(storyLinkId);
+    await this.page.locator(storyLinkId).waitFor();
     const storyLink = this.page.locator('*', { has: this.page.locator(`> ${storyLinkId}`) });
-    await storyLink.click({ force: true });
+    await storyLink.click();
 
     await this.page.waitForURL((url) =>
       url.search.includes(
@@ -53,8 +53,8 @@ export class SbPage {
       )
     );
 
-    const selected = await storyLink.getAttribute('data-selected');
-    await expect(selected).toBe('true');
+    const selected = storyLink;
+    await expect(selected).toHaveAttribute('data-selected', 'true');
 
     await this.previewRoot();
   }
@@ -65,16 +65,16 @@ export class SbPage {
     const titleId = toId(title);
     const storyId = toId(name);
     const storyLinkId = `#${titleId}-${storyId}--docs`;
-    await this.page.waitForSelector(storyLinkId);
+    await this.page.locator(storyLinkId).waitFor();
     const storyLink = this.page.locator('*', { has: this.page.locator(`> ${storyLinkId}`) });
-    await storyLink.click({ force: true });
+    await storyLink.click();
 
     await this.page.waitForURL((url) =>
       url.search.includes(`path=/docs/${titleId}-${storyId}--docs`)
     );
 
-    const selected = await storyLink.getAttribute('data-selected');
-    await expect(selected).toBe('true');
+    const selected = storyLink;
+    await expect(selected).toHaveAttribute('data-selected', 'true');
 
     await this.previewRoot();
   }
@@ -124,7 +124,7 @@ export class SbPage {
   }
 
   async viewAddonPanel(name: string) {
-    const tabs = await this.page.locator('[role=tablist] button[role=tab]');
+    const tabs = this.page.locator('[role=tablist] button[role=tab]');
     const tab = tabs.locator(`text=/^${name}/`);
     await tab.click();
   }

--- a/code/package.json
+++ b/code/package.json
@@ -192,6 +192,7 @@
     "eslint": "^8.56.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-local-rules": "portal:../scripts/eslint-plugin-local-rules",
+    "eslint-plugin-playwright": "^1.6.2",
     "eslint-plugin-storybook": "^0.8.0",
     "fs-extra": "^11.1.0",
     "github-release-from-changelog": "^2.1.1",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6785,6 +6785,7 @@ __metadata:
     eslint: "npm:^8.56.0"
     eslint-import-resolver-typescript: "npm:^3.6.1"
     eslint-plugin-local-rules: "portal:../scripts/eslint-plugin-local-rules"
+    eslint-plugin-playwright: "npm:^1.6.2"
     eslint-plugin-storybook: "npm:^0.8.0"
     fs-extra: "npm:^11.1.0"
     github-release-from-changelog: "npm:^2.1.1"
@@ -14346,6 +14347,21 @@ __metadata:
   languageName: node
   linkType: soft
 
+"eslint-plugin-playwright@npm:^1.6.2":
+  version: 1.6.2
+  resolution: "eslint-plugin-playwright@npm:1.6.2"
+  dependencies:
+    globals: "npm:^13.23.0"
+  peerDependencies:
+    eslint: ">=8.40.0"
+    eslint-plugin-jest: ">=25"
+  peerDependenciesMeta:
+    eslint-plugin-jest:
+      optional: true
+  checksum: 10c0/0785b7031507699eac6a45fdcd90705d9759d5943a4033354b735ae856c9d71345ecacb6a7ff0c4cd0e24f523e9d59dee7081dc96c7b5c492fcbed77496a0a19
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-prettier@npm:^5.1.3":
   version: 5.1.3
   resolution: "eslint-plugin-prettier@npm:5.1.3"
@@ -16157,7 +16173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^13.19.0, globals@npm:^13.6.0":
+"globals@npm:^13.19.0, globals@npm:^13.23.0, globals@npm:^13.6.0":
   version: 13.24.0
   resolution: "globals@npm:13.24.0"
   dependencies:


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Initially I fixed some flaky tests by converting to [auto-retrying assertions](https://playwright.dev/docs/test-assertions#auto-retrying-assertions).

Then I realised this this the third time I do this, so I installed and configured [eslint-plugin-playwright](https://github.com/playwright-community/eslint-plugin-playwright) to hopefully ensure it won't happen again. This required a lot of fixing of all the E2E tests, so I did that too.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | **2.43** | 0% |
| initSize |  161 MB | 161 MB | 8.44 kB | -0.26 | 0% |
| diffSize |  84.7 MB | 84.7 MB | 8.44 kB | -0.67 | 0% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | **-1.39** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | **2.64** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | **-3** | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **2.44** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **-1.46** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.3s | 18.3s | 12s | 0.58 | 65.7% |
| generateTime |  18.3s | 20.3s | 1.9s | -0.49 | 9.8% |
| initTime |  14.6s | 17s | 2.4s | -0.5 | 14.1% |
| buildTime |  11.9s | 11.2s | -690ms | -0.8 | -6.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  9.4s | 6.8s | -2s -623ms | -0.21 | -38.2% |
| devManagerResponsive |  6.3s | 4.4s | -1s -848ms | -0.07 | -41.3% |
| devManagerHeaderVisible |  1.2s | 689ms | -525ms | -0.85 | -76.2% |
| devManagerIndexVisible |  1.2s | 722ms | -535ms | -0.9 | -74.1% |
| devStoryVisibleUncached |  1.7s | 896ms | -885ms | **-1.9** | 🔰-98.8% |
| devStoryVisible |  1.2s | 734ms | -520ms | -0.78 | -70.8% |
| devAutodocsVisible |  1.1s | 667ms | -506ms | -0.44 | -75.9% |
| devMDXVisible |  900ms | 694ms | -206ms | -0.09 | -29.7% |
| buildManagerHeaderVisible |  779ms | 748ms | -31ms | 0.1 | -4.1% |
| buildManagerIndexVisible |  815ms | 753ms | -62ms | -0.06 | -8.2% |
| buildStoryVisible |  816ms | 1s | 222ms | **2.23** | 🔺21.4% |
| buildAutodocsVisible |  788ms | 702ms | -86ms | 0.04 | -12.3% |
| buildMDXVisible |  709ms | 623ms | -86ms | -1.1 | -13.8% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR improves the E2E tests for Storybook by implementing ESLint rules for Playwright tests and updating test files to use more robust practices.

- Added eslint-plugin-playwright and configured rules in code/.eslintrc.js
- Updated E2E test files to use auto-retrying assertions, reducing flaky tests
- Removed unnecessary 'await' keywords and improved selector specificity
- Refactored test structure in framework-specific tests (Next.js, Svelte) for better organization
- Updated JSON file tests to use stricter assertions with toStrictEqual()

<!-- /greptile_comment -->