### PR TITLE
Build: Add jiti as dev dependency to core

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -376,6 +376,7 @@
     "glob": "^10.0.0",
     "globby": "^14.0.1",
     "handlebars": "^4.7.7",
+    "jiti": "^1.21.6",
     "js-yaml": "^4.1.0",
     "lazy-universal-dotenv": "^4.0.0",
     "leven": "^4.0.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6091,6 +6091,7 @@ __metadata:
     glob: "npm:^10.0.0"
     globby: "npm:^14.0.1"
     handlebars: "npm:^4.7.7"
+    jiti: "npm:^1.21.6"
     js-yaml: "npm:^4.1.0"
     jsdoc-type-pratt-parser: "npm:^4.0.0"
     lazy-universal-dotenv: "npm:^4.0.0"
@@ -18337,6 +18338,15 @@ __metadata:
   bin:
     jiti: bin/jiti.js
   checksum: 10c0/7f361219fe6c7a5e440d5f1dba4ab763a5538d2df8708cdc22561cf25ea3e44b837687931fca7cdd8cdd9f567300e90be989dd1321650045012d8f9ed6aab07f
+  languageName: node
+  linkType: hard
+
+"jiti@npm:^1.21.6":
+  version: 1.21.6
+  resolution: "jiti@npm:1.21.6"
+  bin:
+    jiti: bin/jiti.js
+  checksum: 10c0/05b9ed58cd30d0c3ccd3c98209339e74f50abd9a17e716f65db46b6a35812103f6bde6e134be7124d01745586bca8cc5dae1d0d952267c3ebe55171949c32e56
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Add jiti as a dev-dependency of the core package, so that one can simply run `yarn prep` in `code/core`, and everything is working fine (for easier testing).

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.4 MB | 77.4 MB | 0 B | **1.74** | 0% |
| initSize |  162 MB | 162 MB | -1.73 kB | -0.21 | 0% |
| diffSize |  85 MB | 85 MB | -1.73 kB | -0.4 | 0% |
| buildSize |  7.57 MB | 7.57 MB | 0 B | -0.65 | 0% |
| buildSbAddonsSize |  1.66 MB | 1.66 MB | 0 B | -0.65 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 0 B | - | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.55 MB | 4.55 MB | 0 B | -0.65 | 0% |
| buildPreviewSize |  3.02 MB | 3.02 MB | 0 B | -0.65 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.8s | 19.4s | 12.5s | 0.66 | 64.6% |
| generateTime |  21.6s | 22s | 417ms | **1.67** | 1.9% |
| initTime |  16.1s | 15.6s | -423ms | -0.51 | -2.7% |
| buildTime |  11.1s | 10.8s | -289ms | -0.45 | -2.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.9s | 7.9s | 1s | **1.4** | 🔺12.9% |
| devManagerResponsive |  4.6s | 5s | 405ms | 1.2 | 8% |
| devManagerHeaderVisible |  849ms | 816ms | -33ms | -0.1 | -4% |
| devManagerIndexVisible |  895ms | 853ms | -42ms | -0.13 | -4.9% |
| devStoryVisibleUncached |  1.4s | 1.7s | 260ms | **1.33** | 🔺15% |
| devStoryVisible |  893ms | 852ms | -41ms | -0.14 | -4.8% |
| devAutodocsVisible |  840ms | 768ms | -72ms | 0.07 | -9.4% |
| devMDXVisible |  796ms | 873ms | 77ms | **1.98** | 🔺8.8% |
| buildManagerHeaderVisible |  835ms | 799ms | -36ms | -0.21 | -4.5% |
| buildManagerIndexVisible |  837ms | 802ms | -35ms | -0.46 | -4.4% |
| buildStoryVisible |  920ms | 868ms | -52ms | -0.02 | -6% |
| buildAutodocsVisible |  816ms | 920ms | 104ms | **2.06** | 🔺11.3% |
| buildMDXVisible |  773ms | 777ms | 4ms | 0.76 | 0.5% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds 'jiti' as a dev dependency to the @storybook/core package, enabling easier local testing for developers.

- Added 'jiti' to devDependencies in `code/core/package.json`
- Allows running 'yarn prep' in the code/core directory for streamlined testing
- No significant changes or potential issues introduced

<!-- /greptile_comment -->