### PR TITLE
Core: Improve aria labels using test provider `name` property

### DIFF
--- a/code/addons/test/src/manager.tsx
+++ b/code/addons/test/src/manager.tsx
@@ -85,6 +85,7 @@ addons.register(ADDON_ID, (api) => {
     runnable: true,
     watchable: true,
 
+    name: 'Component tests',
     title: ({ crashed }) => (crashed ? "Component tests didn't complete" : 'Component tests'),
     description: ({ failed, running, watching, progress, crashed, details }) => {
       const [isModalOpen, setIsModalOpen] = useState(false);

--- a/code/core/src/manager/components/sidebar/TestingModule.tsx
+++ b/code/core/src/manager/components/sidebar/TestingModule.tsx
@@ -241,7 +241,7 @@ export const TestingModule = ({
                 <Actions>
                   {state.watchable && (
                     <Button
-                      aria-label="Toggle watch mode"
+                      aria-label={`${state.watching ? 'Disable' : 'Enable'} watch mode for ${state.name}`}
                       variant="ghost"
                       padding="small"
                       active={state.watching}
@@ -255,7 +255,7 @@ export const TestingModule = ({
                     <>
                       {state.running && state.cancellable ? (
                         <Button
-                          aria-label={`Cancel tests`}
+                          aria-label={`Stop ${state.name}`}
                           variant="ghost"
                           padding="small"
                           onClick={() => onCancelTests(state.id)}
@@ -265,7 +265,7 @@ export const TestingModule = ({
                         </Button>
                       ) : (
                         <Button
-                          aria-label={`Run ${state.title}`}
+                          aria-label={`Start ${state.name}`}
                           variant="ghost"
                           padding="small"
                           onClick={() => onRunTests(state.id)}

--- a/code/core/src/types/modules/addons.ts
+++ b/code/core/src/types/modules/addons.ts
@@ -471,6 +471,7 @@ export interface Addon_TestProviderType<
   type: Addon_TypesEnum.experimental_TEST_PROVIDER;
   /** The unique id of the test provider. */
   id: string;
+  name: string;
   title: (state: Addon_TestProviderState<Details>) => ReactNode;
   description: (state: Addon_TestProviderState<Details>) => ReactNode;
   mapStatusUpdate?: (state: Addon_TestProviderState<Details>) => API_StatusUpdate;


### PR DESCRIPTION
This adds a required `name` property to the Test Provider API, and uses this name in the aria labels for the start/stop/watch buttons.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds a required 'name' property to the Test Provider API and updates aria labels for improved accessibility in the Storybook testing module.

- Added 'name' property to Addon_TestProviderType interface in `code/core/src/types/modules/addons.ts`
- Updated `code/addons/test/src/manager.tsx` to include 'name' in test provider configuration
- Modified `code/core/src/manager/components/sidebar/TestingModule.tsx` to use 'name' in aria labels for watch mode, start, and stop buttons
- Improved accessibility by providing more specific and descriptive labels for UI elements

<!-- /greptile_comment -->