### PR TITLE
CLI: Fix Solid init by installing `@storybook/test`

### DIFF
--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -245,7 +245,7 @@ export async function baseGenerator(
   ].filter(Boolean);
 
   // TODO: migrate template stories in solid and qwik to use @storybook/test
-  if (['solid', 'qwik'].includes(rendererId)) {
+  if (['qwik'].includes(rendererId)) {
     addonPackages.push('@storybook/testing-library');
   } else {
     addonPackages.push('@storybook/test');


### PR DESCRIPTION
Closes N/A

## What I did

We recently released https://github.com/storybookjs/solidjs/releases/tag/v1.0.0-beta.3 that updates the CLI templates to use `@storybook/test` instead of `@storybook/testing-library`. This `storybook init` in a Solid project.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

If we were to release a canary, install it in a fresh Solid project. I've tested by hand already & it's a simple enough change.

At some point we should get the Solid sandboxes back into shape!

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates the Solid.js project initialization in Storybook CLI to use `@storybook/test` instead of `@storybook/testing-library`, aligning with the recent `storybook-solidjs@1.0.0-beta.3` release.

- Modified `code/lib/create-storybook/src/generators/baseGenerator.ts` to use `@storybook/test` for Solid.js projects
- Kept `@storybook/testing-library` for Qwik projects only
- Change requires manual testing with a fresh Solid project installation

<!-- /greptile_comment -->