### PR TITLE
Vitest plugin: Fix renamed export stories

### DIFF
--- a/code/core/src/csf-tools/CsfFile.test.ts
+++ b/code/core/src/csf-tools/CsfFile.test.ts
@@ -81,6 +81,7 @@ describe('CsfFile', () => {
         stories:
           - id: foo-bar--a
             name: A
+            localName: A
             parameters:
               __id: foo-bar--a
             __stats:
@@ -94,6 +95,7 @@ describe('CsfFile', () => {
               moduleMock: false
           - id: foo-bar--b
             name: B
+            localName: B
             parameters:
               __id: foo-bar--b
             __stats:
@@ -790,6 +792,7 @@ describe('CsfFile', () => {
         stories:
           - id: foo-bar--a
             name: A
+            localName: default
             __stats:
               play: false
               render: false
@@ -801,6 +804,7 @@ describe('CsfFile', () => {
               moduleMock: false
           - id: foo-bar--b
             name: B
+            localName: B
             __stats:
               play: false
               render: false
@@ -878,6 +882,7 @@ describe('CsfFile', () => {
         stories:
           - id: foo-bar--a
             name: A
+            localName: A
             parameters:
               __id: foo-bar--a
             __stats:

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -190,6 +190,7 @@ export interface StaticMeta
 
 export interface StaticStory extends Pick<StoryAnnotations, 'name' | 'parameters' | 'tags'> {
   id: string;
+  localName?: string;
   __stats: IndexInputStats;
 }
 
@@ -488,6 +489,7 @@ export class CsfFile {
             node.specifiers.forEach((specifier) => {
               if (t.isExportSpecifier(specifier) && t.isIdentifier(specifier.exported)) {
                 const { name: exportName } = specifier.exported;
+                const { name: localName } = specifier.local;
                 const decl = t.isProgram(parent)
                   ? findVarInitialization(specifier.local.name, parent)
                   : specifier.local;
@@ -515,6 +517,7 @@ export class CsfFile {
                   self._stories[exportName] = {
                     id: 'FIXME',
                     name: exportName,
+                    localName,
                     parameters: {},
                     __stats: {},
                   };

--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -296,6 +296,40 @@ describe('transformer', () => {
       `);
     });
 
+    it('should add test statement to const declared renamed exported stories', async () => {
+      const code = `
+        export default {};
+        const Primary = {
+          args: {
+            label: 'Primary Button',
+          },
+        };
+
+        export { Primary as PrimaryStory };
+      `;
+
+      const result = await transform({ code });
+
+      expect(result.code).toMatchInlineSnapshot(`
+        import { test as _test, expect as _expect } from "vitest";
+        import { testStory as _testStory } from "@storybook/experimental-addon-test/internal/test-utils";
+        const _meta = {
+          title: "automatic/calculated/title"
+        };
+        export default _meta;
+        const Primary = {
+          args: {
+            label: 'Primary Button'
+          }
+        };
+        export { Primary as PrimaryStory };
+        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+        if (_isRunningFromThisFile) {
+          _test("PrimaryStory", _testStory("PrimaryStory", Primary, _meta, []));
+        }
+      `);
+    });
+
     it('should add tests for multiple stories', async () => {
       const code = `
         export default {};

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -201,10 +201,12 @@ export async function vitestTransform({
     ast.program.body.push(isRunningFromThisFileDeclaration);
 
     const getTestStatementForStory = ({
+      localName,
       exportName,
       testTitle,
       node,
     }: {
+      localName: string;
       exportName: string;
       testTitle: string;
       node: t.Node;
@@ -215,7 +217,7 @@ export async function vitestTransform({
           t.stringLiteral(testTitle),
           t.callExpression(testStoryId, [
             t.stringLiteral(exportName),
-            t.identifier(exportName),
+            t.identifier(localName),
             t.identifier(metaExportName),
             skipTagsId,
           ]),
@@ -243,7 +245,9 @@ export async function vitestTransform({
 
         // use the story's name as the test title for vitest, and fallback to exportName
         const testTitle = parsed._stories[exportName].name ?? exportName;
-        return getTestStatementForStory({ testTitle, exportName, node });
+        const decl = parsed._storyExports[exportName];
+        const localName = parsed._stories[exportName].localName ?? exportName;
+        return getTestStatementForStory({ testTitle, localName, exportName, node });
       })
       .filter((st) => !!st) as t.ExpressionStatement[];
 

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -243,10 +243,9 @@ export async function vitestTransform({
           return;
         }
 
-        // use the story's name as the test title for vitest, and fallback to exportName
-        const testTitle = parsed._stories[exportName].name ?? exportName;
-        const decl = parsed._storyExports[exportName];
         const localName = parsed._stories[exportName].localName ?? exportName;
+        // use the story's name as the test title for vitest, and fallback to exportName
+        const testTitle = parsed._stories[exportName].name ?? localName;
         return getTestStatementForStory({ testTitle, localName, exportName, node });
       })
       .filter((st) => !!st) as t.ExpressionStatement[];

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -245,7 +245,7 @@ export async function vitestTransform({
 
         const localName = parsed._stories[exportName].localName ?? exportName;
         // use the story's name as the test title for vitest, and fallback to exportName
-        const testTitle = parsed._stories[exportName].name ?? localName;
+        const testTitle = parsed._stories[exportName].name ?? exportName;
         return getTestStatementForStory({ testTitle, localName, exportName, node });
       })
       .filter((st) => !!st) as t.ExpressionStatement[];


### PR DESCRIPTION
Closes #29244

## What I did

1. Save the local name of export variables in the CsfFile parsed output
2. Use that local name to fix the generated code in the Vitest plugin

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

In a sandbox, create a story that uses a renamed export and verify that the Vitest test succeeds. (I did not test!)

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 78.5 MB | 714 kB | **9.74** | 0.9% |
| initSize |  150 MB | 153 MB | 2.7 MB | -0.27 | 1.8% |
| diffSize |  72.5 MB | 74.5 MB | 1.98 MB | -0.44 | 2.7% |
| buildSize |  6.77 MB | 6.96 MB | 184 kB | 0.73 | 2.6% |
| buildSbAddonsSize |  1.5 MB | 1.57 MB | 61.8 kB | 0.73 | 3.9% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.91 MB | 80.8 kB | 0.73 | 4.2% |
| buildSbPreviewSize |  270 kB | 311 kB | 41.3 kB | 0.73 | 13.3% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.98 MB | 184 kB | 0.73 | 4.6% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 14 B | -1.15 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  5.9s | 7.3s | 1.4s | -1.01 | 19.6% |
| generateTime |  20.5s | 24.4s | 3.9s | **1.33** | 🔺16% |
| initTime |  14.2s | 19.9s | 5.7s | **2.61** | 🔺28.9% |
| buildTime |  9.7s | 8.7s | -938ms | -1.09 | -10.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7s | 7.2s | 232ms | 0.07 | 3.2% |
| devManagerResponsive |  4.3s | 4.8s | 545ms | 0.4 | 11.2% |
| devManagerHeaderVisible |  564ms | 668ms | 104ms | 0.25 | 15.6% |
| devManagerIndexVisible |  595ms | 722ms | 127ms | 0.39 | 17.6% |
| devStoryVisibleUncached |  1.2s | 1.2s | 8ms | 0.19 | 0.6% |
| devStoryVisible |  594ms | 724ms | 130ms | 0.39 | 18% |
| devAutodocsVisible |  498ms | 646ms | 148ms | 1.06 | 22.9% |
| devMDXVisible |  452ms | 559ms | 107ms | 0.02 | 19.1% |
| buildManagerHeaderVisible |  526ms | 627ms | 101ms | 0.36 | 16.1% |
| buildManagerIndexVisible |  559ms | 632ms | 73ms | 0.24 | 11.6% |
| buildStoryVisible |  560ms | 666ms | 106ms | 0.25 | 15.9% |
| buildAutodocsVisible |  515ms | 587ms | 72ms | 0.23 | 12.3% |
| buildMDXVisible |  504ms | 542ms | 38ms | 0.08 | 7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds support for renamed exports in the Storybook Vitest plugin, addressing issue #29244.

- Added `localName` property to `StaticStory` interface in `CsfFile.ts` to store original variable names
- Modified `transformer.ts` to use `localName` when generating test statements for renamed exports
- Updated `CsfFile.test.ts` to include tests for the new `localName` property
- Added a new test case in `transformer.test.ts` to verify handling of renamed exported stories

<!-- /greptile_comment -->