### PR TITLE
Addon Test: Only register testing module in Vite projects

### DIFF
--- a/code/addons/test/src/manager.tsx
+++ b/code/addons/test/src/manager.tsx
@@ -80,104 +80,106 @@ const RelativeTime = ({ timestamp, testCount }: { timestamp: Date; testCount: nu
 };
 
 addons.register(ADDON_ID, (api) => {
-  const openAddonPanel = () => {
-    api.setSelectedPanel(PANEL_ID);
-    api.togglePanel(true);
-  };
+  if (globalThis.STORYBOOK_BUILDER?.includes('vite')) {
+    const openAddonPanel = () => {
+      api.setSelectedPanel(PANEL_ID);
+      api.togglePanel(true);
+    };
 
-  addons.add(TEST_PROVIDER_ID, {
-    type: Addon_TypesEnum.experimental_TEST_PROVIDER,
-    runnable: true,
-    watchable: true,
+    addons.add(TEST_PROVIDER_ID, {
+      type: Addon_TypesEnum.experimental_TEST_PROVIDER,
+      runnable: true,
+      watchable: true,
 
-    name: 'Component tests',
-    title: ({ crashed, failed }) =>
-      crashed || failed ? 'Component tests failed' : 'Component tests',
-    description: ({ failed, running, watching, progress, crashed, details }) => {
-      const [isModalOpen, setIsModalOpen] = useState(false);
+      name: 'Component tests',
+      title: ({ crashed, failed }) =>
+        crashed || failed ? 'Component tests failed' : 'Component tests',
+      description: ({ failed, running, watching, progress, crashed, details }) => {
+        const [isModalOpen, setIsModalOpen] = useState(false);
 
-      const errorMessage = details?.error?.message;
+        const errorMessage = details?.error?.message;
 
-      let message: string | React.ReactNode = 'Not run';
+        let message: string | React.ReactNode = 'Not run';
 
-      if (running) {
-        message = progress
-          ? `Testing... ${progress.numPassedTests}/${progress.numTotalTests}`
-          : 'Starting...';
-      } else if (failed && !errorMessage) {
-        message = 'Component tests failed';
-      } else if (crashed || (failed && errorMessage)) {
-        message = (
+        if (running) {
+          message = progress
+            ? `Testing... ${progress.numPassedTests}/${progress.numTotalTests}`
+            : 'Starting...';
+        } else if (failed && !errorMessage) {
+          message = 'Component tests failed';
+        } else if (crashed || (failed && errorMessage)) {
+          message = (
+            <>
+              <LinkComponent
+                isButton
+                onClick={() => {
+                  setIsModalOpen(true);
+                }}
+              >
+                {details?.error?.name || 'View full error'}
+              </LinkComponent>
+            </>
+          );
+        } else if (progress?.finishedAt) {
+          message = (
+            <RelativeTime
+              timestamp={new Date(progress.finishedAt)}
+              testCount={progress.numTotalTests}
+            />
+          );
+        } else if (watching) {
+          message = 'Watching for file changes';
+        }
+
+        return (
           <>
-            <LinkComponent
-              isButton
-              onClick={() => {
-                setIsModalOpen(true);
+            {message}
+            <GlobalErrorModal
+              error={errorMessage}
+              open={isModalOpen}
+              onClose={() => {
+                setIsModalOpen(false);
               }}
-            >
-              {details?.error?.name || 'View full error'}
-            </LinkComponent>
+              onRerun={() => {
+                setIsModalOpen(false);
+                api
+                  .getChannel()
+                  .emit(TESTING_MODULE_RUN_ALL_REQUEST, { providerId: TEST_PROVIDER_ID });
+              }}
+            />
           </>
         );
-      } else if (progress?.finishedAt) {
-        message = (
-          <RelativeTime
-            timestamp={new Date(progress.finishedAt)}
-            testCount={progress.numTotalTests}
-          />
-        );
-      } else if (watching) {
-        message = 'Watching for file changes';
-      }
+      },
 
-      return (
-        <>
-          {message}
-          <GlobalErrorModal
-            error={errorMessage}
-            open={isModalOpen}
-            onClose={() => {
-              setIsModalOpen(false);
-            }}
-            onRerun={() => {
-              setIsModalOpen(false);
-              api
-                .getChannel()
-                .emit(TESTING_MODULE_RUN_ALL_REQUEST, { providerId: TEST_PROVIDER_ID });
-            }}
-          />
-        </>
-      );
-    },
-
-    mapStatusUpdate: (state) =>
-      Object.fromEntries(
-        (state.details.testResults || []).flatMap((testResult) =>
-          testResult.results
-            .map(({ storyId, status, testRunId, ...rest }) => {
-              if (storyId) {
-                const statusObject: API_StatusObject = {
-                  title: 'Component tests',
-                  status: statusMap[status],
-                  description:
-                    'failureMessages' in rest && rest.failureMessages?.length
-                      ? rest.failureMessages.join('\n')
-                      : '',
-                  data: {
-                    testRunId,
-                  },
-                  onClick: openAddonPanel,
-                };
-                return [storyId, statusObject];
-              }
-            })
-            .filter(Boolean)
-        )
-      ),
-  } as Addon_TestProviderType<{
-    testResults: TestResult[];
-    error?: { message: string; name: string };
-  }>);
+      mapStatusUpdate: (state) =>
+        Object.fromEntries(
+          (state.details.testResults || []).flatMap((testResult) =>
+            testResult.results
+              .map(({ storyId, status, testRunId, ...rest }) => {
+                if (storyId) {
+                  const statusObject: API_StatusObject = {
+                    title: 'Component tests',
+                    status: statusMap[status],
+                    description:
+                      'failureMessages' in rest && rest.failureMessages?.length
+                        ? rest.failureMessages.join('\n')
+                        : '',
+                    data: {
+                      testRunId,
+                    },
+                    onClick: openAddonPanel,
+                  };
+                  return [storyId, statusObject];
+                }
+              })
+              .filter(Boolean)
+          )
+        ),
+    } as Addon_TestProviderType<{
+      testResults: TestResult[];
+      error?: { message: string; name: string };
+    }>);
+  }
 
   addons.add(PANEL_ID, {
     type: types.PANEL,


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Testing module UI will now only be registered in Vite-based projects.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.6 MB | 77.6 MB | 76 B | 0.6 | 0% |
| initSize |  143 MB | 143 MB | 76 B | **-1.98** | 0% |
| diffSize |  65.1 MB | 65.1 MB | 0 B | **-1.99** | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | -0.29 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | -0.62 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 0 B | **2.38** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | -0.42 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 0 B | -0.29 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | -0.65 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  20.7s | 8.1s | -12s -523ms | -0.59 | -152.8% |
| generateTime |  24.4s | 25.2s | 807ms | **1.82** | 3.2% |
| initTime |  16.6s | 16.4s | -151ms | 1.13 | -0.9% |
| buildTime |  7.8s | 8.9s | 1s | -0.84 | 11.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.7s | 5.8s | 89ms | -1.12 | 1.5% |
| devManagerResponsive |  3.5s | 3.5s | 16ms | **-1.5** | 0.4% |
| devManagerHeaderVisible |  543ms | 526ms | -17ms | -1.11 | -3.2% |
| devManagerIndexVisible |  622ms | 555ms | -67ms | **-1.28** | 🔰-12.1% |
| devStoryVisibleUncached |  1.1s | 1.1s | 32ms | -0.13 | 2.7% |
| devStoryVisible |  620ms | 551ms | -69ms | -1.15 | -12.5% |
| devAutodocsVisible |  486ms | 501ms | 15ms | -0.94 | 3% |
| devMDXVisible |  403ms | 514ms | 111ms | -0.76 | 21.6% |
| buildManagerHeaderVisible |  526ms | 574ms | 48ms | -0.69 | 8.4% |
| buildManagerIndexVisible |  542ms | 591ms | 49ms | -0.68 | 8.3% |
| buildStoryVisible |  518ms | 573ms | 55ms | -0.68 | 9.6% |
| buildAutodocsVisible |  447ms | 434ms | -13ms | **-1.35** | -3% |
| buildMDXVisible |  434ms | 454ms | 20ms | -0.91 | 4.4% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR modifies the test addon to conditionally enable component testing functionality only for Vite-based Storybook projects, while maintaining the UI panel for all projects.

- Added Vite builder check `globalThis.STORYBOOK_BUILDER?.includes('vite')` in `code/addons/test/src/manager.tsx` to gate test provider registration
- Test provider registration with `TEST_PROVIDER_ID` now only occurs for Vite projects
- Panel registration with `PANEL_ID` remains available for all projects regardless of builder
- Maintains backward compatibility by keeping the UI structure intact for non-Vite projects

<!-- /greptile_comment -->