### PR TITLE
Addon Test: Fix hiding stacktrace for assertion errors in test panel

### DIFF
--- a/code/addons/test/package.json
+++ b/code/addons/test/package.json
@@ -103,6 +103,7 @@
     "react-dom": "^18.2.0",
     "semver": "^7.6.3",
     "slash": "^5.0.0",
+    "strip-ansi": "^7.1.0",
     "ts-dedent": "^2.2.0",
     "typescript": "^5.3.2",
     "vitest": "^2.1.3"

--- a/code/addons/test/src/utils.ts
+++ b/code/addons/test/src/utils.ts
@@ -1,6 +1,7 @@
 import { type StorybookTheme, useTheme } from 'storybook/internal/theming';
 
 import Filter from 'ansi-to-html';
+import stripAnsi from 'strip-ansi';
 
 export function isTestAssertionError(error: unknown) {
   return isChaiError(error) || isJestError(error);
@@ -22,7 +23,7 @@ export function isJestError(error: unknown) {
     typeof error === 'object' &&
     'message' in error &&
     typeof error.message === 'string' &&
-    error.message.startsWith('expect(')
+    stripAnsi(error.message).startsWith('expect(')
   );
 }
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6253,6 +6253,7 @@ __metadata:
     react-dom: "npm:^18.2.0"
     semver: "npm:^7.6.3"
     slash: "npm:^5.0.0"
+    strip-ansi: "npm:^7.1.0"
     ts-dedent: "npm:^2.2.0"
     typescript: "npm:^5.3.2"
     vitest: "npm:^2.1.3"


### PR DESCRIPTION
## What I did

Hides the raw error stack trace for assertion errors. This was broken due to the inclusion of ANSI characters in the error message, which tripped up the detection mechanism. Stripping ANSI characters fixes the issue.

<img width="815" alt="Screenshot 2024-10-27 at 21 01 24" src="https://github.com/user-attachments/assets/90f45105-90e8-4b64-a7c2-b5d2394d1425">

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.6 MB | 77.6 MB | 36 kB | -1.1 | 0% |
| initSize |  146 MB | 146 MB | 36 kB | -1.08 | 0% |
| diffSize |  68.5 MB | 68.5 MB | 0 B | 1.15 | 0% |
| buildSize |  6.82 MB | 6.82 MB | 0 B | -0.52 | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | -0.64 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 0 B | 1.09 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | 1.1 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.82 MB | 3.82 MB | 0 B | -0.53 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.82 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.1s | 22.3s | 16.2s | 1.21 | 72.6% |
| generateTime |  21.5s | 19.6s | -1s -842ms | **-1.37** | 🔰-9.4% |
| initTime |  14s | 12.9s | -1s -45ms | **-1.24** | 🔰-8% |
| buildTime |  8s | 8.7s | 671ms | -0.6 | 7.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.1s | 6.6s | 470ms | 0.16 | 7.1% |
| devManagerResponsive |  4.2s | 4.5s | 330ms | 0.39 | 7.2% |
| devManagerHeaderVisible |  541ms | 551ms | 10ms | -0.31 | 1.8% |
| devManagerIndexVisible |  605ms | 620ms | 15ms | -0.01 | 2.4% |
| devStoryVisibleUncached |  921ms | 935ms | 14ms | -0.41 | 1.5% |
| devStoryVisible |  569ms | 580ms | 11ms | -0.35 | 1.9% |
| devAutodocsVisible |  511ms | 506ms | -5ms | -0.28 | -1% |
| devMDXVisible |  486ms | 468ms | -18ms | -0.54 | -3.8% |
| buildManagerHeaderVisible |  546ms | 550ms | 4ms | -0.07 | 0.7% |
| buildManagerIndexVisible |  560ms | 561ms | 1ms | -0.21 | 0.2% |
| buildStoryVisible |  543ms | 551ms | 8ms | -0.5 | 1.5% |
| buildAutodocsVisible |  474ms | 482ms | 8ms | -0.23 | 1.7% |
| buildMDXVisible |  442ms | 447ms | 5ms | -0.61 | 1.1% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Improved error message handling in the test panel by adding ANSI character stripping functionality to properly detect and hide assertion error stack traces.

- Added `strip-ansi` package (v7.1.0) as devDependency in `code/addons/test/package.json`
- Modified `isJestError` function in `code/addons/test/src/utils.ts` to strip ANSI codes before checking error messages
- Fixed assertion error detection that was previously broken by ANSI formatting characters

<!-- /greptile_comment -->