### PR TITLE
Addon-Test: Fix watch mode

### DIFF
--- a/code/addons/test/package.json
+++ b/code/addons/test/package.json
@@ -102,6 +102,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "semver": "^7.6.3",
+    "slash": "^5.0.0",
     "ts-dedent": "^2.2.0",
     "typescript": "^5.3.2",
     "vitest": "^2.1.3"

--- a/code/addons/test/src/node/vitest-manager.ts
+++ b/code/addons/test/src/node/vitest-manager.ts
@@ -1,10 +1,14 @@
-import path from 'node:path';
+import { existsSync } from 'node:fs';
+import path, { normalize } from 'node:path';
 
 import type { TestProject, TestSpecification, Vitest, WorkspaceProject } from 'vitest/node';
 
 import type { Channel } from 'storybook/internal/channels';
 import type { TestingModuleRunRequestPayload } from 'storybook/internal/core-events';
 
+import slash from 'slash';
+
+import { log } from '../logger';
 import { StorybookReporter } from './reporter';
 import type { TestManager } from './test-manager';
 
@@ -44,6 +48,10 @@ export class VitestManager {
     }
 
     await this.vitest.init();
+
+    if (watchMode) {
+      await this.setupWatchers();
+    }
   }
 
   async runAllTests() {
@@ -121,6 +129,101 @@ export class VitestManager {
     return (
       globTestSpecs.filter((workspaceSpec) => this.isStorybookProject(workspaceSpec.project)) ?? []
     );
+  }
+
+  private async getTestDependencies(spec: TestSpecification, deps = new Set<string>()) {
+    const addImports = async (project: WorkspaceProject, filepath: string) => {
+      if (deps.has(filepath)) {
+        return;
+      }
+      deps.add(filepath);
+
+      const mod = project.server.moduleGraph.getModuleById(filepath);
+      const transformed =
+        mod?.ssrTransformResult || (await project.vitenode.transformRequest(filepath));
+      if (!transformed) {
+        return;
+      }
+      const dependencies = [...(transformed.deps || []), ...(transformed.dynamicDeps || [])];
+      await Promise.all(
+        dependencies.map(async (dep) => {
+          const idPath = await project.server.pluginContainer.resolveId(dep, filepath, {
+            ssr: true,
+          });
+          const fsPath = idPath && !idPath.external && idPath.id.split('?')[0];
+          if (
+            fsPath &&
+            !fsPath.includes('node_modules') &&
+            !deps.has(fsPath) &&
+            existsSync(fsPath)
+          ) {
+            await addImports(project, fsPath);
+          }
+        })
+      );
+    };
+
+    await addImports(spec.project.workspaceProject, spec.moduleId);
+    deps.delete(spec.moduleId);
+
+    return deps;
+  }
+
+  async runAffectedTests(trigger: string) {
+    if (!this.vitest) {
+      return;
+    }
+
+    const globTestFiles = await this.vitest.globTestSpecs();
+    const testGraphs = await Promise.all(
+      globTestFiles
+        .filter((workspace) => this.isStorybookProject(workspace.project))
+        .map(async (spec) => {
+          const deps = await this.getTestDependencies(spec);
+          return [spec, deps] as const;
+        })
+    );
+    const triggerAffectedTests: TestSpecification[] = [];
+
+    for (const [workspaceSpec, deps] of testGraphs) {
+      if (trigger && (trigger === workspaceSpec.moduleId || deps.has(trigger))) {
+        triggerAffectedTests.push(workspaceSpec);
+      }
+    }
+
+    if (triggerAffectedTests.length) {
+      await this.vitest.cancelCurrentRun('keyboard-input');
+      await this.vitest.runningPromise;
+      await this.vitest.runFiles(triggerAffectedTests, true);
+    }
+  }
+
+  async runAffectedTestsAfterChange(file: string) {
+    const id = slash(file);
+    this.vitest?.logger.clearHighlightCache(id);
+    this.updateLastChanged(id);
+
+    await this.runAffectedTests(file);
+  }
+
+  async registerVitestConfigListener() {
+    this.vitest?.server?.watcher.on('change', async (file) => {
+      file = normalize(file);
+      const isConfig = file === this.vitest.server.config.configFile;
+      if (isConfig) {
+        log('Restarting Vitest due to config change');
+        await this.closeVitest();
+        await this.startVitest();
+      }
+    });
+  }
+
+  async setupWatchers() {
+    this.vitest?.server?.watcher.removeAllListeners('change');
+    this.vitest?.server?.watcher.removeAllListeners('add');
+    this.vitest?.server?.watcher.on('change', this.runAffectedTestsAfterChange.bind(this));
+    this.vitest?.server?.watcher.on('add', this.runAffectedTestsAfterChange.bind(this));
+    this.registerVitestConfigListener();
   }
 
   isStorybookProject(project: TestProject | WorkspaceProject) {

--- a/code/core/src/manager/components/sidebar/SidebarBottom.tsx
+++ b/code/core/src/manager/components/sidebar/SidebarBottom.tsx
@@ -180,7 +180,7 @@ export const SidebarBottomBase = ({ api, notifications = [], status = {} }: Side
 
   useEffect(() => {
     const onCrashReport = ({ providerId, ...details }: { providerId: string }) => {
-      updateTestProvider(providerId, { details, running: false, crashed: true });
+      updateTestProvider(providerId, { details, running: false, crashed: true, watching: false });
     };
 
     const onProgressReport = ({ providerId, ...payload }: TestingModuleProgressReportPayload) => {

--- a/code/core/src/manager/components/sidebar/TestingModule.tsx
+++ b/code/core/src/manager/components/sidebar/TestingModule.tsx
@@ -246,7 +246,7 @@ export const TestingModule = ({
                       padding="small"
                       active={state.watching}
                       onClick={() => onSetWatchMode(state.id, !state.watching)}
-                      disabled={state.crashed}
+                      disabled={state.crashed || state.running}
                     >
                       <EyeIcon />
                     </Button>

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6253,6 +6253,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     semver: "npm:^7.6.3"
+    slash: "npm:^5.0.0"
     ts-dedent: "npm:^2.2.0"
     typescript: "npm:^5.3.2"
     vitest: "npm:^2.1.3"


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Vitest's default behavior in watch mode is to only trigger tests if test files are changing or to trigger tests for non-test files if the affected tests for the changed files were executed/run before.

This PR changes the watch behavior by always traversing the dependency graph of all tests to determine whether a specific file change relates to a particular test. This ensures that when I change a `button.tsx` file, all affected tests importing this file or parent files importing `button.tsx` will be executed.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | -4.93 kB | 0.3 | 0% |
| initSize |  147 MB | 147 MB | 11.2 kB | -0.48 | 0% |
| diffSize |  68.3 MB | 68.3 MB | 16.2 kB | -0.48 | 0% |
| buildSize |  7.1 MB | 7.1 MB | 27 B | -0.27 | 0% |
| buildSbAddonsSize |  1.79 MB | 1.79 MB | 0 B | -0.29 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 27 B | -0.35 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | -0.33 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.1 MB | 4.1 MB | 27 B | -0.32 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.52 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  14.7s | 15.5s | 761ms | 0.17 | 4.9% |
| generateTime |  18.9s | 20s | 1.1s | -0.67 | 5.5% |
| initTime |  12.9s | 13.7s | 766ms | -0.69 | 5.6% |
| buildTime |  10.7s | 8.5s | -2s -187ms | -0.9 | -25.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.1s | 5.5s | -1s -519ms | **-1.72** | 🔰-27.2% |
| devManagerResponsive |  4.3s | 3.8s | -542ms | **-1.45** | 🔰-14.2% |
| devManagerHeaderVisible |  837ms | 542ms | -295ms | -1.02 | -54.4% |
| devManagerIndexVisible |  880ms | 568ms | -312ms | -1.07 | -54.9% |
| devStoryVisibleUncached |  1.1s | 722ms | -415ms | **-1.53** | 🔰-57.5% |
| devStoryVisible |  882ms | 574ms | -308ms | -1 | -53.7% |
| devAutodocsVisible |  835ms | 500ms | -335ms | -0.69 | -67% |
| devMDXVisible |  591ms | 472ms | -119ms | **-1.7** | 🔰-25.2% |
| buildManagerHeaderVisible |  577ms | 530ms | -47ms | -0.75 | -8.9% |
| buildManagerIndexVisible |  583ms | 594ms | 11ms | -0.35 | 1.9% |
| buildStoryVisible |  865ms | 594ms | -271ms | -0.62 | -45.6% |
| buildAutodocsVisible |  576ms | 463ms | -113ms | **-1.45** | 🔰-24.4% |
| buildMDXVisible |  499ms | 451ms | -48ms | -1.23 | -10.6% |

<!-- BENCHMARK_SECTION -->