### PR TITLE
Viewport-addon: Add InitialViewportKeys type to viewport addon

### DIFF
--- a/code/addons/viewport/src/defaults.ts
+++ b/code/addons/viewport/src/defaults.ts
@@ -1,6 +1,6 @@
 import type { ViewportMap } from './types';
 
-export const INITIAL_VIEWPORTS: ViewportMap = {
+const INITIAL_VIEWPORTS_DATA = {
   iphone5: {
     name: 'iPhone 5',
     styles: {
@@ -225,7 +225,12 @@ export const INITIAL_VIEWPORTS: ViewportMap = {
     },
     type: 'mobile',
   },
-};
+} as const;
+
+export type InitialViewportKeyUnion = keyof typeof INITIAL_VIEWPORTS_DATA;
+
+export const INITIAL_VIEWPORTS: ViewportMap = INITIAL_VIEWPORTS_DATA;
+
 export const DEFAULT_VIEWPORT = 'responsive';
 
 export const MINIMAL_VIEWPORTS: ViewportMap = {

--- a/code/addons/viewport/src/defaults.ts
+++ b/code/addons/viewport/src/defaults.ts
@@ -227,7 +227,7 @@ const INITIAL_VIEWPORTS_DATA = {
   },
 } as const;
 
-export type InitialViewportKeyUnion = keyof typeof INITIAL_VIEWPORTS_DATA;
+export type InitialViewportKeys = keyof typeof INITIAL_VIEWPORTS_DATA;
 
 export const INITIAL_VIEWPORTS: ViewportMap = INITIAL_VIEWPORTS_DATA;
 


### PR DESCRIPTION
(No Issue)

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

In this PR, the `InitialViewportKeyUnion` type was added to the viewport addon.

I use the `INITIAL_VIEWPORTS` of the viewport addon, and I need a union type made up of the keys of the object.

For example, by specifying the type of defaultViewport with the above type, we were able to improve convenience and stability in the viewport declaration of the story.

Currently, when trying to extract the `INITIAL_VIEWPORTS` type, the `INITIAL_VIEWPORTS` type is `Record<string, Viewport>`, so the type is inferred as a `string` as shown below, so we want to export a union type composed of accurate keys in the addon stage.

<img width="548" alt="screenshot" src="https://github.com/user-attachments/assets/e0db2496-03dc-4662-b54e-80e9887cd849">

With this operation, the type of InitialViewportKeyUnion exported from the viewport addon is inferred as follows.

<img width="925" alt="screenshot" src="https://github.com/user-attachments/assets/3c4c6b21-e37d-443b-94ba-d73c95bf2a0b">

---

### My application example

An example of using the type in my project is below.

```ts
declare module '@storybook/react' {
  export interface Parameters {
    viewport?: {
      defaultViewport?: InitialViewportKeyUnion | typeof DEFAULT_VIEWPORT;
    };
  }
}
```

Then, when assigning defaultViewport, auto-completion and type checking are possible as shown below.

<img width="339" alt="screenshot" src="https://github.com/user-attachments/assets/bc11a9ad-b32d-4d2b-91bc-3037cc073f7b">

---

Of course, this type may just be what I need.

Also, I think there may be inconveniences when adding devices to `INITIAL_VIEWPORTS` in the future.

Nevertheless, I am requesting a merge because I think adding this type will provide convenience to many developers, including me.

Additionally, if there is any way I can further improve my work, please let me know.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

In the viewport addon, need to check whether the `InitialViewportKeyUnion` type is properly exported as a union type based on the `INITIAL_VIEWPORTS` key.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.5 MB | 77.5 MB | 100 B | **3.74** | 0% |
| initSize |  162 MB | 162 MB | 6.42 kB | 0.43 | 0% |
| diffSize |  85 MB | 85 MB | 6.32 kB | -0.41 | 0% |
| buildSize |  7.57 MB | 7.57 MB | 0 B | -0.42 | 0% |
| buildSbAddonsSize |  1.66 MB | 1.66 MB | 0 B | -0.42 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 0 B | - | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.55 MB | 4.55 MB | 0 B | -0.42 | 0% |
| buildPreviewSize |  3.02 MB | 3.02 MB | 0 B | -0.42 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  17.5s | 7.1s | -10s -366ms | -1.07 | -144.7% |
| generateTime |  22.8s | 22.1s | -753ms | **1.3** | -3.4% |
| initTime |  14.6s | 18.3s | 3.7s | **1.72** | 🔺20.4% |
| buildTime |  9.9s | 11s | 1.1s | -0.16 | 10.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.6s | 6.8s | 267ms | -0.32 | 3.9% |
| devManagerResponsive |  4.4s | 4.4s | 68ms | -0.32 | 1.5% |
| devManagerHeaderVisible |  782ms | 883ms | 101ms | 1.12 | 11.4% |
| devManagerIndexVisible |  817ms | 928ms | 111ms | 1.09 | 12% |
| devStoryVisibleUncached |  1.3s | 1.4s | 78ms | 0 | 5.5% |
| devStoryVisible |  816ms | 926ms | 110ms | 1.08 | 11.9% |
| devAutodocsVisible |  632ms | 774ms | 142ms | 0.29 | 18.3% |
| devMDXVisible |  666ms | 727ms | 61ms | 0.02 | 8.4% |
| buildManagerHeaderVisible |  716ms | 773ms | 57ms | -0.18 | 7.4% |
| buildManagerIndexVisible |  722ms | 846ms | 124ms | 0.3 | 14.7% |
| buildStoryVisible |  782ms | 847ms | 65ms | 0 | 7.7% |
| buildAutodocsVisible |  664ms | 622ms | -42ms | -1.15 | -6.8% |
| buildMDXVisible |  652ms | 718ms | 66ms | 0.18 | 9.2% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request adds a new type `InitialViewportKeyUnion` to the viewport addon in Storybook, enhancing TypeScript support for viewport keys.

- Added `InitialViewportKeyUnion` type in `code/addons/viewport/src/defaults.ts`, derived from `INITIAL_VIEWPORTS_DATA` keys
- Exported `InitialViewportKeyUnion` for use in other parts of the codebase
- Improved type safety and autocomplete functionality for viewport keys
- No functional changes to the existing code, purely a TypeScript enhancement

<!-- /greptile_comment -->