### PR TITLE
Vite: Add jsdoc-type-pratt-parser to `optimizeDeps`

### DIFF
--- a/code/builders/builder-vite/src/optimizeDeps.ts
+++ b/code/builders/builder-vite/src/optimizeDeps.ts
@@ -32,6 +32,7 @@ const INCLUDE_CANDIDATES = [
   'fast-deep-equal',
   'html-tags',
   'isobject',
+  'jsdoc-type-pratt-parser', // TODO: Remove this once it's converted to ESM: https://github.com/jsdoc-type-pratt-parser/jsdoc-type-pratt-parser/issues/173
   'loader-utils',
   'lodash/camelCase.js',
   'lodash/camelCase',


### PR DESCRIPTION
Closes https://github.com/nuxt-modules/storybook/issues/776.

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

With #29134, jsdoc-type-pratt-parser is no longer bundled. However, it is a CJS-only module so should be declared in `optimizeDeps`.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.5 MB | 77.5 MB | 100 B | **3.74** | 0% |
| initSize |  162 MB | 162 MB | -1.7 kB | 0.38 | 0% |
| diffSize |  85 MB | 85 MB | -1.8 kB | -0.46 | 0% |
| buildSize |  7.57 MB | 7.57 MB | 0 B | -0.42 | 0% |
| buildSbAddonsSize |  1.66 MB | 1.66 MB | 0 B | -0.42 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 0 B | - | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.55 MB | 4.55 MB | 0 B | -0.42 | 0% |
| buildPreviewSize |  3.02 MB | 3.02 MB | 0 B | -0.42 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  17.5s | 6.2s | -11s -241ms | -1.18 | -178.8% |
| generateTime |  22.8s | 20.7s | -2s -144ms | 0.22 | -10.3% |
| initTime |  14.6s | 15.4s | 885ms | -0.49 | 5.7% |
| buildTime |  9.9s | 9.6s | -324ms | **-1.54** | -3.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.6s | 7.4s | 816ms | 0.59 | 11% |
| devManagerResponsive |  4.4s | 4.8s | 426ms | 0.59 | 8.8% |
| devManagerHeaderVisible |  782ms | 858ms | 76ms | 0.78 | 8.9% |
| devManagerIndexVisible |  817ms | 891ms | 74ms | 0.64 | 8.3% |
| devStoryVisibleUncached |  1.3s | 1.4s | 150ms | 0.33 | 10.1% |
| devStoryVisible |  816ms | 892ms | 76ms | 0.65 | 8.5% |
| devAutodocsVisible |  632ms | 698ms | 66ms | -0.57 | 9.5% |
| devMDXVisible |  666ms | 756ms | 90ms | 0.41 | 11.9% |
| buildManagerHeaderVisible |  716ms | 737ms | 21ms | -0.56 | 2.8% |
| buildManagerIndexVisible |  722ms | 740ms | 18ms | -0.72 | 2.4% |
| buildStoryVisible |  782ms | 777ms | -5ms | -0.71 | -0.6% |
| buildAutodocsVisible |  664ms | 645ms | -19ms | -0.89 | -2.9% |
| buildMDXVisible |  652ms | 672ms | 20ms | -0.36 | 3% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This change adds 'jsdoc-type-pratt-parser' to Vite's optimizeDeps configuration in Storybook's builder-vite, addressing compatibility issues with CJS-only modules.

- Added 'jsdoc-type-pratt-parser' to `include` array in `code/builders/builder-vite/src/optimizeDeps.ts`
- Temporary solution until the package is converted to ESM
- Addresses potential issues with Unicode character class escapes in React Native environments
- Follows up on PR #29134, which removed prebundling of jsdoc-type-pratt-parser

<!-- /greptile_comment -->