### PR TITLE
Docs: storybookNextjsPlugin to storybookNextJsPlugin

### DIFF
--- a/docs/_snippets/vitest-plugin-vitest-config.md
+++ b/docs/_snippets/vitest-plugin-vitest-config.md
@@ -2,7 +2,7 @@
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
 // 👇 If you're using Next.js, apply this framework plugin as well
-// import { storybookNextjsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin';
+// import { storybookNextJsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin';
 
 import viteConfig from './vite.config';
 
@@ -15,7 +15,7 @@ export default mergeConfig(
         // The --ci flag will skip prompts and not open a browser
         storybookScript: 'yarn storybook --ci',
       }),
-      // storybookNextjsPlugin(),
+      // storybookNextJsPlugin(),
     ],
     test: {
       // Glob pattern to find story files

--- a/docs/_snippets/vitest-plugin-vitest-workspace.md
+++ b/docs/_snippets/vitest-plugin-vitest-workspace.md
@@ -2,7 +2,7 @@
 import { defineWorkspace } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
 // 👇 If you're using Next.js, apply this framework plugin as well
-// import { storybookNextjsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin';
+// import { storybookNextJsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin';
 
 export default defineWorkspace([
   // This is the path to your existing Vitest config file
@@ -16,7 +16,7 @@ export default defineWorkspace([
         // The --ci flag will skip prompts and not open a browser
         storybookScript: 'yarn storybook --ci',
       }),
-      // storybookNextjsPlugin(),
+      // storybookNextJsPlugin(),
     ],
     test: {
       name: 'storybook',
@@ -87,7 +87,7 @@ export default defineWorkspace([
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
 // 👇 If you're using Sveltekit, apply this framework plugin as well
-// import { storybookNextjsPlugin } from '@storybook/sveltekit/vite-plugin';
+// import { storybookNextJsPlugin } from '@storybook/sveltekit/vite-plugin';
 
 import viteConfig from './vite.config';
 

--- a/docs/_snippets/vitest-plugin-vitest-workspace.md
+++ b/docs/_snippets/vitest-plugin-vitest-workspace.md
@@ -87,7 +87,7 @@ export default defineWorkspace([
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
 // 👇 If you're using Sveltekit, apply this framework plugin as well
-// import { storybookNextJsPlugin } from '@storybook/sveltekit/vite-plugin';
+// import { storybookSveltekitPlugin } from '@storybook/sveltekit/vite-plugin';
 
 import viteConfig from './vite.config';
 

--- a/docs/writing-tests/vitest-plugin.mdx
+++ b/docs/writing-tests/vitest-plugin.mdx
@@ -79,7 +79,7 @@ Some Storybook frameworks require additional setup to enable the framework's fea
   ```js title="vitest.config.ts"
   import { defineConfig, mergeConfig } from 'vitest/config';
   import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
-  import { storybookNextjsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin';
+  import { storybookNextJsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin';
 
   import viteConfig from './vite.config';
 
@@ -88,7 +88,7 @@ Some Storybook frameworks require additional setup to enable the framework's fea
     defineConfig({
       plugins: [
         storybookTest(),
-        storybookNextjsPlugin(), // 👈 Apply the framework plugin here
+        storybookNextJsPlugin(), // 👈 Apply the framework plugin here
       ],
       // ...
     })


### PR DESCRIPTION
## What I did

The code in the [Storybook Vitest plugin chapter](https://storybook.js.org/docs/writing-tests/vitest-plugin) was incorrect and has been corrected.

The `NextJs` part of `storybookNextJsPlugin`'s name was `Nextjs`(The correct name is referenced [here](https://github.com/storybookjs/storybook/blob/next/code/frameworks/experimental-nextjs-vite/src/index.ts#L9)).

Additionally, a problem with `storybookSveltekitPlugin` being imported with `storybookNextJsPlugin` has been corrected.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request corrects naming conventions and import statements for Next.js and SvelteKit plugins in the Storybook Vitest plugin documentation.

- Changed `storybookNextjsPlugin` to `storybookNextJsPlugin` for consistency with the actual plugin name
- Fixed incorrect import of `storybookSveltekitPlugin` alongside `storybookNextJsPlugin` in example code
- Updated code snippets in `vitest-plugin-vitest-config.md` and `vitest-plugin-vitest-workspace.md` to reflect correct plugin names and imports
- Modified `docs/writing-tests/vitest-plugin.mdx` to use the correct plugin naming convention

<!-- /greptile_comment -->