### PR TITLE
Next.js: Update dependencies

### DIFF
--- a/code/frameworks/experimental-nextjs-vite/package.json
+++ b/code/frameworks/experimental-nextjs-vite/package.json
@@ -107,6 +107,7 @@
     "typescript": "^5.3.2"
   },
   "peerDependencies": {
+    "@storybook/test": "workspace:*",
     "next": "^14.1.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",

--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -160,7 +160,7 @@
     "sass-loader": "^12.4.0",
     "semver": "^7.3.5",
     "style-loader": "^3.3.1",
-    "styled-jsx": "5.1.1",
+    "styled-jsx": "^5.1.6",
     "ts-dedent": "^2.0.0",
     "tsconfig-paths": "^4.0.0",
     "tsconfig-paths-webpack-plugin": "^4.0.1"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6157,6 +6157,7 @@ __metadata:
     typescript: "npm:^5.3.2"
     vite-plugin-storybook-nextjs: "npm:^1.0.10"
   peerDependencies:
+    "@storybook/test": "workspace:*"
     next: ^14.1.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -6336,7 +6337,7 @@ __metadata:
     semver: "npm:^7.3.5"
     sharp: "npm:^0.33.3"
     style-loader: "npm:^3.3.1"
-    styled-jsx: "npm:5.1.1"
+    styled-jsx: "npm:^5.1.6"
     ts-dedent: "npm:^2.0.0"
     tsconfig-paths: "npm:^4.0.0"
     tsconfig-paths-webpack-plugin: "npm:^4.0.1"
@@ -26458,7 +26459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"styled-jsx@npm:5.1.6":
+"styled-jsx@npm:5.1.6, styled-jsx@npm:^5.1.6":
   version: 5.1.6
   resolution: "styled-jsx@npm:5.1.6"
   dependencies:


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | **1.46** | 0% |
| initSize |  161 MB | 161 MB | 0 B | **-1.68** | 0% |
| diffSize |  84.6 MB | 84.6 MB | 0 B | **-1.81** | 0% |
| buildSize |  7.48 MB | 7.48 MB | 0 B | -1.03 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | **1.75** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.31 MB | 2.31 MB | 0 B | **-1.73** | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | **1.69** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | -1.09 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  16.4s | 26.7s | 10.3s | **2.17** | 🔺38.6% |
| generateTime |  19.5s | 23.5s | 3.9s | 0.66 | 17% |
| initTime |  16.4s | 18.3s | 1.8s | -0.03 | 10.3% |
| buildTime |  16.6s | 11.1s | -5s -571ms | -0.72 | -50.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.7s | 6.8s | 1s | -0.16 | 15.4% |
| devManagerResponsive |  3.7s | 4.3s | 573ms | -0.27 | 13.3% |
| devManagerHeaderVisible |  643ms | 763ms | 120ms | -0.11 | 15.7% |
| devManagerIndexVisible |  677ms | 799ms | 122ms | -0.14 | 15.3% |
| devStoryVisibleUncached |  1.1s | 1.4s | 301ms | 0.18 | 21.5% |
| devStoryVisible |  677ms | 800ms | 123ms | -0.13 | 15.4% |
| devAutodocsVisible |  564ms | 752ms | 188ms | 0.32 | 25% |
| devMDXVisible |  595ms | 725ms | 130ms | 0.27 | 17.9% |
| buildManagerHeaderVisible |  619ms | 775ms | 156ms | 0.33 | 20.1% |
| buildManagerIndexVisible |  688ms | 869ms | 181ms | 1.22 | 20.8% |
| buildStoryVisible |  685ms | 870ms | 185ms | 0.49 | 21.3% |
| buildAutodocsVisible |  573ms | 868ms | 295ms | **1.6** | 🔺34% |
| buildMDXVisible |  533ms | 792ms | 259ms | **2.1** | 🔺32.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR updates dependencies in two Storybook framework packages for Next.js, focusing on improving testing capabilities and compatibility.

- Added '@storybook/test' as a peer dependency in `code/frameworks/experimental-nextjs-vite/package.json`
- Updated 'styled-jsx' dependency from 5.1.1 to ^5.1.6 in `code/frameworks/nextjs/package.json`
- These changes are minor but enhance testing support and ensure compatibility with recent versions of styled-jsx

<!-- /greptile_comment -->