### PR TITLE
Addon Test: Fix test run cache

### DIFF
--- a/code/addons/test/src/node/vitest-manager.ts
+++ b/code/addons/test/src/node/vitest-manager.ts
@@ -13,8 +13,6 @@ export class VitestManager {
 
   vitestStartupCounter = 0;
 
-  private watchMode = false;
-
   constructor(
     private channel: Channel,
     private testManager: TestManager
@@ -23,7 +21,6 @@ export class VitestManager {
   async startVitest(watchMode = false) {
     const { createVitest } = await import('vitest/node');
 
-    this.watchMode = watchMode;
     this.vitest = await createVitest('test', {
       watch: watchMode,
       passWithNoTests: true,

--- a/code/addons/test/src/node/vitest-manager.ts
+++ b/code/addons/test/src/node/vitest-manager.ts
@@ -89,7 +89,7 @@ export class VitestManager {
       });
       if (match) {
         // make sure to clear the file cache so test results are updated even if watch mode is not enabled
-        if (!this.watchMode) {
+        if (!this.testManager.watchMode) {
           this.updateLastChanged(storybookTest.moduleId);
         }
 

--- a/code/addons/test/src/node/vitest-manager.ts
+++ b/code/addons/test/src/node/vitest-manager.ts
@@ -40,10 +40,7 @@ export class VitestManager {
       },
     });
 
-    // TODO what should happen if there's no projects?
-    if (this.vitest?.projects.length) {
-      await this.vitest.init();
-    }
+    await this.vitest.init();
   }
 
   async runAllTests() {
@@ -51,9 +48,15 @@ export class VitestManager {
       await this.startVitest();
     }
 
-    const tests = await this.getStorybookTestSpecs();
+    const storybookTests = await this.getStorybookTestSpecs();
+    for (const storybookTest of storybookTests) {
+      // make sure to clear the file cache so test results are updated even if watch mode is not enabled
+      if (!this.testManager.watchMode) {
+        this.updateLastChanged(storybookTest.moduleId);
+      }
+    }
     await this.cancelCurrentRun();
-    await this.vitest!.runFiles(tests, true);
+    await this.vitest!.runFiles(storybookTests, true);
   }
 
   private updateLastChanged(filepath: string) {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/29289

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR updates the vitest manager code to invalidate cache on test request.
This was implemented before in the coverage prototype, so I'm bringing it over and adding a minor improvement on top of it:
https://github.com/storybookjs/storybook/pull/28882/files#diff-2ee3063481b394f275d2b92ed78e32eafb5ea0eefeb838e3ab890595b90bc901R200

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.5 MB | 78.7 MB | 128 kB | **1.55** | 0.2% |
| initSize |  151 MB | 152 MB | 1.25 MB | 0.3 | 0.8% |
| diffSize |  72.6 MB | 73.7 MB | 1.12 MB | -0.54 | 1.5% |
| buildSize |  7.07 MB | 7.07 MB | 0 B | **-2** | 0% |
| buildSbAddonsSize |  1.78 MB | 1.78 MB | 0 B | **-2** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 0 B | **-1.99** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | **-2** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.09 MB | 4.09 MB | 0 B | **-2** | 0% |
| buildPreviewSize |  2.98 MB | 2.98 MB | 0 B | 0.5 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  21.2s | 12.5s | -8s -639ms | -0.65 | -68.7% |
| generateTime |  19.6s | 44.7s | 25s | **27.96** | 🔺56% |
| initTime |  14s | 34.1s | 20s | **24.67** | 🔺58.8% |
| buildTime |  10.8s | 10.8s | 38ms | 0.22 | 0.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.5s | 6.1s | -424ms | -0.58 | -6.9% |
| devManagerResponsive |  4.3s | 4s | -237ms | -0.44 | -5.8% |
| devManagerHeaderVisible |  588ms | 538ms | -50ms | -1 | -9.3% |
| devManagerIndexVisible |  623ms | 569ms | -54ms | -1.05 | -9.5% |
| devStoryVisibleUncached |  1.2s | 864ms | -401ms | **-2.36** | 🔰-46.4% |
| devStoryVisible |  625ms | 571ms | -54ms | -1.04 | -9.5% |
| devAutodocsVisible |  576ms | 480ms | -96ms | -1.18 | -20% |
| devMDXVisible |  557ms | 507ms | -50ms | -0.55 | -9.9% |
| buildManagerHeaderVisible |  582ms | 484ms | -98ms | **-1.76** | 🔰-20.2% |
| buildManagerIndexVisible |  592ms | 486ms | -106ms | **-1.67** | 🔰-21.8% |
| buildStoryVisible |  619ms | 536ms | -83ms | **-1.38** | 🔰-15.5% |
| buildAutodocsVisible |  571ms | 409ms | -162ms | **-1.95** | 🔰-39.6% |
| buildMDXVisible |  519ms | 462ms | -57ms | **-2.09** | 🔰-12.3% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR addresses a cache invalidation issue in the VitestManager class, improving test execution in non-watch mode.

- Added `updateLastChanged` method in `VitestManager` to invalidate module cache for server and browser
- Implemented cache invalidation in `runTests` method when not in watch mode
- Ensures file changes are detected when running tests directly without watch mode
- Fixes issue #29289 related to cache problems with direct story test runs
- Improves test reliability by ensuring the latest file changes are considered

<!-- /greptile_comment -->