### PR TITLE
Addon Test: Only optimize react deps if applicable in vitest-plugin

### DIFF
--- a/code/addons/test/src/vitest-plugin/index.ts
+++ b/code/addons/test/src/vitest-plugin/index.ts
@@ -134,12 +134,12 @@ export const storybookTest = (options?: UserOptions): Plugin => {
       config.optimizeDeps ??= {};
       config.optimizeDeps = {
         ...config.optimizeDeps,
-        include: [
-          ...(config.optimizeDeps.include ?? []),
-          'react-dom/test-utils',
-          '@storybook/experimental-addon-test/**',
-        ],
+        include: [...(config.optimizeDeps.include ?? []), '@storybook/experimental-addon-test/**'],
       };
+
+      if (frameworkName?.includes('react') || frameworkName?.includes('nextjs')) {
+        config.optimizeDeps.include.push('react-dom/test-utils');
+      }
 
       if (frameworkName?.includes('vue3')) {
         config.define ??= {};


### PR DESCRIPTION
Closes #29616

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR changes the logic in the dep optimization so that it only includes react-dom/test-utils (which we use in sb for react) if applicable

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.2 MB | 78.2 MB | 0 B | **1.26** | 0% |
| initSize |  143 MB | 143 MB | 0 B | 1.05 | 0% |
| diffSize |  65.2 MB | 65.2 MB | 0 B | 0.34 | 0% |
| buildSize |  6.88 MB | 6.88 MB | 0 B | **1.72** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.33 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 0 B | **1.74** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 0 B | **1.72** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | - | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.7s | 23.1s | 16.4s | **1.36** | 🔺71% |
| generateTime |  20s | 19.5s | -499ms | -0.68 | -2.6% |
| initTime |  14.4s | 13.6s | -820ms | **-1.53** | 🔰-6% |
| buildTime |  8.3s | 7.7s | -623ms | -0.95 | -8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.7s | 6.6s | 1.9s | **1.55** | 🔺28.9% |
| devManagerResponsive |  3s | 4.1s | 1.1s | **1.68** | 🔺28.4% |
| devManagerHeaderVisible |  496ms | 535ms | 39ms | -0.45 | 7.3% |
| devManagerIndexVisible |  527ms | 571ms | 44ms | -0.76 | 7.7% |
| devStoryVisibleUncached |  1s | 1s | -33ms | -0.3 | -3.2% |
| devStoryVisible |  526ms | 570ms | 44ms | -0.62 | 7.7% |
| devAutodocsVisible |  400ms | 564ms | 164ms | 0.68 | 29.1% |
| devMDXVisible |  436ms | 463ms | 27ms | -0.68 | 5.8% |
| buildManagerHeaderVisible |  483ms | 556ms | 73ms | -0.17 | 13.1% |
| buildManagerIndexVisible |  496ms | 594ms | 98ms | 0.09 | 16.5% |
| buildStoryVisible |  484ms | 546ms | 62ms | -0.28 | 11.4% |
| buildAutodocsVisible |  380ms | 475ms | 95ms | 0.16 | 20% |
| buildMDXVisible |  370ms | 487ms | 117ms | 0.57 | 24% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Modifies the Vitest plugin to conditionally optimize React dependencies, preventing failures in non-React frameworks while maintaining functionality for React-based projects.

- Modified `code/addons/test/src/vitest-plugin/index.ts` to conditionally include 'react-dom/test-utils' in optimizeDeps only for React/Next.js frameworks
- Added framework detection logic to prevent dependency resolution errors in non-React environments
- Added debug logging for optimizeDeps configuration troubleshooting

<!-- /greptile_comment -->