### PR TITLE
Addon Docs: Dynamically import rehype

### DIFF
--- a/code/addons/docs/src/plugins/mdx-plugin.ts
+++ b/code/addons/docs/src/plugins/mdx-plugin.ts
@@ -3,8 +3,6 @@ import { dirname, join } from 'node:path';
 import type { Options } from 'storybook/internal/types';
 
 import { createFilter } from '@rollup/pluginutils';
-import rehypeExternalLinks from 'rehype-external-links';
-import rehypeSlug from 'rehype-slug';
 import type { Plugin } from 'vite';
 
 import type { CompileOptions } from '../compiler';
@@ -23,6 +21,9 @@ export async function mdxPlugin(options: Options): Promise<Plugin> {
   const { presets } = options;
   const presetOptions = await presets.apply<Record<string, any>>('options', {});
   const mdxPluginOptions = presetOptions?.mdxPluginOptions as CompileOptions;
+
+  const rehypeSlug = (await import('rehype-slug')).default;
+  const rehypeExternalLinks = (await import('rehype-external-links')).default;
 
   return {
     name: 'storybook:mdx-plugin',

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -5,9 +5,6 @@ import type { DocsOptions, Options, PresetProperty } from 'storybook/internal/ty
 
 import type { CsfPluginOptions } from '@storybook/csf-plugin';
 
-import rehypeExternalLinks from 'rehype-external-links';
-import rehypeSlug from 'rehype-slug';
-
 import type { CompileOptions } from './compiler';
 
 /**
@@ -41,6 +38,9 @@ async function webpack(
   const { module = {} } = webpackConfig;
 
   const { csfPluginOptions = {}, mdxPluginOptions = {} } = options;
+
+  const rehypeSlug = (await import('rehype-slug')).default;
+  const rehypeExternalLinks = (await import('rehype-external-links')).default;
 
   const mdxLoaderOptions: CompileOptions = await options.presets.apply('mdxLoaderOptions', {
     ...mdxPluginOptions,
@@ -174,6 +174,9 @@ export const addons: PresetProperty<'addons'> = [
 export const viteFinal = async (config: any, options: Options) => {
   const { plugins = [] } = config;
   const { mdxPlugin } = await import('./plugins/mdx-plugin');
+
+  const rehypeSlug = (await import('rehype-slug')).default;
+  const rehypeExternalLinks = (await import('rehype-external-links')).default;
 
   // Use the resolvedReact preset to alias react and react-dom to either the users version or the version shipped with addon-docs
   const { react, reactDom, mdx } = await getResolvedReact(options);


### PR DESCRIPTION
Relates https://github.com/storybookjs/storybook/issues/29467

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have rewritten `rehype` imports to dynamic imports so that the import doesn't break in CJS environments.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29544-sha-fd7f82f1`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29544-sha-fd7f82f1 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29544-sha-fd7f82f1 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29544-sha-fd7f82f1`](https://npmjs.com/package/storybook/v/0.0.0-pr-29544-sha-fd7f82f1) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/dynamic-import-of-rehype`](https://github.com/storybookjs/storybook/tree/valentin/dynamic-import-of-rehype) |
| **Commit** | [`fd7f82f1`](https://github.com/storybookjs/storybook/commit/fd7f82f1f620ba07de603f2135420cfcf451a2ba) |
| **Datetime** | Tue Nov  5 11:21:27 UTC 2024 (`1730805687`) |
| **Workflow run** | [11683115704](https://github.com/storybookjs/storybook/actions/runs/11683115704) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29544`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.2 MB | 78.2 MB | 0 B | 1.16 | 0% |
| initSize |  143 MB | 143 MB | 3.6 kB | 1.19 | 0% |
| diffSize |  65.1 MB | 65.1 MB | 3.6 kB | **1.29** | 0% |
| buildSize |  6.88 MB | 6.88 MB | 0 B | 1.12 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 0 B | 1.11 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 0 B | 1.11 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 1.11 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.5s | 20.3s | 13.7s | 0.92 | 67.7% |
| generateTime |  19.5s | 19.7s | 148ms | -0.7 | 0.8% |
| initTime |  13.5s | 13.9s | 425ms | -0.84 | 3% |
| buildTime |  8.1s | 9.1s | 981ms | 0.1 | 10.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.5s | 5.6s | 163ms | -0.52 | 2.9% |
| devManagerResponsive |  3.5s | 3.3s | -176ms | -0.93 | -5.2% |
| devManagerHeaderVisible |  473ms | 517ms | 44ms | -0.88 | 8.5% |
| devManagerIndexVisible |  500ms | 551ms | 51ms | -1.12 | 9.3% |
| devStoryVisibleUncached |  602ms | 1.1s | 511ms | 0.31 | 45.9% |
| devStoryVisible |  499ms | 550ms | 51ms | -1.03 | 9.3% |
| devAutodocsVisible |  467ms | 481ms | 14ms | -0.63 | 2.9% |
| devMDXVisible |  450ms | 501ms | 51ms | -0.39 | 10.2% |
| buildManagerHeaderVisible |  631ms | 503ms | -128ms | -0.87 | -25.4% |
| buildManagerIndexVisible |  648ms | 523ms | -125ms | -0.78 | -23.9% |
| buildStoryVisible |  630ms | 501ms | -129ms | -0.89 | -25.7% |
| buildAutodocsVisible |  477ms | 412ms | -65ms | -0.93 | -15.8% |
| buildMDXVisible |  478ms | 414ms | -64ms | -0.77 | -15.5% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Modified the import method for rehype plugins in MDX-related files to use dynamic imports instead of static imports, improving CommonJS environment compatibility.

- Changed static imports to dynamic imports using `await import()` in `code/addons/docs/src/plugins/mdx-plugin.ts`
- Updated rehype plugin imports in `code/addons/docs/src/preset.ts` to use dynamic imports
- Resolves issue #29467 where ESM modules were causing errors in CommonJS environments
- Maintains existing functionality while ensuring compatibility across module systems

<!-- /greptile_comment -->