### PR TITLE
Addon Test: Promote Nextjs Vite

### DIFF
--- a/code/addons/test/src/preset.ts
+++ b/code/addons/test/src/preset.ts
@@ -2,7 +2,6 @@ import { readFileSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 
 import type { Channel } from 'storybook/internal/channels';
-import { logger } from 'storybook/internal/client-logger';
 import { checkAddonOrder, getFrameworkName, serverRequire } from 'storybook/internal/common';
 import {
   TESTING_MODULE_RUN_ALL_REQUEST,
@@ -15,6 +14,7 @@ import type { Options, StoryId } from 'storybook/internal/types';
 import { dedent } from 'ts-dedent';
 
 import { STORYBOOK_ADDON_TEST_CHANNEL } from './constants';
+import { log } from './logger';
 import { runTestRunner } from './node/boot-test-runner';
 
 export const checkActionsLoaded = (configDir: string) => {
@@ -33,11 +33,6 @@ export const checkActionsLoaded = (configDir: string) => {
     getConfig: (configFile) => serverRequire(configFile),
   });
 };
-
-const log = (message: string) => {
-  logger.log(`[@storybook/experimental-addon-test] ${message}`);
-};
-
 type Event = {
   type: 'test-discrepancy';
   payload: {
@@ -58,8 +53,8 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
   if (!builderName?.includes('vite')) {
     if (framework.includes('nextjs')) {
       log(dedent`
-        It seems that you are using Next.js in Storybook with a Webpack based builder. Storybook now provides a way to use Vite with Next.js.
-        If configure your Storybook to use Vite, the test addon will contain extra capabilities to run tests in Storybook.
+        It seems that you are using Next.js in Storybook with a Webpack-based builder. Storybook now provides a new, performant way to use Vite with Next.js.
+        If you configure your Storybook to use Vite, the test addon will contain extra capabilities to run tests in Storybook.
 
         More info: https://storybook.js.org/docs/get-started/frameworks/nextjs#with-vite
       `);

--- a/code/addons/test/src/preset.ts
+++ b/code/addons/test/src/preset.ts
@@ -11,6 +11,7 @@ import {
 import { oneWayHash, telemetry } from 'storybook/internal/telemetry';
 import type { Options, StoryId } from 'storybook/internal/types';
 
+import picocolors from 'picocolors';
 import { dedent } from 'ts-dedent';
 
 import { STORYBOOK_ADDON_TEST_CHANNEL } from './constants';
@@ -53,10 +54,9 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
   if (!builderName?.includes('vite')) {
     if (framework.includes('nextjs')) {
       log(dedent`
-        It seems that you are using Next.js in Storybook with a Webpack-based builder. Storybook now provides a new, performant way to use Vite with Next.js.
-        If you configure your Storybook to use Vite, the test addon will contain extra capabilities to run tests in Storybook.
+        You're using ${framework}, which is a Webpack-based builder. In order to use Storybook Test, with your project, you need to use '@storybook/experimental-nextjs-vite', a high performance Vite-based equivalent.
 
-        More info: https://storybook.js.org/docs/get-started/frameworks/nextjs#with-vite
+        Information on how to upgrade here: ${picocolors.yellow('https://storybook.js.org/docs/get-started/frameworks/nextjs#with-vite')}\n
       `);
     }
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds a simple check that upon detecting Nextjs+Webpack, promotes the experimental Nextjs vite framework, so that the addon can have extra capabilities.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 4.93 kB | 0.55 | 0% |
| initSize |  147 MB | 147 MB | 4.93 kB | -0.76 | 0% |
| diffSize |  68.3 MB | 68.3 MB | 0 B | -0.76 | 0% |
| buildSize |  7.1 MB | 7.1 MB | 0 B | -0.51 | 0% |
| buildSbAddonsSize |  1.79 MB | 1.79 MB | 0 B | -0.54 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 0 B | -0.56 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | -0.58 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.1 MB | 4.1 MB | 0 B | -0.56 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.77 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  14.7s | 5.7s | -8s -969ms | **-1.47** | 🔰-154.7% |
| generateTime |  22.1s | 20.2s | -1s -876ms | -0.66 | -9.3% |
| initTime |  14.4s | 12.9s | -1s -538ms | **-1.34** | 🔰-11.9% |
| buildTime |  9.1s | 7.7s | -1s -375ms | **-1.45** | 🔰-17.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.7s | 7.2s | 1.5s | **1.25** | 🔺20.7% |
| devManagerResponsive |  4s | 5s | 1s | **2.25** | 🔺20.3% |
| devManagerHeaderVisible |  536ms | 764ms | 228ms | **3.17** | 🔺29.8% |
| devManagerIndexVisible |  565ms | 784ms | 219ms | **2.75** | 🔺27.9% |
| devStoryVisibleUncached |  1s | 1.4s | 413ms | **1.68** | 🔺29.1% |
| devStoryVisible |  573ms | 819ms | 246ms | **3.47** | 🔺30% |
| devAutodocsVisible |  491ms | 611ms | 120ms | 1.05 | 19.6% |
| devMDXVisible |  484ms | 655ms | 171ms | **2.57** | 🔺26.1% |
| buildManagerHeaderVisible |  877ms | 593ms | -284ms | 0.11 | -47.9% |
| buildManagerIndexVisible |  880ms | 893ms | 13ms | **3.32** | 1.5% |
| buildStoryVisible |  922ms | 894ms | -28ms | **2.98** | -3.1% |
| buildAutodocsVisible |  670ms | 660ms | -10ms | **2.35** | -1.5% |
| buildMDXVisible |  771ms | 586ms | -185ms | 0.47 | -31.6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds a check to promote the Next.js Vite framework when Next.js with Webpack is detected in the Storybook addon-test.

- Added conditional check in `code/addons/test/src/preset.ts` to detect Next.js with Webpack
- Implemented log function to display message encouraging users to switch to Vite for Next.js projects
- Provides information on additional capabilities available when using Vite with Next.js in Storybook
- Enhances user experience by guiding them towards a more feature-rich configuration

<!-- /greptile_comment -->