### PR TITLE
CLI: Update the React Native init to include v8 dependencies

### DIFF
--- a/code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts
+++ b/code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts
@@ -14,15 +14,19 @@ const generator = async (
 
   const reactVersion = packageJson.dependencies.react;
 
-  const controlsPeerDependencies = [
+  const peerDependencies = [
     'react-native-safe-area-context',
     '@react-native-async-storage/async-storage',
     '@react-native-community/datetimepicker',
     '@react-native-community/slider',
+    'react-native-reanimated',
+    'react-native-gesture-handler',
+    '@gorhom/bottom-sheet',
+    'react-native-svg',
   ].filter((dep) => !packageJson.dependencies[dep] && !packageJson.devDependencies[dep]);
 
   const packagesToResolve = [
-    ...controlsPeerDependencies,
+    ...peerDependencies,
     '@storybook/addon-ondevice-controls',
     '@storybook/addon-ondevice-actions',
     '@storybook/react-native',
@@ -57,7 +61,8 @@ const generator = async (
   await copyTemplateFiles({
     packageManager,
     renderer: 'react-native',
-    language: SupportedLanguage.TYPESCRIPT_3_8,
+    // this value for language is not used since we only ship the ts template. This means we just fallback to @storybook/react-native/template/cli.
+    language: SupportedLanguage.TYPESCRIPT_4_9,
     destination: storybookConfigFolder,
   });
 };

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -356,7 +356,7 @@ export async function doInitiate(options: CommandOptions): Promise<
       
       ${picocolors.inverse(' ' + "export {default} from './.storybook';" + ' ')}
       
-      2. Wrap your metro config with the withStorybook enhancer function like: 
+      2. Wrap your metro config with the withStorybook enhancer function like this: 
       
       ${picocolors.inverse(' ' + "const withStorybook = require('@storybook/react-native/metro/withStorybook');" + ' ')}
       ${picocolors.inverse(' ' + 'module.exports = withStorybook(defaultConfig);' + ' ')}

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -356,10 +356,13 @@ export async function doInitiate(options: CommandOptions): Promise<
       
       ${picocolors.inverse(' ' + "export {default} from './.storybook';" + ' ')}
       
-      2. Enable transformer.unstable_allowRequireContext in your metro config
+      2. Wrap your metro config with the withStorybook enhancer function like: 
       
-      For a more detailed guide go to:
-      ${picocolors.cyan('https://github.com/storybookjs/react-native#existing-project')}
+      ${picocolors.inverse(' ' + "const withStorybook = require('@storybook/react-native/metro/withStorybook');" + ' ')}
+      ${picocolors.inverse(' ' + 'module.exports = withStorybook(defaultConfig);' + ' ')}
+
+      For more details go to:
+      ${picocolors.cyan('https://github.com/storybookjs/react-native#getting-started')}
       
       Then to run your Storybook, type:
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I've added new dependencies for react native storybook v8 so we can be ready to release

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.5 MB | 78.5 MB | 102 B | **2.92** | 0% |
| initSize |  151 MB | 151 MB | 3.47 kB | -0.55 | 0% |
| diffSize |  72.6 MB | 72.6 MB | 3.37 kB | -0.71 | 0% |
| buildSize |  6.77 MB | 6.77 MB | 0 B | -1.09 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | -1.11 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 0 B | -1.07 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | -1.11 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 0 B | -1.09 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | **-1.45** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  16.7s | 12s | -4s -773ms | -0.33 | -39.7% |
| generateTime |  18.7s | 30s | 11.3s | **3.34** | 🔺37.7% |
| initTime |  13.2s | 15.8s | 2.6s | 0.45 | 16.6% |
| buildTime |  8.8s | 9.3s | 428ms | -0.5 | 4.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.3s | 7.1s | -1s -148ms | -0.06 | -16% |
| devManagerResponsive |  5.7s | 4.5s | -1s -153ms | -0.09 | -25.2% |
| devManagerHeaderVisible |  545ms | 580ms | 35ms | -0.36 | 6% |
| devManagerIndexVisible |  574ms | 615ms | 41ms | -0.34 | 6.7% |
| devStoryVisibleUncached |  1.2s | 1.3s | 92ms | 0.33 | 7% |
| devStoryVisible |  573ms | 613ms | 40ms | -0.37 | 6.5% |
| devAutodocsVisible |  459ms | 591ms | 132ms | 0.61 | 22.3% |
| devMDXVisible |  455ms | 630ms | 175ms | 0.74 | 27.8% |
| buildManagerHeaderVisible |  532ms | 647ms | 115ms | 0.47 | 17.8% |
| buildManagerIndexVisible |  560ms | 719ms | 159ms | 0.72 | 22.1% |
| buildStoryVisible |  562ms | 720ms | 158ms | 0.6 | 21.9% |
| buildAutodocsVisible |  490ms | 501ms | 11ms | -0.3 | 2.2% |
| buildMDXVisible |  538ms | 507ms | -31ms | -0.16 | -6.1% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated React Native generator for Storybook version 8, focusing on new dependencies and setup process.

- Added new peer dependencies in `code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts`
- Updated language version to TypeScript 4.9 for React Native template
- Modified `code/lib/create-storybook/src/initiate.ts` to include new setup instructions for React Native projects
- Introduced 'withStorybook' enhancer function for Metro config in React Native setup
- Adjusted package installation process for React Native Storybook integration

<!-- /greptile_comment -->