### PR TITLE
Addon Test: Add telemetry on discrepancy results

### DIFF
--- a/code/addons/test/src/Panel.tsx
+++ b/code/addons/test/src/Panel.tsx
@@ -290,6 +290,7 @@ export const Panel = memo<{ storyId: string }>(function PanelMemoized({ storyId 
         pausedAt={pausedAt}
         endRef={endRef}
         onScrollToEnd={scrollTarget && scrollToTarget}
+        storyId={storyId}
       />
     </Fragment>
   );

--- a/code/addons/test/src/Panel.tsx
+++ b/code/addons/test/src/Panel.tsx
@@ -291,6 +291,7 @@ export const Panel = memo<{ storyId: string }>(function PanelMemoized({ storyId 
         endRef={endRef}
         onScrollToEnd={scrollTarget && scrollToTarget}
         storyId={storyId}
+        testRunId={storyStatus?.data?.testRunId}
       />
     </Fragment>
   );

--- a/code/addons/test/src/components/InteractionsPanel.stories.tsx
+++ b/code/addons/test/src/components/InteractionsPanel.stories.tsx
@@ -29,6 +29,7 @@ const managerContext: any = {
   state: {},
   api: {
     getDocsUrl: fn().mockName('api::getDocsUrl'),
+    emit: fn().mockName('api::emit'),
   },
 };
 
@@ -57,6 +58,7 @@ const meta = {
     endRef: null,
     // prop for the AddonPanel used as wrapper of Panel
     active: true,
+    storyId: 'story-id',
   },
 } as Meta<typeof InteractionsPanel>;
 

--- a/code/addons/test/src/components/InteractionsPanel.tsx
+++ b/code/addons/test/src/components/InteractionsPanel.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { styled } from 'storybook/internal/theming';
+import type { StoryId } from 'storybook/internal/types';
 
 import type { CallStates } from '@storybook/instrumenter';
 import { type Call, type ControlStates } from '@storybook/instrumenter';
@@ -43,6 +44,7 @@ interface InteractionsPanelProps {
   onScrollToEnd?: () => void;
   hasResultMismatch?: boolean;
   browserTestStatus?: CallStates;
+  storyId: StoryId;
 }
 
 const Container = styled.div(({ theme }) => ({
@@ -102,12 +104,15 @@ export const InteractionsPanel: React.FC<InteractionsPanelProps> = React.memo(
     endRef,
     hasResultMismatch,
     browserTestStatus,
+    storyId,
   }) {
     const filter = useAnsiToHtmlFilter();
 
     return (
       <Container>
-        {hasResultMismatch && <TestDiscrepancyMessage browserTestStatus={browserTestStatus} />}
+        {hasResultMismatch && (
+          <TestDiscrepancyMessage browserTestStatus={browserTestStatus} storyId={storyId} />
+        )}
         {(interactions.length > 0 || hasException) && (
           <Subnav
             controls={controls}

--- a/code/addons/test/src/components/InteractionsPanel.tsx
+++ b/code/addons/test/src/components/InteractionsPanel.tsx
@@ -45,6 +45,7 @@ interface InteractionsPanelProps {
   hasResultMismatch?: boolean;
   browserTestStatus?: CallStates;
   storyId: StoryId;
+  testRunId: string;
 }
 
 const Container = styled.div(({ theme }) => ({
@@ -105,13 +106,18 @@ export const InteractionsPanel: React.FC<InteractionsPanelProps> = React.memo(
     hasResultMismatch,
     browserTestStatus,
     storyId,
+    testRunId,
   }) {
     const filter = useAnsiToHtmlFilter();
 
     return (
       <Container>
         {hasResultMismatch && (
-          <TestDiscrepancyMessage browserTestStatus={browserTestStatus} storyId={storyId} />
+          <TestDiscrepancyMessage
+            browserTestStatus={browserTestStatus}
+            storyId={storyId}
+            testRunId={testRunId}
+          />
         )}
         {(interactions.length > 0 || hasException) && (
           <Subnav

--- a/code/addons/test/src/components/TestDiscrepancyMessage.stories.tsx
+++ b/code/addons/test/src/components/TestDiscrepancyMessage.stories.tsx
@@ -13,6 +13,7 @@ const managerContext: any = {
   state: {},
   api: {
     getDocsUrl: fn().mockName('api::getDocsUrl'),
+    emit: fn().mockName('api::emit'),
   },
 };
 
@@ -21,6 +22,9 @@ export default {
   component: TestDiscrepancyMessage,
   parameters: {
     layout: 'fullscreen',
+  },
+  args: {
+    storyId: 'story-id',
   },
   decorators: [
     (storyFn) => (

--- a/code/addons/test/src/components/TestDiscrepancyMessage.tsx
+++ b/code/addons/test/src/components/TestDiscrepancyMessage.tsx
@@ -34,10 +34,12 @@ const Wrapper = styled.div(({ theme: { color, typography, background } }) => ({
 interface TestDiscrepancyMessageProps {
   browserTestStatus: CallStates;
   storyId: StoryId;
+  testRunId: string;
 }
 export const TestDiscrepancyMessage = ({
   browserTestStatus,
   storyId,
+  testRunId,
 }: TestDiscrepancyMessageProps) => {
   const api = useStorybookApi();
   const docsUrl = api.getDocsUrl({
@@ -54,11 +56,11 @@ export const TestDiscrepancyMessage = ({
         payload: {
           browserStatus: browserTestStatus === CallStates.DONE ? 'PASS' : 'FAIL',
           cliStatus: browserTestStatus === CallStates.DONE ? 'FAIL' : 'PASS',
-          message,
           storyId,
+          testRunId,
         },
       }),
-    [api, message, browserTestStatus, storyId]
+    [api, browserTestStatus, storyId, testRunId]
   );
 
   return (

--- a/code/addons/test/src/constants.ts
+++ b/code/addons/test/src/constants.ts
@@ -1,6 +1,7 @@
 export const ADDON_ID = 'storybook/test';
 export const TEST_PROVIDER_ID = `${ADDON_ID}/test-provider`;
 export const PANEL_ID = `${ADDON_ID}/panel`;
+export const STORYBOOK_ADDON_TEST_CHANNEL = 'STORYBOOK_ADDON_TEST_CHANNEL';
 
 export const TUTORIAL_VIDEO_LINK = 'https://youtu.be/Waht9qq7AoA';
 export const DOCUMENTATION_LINK = 'writing-tests/component-testing';

--- a/code/addons/test/src/manager.tsx
+++ b/code/addons/test/src/manager.tsx
@@ -137,7 +137,7 @@ addons.register(ADDON_ID, (api) => {
       Object.fromEntries(
         (state.details.testResults || []).flatMap((testResult) =>
           testResult.results
-            .map(({ storyId, status, ...rest }) => {
+            .map(({ storyId, status, testRunId, ...rest }) => {
               if (storyId) {
                 const statusObject: API_StatusObject = {
                   title: 'Vitest',
@@ -146,6 +146,9 @@ addons.register(ADDON_ID, (api) => {
                     'failureMessages' in rest && rest.failureMessages?.length
                       ? rest.failureMessages.join('\n')
                       : '',
+                  data: {
+                    testRunId,
+                  },
                 };
                 return [storyId, statusObject];
               }

--- a/code/addons/test/src/node/reporter.ts
+++ b/code/addons/test/src/node/reporter.ts
@@ -24,12 +24,14 @@ export type TestResultResult =
   | {
       status: 'success' | 'pending';
       storyId: string;
+      testRunId: string;
       duration: number;
     }
   | {
       status: 'failed';
       storyId: string;
       duration: number;
+      testRunId: string;
       failureMessages: string[];
     };
 
@@ -112,14 +114,15 @@ export class StorybookReporter implements Reporter {
         const status = StatusMap[t.result?.state || t.mode] || 'skipped';
         const storyId = (t.meta as any).storyId as string;
         const duration = t.result?.duration || 0;
+        const testRunId = this.start.toString();
 
         switch (status) {
           case 'passed':
           case 'pending':
-            return [{ status, storyId, duration } as TestResultResult];
+            return [{ status, storyId, duration, testRunId } as TestResultResult];
           case 'failed':
             const failureMessages = t.result?.errors?.map((e) => e.stack || e.message) || [];
-            return [{ status, storyId, duration, failureMessages } as TestResultResult];
+            return [{ status, storyId, duration, failureMessages, testRunId } as TestResultResult];
           default:
             return [];
         }

--- a/code/addons/test/src/preset.ts
+++ b/code/addons/test/src/preset.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 
 import type { Channel } from 'storybook/internal/channels';
@@ -7,8 +8,10 @@ import {
   TESTING_MODULE_RUN_REQUEST,
   TESTING_MODULE_WATCH_MODE_REQUEST,
 } from 'storybook/internal/core-events';
-import type { Options } from 'storybook/internal/types';
+import { oneWayHash, telemetry } from 'storybook/internal/telemetry';
+import type { Options, StoryId } from 'storybook/internal/types';
 
+import { STORYBOOK_ADDON_TEST_CHANNEL } from './constants';
 import { bootTestRunner } from './node/boot-test-runner';
 
 export const checkActionsLoaded = (configDir: string) => {
@@ -26,6 +29,16 @@ export const checkActionsLoaded = (configDir: string) => {
       : join(process.cwd(), configDir, 'main'),
     getConfig: (configFile) => serverRequire(configFile),
   });
+};
+
+type Event = {
+  type: 'test-discrepancy';
+  payload: {
+    storyId: StoryId;
+    browserStatus: 'PASS' | 'FAIL';
+    cliStatus: 'FAIL' | 'PASS';
+    message: string;
+  };
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -64,6 +77,26 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
       start(TESTING_MODULE_WATCH_MODE_REQUEST)(payload);
     }
   });
+
+  if (!core.disableTelemetry) {
+    const packageJsonPath = require.resolve('@storybook/experimental-addon-test/package.json');
+
+    const { version: addonVersion } = JSON.parse(
+      readFileSync(packageJsonPath, { encoding: 'utf-8' })
+    );
+
+    channel.on(STORYBOOK_ADDON_TEST_CHANNEL, (event: Event) => {
+      // @ts-expect-error This telemetry is not a core one, so we don't have official types for it (similar to onboarding addon)
+      telemetry('addon-test', {
+        ...event,
+        payload: {
+          ...event.payload,
+          storyId: oneWayHash(event.payload.storyId),
+        },
+        addonVersion,
+      });
+    });
+  }
 
   return channel;
 };


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/29162

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR implements a telemetry event for scenarios where there is a discrepancy between test results, with the following payload:

```
type Event = {
  type: 'test-discrepancy';
  payload: {
    storyId: StoryId;
    browserStatus: 'PASS' | 'FAIL';
    cliStatus: 'FAIL' | 'PASS';
    message: string;
  };
};
```

Perhaps in the future there would be other events, such as "global-error" or something like that.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 0 B | 0.69 | 0% |
| initSize |  147 MB | 147 MB | 0 B | -1.08 | 0% |
| diffSize |  68.3 MB | 68.3 MB | 0 B | -1.08 | 0% |
| buildSize |  7.1 MB | 7.1 MB | 335 B | -0.66 | 0% |
| buildSbAddonsSize |  1.79 MB | 1.79 MB | 335 B | -0.71 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 0 B | -0.73 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | -0.76 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.1 MB | 4.1 MB | 335 B | -0.73 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 1.09 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  5.9s | 15.8s | 9.9s | 0.34 | 62.8% |
| generateTime |  22.1s | 20.9s | -1s -208ms | -0.29 | -5.8% |
| initTime |  14.7s | 14.6s | -87ms | -0.48 | -0.6% |
| buildTime |  10.7s | 9.3s | -1s -410ms | -0.48 | -15.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6s | 6.1s | 84ms | -0.34 | 1.4% |
| devManagerResponsive |  4s | 3.9s | -79ms | -0.54 | -2% |
| devManagerHeaderVisible |  589ms | 631ms | 42ms | 0.61 | 6.7% |
| devManagerIndexVisible |  620ms | 658ms | 38ms | 0.44 | 5.8% |
| devStoryVisibleUncached |  809ms | 946ms | 137ms | -0.54 | 14.5% |
| devStoryVisible |  619ms | 656ms | 37ms | 0.41 | 5.6% |
| devAutodocsVisible |  568ms | 515ms | -53ms | -0.72 | -10.3% |
| devMDXVisible |  573ms | 563ms | -10ms | 0.49 | -1.8% |
| buildManagerHeaderVisible |  572ms | 519ms | -53ms | -0.88 | -10.2% |
| buildManagerIndexVisible |  638ms | 593ms | -45ms | 0.16 | -7.6% |
| buildStoryVisible |  639ms | 594ms | -45ms | -0.2 | -7.6% |
| buildAutodocsVisible |  542ms | 465ms | -77ms | **-1.39** | 🔰-16.6% |
| buildMDXVisible |  690ms | 458ms | -232ms | -1.23 | -50.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds telemetry functionality for tracking discrepancies between browser and CLI test results in the Storybook addon-test.

- Added `STORYBOOK_ADDON_TEST_CHANNEL` constant for telemetry events
- Implemented telemetry emission in `TestDiscrepancyMessage` component
- Updated `InteractionsPanel` to conditionally render `TestDiscrepancyMessage`
- Modified `preset.ts` to handle telemetry events and include addon version
- Added `storyId` prop to relevant components for accurate event tracking

<!-- /greptile_comment -->