### PR TITLE
Core: Do not prebundle better-opn

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -279,6 +279,7 @@
   "dependencies": {
     "@storybook/csf": "^0.1.11",
     "@types/express": "^4.17.21",
+    "better-opn": "^3.0.2",
     "browser-assert": "^1.2.1",
     "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0",
     "esbuild-register": "^3.5.0",
@@ -340,7 +341,6 @@
     "ansi-to-html": "^0.7.2",
     "assert": "^2.1.0",
     "babel-plugin-react-docgen": "4.2.1",
-    "better-opn": "^3.0.2",
     "boxen": "^7.1.1",
     "browser-dtector": "^3.4.0",
     "camelcase": "^8.0.0",


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/29123

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Do not prebundle `better-opn` since its binary osascript cannot be found.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.3 MB | 77.3 MB | 0 B | 0.49 | 0% |
| initSize |  162 MB | 163 MB | 339 kB | **1.63** | 0.2% |
| diffSize |  85 MB | 85.3 MB | 339 kB | **2.78** | 0.4% |
| buildSize |  7.58 MB | 7.58 MB | 0 B | **1.5** | 0% |
| buildSbAddonsSize |  1.67 MB | 1.67 MB | 0 B | **1.53** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 0 B | 1.22 | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | 1 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.55 MB | 4.55 MB | 0 B | **1.53** | 0% |
| buildPreviewSize |  3.02 MB | 3.02 MB | 0 B | 1 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.8s | 23.2s | 16.3s | **1.73** | 🔺70.4% |
| generateTime |  19.7s | 21.1s | 1.4s | 0.16 | 6.6% |
| initTime |  16.8s | 16.7s | -94ms | -0.48 | -0.6% |
| buildTime |  11.9s | 11.7s | -134ms | 0.11 | -1.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.1s | 7s | 940ms | 0.12 | 13.3% |
| devManagerResponsive |  3.9s | 4.6s | 693ms | 0.24 | 15% |
| devManagerHeaderVisible |  693ms | 744ms | 51ms | -0.57 | 6.9% |
| devManagerIndexVisible |  725ms | 777ms | 52ms | -0.59 | 6.7% |
| devStoryVisibleUncached |  1s | 1.3s | 317ms | 0.05 | 22.8% |
| devStoryVisible |  724ms | 776ms | 52ms | -0.6 | 6.7% |
| devAutodocsVisible |  621ms | 730ms | 109ms | 0.08 | 14.9% |
| devMDXVisible |  621ms | 763ms | 142ms | 0.35 | 18.6% |
| buildManagerHeaderVisible |  736ms | 733ms | -3ms | -0.34 | -0.4% |
| buildManagerIndexVisible |  767ms | 806ms | 39ms | 0.14 | 4.8% |
| buildStoryVisible |  768ms | 804ms | 36ms | -0.15 | 4.5% |
| buildAutodocsVisible |  603ms | 640ms | 37ms | -0.75 | 5.8% |
| buildMDXVisible |  594ms | 659ms | 65ms | -0.36 | 9.9% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR moves the 'better-opn' package from devDependencies to dependencies in the @storybook/core package.json file to address an issue with missing scripts at runtime.

- Moved 'better-opn' from devDependencies to dependencies in `code/core/package.json`
- Addresses issue #29123 where 'openChrome.applescript' was missing due to bundling
- Ensures 'better-opn' and its associated scripts are available at runtime
- Improves reliability of browser opening functionality in Storybook
- May affect package size and installation process for @storybook/core

<!-- /greptile_comment -->