### PR TITLE
Manager: Fix size regression

### DIFF
--- a/code/core/src/manager/components/sidebar/StatusContext.tsx
+++ b/code/core/src/manager/components/sidebar/StatusContext.tsx
@@ -2,7 +2,8 @@ import { createContext, useContext } from 'react';
 
 import type { API_StatusObject, API_StatusState, API_StatusValue, StoryId } from '@storybook/types';
 
-import type { StoriesHash } from '../../../manager-api';
+import type { StoriesHash } from '@storybook/core/manager-api';
+
 import type { Item } from '../../container/Sidebar';
 import { getDescendantIds } from '../../utils/tree';
 

--- a/code/core/src/manager/components/sidebar/TestingModule.stories.tsx
+++ b/code/core/src/manager/components/sidebar/TestingModule.stories.tsx
@@ -5,8 +5,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { fn, userEvent } from '@storybook/test';
 
 import type { TestProviders } from '@storybook/core/core-events';
+import { ManagerContext } from '@storybook/core/manager-api';
 
-import { ManagerContext } from '../../../manager-api';
 import { TestingModule } from './TestingModule';
 
 const baseState = {

--- a/code/core/src/manager/components/sidebar/TestingModule.tsx
+++ b/code/core/src/manager/components/sidebar/TestingModule.tsx
@@ -1,13 +1,13 @@
 import React, { type SyntheticEvent, useEffect, useRef, useState } from 'react';
 
 import { Button, TooltipNote } from '@storybook/core/components';
+import { WithTooltip } from '@storybook/core/components';
 import { keyframes, styled } from '@storybook/core/theming';
 import { ChevronSmallUpIcon, PlayAllHollowIcon } from '@storybook/icons';
 
 import type { TestProviders } from '@storybook/core/core-events';
+import { useStorybookApi } from '@storybook/core/manager-api';
 
-import { WithTooltip } from '../../../components/components/tooltip/WithTooltip';
-import { useStorybookApi } from '../../../manager-api';
 import { LegacyRender } from './LegacyRender';
 
 const DEFAULT_HEIGHT = 500;

--- a/code/core/src/manager/settings/defaultShortcuts.tsx
+++ b/code/core/src/manager/settings/defaultShortcuts.tsx
@@ -1,4 +1,4 @@
-import type { State } from '../../manager-api/root';
+import type { State } from '@storybook/core/manager-api';
 
 export const defaultShortcuts: State['shortcuts'] = {
   fullScreen: ['F'],


### PR DESCRIPTION
Follow-up to https://github.com/storybookjs/storybook/pull/29557

See regression at https://github.com/storybookjs/storybook/pull/29657#issuecomment-2485830589

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed imports in `manager` that imports from `manager-api`. `manager-api` is globalized when correctly imported as `@storybook/core/manager-api`, but we had introduced a few relative imports, which meant that `manager` was now bundling in `manager-api` directly, causing its size to increase by 168 KB.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.4 MB | 78.4 MB | 0 B | 0.28 | 0% |
| initSize |  144 MB | 144 MB | -201 kB | -0.05 | -0.1% |
| diffSize |  65.3 MB | 65.1 MB | -201 kB | -1.06 | -0.3% |
| buildSize |  7.03 MB | 6.83 MB | -201 kB | **-1.49** | -2.9% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.06 MB | 1.86 MB | -201 kB | **-1.56** | 🔰-10.8% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.04 MB | 3.83 MB | -201 kB | **-1.56** | 🔰-5.2% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.99 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  25.8s | 21.9s | -3s -885ms | 0.73 | -17.7% |
| generateTime |  22.9s | 22.1s | -803ms | 0.21 | -3.6% |
| initTime |  14.9s | 16.3s | 1.4s | 0.96 | 8.6% |
| buildTime |  8s | 8s | 19ms | -0.9 | 0.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.8s | 6.7s | -169ms | **1.8** | -2.5% |
| devManagerResponsive |  4s | 4s | -5ms | **1.5** | -0.1% |
| devManagerHeaderVisible |  608ms | 693ms | 85ms | **2** | 🔺12.3% |
| devManagerIndexVisible |  702ms | 775ms | 73ms | **1.71** | 🔺9.4% |
| devStoryVisibleUncached |  1.1s | 1.7s | 594ms | **4.53** | 🔺33.6% |
| devStoryVisible |  647ms | 741ms | 94ms | **1.55** | 🔺12.7% |
| devAutodocsVisible |  502ms | 555ms | 53ms | 1.04 | 9.5% |
| devMDXVisible |  548ms | 495ms | -53ms | 0 | -10.7% |
| buildManagerHeaderVisible |  611ms | 671ms | 60ms | **1.68** | 🔺8.9% |
| buildManagerIndexVisible |  628ms | 689ms | 61ms | **1.6** | 🔺8.9% |
| buildStoryVisible |  613ms | 669ms | 56ms | **1.69** | 🔺8.4% |
| buildAutodocsVisible |  601ms | 569ms | -32ms | **1.45** | 🔰-5.6% |
| buildMDXVisible |  493ms | 585ms | 92ms | **2.83** | 🔺15.7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updated import paths in manager components to use globalized @storybook/core/manager-api, fixing a 168KB size regression caused by direct bundling of manager-api through relative imports.

- Changed StoriesHash import in `code/core/src/manager/components/sidebar/StatusContext.tsx` to use @storybook/core/manager-api
- Updated ManagerContext import in `TestingModule.stories.tsx` to use absolute path
- Modified imports in `TestingModule.tsx` to use @storybook/core prefixes for components and manager-api
- Updated State type import in `defaultShortcuts.tsx` to use globalized path

<!-- /greptile_comment -->