### PR TITLE
Addon-Test: Implement Global Error Modal

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -92,6 +92,10 @@ const config: StorybookConfig = {
       directory: '../addons/test/template/stories',
       titlePrefix: 'addons/test',
     },
+    {
+      directory: '../addons/test/src',
+      titlePrefix: 'addons/test',
+    },
   ],
   addons: [
     '@storybook/addon-themes',

--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -92,10 +92,6 @@ const config: StorybookConfig = {
       directory: '../addons/test/template/stories',
       titlePrefix: 'addons/test',
     },
-    {
-      directory: '../addons/test/src',
-      titlePrefix: 'addons/test',
-    },
   ],
   addons: [
     '@storybook/addon-themes',

--- a/code/addons/test/package.json
+++ b/code/addons/test/package.json
@@ -80,6 +80,7 @@
     "@storybook/icons": "^1.2.12",
     "@storybook/instrumenter": "workspace:*",
     "@storybook/test": "workspace:*",
+    "@storybook/theming": "workspace:*",
     "polished": "^4.2.2",
     "ts-dedent": "^2.2.0"
   },

--- a/code/addons/test/src/components/GlobalErrorModal.stories.tsx
+++ b/code/addons/test/src/components/GlobalErrorModal.stories.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from '@storybook/test';
+
+import dedent from 'ts-dedent';
+
+import { GlobalErrorModal } from './GlobalErrorModal';
+
+type Story = StoryObj<typeof meta>;
+
+const meta = {
+  component: GlobalErrorModal,
+  decorators: [
+    (storyFn) => (
+      <div
+        style={{
+          width: '100%',
+          minWidth: '1200px',
+          height: '800px',
+          background:
+            'repeating-linear-gradient(45deg, #000000, #ffffff 50px, #ffffff 50px, #ffffff 80px)',
+        }}
+      >
+        {storyFn()}
+      </div>
+    ),
+  ],
+  args: {
+    onRerun: fn(),
+    onClose: fn(),
+    open: false,
+  },
+} satisfies Meta<typeof GlobalErrorModal>;
+
+export default meta;
+
+export const Default: Story = {
+  args: {
+    error: dedent`
+    ReferenceError: FAIL is not defined
+      at Constraint.execute (the-best-file.js:525:2)
+      at Constraint.recalculate (the-best-file.js:424:21)
+      at Planner.addPropagate (the-best-file.js:701:6)
+      at Constraint.satisfy (the-best-file.js:184:15)
+      at Planner.incrementalAdd (the-best-file.js:591:21)
+      at Constraint.addConstraint (the-best-file.js:162:10)
+      at Constraint.BinaryConstraint (the-best-file.js:346:7)
+      at Constraint.EqualityConstraint (the-best-file.js:515:38)
+      at chainTest (the-best-file.js:807:6)
+      at deltaBlue (the-best-file.js:879:2)`,
+  },
+  render: (props) => {
+    const [isOpen, setOpen] = useState(false);
+
+    return (
+      <>
+        <GlobalErrorModal {...props} open={isOpen} />
+        <button onClick={() => setOpen(true)}>Open modal</button>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.parentElement!);
+    const button = canvas.getByText('Open modal');
+    await userEvent.click(button);
+    await expect(canvas.findByText('Storybook Tests error details')).resolves.toBeInTheDocument();
+  },
+};

--- a/code/addons/test/src/components/GlobalErrorModal.stories.tsx
+++ b/code/addons/test/src/components/GlobalErrorModal.stories.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import { ManagerContext } from 'storybook/internal/manager-api';
+
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from '@storybook/test';
 
@@ -9,21 +11,32 @@ import { GlobalErrorModal } from './GlobalErrorModal';
 
 type Story = StoryObj<typeof meta>;
 
+const managerContext: any = {
+  state: {},
+  api: {
+    getDocsUrl: fn(({ subpath }) => `https://storybook.js.org/docs/${subpath}`).mockName(
+      'api::getDocsUrl'
+    ),
+  },
+};
+
 const meta = {
   component: GlobalErrorModal,
   decorators: [
     (storyFn) => (
-      <div
-        style={{
-          width: '100%',
-          minWidth: '1200px',
-          height: '800px',
-          background:
-            'repeating-linear-gradient(45deg, #000000, #ffffff 50px, #ffffff 50px, #ffffff 80px)',
-        }}
-      >
-        {storyFn()}
-      </div>
+      <ManagerContext.Provider value={managerContext}>
+        <div
+          style={{
+            width: '100%',
+            minWidth: '1200px',
+            height: '800px',
+            background:
+              'repeating-linear-gradient(45deg, #000000, #ffffff 50px, #ffffff 50px, #ffffff 80px)',
+          }}
+        >
+          {storyFn()}
+        </div>
+      </ManagerContext.Provider>
     ),
   ],
   args: {

--- a/code/addons/test/src/components/GlobalErrorModal.tsx
+++ b/code/addons/test/src/components/GlobalErrorModal.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+
+import { Button, IconButton, Modal } from 'storybook/internal/components';
+
+import { CloseIcon, SyncIcon } from '@storybook/icons';
+import { styled } from '@storybook/theming';
+
+interface GlobalErrorModalProps {
+  error: string;
+  open: boolean;
+  onClose: () => void;
+  onRerun: () => void;
+}
+
+const ModalBar = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '6px 6px 6px 20px',
+});
+
+const ModalActionBar = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+const ModalTitle = styled.div(({ theme: { typography } }) => ({
+  fontSize: typography.size.s2,
+  fontWeight: typography.weight.bold,
+}));
+
+const ModalStackTrace = styled.pre(({ theme }) => ({
+  whiteSpace: 'pre-wrap',
+  overflow: 'auto',
+  maxHeight: '60vh',
+  margin: 0,
+  padding: `20px`,
+  fontFamily: theme.typography.fonts.mono,
+  fontSize: '12px',
+  borderTop: `1px solid ${theme.appBorderColor}`,
+}));
+
+const TroubleshootLink = styled.a(({ theme }) => ({
+  color: theme.color.defaultText,
+}));
+
+const TROUBLESHOOT_LINK = `https://storybook.js.org/docs/vitest/troubleshooting`;
+
+export function GlobalErrorModal({ onRerun, onClose, error, open }: GlobalErrorModalProps) {
+  return (
+    <Modal onEscapeKeyDown={onClose} onInteractOutside={onClose} open={open}>
+      <ModalBar>
+        <ModalTitle>Storybook Tests error details</ModalTitle>
+        <ModalActionBar>
+          <Button onClick={onRerun} variant="ghost">
+            <SyncIcon />
+            Rerun
+          </Button>
+          <Button variant="ghost" asChild>
+            {/* TODO: Is this the right link? */}
+            <a target="_blank" href={TROUBLESHOOT_LINK} rel="noreferrer">
+              Troubleshoot
+            </a>
+          </Button>
+          <IconButton onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        </ModalActionBar>
+      </ModalBar>
+      <ModalStackTrace>
+        {error}
+        <br />
+        <br />
+        Troubleshoot:{' '}
+        <TroubleshootLink target="_blank" href={TROUBLESHOOT_LINK}>
+          {TROUBLESHOOT_LINK}
+        </TroubleshootLink>
+      </ModalStackTrace>
+    </Modal>
+  );
+}

--- a/code/addons/test/src/components/GlobalErrorModal.tsx
+++ b/code/addons/test/src/components/GlobalErrorModal.tsx
@@ -42,6 +42,7 @@ const ModalStackTrace = styled.pre(({ theme }) => ({
   fontFamily: theme.typography.fonts.mono,
   fontSize: '12px',
   borderTop: `1px solid ${theme.appBorderColor}`,
+  borderRadius: 0,
 }));
 
 const TroubleshootLink = styled.a(({ theme }) => ({

--- a/code/addons/test/src/components/GlobalErrorModal.tsx
+++ b/code/addons/test/src/components/GlobalErrorModal.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 
 import { Button, IconButton, Modal } from 'storybook/internal/components';
+import { useStorybookApi } from 'storybook/internal/manager-api';
 
 import { CloseIcon, SyncIcon } from '@storybook/icons';
 import { styled } from '@storybook/theming';
+
+import { TROUBLESHOOTING_LINK } from '../constants';
 
 interface GlobalErrorModalProps {
   error: string;
@@ -45,9 +48,15 @@ const TroubleshootLink = styled.a(({ theme }) => ({
   color: theme.color.defaultText,
 }));
 
-const TROUBLESHOOT_LINK = `https://storybook.js.org/docs/vitest/troubleshooting`;
-
 export function GlobalErrorModal({ onRerun, onClose, error, open }: GlobalErrorModalProps) {
+  const api = useStorybookApi();
+
+  const troubleshootURL = api.getDocsUrl({
+    subpath: TROUBLESHOOTING_LINK,
+    versioned: true,
+    renderer: true,
+  });
+
   return (
     <Modal onEscapeKeyDown={onClose} onInteractOutside={onClose} open={open}>
       <ModalBar>
@@ -58,8 +67,7 @@ export function GlobalErrorModal({ onRerun, onClose, error, open }: GlobalErrorM
             Rerun
           </Button>
           <Button variant="ghost" asChild>
-            {/* TODO: Is this the right link? */}
-            <a target="_blank" href={TROUBLESHOOT_LINK} rel="noreferrer">
+            <a target="_blank" href={troubleshootURL} rel="noreferrer">
               Troubleshoot
             </a>
           </Button>
@@ -73,8 +81,8 @@ export function GlobalErrorModal({ onRerun, onClose, error, open }: GlobalErrorM
         <br />
         <br />
         Troubleshoot:{' '}
-        <TroubleshootLink target="_blank" href={TROUBLESHOOT_LINK}>
-          {TROUBLESHOOT_LINK}
+        <TroubleshootLink target="_blank" href={troubleshootURL}>
+          {troubleshootURL}
         </TroubleshootLink>
       </ModalStackTrace>
     </Modal>

--- a/code/addons/test/src/constants.ts
+++ b/code/addons/test/src/constants.ts
@@ -4,3 +4,4 @@ export const PANEL_ID = `${ADDON_ID}/panel`;
 
 export const TUTORIAL_VIDEO_LINK = 'https://youtu.be/Waht9qq7AoA';
 export const DOCUMENTATION_LINK = 'writing-tests/component-testing';
+export const TROUBLESHOOTING_LINK = `${DOCUMENTATION_LINK}#troubleshooting`;

--- a/code/core/src/components/components/Modal/Modal.stories.tsx
+++ b/code/core/src/components/components/Modal/Modal.stories.tsx
@@ -10,7 +10,21 @@ type Story = StoryObj<typeof meta>;
 
 const meta = {
   component: Modal,
-  decorators: [(storyFn) => <div style={{ width: '1200px', height: '800px' }}>{storyFn()}</div>],
+  decorators: [
+    (storyFn) => (
+      <div
+        style={{
+          width: '100%',
+          minWidth: '1200px',
+          height: '800px',
+          background:
+            'repeating-linear-gradient(45deg, #000000, #ffffff 50px, #ffffff 50px, #ffffff 80px)',
+        }}
+      >
+        {storyFn()}
+      </div>
+    ),
+  ],
 } satisfies Meta<typeof Modal>;
 
 export default meta;

--- a/code/core/src/components/components/Modal/Modal.styled.tsx
+++ b/code/core/src/components/components/Modal/Modal.styled.tsx
@@ -30,7 +30,7 @@ const zoomIn = keyframes({
 });
 
 export const Overlay = styled.div({
-  backgroundColor: 'rgba(27, 28, 29, 0.2)',
+  backdropFilter: 'blur(24px)',
   position: 'fixed',
   inset: 0,
   width: '100%',
@@ -43,7 +43,7 @@ export const Container = styled.div<{ width?: number; height?: number }>(
   ({ theme, width, height }) => ({
     backgroundColor: theme.background.bar,
     borderRadius: 6,
-    boxShadow: `rgba(255, 255, 255, 0.05) 0 0 0 1px inset, rgba(14, 18, 22, 0.35) 0px 10px 38px -10px`,
+    boxShadow: '0px 4px 67px 0px #00000040',
     position: 'fixed',
     top: '50%',
     left: '50%',

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6239,6 +6239,7 @@ __metadata:
     "@storybook/icons": "npm:^1.2.12"
     "@storybook/instrumenter": "workspace:*"
     "@storybook/test": "workspace:*"
+    "@storybook/theming": "workspace:*"
     "@types/node": "npm:^22.0.0"
     "@types/semver": "npm:^7"
     "@vitest/browser": "npm:^2.1.1"


### PR DESCRIPTION
Relates https://github.com/storybookjs/storybook/issues/29312

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Implemented the Global Error Modal for the Testing Addon and changed slightly the background css of the Modal component.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 148 B | 1.2 | 0% |
| initSize |  152 MB | 152 MB | 488 B | 0.27 | 0% |
| diffSize |  73.7 MB | 73.7 MB | 340 B | -0.48 | 0% |
| buildSize |  7.07 MB | 7.07 MB | -142 B | **-1.41** | 0% |
| buildSbAddonsSize |  1.78 MB | 1.78 MB | 0 B | **-1.4** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | -71 B | **-1.41** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | **-1.41** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.09 MB | 4.09 MB | -71 B | **-1.41** | 0% |
| buildPreviewSize |  2.98 MB | 2.97 MB | -71 B | 0.35 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  14.9s | 20.9s | 5.9s | 0.81 | 28.5% |
| generateTime |  20.9s | 18.7s | -2s -160ms | **-1.86** | 🔰-11.5% |
| initTime |  16.2s | 13.2s | -3s -71ms | **-2.25** | 🔰-23.2% |
| buildTime |  9.4s | 8.2s | -1s -170ms | **-1.59** | 🔰-14.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.8s | 7.1s | 338ms | 0.45 | 4.7% |
| devManagerResponsive |  4.3s | 4.3s | -24ms | 0.02 | -0.5% |
| devManagerHeaderVisible |  575ms | 793ms | 218ms | **2.82** | 🔺27.5% |
| devManagerIndexVisible |  613ms | 828ms | 215ms | **2.59** | 🔺26% |
| devStoryVisibleUncached |  737ms | 1.2s | 472ms | 0.02 | 39% |
| devStoryVisible |  610ms | 829ms | 219ms | **2.65** | 🔺26.4% |
| devAutodocsVisible |  532ms | 784ms | 252ms | **2.9** | 🔺32.1% |
| devMDXVisible |  492ms | 662ms | 170ms | **1.82** | 🔺25.7% |
| buildManagerHeaderVisible |  543ms | 555ms | 12ms | -0.09 | 2.2% |
| buildManagerIndexVisible |  550ms | 562ms | 12ms | -0.28 | 2.1% |
| buildStoryVisible |  580ms | 625ms | 45ms | 0.38 | 7.2% |
| buildAutodocsVisible |  515ms | 465ms | -50ms | -1.12 | -10.8% |
| buildMDXVisible |  460ms | 508ms | 48ms | -0.11 | 9.4% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR implements a Global Error Modal for the Testing Addon and updates the Modal component's stories and styles. Here are the key changes:

- Added new `GlobalErrorModal` component in `/code/addons/test/src/components/GlobalErrorModal.tsx`
- Created corresponding stories for `GlobalErrorModal` in `/code/addons/test/src/components/GlobalErrorModal.stories.tsx`
- Updated Modal stories in `/code/core/src/components/components/Modal/Modal.stories.tsx` with improved visual presentation
- Modified Modal styling in `/code/core/src/components/components/Modal/Modal.styled.tsx` for better error handling
- Added `@storybook/theming` as a dependency in `/code/addons/test/package.json`

<!-- /greptile_comment -->