### PR TITLE
Addon-docs, blocks: Prebundle dependencies

### DIFF
--- a/code/addons/docs/angular/index.js
+++ b/code/addons/docs/angular/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-underscore-dangle */
-import { global } from '@storybook/global';
 
 export const setCompodocJson = (compodocJson) => {
   // @ts-expect-error (Converted from ts-ignore)
-  global.__STORYBOOK_COMPODOC_JSON__ = compodocJson;
+  globalThis.__STORYBOOK_COMPODOC_JSON__ = compodocJson;
 };

--- a/code/addons/docs/ember/index.js
+++ b/code/addons/docs/ember/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { global } from '@storybook/global';
 
 export const setJSONDoc = (jsondoc) => {
-  global.__EMBER_GENERATED_DOC_JSON__ = jsondoc;
+  globalThis.__EMBER_GENERATED_DOC_JSON__ = jsondoc;
 };

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -99,7 +99,6 @@
   "dependencies": {
     "@storybook/blocks": "workspace:*",
     "@storybook/csf-plugin": "workspace:*",
-    "@storybook/global": "^5.0.0",
     "@storybook/react-dom-shim": "workspace:*",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -97,23 +97,23 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@mdx-js/react": "^3.0.0",
     "@storybook/blocks": "workspace:*",
     "@storybook/csf-plugin": "workspace:*",
     "@storybook/global": "^5.0.0",
     "@storybook/react-dom-shim": "workspace:*",
-    "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "rehype-external-links": "^3.0.0",
-    "rehype-slug": "^6.0.0",
     "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
     "@mdx-js/mdx": "^3.0.0",
+    "@mdx-js/react": "^3.0.0",
     "@rollup/pluginutils": "^5.0.2",
+    "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "rehype-external-links": "^3.0.0",
+    "rehype-slug": "^6.0.0",
     "typescript": "^5.3.2",
     "vite": "^4.0.4"
   },

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -97,6 +97,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
+    "@mdx-js/react": "^3.0.0",
     "@storybook/blocks": "workspace:*",
     "@storybook/csf-plugin": "workspace:*",
     "@storybook/react-dom-shim": "workspace:*",
@@ -106,7 +107,6 @@
   },
   "devDependencies": {
     "@mdx-js/mdx": "^3.0.0",
-    "@mdx-js/react": "^3.0.0",
     "@rollup/pluginutils": "^5.0.2",
     "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react": "^18.2.0",

--- a/code/addons/docs/src/preview.ts
+++ b/code/addons/docs/src/preview.ts
@@ -1,8 +1,6 @@
 import type { PreparedStory } from 'storybook/internal/types';
 
-import { global } from '@storybook/global';
-
-const excludeTags = Object.entries(global.TAGS_OPTIONS ?? {}).reduce(
+const excludeTags = Object.entries(globalThis.TAGS_OPTIONS ?? {}).reduce(
   (acc, entry) => {
     const [tag, option] = entry;
     if ((option as any).excludeFromDocsStories) {

--- a/code/addons/docs/template/stories/docs2/button.stories.ts
+++ b/code/addons/docs/template/stories/docs2/button.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   component: globalThis.Components.Button,
   tags: ['autodocs'],

--- a/code/addons/docs/template/stories/docs2/multiple-csf-files-a.stories.ts
+++ b/code/addons/docs/template/stories/docs2/multiple-csf-files-a.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   title: 'Multiple CSF Files Same Title',
   component: globalThis.Components.Html,

--- a/code/addons/docs/template/stories/docs2/multiple-csf-files-b.stories.ts
+++ b/code/addons/docs/template/stories/docs2/multiple-csf-files-b.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   title: 'Multiple CSF Files Same Title',
   component: globalThis.Components.Html,

--- a/code/addons/docs/template/stories/docspage/autoplay.stories.ts
+++ b/code/addons/docs/template/stories/docspage/autoplay.stories.ts
@@ -1,4 +1,3 @@
-import { global as globalThis } from '@storybook/global';
 import { expect, within } from '@storybook/test';
 
 export default {

--- a/code/addons/docs/template/stories/docspage/basic.stories.ts
+++ b/code/addons/docs/template/stories/docspage/basic.stories.ts
@@ -1,4 +1,3 @@
-import { global as globalThis } from '@storybook/global';
 import { fn } from '@storybook/test';
 
 export default {

--- a/code/addons/docs/template/stories/docspage/description.stories.ts
+++ b/code/addons/docs/template/stories/docspage/description.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   component: globalThis.Components.Button,
   subcomponents: {

--- a/code/addons/docs/template/stories/docspage/error.stories.ts
+++ b/code/addons/docs/template/stories/docspage/error.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   component: globalThis.Components.Button,
   tags: ['autodocs', '!test', '!vitest'],

--- a/code/addons/docs/template/stories/docspage/extract-description.stories.ts
+++ b/code/addons/docs/template/stories/docspage/extract-description.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   component: globalThis.Components.Button,
   tags: ['autodocs'],

--- a/code/addons/docs/template/stories/docspage/iframe.stories.ts
+++ b/code/addons/docs/template/stories/docspage/iframe.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   component: globalThis.Components.Button,
   tags: ['autodocs'],

--- a/code/addons/docs/template/stories/docspage/overflow.stories.ts
+++ b/code/addons/docs/template/stories/docspage/overflow.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   component: globalThis.Components.Pre,
   tags: ['autodocs'],

--- a/code/addons/docs/template/stories/docspage/override.stories.ts
+++ b/code/addons/docs/template/stories/docspage/override.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 // FIXME: do this using basic React functions for multi-framework
 //        once sandbox linking is working
 //

--- a/code/addons/docs/template/stories/docspage/source.stories.ts
+++ b/code/addons/docs/template/stories/docspage/source.stories.ts
@@ -1,7 +1,5 @@
 import type { StoryContext } from 'storybook/internal/types';
 
-import { global as globalThis } from '@storybook/global';
-
 import { dedent } from 'ts-dedent';
 
 export default {

--- a/code/addons/docs/template/stories/toc/basic.stories.ts
+++ b/code/addons/docs/template/stories/toc/basic.stories.ts
@@ -1,6 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-import { fn } from '@storybook/test';
-
 export default {
   component: globalThis.Components.Button,
   tags: ['autodocs'],

--- a/code/addons/docs/template/stories/toc/custom-selector.stories.ts
+++ b/code/addons/docs/template/stories/toc/custom-selector.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   component: globalThis.Components.Button,
   tags: ['autodocs'],

--- a/code/addons/docs/template/stories/toc/custom-title.stories.ts
+++ b/code/addons/docs/template/stories/toc/custom-title.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   component: globalThis.Components.Button,
   tags: ['autodocs'],

--- a/code/addons/docs/template/stories/toc/ignore-selector.stories.ts
+++ b/code/addons/docs/template/stories/toc/ignore-selector.stories.ts
@@ -1,5 +1,3 @@
-import { global as globalThis } from '@storybook/global';
-
 export default {
   component: globalThis.Components.Button,
   tags: ['autodocs'],

--- a/code/lib/blocks/package.json
+++ b/code/lib/blocks/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "@storybook/csf": "^0.1.11",
-    "@storybook/global": "^5.0.0",
     "@storybook/icons": "^1.2.10",
     "color-convert": "^2.0.1",
     "dequal": "^2.0.2",

--- a/code/lib/blocks/package.json
+++ b/code/lib/blocks/package.json
@@ -45,22 +45,20 @@
   "dependencies": {
     "@storybook/csf": "^0.1.11",
     "@storybook/icons": "^1.2.10",
-    "color-convert": "^2.0.1",
-    "dequal": "^2.0.2",
-    "markdown-to-jsx": "^7.4.5",
-    "memoizerific": "^1.11.3",
-    "polished": "^4.2.2",
-    "react-colorful": "^5.1.2",
-    "telejson": "^7.2.0",
-    "ts-dedent": "^2.0.0",
-    "util-deprecate": "^1.0.2"
+    "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/test": "workspace:*",
     "@types/color-convert": "^2.0.0",
+    "color-convert": "^2.0.1",
     "es-toolkit": "^1.21.0",
+    "markdown-to-jsx": "^7.4.5",
+    "memoizerific": "^1.11.3",
+    "polished": "^4.2.2",
+    "react-colorful": "^5.1.2",
+    "telejson": "^7.2.0",
     "tocbot": "^4.20.1"
   },
   "peerDependencies": {

--- a/code/lib/blocks/src/blocks/DocsContainer.tsx
+++ b/code/lib/blocks/src/blocks/DocsContainer.tsx
@@ -5,7 +5,6 @@ import type { ThemeVars } from 'storybook/internal/theming';
 import { ThemeProvider, ensure as ensureTheme } from 'storybook/internal/theming';
 import type { Renderer } from 'storybook/internal/types';
 
-
 import { DocsPageWrapper } from '../components';
 import { TableOfContents } from '../components/TableOfContents';
 import type { DocsContextProps } from './DocsContext';

--- a/code/lib/blocks/src/blocks/DocsContainer.tsx
+++ b/code/lib/blocks/src/blocks/DocsContainer.tsx
@@ -5,7 +5,6 @@ import type { ThemeVars } from 'storybook/internal/theming';
 import { ThemeProvider, ensure as ensureTheme } from 'storybook/internal/theming';
 import type { Renderer } from 'storybook/internal/types';
 
-import { global } from '@storybook/global';
 
 import { DocsPageWrapper } from '../components';
 import { TableOfContents } from '../components/TableOfContents';
@@ -14,7 +13,7 @@ import { DocsContext } from './DocsContext';
 import { SourceContainer } from './SourceContainer';
 import { scrollToElement } from './utils';
 
-const { document, window: globalWindow } = global;
+const { document, window: globalWindow } = globalThis;
 
 export interface DocsContainerProps<TFramework extends Renderer = Renderer> {
   context: DocsContextProps<TFramework>;

--- a/code/lib/blocks/src/blocks/DocsContext.ts
+++ b/code/lib/blocks/src/blocks/DocsContext.ts
@@ -4,8 +4,6 @@ import { createContext } from 'react';
 
 import type { DocsContextProps, Renderer } from 'storybook/internal/types';
 
-import { global } from '@storybook/global';
-
 export type { DocsContextProps };
 
 // We add DocsContext to window. The reason is that in case DocsContext.ts is
@@ -13,11 +11,11 @@ export type { DocsContextProps };
 // we will have multiple DocsContext definitions - leading to lost context in
 // the React component tree.
 // This was specifically a problem with the Vite builder.
-if (global && global.__DOCS_CONTEXT__ === undefined) {
-  global.__DOCS_CONTEXT__ = createContext(null);
-  global.__DOCS_CONTEXT__.displayName = 'DocsContext';
+if (globalThis && globalThis.__DOCS_CONTEXT__ === undefined) {
+  globalThis.__DOCS_CONTEXT__ = createContext(null);
+  globalThis.__DOCS_CONTEXT__.displayName = 'DocsContext';
 }
 
-export const DocsContext: Context<DocsContextProps<Renderer>> = global
-  ? global.__DOCS_CONTEXT__
+export const DocsContext: Context<DocsContextProps<Renderer>> = globalThis
+  ? globalThis.__DOCS_CONTEXT__
   : createContext(null);

--- a/code/lib/blocks/src/blocks/mdx.tsx
+++ b/code/lib/blocks/src/blocks/mdx.tsx
@@ -6,14 +6,13 @@ import { Code, components, nameSpaceClassNames } from 'storybook/internal/compon
 import { NAVIGATE_URL } from 'storybook/internal/core-events';
 import { styled } from 'storybook/internal/theming';
 
-import { global } from '@storybook/global';
 import { LinkIcon } from '@storybook/icons';
 
 import { Source } from '../components';
 import type { DocsContextProps } from './DocsContext';
 import { DocsContext } from './DocsContext';
 
-const { document } = global;
+const { document } = globalThis;
 
 // Hacky utility for asserting identifiers in MDX Story elements
 export const assertIsFn = (val: any) => {

--- a/code/lib/blocks/src/components/IFrame.tsx
+++ b/code/lib/blocks/src/components/IFrame.tsx
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 
-import { global } from '@storybook/global';
 
-const { window: globalWindow } = global;
+const { window: globalWindow } = globalThis;
 
 interface IFrameProps {
   id: string;

--- a/code/lib/blocks/src/components/IFrame.tsx
+++ b/code/lib/blocks/src/components/IFrame.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 
-
 const { window: globalWindow } = globalThis;
 
 interface IFrameProps {

--- a/code/lib/blocks/src/components/Preview.stories.tsx
+++ b/code/lib/blocks/src/components/Preview.stories.tsx
@@ -5,8 +5,6 @@ import { Button, Spaced } from 'storybook/internal/components';
 import { styled } from 'storybook/internal/theming';
 import type { DocsContextProps, ModuleExport } from 'storybook/internal/types';
 
-import { global } from '@storybook/global';
-
 import * as ButtonStories from '../examples/Button.stories';
 import { Preview, PreviewSkeleton } from './Preview';
 import * as sourceStories from './Source.stories';
@@ -251,7 +249,7 @@ export const WithAdditionalActions = (
       {
         title: 'Open on GitHub',
         onClick: () => {
-          global.location.href =
+          globalThis.location.href =
             'https://github.com/storybookjs/storybook/blob/next/code/lib/blocks/src/components/Preview.stories.tsx#L165-L186';
         },
       },

--- a/code/lib/blocks/src/components/Preview.tsx
+++ b/code/lib/blocks/src/components/Preview.tsx
@@ -5,8 +5,6 @@ import { ActionBar, Zoom } from 'storybook/internal/components';
 import type { ActionItem } from 'storybook/internal/components';
 import { styled } from 'storybook/internal/theming';
 
-import { global } from '@storybook/global';
-
 import { darken } from 'polished';
 
 import type { SourceProps } from '.';
@@ -204,7 +202,7 @@ export const Preview: FC<PreviewProps> = ({
   );
   const actionItems = [...defaultActionItems, ...additionalActionItems];
 
-  const { window: globalWindow } = global;
+  const { window: globalWindow } = globalThis;
 
   const copyToClipboard = useCallback(async (text: string) => {
     const { createCopyToClipboardFunction } = await import('storybook/internal/components');

--- a/code/lib/blocks/src/components/Story.tsx
+++ b/code/lib/blocks/src/components/Story.tsx
@@ -6,7 +6,6 @@ import { ErrorFormatter, Loader, getStoryHref } from 'storybook/internal/compone
 import { styled } from 'storybook/internal/theming';
 import type { DocsContextProps, PreparedStory } from 'storybook/internal/types';
 
-
 import { IFrame } from './IFrame';
 import { ZoomContext } from './ZoomContext';
 

--- a/code/lib/blocks/src/components/Story.tsx
+++ b/code/lib/blocks/src/components/Story.tsx
@@ -6,12 +6,11 @@ import { ErrorFormatter, Loader, getStoryHref } from 'storybook/internal/compone
 import { styled } from 'storybook/internal/theming';
 import type { DocsContextProps, PreparedStory } from 'storybook/internal/types';
 
-import { global } from '@storybook/global';
 
 import { IFrame } from './IFrame';
 import { ZoomContext } from './ZoomContext';
 
-const { PREVIEW_URL } = global;
+const { PREVIEW_URL } = globalThis;
 const BASE_URL = PREVIEW_URL || 'iframe.html';
 
 interface CommonProps {

--- a/code/lib/blocks/src/controls/Object.tsx
+++ b/code/lib/blocks/src/controls/Object.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Form, IconButton } from 'storybook/internal/components';
 import { type Theme, styled, useTheme } from 'storybook/internal/theming';
 
-import { global } from '@storybook/global';
 import { AddIcon, EyeCloseIcon, EyeIcon, SubtractIcon } from '@storybook/icons';
 
 import { cloneDeep } from 'es-toolkit/compat';
@@ -13,7 +12,7 @@ import { getControlId, getControlSetterButtonId } from './helpers';
 import { JsonTree } from './react-editable-json-tree';
 import type { ControlProps, ObjectConfig, ObjectValue } from './types';
 
-const { window: globalWindow } = global;
+const { window: globalWindow } = globalThis;
 
 type JsonTreeProps = ComponentProps<typeof JsonTree>;
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5763,13 +5763,11 @@ __metadata:
   dependencies:
     "@storybook/addon-actions": "workspace:*"
     "@storybook/csf": "npm:^0.1.11"
-    "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.2.10"
     "@storybook/react": "workspace:*"
     "@storybook/test": "workspace:*"
     "@types/color-convert": "npm:^2.0.0"
     color-convert: "npm:^2.0.1"
-    dequal: "npm:^2.0.2"
     es-toolkit: "npm:^1.21.0"
     markdown-to-jsx: "npm:^7.4.5"
     memoizerific: "npm:^1.11.3"
@@ -5778,7 +5776,6 @@ __metadata:
     telejson: "npm:^7.2.0"
     tocbot: "npm:^4.20.1"
     ts-dedent: "npm:^2.0.0"
-    util-deprecate: "npm:^1.0.2"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5446,7 +5446,6 @@ __metadata:
     "@rollup/pluginutils": "npm:^5.0.2"
     "@storybook/blocks": "workspace:*"
     "@storybook/csf-plugin": "workspace:*"
-    "@storybook/global": "npm:^5.0.0"
     "@storybook/react-dom-shim": "workspace:*"
     "@types/react": "npm:^16.8.0 || ^17.0.0 || ^18.0.0"
     react: "npm:^18.2.0"


### PR DESCRIPTION
Works on https://github.com/storybookjs/storybook/issues/29038

## What I did

|  | **Before** | **After** |
|---|---|---|
| pkg-size | ![image](https://github.com/user-attachments/assets/972c14a5-12ba-454f-91c3-c32714fd81bb) | ![image](https://github.com/user-attachments/assets/ff3cedff-2973-41f1-8463-2304959bc61a) |
| npmgraph | ![image](https://github.com/user-attachments/assets/3794cb55-a8f4-464e-9c16-3ccfc61c74e4) | ![image](https://github.com/user-attachments/assets/c949b846-bdda-4e5e-a108-7b91636f90cf) |

### Sources

https://pkg-size.dev/@storybook%2Faddon-docs@8.4.0-alpha.5?no-peers

https://pkg-size.dev/@storybook%2Faddon-docs@0.0.0-pr-29301-sha-991d41fc?no-peers

https://npmgraph.js.org/?q=@storybook/addon-docs@8.4.0-alpha.5#hide=

https://npmgraph.js.org/?q=@storybook/addon-docs@0.0.0-pr-29301-sha-991d41fc#zoom=w

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29301-sha-991d41fc`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29301-sha-991d41fc sandbox` or in an existing project with `npx storybook@0.0.0-pr-29301-sha-991d41fc upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29301-sha-991d41fc`](https://npmjs.com/package/storybook/v/0.0.0-pr-29301-sha-991d41fc) |
| **Triggered by** | @JReinhold |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`jeppe/prebundle-addon-docs`](https://github.com/storybookjs/storybook/tree/jeppe/prebundle-addon-docs) |
| **Commit** | [`991d41fc`](https://github.com/storybookjs/storybook/commit/991d41fc8a1bff88dc1a7e208446b234e503b8a9) |
| **Datetime** | Tue Oct  8 20:01:14 UTC 2024 (`1728417674`) |
| **Workflow run** | [11242809433](https://github.com/storybookjs/storybook/actions/runs/11242809433) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29301`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 0 B | 0.83 | 0% |
| initSize |  148 MB | 147 MB | -1 MB | **-4.13** | -0.7% |
| diffSize |  69.3 MB | 68.3 MB | -1 MB | **-3.74** | -1.5% |
| buildSize |  6.79 MB | 6.79 MB | 4.49 kB | **5.4** | 0.1% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | -281 B | **-Infinity** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 0 B | 0.58 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | -281 B | 0.29 | 0% |
| buildPreviewSize |  2.99 MB | 2.99 MB | 4.77 kB | **5.7** | 0.2% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  16.5s | 23.4s | 6.8s | **1.66** | 🔺29.3% |
| generateTime |  20.6s | 18.6s | -2s -1ms | -1.18 | -10.7% |
| initTime |  13.5s | 12.5s | -1s -27ms | **-1.37** | 🔰-8.2% |
| buildTime |  8.2s | 8.2s | 8ms | -0.8 | 0.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.7s | 5.8s | -870ms | -1.18 | -14.9% |
| devManagerResponsive |  4.1s | 3.9s | -251ms | -1.15 | -6.4% |
| devManagerHeaderVisible |  587ms | 541ms | -46ms | -0.78 | -8.5% |
| devManagerIndexVisible |  618ms | 563ms | -55ms | -0.87 | -9.8% |
| devStoryVisibleUncached |  1s | 851ms | -176ms | -0.91 | -20.7% |
| devStoryVisible |  617ms | 570ms | -47ms | -0.79 | -8.2% |
| devAutodocsVisible |  495ms | 494ms | -1ms | -0.31 | -0.2% |
| devMDXVisible |  519ms | 457ms | -62ms | -0.88 | -13.6% |
| buildManagerHeaderVisible |  492ms | 449ms | -43ms | -1.14 | -9.6% |
| buildManagerIndexVisible |  495ms | 460ms | -35ms | -1.15 | -7.6% |
| buildStoryVisible |  525ms | 716ms | 191ms | 1.09 | 26.7% |
| buildAutodocsVisible |  445ms | 504ms | 59ms | -0.05 | 11.7% |
| buildMDXVisible |  496ms | 437ms | -59ms | -0.84 | -13.5% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR focuses on prebundling dependencies for the addon-docs and blocks packages to reduce Storybook's install footprint. Key changes include:

- Removed several dependencies from `@storybook/blocks` package.json, moving them to devDependencies
- Replaced imports of `global` from '@storybook/global' with direct use of `globalThis` across multiple files
- Simplified code in various components by removing unnecessary imports and using standardized global object access
- Updated package.json files to optimize dependencies and reduce bundle size

These changes align with the goal of reducing Storybook's install size and dependency count, as outlined in issue #29038.

<!-- /greptile_comment -->