### PR TITLE
UI: Add support for groups to `TooltipLinkList` and use it in main menu

### DIFF
--- a/code/core/src/components/components/tooltip/ListItem.tsx
+++ b/code/core/src/components/components/tooltip/ListItem.tsx
@@ -123,6 +123,7 @@ const Item = styled.div<ItemProps>(
   ({ theme }) => ({
     width: '100%',
     border: 'none',
+    borderRadius: theme.appBorderRadius,
     background: 'none',
     fontSize: theme.typography.size.s1,
     transition: 'all 150ms ease-out',

--- a/code/core/src/components/components/tooltip/Tooltip.tsx
+++ b/code/core/src/components/components/tooltip/Tooltip.tsx
@@ -109,7 +109,7 @@ const Wrapper = styled.div<WrapperProps>(
             drop-shadow(0px 5px 5px rgba(0,0,0,0.05))
             drop-shadow(0 1px 3px rgba(0,0,0,0.1))
           `,
-          borderRadius: theme.appBorderRadius,
+          borderRadius: theme.appBorderRadius + 2,
           fontSize: theme.typography.size.s1,
         }
       : {}

--- a/code/core/src/components/components/tooltip/TooltipLinkList.stories.tsx
+++ b/code/core/src/components/components/tooltip/TooltipLinkList.stories.tsx
@@ -191,3 +191,45 @@ export const WithCustomIcon = {
     ],
   },
 } satisfies Story;
+
+export const WithGroups = {
+  args: {
+    links: [
+      [
+        {
+          id: '1',
+          title: 'Link 1',
+          center: 'This is an addition description',
+          href: 'http://google.com',
+          onClick: onLinkClick,
+        },
+      ],
+      [
+        {
+          id: '1',
+          title: 'Link 1',
+          center: 'This is an addition description',
+          icon: <LinkIcon />,
+          href: 'http://google.com',
+          onClick: onLinkClick,
+        },
+        {
+          id: '2',
+          title: 'Link 2',
+          center: 'This is an addition description',
+          href: 'http://google.com',
+          onClick: onLinkClick,
+        },
+      ],
+      [
+        {
+          id: '2',
+          title: 'Link 2',
+          center: 'This is an addition description',
+          href: 'http://google.com',
+          onClick: onLinkClick,
+        },
+      ],
+    ],
+  },
+} satisfies Story;

--- a/code/core/src/components/components/tooltip/TooltipLinkList.tsx
+++ b/code/core/src/components/components/tooltip/TooltipLinkList.tsx
@@ -55,12 +55,12 @@ export interface TooltipLinkListProps extends ComponentProps<typeof List> {
 
 export const TooltipLinkList = ({ links, LinkWrapper, ...props }: TooltipLinkListProps) => {
   const groups = Array.isArray(links[0]) ? (links as Link[][]) : [links as Link[]];
+  const isIndented = groups.some((group) => group.some((link) => link.icon));
   return (
     <List {...props}>
       {groups
         .filter((group) => group.length)
         .map((group, index) => {
-          const isIndented = group.some((link) => link.icon);
           return (
             <Group key={group.map((link) => link.id).join(`~${index}~`)}>
               {group.map((link) => (

--- a/code/core/src/components/components/tooltip/TooltipLinkList.tsx
+++ b/code/core/src/components/components/tooltip/TooltipLinkList.tsx
@@ -11,12 +11,19 @@ const List = styled.div(
     minWidth: 180,
     overflow: 'hidden',
     overflowY: 'auto',
-    maxHeight: 15.5 * 32, // 11.5 items
+    maxHeight: 15.5 * 32 + 8, // 15.5 items at 32px each + 8px padding
   },
   ({ theme }) => ({
-    borderRadius: theme.appBorderRadius,
+    borderRadius: theme.appBorderRadius + 2,
   })
 );
+
+const Group = styled.div(({ theme }) => ({
+  padding: 4,
+  '& + &': {
+    borderTop: `1px solid ${theme.appBorderColor}`,
+  },
+}));
 
 export interface Link extends Omit<ListItemProps, 'onClick'> {
   id: string;
@@ -42,17 +49,26 @@ const Item = ({ id, onClick, ...rest }: ItemProps) => {
 };
 
 export interface TooltipLinkListProps extends ComponentProps<typeof List> {
-  links: Link[];
+  links: Link[] | Link[][];
   LinkWrapper?: LinkWrapperType;
 }
 
 export const TooltipLinkList = ({ links, LinkWrapper, ...props }: TooltipLinkListProps) => {
-  const isIndented = links.some((link) => link.icon);
+  const groups = Array.isArray(links[0]) ? (links as Link[][]) : [links as Link[]];
   return (
     <List {...props}>
-      {links.map((link) => (
-        <Item key={link.id} isIndented={isIndented} LinkWrapper={LinkWrapper} {...link} />
-      ))}
+      {groups
+        .filter((group) => group.length)
+        .map((group, index) => {
+          const isIndented = group.some((link) => link.icon);
+          return (
+            <Group key={group.map((link) => link.id).join(`~${index}~`)}>
+              {group.map((link) => (
+                <Item key={link.id} isIndented={isIndented} LinkWrapper={LinkWrapper} {...link} />
+              ))}
+            </Group>
+          );
+        })}
     </List>
   );
 };

--- a/code/core/src/manager/components/sidebar/Menu.tsx
+++ b/code/core/src/manager/components/sidebar/Menu.tsx
@@ -8,9 +8,10 @@ import { CloseIcon, CogIcon } from '@storybook/icons';
 
 import { transparentize } from 'polished';
 
+import type { useMenu } from '../../container/Menu';
 import { useLayout } from '../layout/LayoutProvider';
 
-export type MenuList = ComponentProps<typeof TooltipLinkList>['links'];
+export type MenuList = ReturnType<typeof useMenu>;
 
 export const SidebarIconButton: FC<ComponentProps<typeof Button> & { highlighted: boolean }> =
   styled(IconButton)<
@@ -60,17 +61,21 @@ const SidebarMenuList: FC<{
   menu: MenuList;
   onHide: () => void;
 }> = ({ menu, onHide }) => {
-  const links = useMemo(() => {
-    return menu.map(({ onClick, ...rest }) => ({
-      ...rest,
-      onClick: ((event, item) => {
-        if (onClick) {
-          onClick(event, item);
-        }
-        onHide();
-      }) as ClickHandler,
-    }));
-  }, [menu, onHide]);
+  const links = useMemo(
+    () =>
+      menu.map((group) =>
+        group.map(({ onClick, ...rest }) => ({
+          ...rest,
+          onClick: ((event, item) => {
+            if (onClick) {
+              onClick(event, item);
+            }
+            onHide();
+          }) as ClickHandler,
+        }))
+      ),
+    [menu, onHide]
+  );
   return <TooltipLinkList links={links} />;
 };
 

--- a/code/core/src/manager/components/sidebar/TagsFilterPanel.tsx
+++ b/code/core/src/manager/components/sidebar/TagsFilterPanel.tsx
@@ -7,6 +7,8 @@ import type { Tag } from '@storybook/types';
 
 import type { API } from '@storybook/core/manager-api';
 
+import type { Link } from '../../../components/components/tooltip/TooltipLinkList';
+
 const BUILT_IN_TAGS_SHOW = new Set(['play-fn']);
 
 const Wrapper = styled.div({
@@ -29,56 +31,60 @@ export const TagsFilterPanel = ({
   toggleTag,
   isDevelopment,
 }: TagsFilterPanelProps) => {
-  const theme = useTheme();
   const userTags = allTags.filter((tag) => !BUILT_IN_TAGS_SHOW.has(tag));
   const docsUrl = api.getDocsUrl({ subpath: 'writing-stories/tags#filtering-by-custom-tags' });
-  const items = allTags.map((tag) => {
-    const checked = selectedTags.includes(tag);
-    const id = `tag-${tag}`;
-    return {
-      id,
-      title: tag,
-      right: (
-        <input
-          type="checkbox"
-          id={id}
-          name={id}
-          value={tag}
-          checked={checked}
-          onChange={() => {
-            // The onClick handler higher up the tree will handle the toggle
-            // For controlled inputs, a onClick handler is needed, though
-            // Accessibility-wise this isn't optimal, but I guess that's a limitation
-            // of the current design of TooltipLinkList
-          }}
-        />
-      ),
-      onClick: () => toggleTag(tag),
-    };
-  }) as any[];
+
+  const groups = [
+    allTags.map((tag) => {
+      const checked = selectedTags.includes(tag);
+      const id = `tag-${tag}`;
+      return {
+        id,
+        title: tag,
+        right: (
+          <input
+            type="checkbox"
+            id={id}
+            name={id}
+            value={tag}
+            checked={checked}
+            onChange={() => {
+              // The onClick handler higher up the tree will handle the toggle
+              // For controlled inputs, a onClick handler is needed, though
+              // Accessibility-wise this isn't optimal, but I guess that's a limitation
+              // of the current design of TooltipLinkList
+            }}
+          />
+        ),
+        onClick: () => toggleTag(tag),
+      };
+    }),
+  ] as Link[][];
 
   if (allTags.length === 0) {
-    items.push({
-      id: 'no-tags',
-      title: 'There are no tags. Use tags to organize and filter your Storybook.',
-      isIndented: false,
-    });
-  }
-  if (userTags.length === 0 && isDevelopment) {
-    items.push({
-      id: 'tags-docs',
-      title: 'Learn how to add tags',
-      icon: <ShareAltIcon />,
-      href: docsUrl,
-      style: {
-        borderTop: `4px solid ${theme.appBorderColor}`,
+    groups.push([
+      {
+        id: 'no-tags',
+        title: 'There are no tags. Use tags to organize and filter your Storybook.',
+        isIndented: false,
       },
-    });
+    ]);
+  }
+
+  if (userTags.length === 0 && isDevelopment) {
+    groups.push([
+      {
+        id: 'tags-docs',
+        title: 'Learn how to add tags',
+        icon: <ShareAltIcon />,
+        href: docsUrl,
+      },
+    ]);
   }
 
   return (
     <Wrapper>
-      <TooltipLinkList links={items} />
+      <TooltipLinkList links={groups} />
     </Wrapper>
   );
 };

--- a/code/core/src/manager/container/Menu.tsx
+++ b/code/core/src/manager/container/Menu.tsx
@@ -9,6 +9,8 @@ import { STORIES_COLLAPSE_ALL } from '@storybook/core/core-events';
 import type { API, State } from '@storybook/core/manager-api';
 import { shortcutToHumanString } from '@storybook/core/manager-api';
 
+import type { Link } from '../../components/components/tooltip/TooltipLinkList';
+
 const focusableUIElements = {
   storySearchField: 'storybook-explorer-searchfield',
   storyListMenu: 'storybook-explorer-menu',
@@ -58,8 +60,7 @@ export const useMenu = (
   isPanelShown: boolean,
   isNavShown: boolean,
   enableShortcuts: boolean
-) => {
-  const theme = useTheme();
+): Link[][] => {
   const shortcutKeys = api.getShortcutKeys();
 
   const about = useMemo(
@@ -105,11 +106,8 @@ export const useMenu = (
       title: 'Keyboard shortcuts',
       onClick: () => api.changeSettingsTab('shortcuts'),
       right: enableShortcuts ? <Shortcut keys={shortcutKeys.shortcutsPage} /> : null,
-      style: {
-        borderBottom: `4px solid ${theme.appBorderColor}`,
-      },
     }),
-    [api, enableShortcuts, shortcutKeys.shortcutsPage, theme.appBorderColor]
+    [api, enableShortcuts, shortcutKeys.shortcutsPage]
   );
 
   const sidebarToggle = useMemo(
@@ -244,24 +242,29 @@ export const useMenu = (
   }, [api, enableShortcuts, shortcutKeys]);
 
   return useMemo(
-    () => [
-      about,
-      ...(state.whatsNewData?.status === 'SUCCESS' ? [whatsNew] : []),
-      documentation,
-      shortcuts,
-      sidebarToggle,
-      toolbarToogle,
-      addonsToggle,
-      addonsOrientationToggle,
-      fullscreenToggle,
-      searchToggle,
-      up,
-      down,
-      prev,
-      next,
-      collapse,
-      ...getAddonsShortcuts(),
-    ],
+    () =>
+      [
+        [
+          about,
+          ...(state.whatsNewData?.status === 'SUCCESS' ? [whatsNew] : []),
+          documentation,
+          shortcuts,
+        ],
+        [
+          sidebarToggle,
+          toolbarToogle,
+          addonsToggle,
+          addonsOrientationToggle,
+          fullscreenToggle,
+          searchToggle,
+          up,
+          down,
+          prev,
+          next,
+          collapse,
+        ],
+        getAddonsShortcuts(),
+      ] satisfies Link[][],
     [
       about,
       state,


### PR DESCRIPTION
Closes #29214

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Updated the `TooltipLinkList` component to accept a `Link[][]` besides the usual `Link[]`. Added padding and updated the border radius to match the new designs. Updated the main Storybook menu to use groups.

<img width="514" alt="Screenshot 2024-11-01 at 11 23 45" src="https://github.com/user-attachments/assets/dbfdf46d-6391-4d74-a857-4813642e3699">


<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78 MB | 78 MB | 0 B | 1.11 | 0% |
| initSize |  143 MB | 143 MB | -12.3 kB | 1.07 | 0% |
| diffSize |  65.1 MB | 65.1 MB | -12.3 kB | -0.75 | 0% |
| buildSize |  6.87 MB | 6.88 MB | 659 B | **6.67** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.5 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 399 B | **5.13** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 399 B | **4.37** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 260 B | **49.47** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.5s | 22.2s | 15.7s | 1.1 | 70.5% |
| generateTime |  19.9s | 19.5s | -483ms | -1.16 | -2.5% |
| initTime |  13.9s | 13.9s | -21ms | **-1.39** | -0.2% |
| buildTime |  7.8s | 9.9s | 2s | 0.9 | 20.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5s | 6.7s | 1.7s | 0.62 | 25.5% |
| devManagerResponsive |  3.2s | 4.1s | 860ms | 0.35 | 20.7% |
| devManagerHeaderVisible |  515ms | 741ms | 226ms | 1.03 | 30.5% |
| devManagerIndexVisible |  549ms | 771ms | 222ms | 0.69 | 28.8% |
| devStoryVisibleUncached |  614ms | 1.2s | 600ms | 0.33 | 49.4% |
| devStoryVisible |  547ms | 770ms | 223ms | 0.78 | 29% |
| devAutodocsVisible |  449ms | 703ms | 254ms | **1.39** | 🔺36.1% |
| devMDXVisible |  455ms | 586ms | 131ms | 0.44 | 22.4% |
| buildManagerHeaderVisible |  519ms | 587ms | 68ms | -0.23 | 11.6% |
| buildManagerIndexVisible |  540ms | 607ms | 67ms | -0.18 | 11% |
| buildStoryVisible |  521ms | 588ms | 67ms | -0.2 | 11.4% |
| buildAutodocsVisible |  421ms | 520ms | 99ms | 0.29 | 19% |
| buildMDXVisible |  413ms | 513ms | 100ms | 0.15 | 19.5% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Here's my concise summary of the PR changes:

Enhanced TooltipLinkList component to support grouped menu items with visual separators, primarily used in Storybook's main menu system.

- Added support for nested arrays (`Link[][]`) in `TooltipLinkList` component for grouped menu items
- Updated menu styling with new border radius, padding, and group separators in `/code/core/src/components/components/tooltip/TooltipLinkList.tsx`
- Restructured main Storybook menu into 3 logical groups (about/docs, navigation, addon shortcuts) in `/code/core/src/manager/container/Menu.tsx`
- Added new story `WithGroups` to demonstrate grouped links functionality in `/code/core/src/components/components/tooltip/TooltipLinkList.stories.tsx`
- Fixed type definitions and improved type safety across menu-related components

<!-- /greptile_comment -->