### PR TITLE
RNW-Vite: Integrate with experimental-addon-test

### DIFF
--- a/code/addons/test/src/postinstall.ts
+++ b/code/addons/test/src/postinstall.ts
@@ -453,6 +453,12 @@ const getVitestPluginInfo = (framework: string) => {
     frameworkPluginCall = 'storybookVuePlugin()';
   }
 
+  if (framework === '@storybook/react-native-web-vite') {
+    frameworkPluginImport =
+      "import { storybookReactNativeWeb } from '@storybook/react-native-web-vite/vite-plugin';";
+    frameworkPluginCall = 'storybookReactNativeWeb()';
+  }
+
   // spaces for file identation
   frameworkPluginImport = `\n${frameworkPluginImport}`;
   frameworkPluginDocs = frameworkPluginDocs ? `\n    ${frameworkPluginDocs}` : '';
@@ -491,14 +497,19 @@ async function getStorybookInfo({ configDir, packageManager: pkgMgr }: Postinsta
   }
 
   const builderPackageJson = await fs.readFile(
-    `${typeof builder === 'string' ? builder : builder.name}/package.json`,
+    require.resolve(
+      path.join(typeof builder === 'string' ? builder : builder.name, 'package.json')
+    ),
     'utf8'
   );
   const builderPackageName = JSON.parse(builderPackageJson).name;
 
   let rendererPackageName: string | undefined;
   if (renderer) {
-    const rendererPackageJson = await fs.readFile(`${renderer}/package.json`, 'utf8');
+    const rendererPackageJson = await fs.readFile(
+      require.resolve(path.join(renderer, 'package.json')),
+      'utf8'
+    );
     rendererPackageName = JSON.parse(rendererPackageJson).name;
   }
 

--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -30,6 +30,11 @@
       "types": "./dist/preset.d.ts",
       "require": "./dist/preset.js"
     },
+    "./vite-plugin": {
+      "types": "./dist/vite-plugin.d.ts",
+      "import": "./dist/vite-plugin.mjs",
+      "require": "./dist/vite-plugin.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",
@@ -75,7 +80,8 @@
   "bundler": {
     "entries": [
       "./src/index.ts",
-      "./src/preset.ts"
+      "./src/preset.ts",
+      "./src/vite-plugin.ts"
     ],
     "platform": "node"
   },

--- a/code/frameworks/react-native-web-vite/src/preset.ts
+++ b/code/frameworks/react-native-web-vite/src/preset.ts
@@ -1,15 +1,12 @@
 // @ts-expect-error FIXME
 import { viteFinal as reactViteFinal } from '@storybook/react-vite/preset';
 
-import type { BabelOptions, Options as ReactOptions } from '@vitejs/plugin-react';
 import react from '@vitejs/plugin-react';
 import type { PluginOption } from 'vite';
 
 import type { FrameworkOptions, StorybookConfig } from './types';
 
-function reactNativeWeb(
-  reactOptions: Omit<ReactOptions, 'babel'> & { babel?: BabelOptions }
-): PluginOption {
+export function reactNativeWeb(): PluginOption {
   return {
     name: 'vite:react-native-web',
     config(_userConfig, env) {
@@ -80,7 +77,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
       ...pluginReactOptions,
     })
   );
-  plugins.push(reactNativeWeb(pluginReactOptions));
+  plugins.push(reactNativeWeb());
 
   return reactConfig;
 };

--- a/code/frameworks/react-native-web-vite/src/vite-plugin.ts
+++ b/code/frameworks/react-native-web-vite/src/vite-plugin.ts
@@ -1,0 +1,16 @@
+import react from '@vitejs/plugin-react';
+
+import { reactNativeWeb } from './preset';
+
+export const storybookReactNativeWeb = () => {
+  return [
+    react({
+      babel: {
+        babelrc: false,
+        configFile: false,
+      },
+      jsxRuntime: 'automatic',
+    }),
+    reactNativeWeb(),
+  ];
+};


### PR DESCRIPTION
Closes N/A

## What I did

- [x] Add a new `vite-plugin` entry point
- [x] Use that entry point in the `experimental-addon-test` postinstall

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a new expo project: `npm create expo`
2. Initialize storybook `npx storybook@next init --type react_native_web`
3. Add Storybook Test `npx storybook add @storybook/experimental-addon-test`
3. Add Addon A11y `npx storybook add @storybook/experimental-addon-test`
4. Verify that testing works in Vitest and in the browser.

---

Here's how I tested:
1. Created a new sandbox of type `react-native-web/vite-expo-ts` in `dev --no-link` mode
2. After the sandbox is created, and while `dev` is still running, in a separate terminal

```sh
cd sandbox/react-native-web-vite-expo-ts
npx storybook add @storybook/experimental-addon-test
yarn vitest
```

The tests don't all pass, but many of them do.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.5 MB | 78.4 MB | -57.4 kB | 0.71 | -0.1% |
| initSize |  144 MB | 144 MB | -57.4 kB | 0.72 | 0% |
| diffSize |  65.2 MB | 65.2 MB | 0 B | **1.45** | 0% |
| buildSize |  6.87 MB | 6.88 MB | 3.33 kB | 1.05 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 0 B | 0.97 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 0 B | 0.97 | 0% |
| buildPreviewSize |  2.99 MB | 3 MB | 3.33 kB | 0.9 | 0.1% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  13.2s | 25.4s | 12.1s | **1.55** | 🔺47.8% |
| generateTime |  35.1s | 20.8s | -14s -218ms | -0.36 | -68.1% |
| initTime |  15.3s | 13.8s | -1s -520ms | -0.88 | -11% |
| buildTime |  8.8s | 8.7s | -119ms | 0.01 | -1.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6s | 6.3s | 279ms | 1.11 | 4.4% |
| devManagerResponsive |  3.7s | 3.8s | 121ms | 0.67 | 3.1% |
| devManagerHeaderVisible |  513ms | 602ms | 89ms | 0.58 | 14.8% |
| devManagerIndexVisible |  580ms | 684ms | 104ms | 0.69 | 15.2% |
| devStoryVisibleUncached |  932ms | 1.1s | 202ms | 0.68 | 17.8% |
| devStoryVisible |  547ms | 679ms | 132ms | 0.93 | 19.4% |
| devAutodocsVisible |  540ms | 527ms | -13ms | 0.38 | -2.5% |
| devMDXVisible |  515ms | 536ms | 21ms | 0.52 | 3.9% |
| buildManagerHeaderVisible |  567ms | 549ms | -18ms | -0.28 | -3.3% |
| buildManagerIndexVisible |  577ms | 572ms | -5ms | -0.21 | -0.9% |
| buildStoryVisible |  565ms | 550ms | -15ms | -0.25 | -2.7% |
| buildAutodocsVisible |  456ms | 480ms | 24ms | -0.12 | 5% |
| buildMDXVisible |  412ms | 447ms | 35ms | 0.04 | 7.8% |

<!-- BENCHMARK_SECTION -->
