### PR TITLE
Docs: Fix outdated documentation URLs

### DIFF
--- a/code/addons/actions/ADVANCED.md
+++ b/code/addons/actions/ADVANCED.md
@@ -1,6 +1,6 @@
 ## Advanced/Legacy Actions usage
 
-For basic usage, see the [documentation](https://storybook.js.org/docs/react/essentials/actions).
+For basic usage, see the [documentation](https://storybook.js.org/docs/essentials/actions).
 
 This document describes the pre-6.0 usage of the addon, and as such is no longer recommended (although it will be supported until at least 7.0).
 

--- a/code/addons/actions/README.md
+++ b/code/addons/actions/README.md
@@ -24,4 +24,4 @@ export default {
 
 ## Usage
 
-The basic usage is documented in the [documentation](https://storybook.js.org/docs/react/essentials/actions). For legacy usage, see the [advanced README](./ADVANCED.md).
+The basic usage is documented in the [documentation](https://storybook.js.org/docs/essentials/actions). For legacy usage, see the [advanced README](./ADVANCED.md).

--- a/code/addons/backgrounds/README.md
+++ b/code/addons/backgrounds/README.md
@@ -26,4 +26,4 @@ export default {
 
 ## Usage
 
-The usage is documented in the [documentation](https://storybook.js.org/docs/react/essentials/backgrounds).
+The usage is documented in the [documentation](https://storybook.js.org/docs/essentials/backgrounds).

--- a/code/addons/controls/README.md
+++ b/code/addons/controls/README.md
@@ -24,7 +24,7 @@ export default {
 
 ## Usage
 
-The usage is documented in the [documentation](https://storybook.js.org/docs/react/essentials/controls).
+The usage is documented in the [documentation](https://storybook.js.org/docs/essentials/controls).
 
 ## FAQs
 
@@ -92,7 +92,7 @@ export const Reflow = () => {
 };
 ```
 
-And again, as above, this can be rewritten using [fully custom args](https://storybook.js.org/docs/react/essentials/controls#fully-custom-args):
+And again, as above, this can be rewritten using [fully custom args](https://storybook.js.org/docs/essentials/controls#fully-custom-args):
 
 ```jsx
 export const Reflow = ({ count, label, ...args }) => (
@@ -147,7 +147,7 @@ Basic.args = {
 };
 ```
 
-The `argTypes` annotation (which can also be applied to individual stories if needed), gives Storybook the hints it needs to generate controls in these unsupported cases. See [control annotations](https://storybook.js.org/docs/react/essentials/controls#annotation) for a full list of control types.
+The `argTypes` annotation (which can also be applied to individual stories if needed), gives Storybook the hints it needs to generate controls in these unsupported cases. See [control annotations](https://storybook.js.org/docs/essentials/controls#annotation) for a full list of control types.
 
 It's also possible that your Storybook is misconfigured. If you think this might be the case, please search through Storybook's [Github issues](https://github.com/storybookjs/storybook/issues), and file a new issue if you don't find one that matches your use case.
 

--- a/code/addons/docs/docs/props-tables.md
+++ b/code/addons/docs/docs/props-tables.md
@@ -82,7 +82,7 @@ export const WithControls = (args) => <MyComponent {...args} />;
 <ArgsTable story="Controls" />
 ```
 
-For a very detailed walkthrough of how to write stories that use controls, read the [documentation](https://storybook.js.org/docs/react/essentials/controls).
+For a very detailed walkthrough of how to write stories that use controls, read the [documentation](https://storybook.js.org/docs/essentials/controls).
 
 ## Customization
 
@@ -187,7 +187,7 @@ This would render a row with a modified description, a type display with a dropd
 > - `type: 'number'` is shorthand for `type: { name: 'number' }`
 > - `control: 'radio'` is shorthand for `control: { type: 'radio' }`
 
-Controls customization has an entire section in the [documentation](https://storybook.js.org/docs/react/essentials/controls#configuration).
+Controls customization has an entire section in the [documentation](https://storybook.js.org/docs/essentials/controls#configuration).
 
 Here are the possible customizations for the rest of the prop table:
 
@@ -200,7 +200,7 @@ Here are the possible customizations for the rest of the prop table:
 | `table.type.detail`          | A longer version of the type (if it's a complex type)                                                |
 | `table.defaultValue.summary` | A short version of the default value                                                                 |
 | `table.defaultValue.detail`  | A longer version of the default value (if it's a complex value)                                      |
-| `control`                    | See [`addon-controls` README](https://storybook.js.org/docs/react/essentials/controls#configuration) |
+| `control`                    | See [`addon-controls` README](https://storybook.js.org/docs/essentials/controls#configuration) |
 
 ## Reporting a bug
 

--- a/code/addons/toolbars/README.md
+++ b/code/addons/toolbars/README.md
@@ -28,7 +28,7 @@ export default {
 
 ## Usage
 
-The usage is documented in the [documentation](https://storybook.js.org/docs/react/essentials/toolbars-and-globals).
+The usage is documented in the [documentation](https://storybook.js.org/docs/essentials/toolbars-and-globals).
 
 ## FAQs
 
@@ -40,6 +40,6 @@ The primary difference between the two packages is that `addon-toolbars` makes u
 
 - **Standardization**. Args are built into Storybook in 6.x. Since `addon-toolbars` is based on args, you don't need to learn any addon-specific APIs to use it.
 
-- **Ergonomics**. Global args are easy to consume [in stories](https://storybook.js.org/docs/react/essentials/toolbars-and-globals#consuming-globals-from-within-a-story), in [Storybook Docs](https://github.com/storybookjs/storybook/tree/next/code/addons/docs), or even in other addons.
+- **Ergonomics**. Global args are easy to consume [in stories](https://storybook.js.org/docs/essentials/toolbars-and-globals#consuming-globals-from-within-a-story), in [Storybook Docs](https://github.com/storybookjs/storybook/tree/next/code/addons/docs), or even in other addons.
 
 * **Framework compatibility**. Args are completely framework-independent, so `addon-toolbars` is compatible with React, Vue 3, Angular, etc. out of the box with no framework logic needed in the addon.

--- a/code/addons/viewport/README.md
+++ b/code/addons/viewport/README.md
@@ -26,4 +26,4 @@ You should now be able to see the viewport addon icon in the toolbar at the top 
 
 ## Usage
 
-The usage is documented in the [documentation](https://storybook.js.org/docs/react/essentials/viewport).
+The usage is documented in the [documentation](https://storybook.js.org/docs/essentials/viewport).

--- a/code/core/src/preview-api/modules/store/inferArgTypes.ts
+++ b/code/core/src/preview-api/modules/store/inferArgTypes.ts
@@ -25,8 +25,8 @@ const inferType = (value: any, name: string, visited: Set<any>): SBType => {
         We've detected a cycle in arg '${name}'. Args should be JSON-serializable.
 
         Consider using the mapping feature or fully custom args:
-        - Mapping: https://storybook.js.org/docs/react/writing-stories/args#mapping-to-complex-arg-values
-        - Custom args: https://storybook.js.org/docs/react/essentials/controls#fully-custom-args
+        - Mapping: https://storybook.js.org/docs/writing-stories/args#mapping-to-complex-arg-values
+        - Custom args: https://storybook.js.org/docs/essentials/controls#fully-custom-args
       `);
       return { name: 'other', value: 'cyclic object' };
     }

--- a/code/lib/blocks/src/blocks/Canvas.stories.tsx
+++ b/code/lib/blocks/src/blocks/Canvas.stories.tsx
@@ -94,7 +94,7 @@ export const PropAdditionalActions: Story = {
         title: 'Go to documentation',
         onClick: () => {
           window.open(
-            'https://storybook.js.org/docs/react/essentials/controls#annotation',
+            'https://storybook.js.org/docs/essentials/controls#annotation',
             '_blank'
           );
         },

--- a/code/lib/blocks/src/components/ArgsTable/ArgControl.tsx
+++ b/code/lib/blocks/src/components/ArgsTable/ArgControl.tsx
@@ -72,7 +72,7 @@ export const ArgControl: FC<ArgControlProps> = ({ row, arg, updateArgs, isHovere
     const canBeSetup = control?.disable !== true && row?.type?.name !== 'function';
     return isHovered && canBeSetup ? (
       <Link
-        href="https://storybook.js.org/docs/react/essentials/controls"
+        href="https://storybook.js.org/docs/essentials/controls"
         target="_blank"
         withArrow
       >

--- a/code/lib/blocks/src/examples/CanvasParameters.stories.tsx
+++ b/code/lib/blocks/src/examples/CanvasParameters.stories.tsx
@@ -31,7 +31,7 @@ export const AdditionalActions: Story = {
             title: 'Go to documentation',
             onClick: () => {
               window.open(
-                'https://storybook.js.org/docs/react/essentials/controls#annotation',
+                'https://storybook.js.org/docs/essentials/controls#annotation',
                 '_blank'
               );
             },

--- a/code/lib/test/src/testing-library.ts
+++ b/code/lib/test/src/testing-library.ts
@@ -28,7 +28,7 @@ testingLibrary.screen = new Proxy(testingLibrary.screen, {
   get(target, prop, receiver) {
     once.warn(dedent`
           You are using Testing Library's \`screen\` object. Use \`within(canvasElement)\` instead.
-          More info: https://storybook.js.org/docs/react/essentials/interactions
+          More info: https://storybook.js.org/docs/essentials/interactions
         `);
     return Reflect.get(target, prop, receiver);
   },


### PR DESCRIPTION
## What I did

I encountered an error on the terminal.
Clinking on the link does not sparks joy.

![CleanShot 2024-10-14 at 11 20 30](https://github.com/user-attachments/assets/3f24c540-c0ec-4fbd-a81b-f168539473c3)

**before**

![CleanShot 2024-10-14 at 11 11 16](https://github.com/user-attachments/assets/501735d8-4ef3-4a2e-9f40-31ec99688f58)

**after**

![CleanShot 2024-10-14 at 11 20 11](https://github.com/user-attachments/assets/31e00332-1652-4796-b3e7-5fa29210cb4a)

I removed the reference of `/react` from the url because for addons we are not using it.

```diff
--https://storybook.js.org/docs/react/essentials/controls#fully-custom-args
++https://storybook.js.org/docs/essentials/controls#fully-custom-args
```

## Checklist for Contributors

#### Manual testing

1. Open changed links.
2. should not be a 500.

### Documentation

- [x] Add or update documentation reflecting your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

<!-- greptile_comment -->

## Greptile Summary

This pull request updates documentation links across multiple Storybook files by removing the '/react' slug from URLs, improving link consistency and accessibility.

- Updated MIGRATION.md with framework-agnostic documentation links
- Modified README files for various addons (actions, backgrounds, controls, toolbars, viewport) to use generic URLs
- Updated documentation references in core files like `inferArgTypes.ts` and `ArgControl.tsx`
- Changed links in story files (Canvas.stories.tsx, CanvasParameters.stories.tsx) to use updated URL structure
- Adjusted warning message in `testing-library.ts` to reflect new documentation link format

<!-- /greptile_comment -->