### PR TITLE
CI: Fix package benchmarking failing on `next`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,7 @@ jobs:
           steps:
             - run:
                 name: Benchmarking packages against base branch
+                working_directory: scripts
                 command: yarn bench-packages --base-branch << pipeline.parameters.ghBaseBranch >> --pull-request << pipeline.parameters.ghPrNumber >> --upload
       # if there is a NOT a base branch OR NOT a PR number in parameters, just upload benchmarks for the branch
       # this happens when runned directly on branches, like next or main
@@ -250,6 +251,7 @@ jobs:
           steps:
             - run:
                 name: Uploading package benchmarks for branch
+                working_directory: scripts
                 command: yarn bench-packages --upload
       - store_artifacts: 
           path: bench/packages/results.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Benchmarking Packages
+          name: Starting local registry
           working_directory: scripts
           command: |
             yarn local-registry --open &
@@ -229,7 +229,28 @@ jobs:
               echo 'Waiting for local registry to be available...'
               sleep 2
             done
-            yarn bench-packages --baseBranch << pipeline.parameters.ghBaseBranch >> --pull-request << pipeline.parameters.ghPrNumber >> --upload
+      # if there is a base branch AND a PR number in parameters, benchmark packages against those
+      # this happens when run against a PR
+      - when:
+          condition: 
+            and:
+              - << pipeline.parameters.ghBaseBranch >>
+              - << pipeline.parameters.ghPrNumber >>
+          steps:
+            - run:
+                name: Benchmarking packages against base branch
+                command: yarn bench-packages --baseBranch << pipeline.parameters.ghBaseBranch >> --pull-request << pipeline.parameters.ghPrNumber >> --upload
+      # if there is a NOT a base branch OR NOT a PR number in parameters, just upload benchmarks for the branch
+      # this happens when runned directly on branches, like next or main
+      - when:
+          condition:
+            or:
+              - not: << pipeline.parameters.ghBaseBranch >>
+              - not: << pipeline.parameters.ghPrNumber >>
+          steps:
+            - run:
+                name: Uploading package benchmarks for branch
+                command: yarn bench-packages --upload
       - store_artifacts: 
           path: bench/packages/results.json
       - store_artifacts: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
           steps:
             - run:
                 name: Benchmarking packages against base branch
-                command: yarn bench-packages --baseBranch << pipeline.parameters.ghBaseBranch >> --pull-request << pipeline.parameters.ghPrNumber >> --upload
+                command: yarn bench-packages --base-branch << pipeline.parameters.ghBaseBranch >> --pull-request << pipeline.parameters.ghPrNumber >> --upload
       # if there is a NOT a base branch OR NOT a PR number in parameters, just upload benchmarks for the branch
       # this happens when runned directly on branches, like next or main
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,15 +220,6 @@ jobs:
           clone_options: "--depth 1 --verbose"
       - attach_workspace:
           at: .
-      - run:
-          name: Starting local registry
-          working_directory: scripts
-          command: |
-            yarn local-registry --open &
-            until curl -s http://localhost:6001 > /dev/null; do
-              echo 'Waiting for local registry to be available...'
-              sleep 2
-            done
       # if there is a base branch AND a PR number in parameters, benchmark packages against those
       # this happens when run against a PR
       - when:
@@ -240,7 +231,13 @@ jobs:
             - run:
                 name: Benchmarking packages against base branch
                 working_directory: scripts
-                command: yarn bench-packages --base-branch << pipeline.parameters.ghBaseBranch >> --pull-request << pipeline.parameters.ghPrNumber >> --upload
+                command: |
+                  yarn local-registry --open &
+                  until curl -s http://localhost:6001 > /dev/null; do
+                    echo 'Waiting for local registry to be available...'
+                    sleep 2
+                  done
+                  yarn bench-packages --base-branch << pipeline.parameters.ghBaseBranch >> --pull-request << pipeline.parameters.ghPrNumber >> --upload
       # if there is a NOT a base branch OR NOT a PR number in parameters, just upload benchmarks for the branch
       # this happens when runned directly on branches, like next or main
       - when:
@@ -252,7 +249,13 @@ jobs:
             - run:
                 name: Uploading package benchmarks for branch
                 working_directory: scripts
-                command: yarn bench-packages --upload
+                command: |
+                  yarn local-registry --open &
+                  until curl -s http://localhost:6001 > /dev/null; do
+                    echo 'Waiting for local registry to be available...'
+                    sleep 2
+                  done
+                  yarn bench-packages --upload
       - store_artifacts: 
           path: bench/packages/results.json
       - store_artifacts: 

--- a/scripts/bench/bench-packages.ts
+++ b/scripts/bench/bench-packages.ts
@@ -370,7 +370,7 @@ const uploadToGithub = async ({
 const run = async () => {
   program
     .option(
-      '-b, --baseBranch <string>',
+      '-b, --base-branch <string>',
       'The base branch to compare the results with. Requires GCP_CREDENTIALS env var'
     )
     .option(


### PR DESCRIPTION
Follow-up to #29356


<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added conditions to the CircleCI config so it only includes the `--base-branch` and `--pull-request` arguments if they are set on the CI workflow (ie in PRs, not on `next`)

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.1 MB | 78.1 MB | 8 B | 0.04 | 0% |
| initSize |  143 MB | 143 MB | 8 B | 0.72 | 0% |
| diffSize |  65.2 MB | 65.2 MB | 0 B | **1.63** | 0% |
| buildSize |  6.88 MB | 6.88 MB | 0 B | 1.05 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | **1.36** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 0 B | 0.58 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 0 B | 1.05 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | - | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  14.9s | 23s | 8.1s | **1.36** | 🔺35.3% |
| generateTime |  23.4s | 23.6s | 225ms | 0.48 | 1% |
| initTime |  17.1s | 15.7s | -1s -418ms | 0.17 | -9% |
| buildTime |  8.9s | 7.6s | -1s -239ms | -1.08 | -16.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.3s | 6s | 701ms | 0.34 | 11.5% |
| devManagerResponsive |  3.4s | 3.9s | 529ms | 0.9 | 13.4% |
| devManagerHeaderVisible |  521ms | 523ms | 2ms | -0.68 | 0.4% |
| devManagerIndexVisible |  592ms | 604ms | 12ms | -0.27 | 2% |
| devStoryVisibleUncached |  1.1s | 1.1s | -10ms | 0.57 | -0.9% |
| devStoryVisible |  553ms | 601ms | 48ms | -0.13 | 8% |
| devAutodocsVisible |  534ms | 470ms | -64ms | -0.59 | -13.6% |
| devMDXVisible |  462ms | 482ms | 20ms | -0.34 | 4.1% |
| buildManagerHeaderVisible |  668ms | 520ms | -148ms | -0.61 | -28.5% |
| buildManagerIndexVisible |  684ms | 532ms | -152ms | -0.63 | -28.6% |
| buildStoryVisible |  669ms | 522ms | -147ms | -0.56 | -28.2% |
| buildAutodocsVisible |  456ms | 435ms | -21ms | -0.35 | -4.8% |
| buildMDXVisible |  493ms | 406ms | -87ms | -0.75 | -21.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request changes:

Modified CircleCI configuration to fix package benchmarking failures on the 'next' branch by implementing conditional benchmark argument handling.

- Added conditional logic for `--baseBranch` and `--pull-request` arguments in benchmarking job
- Arguments only included when running in PR context, not on direct 'next' branch runs
- Splits benchmarking workflow into PR path (with comparison args) and direct branch path (upload only)
- Improves CI stability by preventing benchmark comparison failures when running on 'next'

The changes are focused and specific to the CI configuration, making the benchmarking process more robust by properly handling different execution contexts.

<!-- /greptile_comment -->