### PR TITLE
React-vite: Upgrade react-docgen-typescript plugin

### DIFF
--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -47,7 +47,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.0",
+    "@joshwooding/vite-plugin-react-docgen-typescript": "^0.4.1",
     "@rollup/pluginutils": "^5.0.2",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -3677,12 +3677,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.0":
-  version: 0.3.0
-  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.0"
+"@joshwooding/vite-plugin-react-docgen-typescript@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.4.1"
   dependencies:
-    glob: "npm:^7.2.0"
-    glob-promise: "npm:^4.2.0"
     magic-string: "npm:^0.27.0"
     react-docgen-typescript: "npm:^2.2.2"
   peerDependencies:
@@ -3691,7 +3689,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/31098ad8fcc2440437534599c111d9f2951dd74821e8ba46c521b969bae4c918d830b7bb0484efbad29a51711bb62d3bc623d5a1ed5b1695b5b5594ea9dd4ca0
+  checksum: 10c0/bd8f1fd723fdf8110831cd07eae5e9ad988331d7232150b72c2e2b49bccdd939a5735ba6b1b146a2a9632bba80bbd3b1782f8cf81279c7add45354d6f7b3e02d
   languageName: node
   linkType: hard
 
@@ -6701,7 +6699,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/react-vite@workspace:frameworks/react-vite"
   dependencies:
-    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.3.0"
+    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:^0.4.1"
     "@rollup/pluginutils": "npm:^5.0.2"
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": "workspace:*"
@@ -7882,7 +7880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/glob@npm:^7.1.1, @types/glob@npm:^7.1.3":
+"@types/glob@npm:^7.1.1":
   version: 7.2.0
   resolution: "@types/glob@npm:7.2.0"
   dependencies:
@@ -16212,17 +16210,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-promise@npm:^4.2.0":
-  version: 4.2.2
-  resolution: "glob-promise@npm:4.2.2"
-  dependencies:
-    "@types/glob": "npm:^7.1.3"
-  peerDependencies:
-    glob: ^7.1.6
-  checksum: 10c0/3eb01bed2901539365df6a4d27800afb8788840647d01f9bf3500b3de756597f2ff4b8c823971ace34db228c83159beca459dc42a70968d4e9c8200ed2cc96bd
-  languageName: node
-  linkType: hard
-
 "glob-to-regexp@npm:^0.4.1":
   version: 0.4.1
   resolution: "glob-to-regexp@npm:0.4.1"
@@ -16259,7 +16246,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.2.0":
+"glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:


### PR DESCRIPTION
## What I did

I updated [@joshwooding/vite-plugin-react-docgen-typescript@0.4.1](https://github.com/joshwooding/vite-plugin-react-docgen-typescript/releases/tag/%40joshwooding%2Fvite-plugin-react-docgen-typescript%400.4.1) in the react-vite framework.

The current version uses a deprecated version of `glob`, which throws warnings when Storybook is used with PNPM and looks kinda goofy.

There still is one instance of the deprecated `glob` in the ecosystem, through `auto` used in the addon-kit, but those aren't as public-facing so they're less detrimental reputation-wise.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

> [!CAUTION]
> No automated tests were made. **I do not know if CI would catch react docgen issues.**

#### Manual testing

I built the package and ran `storybook:ui`, did not spot any errors, but there is relatively little docgen input data in that stack as almost no prop tables have descriptions.

I cannot guarantee for sure an absence of regressions, though I believe the upstream dep update was non-breaking despite the < v0 minor change.


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 0 B | **1.53** | 0% |
| initSize |  151 MB | 151 MB | -111 kB | -0.53 | -0.1% |
| diffSize |  72.6 MB | 72.4 MB | -111 kB | -1.08 | -0.2% |
| buildSize |  6.77 MB | 6.77 MB | 0 B | -0.65 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | -0.65 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 0 B | -0.63 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | -0.65 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 0 B | -0.65 | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | -0.93 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  20s | 15.1s | -4s -862ms | 0.2 | -32.1% |
| generateTime |  21.1s | 23.6s | 2.4s | 0.97 | 10.5% |
| initTime |  15.4s | 16s | 524ms | 0.56 | 3.3% |
| buildTime |  10s | 9.3s | -649ms | -0.37 | -6.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.8s | 7.7s | 871ms | 0.59 | 11.2% |
| devManagerResponsive |  4.3s | 5s | 635ms | 0.64 | 12.6% |
| devManagerHeaderVisible |  656ms | 627ms | -29ms | 0.1 | -4.6% |
| devManagerIndexVisible |  690ms | 676ms | -14ms | 0.22 | -2.1% |
| devStoryVisibleUncached |  1.2s | 1.1s | -67ms | -0.11 | -5.8% |
| devStoryVisible |  684ms | 674ms | -10ms | 0.19 | -1.5% |
| devAutodocsVisible |  547ms | 512ms | -35ms | -0.09 | -6.8% |
| devMDXVisible |  613ms | 501ms | -112ms | -0.3 | -22.4% |
| buildManagerHeaderVisible |  593ms | 533ms | -60ms | -0.22 | -11.3% |
| buildManagerIndexVisible |  595ms | 572ms | -23ms | -0.1 | -4% |
| buildStoryVisible |  670ms | 570ms | -100ms | -0.29 | -17.5% |
| buildAutodocsVisible |  498ms | 520ms | 22ms | -0.16 | 4.2% |
| buildMDXVisible |  556ms | 620ms | 64ms | 0.73 | 10.3% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request updates the @joshwooding/vite-plugin-react-docgen-typescript dependency in the react-vite framework to address warnings related to a deprecated 'glob' version when using Storybook with PNPM.

- Updated `@joshwooding/vite-plugin-react-docgen-typescript` from 0.3.0 to ^0.4.1 in `code/frameworks/react-vite/package.json`
- Change aims to resolve warnings when Storybook is used with PNPM
- No automated tests added; manual testing limited to building and running 'storybook:ui'
- Potential impact on React docgen functionality, though believed to be non-breaking
- Author notes one remaining instance of deprecated 'glob' in the ecosystem through 'auto' in addon-kit

<!-- /greptile_comment -->