### PR TITLE
Addon Test: Register as `experimental_TEST_PROVIDER` addon type

### DIFF
--- a/code/addons/test/package.json
+++ b/code/addons/test/package.json
@@ -70,7 +70,8 @@
     "prep": "jiti ../../../scripts/prepare/addon-bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "^0.1.11"
+    "@storybook/csf": "^0.1.11",
+    "@storybook/icons": "^1.2.10"
   },
   "devDependencies": {
     "@types/semver": "^7",

--- a/code/addons/test/src/constants.ts
+++ b/code/addons/test/src/constants.ts
@@ -1,1 +1,2 @@
-export const ADDON_ID = 'storybook/vitest';
+export const ADDON_ID = 'storybook/test';
+export const TEST_PROVIDER_ID = `${ADDON_ID}/test-provider`;

--- a/code/addons/test/src/manager.tsx
+++ b/code/addons/test/src/manager.tsx
@@ -1,5 +1,17 @@
-import { type API, addons } from 'storybook/internal/manager-api';
+import React from 'react';
 
-import { ADDON_ID } from './constants';
+import { addons } from 'storybook/internal/manager-api';
+import { Addon_TypesEnum } from 'storybook/internal/types';
 
-addons.register(ADDON_ID, () => {});
+import { PointerHandIcon } from '@storybook/icons';
+
+import { ADDON_ID, TEST_PROVIDER_ID } from './constants';
+
+addons.register(ADDON_ID, () => {
+  addons.add(TEST_PROVIDER_ID, {
+    type: Addon_TypesEnum.experimental_TEST_PROVIDER,
+    icon: <PointerHandIcon />,
+    title: 'Component tests',
+    description: () => 'Not yet run',
+  });
+});

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6239,6 +6239,7 @@ __metadata:
   resolution: "@storybook/experimental-addon-test@workspace:addons/test"
   dependencies:
     "@storybook/csf": "npm:^0.1.11"
+    "@storybook/icons": "npm:^1.2.10"
     "@types/semver": "npm:^7"
     "@vitest/browser": "npm:^2.0.0"
     boxen: "npm:^8.0.1"


### PR DESCRIPTION
Closes #29094

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This registers the Test addon as a test provider using the new `experimental_TEST_PROVIDER` addon type.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.3 MB | 77.4 MB | 32.4 kB | **Infinity** | 0% |
| initSize |  162 MB | 162 MB | 77.1 kB | **Infinity** | 0% |
| diffSize |  84.9 MB | 85 MB | 44.7 kB | **Infinity** | 0.1% |
| buildSize |  7.52 MB | 7.52 MB | 9 B | **Infinity** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 0 B | - | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.51 MB | 4.51 MB | 0 B | - | 0% |
| buildPreviewSize |  3.01 MB | 3.01 MB | 9 B | **Infinity** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  11.5s | 22.6s | 11s | **Infinity** | 🔺48.9% |
| generateTime |  33.5s | 20.1s | -13s -342ms | **-Infinity** | 🔰-66.1% |
| initTime |  29.9s | 17.9s | -12s -14ms | **-Infinity** | 🔰-66.9% |
| buildTime |  14.7s | 12.2s | -2s -471ms | **-Infinity** | 🔰-20.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.3s | 8s | -243ms | **-Infinity** | -3% |
| devManagerResponsive |  5.5s | 4.6s | -914ms | **-Infinity** | 🔰-19.8% |
| devManagerHeaderVisible |  1s | 721ms | -280ms | **-Infinity** | 🔰-38.8% |
| devManagerIndexVisible |  1s | 753ms | -293ms | **-Infinity** | 🔰-38.9% |
| devStoryVisibleUncached |  1.7s | 1.4s | -309ms | **-Infinity** | 🔰-21.9% |
| devStoryVisible |  1s | 751ms | -297ms | **-Infinity** | 🔰-39.5% |
| devAutodocsVisible |  916ms | 680ms | -236ms | **-Infinity** | 🔰-34.7% |
| devMDXVisible |  959ms | 719ms | -240ms | **-Infinity** | 🔰-33.4% |
| buildManagerHeaderVisible |  939ms | 687ms | -252ms | **-Infinity** | 🔰-36.7% |
| buildManagerIndexVisible |  941ms | 721ms | -220ms | **-Infinity** | 🔰-30.5% |
| buildStoryVisible |  1s | 722ms | -306ms | **-Infinity** | 🔰-42.4% |
| buildAutodocsVisible |  835ms | 652ms | -183ms | **-Infinity** | 🔰-28.1% |
| buildMDXVisible |  841ms | 646ms | -195ms | **-Infinity** | 🔰-30.2% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request implements the Test addon as an experimental test provider in Storybook, addressing issue #29094.

- Updated `code/addons/test/src/manager.tsx` to register the addon with `experimental_TEST_PROVIDER` type, icon, title, and description
- Modified `code/addons/test/src/constants.ts` to change ADDON_ID to 'storybook/test' and add TEST_PROVIDER_ID
- Added '@storybook/icons' as a dependency in `code/addons/test/package.json` for the new icon implementation
- Aligned the Test addon with Storybook's new Test Provider API, improving integration and functionality

<!-- /greptile_comment -->