### PR TITLE
docs: Consistently adopt recommended meta pattern

### DIFF
--- a/docs/_snippets/typed-csf-file.md
+++ b/docs/_snippets/typed-csf-file.md
@@ -8,7 +8,7 @@ const meta: Meta<Button> = {
 };
 export default meta;
 
-type Story = StoryObj<Button>;
+type Story = StoryObj<meta>;
 
 export const Basic: Story = {};
 
@@ -52,7 +52,7 @@ const meta: Meta<typeof Button> = {
 };
 export default meta;
 
-type Story = StoryObj<typeof Button>;
+type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {};
 


### PR DESCRIPTION
Updating docs with suggestion from https://github.com/storybookjs/storybook/issues/21221#issuecomment-144286038

(If this is no longer the suggestion, then a direct export of meta would be cleaner instead. Like this: https://github.com/storybookjs/storybook/issues/21221#issuecomment-1442284205)

<!-- greptile_comment -->

## Greptile Summary

This PR updates the TypeScript type definitions in code snippets for Storybook stories, improving type inference and aligning with recommended meta patterns.

- Changed `Story` type definition to use `typeof meta` instead of direct component type in `/docs/_snippets/typed-csf-file.md`
- Updated code snippets for Angular, common (TypeScript 4.9+), common (TypeScript), and Web Components renderers
- Maintained consistency across different renderer examples while applying the new type definition approach
- Aligned documentation with the suggestion from the related issue (#21221) discussion

<!-- /greptile_comment -->