### PR TITLE
Angular: Updates to Angular argsToTemplate

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.ts
+++ b/code/frameworks/angular/src/client/angular-beta/ComputesTemplateFromComponent.ts
@@ -96,7 +96,7 @@ function stringifyCircular(obj: any) {
   });
 }
 
-const createAngularInputProperty = ({
+export const createAngularInputProperty = ({
   propertyName,
   value,
   argType,

--- a/code/frameworks/angular/src/client/argsToTemplate.test.ts
+++ b/code/frameworks/angular/src/client/argsToTemplate.test.ts
@@ -116,7 +116,7 @@ describe('argsToTemplate', () => {
       prop2: undefined,
       prop3: 'value3',
     };
-    const options: ArgsToTemplateOptions<keyof typeof args> = { bindVariableNames: true };
+    const options: ArgsToTemplateOptions<keyof typeof args> = { useVariableNames: true };
     const result = argsToTemplate(args, options);
     expect(result).toBe('[prop1]="prop1" [prop3]="prop3"');
   });
@@ -129,7 +129,7 @@ describe('argsToTemplate', () => {
     };
     const options: ArgsToTemplateOptions<keyof typeof args> = {
       include: ['prop1', 'prop3'],
-      bindVariableNames: true,
+      useVariableNames: true,
     };
     const result = argsToTemplate(args, options);
     expect(result).toBe('[prop1]="prop1" [prop3]="prop3"');
@@ -143,7 +143,7 @@ describe('argsToTemplate', () => {
     };
     const options: ArgsToTemplateOptions<keyof typeof args> = {
       include: ['prop1', 'prop3'],
-      bindVariableNames: true,
+      useVariableNames: true,
     };
     const result = argsToTemplate(args, options);
     expect(result).toBe('[prop1]="prop1"');
@@ -157,7 +157,7 @@ describe('argsToTemplate', () => {
     };
     const options: ArgsToTemplateOptions<keyof typeof args> = {
       exclude: ['prop2'],
-      bindVariableNames: true,
+      useVariableNames: true,
     };
     const result = argsToTemplate(args, options);
     expect(result).toBe('[prop1]="prop1" [prop3]="prop3"');
@@ -171,7 +171,7 @@ describe('argsToTemplate', () => {
     };
     const options: ArgsToTemplateOptions<keyof typeof args> = {
       exclude: ['prop2'],
-      bindVariableNames: true,
+      useVariableNames: true,
     };
     const result = argsToTemplate(args, options);
     expect(result).toBe('[prop1]="prop1"');
@@ -186,7 +186,7 @@ describe('argsToTemplate', () => {
     const options: ArgsToTemplateOptions<keyof typeof args> = {
       include: ['prop1', 'prop2'],
       exclude: ['prop2', 'prop3'],
-      bindVariableNames: true,
+      useVariableNames: true,
     };
     const result = argsToTemplate(args, options);
     expect(result).toBe('[prop1]="prop1" [prop2]="prop2"');
@@ -197,26 +197,26 @@ describe('argsToTemplate', () => {
       prop1: 'value1',
       prop2: 'value2',
     };
-    const options: ArgsToTemplateOptions<keyof typeof args> = { bindVariableNames: true };
+    const options: ArgsToTemplateOptions<keyof typeof args> = { useVariableNames: true };
     const result = argsToTemplate(args, options);
     expect(result).toBe('[prop1]="prop1" [prop2]="prop2"');
   });
 
   it('should bind events correctly when variable binding', () => {
     const args = { event1: () => {}, event2: () => {} };
-    const result = argsToTemplate(args, { bindVariableNames: true });
+    const result = argsToTemplate(args, { useVariableNames: true });
     expect(result).toEqual('(event1)="event1($event)" (event2)="event2($event)"');
   });
 
   it('should mix properties and events correctly when variable binding', () => {
     const args = { input: 'Value1', event1: () => {} };
-    const result = argsToTemplate(args, { bindVariableNames: true });
+    const result = argsToTemplate(args, { useVariableNames: true });
     expect(result).toEqual('[input]="input" (event1)="event1($event)"');
   });
 
   it('should format for non dot notation when variable binding', () => {
     const args = { 'non-dot': 'Value1', 'dash-out': () => {} };
-    const result = argsToTemplate(args, { bindVariableNames: true });
+    const result = argsToTemplate(args, { useVariableNames: true });
     expect(result).toEqual('[non-dot]="this[\'non-dot\']" (dash-out)="this[\'dash-out\']($event)"');
   });
 

--- a/code/frameworks/angular/src/client/argsToTemplate.test.ts
+++ b/code/frameworks/angular/src/client/argsToTemplate.test.ts
@@ -13,7 +13,7 @@ describe('argsToTemplate', () => {
     };
     const options: ArgsToTemplateOptions<keyof typeof args> = {};
     const result = argsToTemplate(args, options);
-    expect(result).toBe('[prop1]="prop1" [prop3]="prop3"');
+    expect(result).toBe(`[prop1]="'value1'" [prop3]="'value3'"`);
   });
 
   it('should include properties from include option', () => {
@@ -26,7 +26,7 @@ describe('argsToTemplate', () => {
       include: ['prop1', 'prop3'],
     };
     const result = argsToTemplate(args, options);
-    expect(result).toBe('[prop1]="prop1" [prop3]="prop3"');
+    expect(result).toBe(`[prop1]="'value1'" [prop3]="'value3'"`);
   });
 
   it('should include non-undefined properties from include option', () => {
@@ -39,7 +39,7 @@ describe('argsToTemplate', () => {
       include: ['prop1', 'prop3'],
     };
     const result = argsToTemplate(args, options);
-    expect(result).toBe('[prop1]="prop1"');
+    expect(result).toBe(`[prop1]="'value1'"`);
   });
 
   it('should exclude properties from exclude option', () => {
@@ -52,7 +52,7 @@ describe('argsToTemplate', () => {
       exclude: ['prop2'],
     };
     const result = argsToTemplate(args, options);
-    expect(result).toBe('[prop1]="prop1" [prop3]="prop3"');
+    expect(result).toBe(`[prop1]="'value1'" [prop3]="'value3'"`);
   });
 
   it('should exclude properties from exclude option and undefined properties', () => {
@@ -65,7 +65,7 @@ describe('argsToTemplate', () => {
       exclude: ['prop2'],
     };
     const result = argsToTemplate(args, options);
-    expect(result).toBe('[prop1]="prop1"');
+    expect(result).toBe(`[prop1]="'value1'"`);
   });
 
   it('should prioritize include over exclude when both options are given', () => {
@@ -79,7 +79,7 @@ describe('argsToTemplate', () => {
       exclude: ['prop2', 'prop3'],
     };
     const result = argsToTemplate(args, options);
-    expect(result).toBe('[prop1]="prop1" [prop2]="prop2"');
+    expect(result).toBe(`[prop1]="'value1'" [prop2]="'value2'"`);
   });
 
   it('should work when neither include nor exclude options are given', () => {
@@ -89,7 +89,7 @@ describe('argsToTemplate', () => {
     };
     const options: ArgsToTemplateOptions<keyof typeof args> = {};
     const result = argsToTemplate(args, options);
-    expect(result).toBe('[prop1]="prop1" [prop2]="prop2"');
+    expect(result).toBe(`[prop1]="'value1'" [prop2]="'value2'"`);
   });
 
   it('should bind events correctly when value is a function', () => {
@@ -101,12 +101,150 @@ describe('argsToTemplate', () => {
   it('should mix properties and events correctly', () => {
     const args = { input: 'Value1', event1: () => {} };
     const result = argsToTemplate(args, {});
-    expect(result).toEqual('[input]="input" (event1)="event1($event)"');
+    expect(result).toEqual(`[input]="'Value1'" (event1)="event1($event)"`);
   });
 
   it('should format for non dot notation', () => {
     const args = { 'non-dot': 'Value1', 'dash-out': () => {} };
     const result = argsToTemplate(args, {});
+    expect(result).toEqual(`[non-dot]="'Value1'" (dash-out)="this[\'dash-out\']($event)"`);
+  });
+
+  it('should correctly convert args to variable bindings and exclude undefined values', () => {
+    const args: Record<string, any> = {
+      prop1: 'value1',
+      prop2: undefined,
+      prop3: 'value3',
+    };
+    const options: ArgsToTemplateOptions<keyof typeof args> = { bindVariableNames: true };
+    const result = argsToTemplate(args, options);
+    expect(result).toBe('[prop1]="prop1" [prop3]="prop3"');
+  });
+
+  it('should include variable bindings from include option', () => {
+    const args = {
+      prop1: 'value1',
+      prop2: 'value2',
+      prop3: 'value3',
+    };
+    const options: ArgsToTemplateOptions<keyof typeof args> = {
+      include: ['prop1', 'prop3'],
+      bindVariableNames: true,
+    };
+    const result = argsToTemplate(args, options);
+    expect(result).toBe('[prop1]="prop1" [prop3]="prop3"');
+  });
+
+  it('should exclude non-undefined variable bindings from include option', () => {
+    const args: Record<string, any> = {
+      prop1: 'value1',
+      prop2: 'value2',
+      prop3: undefined,
+    };
+    const options: ArgsToTemplateOptions<keyof typeof args> = {
+      include: ['prop1', 'prop3'],
+      bindVariableNames: true,
+    };
+    const result = argsToTemplate(args, options);
+    expect(result).toBe('[prop1]="prop1"');
+  });
+
+  it('should exclude variable bindings from exclude option', () => {
+    const args = {
+      prop1: 'value1',
+      prop2: 'value2',
+      prop3: 'value3',
+    };
+    const options: ArgsToTemplateOptions<keyof typeof args> = {
+      exclude: ['prop2'],
+      bindVariableNames: true,
+    };
+    const result = argsToTemplate(args, options);
+    expect(result).toBe('[prop1]="prop1" [prop3]="prop3"');
+  });
+
+  it('should exclude variable binding from exclude option and undefined properties', () => {
+    const args: Record<string, any> = {
+      prop1: 'value1',
+      prop2: 'value2',
+      prop3: undefined,
+    };
+    const options: ArgsToTemplateOptions<keyof typeof args> = {
+      exclude: ['prop2'],
+      bindVariableNames: true,
+    };
+    const result = argsToTemplate(args, options);
+    expect(result).toBe('[prop1]="prop1"');
+  });
+
+  it('should prioritize include over exclude when both options are given and show variable bindings', () => {
+    const args = {
+      prop1: 'value1',
+      prop2: 'value2',
+      prop3: 'value3',
+    };
+    const options: ArgsToTemplateOptions<keyof typeof args> = {
+      include: ['prop1', 'prop2'],
+      exclude: ['prop2', 'prop3'],
+      bindVariableNames: true,
+    };
+    const result = argsToTemplate(args, options);
+    expect(result).toBe('[prop1]="prop1" [prop2]="prop2"');
+  });
+
+  it('should work when neither include nor exclude options are given and show variable bindings', () => {
+    const args = {
+      prop1: 'value1',
+      prop2: 'value2',
+    };
+    const options: ArgsToTemplateOptions<keyof typeof args> = { bindVariableNames: true };
+    const result = argsToTemplate(args, options);
+    expect(result).toBe('[prop1]="prop1" [prop2]="prop2"');
+  });
+
+  it('should bind events correctly when variable binding', () => {
+    const args = { event1: () => {}, event2: () => {} };
+    const result = argsToTemplate(args, { bindVariableNames: true });
+    expect(result).toEqual('(event1)="event1($event)" (event2)="event2($event)"');
+  });
+
+  it('should mix properties and events correctly when variable binding', () => {
+    const args = { input: 'Value1', event1: () => {} };
+    const result = argsToTemplate(args, { bindVariableNames: true });
+    expect(result).toEqual('[input]="input" (event1)="event1($event)"');
+  });
+
+  it('should format for non dot notation when variable binding', () => {
+    const args = { 'non-dot': 'Value1', 'dash-out': () => {} };
+    const result = argsToTemplate(args, { bindVariableNames: true });
     expect(result).toEqual('[non-dot]="this[\'non-dot\']" (dash-out)="this[\'dash-out\']($event)"');
+  });
+
+  it('should display event binding after property binding', () => {
+    const args = { event: () => {}, input: 'Value1' };
+    const results = argsToTemplate(args);
+    expect(results).toEqual(`[input]="'Value1'" (event)="event($event)"`);
+  });
+
+  it('should keep args key order by default', () => {
+    const args = { zInput: 'ValueZ', event: () => {}, input: 'Value1' };
+    const results = argsToTemplate(args);
+    expect(results).toEqual(`[zInput]="'ValueZ'" [input]="'Value1'" (event)="event($event)"`);
+  });
+
+  it('should keep args key order by default', () => {
+    const args = { zEvent: () => {}, zInput: 'ValueZ', event: () => {}, input: 'Value1' };
+    const results = argsToTemplate(args);
+    expect(results).toEqual(
+      `[zInput]="'ValueZ'" [input]="'Value1'" (zEvent)="zEvent($event)" (event)="event($event)"`
+    );
+  });
+
+  it('should sort args keys when sort set to true', () => {
+    const args = { zEvent: () => {}, zInput: 'ValueZ', event: () => {}, input: 'Value1' };
+    const results = argsToTemplate(args, { sort: true });
+    expect(results).toEqual(
+      `[input]="'Value1'" [zInput]="'ValueZ'" (event)="event($event)" (zEvent)="zEvent($event)"`
+    );
   });
 });

--- a/code/frameworks/angular/src/client/argsToTemplate.ts
+++ b/code/frameworks/angular/src/client/argsToTemplate.ts
@@ -21,8 +21,8 @@ export interface ArgsToTemplateOptions<T> {
    */
   exclude?: Array<T>;
   /** Toggle between showing current value or variable name for template bindings. */
-  bindVariableNames?: boolean;
-  /** Toogle between sorting properties by name */
+  useVariableNames?: boolean;
+  /** Toggle between sorting properties by name */
   sort?: boolean;
   /** Object of key:value pairs. When values are set to default the bindings will not appear. */
   defaultValues?: { [key: string]: any };
@@ -76,7 +76,7 @@ export function argsToTemplate<A extends Record<string, any>>(
   return Object.entries(args)
     .filter(
       ([key]) =>
-        args[key] !== undefined && (options.bindVariableNames || args[key] !== defaultValues[key])
+        args[key] !== undefined && (options.useVariableNames || args[key] !== defaultValues[key])
     )
     .filter(([key]) => {
       if (includeSet) return includeSet.has(key);
@@ -93,7 +93,7 @@ export function argsToTemplate<A extends Record<string, any>>(
     .map(([key, value]) =>
       typeof value === 'function'
         ? `(${key})="${formatPropInTemplate(key)}($event)"`
-        : options.bindVariableNames
+        : options.useVariableNames
           ? `[${key}]="${formatPropInTemplate(key)}"`
           : createAngularInputProperty({ propertyName: key, value: args[key] })
     )


### PR DESCRIPTION
Update default functionality of argsToTemplate to align with autodocs data binding. Use existing function that's used by autodocs to replace variable names with current values. 
Add toggle to use variable names instead of values. 
Add option to sort keys alphabetically.
Update order of bindings to group data bindings before event listener bindings. 
Add option to define default values in order to remove unecessary/redundant bindings from being shown.

Closes #24557

## What I did

Update functionality of argsToTemplate to be closer to existing non-template solution which shows the current value of bindings. Add quality of life features. 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

Run angular sandbox for template, e.g. yarn task --task dev --template angular-cli/default-ts --prod --start-from=compile
Open Storybook in your browser
Navigate to Button/Docs
Select 'Show code' on the Primary canvas and note structure.
Open editor to sandbox/angular-cli-default-ts/src/stories/button.stories.ts
In the Primary story add:

```
  render: (args) => ({
    props: args,
    template: `<storybook-button ${argsToTemplate(args)}></storybook-button>`
  })
```

Select 'show code' again on the Primary story. The code snippet should match.

Also added `sort`, `useVariableNames`, and `defaultValues` options to `argsToTemplate`. Can manually test those features.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->