### PR TITLE
Dependencies: Upgrade VTA to v3.1.0

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/vta.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/vta.ts
@@ -32,7 +32,7 @@ export const vta: Fix<Options> = {
       New to Storybook 8: Storybook's Visual Tests addon helps you catch unintentional changes/bugs in your stories. The addon is powered by Chromatic, a cloud-based testing tool developed by Storybook's core team.
 
       Learn more: ${picocolors.yellow('https://storybook.js.org/docs/writing-tests/visual-testing')}
-      
+
       Install Visual Tests addon in your project?
     `;
   },
@@ -42,7 +42,7 @@ export const vta: Fix<Options> = {
       const packageJson = await packageManager.retrievePackageJson();
       await packageManager.addDependencies(
         { installAsDevDependencies: true, skipInstall, packageJson },
-        [`@chromatic-com/storybook@^1`]
+        [`@chromatic-com/storybook@^3`]
       );
 
       await updateMainConfig({ mainConfigPath, dryRun: !!dryRun }, async (main) => {

--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -229,7 +229,7 @@ export async function baseGenerator(
         })
       : extraAddonPackages;
 
-  extraAddonsToInstall.push('@storybook/addon-essentials', '@chromatic-com/storybook@^1');
+  extraAddonsToInstall.push('@storybook/addon-essentials', '@chromatic-com/storybook@^3');
 
   // added to main.js
   const addons = [
@@ -337,14 +337,14 @@ export async function baseGenerator(
             ? dedent`/**
             * This function is used to resolve the absolute path of a package.
             * It is needed in projects that use Yarn PnP or are set up within a monorepo.
-            */ 
+            */
             function getAbsolutePath(value) {
               return dirname(require.resolve(join(value, 'package.json')))
             }`
             : dedent`/**
           * This function is used to resolve the absolute path of a package.
           * It is needed in projects that use Yarn PnP or are set up within a monorepo.
-          */ 
+          */
           function getAbsolutePath(value: string): any {
             return dirname(require.resolve(join(value, 'package.json')))
           }`,

--- a/code/package.json
+++ b/code/package.json
@@ -90,7 +90,7 @@
     "type-fest": "~2.19"
   },
   "dependencies": {
-    "@chromatic-com/storybook": "^1.6.1",
+    "@chromatic-com/storybook": "^3.1.0",
     "@happy-dom/global-registrator": "^14.12.0",
     "@nx/eslint": "18.0.6",
     "@nx/vite": "18.0.6",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2354,16 +2354,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chromatic-com/storybook@npm:^1.6.1":
-  version: 1.6.1
-  resolution: "@chromatic-com/storybook@npm:1.6.1"
+"@chromatic-com/storybook@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@chromatic-com/storybook@npm:3.1.0"
   dependencies:
-    chromatic: "npm:^11.4.0"
+    "@storybook/channels": "npm:^8.3.0"
+    "@storybook/telemetry": "npm:^8.3.0"
+    "@storybook/types": "npm:^8.3.0"
+    chromatic: "npm:^11.15.0"
     filesize: "npm:^10.0.12"
     jsonfile: "npm:^6.1.0"
     react-confetti: "npm:^6.1.0"
     strip-ansi: "npm:^7.1.0"
-  checksum: 10c0/411a2c9f44542c4940e6452846f1c2b71f4529640cefcf60396c1eb0a16cd2a4d27ba648523c73a7ca9b5b64f2a67b19159281add6730d0a237336a3856c8f37
+  peerDependencies:
+    storybook: ^8.3.0
+  checksum: 10c0/cb9672d828f076e9a6c7277fe08a846d05316fb7d3e625862fc667718f5abc2746ff7cea04507e5cbc0136a4d55950fce88ea91420e8d3c05d84f528050a1dce
   languageName: node
   linkType: hard
 
@@ -5863,6 +5868,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@storybook/channels@npm:^8.3.0":
+  version: 8.3.6
+  resolution: "@storybook/channels@npm:8.3.6"
+  peerDependencies:
+    storybook: ^8.3.6
+  checksum: 10c0/3c34ed2b03c60c6ed1160d9a0efdb836be892e333556848ff492c16ab6d92521207512670d42f69d681f521e50f130a00f692610a3ca63228a8d2b49be57f4fa
+  languageName: node
+  linkType: hard
+
 "@storybook/channels@workspace:deprecated/channels":
   version: 0.0.0-use.local
   resolution: "@storybook/channels@workspace:deprecated/channels"
@@ -6818,7 +6832,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/root@workspace:."
   dependencies:
-    "@chromatic-com/storybook": "npm:^1.6.1"
+    "@chromatic-com/storybook": "npm:^3.1.0"
     "@happy-dom/global-registrator": "npm:^14.12.0"
     "@nx/eslint": "npm:18.0.6"
     "@nx/vite": "npm:18.0.6"
@@ -7107,6 +7121,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@storybook/telemetry@npm:^8.3.0":
+  version: 8.3.6
+  resolution: "@storybook/telemetry@npm:8.3.6"
+  peerDependencies:
+    storybook: ^8.3.6
+  checksum: 10c0/b4fd8d0e238335249aa82dea49bde56813e0c771e67dd7110fb9e038d1e2bd64aa03e76ee865ef6a7f0fd5220d02bd7bcf3273bb4c19403e3d527d9dd7a258d4
+  languageName: node
+  linkType: hard
+
 "@storybook/telemetry@workspace:deprecated/telemetry":
   version: 0.0.0-use.local
   resolution: "@storybook/telemetry@workspace:deprecated/telemetry"
@@ -7155,6 +7178,15 @@ __metadata:
     storybook: "workspace:^"
   languageName: unknown
   linkType: soft
+
+"@storybook/types@npm:^8.3.0":
+  version: 8.3.6
+  resolution: "@storybook/types@npm:8.3.6"
+  peerDependencies:
+    storybook: ^8.3.6
+  checksum: 10c0/482f55e34877f9eb94a8ff4627a254f3b5442f91f13363e6837e3a9c220a369be1c6ce4652b870b7fa4e522c3365825651f9e04a21bda76b104a6c1f7435e274
+  languageName: node
+  linkType: hard
 
 "@storybook/types@workspace:*, @storybook/types@workspace:deprecated/types":
   version: 0.0.0-use.local
@@ -11687,9 +11719,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromatic@npm:^11.4.0":
-  version: 11.5.5
-  resolution: "chromatic@npm:11.5.5"
+"chromatic@npm:^11.15.0":
+  version: 11.15.0
+  resolution: "chromatic@npm:11.15.0"
   peerDependencies:
     "@chromatic-com/cypress": ^0.*.* || ^1.0.0
     "@chromatic-com/playwright": ^0.*.* || ^1.0.0
@@ -11702,7 +11734,7 @@ __metadata:
     chroma: dist/bin.js
     chromatic: dist/bin.js
     chromatic-cli: dist/bin.js
-  checksum: 10c0/3d812122548f9c29ab7116f7054e03cbf523b30ddde7e3142017cd23c42b6b99b3023e0146ef3afcfe4245a8cbb2ed97cedecca4e2cf9e5f6e8666db84a827d4
+  checksum: 10c0/8add464ff39417c402b77d973300806a50bd5e3b8f95eeccd965787536b4273e6bfa6b6e0716417bf342cd5106e82e8f1e0dec4a290a89c00e7862f3833fff10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrade the Visual Tests addon to the latest version, which integrates with the v8.4 Testing Module.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.6 MB | 77.6 MB | 0 B | -0.73 | 0% |
| initSize |  146 MB | 143 MB | -3.47 MB | **-9.55** | -2.4% |
| diffSize |  68.5 MB | 65.1 MB | -3.47 MB | **-30.69** | 🔰-5.3% |
| buildSize |  6.82 MB | 6.82 MB | 6.64 kB | -0.52 | 0.1% |
| buildSbAddonsSize |  1.5 MB | 1.51 MB | 6.64 kB | -0.6 | 0.4% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 0 B | 0.72 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | 0.73 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.82 MB | 3.83 MB | 6.64 kB | -0.53 | 0.2% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.51 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7s | 5.6s | -1s -379ms | -1.01 | -24.5% |
| generateTime |  24.9s | 19.9s | -5s -42ms | **-1.31** | 🔰-25.3% |
| initTime |  16.9s | 12.8s | -4s -156ms | **-1.52** | 🔰-32.4% |
| buildTime |  9.6s | 9.8s | 238ms | 0.27 | 2.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  9.1s | 6.9s | -2s -222ms | 0.09 | -32.1% |
| devManagerResponsive |  6.1s | 4.4s | -1s -648ms | -0.15 | -36.9% |
| devManagerHeaderVisible |  968ms | 593ms | -375ms | -0.07 | -63.2% |
| devManagerIndexVisible |  1.1s | 666ms | -439ms | 0.07 | -65.9% |
| devStoryVisibleUncached |  2.1s | 752ms | -1s -353ms | -1.06 | -179.9% |
| devStoryVisible |  1s | 664ms | -429ms | 0.18 | -64.6% |
| devAutodocsVisible |  965ms | 598ms | -367ms | 0.34 | -61.4% |
| devMDXVisible |  965ms | 584ms | -381ms | 0.28 | -65.2% |
| buildManagerHeaderVisible |  759ms | 671ms | -88ms | 0.86 | -13.1% |
| buildManagerIndexVisible |  805ms | 680ms | -125ms | 0.71 | -18.4% |
| buildStoryVisible |  758ms | 668ms | -90ms | 0.88 | -13.5% |
| buildAutodocsVisible |  747ms | 514ms | -233ms | -0.01 | -45.3% |
| buildMDXVisible |  685ms | 512ms | -173ms | 0.09 | -33.8% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Upgrades the Visual Tests addon (@chromatic-com/storybook) from v1.x to v3.1.0 to integrate with Storybook's v8.4 Testing Module across multiple configuration files.

- Updated version to `@^3` in `code/lib/create-storybook/src/generators/baseGenerator.ts` for new project generation
- Modified `code/lib/cli-storybook/src/automigrate/fixes/vta.ts` to handle migration of existing projects
- Updated dependency to `@chromatic-com/storybook@^3.1.0` in root `package.json`
- Lacks testing information and documentation updates for a major version upgrade

<!-- /greptile_comment -->