### PR TITLE
UI: Fix composed storybook TooltipLinkList bug where href isn't passed forward

### DIFF
--- a/code/core/src/components/components/tooltip/ListItem.tsx
+++ b/code/core/src/components/components/tooltip/ListItem.tsx
@@ -169,7 +169,7 @@ const getItemProps = memoize(100)((onClick, href, LinkWrapper) => ({
 
 export type LinkWrapperType = (props: any) => ReactNode;
 
-export interface ListItemProps extends Omit<ComponentProps<typeof Item>, 'href' | 'title'> {
+export interface ListItemProps extends Omit<ComponentProps<typeof Item>, 'title'> {
   loading?: boolean;
   title?: ReactNode;
   center?: ReactNode;

--- a/code/core/src/components/components/tooltip/TooltipLinkList.tsx
+++ b/code/core/src/components/components/tooltip/TooltipLinkList.tsx
@@ -31,11 +31,11 @@ interface ItemProps extends Link {
 }
 
 const Item = ({ id, onClick, ...rest }: ItemProps) => {
-  const { active, disabled, title } = rest;
+  const { active, disabled, title, href } = rest;
 
   const handleClick = useCallback(
-    (event: SyntheticEvent) => onClick?.(event, { id, active, disabled, title }),
-    [onClick, id, active, disabled, title]
+    (event: SyntheticEvent) => onClick?.(event, { id, active, disabled, title, href }),
+    [onClick, id, active, disabled, title, href]
   );
 
   return <ListItem id={`list-item-${id}`} {...rest} {...(onClick && { onClick: handleClick })} />;

--- a/code/core/src/components/components/tooltip/TooltipLinkList.tsx
+++ b/code/core/src/components/components/tooltip/TooltipLinkList.tsx
@@ -22,7 +22,7 @@ export interface Link extends Omit<ListItemProps, 'onClick'> {
   id: string;
   onClick?: (
     event: SyntheticEvent,
-    item: Pick<ListItemProps, 'id' | 'active' | 'disabled' | 'title'>
+    item: Pick<ListItemProps, 'id' | 'active' | 'disabled' | 'title' | 'href'>
   ) => void;
 }
 


### PR DESCRIPTION
https://github.com/storybookjs/storybook/blob/v8.3.2/code/core/src/manager/components/sidebar/RefIndicator.tsx#L226 requires item.href

## What I did

Composed storybook sidebar ref list expects `href` to be passed from list item https://github.com/storybookjs/storybook/blob/v8.3.2/code/core/src/manager/components/sidebar/RefIndicator.tsx#L226 , this property was not present on the object getting passed to the onClick function https://github.com/storybookjs/storybook/blob/v8.3.2/code/core/src/components/components/tooltip/TooltipLinkList.tsx#L37. This PR adds the `href` property to the object to prevent `url.match` from failing on an `undefined` variable in https://github.com/storybookjs/storybook/blob/v8.3.2/code/core/src/manager-api/modules/refs.ts#L144

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

This is difficult to create a manual test for, you'd need to set up a composed storybook locally and inject a metadata.json file with a list of key/value pairs of label/url to other storybooks to cause the TooltipLinkList to generate for the composed storybook. I tested this in the debugger for my existing storybook implementation. I can potentially set up a call to review if necessary (my company is a chromatic client).

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

@shilman I would appreciate a canary release, this bug is impacting our storybook in production.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.5 MB | 77.5 MB | 100 B | **3.74** | 0% |
| initSize |  162 MB | 162 MB | 163 B | 0.39 | 0% |
| diffSize |  85 MB | 85 MB | 63 B | -0.45 | 0% |
| buildSize |  7.57 MB | 7.57 MB | 37 B | -0.41 | 0% |
| buildSbAddonsSize |  1.66 MB | 1.66 MB | 0 B | -0.42 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 21 B | **Infinity** | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.55 MB | 4.55 MB | 21 B | -0.41 | 0% |
| buildPreviewSize |  3.02 MB | 3.02 MB | 16 B | -0.41 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  17.5s | 6.5s | -11s -3ms | -1.15 | -168.6% |
| generateTime |  22.8s | 21.4s | -1s -401ms | 0.8 | -6.5% |
| initTime |  14.6s | 16.7s | 2.1s | 0.51 | 12.9% |
| buildTime |  9.9s | 10.4s | 573ms | -0.69 | 5.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.6s | 7.4s | 872ms | 0.68 | 11.6% |
| devManagerResponsive |  4.4s | 5s | 599ms | 1.03 | 11.9% |
| devManagerHeaderVisible |  782ms | 932ms | 150ms | **1.79** | 🔺16.1% |
| devManagerIndexVisible |  817ms | 970ms | 153ms | **1.62** | 🔺15.8% |
| devStoryVisibleUncached |  1.3s | 1.4s | 130ms | 0.24 | 8.9% |
| devStoryVisible |  816ms | 971ms | 155ms | **1.64** | 🔺16% |
| devAutodocsVisible |  632ms | 724ms | 92ms | -0.28 | 12.7% |
| devMDXVisible |  666ms | 688ms | 22ms | -0.5 | 3.2% |
| buildManagerHeaderVisible |  716ms | 735ms | 19ms | -0.59 | 2.6% |
| buildManagerIndexVisible |  722ms | 743ms | 21ms | -0.69 | 2.8% |
| buildStoryVisible |  782ms | 775ms | -7ms | -0.73 | -0.9% |
| buildAutodocsVisible |  664ms | 660ms | -4ms | -0.73 | -0.6% |
| buildMDXVisible |  652ms | 623ms | -29ms | -0.93 | -4.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request addresses a bug in the TooltipLinkList component, specifically focusing on the handling of the 'href' property in onClick events.

- Added 'href' to the object passed to onClick in `code/core/src/components/components/tooltip/TooltipLinkList.tsx`
- Fixes an issue in the composed storybook sidebar ref list where 'url.match' was failing
- Ensures compatibility with the RefIndicator component, which expects the 'href' property
- Improves the functionality of version switching in composed Storybooks

<!-- /greptile_comment -->