### PR TITLE
Manager: Add tags property to ComponentEntry objects

### DIFF
--- a/code/core/src/manager-api/lib/intersect.ts
+++ b/code/core/src/manager-api/lib/intersect.ts
@@ -1,0 +1,14 @@
+export default <T>(a: T[], b: T[]): T[] => {
+  // no point in intersecting if one of the input is ill-defined
+  if (!a || !b) {
+    return [];
+  }
+
+  return a.reduce((acc: T[], aValue) => {
+    if (b.includes(aValue)) {
+      acc.push(aValue);
+    }
+
+    return acc;
+  }, []);
+};

--- a/code/core/src/manager-api/lib/stories.ts
+++ b/code/core/src/manager-api/lib/stories.ts
@@ -24,6 +24,7 @@ import memoize from 'memoizerific';
 import { dedent } from 'ts-dedent';
 
 import { type API, type State, combineParameters } from '../root';
+import intersect from './intersect';
 import merge from './merge';
 
 const TITLE_PATH_SEPARATOR = /\s*\/\s*/;
@@ -273,6 +274,9 @@ export const transformStoryIndexToStoriesHash = (
             children: [childId],
           }),
         });
+        // merge computes a union of arrays but we want an intersection on this
+        // specific array property, so it's easier to add it after the merge.
+        acc[id].tags = intersect(acc[id]?.tags ?? item.tags, item.tags);
       } else {
         acc[id] = merge<API_GroupEntry>((acc[id] || {}) as API_GroupEntry, {
           type: 'group',

--- a/code/core/src/manager-api/tests/intersect.test.ts
+++ b/code/core/src/manager-api/tests/intersect.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import intersect from '../lib/intersect';
+
+describe('Manager API utilities - intersect', () => {
+  it('returns identity when intersecting identity', () => {
+    const a = ['foo', 'bar'];
+    expect(intersect(a, a)).toEqual(a);
+  });
+
+  it('returns a when b is a superset of a', () => {
+    const a = ['foo', 'bar'];
+    const b = ['a', 'foo', 'b', 'bar', 'c', 'ter'];
+    expect(intersect(a, b)).toEqual(a);
+  });
+
+  it('returns b when a is a superset of b', () => {
+    const a = ['a', 'foo', 'b', 'bar', 'c', 'ter'];
+    const b = ['foo', 'bar'];
+    expect(intersect(a, b)).toEqual(b);
+  });
+
+  it('returns an intersection', () => {
+    const a = ['a', 'bar', 'b', 'c'];
+    const b = ['foo', 'bar', 'ter'];
+    expect(intersect(a, b)).toEqual(['bar']);
+  });
+
+  it('returns an empty set when there is no overlap', () => {
+    const a = ['a', 'b', 'c'];
+    const b = ['foo', 'bar', 'ter'];
+    expect(intersect(a, b)).toEqual([]);
+  });
+
+  it('returns an empty set if a is undefined', () => {
+    const b = ['foo', 'bar', 'ter'];
+    expect(intersect(undefined as unknown as [], b)).toEqual([]);
+  });
+
+  it('returns an empty set if b is undefined', () => {
+    const a = ['foo', 'bar', 'ter'];
+    expect(intersect(a, undefined as unknown as [])).toEqual([]);
+  });
+});

--- a/code/core/src/manager-api/tests/stories.test.ts
+++ b/code/core/src/manager-api/tests/stories.test.ts
@@ -281,6 +281,57 @@ describe('stories API', () => {
         name: '1',
       });
     });
+    it('intersects story/docs tags to compute tags for component entries', () => {
+      const moduleArgs = createMockModuleArgs({});
+      const { api } = initStories(moduleArgs as unknown as ModuleArgs);
+      const { store } = moduleArgs;
+      api.setIndex({
+        v: 5,
+        entries: {
+          'a--1': {
+            type: 'story',
+            id: 'a--1',
+            title: 'a',
+            name: '1',
+            tags: ['shared', 'one-specific'],
+            importPath: './a.ts',
+          },
+          'a--2': {
+            type: 'story',
+            id: 'a--2',
+            title: 'a',
+            name: '2',
+            tags: ['shared', 'two-specific'],
+            importPath: './a.ts',
+          },
+        },
+      });
+      const { index } = store.getState();
+      // We need exact key ordering, even if in theory JS doesn't guarantee it
+      expect(Object.keys(index!)).toEqual(['a', 'a--1', 'a--2']);
+      expect(index!.a).toMatchObject({
+        type: 'component',
+        id: 'a',
+        tags: ['shared'],
+        children: ['a--1', 'a--2'],
+      });
+      expect(index!['a--1']).toMatchObject({
+        type: 'story',
+        id: 'a--1',
+        parent: 'a',
+        title: 'a',
+        name: '1',
+        tags: ['shared', 'one-specific'],
+      });
+      expect(index!['a--2']).toMatchObject({
+        type: 'story',
+        id: 'a--2',
+        parent: 'a',
+        title: 'a',
+        name: '2',
+        tags: ['shared', 'two-specific'],
+      });
+    });
     // Stories can get out of order for a few reasons -- see reproductions on
     //   https://github.com/storybookjs/storybook/issues/5518
     it('does the right thing for out of order stories', async () => {
@@ -1453,6 +1504,7 @@ describe('stories API', () => {
             "name": "a",
             "parent": undefined,
             "renderLabel": undefined,
+            "tags": [],
             "type": "component",
           },
           "a--1": {
@@ -1518,6 +1570,7 @@ describe('stories API', () => {
             "name": "a",
             "parent": undefined,
             "renderLabel": undefined,
+            "tags": [],
             "type": "component",
           },
           "a--1": {
@@ -1559,6 +1612,7 @@ describe('stories API', () => {
             "name": "a",
             "parent": undefined,
             "renderLabel": undefined,
+            "tags": [],
             "type": "component",
           },
           "a--1": {

--- a/code/core/src/manager/components/sidebar/__tests__/Sidebar.test.tsx
+++ b/code/core/src/manager/components/sidebar/__tests__/Sidebar.test.tsx
@@ -59,6 +59,7 @@ const generateStories = ({ title, refId }: { title: string; refId?: string }): A
       name: componentName,
       children: [docsId],
       parent: rootId,
+      tags: [],
     },
     // @ts-expect-error the missing fields are deprecated and replaced by the type prop
     {

--- a/code/core/src/types/modules/api-stories.ts
+++ b/code/core/src/types/modules/api-stories.ts
@@ -27,6 +27,7 @@ export interface API_ComponentEntry extends API_BaseEntry {
   type: 'component';
   parent?: StoryId;
   children: StoryId[];
+  tags: Tag[];
 }
 
 export interface API_DocsEntry extends API_BaseEntry {


### PR DESCRIPTION
## What I did

I added a piece of logic to the code converting the story index to story hashes for use in the manager (`transformStoryIndexToStoriesHash`).

This extra code computes a `tags` property for Component entries, which is the intersection of all their stories' hashes. This enables me to display hashes in the sidebar, and [this gist from a third party](https://gist.github.com/jpzwarte/b7cc6cc1aa2ca03b288c42bef823e344) shows that others have sought to achieve the same thing in the past.

Having a definition of tags for component entries allows us to separate story-specific tags from component-specific tags and imo gives a clearer meaning to the `tags` added to a CSF meta.

Below are screenshots of what can be achieved with tags with and without this PR.

### Without this PR
![image](https://github.com/user-attachments/assets/4ff5c79a-8375-4112-84f8-3750d3b5f989)

### With this PR
![image](https://github.com/user-attachments/assets/77f7b870-063d-4153-8968-0dc411c4d7dc)


## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing


1. Add custom tags to any story you like in the storybook stories, e.g. change the meta in `code/core/src/manager/components/panel/Panel.stories.tsx` to have `tags: ['myCustomTag'],`
2. Add a sidebar `renderLabel` function of your choice to be able to inspect the entry, or console log in `code/core/src/manager/components/sidebar/Tree.tsx`'s `Node` ctor
3. Notice the presence of the tags in the component entry

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

> [!CAUTION]
> I am not sure what the most appropriate documentation format is for this. Guidance is welcome.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 0 B | 0.42 | 0% |
| initSize |  147 MB | 147 MB | 748 B | -1.06 | 0% |
| diffSize |  68.3 MB | 68.3 MB | 748 B | -1.06 | 0% |
| buildSize |  6.79 MB | 6.79 MB | 245 B | 1.11 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | -1.22 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 245 B | **Infinity** | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 245 B | 0.55 | 0% |
| buildPreviewSize |  2.99 MB | 2.99 MB | 0 B | 1.09 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  16.4s | 19.5s | 3.1s | 1.17 | 16% |
| generateTime |  21.6s | 18.3s | -3s -353ms | **-2.25** | 🔰-18.3% |
| initTime |  12.9s | 12.5s | -395ms | **-1.44** | -3.1% |
| buildTime |  8.4s | 7.2s | -1s -117ms | -0.96 | -15.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.8s | 5.5s | -230ms | -1.17 | -4.1% |
| devManagerResponsive |  3.8s | 3.9s | 52ms | -1.02 | 1.3% |
| devManagerHeaderVisible |  533ms | 521ms | -12ms | -1.1 | -2.3% |
| devManagerIndexVisible |  562ms | 544ms | -18ms | -1.15 | -3.3% |
| devStoryVisibleUncached |  931ms | 903ms | -28ms | -0.54 | -3.1% |
| devStoryVisible |  572ms | 551ms | -21ms | -1.09 | -3.8% |
| devAutodocsVisible |  463ms | 444ms | -19ms | **-1.27** | -4.3% |
| devMDXVisible |  501ms | 461ms | -40ms | -0.98 | -8.7% |
| buildManagerHeaderVisible |  480ms | 445ms | -35ms | -1.18 | -7.9% |
| buildManagerIndexVisible |  494ms | 448ms | -46ms | -1.21 | -10.3% |
| buildStoryVisible |  516ms | 708ms | 192ms | 0.62 | 27.1% |
| buildAutodocsVisible |  453ms | 406ms | -47ms | **-1.34** | 🔰-11.6% |
| buildMDXVisible |  669ms | 394ms | -275ms | **-1.27** | 🔰-69.8% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds a new `tags` property to ComponentEntry objects, computed as the intersection of all their stories' tags, enhancing tag organization and display in the Storybook sidebar.

- Introduced `intersect` function in `code/core/src/manager-api/lib/intersect.ts` for efficient array intersection
- Modified `transformStoryIndexToStoriesHash` in `code/core/src/manager-api/lib/stories.ts` to compute component tags
- Added comprehensive unit tests for `intersect` function in `code/core/src/manager-api/tests/intersect.test.ts`
- Updated `API_ComponentEntry` interface in `code/core/src/types/modules/api-stories.ts` to include `tags` property
- Added test case in `code/core/src/manager-api/tests/stories.test.ts` to verify component tag computation

<!-- /greptile_comment -->