### PR TITLE
UI: Fix RefIndicator to use CheckIcon instead of string

### DIFF
--- a/code/core/src/manager/components/sidebar/RefIndicator.tsx
+++ b/code/core/src/manager/components/sidebar/RefIndicator.tsx
@@ -7,6 +7,7 @@ import { styled, useTheme } from '@storybook/core/theming';
 import { global } from '@storybook/global';
 import {
   AlertIcon,
+  CheckIcon,
   ChevronDownIcon,
   DocumentIcon,
   GlobeIcon,
@@ -216,7 +217,7 @@ export const RefIndicator = React.memo(
                 <TooltipLinkList
                   // @ts-expect-error (non strict)
                   links={Object.entries(ref.versions).map(([id, href]) => ({
-                    icon: href === ref.url ? 'check' : undefined,
+                    icon: href === ref.url ? <CheckIcon /> : undefined,
                     id,
                     title: id,
                     href,


### PR DESCRIPTION
Currently there's a bug in the composed storybook version picker where the currently selected version has the word 'check' in front of it instead of a check icon.

https://github.com/storybookjs/storybook/blob/v8.3.3/code/core/src/manager/components/sidebar/RefIndicator.tsx#L219
https://github.com/storybookjs/storybook/blob/v8.3.3/code/core/src/components/components/tooltip/TooltipLinkList.tsx#L54
https://github.com/storybookjs/storybook/blob/v8.3.3/code/core/src/components/components/tooltip/TooltipLinkList.tsx#L41
https://github.com/storybookjs/storybook/blob/v8.3.3/code/core/src/components/components/tooltip/ListItem.tsx#L177
https://github.com/storybookjs/storybook/blob/v8.3.3/code/core/src/components/components/tooltip/ListItem.tsx#L206

## What I did

Fix bug in refIndicator where reactNode is expected but string is passed.
Import `CheckIcon` from `@storybook/icons` and replace string `'check'` with `CheckIcon`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Create a sandbox: `yarn task --task sandbox --template react-vite/default-ts`

2. Modify ./sandbox/react-vite-default-ts/.storybook/main.ts:

Add key to exports: 

```
refs: {  test: { title: 'test', url: 'http://localhost:8080'  } },
```

3. Build sandbox:

```
cd sandbox/react-vite-default-ts
yarn build-storybook
```

4. Create metadata.json:

in code editor go to ./sandbox/react-vite-default-ts/storybook-static
create file 'metadata.json' with contents:

```
{
  "versions": {
    "v0": "http://localhost:8080"
  }
}
```

5. Serve storybook-static: (this must be running before starting the other storybook)

```
cd sandbox/react-vite-default-ts/storybook-static
npx http-server . --cors
```

6. Run sandbox:

```
cd sandbox/react-vite-default-ts
yarn storybook
```
5. Open Storybook in your browser
6. Scroll to bottom of sidebar to see composed storybook
7. Select version picker dropdown for composed storybook. Expect to see checkmark instead of word 'check'.


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 0 B | **3.11** | 0% |
| initSize |  147 MB | 147 MB | 34 B | **2.62** | 0% |
| diffSize |  68.3 MB | 68.3 MB | 34 B | **1.79** | 0% |
| buildSize |  6.79 MB | 6.79 MB | 34 B | 1 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | -1.11 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 34 B | 1.1 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | -1.11 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 34 B | 1.03 | 0% |
| buildPreviewSize |  2.99 MB | 2.99 MB | 0 B | -1.11 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  19.4s | 18s | -1s -381ms | 1.19 | -7.6% |
| generateTime |  19.4s | 21.9s | 2.5s | 0.03 | 11.4% |
| initTime |  13.1s | 13.8s | 689ms | -0.23 | 5% |
| buildTime |  8.1s | 8.2s | 106ms | -0.53 | 1.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.3s | 5.9s | -429ms | -0.7 | -7.2% |
| devManagerResponsive |  3.9s | 4s | 117ms | -0.4 | 2.9% |
| devManagerHeaderVisible |  585ms | 557ms | -28ms | -0.55 | -5% |
| devManagerIndexVisible |  615ms | 593ms | -22ms | -0.5 | -3.7% |
| devStoryVisibleUncached |  996ms | 875ms | -121ms | -0.62 | -13.8% |
| devStoryVisible |  616ms | 587ms | -29ms | -0.58 | -4.9% |
| devAutodocsVisible |  514ms | 483ms | -31ms | -0.63 | -6.4% |
| devMDXVisible |  558ms | 516ms | -42ms | -0.3 | -8.1% |
| buildManagerHeaderVisible |  548ms | 511ms | -37ms | -0.56 | -7.2% |
| buildManagerIndexVisible |  559ms | 515ms | -44ms | -0.63 | -8.5% |
| buildStoryVisible |  623ms | 579ms | -44ms | -0.5 | -7.6% |
| buildAutodocsVisible |  537ms | 475ms | -62ms | -0.48 | -13.1% |
| buildMDXVisible |  492ms | 471ms | -21ms | -0.42 | -4.5% |

<!-- BENCHMARK_SECTION -->