### PR TITLE
CLI: Fix `yarn` detection

### DIFF
--- a/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
@@ -61,7 +61,7 @@ export class JsPackageManagerFactory {
     const hasPNPMCommand = hasPNPM(cwd);
     const yarnVersion = getYarnVersion(cwd);
 
-    if (yarnVersion && closestLockfile === YARN_LOCKFILE) {
+    if (yarnVersion && (closestLockfile === YARN_LOCKFILE || (!hasNPMCommand && !hasPNPMCommand))) {
       return yarnVersion === 1 ? new Yarn1Proxy({ cwd }) : new Yarn2Proxy({ cwd });
     }
 

--- a/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
@@ -61,7 +61,7 @@ export class JsPackageManagerFactory {
     const hasPNPMCommand = hasPNPM(cwd);
     const yarnVersion = getYarnVersion(cwd);
 
-    if (yarnVersion && (closestLockfile === YARN_LOCKFILE || (!hasNPMCommand && !hasPNPMCommand))) {
+    if (yarnVersion && closestLockfile === YARN_LOCKFILE) {
       return yarnVersion === 1 ? new Yarn1Proxy({ cwd }) : new Yarn2Proxy({ cwd });
     }
 
@@ -129,6 +129,7 @@ function hasNPM(cwd?: string) {
     cwd,
     shell: true,
     env: {
+      ...process.env,
       COREPACK_ENABLE_STRICT: '0',
     },
   });
@@ -140,6 +141,7 @@ function hasPNPM(cwd?: string) {
     cwd,
     shell: true,
     env: {
+      ...process.env,
       COREPACK_ENABLE_STRICT: '0',
     },
   });
@@ -151,6 +153,7 @@ function getYarnVersion(cwd?: string): 1 | 2 | undefined {
     cwd,
     shell: true,
     env: {
+      ...process.env,
       COREPACK_ENABLE_STRICT: '0',
     },
   });


### PR DESCRIPTION
## What I did

- [x] ensure that spawning yarn works, by adding back all default `env` variables (like `PATH`)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.6 MB | 77.6 MB | 0 B | -1 | 0% |
| initSize |  146 MB | 146 MB | 132 B | -0.98 | 0% |
| diffSize |  68.5 MB | 68.5 MB | 132 B | 1.04 | 0% |
| buildSize |  6.82 MB | 6.82 MB | 0 B | -0.53 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | -0.64 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 0 B | 0.99 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | 0.99 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.82 MB | 3.82 MB | 0 B | -0.54 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.74 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  5.8s | 24.9s | 19s | **1.66** | 🔺76.5% |
| generateTime |  20.9s | 23.3s | 2.3s | 0.79 | 10.3% |
| initTime |  14.6s | 17.1s | 2.4s | **1.73** | 🔺14.2% |
| buildTime |  8s | 9.7s | 1.7s | 0.4 | 17.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.5s | 6.6s | 85ms | 0.17 | 1.3% |
| devManagerResponsive |  4.5s | 4.3s | -189ms | 0.02 | -4.3% |
| devManagerHeaderVisible |  550ms | 680ms | 130ms | **1.29** | 🔺19.1% |
| devManagerIndexVisible |  630ms | 761ms | 131ms | **1.43** | 🔺17.2% |
| devStoryVisibleUncached |  1.1s | 1.1s | 32ms | 0.59 | 2.7% |
| devStoryVisible |  583ms | 731ms | 148ms | **1.41** | 🔺20.2% |
| devAutodocsVisible |  498ms | 387ms | -111ms | **-1.65** | 🔰-28.7% |
| devMDXVisible |  565ms | 571ms | 6ms | 0.66 | 1.1% |
| buildManagerHeaderVisible |  555ms | 500ms | -55ms | -0.59 | -11% |
| buildManagerIndexVisible |  573ms | 513ms | -60ms | -0.71 | -11.7% |
| buildStoryVisible |  554ms | 499ms | -55ms | -1.2 | -11% |
| buildAutodocsVisible |  484ms | 439ms | -45ms | -0.76 | -10.3% |
| buildMDXVisible |  436ms | 464ms | 28ms | -0.32 | 6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Improved package manager detection in Storybook CLI by making Yarn detection more reliable and fixing environment variable handling during command execution.

- Modified `JsPackageManagerFactory.ts` to only use Yarn when a `yarn.lock` file is present
- Added `process.env` to environment variables when spawning package manager version check commands
- Removed fallback condition that would use Yarn without `yarn.lock` when npm/pnpm weren't found
- Ensures PATH and other critical environment variables are properly passed through during command execution

<!-- /greptile_comment -->