### PR TITLE
React-Vite: Downgrade react-docgen-typescript plugin

### DIFF
--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -47,7 +47,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.1",
+    "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.0",
     "@rollup/pluginutils": "^5.0.2",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -3677,9 +3677,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.1":
-  version: 0.3.1
-  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.1"
+"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.0"
   dependencies:
     glob: "npm:^7.2.0"
     glob-promise: "npm:^4.2.0"
@@ -3691,7 +3691,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/a9c7a03d7d1daf5bd64949255516ba64c88d5600366c8c74dcdb6f37c2a6099daaec02860b7587d2220e61afa47a0b2de17ef70d723c2db02f24e0890edfd9f3
+  checksum: 10c0/31098ad8fcc2440437534599c111d9f2951dd74821e8ba46c521b969bae4c918d830b7bb0484efbad29a51711bb62d3bc623d5a1ed5b1695b5b5594ea9dd4ca0
   languageName: node
   linkType: hard
 
@@ -6699,7 +6699,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/react-vite@workspace:frameworks/react-vite"
   dependencies:
-    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.3.1"
+    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.3.0"
     "@rollup/pluginutils": "npm:^5.0.2"
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": "workspace:*"


### PR DESCRIPTION
Closes #28269 

## What I did

Fix HMR performance issue by downgrading the react-docgen-typescript Vite plugin 

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Upgrade repro in #28269 to canary (have not tested)

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29184-sha-d5ba8e56`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29184-sha-d5ba8e56 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29184-sha-d5ba8e56 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29184-sha-d5ba8e56`](https://npmjs.com/package/storybook/v/0.0.0-pr-29184-sha-d5ba8e56) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/28269-downgrade-typescript-docgen`](https://github.com/storybookjs/storybook/tree/shilman/28269-downgrade-typescript-docgen) |
| **Commit** | [`d5ba8e56`](https://github.com/storybookjs/storybook/commit/d5ba8e56e787a3e860e053fc076fe6b818376ab9) |
| **Datetime** | Mon Sep 23 10:08:21 UTC 2024 (`1727086101`) |
| **Workflow run** | [10992103485](https://github.com/storybookjs/storybook/actions/runs/10992103485) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29184`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.4 MB | 77.4 MB | 6 B | **2.01** | 0% |
| initSize |  162 MB | 162 MB | 1.76 kB | -0.16 | 0% |
| diffSize |  85 MB | 85 MB | 1.75 kB | -0.36 | 0% |
| buildSize |  7.57 MB | 7.57 MB | 0 B | -0.04 | 0% |
| buildSbAddonsSize |  1.66 MB | 1.66 MB | 0 B | 0.1 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 0 B | - | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.55 MB | 4.55 MB | 0 B | 0.1 | 0% |
| buildPreviewSize |  3.02 MB | 3.02 MB | 0 B | -0.73 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  14s | 19.4s | 5.4s | 0.65 | 27.9% |
| generateTime |  21.1s | 19.3s | -1s -831ms | -0.7 | -9.5% |
| initTime |  17s | 15.2s | -1s -818ms | -0.88 | -11.9% |
| buildTime |  10.6s | 10.6s | -20ms | -0.68 | -0.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.7s | 8.4s | 1.6s | **2.19** | 🔺20% |
| devManagerResponsive |  4.4s | 5.7s | 1.2s | **2.86** | 🔺22.1% |
| devManagerHeaderVisible |  921ms | 1s | 95ms | **1.76** | 🔺9.4% |
| devManagerIndexVisible |  968ms | 1s | 98ms | **1.77** | 🔺9.2% |
| devStoryVisibleUncached |  1.2s | 1.2s | 16ms | -0.48 | 1.3% |
| devStoryVisible |  968ms | 1s | 86ms | **1.67** | 🔺8.2% |
| devAutodocsVisible |  794ms | 858ms | 64ms | 1.19 | 7.5% |
| devMDXVisible |  788ms | 878ms | 90ms | **2.14** | 🔺10.3% |
| buildManagerHeaderVisible |  891ms | 753ms | -138ms | -0.6 | -18.3% |
| buildManagerIndexVisible |  936ms | 759ms | -177ms | -0.76 | -23.3% |
| buildStoryVisible |  934ms | 796ms | -138ms | -0.67 | -17.3% |
| buildAutodocsVisible |  830ms | 771ms | -59ms | 0.48 | -7.7% |
| buildMDXVisible |  782ms | 668ms | -114ms | -0.49 | -17.1% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request downgrades the @joshwooding/vite-plugin-react-docgen-typescript dependency to address a performance issue with Hot Module Replacement (HMR) in Storybook's React-Vite framework.

- Changed `code/frameworks/react-vite/package.json` to downgrade @joshwooding/vite-plugin-react-docgen-typescript from 0.3.1 to 0.3.0
- Aims to resolve the slow fast refresh issue reported in #28269 when using 'react-docgen-typescript'
- Expected to significantly reduce HMR time from several seconds to milliseconds

<!-- /greptile_comment -->