### PR TITLE
Testing-Module: Add telemetry to testingmodule events

### DIFF
--- a/code/addons/test/src/manager.tsx
+++ b/code/addons/test/src/manager.tsx
@@ -110,7 +110,7 @@ addons.register(ADDON_ID, (api) => {
       } else if (watching) {
         message = 'Watching for file changes';
       } else if (progress?.finishedAt) {
-        message = <RelativeTime timestamp={progress.finishedAt} />;
+        message = <RelativeTime timestamp={new Date(progress.finishedAt)} />;
       }
 
       return (

--- a/code/addons/test/src/node/reporter.ts
+++ b/code/addons/test/src/node/reporter.ts
@@ -73,7 +73,7 @@ export class StorybookReporter implements Reporter {
     this.start = Date.now();
   }
 
-  getProgressReport(finishedAt?: Date) {
+  getProgressReport(finishedAt?: number) {
     const files = this.ctx.state.getFiles();
     const fileTests = getTests(files);
     // The number of total tests is dynamic and can change during the run
@@ -146,7 +146,7 @@ export class StorybookReporter implements Reporter {
         numPassedTests,
         numPendingTests,
         numTotalTests,
-        startedAt: new Date(this.start),
+        startedAt: this.start,
         finishedAt,
       } as TestingModuleProgressReportProgress,
       details: {
@@ -196,10 +196,11 @@ export class StorybookReporter implements Reporter {
         unhandledErrors[0]
       );
     } else {
+      const isCancelled = this.ctx.isCancelling;
       this.sendReport({
         providerId: TEST_PROVIDER_ID,
-        status: 'success',
-        ...this.getProgressReport(new Date()),
+        status: isCancelled ? 'cancelled' : 'success',
+        ...this.getProgressReport(Date.now()),
       });
     }
 

--- a/code/addons/test/src/preset.ts
+++ b/code/addons/test/src/preset.ts
@@ -4,9 +4,11 @@ import { isAbsolute, join } from 'node:path';
 import type { Channel } from 'storybook/internal/channels';
 import { checkAddonOrder, serverRequire } from 'storybook/internal/common';
 import {
+  TESTING_MODULE_PROGRESS_REPORT,
   TESTING_MODULE_RUN_ALL_REQUEST,
   TESTING_MODULE_RUN_REQUEST,
   TESTING_MODULE_WATCH_MODE_REQUEST,
+  type TestingModuleProgressReportPayload,
 } from 'storybook/internal/core-events';
 import { oneWayHash, telemetry } from 'storybook/internal/telemetry';
 import type { Options, StoryId } from 'storybook/internal/types';

--- a/code/core/src/core-events/data/testing-module.ts
+++ b/code/core/src/core-events/data/testing-module.ts
@@ -1,5 +1,7 @@
 import type { Addon_TestProviderState, Addon_TestProviderType } from '@storybook/core/types';
 
+type DateNow = number;
+
 export type TestProviderId = Addon_TestProviderType['id'];
 export type TestProviderConfig = Addon_TestProviderType;
 export type TestProviderState = Addon_TestProviderState;
@@ -27,7 +29,7 @@ export type TestingModuleRunAllRequestPayload = {
 export type TestingModuleProgressReportPayload =
   | {
       providerId: TestProviderId;
-      status: 'success' | 'pending';
+      status: 'success' | 'pending' | 'cancelled';
       cancellable?: boolean;
       progress?: TestingModuleProgressReportProgress;
       details?: { [key: string]: any };
@@ -48,8 +50,8 @@ export type TestingModuleCrashReportPayload = {
 };
 
 export type TestingModuleProgressReportProgress = {
-  startedAt: Date;
-  finishedAt?: Date;
+  startedAt: DateNow;
+  finishedAt?: DateNow;
   numTotalTests?: number;
   numPassedTests?: number;
   numFailedTests?: number;

--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -25,6 +25,15 @@ import { logger } from '@storybook/core/node-logger';
 
 import { dedent } from 'ts-dedent';
 
+import {
+  TESTING_MODULE_CRASH_REPORT,
+  TESTING_MODULE_PROGRESS_REPORT,
+  TESTING_MODULE_WATCH_MODE_REQUEST,
+  type TestingModuleCrashReportPayload,
+  type TestingModuleProgressReportPayload,
+  type TestingModuleWatchModeRequestPayload,
+} from '../../core-events';
+import { cleanPaths, sanitizeError } from '../../telemetry/sanitize';
 import { initCreateNewStoryChannel } from '../server-channel/create-new-story-channel';
 import { initFileSearchChannel } from '../server-channel/file-search-channel';
 import { defaultStaticDirs } from '../utils/constants';
@@ -279,6 +288,56 @@ export const experimental_serverChannel = async (
 
   initFileSearchChannel(channel, options, coreOptions);
   initCreateNewStoryChannel(channel, options, coreOptions);
+
+  if (!options.disableTelemetry) {
+    channel.on(
+      TESTING_MODULE_WATCH_MODE_REQUEST,
+      async (request: TestingModuleWatchModeRequestPayload) => {
+        await telemetry('testing-module-watch-mode', {
+          provider: request.providerId,
+          watchMode: request.watchMode,
+        });
+      }
+    );
+
+    channel.on(
+      TESTING_MODULE_PROGRESS_REPORT,
+      async (payload: TestingModuleProgressReportPayload) => {
+        if (
+          (payload.status === 'success' || payload.status === 'cancelled') &&
+          payload.progress?.finishedAt
+        ) {
+          await telemetry('testing-module-completed-report', {
+            provider: payload.providerId,
+            duration: payload.progress.finishedAt - payload.progress.startedAt,
+            numTotalTests: payload.progress.numTotalTests,
+            numFailedTests: payload.progress.numFailedTests,
+            numPassedTests: payload.progress.numPassedTests,
+            status: payload.status,
+          });
+        }
+
+        if (payload.status === 'failed') {
+          await telemetry('testing-module-completed-report', {
+            provider: payload.providerId,
+            status: 'failed',
+            ...(options.enableCrashReports && {
+              error: sanitizeError(payload.error),
+            }),
+          });
+        }
+      }
+    );
+
+    channel.on(TESTING_MODULE_CRASH_REPORT, async (payload: TestingModuleCrashReportPayload) => {
+      await telemetry('testing-module-crash-report', {
+        provider: payload.providerId,
+        ...(options.enableCrashReports && {
+          error: cleanPaths(payload.message),
+        }),
+      });
+    });
+  }
 
   return channel;
 };

--- a/code/core/src/manager/components/sidebar/SidebarBottom.tsx
+++ b/code/core/src/manager/components/sidebar/SidebarBottom.tsx
@@ -126,6 +126,7 @@ export const SidebarBottomBase = ({ api, notifications = [], status = {} }: Side
         running: true,
         failed: false,
         crashed: false,
+        progress: undefined,
       };
       setTestProviders((state) => ({ ...state, [id]: { ...state[id], ...startingState } }));
       api.experimental_updateStatus(id, (state = {}) =>

--- a/code/core/src/telemetry/types.ts
+++ b/code/core/src/telemetry/types.ts
@@ -20,7 +20,10 @@ export type EventType =
   | 'remove'
   | 'save-story'
   | 'create-new-story-file'
-  | 'create-new-story-file-search';
+  | 'create-new-story-file-search'
+  | 'testing-module-watch-mode'
+  | 'testing-module-completed-report'
+  | 'testing-module-crash-report';
 
 export interface Dependency {
   version: string | undefined;


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/29349

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added telemetry to some testing module events.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 0 B | 0.53 | 0% |
| initSize |  147 MB | 147 MB | 13.1 kB | -0.72 | 0% |
| diffSize |  68.3 MB | 68.3 MB | 13.1 kB | -0.72 | 0% |
| buildSize |  7.1 MB | 7.1 MB | 36 B | -0.49 | 0% |
| buildSbAddonsSize |  1.79 MB | 1.79 MB | 10 B | -0.52 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 26 B | -0.54 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | -0.56 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.1 MB | 4.1 MB | 36 B | -0.53 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.74 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  22.6s | 21.9s | -661ms | 1.23 | -3% |
| generateTime |  18.3s | 21.6s | 3.2s | -0.17 | 15.1% |
| initTime |  11.8s | 14.2s | 2.4s | -0.59 | 17% |
| buildTime |  10.5s | 8.9s | -1s -607ms | -0.73 | -18% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.5s | 5.6s | 87ms | -0.98 | 1.5% |
| devManagerResponsive |  3.7s | 3.7s | -22ms | -1.05 | -0.6% |
| devManagerHeaderVisible |  561ms | 564ms | 3ms | -0.61 | 0.5% |
| devManagerIndexVisible |  589ms | 594ms | 5ms | -0.62 | 0.8% |
| devStoryVisibleUncached |  911ms | 986ms | 75ms | -0.18 | 7.6% |
| devStoryVisible |  587ms | 594ms | 7ms | -0.66 | 1.2% |
| devAutodocsVisible |  510ms | 511ms | 1ms | -0.48 | 0.2% |
| devMDXVisible |  556ms | 490ms | -66ms | -0.85 | -13.5% |
| buildManagerHeaderVisible |  516ms | 491ms | -25ms | -1.05 | -5.1% |
| buildManagerIndexVisible |  588ms | 553ms | -35ms | -0.64 | -6.3% |
| buildStoryVisible |  589ms | 554ms | -35ms | -0.86 | -6.3% |
| buildAutodocsVisible |  524ms | 443ms | -81ms | **-1.62** | 🔰-18.3% |
| buildMDXVisible |  496ms | 494ms | -2ms | -0.63 | -0.4% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Added telemetry to testing module events and enhanced the test addon with new components and stories.

- Introduced new InteractionsPanel, GlobalErrorModal, and MatcherResult components in `code/addons/test/src/components/`
- Updated CircleCI config to include a new 'test-ui-testing-module' job for E2E tests
- Modified Storybook configuration in `code/.storybook/main.ts` to add new story directories for interactions and test components
- Added conditional logic in `code/.storybook/storybook.setup.ts` for different user event and expect implementations based on testing environment
- Updated @storybook/icons dependency from 1.2.10 to 1.2.12 across multiple addon packages

<!-- /greptile_comment -->