### PR TITLE
Core: Fix race condition during empty folder init

### DIFF
--- a/code/core/src/common/utils/file-cache.ts
+++ b/code/core/src/common/utils/file-cache.ts
@@ -85,6 +85,7 @@ export class FileSystemCache {
     orgOpts: CacheSetOptions | number = {}
   ): Promise<void> {
     const opts: CacheSetOptions = typeof orgOpts === 'number' ? { ttl: orgOpts } : orgOpts;
+    mkdirSync(this.cache_dir, { recursive: true });
     await writeFile(this.generateHash(name), this.parseSetData(name, data, opts), {
       encoding: opts.encoding || 'utf8',
     });
@@ -92,6 +93,7 @@ export class FileSystemCache {
 
   public setSync<T>(name: string, data: T, orgOpts: CacheSetOptions | number = {}): void {
     const opts: CacheSetOptions = typeof orgOpts === 'number' ? { ttl: orgOpts } : orgOpts;
+    mkdirSync(this.cache_dir, { recursive: true });
     writeFileSync(this.generateHash(name), this.parseSetData(name, data, opts), {
       encoding: opts.encoding || 'utf8',
     });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Initializing Storybook in an empty directory currently fails due to a race condition with the following error:

```
/.npm/_npx/aa1ee7aee97d6cac/node_modules/create-storybook/bin/index.cjs:23
  throw error;
  ^

[Error: ENOENT: no such file or directory, open '/projects/testing/react-vite-84/.cache/storybook/default/dev-server/storybook-e35710dcf9c6d4f837d5dae15e56122e'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/projects/testing/react-vite-84/.cache/storybook/default/dev-server/storybook-e35710dcf9c6d4f837d5dae15e56122e'
}

Node.js v18.20.3
```

The issue was, that we introduced an alternative implementation for our internal caching, where we relied on file-system-cache, but we removed the package to use a custom caching solution.

The problem with the new solution is that every time we want to write into the cache, we don’t check, whether the cache folder actually exists. The cache folder itself gets initialized during module loading, so it should be, in theory, in place. Now, the crux is that when we initialize into an empty directory, we [remove especially a .cache folder](https://github.com/storybookjs/storybook/pull/24997/files#diff-0c320ffa4a9e90c27911c666133e2b3234f043c2538b11f8bbd9f2c2c9dffdfaR177-R179) before continuing because in the past, we had issues initializing into an empty directory if it wasn’t empty.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 0.92 | 0% |
| initSize |  143 MB | 143 MB | 370 B | -0.49 | 0% |
| diffSize |  65.1 MB | 65.1 MB | 370 B | -0.5 | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | 0.58 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.51 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 0 B | 0.58 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 0 B | 0.58 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | - | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  17.4s | 8.6s | -8s -808ms | -0.82 | -102% |
| generateTime |  27.1s | 24.8s | -2s -374ms | 0.78 | -9.6% |
| initTime |  20.5s | 17.6s | -2s -895ms | 0.58 | -16.4% |
| buildTime |  10.1s | 9s | -1s -96ms | -0.07 | -12.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.9s | 6s | 162ms | -0.46 | 2.7% |
| devManagerResponsive |  4.2s | 3.9s | -311ms | -0.34 | -7.9% |
| devManagerHeaderVisible |  648ms | 599ms | -49ms | -0.55 | -8.2% |
| devManagerIndexVisible |  722ms | 685ms | -37ms | -0.37 | -5.4% |
| devStoryVisibleUncached |  1.9s | 1.1s | -831ms | -0.22 | -74.6% |
| devStoryVisible |  720ms | 684ms | -36ms | -0.35 | -5.3% |
| devAutodocsVisible |  565ms | 536ms | -29ms | -0.6 | -5.4% |
| devMDXVisible |  556ms | 519ms | -37ms | -0.56 | -7.1% |
| buildManagerHeaderVisible |  742ms | 661ms | -81ms | 0.24 | -12.3% |
| buildManagerIndexVisible |  752ms | 718ms | -34ms | 0.62 | -4.7% |
| buildStoryVisible |  744ms | 652ms | -92ms | 0.18 | -14.1% |
| buildAutodocsVisible |  553ms | 600ms | 47ms | 0.74 | 7.8% |
| buildMDXVisible |  517ms | 524ms | 7ms | 0.01 | 1.3% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a race condition in FileSystemCache by ensuring the cache directory exists before writing files during initialization of empty folders.

- Added `mkdirSync` call with `recursive: true` in `set()` and `setSync()` methods in `/code/core/src/common/utils/file-cache.ts`
- Prevents file write failures when cache directory is missing during concurrent operations
- Maintains backward compatibility since directory creation is safe even if directory exists

<!-- /greptile_comment -->