### PR TITLE
Core: Do not add packageManager field to package.json during `storybook dev`

### DIFF
--- a/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
@@ -125,17 +125,35 @@ export class JsPackageManagerFactory {
 }
 
 function hasNPM(cwd?: string) {
-  const npmVersionCommand = spawnSync('npm', ['--version'], { cwd, shell: true });
+  const npmVersionCommand = spawnSync('npm', ['--version'], {
+    cwd,
+    shell: true,
+    env: {
+      COREPACK_ENABLE_STRICT: '0',
+    },
+  });
   return npmVersionCommand.status === 0;
 }
 
 function hasPNPM(cwd?: string) {
-  const pnpmVersionCommand = spawnSync('pnpm', ['--version'], { cwd, shell: true });
+  const pnpmVersionCommand = spawnSync('pnpm', ['--version'], {
+    cwd,
+    shell: true,
+    env: {
+      COREPACK_ENABLE_STRICT: '0',
+    },
+  });
   return pnpmVersionCommand.status === 0;
 }
 
 function getYarnVersion(cwd?: string): 1 | 2 | undefined {
-  const yarnVersionCommand = spawnSync('yarn', ['--version'], { cwd, shell: true });
+  const yarnVersionCommand = spawnSync('yarn', ['--version'], {
+    cwd,
+    shell: true,
+    env: {
+      COREPACK_ENABLE_STRICT: '0',
+    },
+  });
 
   if (yarnVersionCommand.status !== 0) {
     return undefined;


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/29146

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

We run `pnpm --version` in a try/catch block to determine whether the user has pnpm installed to detect the right package manager. I guess that since pnpm 8, pnpm will add a `packageManager` to the package.json if corepack is enabled and if you run the pnpm CLI, even if it is about to check the pnpm version via `pnpm --version`.

The fix is to set `COREPACK_ENABLE_STRICT` to `0` when running `pnpm --version`. This leads to the `packageManager` field not automatically being added to the user's package.json. The `yarn` CLI suffers under the same symptoms of adding `packageManager` fields to the package.json file. Therefore, it is necessary to apply the same fix there as well.

The bug was very likely introduced by https://github.com/storybookjs/storybook/pull/26219.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. `corepack enable`
2. Run `npx storybook@0.0.0-pr-29152-sha-0d238e2d init` in an empty directory
3. `npm run storybook`
4. Ensure the `package.json` does not contain a `packageManager` field.


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29152-sha-0d238e2d`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29152-sha-0d238e2d sandbox` or in an existing project with `npx storybook@0.0.0-pr-29152-sha-0d238e2d upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29152-sha-0d238e2d`](https://npmjs.com/package/storybook/v/0.0.0-pr-29152-sha-0d238e2d) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-package-manager-addition-to-package-json`](https://github.com/storybookjs/storybook/tree/valentin/fix-package-manager-addition-to-package-json) |
| **Commit** | [`0d238e2d`](https://github.com/storybookjs/storybook/commit/0d238e2d4382e03c5d65f8a7267fdcc774a86816) |
| **Datetime** | Thu Sep 19 09:02:18 UTC 2024 (`1726736538`) |
| **Workflow run** | [10937820499](https://github.com/storybookjs/storybook/actions/runs/10937820499) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29152`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.4 MB | 77.4 MB | 18.6 kB | **4.76** | 0% |
| initSize |  162 MB | 162 MB | 19 kB | -0.24 | 0% |
| diffSize |  85 MB | 85 MB | 372 B | -0.38 | 0% |
| buildSize |  7.57 MB | 7.57 MB | 0 B | 0.49 | 0% |
| buildSbAddonsSize |  1.66 MB | 1.66 MB | 0 B | 0.57 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 0 B | 0.5 | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | 0.33 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.55 MB | 4.55 MB | 0 B | 0.57 | 0% |
| buildPreviewSize |  3.02 MB | 3.02 MB | 0 B | -0.3 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  24.3s | 22.2s | -2s -63ms | **1.26** | 🔰-9.3% |
| generateTime |  18.9s | 18.6s | -361ms | **-1.35** | -1.9% |
| initTime |  15.8s | 14.6s | -1s -156ms | **-1.82** | 🔰-7.9% |
| buildTime |  10.4s | 10.2s | -248ms | **-1.26** | -2.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8s | 5.9s | -2s -98ms | **-1.45** | 🔰-35.5% |
| devManagerResponsive |  5.1s | 4s | -1s -108ms | -1.01 | -27.7% |
| devManagerHeaderVisible |  854ms | 686ms | -168ms | -1.14 | -24.5% |
| devManagerIndexVisible |  897ms | 716ms | -181ms | -1.19 | -25.3% |
| devStoryVisibleUncached |  1.3s | 1.1s | -219ms | -0.73 | -19.2% |
| devStoryVisible |  896ms | 715ms | -181ms | -1.2 | -25.3% |
| devAutodocsVisible |  763ms | 658ms | -105ms | -0.78 | -16% |
| devMDXVisible |  753ms | 589ms | -164ms | **-1.56** | 🔰-27.8% |
| buildManagerHeaderVisible |  982ms | 652ms | -330ms | **-1.28** | 🔰-50.6% |
| buildManagerIndexVisible |  985ms | 654ms | -331ms | **-1.36** | 🔰-50.6% |
| buildStoryVisible |  1s | 725ms | -314ms | -1.15 | -43.3% |
| buildAutodocsVisible |  939ms | 634ms | -305ms | -0.86 | -48.1% |
| buildMDXVisible |  821ms | 662ms | -159ms | -0.38 | -24% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request addresses an issue where running `storybook dev` inadvertently added a `packageManager` field to the user's package.json file.

- Modified `code/core/src/common/js-package-manager/JsPackageManagerFactory.ts` to set `COREPACK_ENABLE_STRICT=0` when checking npm and pnpm versions
- Prevents automatic addition of `packageManager` field, likely introduced by pnpm 8 with corepack enabled
- Fixes bug reported in issue #29146 where Storybook was injecting pnpm version information into package.json
- Resolves potential conflicts with Chromatic GitHub Action and unwanted package manager enforcement

<!-- /greptile_comment -->