### PR TITLE
Revert "Addon Test: Error when addon interactions exists"

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -96,6 +96,7 @@ const config: StorybookConfig = {
   addons: [
     '@storybook/addon-themes',
     '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
     '@storybook/addon-storysource',
     '@storybook/addon-designs',
     '@storybook/experimental-addon-test',

--- a/code/addons/interactions/src/preset.ts
+++ b/code/addons/interactions/src/preset.ts
@@ -18,6 +18,3 @@ export const checkActionsLoaded = (configDir: string) => {
     getConfig: (configFile) => serverRequire(configFile),
   });
 };
-
-// This annotation is read by addon-test, so it can throw an error if both addons are used
-export const ADDON_INTERACTIONS_IN_USE = true;

--- a/code/addons/test/src/preset.ts
+++ b/code/addons/test/src/preset.ts
@@ -9,7 +9,7 @@ import {
   TESTING_MODULE_WATCH_MODE_REQUEST,
 } from 'storybook/internal/core-events';
 import { oneWayHash, telemetry } from 'storybook/internal/telemetry';
-import type { Options, PresetProperty, StoryId } from 'storybook/internal/types';
+import type { Options, StoryId } from 'storybook/internal/types';
 
 import picocolors from 'picocolors';
 import { dedent } from 'ts-dedent';
@@ -98,35 +98,4 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
   }
 
   return channel;
-};
-
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  entry = [],
-  options
-) => {
-  checkActionsLoaded(options.configDir);
-  return entry;
-};
-
-export const managerEntries: PresetProperty<'managerEntries'> = async (entry = [], options) => {
-  // Throw an error when addon-interactions is used.
-  // This is done by reading an annotation defined in addon-interactions, which although not ideal,
-  // is a way to handle addon conflict without having to worry about the order of which they are registered
-  const annotation = await options.presets.apply('ADDON_INTERACTIONS_IN_USE', false);
-  if (annotation) {
-    // eslint-disable-next-line local-rules/no-uncategorized-errors
-    const error = new Error(
-      dedent`
-      You have both addon-interactions and addon-test enabled, which is not allowed.
-
-      addon-test is a replacement for addon-interactions, please uninstall and remove addon-interactions from the addons list in your main config at ${options.configDir}.
-      `
-    );
-    error.name = 'AddonConflictError';
-
-    throw error;
-  }
-
-  // for whatever reason seems like the return type of managerEntries is not correct (it expects never instead of string[])
-  return entry as never;
 };


### PR DESCRIPTION
Reverts storybookjs/storybook#29338

<!-- greptile_comment -->

## Greptile Summary

This PR reverts changes related to conflict detection between Storybook addon-interactions and addon-test, simplifying addon configuration.

- Reintroduced '@storybook/addon-interactions' in `code/.storybook/main.ts` addons array
- Removed `ADDON_INTERACTIONS_IN_USE` constant from `code/addons/interactions/src/preset.ts`
- Removed conflict check, `previewAnnotations`, and `managerEntries` functions from `code/addons/test/src/preset.ts`
- Retained `checkActionsLoaded` function in both addon presets for proper addon order

<!-- /greptile_comment -->