### PR TITLE
Addon Test: Improve unsupported vitest message

### DIFF
--- a/code/addons/test/src/postinstall.ts
+++ b/code/addons/test/src/postinstall.ts
@@ -88,7 +88,7 @@ export default async function postInstall(options: PostinstallOptions) {
     if (coercedVitestVersion && !satisfies(coercedVitestVersion, '>=2.1.0')) {
       reasons.push(dedent`
         • The addon requires Vitest 2.1.0 or later. You are currently using ${picocolors.bold(vitestVersionSpecifier)}.
-          Please update your ${picocolors.bold(colors.pink('vitest'))} dependencies and try again.
+          Please update all of your Vitest dependencies and try again.
       `);
     }
 

--- a/code/addons/test/src/postinstall.ts
+++ b/code/addons/test/src/postinstall.ts
@@ -88,7 +88,7 @@ export default async function postInstall(options: PostinstallOptions) {
     if (coercedVitestVersion && !satisfies(coercedVitestVersion, '>=2.1.0')) {
       reasons.push(dedent`
         • The addon requires Vitest 2.1.0 or later. You are currently using ${picocolors.bold(vitestVersionSpecifier)}.
-          Please update your ${picocolors.bold(colors.pink('vitest'))} dependency and try again.
+          Please update your ${picocolors.bold(colors.pink('vitest'))} dependencies and try again.
       `);
     }
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 1.01 | 0% |
| initSize |  143 MB | 143 MB | 0 B | -0.57 | 0% |
| diffSize |  65.1 MB | 65.1 MB | 0 B | -0.57 | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | 0.66 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.59 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 0 B | 0.66 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 0 B | 0.66 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | - | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.4s | 14.4s | 6.9s | 0.04 | 48.3% |
| generateTime |  22.8s | 23.5s | 658ms | 0.4 | 2.8% |
| initTime |  16.8s | 15.9s | -855ms | -0.02 | -5.4% |
| buildTime |  8.6s | 9.8s | 1.2s | 0.77 | 12.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.7s | 6.9s | 1.2s | 0.24 | 17.5% |
| devManagerResponsive |  3.6s | 4.3s | 732ms | 0.09 | 16.8% |
| devManagerHeaderVisible |  652ms | 637ms | -15ms | -0.22 | -2.4% |
| devManagerIndexVisible |  752ms | 730ms | -22ms | -0.03 | -3% |
| devStoryVisibleUncached |  1.1s | 1.1s | 25ms | 0.01 | 2.2% |
| devStoryVisible |  751ms | 727ms | -24ms | -0.01 | -3.3% |
| devAutodocsVisible |  625ms | 622ms | -3ms | 0.16 | -0.5% |
| devMDXVisible |  562ms | 607ms | 45ms | 0.13 | 7.4% |
| buildManagerHeaderVisible |  648ms | 615ms | -33ms | -0.17 | -5.4% |
| buildManagerIndexVisible |  665ms | 622ms | -43ms | -0.27 | -6.9% |
| buildStoryVisible |  647ms | 615ms | -32ms | -0.14 | -5.2% |
| buildAutodocsVisible |  602ms | 470ms | -132ms | -0.82 | -28.1% |
| buildMDXVisible |  571ms | 483ms | -88ms | -0.57 | -18.2% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request changes:

Updates error message wording in Storybook's experimental test addon to improve clarity when incompatible Vitest versions are detected during installation.

- Modified error message in `code/addons/test/src/postinstall.ts` to use "dependencies" instead of "dependency" for better accuracy
- Improves user experience by providing clearer guidance when version compatibility issues occur with Vitest packages
- Change affects the prerequisiteCheck() function's version validation message
- Part of the experimental test addon's installation process validation

<!-- /greptile_comment -->