### PR TITLE
Documentation: How to release changes to older minors

### DIFF
--- a/CONTRIBUTING/RELEASING.md
+++ b/CONTRIBUTING/RELEASING.md
@@ -367,7 +367,7 @@ If you need to release a change to an older minor version that is not the latest
 15. Confirm the new version has been released on npmjs with the tag `tag-for-publishing-older-releases`:
     1. [`@storybook/react-vite`](https://www.npmjs.com/package/@storybook/react-vite?activeTab=versions)
     2. [`storybook`](https://www.npmjs.com/package/storybook?activeTab=versions)
-    3. [`sb`](phttps://www.npmjs.com/package/sb?activeTab=versions)
+    3. [`sb`](https://www.npmjs.com/package/sb?activeTab=versions)
     4. [`create-storybook`](https://www.npmjs.com/package/create-storybook?activeTab=versions)
 16. Push
 17. Manually create a GitHub Release at https://github.com/storybookjs/storybook/releases/new with:

--- a/CONTRIBUTING/RELEASING.md
+++ b/CONTRIBUTING/RELEASING.md
@@ -336,31 +336,31 @@ Done! 🚀
 If you need to release a change to an older minor version that is not the latest, you have to do it manually, locally. The process is described below, with an example of releasing a new `v8.3.7` in a situation where `8.4.0` is currently the latest version.
 
 1. Checkout the _existing_ tag that matches the latest minor release you want to bump, and create a new branch from it. In this case, we want to do:
-  1. `git fetch --all --tags`
-  2. `git checkout tags/v8.3.6 -b patch-8-3-7`
+    1. `git fetch --all --tags`
+    2. `git checkout tags/v8.3.6 -b patch-8-3-7`
 2. Make the changes you need to, most likely cherry-picking commits from the fix you need to back-port.
 3. Run `yarn install` in `scripts` and `code`
 4. Build all packages in `code` with `yarn task --task compile --no-link`
 5. Commit and push your changes.
 6. Trigger _daily_ CI manually on your branch:
-  1. Open [CircleCI](https://app.circleci.com/pipelines/github/storybookjs/storybook) and click "Trigger Pipeline" on the top right corner of the page.
-  2. Set the following configuration options:
-    - Pipeline: _"storybook default"_
-    - Config Source: _"storybook"_
-    - Branch: Your branch, eg. `patch-8-3-7`
-  3. Add a parameter, with _"name"_ `workflow`, _"value"_ `daily`
+    1. Open [CircleCI](https://app.circleci.com/pipelines/github/storybookjs/storybook) and click "Trigger Pipeline" on the top right corner of the page.
+    2. Set the following configuration options:
+        - Pipeline: _"storybook default"_
+        - Config Source: _"storybook"_
+        - Branch: Your branch, eg. `patch-8-3-7`
+    3. Add a parameter, with _"name"_ `workflow`, _"value"_ `daily`
 7. Wait for CI to finish successfully.
 8. Bump all package versions:
-  1. `cd scripts`
-  2. `yarn release:version --release-type patch`
+    1. `cd scripts`
+    2. `yarn release:version --release-type patch`
 9.  Commit with `git commit -m "Bump version from <CURRENT_VERSION> to <NEXT_VERSION> MANUALLY"`
 10. Add a new entry to `CHANGELOG.md`, describing your changes
 11. Commit with `git commit -m "Update CHANGELOG.md with <NEXT_VERSION> MANUALLY"`
 12. Ensure you have the correct write permissions for all the Storybook npm packages. You need to be an admin of the _storybook_ org, and the packages that are not in the org. The simplest way to check this is to ensure you can see the _"Settings"_ tab in the following packages:
-  1.  [`@storybook/react-vite`](https://www.npmjs.com/package/@storybook/react-vite/access)
-  2.  [`storybook`](https://www.npmjs.com/package/storybook/access)
-  3.  [`sb`](https://www.npmjs.com/package/sb/access)
-  4.  [`create-storybook`](https://www.npmjs.com/package/create-storybook/access)
+    1.  [`@storybook/react-vite`](https://www.npmjs.com/package/@storybook/react-vite/access)
+    2.  [`storybook`](https://www.npmjs.com/package/storybook/access)
+    3.  [`sb`](https://www.npmjs.com/package/sb/access)
+    4.  [`create-storybook`](https://www.npmjs.com/package/create-storybook/access)
 13. Get your npm access token or generate a new one at https://www.npmjs.com/settings/your-username/tokens. Remember to give it access to the `storybook` org and the packages not in the org, as listed above.
 14. Publish all packages with `YARN_NPM_AUTH_TOKEN=<NPM_TOKEN> yarn release:publish --tag tag-for-publishing-older-releases --verbose`
     - It goes through all packages and publishes them. If any number of packages fails to publish, it will retry 5 times, skipping those that have already been published.

--- a/CONTRIBUTING/RELEASING.md
+++ b/CONTRIBUTING/RELEASING.md
@@ -19,6 +19,7 @@
   - [5. Make Manual Changes](#5-make-manual-changes)
   - [6. Merge](#6-merge)
   - [7. See the "Publish" Workflow Finish](#7-see-the-publish-workflow-finish)
+- [Releasing changes to older minor versions](#releasing-changes-to-older-minor-versions)
 - [Releasing Locally in an Emergency 🚨](#releasing-locally-in-an-emergency-)
 - [Canary Releases](#canary-releases)
   - [With GitHub UI](#with-github-ui)
@@ -329,6 +330,59 @@ When the pull request was frozen, a CI run was triggered on the branch. If it's 
 Merging the pull request will trigger [the publish workflow](https://github.com/storybookjs/storybook/actions/workflows/publish.yml), which does the final version bumping and publishing. As a Releaser, you're responsible for this to finish successfully, so you should watch it until the end. If it fails, it will notify in Discord, so you can monitor that instead if you want to.
 
 Done! 🚀
+
+## Releasing changes to older minor versions
+
+If you need to release a change to an older minor version that is not the latest, you have to do it manually, locally. The process is described below, with an example of releasing a new `v8.3.7` in a situation where `8.4.0` is currently the latest version.
+
+1. Checkout the _existing_ tag that matches the latest minor release you want to bump, and create a new branch from it. In this case, we want to do:
+  1. `git fetch --all --tags`
+  2. `git checkout tags/v8.3.6 -b patch-8-3-7`
+2. Make the changes you need to, most likely cherry-picking commits from the fix you need to back-port.
+3. Run `yarn install` in `scripts` and `code`
+4. Build all packages in `code` with `yarn task --task compile --no-link`
+5. Commit and push your changes.
+6. Trigger _daily_ CI manually on your branch:
+  1. Open https://app.circleci.com/pipelines/github/storybookjs/storybook
+  2. Click "Trigger Pipeline", top right corner
+  3. Pipeline: _"storybook default"_
+  4. Config Source: _"storybook"_
+  5. Branch: Your branch, eg. `patch-8-3-7`
+  6. Add a parameter, with _"name"_ `workflow`, _"value"_ `daily`
+7. Wait for CI to finish successfully.
+8. Bump all package versions:
+  1. `cd scripts`
+  2. `yarn release:version --release-type patch`
+9.  Commit with `git commit -m "Bump version from <CURRENT_VERSION> to <NEXT_VERSION> MANUALLY"`
+10. Add a new entry to `CHANGELOG.md`, describing your changes
+11. Commit with `git commit -m "Update CHANGELOG.md with <NEXT_VERSION> MANUALLY"`
+12. Ensure you have the correct write permissions to all the Storybook npm packages. You need to be an admin of the _storybook_ org, as well as the packages not in the org. The simplest way to check this, is to ensure you can see the _"Settings"_ tab in the follwing packages:
+  1.  [`@storybook/react-vite`](https://www.npmjs.com/package/@storybook/react-vite/access)
+  2.  [`storybook`](https://www.npmjs.com/package/storybook/access)
+  3.  [`sb`](https://www.npmjs.com/package/sb/access)
+  4.  [`create-storybook`](https://www.npmjs.com/package/create-storybook/access)
+13. Get your npm access token or generate a new one at https://www.npmjs.com/settings/jreinhold/tokens. Remember to not only give it access to the `storybook` org, but also the packages not in the org as listed above.
+14. Publish all packages with `YARN_NPM_AUTH_TOKEN=<NPM_TOKEN> yarn release:publish --tag tag-for-publishing-older-releases --verbose`
+    - It goes through all packages and publishes them. If any number of packages fails to publish, it will retry 5 times, skipping those that have already been published.
+15. Confirm the new version has been released on npmjs with the tag `tag-for-publishing-older-releases`:
+    1. [`@storybook/react-vite`](https://www.npmjs.com/package/@storybook/react-vite?activeTab=versions)
+    2. [`storybook`](https://www.npmjs.com/package/storybook?activeTab=versions)
+    3. [`sb`](phttps://www.npmjs.com/package/sb?activeTab=versions)
+    4. [`create-storybook`](https://www.npmjs.com/package/create-storybook?activeTab=versions)
+16. Push
+17. Manually create a GitHub Release at https://github.com/storybookjs/storybook/releases/new with:
+    1.  Create new tag: `v<VERSION>`, eg. `v8.3.7`
+    2.  Target: your branch, eg. `patch-8-3-7`
+    3.  Previous tag: `v<PREVIOUS_VERSION>`, eg. `v8.3.6`
+    4.  Title: `v<VERSION>`, eg. `v8.3.7`
+    5.  Description: The content you added to `CHANGELOG.md`
+    6.  Untick _"Set as the latest release"_
+18. Cherry-pick your changelog changes into `next`, so they are actually visible 
+    1.  Checkout the `next` branch
+    2.  Cherry-pick the commit you created with your changelog modifications
+    3.  Push
+
+Done. 🎉
 
 ## Releasing Locally in an Emergency 🚨
 

--- a/CONTRIBUTING/RELEASING.md
+++ b/CONTRIBUTING/RELEASING.md
@@ -343,12 +343,12 @@ If you need to release a change to an older minor version that is not the latest
 4. Build all packages in `code` with `yarn task --task compile --no-link`
 5. Commit and push your changes.
 6. Trigger _daily_ CI manually on your branch:
-  1. Open https://app.circleci.com/pipelines/github/storybookjs/storybook
-  2. Click "Trigger Pipeline", top right corner
-  3. Pipeline: _"storybook default"_
-  4. Config Source: _"storybook"_
-  5. Branch: Your branch, eg. `patch-8-3-7`
-  6. Add a parameter, with _"name"_ `workflow`, _"value"_ `daily`
+  1. Open [CircleCI](https://app.circleci.com/pipelines/github/storybookjs/storybook) and click "Trigger Pipeline" on the top right corner of the page.
+  2. Set the following configuration options:
+    - Pipeline: _"storybook default"_
+    - Config Source: _"storybook"_
+    - Branch: Your branch, eg. `patch-8-3-7`
+  3. Add a parameter, with _"name"_ `workflow`, _"value"_ `daily`
 7. Wait for CI to finish successfully.
 8. Bump all package versions:
   1. `cd scripts`
@@ -356,25 +356,25 @@ If you need to release a change to an older minor version that is not the latest
 9.  Commit with `git commit -m "Bump version from <CURRENT_VERSION> to <NEXT_VERSION> MANUALLY"`
 10. Add a new entry to `CHANGELOG.md`, describing your changes
 11. Commit with `git commit -m "Update CHANGELOG.md with <NEXT_VERSION> MANUALLY"`
-12. Ensure you have the correct write permissions to all the Storybook npm packages. You need to be an admin of the _storybook_ org, as well as the packages not in the org. The simplest way to check this, is to ensure you can see the _"Settings"_ tab in the follwing packages:
+12. Ensure you have the correct write permissions for all the Storybook npm packages. You need to be an admin of the _storybook_ org, and the packages that are not in the org. The simplest way to check this is to ensure you can see the _"Settings"_ tab in the following packages:
   1.  [`@storybook/react-vite`](https://www.npmjs.com/package/@storybook/react-vite/access)
   2.  [`storybook`](https://www.npmjs.com/package/storybook/access)
   3.  [`sb`](https://www.npmjs.com/package/sb/access)
   4.  [`create-storybook`](https://www.npmjs.com/package/create-storybook/access)
-13. Get your npm access token or generate a new one at https://www.npmjs.com/settings/jreinhold/tokens. Remember to not only give it access to the `storybook` org, but also the packages not in the org as listed above.
+13. Get your npm access token or generate a new one at https://www.npmjs.com/settings/your-username/tokens. Remember to give it access to the `storybook` org and the packages not in the org, as listed above.
 14. Publish all packages with `YARN_NPM_AUTH_TOKEN=<NPM_TOKEN> yarn release:publish --tag tag-for-publishing-older-releases --verbose`
     - It goes through all packages and publishes them. If any number of packages fails to publish, it will retry 5 times, skipping those that have already been published.
-15. Confirm the new version has been released on npmjs with the tag `tag-for-publishing-older-releases`:
+15. Confirm the new version has been released on npm with the tag `tag-for-publishing-older-releases`:
     1. [`@storybook/react-vite`](https://www.npmjs.com/package/@storybook/react-vite?activeTab=versions)
     2. [`storybook`](https://www.npmjs.com/package/storybook?activeTab=versions)
     3. [`sb`](https://www.npmjs.com/package/sb?activeTab=versions)
     4. [`create-storybook`](https://www.npmjs.com/package/create-storybook?activeTab=versions)
 16. Push
 17. Manually create a GitHub Release at https://github.com/storybookjs/storybook/releases/new with:
-    1.  Create new tag: `v<VERSION>`, eg. `v8.3.7`
-    2.  Target: your branch, eg. `patch-8-3-7`
-    3.  Previous tag: `v<PREVIOUS_VERSION>`, eg. `v8.3.6`
-    4.  Title: `v<VERSION>`, eg. `v8.3.7`
+    1.  Create new tag: `v<VERSION>` (e.g., `v8.3.7`)
+    2.  Target: your branch (e.g., `patch-8-3-7`)
+    3.  Previous tag: `v<PREVIOUS_VERSION>` (e.g., `v8.3.6`)
+    4.  Title: `v<VERSION>` (e.g., `v8.3.7`)
     5.  Description: The content you added to `CHANGELOG.md`
     6.  Untick _"Set as the latest release"_
 18. Cherry-pick your changelog changes into `next`, so they are actually visible 


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added a section to `RELEASING.md` on how to make changes to older minors, eg. releasing critical bugfixes.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Let me provide a clear and concise summary of this documentation-focused PR:

Added comprehensive documentation for releasing patches to older minor versions of Storybook, detailing the manual release process when the latest version isn't the target.

- Added new section "Releasing changes to older minor versions" in `CONTRIBUTING/RELEASING.md`
- Provided step-by-step instructions for manually releasing patches (e.g. `v8.3.7` when `8.4.0` is current)
- Included critical details about npm permissions, version tagging, and CI workflow
- Documented changelog synchronization between branches for version tracking
- Added guidance for creating GitHub releases for older versions

This documentation fills an important gap in the release process documentation, helping maintainers handle critical backported fixes.

<!-- /greptile_comment -->