### PR TITLE
Core: Close story status menu when selecting an item

### DIFF
--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -210,9 +210,10 @@ const Node = React.memo<NodeProps>(function Node({
         {icon ? (
           <WithTooltip
             closeOnOutsideClick
+            closeOnTriggerHidden
             onClick={(event) => event.stopPropagation()}
             placement="bottom"
-            tooltip={() => (
+            tooltip={({ onHide }) => (
               <TooltipLinkList
                 links={Object.entries(status || {})
                   .sort(
@@ -233,6 +234,7 @@ const Node = React.memo<NodeProps>(function Node({
                     onClick: () => {
                       onSelectStoryId(item.id);
                       value.onClick?.();
+                      onHide();
                     },
                   }))}
               />


### PR DESCRIPTION
## What I did

Closes the story status menu when selecting an item from the list, and whenever the story is hidden from view (due to scrolling the sidebar).

<img width="246" alt="Screenshot 2024-10-27 at 14 04 28" src="https://github.com/user-attachments/assets/528ed0fd-73e7-4d48-9c84-ed20bcc2c493">

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.6 MB | 77.6 MB | 0 B | -0.82 | 0% |
| initSize |  146 MB | 146 MB | 54 B | -0.8 | 0% |
| diffSize |  68.5 MB | 68.5 MB | 54 B | 0.85 | 0% |
| buildSize |  6.82 MB | 6.82 MB | 54 B | -0.56 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | -0.65 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 54 B | 0.81 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | 0.81 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.82 MB | 3.82 MB | 54 B | -0.57 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.59 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  5.6s | 6.4s | 736ms | -0.96 | 11.5% |
| generateTime |  20.2s | 22.1s | 1.9s | 0.05 | 8.9% |
| initTime |  13s | 16.5s | 3.5s | **1.32** | 🔺21.4% |
| buildTime |  10s | 9s | -962ms | -0.43 | -10.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  8.8s | 7s | -1s -842ms | 0.29 | -26.3% |
| devManagerResponsive |  5.6s | 4.7s | -928ms | 0.41 | -19.5% |
| devManagerHeaderVisible |  659ms | 571ms | -88ms | -0.13 | -15.4% |
| devManagerIndexVisible |  703ms | 648ms | -55ms | 0.17 | -8.5% |
| devStoryVisibleUncached |  1s | 1.2s | 124ms | 0.66 | 10.2% |
| devStoryVisible |  692ms | 600ms | -92ms | -0.18 | -15.3% |
| devAutodocsVisible |  553ms | 521ms | -32ms | -0.17 | -6.1% |
| devMDXVisible |  606ms | 516ms | -90ms | -0.12 | -17.4% |
| buildManagerHeaderVisible |  652ms | 550ms | -102ms | -0.23 | -18.5% |
| buildManagerIndexVisible |  665ms | 561ms | -104ms | -0.33 | -18.5% |
| buildStoryVisible |  650ms | 549ms | -101ms | -0.55 | -18.4% |
| buildAutodocsVisible |  528ms | 461ms | -67ms | -0.53 | -14.5% |
| buildMDXVisible |  580ms | 465ms | -115ms | -0.35 | -24.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Adds functionality to automatically close the story status menu in the sidebar when selecting an item or when the trigger becomes hidden from view.

- Added `closeOnTriggerHidden` prop to `WithTooltip` component in `/code/core/src/manager/components/sidebar/Tree.tsx`
- Added `onHide()` calls in click handlers for story and group status tooltips
- Improves UX by preventing tooltips from remaining open when no longer relevant

<!-- /greptile_comment -->