### PR TITLE
CLI: Fix qwik init

### DIFF
--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -244,12 +244,7 @@ export async function baseGenerator(
     ...extraAddonsToInstall,
   ].filter(Boolean);
 
-  // TODO: migrate template stories in solid and qwik to use @storybook/test
-  if (['qwik'].includes(rendererId)) {
-    addonPackages.push('@storybook/testing-library');
-  } else {
-    addonPackages.push('@storybook/test');
-  }
+  addonPackages.push('@storybook/test');
 
   if (hasInteractiveStories(rendererId)) {
     addons.push('@storybook/addon-interactions');


### PR DESCRIPTION
Closes N/A

## What I did

See https://github.com/literalpie/storybook-framework-qwik/blob/main/CHANGELOG.md#040

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR standardizes the testing library usage across all Storybook frameworks by removing special handling for Qwik and using @storybook/test consistently.

- Modified `code/lib/create-storybook/src/generators/baseGenerator.ts` to remove Qwik-specific testing library condition
- Aligns with Qwik framework's migration to @storybook/test in v0.4.0
- Simplifies testing setup by using a single consistent package (@storybook/test) across all frameworks
- Removes technical debt from framework-specific testing library variations

<!-- /greptile_comment -->