### PR TITLE
Addon Test: Throttle Vitest progress updates more heavily

### DIFF
--- a/code/addons/test/src/node/reporter.ts
+++ b/code/addons/test/src/node/reporter.ts
@@ -65,7 +65,7 @@ export class StorybookReporter implements Reporter {
   sendReport: (payload: TestingModuleProgressReportPayload) => void;
 
   constructor(private testManager: TestManager) {
-    this.sendReport = throttle((payload) => this.testManager.sendProgressReport(payload), 200);
+    this.sendReport = throttle((payload) => this.testManager.sendProgressReport(payload), 1000);
   }
 
   onInit(ctx: Vitest) {


### PR DESCRIPTION
Increases the throttle time from 200 ms to 1 second for progress updates from Vitest, because it was seemingly interfering with other websocket events, specifically the VTA connection check heartbeat.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29482-sha-5d433a45`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29482-sha-5d433a45 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29482-sha-5d433a45 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29482-sha-5d433a45`](https://npmjs.com/package/storybook/v/0.0.0-pr-29482-sha-5d433a45) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`throttle-vitest-progress-updates`](https://github.com/storybookjs/storybook/tree/throttle-vitest-progress-updates) |
| **Commit** | [`5d433a45`](https://github.com/storybookjs/storybook/commit/5d433a4556c798941d0f671ff20c31b55a22cdf3) |
| **Datetime** | Wed Oct 30 10:54:07 UTC 2024 (`1730285647`) |
| **Workflow run** | [11591737579](https://github.com/storybookjs/storybook/actions/runs/11591737579) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29482`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 0.96 | 0% |
| initSize |  143 MB | 143 MB | -215 B | -0.9 | 0% |
| diffSize |  65.1 MB | 65.1 MB | -215 B | -0.9 | 0% |
| buildSize |  6.87 MB | 6.87 MB | 6 B | 1 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.92 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 6 B | 1 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 6 B | 1 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | - | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  22.1s | 6.3s | -15s -730ms | -0.98 | -246.8% |
| generateTime |  19.4s | 19.8s | 365ms | -1.17 | 1.8% |
| initTime |  13.7s | 13.6s | -120ms | -0.95 | -0.9% |
| buildTime |  8.9s | 11.2s | 2.3s | **2.19** | 🔺20.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.6s | 6.8s | 215ms | -0.03 | 3.1% |
| devManagerResponsive |  4.2s | 4.4s | 199ms | 0 | 4.4% |
| devManagerHeaderVisible |  593ms | 663ms | 70ms | 0.15 | 10.6% |
| devManagerIndexVisible |  621ms | 741ms | 120ms | 0.22 | 16.2% |
| devStoryVisibleUncached |  1.2s | 775ms | -501ms | **-1.25** | 🔰-64.6% |
| devStoryVisible |  620ms | 704ms | 84ms | -0.01 | 11.9% |
| devAutodocsVisible |  541ms | 637ms | 96ms | 0.34 | 15.1% |
| devMDXVisible |  593ms | 660ms | 67ms | 0.61 | 10.2% |
| buildManagerHeaderVisible |  667ms | 613ms | -54ms | -0.14 | -8.8% |
| buildManagerIndexVisible |  696ms | 634ms | -62ms | -0.1 | -9.8% |
| buildStoryVisible |  669ms | 611ms | -58ms | -0.13 | -9.5% |
| buildAutodocsVisible |  518ms | 509ms | -9ms | -0.32 | -1.8% |
| buildMDXVisible |  495ms | 513ms | 18ms | -0.09 | 3.5% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Increased throttle time for Vitest progress updates from 200ms to 1000ms in the experimental test addon to reduce interference with websocket events, particularly VTA connection check heartbeat.

- Modified throttle timing in `code/addons/test/src/node/reporter.ts` from 200ms to 1000ms for test progress reporting
- Change may impact UI responsiveness and test feedback latency, requiring manual verification
- Addresses potential websocket event conflicts with VTA connection heartbeat

<!-- /greptile_comment -->