### PR TITLE
Core: Show checkmark icon in story status dropdown and update status label for component tests

### DIFF
--- a/code/addons/test/src/manager.tsx
+++ b/code/addons/test/src/manager.tsx
@@ -152,7 +152,7 @@ addons.register(ADDON_ID, (api) => {
             .map(({ storyId, status, testRunId, ...rest }) => {
               if (storyId) {
                 const statusObject: API_StatusObject = {
-                  title: 'Vitest',
+                  title: 'Component tests',
                   status: statusMap[status],
                   description:
                     'failureMessages' in rest && rest.failureMessages?.length

--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -7,6 +7,7 @@ import {
   CollapseIcon as CollapseIconSvg,
   ExpandAltIcon,
   StatusFailIcon,
+  StatusPassIcon,
   StatusWarnIcon,
   SyncIcon,
 } from '@storybook/icons';
@@ -224,7 +225,7 @@ const Node = React.memo<NodeProps>(function Node({
                     description: value.description,
                     'aria-label': `Test status for ${value.title}: ${value.status}`,
                     icon: {
-                      success: null, // We don't show a checkmark, to avoid clutter
+                      success: <StatusPassIcon color={theme.color.positive} />,
                       error: <StatusFailIcon color={theme.color.negative} />,
                       warn: <StatusWarnIcon color={theme.color.warning} />,
                       pending: <SyncIcon size={12} color={theme.color.defaultText} />,


### PR DESCRIPTION
## What I did

Added missing checkmark icon to the story status menu, and updated the "Vitest" label to "Component tests".

<img width="209" alt="Screenshot 2024-10-25 at 21 28 27" src="https://github.com/user-attachments/assets/c91843bf-9d36-4d53-8f3e-f00dd3351a30">


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.6 MB | 77.6 MB | 104 B | **-1.46** | 0% |
| initSize |  146 MB | 146 MB | 1.05 kB | **-1.46** | 0% |
| diffSize |  68.5 MB | 68.5 MB | 949 B | **1.42** | 0% |
| buildSize |  6.82 MB | 6.82 MB | -5 B | -0.5 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | -0.64 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | -5 B | **1.34** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | **1.35** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.82 MB | 3.82 MB | -5 B | -0.51 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 1 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  5.9s | 20.8s | 14.9s | 1.14 | 71.6% |
| generateTime |  20.6s | 19.8s | -768ms | -0.67 | -3.9% |
| initTime |  14.1s | 14.3s | 156ms | -0.29 | 1.1% |
| buildTime |  10.4s | 8.8s | -1s -656ms | -0.56 | -18.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  9.3s | 6s | -3s -304ms | -0.44 | -54.5% |
| devManagerResponsive |  6.2s | 4.1s | -2s -166ms | -0.26 | -52.5% |
| devManagerHeaderVisible |  803ms | 552ms | -251ms | -0.34 | -45.5% |
| devManagerIndexVisible |  921ms | 616ms | -305ms | -0.08 | -49.5% |
| devStoryVisibleUncached |  1.8s | 1.1s | -699ms | 0.52 | -59.8% |
| devStoryVisible |  852ms | 615ms | -237ms | 0 | -38.5% |
| devAutodocsVisible |  717ms | 470ms | -247ms | -0.69 | -52.6% |
| devMDXVisible |  747ms | 456ms | -291ms | -0.67 | -63.8% |
| buildManagerHeaderVisible |  814ms | 501ms | -313ms | -0.58 | -62.5% |
| buildManagerIndexVisible |  838ms | 508ms | -330ms | -0.75 | -65% |
| buildStoryVisible |  774ms | 503ms | -271ms | -1.15 | -53.9% |
| buildAutodocsVisible |  689ms | 413ms | -276ms | -0.97 | -66.8% |
| buildMDXVisible |  679ms | 441ms | -238ms | -0.71 | -54% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updates test status UI elements by adding a checkmark icon for successful tests in the status dropdown and changing the label from "Vitest" to "Component tests" across the interface.

- Added `StatusPassIcon` for successful test status in `code/core/src/manager/components/sidebar/Tree.tsx`
- Updated test status title from "Vitest" to "Component tests" in `code/addons/test/src/manager.tsx`
- Maintains consistent labeling across UI components
- Improves visual feedback for successful test states

<!-- /greptile_comment -->