### PR TITLE
Core: Prevent clipping box shadow on file search modal

### DIFF
--- a/code/core/src/manager/components/sidebar/FileSearchModal.tsx
+++ b/code/core/src/manager/components/sidebar/FileSearchModal.tsx
@@ -13,6 +13,7 @@ const MODAL_HEIGHT = 418;
 const ModalStyled = styled(Modal)(() => ({
   boxShadow: 'none',
   background: 'transparent',
+  overflow: 'visible',
 }));
 
 const ModalChild = styled.div<{ height?: number }>(({ theme, height }) => ({


### PR DESCRIPTION
The box shadow on the file search modal was being clipped on the sides:

<img width="763" alt="Screenshot 2024-11-04 at 12 12 28" src="https://github.com/user-attachments/assets/feeb81d3-ba36-4070-9014-9c6d54d8682a">

Overriding `overflow: hidden` fixes this and is safe to do because the inner ModalChild wrapper already does that.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.1 MB | 78.2 MB | 51.9 kB | **1.28** | 0.1% |
| initSize |  143 MB | 143 MB | 51.9 kB | **1.3** | 0% |
| diffSize |  65.1 MB | 65.1 MB | 23 B | **1.42** | 0% |
| buildSize |  6.88 MB | 6.88 MB | 23 B | **1.74** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 23 B | **1.73** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 23 B | **1.73** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **1.73** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.2s | 23.2s | 14.9s | **1.47** | 🔺64.5% |
| generateTime |  25.5s | 22.2s | -3s -254ms | -0.21 | -14.6% |
| initTime |  17.6s | 14.8s | -2s -888ms | -0.66 | -19.5% |
| buildTime |  8.7s | 9.5s | 732ms | 0.56 | 7.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.5s | 6.3s | -197ms | 0.25 | -3.1% |
| devManagerResponsive |  4.4s | 3.9s | -532ms | -0.04 | -13.6% |
| devManagerHeaderVisible |  604ms | 564ms | -40ms | -0.63 | -7.1% |
| devManagerIndexVisible |  693ms | 599ms | -94ms | -0.9 | -15.7% |
| devStoryVisibleUncached |  1.1s | 819ms | -360ms | -0.88 | -44% |
| devStoryVisible |  686ms | 598ms | -88ms | -0.82 | -14.7% |
| devAutodocsVisible |  577ms | 521ms | -56ms | -0.39 | -10.7% |
| devMDXVisible |  558ms | 549ms | -9ms | 0.01 | -1.6% |
| buildManagerHeaderVisible |  682ms | 706ms | 24ms | 1.07 | 3.4% |
| buildManagerIndexVisible |  704ms | 712ms | 8ms | 0.95 | 1.1% |
| buildStoryVisible |  680ms | 703ms | 23ms | 1.06 | 3.3% |
| buildAutodocsVisible |  478ms | 480ms | 2ms | -0.07 | 0.4% |
| buildMDXVisible |  511ms | 472ms | -39ms | -0.15 | -8.3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixed box shadow clipping in the file search modal by modifying overflow behavior in the styled modal component.

- Modified `code/core/src/manager/components/sidebar/FileSearchModal.tsx` to set `overflow: 'visible'` on `ModalStyled` component
- Change is safe as inner `ModalChild` wrapper maintains overflow control
- Resolves visual issue where modal box shadow was being cut off on sides

<!-- /greptile_comment -->