### PR TITLE
Add init command to common CLI commands

### DIFF
--- a/code/lib/cli-storybook/src/bin/index.ts
+++ b/code/lib/cli-storybook/src/bin/index.ts
@@ -211,14 +211,14 @@ command('init')
   .option(
     '--dev',
     'Launch the development server after completing initialization. Enabled by default',
-    process.env.CI !== 'true' && process.env.IN_STORYBOOK_SANDBOX !== 'true'
+    !Boolean(process.env.CI) && !Boolean(process.env.IN_STORYBOOK_SANDBOX)
   )
   .option(
     '--no-dev',
     'Complete the initialization of Storybook without launching the Storybook development server'
   )
-  .action((options: any) => {
-    initiate(options).catch((err: any) => {
+  .action((options) => {
+    initiate(options).catch((err) => {
       logger.error(err);
       process.exit(1);
     });

--- a/code/lib/cli-storybook/src/bin/index.ts
+++ b/code/lib/cli-storybook/src/bin/index.ts
@@ -8,6 +8,7 @@ import { logger } from 'storybook/internal/node-logger';
 import { addToGlobalContext, telemetry } from 'storybook/internal/telemetry';
 
 import { program } from 'commander';
+import { initiate } from 'create-storybook';
 import envinfo from 'envinfo';
 import { findPackageSync } from 'fd-package-json';
 import leven from 'leven';
@@ -179,6 +180,46 @@ command('doctor')
   .action(async (options) => {
     await doctor(options).catch((e) => {
       logger.error(e);
+      process.exit(1);
+    });
+  });
+
+command('init')
+  .description('Initialize Storybook in your project.')
+  .option(
+    '--disable-telemetry',
+    'Disable sending telemetry data',
+    process.env.STORYBOOK_DISABLE_TELEMETRY && process.env.STORYBOOK_DISABLE_TELEMETRY !== 'false'
+  )
+  .option('--debug', 'Get more logs in debug mode', false)
+  .option('--enable-crash-reports', 'Enable sending crash reports to telemetry data')
+  .option('-f --force', 'Force add Storybook')
+  .option('-s --skip-install', 'Skip installing dependencies')
+  .option(
+    '--package-manager <npm|pnpm|yarn1|yarn2>',
+    'Force package manager for installing dependencies'
+  )
+  .option('--use-pnp', 'Enable PnP mode for Yarn 2+')
+  .option(
+    '-p --parser <babel | babylon | flow | ts | tsx>',
+    'Specify the parser to use (e.g., babel, flow, typescript)'
+  )
+  .option('-t --type <type>', 'Add Storybook for a specific project type')
+  .option('-y --yes', 'Answer yes to all prompts')
+  .option('-b --builder <webpack5 | vite>', 'Specify the builder to use')
+  .option('-l --linkable', 'Prepare installation for link (contributor helper)')
+  .option(
+    '--dev',
+    'Launch the development server after completing initialization. Enabled by default',
+    process.env.CI !== 'true' && process.env.IN_STORYBOOK_SANDBOX !== 'true'
+  )
+  .option(
+    '--no-dev',
+    'Complete the initialization of Storybook without launching the Storybook development server'
+  )
+  .action((options: any) => {
+    initiate(options).catch((err: any) => {
+      logger.error(err);
       process.exit(1);
     });
   });


### PR DESCRIPTION
#29276 

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Add `init` command to common CLI commands

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

It doesn't seems that there are no tests for `cli-storybook`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Added the 'init' command to the Storybook CLI's help output, implementing comprehensive initialization options for new Storybook projects.

- Added `init` command in `code/lib/cli-storybook/src/bin/index.ts` with options for telemetry, debugging, package management, and project configuration
- Integrated with `initiate` function from `create-storybook` package for initialization logic
- Included error handling and process exit on failures consistent with other CLI commands
- Added documentation for the `init` command in `cli-options.mdx`

<!-- /greptile_comment -->