### PR TITLE
Core: Fix building Storybook deleting project root files

### DIFF
--- a/code/core/src/core-server/build-static.ts
+++ b/code/core/src/core-server/build-static.ts
@@ -47,22 +47,8 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
   if (options.outputDir === '/') {
     throw new Error("Won't remove directory '/'. Check your outputDir!");
   }
-
-  try {
-    const outputDirFiles = await readdir(options.outputDir);
-    for (const file of outputDirFiles) {
-      await rm(file, { recursive: true, force: true });
-    }
-  } catch {
-    await mkdir(options.outputDir, { recursive: true });
-  }
-
-  if (!existsSync(options.outputDir)) {
-    await mkdir(options.outputDir, { recursive: true });
-  } else if ((await readdir(options.outputDir)).length > 0) {
-    await rm(options.outputDir, { recursive: true, force: true });
-    await mkdir(options.outputDir, { recursive: true });
-  }
+  await rm(options.outputDir, { recursive: true, force: true }).catch(() => {});
+  await mkdir(options.outputDir, { recursive: true });
 
   const config = await loadMainConfig(options);
   const { framework } = config;


### PR DESCRIPTION
Closes #29358

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Changed the logic for cleaning the outDir (ie. `storybook-static`), so it now simply removes the directory and adds an empty one.

A regression was introduced in https://github.com/storybookjs/storybook/pull/29126 that did this when attempting to clear the `outDir`:

```ts
const outputDirFiles = await readdir(options.outputDir);
for (const file of outputDirFiles) {
  await rm(file, { recursive: true, force: true });
}
```
 
However the problem with that is that `readdir` doesn't return the full file paths, only the file names. So it would find `storybook-static/index.html`, return `index.html`, and we would then just delete `./index.html`. CC @ziebam for knowledge sharing.

I've searched through the PR for other similar uses of `readdir` and didn't find anything.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 2.56 kB | **3.23** | 0% |
| initSize |  147 MB | 148 MB | 1.03 MB | 0.33 | 0.7% |
| diffSize |  68.3 MB | 69.3 MB | 1.02 MB | 0.32 | 1.5% |
| buildSize |  6.79 MB | 6.79 MB | -4.68 kB | -0.13 | -0.1% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 311 B | **1.72** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | -245 B | -0.73 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 12 B | 0.5 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 78 B | 1.08 | 0% |
| buildPreviewSize |  2.99 MB | 2.99 MB | -4.76 kB | -0.15 | -0.2% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.3s | 17.8s | 10.4s | 1.18 | 58.8% |
| generateTime |  18.8s | 20.1s | 1.3s | -0.29 | 6.9% |
| initTime |  11.2s | 12.7s | 1.5s | -0.77 | 12% |
| buildTime |  8s | 8.3s | 253ms | -0.47 | 3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.4s | 7s | 562ms | 0.4 | 8% |
| devManagerResponsive |  4.1s | 4.4s | 368ms | 0.19 | 8.2% |
| devManagerHeaderVisible |  525ms | 604ms | 79ms | -0.19 | 13.1% |
| devManagerIndexVisible |  560ms | 631ms | 71ms | -0.25 | 11.3% |
| devStoryVisibleUncached |  892ms | 1s | 141ms | 0.03 | 13.6% |
| devStoryVisible |  561ms | 629ms | 68ms | -0.28 | 10.8% |
| devAutodocsVisible |  544ms | 491ms | -53ms | -0.6 | -10.8% |
| devMDXVisible |  504ms | 465ms | -39ms | -1.02 | -8.4% |
| buildManagerHeaderVisible |  530ms | 477ms | -53ms | -0.87 | -11.1% |
| buildManagerIndexVisible |  559ms | 546ms | -13ms | -0.36 | -2.4% |
| buildStoryVisible |  560ms | 546ms | -14ms | -0.81 | -2.6% |
| buildAutodocsVisible |  496ms | 475ms | -21ms | -0.33 | -4.4% |
| buildMDXVisible |  502ms | 440ms | -62ms | -0.69 | -14.1% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR simplifies the output directory cleaning process in the Storybook build, addressing an issue where files were being incorrectly deleted during subsequent builds.

- Modified `code/core/src/core-server/build-static.ts` to remove and recreate the entire output directory
- Fixed a bug where `index.html` and other files were accidentally deleted when building Storybook multiple times
- Replaced the previous logic that used `readdir` and `rm` with a more straightforward approach
- Ensures consistent and reliable cleaning of the output directory before each build
- Resolves issue #29358 where `index.html` was deleted when Storybook was built twice

<!-- /greptile_comment -->