### PR TITLE
Addon-Test: Refactor bootTestRunner to handle fatal errors and improve error reporting

### DIFF
--- a/code/addons/test/src/node/boot-test-runner.ts
+++ b/code/addons/test/src/node/boot-test-runner.ts
@@ -131,3 +131,10 @@ export const runTestRunner = async (channel: Channel, initEvent?: string, initAr
     ready = true;
   }
 };
+
+export const killTestRunner = () => {
+  if (child) {
+    child.kill();
+    child = null;
+  }
+};

--- a/code/addons/test/src/preset.ts
+++ b/code/addons/test/src/preset.ts
@@ -9,7 +9,7 @@ import {
 } from 'storybook/internal/core-events';
 import type { Options } from 'storybook/internal/types';
 
-import { bootTestRunner } from './node/boot-test-runner';
+import { runTestRunner } from './node/boot-test-runner';
 
 export const checkActionsLoaded = (configDir: string) => {
   checkAddonOrder({
@@ -37,31 +37,17 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
     return channel;
   }
 
-  let booting = false;
-  let booted = false;
-  const start =
+  const execute =
     (eventName: string) =>
     (...args: any[]) => {
-      if (!booted && !booting) {
-        booting = true;
-        bootTestRunner(channel, eventName, args)
-          .then(() => {
-            booted = true;
-          })
-          .catch(() => {
-            booted = false;
-          })
-          .finally(() => {
-            booting = false;
-          });
-      }
+      runTestRunner(channel, eventName, args);
     };
 
-  channel.on(TESTING_MODULE_RUN_ALL_REQUEST, start(TESTING_MODULE_RUN_ALL_REQUEST));
-  channel.on(TESTING_MODULE_RUN_REQUEST, start(TESTING_MODULE_RUN_REQUEST));
+  channel.on(TESTING_MODULE_RUN_ALL_REQUEST, execute(TESTING_MODULE_RUN_ALL_REQUEST));
+  channel.on(TESTING_MODULE_RUN_REQUEST, execute(TESTING_MODULE_RUN_REQUEST));
   channel.on(TESTING_MODULE_WATCH_MODE_REQUEST, (payload) => {
     if (payload.watchMode) {
-      start(TESTING_MODULE_WATCH_MODE_REQUEST)(payload);
+      execute(TESTING_MODULE_WATCH_MODE_REQUEST)(payload);
     }
   });
 


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Refactored bootTestRunner to handle fatal errors and improve error reporting

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 0 B | 0.65 | 0% |
| initSize |  147 MB | 147 MB | 0 B | -0.99 | 0% |
| diffSize |  68.3 MB | 68.3 MB | 0 B | -0.98 | 0% |
| buildSize |  7.1 MB | 7.1 MB | 0 B | -0.62 | 0% |
| buildSbAddonsSize |  1.79 MB | 1.79 MB | 0 B | -0.66 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 0 B | -0.68 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | -0.71 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.1 MB | 4.1 MB | 0 B | -0.68 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 1 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  12.4s | 21.7s | 9.2s | **1.34** | 🔺42.8% |
| generateTime |  32.2s | 18.9s | -13s -232ms | -0.92 | -69.6% |
| initTime |  22.3s | 13.5s | -8s -788ms | -1.01 | -64.9% |
| buildTime |  8s | 7.8s | -167ms | **-1.46** | -2.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.7s | 5.9s | -807ms | -0.7 | -13.6% |
| devManagerResponsive |  4.2s | 4.1s | -174ms | -0.24 | -4.2% |
| devManagerHeaderVisible |  582ms | 651ms | 69ms | 1.03 | 10.6% |
| devManagerIndexVisible |  611ms | 685ms | 74ms | 0.95 | 10.8% |
| devStoryVisibleUncached |  1s | 872ms | -226ms | -0.88 | -25.9% |
| devStoryVisible |  612ms | 686ms | 74ms | 0.98 | 10.8% |
| devAutodocsVisible |  599ms | 496ms | -103ms | -1.13 | -20.8% |
| devMDXVisible |  520ms | 532ms | 12ms | -0.04 | 2.3% |
| buildManagerHeaderVisible |  583ms | 472ms | -111ms | **-2** | 🔰-23.5% |
| buildManagerIndexVisible |  592ms | 506ms | -86ms | **-1.43** | 🔰-17% |
| buildStoryVisible |  621ms | 507ms | -114ms | **-1.93** | 🔰-22.5% |
| buildAutodocsVisible |  471ms | 442ms | -29ms | **-1.75** | 🔰-6.6% |
| buildMDXVisible |  631ms | 473ms | -158ms | -1.06 | -33.4% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Refactored bootTestRunner function in addon-test to improve error handling and reporting for fatal errors, with focus on better error information and graceful handling.

- Introduced `reportFatalError` function in `code/addons/test/src/node/boot-test-runner.ts` for consistent error reporting
- Increased `MAX_START_TIME` from 8000ms to 30000ms in `boot-test-runner.ts` to allow more time for process startup
- Modified error handling logic in `boot-test-runner.ts` to differentiate between errors before and after child process is ready
- Replaced `bootTestRunner` with `runTestRunner` in `code/addons/test/src/preset.ts` for simplified event handling and immediate execution

<!-- /greptile_comment -->