### PR TITLE
Build: Filter out @storybook/root from buildable packages

### DIFF
--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -9,7 +9,7 @@ import windowSize from 'window-size';
 import { getWorkspaces } from './utils/workspace';
 
 async function run() {
-  const packages = await getWorkspaces();
+  const packages = (await getWorkspaces()).filter(({ name }) => name !== '@storybook/root');
   const packageTasks = packages
     .map((pkg) => {
       let suffix = pkg.name.replace('@storybook/', '');


### PR DESCRIPTION
## What I did

I noticed while peering with @shilman that the `yarn build --watch` commands includes the root dummy package which isn't buildable and causes the script to fail if selected.

This PR removes that specific package from the available package list. It is done on the script side to avoid any future issues with other consumers of the getPackages function.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
> [!CAUTION]
> No automatic tests.

#### Manual testing

1. Run `yarn build` command
2. Notice `@storybook/root` is gone


### Documentation
> [!CAUTION]
> No doc.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 0 B | 1.23 | 0% |
| initSize |  150 MB | 151 MB | 792 kB | -0.17 | 0.5% |
| diffSize |  71.8 MB | 72.6 MB | 792 kB | -0.7 | 1.1% |
| buildSize |  6.77 MB | 6.77 MB | 0 B | -0.49 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | -0.5 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 0 B | -0.48 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | -0.5 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 0 B | -0.49 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | -0.77 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  20.4s | 5.8s | -14s -588ms | **-1.46** | 🔰-248.9% |
| generateTime |  19.8s | 21.1s | 1.2s | -0.06 | 6.1% |
| initTime |  13.5s | 17.3s | 3.8s | 1.22 | 22.1% |
| buildTime |  9.9s | 8.2s | -1s -686ms | **-1.45** | 🔰-20.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.1s | 6.5s | 357ms | -0.62 | 5.5% |
| devManagerResponsive |  3.9s | 4.2s | 239ms | -0.63 | 5.6% |
| devManagerHeaderVisible |  582ms | 601ms | 19ms | -0.19 | 3.2% |
| devManagerIndexVisible |  617ms | 634ms | 17ms | -0.2 | 2.7% |
| devStoryVisibleUncached |  1s | 1.1s | 56ms | -0.44 | 5.1% |
| devStoryVisible |  619ms | 635ms | 16ms | -0.2 | 2.5% |
| devAutodocsVisible |  443ms | 518ms | 75ms | -0.14 | 14.5% |
| devMDXVisible |  496ms | 452ms | -44ms | -0.74 | -9.7% |
| buildManagerHeaderVisible |  463ms | 471ms | 8ms | -0.65 | 1.7% |
| buildManagerIndexVisible |  466ms | 500ms | 34ms | -0.56 | 6.8% |
| buildStoryVisible |  542ms | 501ms | -41ms | -0.74 | -8.2% |
| buildAutodocsVisible |  412ms | 473ms | 61ms | -0.48 | 12.9% |
| buildMDXVisible |  437ms | 416ms | -21ms | -0.87 | -5% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This change modifies the build script to exclude the non-buildable '@storybook/root' package from the list of buildable packages.

- Updated `scripts/build-package.ts` to filter out '@storybook/root' from buildable packages
- Prevents build script failures when the non-buildable root dummy package is selected
- Modification made in the script to avoid potential issues with other consumers of getPackages function
- Improves reliability of `yarn build` and `yarn build --watch` commands

<!-- /greptile_comment -->