### PR TITLE
CLI: Show constraints in error when getting depndencies

### DIFF
--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -418,7 +418,7 @@ export abstract class JsPackageManager {
       .find((version) => satisfies(version, constraint));
     invariant(
       latestVersionSatisfyingTheConstraint != null,
-      'No version satisfying the constraint.'
+      `No version satisfying the constraint: ${packageName}${constraint}`
     );
     return latestVersionSatisfyingTheConstraint;
   }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.5 MB | 77.5 MB | 100 B | **3.74** | 0% |
| initSize |  162 MB | 162 MB | 118 B | 0.39 | 0% |
| diffSize |  85 MB | 85 MB | 18 B | -0.45 | 0% |
| buildSize |  7.57 MB | 7.57 MB | 0 B | -0.42 | 0% |
| buildSbAddonsSize |  1.66 MB | 1.66 MB | 0 B | -0.42 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.34 MB | 2.34 MB | 0 B | - | 0% |
| buildSbPreviewSize |  352 kB | 352 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.55 MB | 4.55 MB | 0 B | -0.42 | 0% |
| buildPreviewSize |  3.02 MB | 3.02 MB | 0 B | -0.42 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  17.5s | 22.7s | 5.2s | 0.98 | 22.9% |
| generateTime |  22.8s | 19.5s | -3s -357ms | -0.71 | -17.2% |
| initTime |  14.6s | 15s | 479ms | -0.8 | 3.2% |
| buildTime |  9.9s | 10.7s | 819ms | -0.46 | 7.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.6s | 8.7s | 2.1s | **2.84** | 🔺24.7% |
| devManagerResponsive |  4.4s | 5.7s | 1.3s | **3** | 🔺23.7% |
| devManagerHeaderVisible |  782ms | 1.1s | 355ms | **4.57** | 🔺31.2% |
| devManagerIndexVisible |  817ms | 1.1s | 356ms | **4.14** | 🔺30.3% |
| devStoryVisibleUncached |  1.3s | 2.1s | 790ms | **3.19** | 🔺37.3% |
| devStoryVisible |  816ms | 1.1s | 373ms | **4.35** | 🔺31.4% |
| devAutodocsVisible |  632ms | 1s | 390ms | **3.07** | 🔺38.2% |
| devMDXVisible |  666ms | 1s | 421ms | **4.83** | 🔺38.7% |
| buildManagerHeaderVisible |  716ms | 895ms | 179ms | 1.1 | 20% |
| buildManagerIndexVisible |  722ms | 897ms | 175ms | 0.79 | 19.5% |
| buildStoryVisible |  782ms | 934ms | 152ms | 0.87 | 16.3% |
| buildAutodocsVisible |  664ms | 881ms | 217ms | **1.73** | 🔺24.6% |
| buildMDXVisible |  652ms | 858ms | 206ms | **1.81** | 🔺24% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR updates the error message in the `latestVersion` method of the `JsPackageManager` class to provide more detailed information about package version constraints.

- Modified `code/core/src/common/js-package-manager/JsPackageManager.ts` to include constraint details in error messages
- Improved error handling for cases where no version satisfies a given constraint for a package
- Enhanced developer experience by providing more context in package version-related errors
- This change may help in debugging and resolving dependency issues more efficiently

<!-- /greptile_comment -->