### PR TITLE
Addon Test: Support viewport globals

### DIFF
--- a/code/.storybook/preview.tsx
+++ b/code/.storybook/preview.tsx
@@ -18,8 +18,6 @@ import { DocsContext } from '@storybook/blocks';
 import { global } from '@storybook/global';
 import type { Decorator, Loader, ReactRenderer } from '@storybook/react';
 
-import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
-
 import { DocsPageWrapper } from '../lib/blocks/src/components';
 import { isChromatic } from './isChromatic';
 

--- a/code/addons/test/src/vitest-plugin/test-utils.ts
+++ b/code/addons/test/src/vitest-plugin/test-utils.ts
@@ -25,7 +25,7 @@ export const testStory = (
     const _task = context.task as RunnerTask & { meta: TaskMeta & { storyId: string } };
     _task.meta.storyId = composedStory.id;
 
-    await setViewport(composedStory.parameters.viewport);
+    await setViewport(composedStory.parameters, composedStory.globals);
     await composedStory.run();
   };
 };

--- a/code/addons/test/src/vitest-plugin/viewports.test.ts
+++ b/code/addons/test/src/vitest-plugin/viewports.test.ts
@@ -5,7 +5,12 @@ import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 import { page } from '@vitest/browser/context';
 
-import { DEFAULT_VIEWPORT_DIMENSIONS, type ViewportsParam, setViewport } from './viewports';
+import {
+  DEFAULT_VIEWPORT_DIMENSIONS,
+  type ViewportsGlobal,
+  type ViewportsParam,
+  setViewport,
+} from './viewports';
 
 vi.mock('@vitest/browser/context', () => ({
   page: {
@@ -30,121 +35,151 @@ describe('setViewport', () => {
     expect(page.viewport).not.toHaveBeenCalled();
   });
 
-  it('should fall back to DEFAULT_VIEWPORT_DIMENSIONS if defaultViewport does not exist', async () => {
-    const viewportsParam: any = {
-      defaultViewport: 'nonExistentViewport',
-    };
+  describe('globals API', () => {
+    it('should fall back to DEFAULT_VIEWPORT_DIMENSIONS if selected viewport does not exist', async () => {
+      const viewportsGlobal: ViewportsGlobal = {
+        value: 'nonExistentViewport',
+      };
 
-    await setViewport(viewportsParam);
-    expect(page.viewport).toHaveBeenCalledWith(
-      DEFAULT_VIEWPORT_DIMENSIONS.width,
-      DEFAULT_VIEWPORT_DIMENSIONS.height
-    );
-  });
+      await setViewport({}, { viewport: viewportsGlobal });
+      expect(page.viewport).toHaveBeenCalledWith(
+        DEFAULT_VIEWPORT_DIMENSIONS.width,
+        DEFAULT_VIEWPORT_DIMENSIONS.height
+      );
+    });
 
-  it('should set the dimensions of viewport from INITIAL_VIEWPORTS', async () => {
-    const viewportsParam: any = {
-      viewports: INITIAL_VIEWPORTS,
-      // supported by default in addon viewports
-      defaultViewport: 'ipad',
-    };
+    it('should fall back to DEFAULT_VIEWPORT_DIMENSIONS if viewport is disabled, even if a viewport is set', async () => {
+      const viewportsParam: ViewportsParam = {
+        options: INITIAL_VIEWPORTS,
+        disable: true,
+      };
+      const viewportsGlobal: ViewportsGlobal = {
+        value: 'ipad',
+      };
 
-    await setViewport(viewportsParam);
-    expect(page.viewport).toHaveBeenCalledWith(768, 1024);
-  });
+      await setViewport({ viewport: viewportsParam }, { viewport: viewportsGlobal });
+      expect(page.viewport).toHaveBeenCalledWith(
+        DEFAULT_VIEWPORT_DIMENSIONS.width,
+        DEFAULT_VIEWPORT_DIMENSIONS.height
+      );
+    });
 
-  it('should set custom defined viewport dimensions', async () => {
-    const viewportsParam: ViewportsParam = {
-      defaultViewport: 'customViewport',
-      viewports: {
-        customViewport: {
-          name: 'Custom Viewport',
-          type: 'mobile',
-          styles: {
-            width: '800px',
-            height: '600px',
+    it('should set the dimensions of viewport from INITIAL_VIEWPORTS', async () => {
+      const viewportsParam: ViewportsParam = {
+        options: INITIAL_VIEWPORTS,
+      };
+      const viewportsGlobal: ViewportsGlobal = {
+        // supported by default in addon viewports
+        value: 'ipad',
+      };
+
+      await setViewport({ viewport: viewportsParam }, { viewport: viewportsGlobal });
+      expect(page.viewport).toHaveBeenCalledWith(768, 1024);
+    });
+
+    it('should set custom defined viewport dimensions', async () => {
+      const viewportsParam: ViewportsParam = {
+        options: {
+          customViewport: {
+            name: 'Custom Viewport',
+            type: 'mobile',
+            styles: {
+              width: '800px',
+              height: '600px',
+            },
           },
         },
-      },
-    };
+      };
+      const viewportsGlobal: ViewportsGlobal = {
+        value: 'customViewport',
+      };
 
-    await setViewport(viewportsParam);
-    expect(page.viewport).toHaveBeenCalledWith(800, 600);
-  });
+      await setViewport({ viewport: viewportsParam }, { viewport: viewportsGlobal });
+      expect(page.viewport).toHaveBeenCalledWith(800, 600);
+    });
 
-  it('should correctly handle percentage-based dimensions', async () => {
-    const viewportsParam: ViewportsParam = {
-      defaultViewport: 'percentageViewport',
-      viewports: {
-        percentageViewport: {
-          name: 'Percentage Viewport',
-          type: 'desktop',
-          styles: {
-            width: '50%',
-            height: '50%',
+    it('should correctly handle percentage-based dimensions', async () => {
+      const viewportsParam: ViewportsParam = {
+        options: {
+          percentageViewport: {
+            name: 'Percentage Viewport',
+            type: 'desktop',
+            styles: {
+              width: '50%',
+              height: '50%',
+            },
           },
         },
-      },
-    };
+      };
+      const viewportsGlobal: ViewportsGlobal = {
+        value: 'percentageViewport',
+      };
 
-    await setViewport(viewportsParam);
-    expect(page.viewport).toHaveBeenCalledWith(600, 450); // 50% of 1920 and 1080
-  });
+      await setViewport({ viewport: viewportsParam }, { viewport: viewportsGlobal });
+      expect(page.viewport).toHaveBeenCalledWith(600, 450); // 50% of 1920 and 1080
+    });
 
-  it('should correctly handle vw and vh based dimensions', async () => {
-    const viewportsParam: ViewportsParam = {
-      defaultViewport: 'viewportUnits',
-      viewports: {
-        viewportUnits: {
-          name: 'VW/VH Viewport',
-          type: 'desktop',
-          styles: {
-            width: '50vw',
-            height: '50vh',
+    it('should correctly handle vw and vh based dimensions', async () => {
+      const viewportsParam: ViewportsParam = {
+        options: {
+          viewportUnits: {
+            name: 'VW/VH Viewport',
+            type: 'desktop',
+            styles: {
+              width: '50vw',
+              height: '50vh',
+            },
           },
         },
-      },
-    };
+      };
+      const viewportsGlobal: ViewportsGlobal = {
+        value: 'viewportUnits',
+      };
 
-    await setViewport(viewportsParam);
-    expect(page.viewport).toHaveBeenCalledWith(600, 450); // 50% of 1920 and 1080
-  });
+      await setViewport({ viewport: viewportsParam }, { viewport: viewportsGlobal });
+      expect(page.viewport).toHaveBeenCalledWith(600, 450); // 50% of 1920 and 1080
+    });
 
-  it('should correctly handle em based dimensions', async () => {
-    const viewportsParam: ViewportsParam = {
-      defaultViewport: 'viewportUnits',
-      viewports: {
-        viewportUnits: {
-          name: 'em/rem Viewport',
-          type: 'mobile',
-          styles: {
-            width: '20em',
-            height: '40rem',
+    it('should correctly handle em based dimensions', async () => {
+      const viewportsParam: ViewportsParam = {
+        options: {
+          viewportUnits: {
+            name: 'em/rem Viewport',
+            type: 'mobile',
+            styles: {
+              width: '20em',
+              height: '40rem',
+            },
           },
         },
-      },
-    };
+      };
+      const viewportsGlobal: ViewportsGlobal = {
+        value: 'viewportUnits',
+      };
 
-    await setViewport(viewportsParam);
-    expect(page.viewport).toHaveBeenCalledWith(320, 640); // dimensions * 16
-  });
+      await setViewport({ viewport: viewportsParam }, { viewport: viewportsGlobal });
+      expect(page.viewport).toHaveBeenCalledWith(320, 640); // dimensions * 16
+    });
 
-  it('should throw an error for unsupported dimension values', async () => {
-    const viewportsParam: ViewportsParam = {
-      defaultViewport: 'invalidViewport',
-      viewports: {
-        invalidViewport: {
-          name: 'Invalid Viewport',
-          type: 'desktop',
-          styles: {
-            width: 'calc(100vw - 20px)',
-            height: '10pc',
+    it('should throw an error for unsupported dimension values', async () => {
+      const viewportsParam: ViewportsParam = {
+        options: {
+          invalidViewport: {
+            name: 'Invalid Viewport',
+            type: 'desktop',
+            styles: {
+              width: 'calc(100vw - 20px)',
+              height: '10pc',
+            },
           },
         },
-      },
-    };
+      };
+      const viewportsGlobal: ViewportsGlobal = {
+        value: 'invalidViewport',
+      };
 
-    await expect(setViewport(viewportsParam)).rejects.toThrowErrorMatchingInlineSnapshot(`
+      await expect(setViewport({ viewport: viewportsParam }, { viewport: viewportsGlobal })).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
       [SB_ADDON_VITEST_0001 (UnsupportedViewportDimensionError): Encountered an unsupported value "calc(100vw - 20px)" when setting the viewport width dimension.
 
       The Storybook plugin only supports values in the following units:
@@ -152,6 +187,142 @@ describe('setViewport', () => {
 
       You can either change the viewport for this story to use one of the supported units or skip the test by adding '!test' to the story's tags per https://storybook.js.org/docs/writing-stories/tags]
     `);
-    expect(page.viewport).not.toHaveBeenCalled();
+      expect(page.viewport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('parameters API (legacy)', () => {
+    it('should no op outside when not in Vitest browser mode', async () => {
+      globalThis.__vitest_browser__ = false;
+
+      await setViewport();
+      expect(page.viewport).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to DEFAULT_VIEWPORT_DIMENSIONS if defaultViewport does not exist', async () => {
+      const viewportsParam: any = {
+        defaultViewport: 'nonExistentViewport',
+      };
+
+      await setViewport({ viewport: viewportsParam });
+      expect(page.viewport).toHaveBeenCalledWith(
+        DEFAULT_VIEWPORT_DIMENSIONS.width,
+        DEFAULT_VIEWPORT_DIMENSIONS.height
+      );
+    });
+
+    it('should set the dimensions of viewport from INITIAL_VIEWPORTS', async () => {
+      const viewportsParam: any = {
+        viewports: INITIAL_VIEWPORTS,
+        // supported by default in addon viewports
+        defaultViewport: 'ipad',
+      };
+
+      await setViewport({ viewport: viewportsParam });
+      expect(page.viewport).toHaveBeenCalledWith(768, 1024);
+    });
+
+    it('should set custom defined viewport dimensions', async () => {
+      const viewportsParam: ViewportsParam = {
+        defaultViewport: 'customViewport',
+        viewports: {
+          customViewport: {
+            name: 'Custom Viewport',
+            type: 'mobile',
+            styles: {
+              width: '800px',
+              height: '600px',
+            },
+          },
+        },
+      };
+
+      await setViewport({ viewport: viewportsParam });
+      expect(page.viewport).toHaveBeenCalledWith(800, 600);
+    });
+
+    it('should correctly handle percentage-based dimensions', async () => {
+      const viewportsParam: ViewportsParam = {
+        defaultViewport: 'percentageViewport',
+        viewports: {
+          percentageViewport: {
+            name: 'Percentage Viewport',
+            type: 'desktop',
+            styles: {
+              width: '50%',
+              height: '50%',
+            },
+          },
+        },
+      };
+
+      await setViewport({ viewport: viewportsParam });
+      expect(page.viewport).toHaveBeenCalledWith(600, 450); // 50% of 1920 and 1080
+    });
+
+    it('should correctly handle vw and vh based dimensions', async () => {
+      const viewportsParam: ViewportsParam = {
+        defaultViewport: 'viewportUnits',
+        viewports: {
+          viewportUnits: {
+            name: 'VW/VH Viewport',
+            type: 'desktop',
+            styles: {
+              width: '50vw',
+              height: '50vh',
+            },
+          },
+        },
+      };
+
+      await setViewport({ viewport: viewportsParam });
+      expect(page.viewport).toHaveBeenCalledWith(600, 450); // 50% of 1920 and 1080
+    });
+
+    it('should correctly handle em based dimensions', async () => {
+      const viewportsParam: ViewportsParam = {
+        defaultViewport: 'viewportUnits',
+        viewports: {
+          viewportUnits: {
+            name: 'em/rem Viewport',
+            type: 'mobile',
+            styles: {
+              width: '20em',
+              height: '40rem',
+            },
+          },
+        },
+      };
+
+      await setViewport({ viewport: viewportsParam });
+      expect(page.viewport).toHaveBeenCalledWith(320, 640); // dimensions * 16
+    });
+
+    it('should throw an error for unsupported dimension values', async () => {
+      const viewportsParam: ViewportsParam = {
+        defaultViewport: 'invalidViewport',
+        viewports: {
+          invalidViewport: {
+            name: 'Invalid Viewport',
+            type: 'desktop',
+            styles: {
+              width: 'calc(100vw - 20px)',
+              height: '10pc',
+            },
+          },
+        },
+      };
+
+      await expect(setViewport({ viewport: viewportsParam })).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+      [SB_ADDON_VITEST_0001 (UnsupportedViewportDimensionError): Encountered an unsupported value "calc(100vw - 20px)" when setting the viewport width dimension.
+
+      The Storybook plugin only supports values in the following units:
+      - px, vh, vw, em, rem and %.
+
+      You can either change the viewport for this story to use one of the supported units or skip the test by adding '!test' to the story's tags per https://storybook.js.org/docs/writing-stories/tags]
+    `);
+      expect(page.viewport).not.toHaveBeenCalled();
+    });
   });
 });

--- a/code/addons/test/src/vitest-plugin/viewports.ts
+++ b/code/addons/test/src/vitest-plugin/viewports.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-underscore-dangle */
 import { UnsupportedViewportDimensionError } from 'storybook/internal/preview-errors';
 
+import type { Globals, Parameters } from '@storybook/csf';
+
 import { page } from '@vitest/browser/context';
 
 import { MINIMAL_VIEWPORTS } from '../../../viewport/src/defaults';
@@ -12,8 +14,16 @@ declare global {
 }
 
 export interface ViewportsParam {
-  defaultViewport: string;
-  viewports: ViewportMap;
+  defaultViewport?: string;
+  viewports?: ViewportMap;
+  options?: ViewportMap;
+  disable?: boolean;
+  disabled?: boolean;
+}
+
+export interface ViewportsGlobal {
+  value?: string;
+  disable?: boolean;
 }
 
 export const DEFAULT_VIEWPORT_DIMENSIONS = {
@@ -47,8 +57,18 @@ const parseDimension = (value: string, dimension: 'width' | 'height') => {
   }
 };
 
-export const setViewport = async (viewportsParam: ViewportsParam = {} as ViewportsParam) => {
-  const defaultViewport = viewportsParam.defaultViewport;
+export const setViewport = async (parameters: Parameters = {}, globals: Globals = {}) => {
+  let defaultViewport;
+  const viewportsParam: ViewportsParam = parameters.viewport ?? {};
+  const viewportsGlobal: ViewportsGlobal = globals.viewport ?? {};
+  const isDisabled = viewportsParam.disable || viewportsParam.disabled;
+
+  // Support new setting from globals, else use the one from parameters
+  if (viewportsGlobal.value && !isDisabled) {
+    defaultViewport = viewportsGlobal.value;
+  } else if (!isDisabled) {
+    defaultViewport = viewportsParam.defaultViewport;
+  }
 
   if (!page || !globalThis.__vitest_browser__) {
     return;
@@ -57,6 +77,7 @@ export const setViewport = async (viewportsParam: ViewportsParam = {} as Viewpor
   const viewports = {
     ...MINIMAL_VIEWPORTS,
     ...viewportsParam.viewports,
+    ...viewportsParam.options,
   };
 
   let viewportWidth = DEFAULT_VIEWPORT_DIMENSIONS.width;

--- a/code/core/src/components/components/tabs/tabs.stories.tsx
+++ b/code/core/src/components/components/tabs/tabs.stories.tsx
@@ -178,8 +178,6 @@ const customViewports = {
 };
 
 export const StatefulDynamicWithOpenTooltip = {
-  // TODO VITEST INTEGRATION: remove this when we support new viewport global format in the vitest integration
-  tags: ['!vitest'],
   parameters: {
     viewport: {
       options: customViewports,
@@ -224,8 +222,6 @@ export const StatefulDynamicWithOpenTooltip = {
 
 export const StatefulDynamicWithSelectedAddon = {
   ...StatefulDynamicWithOpenTooltip,
-  // TODO VITEST INTEGRATION: remove this when we support new viewport global format in the vitest integration
-  tags: ['!vitest'],
   play: async (context) => {
     await StatefulDynamicWithOpenTooltip.play(context);
     const canvas = within(context.canvasElement);

--- a/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
@@ -179,8 +179,6 @@ export const WithRefsNarrow: Story = {
       value: 'narrow',
     },
   },
-  // TODO VITEST INTEGRATION: remove this when we support new viewport global format in the vitest integration
-  tags: ['!vitest'],
 };
 
 export const LoadingWithRefs: Story = {

--- a/code/core/src/manager/components/sidebar/Tree.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.stories.tsx
@@ -208,7 +208,21 @@ export const DocsOnlySingleStoryComponents = {
 export const SkipToCanvasLinkFocused: Story = {
   ...DocsOnlySingleStoryComponents,
   parameters: {
-    chromatic: { disable: true },
+    chromatic: { viewports: [1280] },
+    viewport: {
+      options: {
+        desktop: {
+          name: 'Desktop',
+          styles: {
+            width: '100%',
+            height: '100%',
+          },
+        },
+      },
+    },
+  },
+  globals: {
+    viewport: { value: 'desktop' },
   },
   play: async ({ canvasElement }) => {
     const screen = await within(canvasElement);

--- a/code/core/src/preview-api/modules/store/csf/portable-stories.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.ts
@@ -139,16 +139,17 @@ export function composeStory<TRenderer extends Renderer = Renderer, TArgs extend
   );
 
   const globalsFromGlobalTypes = getValuesFromArgTypes(normalizedProjectAnnotations.globalTypes);
+  const globals = {
+    // TODO: remove loading from globalTypes in 9.0
+    ...globalsFromGlobalTypes,
+    ...normalizedProjectAnnotations.initialGlobals,
+    ...story.storyGlobals,
+  };
 
   const initializeContext = () => {
     const context: StoryContext<TRenderer> = prepareContext({
       hooks: new HooksContext(),
-      globals: {
-        // TODO: remove loading from globalTypes in 9.0
-        ...globalsFromGlobalTypes,
-        ...normalizedProjectAnnotations.initialGlobals,
-        ...story.storyGlobals,
-      },
+      globals,
       args: { ...story.initialArgs },
       viewMode: 'story',
       loaded: {},
@@ -251,6 +252,7 @@ export function composeStory<TRenderer extends Renderer = Renderer, TArgs extend
 
         loadedContext = context;
       },
+      globals,
       args: story.initialArgs as Partial<TArgs>,
       parameters: story.parameters as Parameters,
       argTypes: story.argTypes as StrictArgTypes<TArgs>,

--- a/code/core/src/types/modules/composedStory.ts
+++ b/code/core/src/types/modules/composedStory.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type {
+  Globals,
   ProjectAnnotations,
   Renderer,
   StoryContext,
@@ -49,6 +50,7 @@ export type ComposedStoryFn<
   parameters: Parameters;
   argTypes: StrictArgTypes<TArgs>;
   tags: Tag[];
+  globals: Globals;
 };
 /**
  * Based on a module of stories, it returns all stories within it, filtering non-stories Each story


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/29324

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds support for the new globals API for viewports, so that users that use the new test addon can get Playwright to use the correct dimensions respecting the viewports addon, both via parameters (legacy) API as well as globals (new) API

To make this work, I had to update portable stories to also include globals as part of its return type.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->
There are tests for all use cases, but to test it manually you can use a story like the following (using both parameters and globals apis):
```ts
const customViewports = {
  sized: {
    name: 'Sized',
    styles: {
      width: '380px',
      height: '500px',
    },
  },
};
const parametersApi = {
  defaultViewport: 'sized',
  viewports: customViewports,
}
const globalsApi = {
  options: customViewports,
}

export const ExpectedSuccess = {
  parameters: {
    viewport: {
      ...parametersApi,
      ...globalsApi
    },
  },
  globals: { viewport: { value: 'sized' } },
};
```

Then run Vitest browser mode tests visually, and notice the viewport changing in size.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 6 B | 0.69 | 0% |
| initSize |  147 MB | 147 MB | 22 B | -1.08 | 0% |
| diffSize |  68.3 MB | 68.3 MB | 16 B | -1.08 | 0% |
| buildSize |  7.1 MB | 7.1 MB | 28 B | -0.66 | 0% |
| buildSbAddonsSize |  1.79 MB | 1.79 MB | 30 B | -0.72 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 0 B | -0.73 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | -2 B | -0.76 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.1 MB | 4.1 MB | 28 B | -0.73 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 1.09 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  5.9s | 5.6s | -233ms | **-1.28** | -4.1% |
| generateTime |  22.1s | 19.2s | -2s -861ms | -0.93 | -14.9% |
| initTime |  14.7s | 12.7s | -2s -5ms | **-1.69** | 🔰-15.7% |
| buildTime |  10.7s | 7.8s | -2s -904ms | **-1.7** | 🔰-37.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6s | 6.1s | 19ms | -0.42 | 0.3% |
| devManagerResponsive |  4s | 3.9s | -118ms | -0.63 | -3% |
| devManagerHeaderVisible |  589ms | 602ms | 13ms | 0.09 | 2.2% |
| devManagerIndexVisible |  620ms | 636ms | 16ms | 0.08 | 2.5% |
| devStoryVisibleUncached |  809ms | 894ms | 85ms | -0.75 | 9.5% |
| devStoryVisible |  619ms | 638ms | 19ms | 0.1 | 3% |
| devAutodocsVisible |  568ms | 533ms | -35ms | -0.4 | -6.6% |
| devMDXVisible |  573ms | 528ms | -45ms | -0.13 | -8.5% |
| buildManagerHeaderVisible |  572ms | 526ms | -46ms | -0.72 | -8.7% |
| buildManagerIndexVisible |  638ms | 594ms | -44ms | 0.18 | -7.4% |
| buildStoryVisible |  639ms | 594ms | -45ms | -0.2 | -7.6% |
| buildAutodocsVisible |  542ms | 547ms | 5ms | 0.4 | 0.9% |
| buildMDXVisible |  690ms | 464ms | -226ms | -1.13 | -48.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds support for viewport globals in the Storybook addon testing framework, enhancing the ability to test responsive designs across different viewport sizes.

- Updated `setViewport` function in `viewports.ts` to handle both parameters and globals for viewport settings
- Added new tests in `viewports.test.ts` to cover the globals API and various viewport dimension formats
- Modified `testStory` function in `test-utils.ts` to pass both parameters and globals to `setViewport`
- Updated `ComposedStoryFn` type in `composedStory.ts` to include a `globals` property
- Removed '!vitest' tags from some stories in `tabs.stories.tsx` and `Sidebar.stories.tsx` to enable testing with viewport globals

<!-- /greptile_comment -->