### PR TITLE
Core: Add `experimental_TEST_PROVIDER` addon type

### DIFF
--- a/code/core/src/manager-api/lib/addons.ts
+++ b/code/core/src/manager-api/lib/addons.ts
@@ -8,6 +8,7 @@ import type {
   Addon_PageType,
   Addon_SidebarBottomType,
   Addon_SidebarTopType,
+  Addon_TestProviderType,
   Addon_Type,
   Addon_Types,
   Addon_TypesMapping,
@@ -70,7 +71,8 @@ export class AddonStore {
       | Addon_Types
       | Addon_TypesEnum.experimental_PAGE
       | Addon_TypesEnum.experimental_SIDEBAR_BOTTOM
-      | Addon_TypesEnum.experimental_SIDEBAR_TOP,
+      | Addon_TypesEnum.experimental_SIDEBAR_TOP
+      | Addon_TypesEnum.experimental_TEST_PROVIDER,
   >(type: T): Addon_Collection<Addon_TypesMapping[T]> | any {
     if (!this.elements[type]) {
       this.elements[type] = {};
@@ -91,6 +93,7 @@ export class AddonStore {
       | Addon_BaseType
       | Omit<Addon_SidebarTopType, 'id'>
       | Omit<Addon_SidebarBottomType, 'id'>
+      | Omit<Addon_TestProviderType, 'id'>
       | Omit<Addon_PageType, 'id'>
       | Omit<Addon_WrapperType, 'id'>
   ): void {

--- a/code/core/src/manager-api/tests/addons.test.js
+++ b/code/core/src/manager-api/tests/addons.test.js
@@ -19,10 +19,20 @@ const PANELS = {
   },
 };
 
+const TEST_PROVIDERS = {
+  'storybook/test/test-provider': {
+    id: 'storybook/test/test-provider',
+    title: 'Component tests',
+  },
+}
+
 const provider = {
   getElements(type) {
     if (type === types.PANEL) {
       return PANELS;
+    }
+    if (type === types.experimental_TEST_PROVIDER) {
+      return TEST_PROVIDERS;
     }
     return null;
   },
@@ -38,14 +48,13 @@ const store = {
 describe('Addons API', () => {
   describe('#getElements', () => {
     it('should return provider elements', () => {
-      // given
       const { api } = initAddons({ provider, store });
 
-      // when
       const panels = api.getElements(types.PANEL);
-
-      // then
       expect(panels).toBe(PANELS);
+
+      const testProviders = api.getElements(types.experimental_TEST_PROVIDER);
+      expect(testProviders).toBe(TEST_PROVIDERS);
     });
   });
 

--- a/code/core/src/types/modules/addons.ts
+++ b/code/core/src/types/modules/addons.ts
@@ -461,12 +461,22 @@ export interface Addon_SidebarTopType {
   render: FC;
 }
 
+export interface Addon_TestProviderType {
+  type: Addon_TypesEnum.experimental_TEST_PROVIDER;
+  /** The unique id of the test provider. */
+  id: string;
+  icon: ReactNode;
+  title: string;
+  description: FC;
+}
+
 type Addon_TypeBaseNames = Exclude<
   Addon_TypesEnum,
   | Addon_TypesEnum.PREVIEW
   | Addon_TypesEnum.experimental_PAGE
   | Addon_TypesEnum.experimental_SIDEBAR_BOTTOM
   | Addon_TypesEnum.experimental_SIDEBAR_TOP
+  | Addon_TypesEnum.experimental_TEST_PROVIDER
 >;
 
 export interface Addon_TypesMapping extends Record<Addon_TypeBaseNames, Addon_BaseType> {
@@ -474,6 +484,7 @@ export interface Addon_TypesMapping extends Record<Addon_TypeBaseNames, Addon_Ba
   [Addon_TypesEnum.experimental_PAGE]: Addon_PageType;
   [Addon_TypesEnum.experimental_SIDEBAR_BOTTOM]: Addon_SidebarBottomType;
   [Addon_TypesEnum.experimental_SIDEBAR_TOP]: Addon_SidebarTopType;
+  [Addon_TypesEnum.experimental_TEST_PROVIDER]: Addon_TestProviderType;
 }
 
 export type Addon_Loader<API> = (api: API) => void;
@@ -537,4 +548,6 @@ export enum Addon_TypesEnum {
    * @deprecated This will be removed in Storybook 9.0.
    */
   experimental_SIDEBAR_TOP = 'sidebar-top',
+  /** This adds items to the Testing Module in the sidebar. */
+  experimental_TEST_PROVIDER = 'test-provider',
 }


### PR DESCRIPTION
Closes #29092

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This adds a new addon type `experimental_TEST_PROVIDER`. It takes a title, icon and description which will eventually (in another PR) be displayed in the Testing Module in the sidebar.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.3 MB | 77.3 MB | 76 B | 0.95 | 0% |
| initSize |  162 MB | 162 MB | -4.51 kB | 1.02 | 0% |
| diffSize |  84.9 MB | 84.9 MB | -4.58 kB | 0.91 | 0% |
| buildSize |  7.53 MB | 7.52 MB | -12.7 kB | 0.38 | -0.2% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | -102 B | 0.53 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 49 B | 0.58 | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | -18 B | **1.34** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.51 MB | 4.51 MB | -71 B | 0.58 | 0% |
| buildPreviewSize |  3.02 MB | 3.01 MB | -12.7 kB | -0.17 | -0.4% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.1s | 11.5s | 4.4s | -0.38 | 38.4% |
| generateTime |  21.5s | 33.5s | 11.9s | **8.29** | 🔺35.8% |
| initTime |  17.2s | 29.9s | 12.7s | **9.06** | 🔺42.4% |
| buildTime |  11.7s | 14.7s | 2.9s | **1.36** | 🔺19.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.5s | 8.3s | 1.8s | **1.75** | 🔺21.9% |
| devManagerResponsive |  4s | 5.5s | 1.4s | **2.1** | 🔺25.9% |
| devManagerHeaderVisible |  786ms | 1s | 215ms | **1.65** | 🔺21.5% |
| devManagerIndexVisible |  837ms | 1s | 209ms | **1.63** | 🔺20% |
| devStoryVisibleUncached |  1.4s | 1.7s | 268ms | 1.15 | 15.6% |
| devStoryVisible |  838ms | 1s | 210ms | **1.64** | 🔺20% |
| devAutodocsVisible |  634ms | 916ms | 282ms | **1.83** | 🔺30.8% |
| devMDXVisible |  663ms | 959ms | 296ms | **2.39** | 🔺30.9% |
| buildManagerHeaderVisible |  645ms | 939ms | 294ms | **2.28** | 🔺31.3% |
| buildManagerIndexVisible |  652ms | 941ms | 289ms | **1.73** | 🔺30.7% |
| buildStoryVisible |  708ms | 1s | 320ms | **2.45** | 🔺31.1% |
| buildAutodocsVisible |  629ms | 835ms | 206ms | **1.25** | 🔺24.7% |
| buildMDXVisible |  608ms | 841ms | 233ms | **2.31** | 🔺27.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR introduces a new experimental addon type called `TEST_PROVIDER` to Storybook, aimed at implementing a Test Provider API for displaying test-related information in the sidebar.

- Added `experimental_TEST_PROVIDER` to `Addon_TypesEnum` in `code/core/src/types/modules/addons.ts`
- Introduced `Addon_TestProviderType` interface defining structure for test provider addons
- Updated `AddonStore` class in `code/core/src/manager-api/lib/addons.ts` to support the new addon type
- Extended `getElements` and `add` methods in `AddonStore` to accommodate `TEST_PROVIDER`
- Prepared groundwork for future implementation of test information display in the sidebar

<!-- /greptile_comment -->