### PR TITLE
CLI: Refactor NPMProxy error parsing logic

### DIFF
--- a/code/core/src/common/js-package-manager/NPMProxy.test.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.test.ts
@@ -428,7 +428,7 @@ describe('NPM Proxy', () => {
 
   describe('parseErrors', () => {
     it('should parse npm errors', () => {
-      const NPM_RESOLVE_ERROR_SAMPLE = `
+      const NPM_LEGACY_RESOLVE_ERROR_SAMPLE = `
         npm ERR!
         npm ERR! code ERESOLVE
         npm ERR! ERESOLVE unable to resolve dependency tree
@@ -437,6 +437,17 @@ describe('NPM Proxy', () => {
         npm ERR! Found: react@undefined
         npm ERR! node_modules/react
         npm ERR!   react@"30" from the root project
+        `;
+
+      const NPM_RESOLVE_ERROR_SAMPLE = `
+        npm error
+        npm error code ERESOLVE
+        npm error ERESOLVE unable to resolve dependency tree
+        npm error 
+        npm error While resolving: before-storybook@1.0.0
+        npm error Found: react@undefined
+        npm error node_modules/react
+        npm error   react@"30" from the root project
         `;
 
       const NPM_TIMEOUT_ERROR_SAMPLE = `
@@ -451,6 +462,9 @@ describe('NPM Proxy', () => {
           npm ERR! network This is a problem related to network connectivity.
       `;
 
+      expect(npmProxy.parseErrorFromLogs(NPM_LEGACY_RESOLVE_ERROR_SAMPLE)).toEqual(
+        'NPM error ERESOLVE - Dependency resolution error.'
+      );
       expect(npmProxy.parseErrorFromLogs(NPM_RESOLVE_ERROR_SAMPLE)).toEqual(
         'NPM error ERESOLVE - Dependency resolution error.'
       );

--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -28,8 +28,8 @@ type NpmDependencies = {
 export type NpmListOutput = {
   dependencies: NpmDependencies;
 };
+const NPM_ERROR_REGEX = /npm (ERR!|error) (code|errno) (\w+)/i;
 
-const NPM_ERROR_REGEX = /npm ERR! code (\w+)/;
 const NPM_ERROR_CODES = {
   E401: 'Authentication failed or is required.',
   E403: 'Access to the resource is forbidden.',
@@ -320,7 +320,7 @@ export class NPMProxy extends JsPackageManager {
     const match = logs.match(NPM_ERROR_REGEX);
 
     if (match) {
-      const errorCode = match[1] as keyof typeof NPM_ERROR_CODES;
+      const errorCode = match[3] as keyof typeof NPM_ERROR_CODES;
       if (errorCode) {
         finalMessage = `${finalMessage} ${errorCode}`;
       }


### PR DESCRIPTION
## What I did

This PR improves the parsing logic from NPMProxy so that it can detect different patterns from different versions of NPM.
I experienced this issue while QAing the new version of Storybook and having some issues which would just show a generic `NPM error` message instead of providing more insights.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.6 MB | 77.6 MB | 0 B | -0.42 | 0% |
| initSize |  143 MB | 143 MB | 34 B | **-4.07** | 0% |
| diffSize |  65.1 MB | 65.1 MB | 34 B | **-4.34** | 0% |
| buildSize |  6.82 MB | 6.82 MB | 0 B | -0.57 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | -0.6 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.85 MB | 1.85 MB | 0 B | 0.42 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | 0.41 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.83 MB | 3.83 MB | 0 B | -0.58 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.19 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.2s | 7.9s | 641ms | -0.57 | 8.1% |
| generateTime |  21.9s | 23.8s | 1.9s | 0.89 | 8% |
| initTime |  15.8s | 17.7s | 1.9s | **2.05** | 🔺10.7% |
| buildTime |  9.9s | 8.7s | -1s -193ms | -1.17 | -13.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.6s | 4.9s | -1s -711ms | **-1.78** | 🔰-34.6% |
| devManagerResponsive |  4s | 3.1s | -906ms | **-2.1** | 🔰-28.9% |
| devManagerHeaderVisible |  621ms | 501ms | -120ms | -1.09 | -24% |
| devManagerIndexVisible |  710ms | 573ms | -137ms | -0.85 | -23.9% |
| devStoryVisibleUncached |  1s | 941ms | -104ms | -0.63 | -11.1% |
| devStoryVisible |  709ms | 536ms | -173ms | -1 | -32.3% |
| devAutodocsVisible |  521ms | 445ms | -76ms | -1.17 | -17.1% |
| devMDXVisible |  543ms | 438ms | -105ms | **-1.24** | 🔰-24% |
| buildManagerHeaderVisible |  558ms | 472ms | -86ms | **-1.59** | 🔰-18.2% |
| buildManagerIndexVisible |  576ms | 481ms | -95ms | **-1.73** | 🔰-19.8% |
| buildStoryVisible |  557ms | 466ms | -91ms | **-1.87** | 🔰-19.5% |
| buildAutodocsVisible |  484ms | 394ms | -90ms | **-1.56** | 🔰-22.8% |
| buildMDXVisible |  463ms | 389ms | -74ms | **-1.47** | 🔰-19% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR improves NPM error parsing in Storybook's package manager implementation, enhancing error message clarity and handling different NPM version formats.

- Updated `NPM_ERROR_REGEX` in `NPMProxy.ts` to handle both legacy ('npm ERR!') and modern ('npm error') formats
- Added comprehensive error code mappings in `NPMProxy.ts` for better error message clarity
- Added test cases in `NPMProxy.test.ts` for different error formats including timeout errors
- Improved error message extraction by adjusting regex capture group references
- Enhanced error handling to provide more specific feedback instead of generic "NPM error" messages

<!-- /greptile_comment -->