### PR TITLE
CLI: Install Svelte CSF v5 in Svelte5 projects

### DIFF
--- a/code/lib/create-storybook/src/generators/SVELTE/index.test.ts
+++ b/code/lib/create-storybook/src/generators/SVELTE/index.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+
+import { JsPackageManager } from '@storybook/core/common';
+import { getAddonSvelteCsfVersion } from './index';
+
+describe('installed', () => {
+  it.each([
+    ['3.0.0', ''],
+    ['4.0.0', '4'],
+    ['5.0.0', '^5.0.0-next.0'],
+    ['6.0.0', ''],
+    ['3.0.0-next.0', ''],
+    ['4.0.0-next.0', '4'],
+    ['5.0.0-next.0',  '^5.0.0-next.0'],
+    ['6.0.0-next.0', '']
+  ])('svelte %s => %s', async (svelteVersion, expectedAddonSpecifier) => {
+    const packageManager = {
+      getInstalledVersion: async (pkg: string) => pkg === 'svelte' ? svelteVersion : undefined,
+      getAllDependencies: async () => ({ svelte: `^${svelteVersion}` })
+    } as any as JsPackageManager;
+    await expect(getAddonSvelteCsfVersion(packageManager)).resolves.toEqual(expectedAddonSpecifier);
+  });
+});
+
+describe('uninstalled', () => {
+  it.each([
+    ['^3', ''],
+    ['^4', '4'],
+    ['^5', '^5.0.0-next.0'],
+    ['^6', ''],
+    ['^3.0.0-next.0', ''],
+    ['^4.0.0-next.0', '4'],
+    ['^5.0.0-next.0', '^5.0.0-next.0'],
+    ['^6.0.0-next.0', '']
+  ])('svelte %s => %s', async (svelteSpecifier, expectedAddonSpecifier) => {
+    const packageManager = {
+      getInstalledVersion: async (pkg: string) => undefined,
+      getAllDependencies: async () => ({ svelte: svelteSpecifier })
+    } as any as JsPackageManager;
+    await expect(getAddonSvelteCsfVersion(packageManager)).resolves.toEqual(expectedAddonSpecifier);
+  });
+});

--- a/code/lib/create-storybook/src/generators/SVELTE/index.test.ts
+++ b/code/lib/create-storybook/src/generators/SVELTE/index.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { JsPackageManager } from '@storybook/core/common';
+import type { JsPackageManager } from '@storybook/core/common';
+
 import { getAddonSvelteCsfVersion } from './index';
 
 describe('installed', () => {
@@ -11,14 +12,15 @@ describe('installed', () => {
     ['6.0.0', ''],
     ['3.0.0-next.0', ''],
     ['4.0.0-next.0', '4'],
-    ['5.0.0-next.0',  '^5.0.0-next.0'],
-    ['6.0.0-next.0', '']
+    ['4.2.19::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fsvelte%2F-%2Fsvelte-4.2.19.tgz', '4'],
+    ['5.0.0-next.0', '^5.0.0-next.0'],
+    ['6.0.0-next.0', ''],
   ])('svelte %s => %s', async (svelteVersion, expectedAddonSpecifier) => {
     const packageManager = {
-      getInstalledVersion: async (pkg: string) => pkg === 'svelte' ? svelteVersion : undefined,
-      getAllDependencies: async () => ({ svelte: `^${svelteVersion}` })
+      getInstalledVersion: async (pkg: string) => (pkg === 'svelte' ? svelteVersion : undefined),
+      getAllDependencies: async () => ({ svelte: `^${svelteVersion}` }),
     } as any as JsPackageManager;
-    await expect(getAddonSvelteCsfVersion(packageManager)).resolves.toEqual(expectedAddonSpecifier);
+    await expect(getAddonSvelteCsfVersion(packageManager)).resolves.toBe(expectedAddonSpecifier);
   });
 });
 
@@ -31,12 +33,12 @@ describe('uninstalled', () => {
     ['^3.0.0-next.0', ''],
     ['^4.0.0-next.0', '4'],
     ['^5.0.0-next.0', '^5.0.0-next.0'],
-    ['^6.0.0-next.0', '']
+    ['^6.0.0-next.0', ''],
   ])('svelte %s => %s', async (svelteSpecifier, expectedAddonSpecifier) => {
     const packageManager = {
       getInstalledVersion: async (pkg: string) => undefined,
-      getAllDependencies: async () => ({ svelte: svelteSpecifier })
+      getAllDependencies: async () => ({ svelte: svelteSpecifier }),
     } as any as JsPackageManager;
-    await expect(getAddonSvelteCsfVersion(packageManager)).resolves.toEqual(expectedAddonSpecifier);
+    await expect(getAddonSvelteCsfVersion(packageManager)).resolves.toBe(expectedAddonSpecifier);
   });
 });

--- a/code/lib/create-storybook/src/generators/SVELTE/index.ts
+++ b/code/lib/create-storybook/src/generators/SVELTE/index.ts
@@ -1,10 +1,39 @@
+import { coerce, major } from 'semver'
+
 import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
+import { JsPackageManager } from '@storybook/core/common';
+
+const versionHelper = (svelteMajor?: number) => {
+  if(svelteMajor === 4) return '4';
+  // TODO: update when addon-svelte-csf v5 is released
+  if(svelteMajor === 5) return '^5.0.0-next.0';
+  return '';
+}
+
+export const getAddonSvelteCsfVersion = async (packageManager: JsPackageManager) => {
+  const svelteVersion = await packageManager.getInstalledVersion('svelte');
+  if(svelteVersion) {
+    return versionHelper(major(svelteVersion));
+  } else {
+    const deps = await packageManager.getAllDependencies();
+    const svelteSpecifier = deps['svelte'];
+    try {
+      const coerced = coerce(svelteSpecifier);
+      if(coerced?.version) {
+        return versionHelper(major(coerced.version));
+      }
+    } catch {}
+  }
+  return '';
+}
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
+  const addonSvelteCsfVersion = await getAddonSvelteCsfVersion(packageManager);
+
   await baseGenerator(packageManager, npmOptions, options, 'svelte', {
     extensions: ['js', 'ts', 'svelte'],
-    extraAddons: ['@storybook/addon-svelte-csf'],
+    extraAddons: [`@storybook/addon-svelte-csf${addonSvelteCsfVersion && `@${addonSvelteCsfVersion}`}`],
   });
 };
 

--- a/code/lib/create-storybook/src/generators/SVELTE/index.ts
+++ b/code/lib/create-storybook/src/generators/SVELTE/index.ts
@@ -1,39 +1,48 @@
-import { coerce, major } from 'semver'
+import type { JsPackageManager } from 'storybook/internal/common';
+
+import { coerce, major } from 'semver';
 
 import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
-import { JsPackageManager } from '@storybook/core/common';
 
 const versionHelper = (svelteMajor?: number) => {
-  if(svelteMajor === 4) return '4';
+  if (svelteMajor === 4) {
+    return '4';
+  }
   // TODO: update when addon-svelte-csf v5 is released
-  if(svelteMajor === 5) return '^5.0.0-next.0';
+  if (svelteMajor === 5) {
+    return '^5.0.0-next.0';
+  }
   return '';
-}
+};
 
 export const getAddonSvelteCsfVersion = async (packageManager: JsPackageManager) => {
   const svelteVersion = await packageManager.getInstalledVersion('svelte');
-  if(svelteVersion) {
-    return versionHelper(major(svelteVersion));
-  } else {
-    const deps = await packageManager.getAllDependencies();
-    const svelteSpecifier = deps['svelte'];
-    try {
+  try {
+    if (svelteVersion) {
+      return versionHelper(major(coerce(svelteVersion) || ''));
+    } else {
+      const deps = await packageManager.getAllDependencies();
+      const svelteSpecifier = deps['svelte'];
       const coerced = coerce(svelteSpecifier);
-      if(coerced?.version) {
+      if (coerced?.version) {
         return versionHelper(major(coerced.version));
       }
-    } catch {}
+    }
+  } catch {
+    // fallback to latest version
   }
   return '';
-}
+};
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
   const addonSvelteCsfVersion = await getAddonSvelteCsfVersion(packageManager);
 
   await baseGenerator(packageManager, npmOptions, options, 'svelte', {
     extensions: ['js', 'ts', 'svelte'],
-    extraAddons: [`@storybook/addon-svelte-csf${addonSvelteCsfVersion && `@${addonSvelteCsfVersion}`}`],
+    extraAddons: [
+      `@storybook/addon-svelte-csf${addonSvelteCsfVersion && `@${addonSvelteCsfVersion}`}`,
+    ],
   });
 };
 

--- a/code/lib/create-storybook/src/generators/SVELTEKIT/index.ts
+++ b/code/lib/create-storybook/src/generators/SVELTEKIT/index.ts
@@ -2,8 +2,11 @@ import { CoreBuilder } from 'storybook/internal/cli';
 
 import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
+import { getAddonSvelteCsfVersion } from '../SVELTE';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
+  const addonSvelteCsfVersion = await getAddonSvelteCsfVersion(packageManager);
+
   await baseGenerator(
     packageManager,
     npmOptions,
@@ -11,7 +14,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
     'svelte',
     {
       extensions: ['js', 'ts', 'svelte'],
-      extraAddons: ['@storybook/addon-svelte-csf'],
+      extraAddons: [`@storybook/addon-svelte-csf${addonSvelteCsfVersion && `@${addonSvelteCsfVersion}`}`],
     },
     'sveltekit'
   );

--- a/code/lib/create-storybook/src/generators/SVELTEKIT/index.ts
+++ b/code/lib/create-storybook/src/generators/SVELTEKIT/index.ts
@@ -1,8 +1,8 @@
 import { CoreBuilder } from 'storybook/internal/cli';
 
+import { getAddonSvelteCsfVersion } from '../SVELTE';
 import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
-import { getAddonSvelteCsfVersion } from '../SVELTE';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
   const addonSvelteCsfVersion = await getAddonSvelteCsfVersion(packageManager);
@@ -14,7 +14,9 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
     'svelte',
     {
       extensions: ['js', 'ts', 'svelte'],
-      extraAddons: [`@storybook/addon-svelte-csf${addonSvelteCsfVersion && `@${addonSvelteCsfVersion}`}`],
+      extraAddons: [
+        `@storybook/addon-svelte-csf${addonSvelteCsfVersion && `@${addonSvelteCsfVersion}`}`,
+      ],
     },
     'sveltekit'
   );


### PR DESCRIPTION
Closes N/A

## What I did

Prepare `storybook init` for the Svelte 5 release, in both Svelte and SvelteKit projects:

- When Svelte 4 is installed, use addon-svelte-csf v4
- When Svelte 5 is installed, use addon-svelte-csf v5 prerelease
- When Svelte 5 is installed and addon-svelte-csf v5 is released, use v5
- When Svelte 5 is not installed, make a best guess of the above using the `package.json` version specifier
- When all else fails, just use the latest version of `addon-svelte-csf`

@JReinhold Do we need to update the template stories for Svelte CSF v5?

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

What I did:
- [x] Create a `svelte-kit/skeleton-ts` sandbox and verify that it's using the latest v4 stable release of `addon-svelte-csf`
- [x] Create a `svelte-kit/prerelease-ts` sandbox and verify that it's using the latest prerelease of `addon-svelte-csf`

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 26 B | 0.57 | 0% |
| initSize |  147 MB | 147 MB | 26 B | **-1.31** | 0% |
| diffSize |  68.3 MB | 68.3 MB | 0 B | **-1.31** | 0% |
| buildSize |  6.79 MB | 6.79 MB | 0 B | **1.33** | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | **-1.53** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 0 B | - | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 0 B | **-1.53** | 0% |
| buildPreviewSize |  2.99 MB | 2.99 MB | 0 B | **1.34** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.5s | 14.5s | 5.9s | 0.29 | 41.2% |
| generateTime |  21s | 20.9s | -79ms | 0.12 | -0.4% |
| initTime |  14.5s | 14.1s | -402ms | -0.1 | -2.8% |
| buildTime |  8.4s | 10.8s | 2.3s | 0.5 | 21.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.6s | 8.1s | 2.5s | 0.72 | 31% |
| devManagerResponsive |  3.9s | 5.1s | 1.2s | 0.74 | 24.3% |
| devManagerHeaderVisible |  633ms | 1s | 404ms | **4.58** | 🔺39% |
| devManagerIndexVisible |  694ms | 1s | 344ms | **3.95** | 🔺33.1% |
| devStoryVisibleUncached |  987ms | 1.7s | 779ms | **1.59** | 🔺44.1% |
| devStoryVisible |  694ms | 1s | 362ms | **4.07** | 🔺34.3% |
| devAutodocsVisible |  574ms | 908ms | 334ms | **5.17** | 🔺36.8% |
| devMDXVisible |  519ms | 924ms | 405ms | **4.41** | 🔺43.8% |
| buildManagerHeaderVisible |  528ms | 635ms | 107ms | 0.49 | 16.9% |
| buildManagerIndexVisible |  534ms | 640ms | 106ms | 0.42 | 16.6% |
| buildStoryVisible |  599ms | 680ms | 81ms | 0.34 | 11.9% |
| buildAutodocsVisible |  486ms | 567ms | 81ms | 0.71 | 14.3% |
| buildMDXVisible |  465ms | 620ms | 155ms | 1.1 | 25% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR updates the Storybook CLI to dynamically install the appropriate version of addon-svelte-csf based on the installed Svelte version, preparing for Svelte 5 compatibility.

- Added `getAddonSvelteCsfVersion` function in `code/lib/create-storybook/src/generators/SVELTE/index.ts` to determine correct addon version
- Implemented comprehensive unit tests in `code/lib/create-storybook/src/generators/SVELTE/index.test.ts` for various Svelte versions
- Updated SvelteKit generator in `code/lib/create-storybook/src/generators/SVELTEKIT/index.ts` to use dynamic addon version
- Ensured backward compatibility with Svelte 4 while preparing for Svelte 5 release
- Handled scenarios for installed, uninstalled, and pre-release Svelte versions

<!-- /greptile_comment -->