### PR TITLE
Build: Disallowed certain packages via ESlint

### DIFF
--- a/code/builders/builder-vite/src/list-stories.ts
+++ b/code/builders/builder-vite/src/list-stories.ts
@@ -3,6 +3,7 @@ import { isAbsolute, join } from 'node:path';
 import { commonGlobOptions, normalizeStories } from 'storybook/internal/common';
 import type { Options } from 'storybook/internal/types';
 
+// eslint-disable-next-line depend/ban-dependencies
 import { glob } from 'glob';
 import slash from 'slash';
 

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
-import type { CommonOptions } from 'execa';
-import { execaCommand, execaCommandSync } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
+import { type CommonOptions, execaCommand, execaCommandSync } from 'execa';
 import picocolors from 'picocolors';
 import { gt, satisfies } from 'semver';
 import invariant from 'tiny-invariant';

--- a/code/core/src/common/utils/validate-configuration-files.ts
+++ b/code/core/src/common/utils/validate-configuration-files.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { once } from '@storybook/core/node-logger';
 import { MainFileMissingError } from '@storybook/core/server-errors';
 
+// eslint-disable-next-line depend/ban-dependencies
 import { glob } from 'glob';
 import slash from 'slash';
 import { dedent } from 'ts-dedent';

--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -130,6 +130,7 @@ export class StoryIndexGenerator {
         const fullGlob = slash(join(specifier.directory, specifier.files));
 
         // Dynamically import globby because it is a pure ESM module
+        // eslint-disable-next-line depend/ban-dependencies
         const { globby } = await import('globby');
 
         const files = await globby(fullGlob, {

--- a/code/core/src/core-server/utils/__tests__/remove-mdx-stories.test.ts
+++ b/code/core/src/core-server/utils/__tests__/remove-mdx-stories.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { normalizeStoriesEntry } from '@storybook/core/common';
 import { type StoriesEntry } from '@storybook/core/types';
 
+// eslint-disable-next-line depend/ban-dependencies
 import { glob as globOriginal } from 'glob';
 import slash from 'slash';
 

--- a/code/core/src/core-server/utils/remove-mdx-entries.ts
+++ b/code/core/src/core-server/utils/remove-mdx-entries.ts
@@ -3,6 +3,7 @@ import { isAbsolute, join, relative } from 'node:path';
 import { commonGlobOptions, normalizeStories } from '@storybook/core/common';
 import type { Options, StoriesEntry } from '@storybook/core/types';
 
+// eslint-disable-next-line depend/ban-dependencies
 import { glob } from 'glob';
 import slash from 'slash';
 

--- a/code/core/src/core-server/utils/search-files.ts
+++ b/code/core/src/core-server/utils/search-files.ts
@@ -31,6 +31,7 @@ export async function searchFiles({
   fileExtensions?: string[];
 }): Promise<SearchResult> {
   // Dynamically import globby because it is a pure ESM module
+  // eslint-disable-next-line depend/ban-dependencies
   const { globby, isDynamicPattern } = await import('globby');
 
   const hasSearchSpecialGlobChars = isDynamicPattern(searchQuery, { cwd });

--- a/code/core/src/core-server/utils/watch-story-specifiers.ts
+++ b/code/core/src/core-server/utils/watch-story-specifiers.ts
@@ -97,6 +97,7 @@ export function watchStorySpecifiers(
             );
 
             // Dynamically import globby because it is a pure ESM module
+            // eslint-disable-next-line depend/ban-dependencies
             const { globby } = await import('globby');
 
             // glob only supports forward slashes

--- a/code/core/src/telemetry/get-portable-stories-usage.ts
+++ b/code/core/src/telemetry/get-portable-stories-usage.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
 
 import { createFileSystemCache, resolvePathInStorybookCache } from '../common';

--- a/code/lib/cli-storybook/src/automigrate/fixes/mdx-1-to-3.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/mdx-1-to-3.ts
@@ -51,6 +51,7 @@ export const mdx1to3: Fix<Mdx1to3Options> = {
 
   async check() {
     // Dynamically import globby because it is a pure ESM module
+    // eslint-disable-next-line depend/ban-dependencies
     const { globby } = await import('globby');
 
     const storiesMdxFiles = await globby('./!(node_modules)**/*.(story|stories).mdx');

--- a/code/lib/cli-storybook/src/automigrate/fixes/mdx-gfm.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/mdx-gfm.ts
@@ -47,6 +47,7 @@ export const mdxgfm: Fix<Options> = {
       }
 
       // Dynamically import globby because it is a pure ESM module
+      // eslint-disable-next-line depend/ban-dependencies
       const { globby } = await import('globby');
 
       const files = await globby(pattern, commonGlobOptions(pattern));

--- a/code/lib/cli-storybook/src/automigrate/fixes/mdx-to-csf.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/mdx-to-csf.ts
@@ -2,6 +2,7 @@ import type { StoriesEntry } from 'storybook/internal/types';
 
 import { runCodemod } from '@storybook/codemod';
 
+// eslint-disable-next-line depend/ban-dependencies
 import { glob } from 'glob';
 import picocolors from 'picocolors';
 import { prompt } from 'prompts';

--- a/code/lib/cli-storybook/src/automigrate/fixes/missing-storybook-dependencies.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/missing-storybook-dependencies.ts
@@ -70,6 +70,7 @@ export const missingStorybookDependencies: Fix<MissingStorybookDependenciesOptio
 
   async check({ packageManager }) {
     // Dynamically import globby because it is a pure ESM module
+    // eslint-disable-next-line depend/ban-dependencies
     const { globby } = await import('globby');
 
     const result = await checkInstallations(packageManager, consolidatedPackages);

--- a/code/lib/cli-storybook/src/automigrate/fixes/prompt-remove-react.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/prompt-remove-react.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { JsPackageManager } from 'storybook/internal/common';
 import type { StorybookConfig } from 'storybook/internal/types';
 
+// eslint-disable-next-line depend/ban-dependencies
 import { glob } from 'glob';
 
 import { removeReactDependency } from './prompt-remove-react';

--- a/code/lib/cli-storybook/src/warn.ts
+++ b/code/lib/cli-storybook/src/warn.ts
@@ -7,6 +7,7 @@ interface Options {
 export const warn = async ({ hasTSDependency }: Options) => {
   if (!hasTSDependency) {
     // Dynamically import globby because it is a pure ESM module
+    // eslint-disable-next-line depend/ban-dependencies
     const { globby } = await import('globby');
 
     const files = await globby(['**/*.@(ts|tsx)', '!**/node_modules', '!**/*.d.ts']);

--- a/code/lib/codemod/src/index.ts
+++ b/code/lib/codemod/src/index.ts
@@ -65,6 +65,7 @@ export async function runCodemod(
   }
 
   // Dynamically import globby because it is a pure ESM module
+  // eslint-disable-next-line depend/ban-dependencies
   const { globby } = await import('globby');
 
   const files = await globby([glob, '!**/node_modules', '!**/dist']);

--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -11,6 +11,7 @@ import type { JsPackageManager } from 'storybook/internal/common';
 import { getPackageDetails, versions as packageVersions } from 'storybook/internal/common';
 import type { SupportedFrameworks } from 'storybook/internal/types';
 
+// eslint-disable-next-line depend/ban-dependencies
 import ora from 'ora';
 import invariant from 'tiny-invariant';
 import { dedent } from 'ts-dedent';

--- a/code/lib/create-storybook/src/scaffold-new-project.ts
+++ b/code/lib/create-storybook/src/scaffold-new-project.ts
@@ -7,6 +7,7 @@ import { GenerateNewProjectOnInitError } from 'storybook/internal/server-errors'
 import { telemetry } from 'storybook/internal/telemetry';
 
 import boxen from 'boxen';
+// eslint-disable-next-line depend/ban-dependencies
 import execa from 'execa';
 import picocolors from 'picocolors';
 import prompts from 'prompts';

--- a/code/package.json
+++ b/code/package.json
@@ -191,6 +191,7 @@
     "esbuild-plugin-alias": "^0.2.1",
     "eslint": "^8.56.0",
     "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-depend": "^0.11.0",
     "eslint-plugin-local-rules": "portal:../scripts/eslint-plugin-local-rules",
     "eslint-plugin-playwright": "^1.6.2",
     "eslint-plugin-storybook": "^0.8.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6891,6 +6891,7 @@ __metadata:
     esbuild-plugin-alias: "npm:^0.2.1"
     eslint: "npm:^8.56.0"
     eslint-import-resolver-typescript: "npm:^3.6.1"
+    eslint-plugin-depend: "npm:^0.11.0"
     eslint-plugin-local-rules: "portal:../scripts/eslint-plugin-local-rules"
     eslint-plugin-playwright: "npm:^1.6.2"
     eslint-plugin-storybook: "npm:^0.8.0"
@@ -14336,6 +14337,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-depend@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "eslint-plugin-depend@npm:0.11.0"
+  dependencies:
+    fd-package-json: "npm:^1.2.0"
+    module-replacements: "npm:^2.1.0"
+    semver: "npm:^7.6.3"
+  checksum: 10c0/64baf4d4f5d406efa1f13bda723ff0eb5fe4cee0ae8c3679fcdfccb4d7ba3a9472416fa3c54d75f1bde3e0123e55a85774662484a5b0355812f21a8968ee784a
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-eslint-comments@npm:^3.2.0":
   version: 3.2.0
   resolution: "eslint-plugin-eslint-comments@npm:3.2.0"
@@ -21037,6 +21049,13 @@ __metadata:
   version: 2.2.3
   resolution: "module-alias@npm:2.2.3"
   checksum: 10c0/47dc5b6d04f6e7df0ff330ca9b2a37c688a682ed661e9432b0b327e1e6c43eedad052151b8d50d6beea8b924828d2a92fa4625c18d651bf2d93d8f03aa0172fa
+  languageName: node
+  linkType: hard
+
+"module-replacements@npm:^2.1.0":
+  version: 2.5.0
+  resolution: "module-replacements@npm:2.5.0"
+  checksum: 10c0/7fcbcb19151778a2f2fa70b7bffb134bb8922b2306e2a0d7b4a863467a9d6d9d5fed537763c43272e22b69dbddaf1610746b42a68b4663aa225e85f9ae9b03c8
   languageName: node
   linkType: hard
 

--- a/scripts/.eslintrc.cjs
+++ b/scripts/.eslintrc.cjs
@@ -1,6 +1,11 @@
 module.exports = {
   root: true,
-  extends: ['@storybook/eslint-config-storybook', 'plugin:storybook/recommended'],
+  extends: [
+    //
+    '@storybook/eslint-config-storybook',
+    'plugin:storybook/recommended',
+    'plugin:depend/recommended'
+  ],
   parserOptions: {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
@@ -11,6 +16,9 @@ module.exports = {
     '@typescript-eslint/consistent-type-imports': ['error', { disallowTypeAnnotations: false }],
     'no-use-before-define': 'off',
     'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
+    "depend/ban-dependencies": ["error", {
+      "modules": ["lodash", "chalk", "qs", "handlebars", "fs-extra"]
+    }]
   },
   overrides: [
     {

--- a/scripts/bench/utils.ts
+++ b/scripts/bench/utils.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { ensureDir, readJSON, readdir, writeJSON } from 'fs-extra';
 import { join } from 'path';
 import type { Page } from 'playwright-core';

--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -1,5 +1,7 @@
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
 import { readJSON } from 'fs-extra';
 import { posix, resolve, sep } from 'path';
 import picocolors from 'picocolors';

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -2,7 +2,9 @@
 // without having to build dts files for all packages in the monorepo.
 // It is not implemented yet for angular, svelte and vue.
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
 import { readJSON } from 'fs-extra';
 import { resolve } from 'path';
 import picocolors from 'picocolors';

--- a/scripts/combine-compodoc.ts
+++ b/scripts/combine-compodoc.ts
@@ -1,8 +1,11 @@
 // Compodoc does not follow symlinks (it ignores them and their contents entirely)
 // So, we need to run a separate compodoc process on every symlink inside the project,
 // then combine the results into one large documentation.json
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
 import { lstat, readFile, realpath, writeFile } from 'fs-extra';
+// eslint-disable-next-line depend/ban-dependencies
 import { globSync } from 'glob';
 import { join, resolve } from 'path';
 

--- a/scripts/dangerfile.ts
+++ b/scripts/dangerfile.ts
@@ -4,8 +4,11 @@ import { danger, fail } from 'danger';
 
 execSync('npm install lodash');
 
+// eslint-disable-next-line depend/ban-dependencies
 const flatten = require('lodash/flatten.js');
+// eslint-disable-next-line depend/ban-dependencies
 const intersection = require('lodash/intersection.js');
+// eslint-disable-next-line depend/ban-dependencies
 const isEmpty = require('lodash/isEmpty.js');
 
 const pkg = require('../code/package.json');

--- a/scripts/get-report-message.ts
+++ b/scripts/get-report-message.ts
@@ -1,4 +1,6 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
 import { readJson } from 'fs-extra';
 import { join } from 'path';
 

--- a/scripts/get-template.ts
+++ b/scripts/get-template.ts
@@ -1,4 +1,5 @@
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import { pathExists, readFile } from 'fs-extra';
 import { readdir } from 'fs/promises';
 import picocolors from 'picocolors';

--- a/scripts/knip.config.ts
+++ b/scripts/knip.config.ts
@@ -1,5 +1,6 @@
 import { join, relative } from 'node:path';
 
+// eslint-disable-next-line depend/ban-dependencies
 import fg from 'fast-glob';
 import type { KnipConfig } from 'knip';
 import { match } from 'minimatch';

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -112,6 +112,7 @@
     "eslint": "^8.57.0",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-depend": "^0.11.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-file-progress": "^1.4.0",
     "eslint-plugin-html": "^8.1.1",

--- a/scripts/prepare/addon-bundle.ts
+++ b/scripts/prepare/addon-bundle.ts
@@ -3,7 +3,9 @@ import { builtinModules } from 'node:module';
 
 import type { Metafile } from 'esbuild';
 import aliasPlugin from 'esbuild-plugin-alias';
+// eslint-disable-next-line depend/ban-dependencies
 import * as fs from 'fs-extra';
+// eslint-disable-next-line depend/ban-dependencies
 import { glob } from 'glob';
 import { dirname, join, parse, posix, relative, sep } from 'path';
 import slash from 'slash';

--- a/scripts/prepare/bundle.ts
+++ b/scripts/prepare/bundle.ts
@@ -3,7 +3,9 @@ import { dirname, join, parse, posix, relative, resolve, sep } from 'node:path';
 
 import type { Metafile } from 'esbuild';
 import aliasPlugin from 'esbuild-plugin-alias';
+// eslint-disable-next-line depend/ban-dependencies
 import * as fs from 'fs-extra';
+// eslint-disable-next-line depend/ban-dependencies
 import { glob } from 'glob';
 import slash from 'slash';
 import { dedent } from 'ts-dedent';

--- a/scripts/prepare/check.ts
+++ b/scripts/prepare/check.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import fs from 'fs-extra';
 import { join } from 'path';
 import ts from 'typescript';

--- a/scripts/prepare/tools.ts
+++ b/scripts/prepare/tools.ts
@@ -5,7 +5,9 @@ import * as process from 'node:process';
 import { globalExternals } from '@fal-works/esbuild-plugin-global-externals';
 import { spawn } from 'cross-spawn';
 import * as esbuild from 'esbuild';
+// eslint-disable-next-line depend/ban-dependencies
 import { readJson } from 'fs-extra';
+// eslint-disable-next-line depend/ban-dependencies
 import { glob } from 'glob';
 import limit from 'p-limit';
 import picocolors from 'picocolors';

--- a/scripts/prepare/tsc.ts
+++ b/scripts/prepare/tsc.ts
@@ -1,4 +1,6 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { emptyDir, move, readJson } from 'fs-extra';
+// eslint-disable-next-line depend/ban-dependencies
 import { globSync } from 'glob';
 import { join } from 'path';
 import * as ts from 'typescript';

--- a/scripts/release/__tests__/is-pr-frozen.test.ts
+++ b/scripts/release/__tests__/is-pr-frozen.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
+// eslint-disable-next-line depend/ban-dependencies
 import * as fsExtraImp from 'fs-extra';
 import * as simpleGitImp from 'simple-git';
 

--- a/scripts/release/__tests__/version.test.ts
+++ b/scripts/release/__tests__/version.test.ts
@@ -3,7 +3,9 @@ import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
 import * as fsExtraImp from 'fs-extra';
 
 import type * as MockedFSToExtra from '../../../code/__mocks__/fs-extra';

--- a/scripts/release/__tests__/write-changelog.test.ts
+++ b/scripts/release/__tests__/write-changelog.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// eslint-disable-next-line depend/ban-dependencies
 import * as fsExtraImp from 'fs-extra';
 import { dedent } from 'ts-dedent';
 

--- a/scripts/release/get-changelog-from-file.ts
+++ b/scripts/release/get-changelog-from-file.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 
 import { setOutput } from '@actions/core';
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import { readFile } from 'fs-extra';
 import picocolors from 'picocolors';
 import semver from 'semver';

--- a/scripts/release/get-current-version.ts
+++ b/scripts/release/get-current-version.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 
 import { setOutput } from '@actions/core';
+// eslint-disable-next-line depend/ban-dependencies
 import { readJson } from 'fs-extra';
 import picocolors from 'picocolors';
 

--- a/scripts/release/is-pr-frozen.ts
+++ b/scripts/release/is-pr-frozen.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 
 import { setOutput } from '@actions/core';
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import { readJson } from 'fs-extra';
 import picocolors from 'picocolors';
 

--- a/scripts/release/label-patches.ts
+++ b/scripts/release/label-patches.ts
@@ -1,4 +1,5 @@
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import ora from 'ora';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/scripts/release/pick-patches.ts
+++ b/scripts/release/pick-patches.ts
@@ -1,5 +1,6 @@
 import { setOutput } from '@actions/core';
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import ora from 'ora';
 import picocolors from 'picocolors';
 import invariant from 'tiny-invariant';

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -1,7 +1,9 @@
 import { join } from 'node:path';
 
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
 import { readJson } from 'fs-extra';
 import pRetry from 'p-retry';
 import picocolors from 'picocolors';

--- a/scripts/release/version.ts
+++ b/scripts/release/version.ts
@@ -2,7 +2,9 @@ import { join } from 'node:path';
 
 import { setOutput } from '@actions/core';
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
 import { readFile, readJson, writeFile, writeJson } from 'fs-extra';
 import picocolors from 'picocolors';
 import semver from 'semver';

--- a/scripts/release/write-changelog.ts
+++ b/scripts/release/write-changelog.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import { readFile, writeFile, writeJson } from 'fs-extra';
 import picocolors from 'picocolors';
 import semver from 'semver';

--- a/scripts/reset.js
+++ b/scripts/reset.js
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import { appendFile, writeFileSync } from 'node:fs';
 
+// eslint-disable-next-line depend/ban-dependencies
 import { remove } from 'fs-extra';
 import trash from 'trash';
 

--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -5,7 +5,9 @@ import type { Server } from 'node:http';
 import { join, resolve as resolvePath } from 'node:path';
 
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import { execa, execaSync } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
 import { pathExists, readJSON, remove } from 'fs-extra';
 import pLimit from 'p-limit';
 import picocolors from 'picocolors';

--- a/scripts/sandbox/generate.ts
+++ b/scripts/sandbox/generate.ts
@@ -1,7 +1,10 @@
 import * as ghActions from '@actions/core';
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import type { Options as ExecaOptions } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
 import { copy, emptyDir, ensureDir, move, remove, rename, writeFile } from 'fs-extra';
 import pLimit from 'p-limit';
 import { join, relative } from 'path';

--- a/scripts/sandbox/publish.ts
+++ b/scripts/sandbox/publish.ts
@@ -1,7 +1,10 @@
 import { program } from 'commander';
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
 import { existsSync } from 'fs';
+// eslint-disable-next-line depend/ban-dependencies
 import { copy, emptyDir, remove, writeFile } from 'fs-extra';
+// eslint-disable-next-line depend/ban-dependencies
 import { glob } from 'glob';
 import { dirname, join, relative } from 'path';
 

--- a/scripts/sandbox/utils/git.ts
+++ b/scripts/sandbox/utils/git.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
 import invariant from 'tiny-invariant';
 

--- a/scripts/sandbox/utils/template.ts
+++ b/scripts/sandbox/utils/template.ts
@@ -1,4 +1,5 @@
 import { render } from 'ejs';
+// eslint-disable-next-line depend/ban-dependencies
 import { readFile } from 'fs-extra';
 import prettier from 'prettier';
 

--- a/scripts/sandbox/utils/yarn.ts
+++ b/scripts/sandbox/utils/yarn.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { move, remove } from 'fs-extra';
 import { join } from 'path';
 

--- a/scripts/strict-ts.ts
+++ b/scripts/strict-ts.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+// eslint-disable-next-line depend/ban-dependencies
 import glob from 'fast-glob';
 import JSON5 from 'json5';
 

--- a/scripts/task.ts
+++ b/scripts/task.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { outputFile, pathExists, readFile } from 'fs-extra';
 import type { TestCase } from 'junit-xml';
 import { getJunitXml } from 'junit-xml';

--- a/scripts/tasks/build.ts
+++ b/scripts/tasks/build.ts
@@ -1,4 +1,5 @@
 import dirSize from 'fast-folder-size';
+// eslint-disable-next-line depend/ban-dependencies
 import { pathExists } from 'fs-extra';
 import { join } from 'path';
 import { promisify } from 'util';

--- a/scripts/tasks/compile.ts
+++ b/scripts/tasks/compile.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { readFile } from 'fs-extra';
 import { resolve } from 'path';
 

--- a/scripts/tasks/generate.ts
+++ b/scripts/tasks/generate.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { pathExists, remove } from 'fs-extra';
 import { join } from 'path';
 

--- a/scripts/tasks/install.ts
+++ b/scripts/tasks/install.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { pathExists, remove } from 'fs-extra';
 import { join } from 'path';
 

--- a/scripts/tasks/publish.ts
+++ b/scripts/tasks/publish.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { pathExists } from 'fs-extra';
 import { resolve } from 'path';
 

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -1,6 +1,7 @@
 // This file requires many imports from `../code`, which requires both an install and bootstrap of
 // the repo to work properly. So we load it async in the task runner *after* those steps.
 import { isFunction } from 'es-toolkit';
+// eslint-disable-next-line depend/ban-dependencies
 import {
   copy,
   ensureDir,

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -1,4 +1,5 @@
 import dirSize from 'fast-folder-size';
+// eslint-disable-next-line depend/ban-dependencies
 import { pathExists, remove } from 'fs-extra';
 import { join } from 'path';
 import { promisify } from 'util';

--- a/scripts/upload-bench.ts
+++ b/scripts/upload-bench.ts
@@ -1,4 +1,5 @@
 import { BigQuery } from '@google-cloud/bigquery';
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
 import { join } from 'path';
 

--- a/scripts/utils/exec.ts
+++ b/scripts/utils/exec.ts
@@ -1,5 +1,5 @@
-import type { ExecaChildProcess, Options } from 'execa';
-import { execa } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
+import { type ExecaChildProcess, type Options, execa } from 'execa';
 import picocolors from 'picocolors';
 
 const logger = console;

--- a/scripts/utils/filterExistsInCodeDir.ts
+++ b/scripts/utils/filterExistsInCodeDir.ts
@@ -1,5 +1,6 @@
 import { join, resolve } from 'node:path';
 
+// eslint-disable-next-line depend/ban-dependencies
 import { pathExists } from 'fs-extra';
 
 import { CODE_DIRECTORY } from './constants';

--- a/scripts/utils/package-json.ts
+++ b/scripts/utils/package-json.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { readJSON, writeJSON } from 'fs-extra';
 import { join } from 'path';
 

--- a/scripts/utils/paths.ts
+++ b/scripts/utils/paths.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { pathExists } from 'fs-extra';
 import { join } from 'path';
 

--- a/scripts/utils/workspace.ts
+++ b/scripts/utils/workspace.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line depend/ban-dependencies
 import { execaCommand } from 'execa';
 import memoize from 'memoizerific';
 

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
 
+// eslint-disable-next-line depend/ban-dependencies
 import { pathExists, readJSON, writeJSON } from 'fs-extra';
 
 // TODO -- should we generate this file a second time outside of CLI?

--- a/scripts/vite-ecosystem-ci/before-test.js
+++ b/scripts/vite-ecosystem-ci/before-test.js
@@ -8,7 +8,8 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { execa, execaCommand } from 'execa';
+// eslint-disable-next-line depend/ban-dependencies
+import { execaCommand } from 'execa';
 
 const filename = fileURLToPath(import.meta.url);
 // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -1576,6 +1576,7 @@ __metadata:
     eslint: "npm:^8.57.0"
     eslint-config-airbnb-typescript: "npm:^18.0.0"
     eslint-config-prettier: "npm:^9.1.0"
+    eslint-plugin-depend: "npm:^0.11.0"
     eslint-plugin-eslint-comments: "npm:^3.2.0"
     eslint-plugin-file-progress: "npm:^1.4.0"
     eslint-plugin-html: "npm:^8.1.1"
@@ -5517,6 +5518,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-depend@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "eslint-plugin-depend@npm:0.11.0"
+  dependencies:
+    fd-package-json: "npm:^1.2.0"
+    module-replacements: "npm:^2.1.0"
+    semver: "npm:^7.6.3"
+  checksum: 10c0/64baf4d4f5d406efa1f13bda723ff0eb5fe4cee0ae8c3679fcdfccb4d7ba3a9472416fa3c54d75f1bde3e0123e55a85774662484a5b0355812f21a8968ee784a
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-eslint-comments@npm:^3.2.0":
   version: 3.2.0
   resolution: "eslint-plugin-eslint-comments@npm:3.2.0"
@@ -6179,6 +6191,15 @@ __metadata:
   dependencies:
     reusify: "npm:^1.0.4"
   checksum: 10c0/5ce4f83afa5f88c9379e67906b4d31bc7694a30826d6cc8d0f0473c966929017fda65c2174b0ec89f064ede6ace6c67f8a4fe04cef42119b6a55b0d465554c24
+  languageName: node
+  linkType: hard
+
+"fd-package-json@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "fd-package-json@npm:1.2.0"
+  dependencies:
+    walk-up-path: "npm:^3.0.1"
+  checksum: 10c0/712a78a12bd8ec8482867b26bbcb2ff1dca9b096a416150c138e1512f1879c6d23dfb41b03b8e9226afc1e58a35df4738e9f9ae57032ff1dbbae75acfb70343b
   languageName: node
   linkType: hard
 
@@ -9820,6 +9841,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"module-replacements@npm:^2.1.0":
+  version: 2.5.0
+  resolution: "module-replacements@npm:2.5.0"
+  checksum: 10c0/7fcbcb19151778a2f2fa70b7bffb134bb8922b2306e2a0d7b4a863467a9d6d9d5fed537763c43272e22b69dbddaf1610746b42a68b4663aa225e85f9ae9b03c8
+  languageName: node
+  linkType: hard
+
 "mount-point@npm:^3.0.0":
   version: 3.0.0
   resolution: "mount-point@npm:3.0.0"
@@ -12378,6 +12406,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/e3d79b609071caa78bcb6ce2ad81c7966a46a7431d9d58b8800cfa9cb6a63699b3899a0e4bcce36167a284578212d9ae6942b6929ba4aa5015c079a67751d42d
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.6.3":
+  version: 7.6.3
+  resolution: "semver@npm:7.6.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/88f33e148b210c153873cb08cfe1e281d518aaa9a666d4d148add6560db5cd3c582f3a08ccb91f38d5f379ead256da9931234ed122057f40bb5766e65e58adaf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/29251

## What I did

- [x] add eslint plugin + preset to disallow packages
- [x] add some packages to custom list
- [x] add ignore lines to where we currently still use those

We will be removing those uses over time.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.5 MB | 78.5 MB | 0 B | **4.04** | 0% |
| initSize |  151 MB | 151 MB | 2.19 kB | -0.62 | 0% |
| diffSize |  72.5 MB | 72.6 MB | 2.19 kB | -0.78 | 0% |
| buildSize |  6.77 MB | 6.77 MB | 0 B | -1.21 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | -1.22 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 0 B | -1.19 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | -1.22 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 0 B | -1.21 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | **-1.61** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  10.3s | 19.8s | 9.5s | 0.96 | 48% |
| generateTime |  24.9s | 23.4s | -1s -511ms | 0.87 | -6.5% |
| initTime |  17.7s | 14.7s | -3s -28ms | -0.24 | -20.6% |
| buildTime |  8.9s | 8.4s | -525ms | **-1.32** | 🔰-6.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.6s | 5.8s | -1s -741ms | -1.13 | -29.6% |
| devManagerResponsive |  4.7s | 3.8s | -889ms | -1.05 | -23% |
| devManagerHeaderVisible |  667ms | 483ms | -184ms | -1.18 | -38.1% |
| devManagerIndexVisible |  701ms | 492ms | -209ms | **-1.32** | 🔰-42.5% |
| devStoryVisibleUncached |  1.4s | 596ms | -876ms | **-1.43** | 🔰-147% |
| devStoryVisible |  716ms | 518ms | -198ms | -1.15 | -38.2% |
| devAutodocsVisible |  609ms | 450ms | -159ms | -0.83 | -35.3% |
| devMDXVisible |  585ms | 465ms | -120ms | -0.71 | -25.8% |
| buildManagerHeaderVisible |  550ms | 468ms | -82ms | -0.6 | -17.5% |
| buildManagerIndexVisible |  553ms | 471ms | -82ms | -0.66 | -17.4% |
| buildStoryVisible |  626ms | 501ms | -125ms | -0.74 | -25% |
| buildAutodocsVisible |  575ms | 395ms | -180ms | -0.94 | -45.6% |
| buildMDXVisible |  506ms | 383ms | -123ms | -1.06 | -32.1% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR implements ESLint rules to disallow certain packages across the Storybook codebase, focusing on dependency management and code quality.

- Added 'eslint-plugin-depend' to enforce stricter dependency rules
- Introduced ESLint disable comments for specific imports (e.g., 'glob', 'execa', 'fs-extra') to maintain functionality while working towards future removal
- Updated scripts/.eslintrc.cjs to ban dependencies like 'lodash', 'chalk', 'qs', 'handlebars', and 'fs-extra'
- Modified multiple files across the codebase to comply with new ESLint rules, primarily by adding disable comments

<!-- /greptile_comment -->