### PR TITLE
Docs: Correct addon-themes README to align text with code example

### DIFF
--- a/code/addons/themes/README.md
+++ b/code/addons/themes/README.md
@@ -36,7 +36,7 @@ Don't see your favorite tool listed? Don't worry! That doesn't mean this addon i
 
 ### ❗️ Overriding theme
 
-If you want to override your theme for a particular component or story, you can use the `themes.themeOverride` parameter.
+If you want to override your theme for a particular component or story, you can use the `globals.theme` parameter.
 
 ```js
 import React from 'react';


### PR DESCRIPTION
Closes #

_none_, fixing miss-alignment in documentation.

## What I did

Align text block reference with below code.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Using latest storybook and addon-themes (8.4.1)
2. able to override the theme for a specific story, as the code was already presenting

### Documentation

- [x] Add or update documentation reflecting your changes

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates the README.md documentation for addon-themes to correct the parameter name for theme overrides from `themes.themeOverride` to `globals.theme`, ensuring consistency with code examples.

- Fixed parameter name in `/code/addons/themes/README.md` to use `globals.theme` instead of `themes.themeOverride`
- Documentation now correctly reflects both meta-level and story-level theme override syntax

<!-- /greptile_comment -->