### PR TITLE
Test: Remove unused `util` dependency

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -340,7 +340,6 @@
     "boxen": "^7.1.1",
     "browser-dtector": "^3.4.0",
     "camelcase": "^8.0.0",
-    "chai": "^4.4.1",
     "cli-table3": "^0.6.1",
     "commander": "^12.1.0",
     "comment-parser": "^1.4.1",

--- a/code/lib/instrumenter/package.json
+++ b/code/lib/instrumenter/package.json
@@ -44,8 +44,7 @@
   },
   "dependencies": {
     "@storybook/global": "^5.0.0",
-    "@vitest/utils": "^2.0.5",
-    "util": "^0.12.4"
+    "@vitest/utils": "^2.0.5"
   },
   "devDependencies": {
     "typescript": "^5.3.2"
@@ -68,6 +67,9 @@
       "@vitest/expect",
       "@vitest/spy",
       "@vitest/utils"
+    ],
+    "externals": [
+      "util"
     ]
   },
   "gitHead": "e6a7fd8a655c69780bc20b9749c2699e44beae16"

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -51,8 +51,7 @@
     "@testing-library/jest-dom": "6.5.0",
     "@testing-library/user-event": "14.5.2",
     "@vitest/expect": "2.0.5",
-    "@vitest/spy": "2.0.5",
-    "util": "^0.12.4"
+    "@vitest/spy": "2.0.5"
   },
   "devDependencies": {
     "chai": "^5.1.1",
@@ -79,6 +78,9 @@
       "@vitest/expect",
       "@vitest/spy",
       "@vitest/utils"
+    ],
+    "externals": [
+      "util"
     ]
   },
   "gitHead": "e6a7fd8a655c69780bc20b9749c2699e44beae16"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6067,7 +6067,6 @@ __metadata:
     browser-assert: "npm:^1.2.1"
     browser-dtector: "npm:^3.4.0"
     camelcase: "npm:^8.0.0"
-    chai: "npm:^4.4.1"
     cli-table3: "npm:^0.6.1"
     commander: "npm:^12.1.0"
     comment-parser: "npm:^1.4.1"
@@ -6360,7 +6359,6 @@ __metadata:
     "@storybook/global": "npm:^5.0.0"
     "@vitest/utils": "npm:^2.0.5"
     typescript: "npm:^5.3.2"
-    util: "npm:^0.12.4"
   peerDependencies:
     storybook: "workspace:^"
   languageName: unknown
@@ -7113,7 +7111,6 @@ __metadata:
     ts-dedent: "npm:^2.2.0"
     type-fest: "npm:~2.19"
     typescript: "npm:^5.3.2"
-    util: "npm:^0.12.4"
   peerDependencies:
     storybook: "workspace:^"
   languageName: unknown
@@ -10130,13 +10127,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assertion-error@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "assertion-error@npm:1.1.0"
-  checksum: 10c0/25456b2aa333250f01143968e02e4884a34588a8538fbbf65c91a637f1dbfb8069249133cd2f4e530f10f624d206a664e7df30207830b659e9f5298b00a4099b
-  languageName: node
-  linkType: hard
-
 "assertion-error@npm:^2.0.1":
   version: 2.0.1
   resolution: "assertion-error@npm:2.0.1"
@@ -11437,21 +11427,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai@npm:^4.4.1":
-  version: 4.5.0
-  resolution: "chai@npm:4.5.0"
-  dependencies:
-    assertion-error: "npm:^1.1.0"
-    check-error: "npm:^1.0.3"
-    deep-eql: "npm:^4.1.3"
-    get-func-name: "npm:^2.0.2"
-    loupe: "npm:^2.3.6"
-    pathval: "npm:^1.1.1"
-    type-detect: "npm:^4.1.0"
-  checksum: 10c0/b8cb596bd1aece1aec659e41a6e479290c7d9bee5b3ad63d2898ad230064e5b47889a3bc367b20100a0853b62e026e2dc514acf25a3c9385f936aa3614d4ab4d
-  languageName: node
-  linkType: hard
-
 "chai@npm:^5.1.1":
   version: 5.1.1
   resolution: "chai@npm:5.1.1"
@@ -11565,15 +11540,6 @@ __metadata:
   version: 0.7.0
   resolution: "chardet@npm:0.7.0"
   checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
-  languageName: node
-  linkType: hard
-
-"check-error@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "check-error@npm:1.0.3"
-  dependencies:
-    get-func-name: "npm:^2.0.2"
-  checksum: 10c0/94aa37a7315c0e8a83d0112b5bfb5a8624f7f0f81057c73e4707729cdd8077166c6aefb3d8e2b92c63ee130d4a2ff94bad46d547e12f3238cc1d78342a973841
   languageName: node
   linkType: hard
 
@@ -12844,15 +12810,6 @@ __metadata:
   version: 1.0.2
   resolution: "deep-diff@npm:1.0.2"
   checksum: 10c0/cc3e315ba95963eba4bbb79ed88d0a37d80ba19bd3b0039b79d2ad0e19e48b0e15c692b49bcd617bbe0dcc7358d40464c993889313dd8bf806bb25978b12375d
-  languageName: node
-  linkType: hard
-
-"deep-eql@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "deep-eql@npm:4.1.3"
-  dependencies:
-    type-detect: "npm:^4.0.0"
-  checksum: 10c0/ff34e8605d8253e1bf9fe48056e02c6f347b81d9b5df1c6650a1b0f6f847b4a86453b16dc226b34f853ef14b626e85d04e081b022e20b00cd7d54f079ce9bbdd
   languageName: node
   linkType: hard
 
@@ -16003,7 +15960,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-func-name@npm:^2.0.1, get-func-name@npm:^2.0.2":
+"get-func-name@npm:^2.0.1":
   version: 2.0.2
   resolution: "get-func-name@npm:2.0.2"
   checksum: 10c0/89830fd07623fa73429a711b9daecdb304386d237c71268007f788f113505ef1d4cc2d0b9680e072c5082490aec9df5d7758bf5ac6f1c37062855e8e3dc0b9df
@@ -19270,15 +19227,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loupe@npm:^2.3.6":
-  version: 2.3.7
-  resolution: "loupe@npm:2.3.7"
-  dependencies:
-    get-func-name: "npm:^2.0.1"
-  checksum: 10c0/71a781c8fc21527b99ed1062043f1f2bb30bdaf54fa4cf92463427e1718bc6567af2988300bc243c1f276e4f0876f29e3cbf7b58106fdc186915687456ce5bf4
-  languageName: node
-  linkType: hard
-
 "loupe@npm:^3.1.0, loupe@npm:^3.1.1":
   version: 3.1.1
   resolution: "loupe@npm:3.1.1"
@@ -22531,13 +22479,6 @@ __metadata:
   version: 1.1.2
   resolution: "pathe@npm:1.1.2"
   checksum: 10c0/64ee0a4e587fb0f208d9777a6c56e4f9050039268faaaaecd50e959ef01bf847b7872785c36483fa5cdcdbdfdb31fef2ff222684d4fc21c330ab60395c681897
-  languageName: node
-  linkType: hard
-
-"pathval@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "pathval@npm:1.1.1"
-  checksum: 10c0/f63e1bc1b33593cdf094ed6ff5c49c1c0dc5dc20a646ca9725cc7fe7cd9995002d51d5685b9b2ec6814342935748b711bafa840f84c0bb04e38ff40a335c94dc
   languageName: node
   linkType: hard
 
@@ -27454,13 +27395,6 @@ __metadata:
   dependencies:
     prelude-ls: "npm:^1.2.1"
   checksum: 10c0/7b3fd0ed43891e2080bf0c5c504b418fbb3e5c7b9708d3d015037ba2e6323a28152ec163bcb65212741fa5d2022e3075ac3c76440dbd344c9035f818e8ecee58
-  languageName: node
-  linkType: hard
-
-"type-detect@npm:^4.0.0, type-detect@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "type-detect@npm:4.1.0"
-  checksum: 10c0/df8157ca3f5d311edc22885abc134e18ff8ffbc93d6a9848af5b682730ca6a5a44499259750197250479c5331a8a75b5537529df5ec410622041650a7f293e2a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Works on #29038

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

`@storybook/test` and `@storybook/instrumenter` originally included the `util` package as a dependency, because otherwise building them would fail with:

```
Error: Build failed with 1 error:
../../node_modules/loupe/lib/index.js:30:29: ERROR: Could not read from file: /Users/jeppe/dev/work/storybook/storybook/code/lib/node_modules/util/util.js
```

That's because [`loupe`](https://github.com/chaijs/loupe) does `require('util')`. [But it does so conditionally](https://github.com/chaijs/loupe/blob/main/src/index.ts#L31-L38), as the whole point of `loupe` is to add support for `inspect` across Node and browsers, so it's fine if `util` isn't present. Our builder doesn't know that of course - causing the error, but marking `util` as external instead fixes that problem.

`util` is still a dependency of `@storybook/core`, but this is a low-effort step in the right direction.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 1.67 kB | 0.75 | 0% |
| initSize |  148 MB | 148 MB | 1.68 kB | **-2.45** | 0% |
| diffSize |  69.3 MB | 69.3 MB | 10 B | **-2.35** | 0% |
| buildSize |  6.79 MB | 6.79 MB | 0 B | **2.96** | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 0 B | 0.5 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 0 B | 0.5 | 0% |
| buildPreviewSize |  2.99 MB | 2.99 MB | 0 B | **3** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  11.3s | 21.4s | 10.1s | **1.47** | 🔺47.1% |
| generateTime |  19.7s | 22.4s | 2.7s | 0.56 | 12.2% |
| initTime |  12.8s | 14.3s | 1.4s | -0.32 | 10.3% |
| buildTime |  8.9s | 8.8s | -78ms | -0.53 | -0.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.7s | 6.4s | -323ms | -0.62 | -5% |
| devManagerResponsive |  4.6s | 4.2s | -402ms | -0.7 | -9.6% |
| devManagerHeaderVisible |  616ms | 660ms | 44ms | 0.7 | 6.7% |
| devManagerIndexVisible |  647ms | 690ms | 43ms | 0.62 | 6.2% |
| devStoryVisibleUncached |  815ms | 1.1s | 366ms | 0.06 | 31% |
| devStoryVisible |  648ms | 691ms | 43ms | 0.61 | 6.2% |
| devAutodocsVisible |  537ms | 649ms | 112ms | **1.88** | 🔺17.3% |
| devMDXVisible |  530ms | 473ms | -57ms | -0.66 | -12.1% |
| buildManagerHeaderVisible |  831ms | 583ms | -248ms | 0.15 | -42.5% |
| buildManagerIndexVisible |  856ms | 586ms | -270ms | 0.03 | -46.1% |
| buildStoryVisible |  857ms | 619ms | -238ms | 0.06 | -38.4% |
| buildAutodocsVisible |  477ms | 508ms | 31ms | 0.12 | 6.1% |
| buildMDXVisible |  466ms | 511ms | 45ms | 0.06 | 8.8% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR removes the unused 'util' dependency from multiple Storybook packages and marks it as external in the bundler configuration.

- Removed 'util' dependency from '@storybook/instrumenter' and '@storybook/test' packages
- Added 'util' to the 'externals' array in bundler configuration for affected packages
- Removed 'chai' dependency from '@storybook/core' package
- These changes are part of a broader effort to reduce Storybook's install footprint (Issue #29038)

<!-- /greptile_comment -->