### PR TITLE
Blocks: Prebundle `es-toolkit`

### DIFF
--- a/code/lib/blocks/package.json
+++ b/code/lib/blocks/package.json
@@ -48,7 +48,6 @@
     "@storybook/icons": "^1.2.10",
     "color-convert": "^2.0.1",
     "dequal": "^2.0.2",
-    "es-toolkit": "^1.21.0",
     "markdown-to-jsx": "^7.4.5",
     "memoizerific": "^1.11.3",
     "polished": "^4.2.2",
@@ -62,6 +61,7 @@
     "@storybook/react": "workspace:*",
     "@storybook/test": "workspace:*",
     "@types/color-convert": "^2.0.0",
+    "es-toolkit": "^1.21.0",
     "tocbot": "^4.20.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Follow-up to https://github.com/storybookjs/storybook/pull/28981

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Moved `es-toolkit` to a `devDependency` so it's properly prebundled and tree-shaken.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 6 kB | 0.72 | 0% |
| initSize |  152 MB | 150 MB | -1.7 MB | -1.2 | -1.1% |
| diffSize |  74 MB | 72.3 MB | -1.7 MB | -1.19 | -2.4% |
| buildSize |  6.77 MB | 6.77 MB | -14 B | -1.16 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | **-1.38** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 0 B | -0.89 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | **-1.62** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 0 B | -1.21 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | -14 B | -0.42 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.2s | 21.8s | 15.5s | **1.25** | 🔺71.2% |
| generateTime |  21.3s | 20s | -1s -322ms | -0.28 | -6.6% |
| initTime |  14.9s | 14s | -899ms | -0.67 | -6.4% |
| buildTime |  9s | 9s | -7ms | -1.15 | -0.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.2s | 7.3s | 1.1s | 0.14 | 15.5% |
| devManagerResponsive |  4s | 4.9s | 859ms | 0.4 | 17.4% |
| devManagerHeaderVisible |  545ms | 553ms | 8ms | -0.77 | 1.4% |
| devManagerIndexVisible |  579ms | 612ms | 33ms | -0.58 | 5.4% |
| devStoryVisibleUncached |  1.2s | 1.5s | 293ms | 0.79 | 19.5% |
| devStoryVisible |  578ms | 607ms | 29ms | -0.63 | 4.8% |
| devAutodocsVisible |  512ms | 581ms | 69ms | 0.22 | 11.9% |
| devMDXVisible |  549ms | 509ms | -40ms | -0.47 | -7.9% |
| buildManagerHeaderVisible |  475ms | 739ms | 264ms | 0.89 | 35.7% |
| buildManagerIndexVisible |  505ms | 811ms | 306ms | 1.13 | 37.7% |
| buildStoryVisible |  506ms | 814ms | 308ms | 0.95 | 37.8% |
| buildAutodocsVisible |  478ms | 535ms | 57ms | -0.14 | 10.7% |
| buildMDXVisible |  414ms | 491ms | 77ms | -0.41 | 15.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR moves the 'es-toolkit' dependency from main dependencies to devDependencies in the @storybook/blocks package, aiming to improve performance through proper prebundling and tree-shaking.

- Modified `code/lib/blocks/package.json` to relocate 'es-toolkit' to devDependencies
- Potential performance improvement and package size reduction for @storybook/blocks
- Requires verification that runtime functionality depending on 'es-toolkit' remains intact
- Follow-up to previous PR #28981, addressing dependency management
- Manual testing needed to ensure no breaking changes in package behavior

<!-- /greptile_comment -->