### PR TITLE
Addon Test: Fix post-install logic for Next.js Vite framework support

### DIFF
--- a/code/addons/test/src/postinstall.ts
+++ b/code/addons/test/src/postinstall.ts
@@ -58,7 +58,9 @@ export default async function postInstall(options: PostinstallOptions) {
     '@storybook/experimental-nextjs-vite',
     '@storybook/sveltekit',
   ].includes(info.frameworkPackageName)
-    ? info.frameworkPackageName
+    ? info.frameworkPackageName === '@storybook/nextjs'
+      ? '@storybook/experimental-nextjs-vite'
+      : info.frameworkPackageName
     : info.rendererPackageName &&
         ['@storybook/react', '@storybook/svelte', '@storybook/vue3'].includes(
           info.rendererPackageName
@@ -431,7 +433,7 @@ const getVitestPluginInfo = (framework: string) => {
   let frameworkPluginCall = '';
   let frameworkPluginDocs = '';
 
-  if (framework === '@storybook/nextjs') {
+  if (framework === '@storybook/nextjs' || framework === '@storybook/experimental-nextjs-vite') {
     frameworkPluginImport =
       "import { storybookNextJsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin';";
     frameworkPluginDocs =


### PR DESCRIPTION
Closes #

## What I did

The `@storybook/experimental-nextjs-vite/vite-plugin` wasn't set up during `@storybook/experimental-addon-test`'s postinstall script when `@storybook/experimental-nextjs-vite` is used as a framework.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.1 MB | 78.2 MB | 51.9 kB | **1.28** | 0.1% |
| initSize |  143 MB | 143 MB | 51.9 kB | **1.3** | 0% |
| diffSize |  65.1 MB | 65.1 MB | 0 B | **1.41** | 0% |
| buildSize |  6.88 MB | 6.88 MB | 0 B | **1.7** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 0 B | **1.67** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 0 B | **1.67** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **1.73** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.2s | 6.5s | -1s -687ms | -0.96 | -25.7% |
| generateTime |  25.5s | 19.3s | -6s -126ms | -0.99 | -31.6% |
| initTime |  17.6s | 13s | -4s -674ms | **-1.59** | 🔰-35.9% |
| buildTime |  8.7s | 9.2s | 496ms | 0.32 | 5.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.5s | 7.2s | 696ms | **1.29** | 🔺9.6% |
| devManagerResponsive |  4.4s | 4.4s | -32ms | 0.89 | -0.7% |
| devManagerHeaderVisible |  604ms | 672ms | 68ms | 0.39 | 10.1% |
| devManagerIndexVisible |  693ms | 750ms | 57ms | 0.5 | 7.6% |
| devStoryVisibleUncached |  1.1s | 1.2s | 66ms | 0.45 | 5.3% |
| devStoryVisible |  686ms | 752ms | 66ms | 0.63 | 8.8% |
| devAutodocsVisible |  577ms | 684ms | 107ms | **1.25** | 🔺15.6% |
| devMDXVisible |  558ms | 610ms | 52ms | 0.72 | 8.5% |
| buildManagerHeaderVisible |  682ms | 632ms | -50ms | 0.33 | -7.9% |
| buildManagerIndexVisible |  704ms | 645ms | -59ms | 0.3 | -9.1% |
| buildStoryVisible |  680ms | 635ms | -45ms | 0.37 | -7.1% |
| buildAutodocsVisible |  478ms | 502ms | 24ms | 0.25 | 4.8% |
| buildMDXVisible |  511ms | 546ms | 35ms | 0.74 | 6.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhanced post-install logic for Next.js Vite framework support in the Storybook test addon, focusing on proper framework detection and plugin configuration.

- Added support for `@storybook/experimental-nextjs-vite` annotations import in `postinstall.ts`
- Fixed framework detection to handle both `@storybook/nextjs` and `@storybook/experimental-nextjs-vite`
- Added automatic installation of `@storybook/experimental-nextjs-vite` when using Next.js
- Updated Vite plugin configuration to properly handle Next.js framework variants

<!-- /greptile_comment -->