### PR TITLE
Addon Test: Support story name as test description

### DIFF
--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -213,6 +213,42 @@ describe('transformer', () => {
       `);
     });
 
+    it("should use the story's explicitly settled name if it's present", async () => {
+      const code = `
+        export default {
+          component: Button,
+        }
+        export const Primary = {
+          name: "basic Primary Button scenario",
+          args: {
+            label: 'Primary Button',
+          },
+        };
+      `;
+
+      const result = await transform({ code });
+
+      expect(result.code).toMatchInlineSnapshot(`
+        import { test as _test, expect as _expect } from "vitest";
+        import { testStory as _testStory } from "@storybook/experimental-addon-test/internal/test-utils";
+        const _meta = {
+          component: Button,
+          title: "automatic/calculated/title"
+        };
+        export default _meta;
+        export const Primary = {
+          name: "basic Primary Button scenario",
+          args: {
+            label: 'Primary Button'
+          }
+        };
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+        if (_isRunningFromThisFile) {
+          _test("basic Primary Button scenario", _testStory("Primary", Primary, _meta, []));
+        }
+      `);
+    });
+
     it('should add test statement to const declared exported stories', async () => {
       const code = `
         export default {};

--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -214,7 +214,7 @@ describe('transformer', () => {
     });
 
     describe("use the story's name as test title", () => {
-      it('should support csf v3 with object config', async () => {
+      it('should support CSF v3 via name property', async () => {
         const code = `
         export default { component: Button }
         export const Primary = { name: "custom name" };`;
@@ -238,30 +238,7 @@ describe('transformer', () => {
         `);
       });
 
-      it('should support csf v3 with function config', async () => {
-        const code = `
-        export default { component: Button };
-        export const Story = () => { name: 'custom name' };`;
-        const result = await transform({ code });
-        expect(result.code).toMatchInlineSnapshot(`
-          import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/experimental-addon-test/internal/test-utils";
-          const _meta = {
-            component: Button,
-            title: "automatic/calculated/title"
-          };
-          export default _meta;
-          export const Story = () => {
-            name: 'custom name';
-          };
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
-          if (_isRunningFromThisFile) {
-            _test("Story", _testStory("Story", Story, _meta, []));
-          }
-        `);
-      });
-
-      it('should support csf v1/v2', async () => {
+      it('should support CSF v1/v2 via storyName property', async () => {
         const code = `
         export default { component: Button }
         export const Story = () => {}

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -208,28 +208,27 @@ export async function vitestTransform({
       node: t.Node;
     }): t.ExpressionStatement => {
       // Get test name from the story's name property, and fallback to exportName
-      const testName = (function getTestName(): string {
-        if (
-          node.type === 'ExportNamedDeclaration' &&
-          node.declaration?.type === 'VariableDeclaration'
-        ) {
-          const storyDeclarator = node.declaration.declarations[0];
-          if (storyDeclarator.init?.type === 'ObjectExpression') {
-            for (const prop of storyDeclarator.init.properties) {
-              if (
-                // Filter out the "name" property and return its value
-                prop.type === 'ObjectProperty' &&
-                prop.key.type === 'Identifier' &&
-                prop.value.type === 'StringLiteral' &&
-                prop.key.name === 'name'
-              ) {
-                return prop.value.value;
-              }
+      let testName = exportName;
+      if (
+        node.type === 'ExportNamedDeclaration' &&
+        node.declaration?.type === 'VariableDeclaration'
+      ) {
+        const storyDeclarator = node.declaration.declarations[0];
+        if (storyDeclarator.init?.type === 'ObjectExpression') {
+          // Find the "name" property and set its value to testName
+          for (const prop of storyDeclarator.init.properties) {
+            if (
+              prop.type === 'ObjectProperty' &&
+              prop.key.type === 'Identifier' &&
+              prop.value.type === 'StringLiteral' &&
+              prop.key.name === 'name'
+            ) {
+              testName = prop.value.value;
+              break;
             }
           }
         }
-        return exportName;
-      })();
+      }
 
       // Create the _test expression directly using the exportName identifier
       const testStoryCall = t.expressionStatement(

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -202,38 +202,17 @@ export async function vitestTransform({
 
     const getTestStatementForStory = ({
       exportName,
+      testTitle,
       node,
     }: {
       exportName: string;
+      testTitle: string;
       node: t.Node;
     }): t.ExpressionStatement => {
-      // Get test name from the story's name property, and fallback to exportName
-      let testName = exportName;
-      if (
-        node.type === 'ExportNamedDeclaration' &&
-        node.declaration?.type === 'VariableDeclaration'
-      ) {
-        const storyDeclarator = node.declaration.declarations[0];
-        if (storyDeclarator.init?.type === 'ObjectExpression') {
-          // Find the "name" property and set its value to testName
-          for (const prop of storyDeclarator.init.properties) {
-            if (
-              prop.type === 'ObjectProperty' &&
-              prop.key.type === 'Identifier' &&
-              prop.value.type === 'StringLiteral' &&
-              prop.key.name === 'name'
-            ) {
-              testName = prop.value.value;
-              break;
-            }
-          }
-        }
-      }
-
       // Create the _test expression directly using the exportName identifier
       const testStoryCall = t.expressionStatement(
         t.callExpression(vitestTestId, [
-          t.stringLiteral(testName),
+          t.stringLiteral(testTitle),
           t.callExpression(testStoryId, [
             t.stringLiteral(exportName),
             t.identifier(exportName),
@@ -262,10 +241,9 @@ export async function vitestTransform({
           return;
         }
 
-        return getTestStatementForStory({
-          exportName,
-          node,
-        });
+        // use the story's name as the test title for vitest, and fallback to exportName
+        const testTitle = parsed._stories[exportName].name ?? exportName;
+        return getTestStatementForStory({ testTitle, exportName, node });
       })
       .filter((st) => !!st) as t.ExpressionStatement[];
 

--- a/docs/writing-tests/vitest-plugin.mdx
+++ b/docs/writing-tests/vitest-plugin.mdx
@@ -379,6 +379,10 @@ We recommend running tests in a browser using Playwright, but you can use WebDri
 
 We recommend using Chromium, because it is most likely to best match the experience of a majority of your users. However, you can use other browsers by adjusting the [browser name in the Vitest configuration file](https://vitest.dev/config/#browser-name). Note that [Playwright and WebDriverIO support different browsers](https://vitest.dev/guide/browser/#browser-option-types).
 
+### How do I customized the test description
+
+We are using the exportName of a story definition by default, but you can provide a `name` property for the story to customize the test description. This is useful when you want have places, brackets or other special characters in the test description.
+
 ## API
 
 ### Exports

--- a/docs/writing-tests/vitest-plugin.mdx
+++ b/docs/writing-tests/vitest-plugin.mdx
@@ -379,9 +379,10 @@ We recommend running tests in a browser using Playwright, but you can use WebDri
 
 We recommend using Chromium, because it is most likely to best match the experience of a majority of your users. However, you can use other browsers by adjusting the [browser name in the Vitest configuration file](https://vitest.dev/config/#browser-name). Note that [Playwright and WebDriverIO support different browsers](https://vitest.dev/guide/browser/#browser-option-types).
 
-### How do I customized the test description
+### How do I customize a test name?
 
-By default, the export name of a story is mapped to the test name. You can provide a `name` property for the story to customize the test description, allowing you to write more descriptive names. This is useful when you want use spaces, brackets or other special characters in the test description.
+By default, the export name of a story is mapped to the test name. To create a more descriptive test description, you can provide a `name` property for the story. This allows you to include spaces, brackets, or other special characters.
+
 ```js
 export const Story = {
   name: 'custom, descriptive name'

--- a/docs/writing-tests/vitest-plugin.mdx
+++ b/docs/writing-tests/vitest-plugin.mdx
@@ -381,7 +381,12 @@ We recommend using Chromium, because it is most likely to best match the experie
 
 ### How do I customized the test description
 
-We are using the exportName of a story definition by default, but you can provide a `name` property for the story to customize the test description. This is useful when you want have places, brackets or other special characters in the test description.
+By default, the export name of a story is mapped to the test name. You can provide a `name` property for the story to customize the test description, allowing you to write more descriptive names. This is useful when you want use spaces, brackets or other special characters in the test description.
+```js
+export const Story = {
+  name: 'custom, descriptive name'
+};
+```
 
 ## API
 


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

I added a new feature to the newly published `vitest-test` plugin:

Now the test description will use the explictly settled `name` of the story, and then fallback to the `exportName`.

The requirement comes from that developers might want to have spaces/brackets/etc... in the test description, which is not allowed in exportName.

At the same time, this can also keep consistent with the name display in storybook preview.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.4 MB | 77.4 MB | 0 B | **1.54** | 0% |
| initSize |  162 MB | 162 MB | 409 B | -0.21 | 0% |
| diffSize |  85 MB | 85 MB | 409 B | -0.39 | 0% |
| buildSize |  7.57 MB | 7.57 MB | 0 B | -0.58 | 0% |
| buildSbAddonsSize |  1.66 MB | 1.66 MB | 0 B | -0.58 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 0 B | - | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.55 MB | 4.55 MB | 0 B | -0.58 | 0% |
| buildPreviewSize |  3.02 MB | 3.02 MB | 0 B | -0.58 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.2s | 10.4s | 3.1s | -0.46 | 30.6% |
| generateTime |  21.5s | 21.2s | -309ms | 0.8 | -1.5% |
| initTime |  16s | 17s | 1s | 0.64 | 5.9% |
| buildTime |  10.6s | 12.9s | 2.3s | **2.26** | 🔺18.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.3s | 6.3s | -947ms | -1.03 | -14.9% |
| devManagerResponsive |  5s | 4.3s | -739ms | -0.53 | -17% |
| devManagerHeaderVisible |  709ms | 723ms | 14ms | -0.86 | 1.9% |
| devManagerIndexVisible |  740ms | 754ms | 14ms | -0.9 | 1.9% |
| devStoryVisibleUncached |  1.1s | 1.1s | 7ms | -0.89 | 0.6% |
| devStoryVisible |  738ms | 753ms | 15ms | -0.91 | 2% |
| devAutodocsVisible |  639ms | 645ms | 6ms | -1.19 | 0.9% |
| devMDXVisible |  606ms | 630ms | 24ms | **-1.31** | 3.8% |
| buildManagerHeaderVisible |  644ms | 694ms | 50ms | **-1.25** | 🔺7.2% |
| buildManagerIndexVisible |  649ms | 701ms | 52ms | **-1.32** | 🔺7.4% |
| buildStoryVisible |  735ms | 768ms | 33ms | -1.02 | 4.3% |
| buildAutodocsVisible |  639ms | 604ms | -35ms | **-1.4** | 🔰-5.8% |
| buildMDXVisible |  572ms | 630ms | 58ms | -0.92 | 9.2% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR enhances the Vitest plugin for Storybook by allowing customizable test descriptions using the story's 'name' property, improving readability and consistency with the Storybook preview.

- Modified `code/core/src/csf-tools/vitest-plugin/transformer.ts` to prioritize story 'name' over 'exportName' for test descriptions
- Added new test case in `code/core/src/csf-tools/vitest-plugin/transformer.test.ts` to verify the 'name' property usage
- Updated `docs/writing-tests/vitest-plugin.mdx` with instructions on customizing test descriptions using the 'name' property
- This change allows for more descriptive test names, including spaces and special characters not permitted in export names

<!-- /greptile_comment -->