### PR TITLE
Add discrepancy handling to A11yPanel

### DIFF
--- a/code/addons/a11y/src/components/A11YPanel.tsx
+++ b/code/addons/a11y/src/components/A11YPanel.tsx
@@ -8,6 +8,7 @@ import { CheckIcon, SyncIcon } from '@storybook/icons';
 import { useA11yContext } from './A11yContext';
 import { Report } from './Report';
 import { Tabs } from './Tabs';
+import { TestDiscrepancyMessage } from './TestDiscrepancyMessage';
 
 export enum RuleType {
   VIOLATION,
@@ -43,7 +44,7 @@ const Centered = styled.span({
 });
 
 export const A11YPanel: React.FC = () => {
-  const { results, status, handleManual, error } = useA11yContext();
+  const { results, status, handleManual, error, discrepancy } = useA11yContext();
 
   const manualActionItems = useMemo(
     () => [{ title: 'Run test', onClick: handleManual }],
@@ -106,31 +107,35 @@ export const A11YPanel: React.FC = () => {
 
   return (
     <>
-      {status === 'initial' && <Centered>Initializing...</Centered>}
-      {status === 'manual' && (
-        <>
-          <Centered>Manually run the accessibility scan.</Centered>
-          <ActionBar key="actionbar" actionItems={manualActionItems} />
-        </>
-      )}
-      {status === 'running' && (
-        <Centered>
-          <RotatingIcon size={12} /> Please wait while the accessibility scan is running ...
-        </Centered>
-      )}
-      {(status === 'ready' || status === 'ran') && (
+      {discrepancy && <TestDiscrepancyMessage discrepancy={discrepancy} />}
+      {status === 'ready' || status === 'ran' ? (
         <>
           <ScrollArea vertical horizontal>
             <Tabs key="tabs" tabs={tabs} />
           </ScrollArea>
           <ActionBar key="actionbar" actionItems={readyActionItems} />
         </>
-      )}
-      {status === 'error' && (
-        <Centered>
-          The accessibility scan encountered an error.
-          <br />
-          {typeof error === 'string' ? error : JSON.stringify(error)}
+      ) : (
+        <Centered style={{ marginTop: discrepancy ? '1em' : 0 }}>
+          {status === 'initial' && 'Initializing...'}
+          {status === 'manual' && (
+            <>
+              <>Manually run the accessibility scan.</>
+              <ActionBar key="actionbar" actionItems={manualActionItems} />
+            </>
+          )}
+          {status === 'running' && (
+            <>
+              <RotatingIcon size={12} /> Please wait while the accessibility scan is running ...
+            </>
+          )}
+          {status === 'error' && (
+            <>
+              The accessibility scan encountered an error.
+              <br />
+              {typeof error === 'string' ? error : JSON.stringify(error)}
+            </>
+          )}
         </Centered>
       )}
     </>

--- a/code/addons/a11y/src/components/TestDiscrepancyMessage.tsx
+++ b/code/addons/a11y/src/components/TestDiscrepancyMessage.tsx
@@ -1,0 +1,73 @@
+import React, { useMemo } from 'react';
+
+import { Link } from 'storybook/internal/components';
+import { useStorybookApi } from 'storybook/internal/manager-api';
+import { styled } from 'storybook/internal/theming';
+
+import { DOCUMENTATION_DISCREPANCY_LINK } from '../constants';
+
+const Wrapper = styled.div(({ theme: { color, typography, background } }) => ({
+  textAlign: 'start',
+  padding: '11px 15px',
+  fontSize: `${typography.size.s2}px`,
+  fontWeight: typography.weight.regular,
+  lineHeight: '1rem',
+  background: background.app,
+  borderBottom: `1px solid ${color.border}`,
+  color: color.defaultText,
+  backgroundClip: 'padding-box',
+  position: 'relative',
+  code: {
+    fontSize: `${typography.size.s1 - 1}px`,
+    color: 'inherit',
+    margin: '0 0.2em',
+    padding: '0 0.2em',
+    background: 'rgba(255, 255, 255, 0.8)',
+    borderRadius: '2px',
+    boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.1)',
+  },
+}));
+
+export type TestDiscrepancy =
+  | 'browserPassedCliFailed'
+  | 'cliPassedBrowserFailed'
+  | 'cliFailedButModeManual'
+  | null;
+
+interface TestDiscrepancyMessageProps {
+  discrepancy: TestDiscrepancy;
+}
+export const TestDiscrepancyMessage = ({ discrepancy }: TestDiscrepancyMessageProps) => {
+  const api = useStorybookApi();
+  const docsUrl = api.getDocsUrl({
+    subpath: DOCUMENTATION_DISCREPANCY_LINK,
+    versioned: true,
+    renderer: true,
+  });
+
+  const message = useMemo(() => {
+    switch (discrepancy) {
+      case 'browserPassedCliFailed':
+        return 'Accessibility checks passed in this browser but failed in the CLI.';
+      case 'cliPassedBrowserFailed':
+        return 'Accessibility checks passed in the CLI but failed in this browser.';
+      case 'cliFailedButModeManual':
+        return 'Accessibility checks failed in the CLI. Run the tests manually to see the results.';
+      default:
+        return null;
+    }
+  }, [discrepancy]);
+
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <Wrapper>
+      {message}{' '}
+      <Link href={docsUrl} target="_blank" withArrow>
+        Learn what could cause this
+      </Link>
+    </Wrapper>
+  );
+};

--- a/code/addons/a11y/src/constants.ts
+++ b/code/addons/a11y/src/constants.ts
@@ -7,4 +7,9 @@ const RUNNING = `${ADDON_ID}/running`;
 const ERROR = `${ADDON_ID}/error`;
 const MANUAL = `${ADDON_ID}/manual`;
 
+export const DOCUMENTATION_LINK = 'writing-tests/accessibility-testing';
+export const DOCUMENTATION_DISCREPANCY_LINK = `${DOCUMENTATION_LINK}#what-happens-when-there-are-different-results-in-multiple-environments`;
+
+export const TEST_PROVIDER_ID = 'storybook/addon-a11y/test-provider';
+
 export const EVENTS = { RESULT, REQUEST, RUNNING, ERROR, MANUAL };

--- a/code/addons/a11y/template/stories/A11YPanel.stories.tsx
+++ b/code/addons/a11y/template/stories/A11YPanel.stories.tsx
@@ -1,22 +1,34 @@
 import React from 'react';
 
+import { ManagerContext } from 'storybook/internal/manager-api';
 import { ThemeProvider, convert, themes } from 'storybook/internal/theming';
 
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 
+import type axe from 'axe-core';
+
 import { A11YPanel } from '../../src/components/A11YPanel';
 import { A11yContext } from '../../src/components/A11yContext';
 import type { A11yContextStore } from '../../src/components/A11yContext';
+
+const managerContext: any = {
+  state: {},
+  api: {
+    getDocsUrl: fn().mockName('api::getDocsUrl'),
+  },
+};
 
 const meta: Meta = {
   title: 'A11YPanel',
   component: A11YPanel,
   decorators: [
     (Story) => (
-      <ThemeProvider theme={convert(themes.light)}>
-        <Story />
-      </ThemeProvider>
+      <ManagerContext.Provider value={managerContext}>
+        <ThemeProvider theme={convert(themes.light)}>
+          <Story />
+        </ThemeProvider>
+      </ManagerContext.Provider>
     ),
   ],
 } satisfies Meta<typeof A11YPanel>;
@@ -25,7 +37,62 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const Template = (args: Pick<A11yContextStore, 'results' | 'error' | 'status'>) => (
+const violations: axe.Result[] = [
+  {
+    id: 'aria-command-name',
+    impact: 'serious',
+    tags: ['cat.aria', 'wcag2a', 'wcag412', 'TTv5', 'TT6.a', 'EN-301-549', 'EN-9.4.1.2', 'ACT'],
+    description: 'Ensures every ARIA button, link and menuitem has an accessible name',
+    help: 'ARIA commands must have an accessible name',
+    helpUrl: 'https://dequeuniversity.com/rules/axe/4.8/aria-command-name?application=axeAPI',
+    nodes: [
+      {
+        any: [
+          {
+            id: 'has-visible-text',
+            data: null,
+            relatedNodes: [],
+            impact: 'serious',
+            message: 'Element does not have text that is visible to screen readers',
+          },
+          {
+            id: 'aria-label',
+            data: null,
+            relatedNodes: [],
+            impact: 'serious',
+            message: 'aria-label attribute does not exist or is empty',
+          },
+          {
+            id: 'aria-labelledby',
+            data: null,
+            relatedNodes: [],
+            impact: 'serious',
+            message:
+              'aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty',
+          },
+          {
+            id: 'non-empty-title',
+            data: {
+              messageKey: 'noAttr',
+            },
+            relatedNodes: [],
+            impact: 'serious',
+            message: 'Element has no title attribute',
+          },
+        ],
+        all: [],
+        none: [],
+        impact: 'serious',
+        html: '<div role="button" class="css-12jpz5t">',
+        target: ['.css-12jpz5t'],
+        failureSummary:
+          'Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
+      },
+    ],
+  },
+];
+
+const Template = (args: Pick<A11yContextStore, 'results' | 'error' | 'status' | 'discrepancy'>) => (
   <A11yContext.Provider
     value={{
       handleManual: fn(),
@@ -49,6 +116,7 @@ export const Initializing: Story = {
         results={{ passes: [], incomplete: [], violations: [] }}
         status="initial"
         error={null}
+        discrepancy={null}
       />
     );
   },
@@ -61,6 +129,20 @@ export const Manual: Story = {
         results={{ passes: [], incomplete: [], violations: [] }}
         status="manual"
         error={null}
+        discrepancy={null}
+      />
+    );
+  },
+};
+
+export const ManualWithDiscrepancy: Story = {
+  render: () => {
+    return (
+      <Template
+        results={{ passes: [], incomplete: [], violations: [] }}
+        status="manual"
+        error={null}
+        discrepancy={'cliFailedButModeManual'}
       />
     );
   },
@@ -73,6 +155,7 @@ export const Running: Story = {
         results={{ passes: [], incomplete: [], violations: [] }}
         status="running"
         error={null}
+        discrepancy={null}
       />
     );
   },
@@ -85,73 +168,28 @@ export const ReadyWithResults: Story = {
         results={{
           passes: [],
           incomplete: [],
-          violations: [
-            {
-              id: 'aria-command-name',
-              impact: 'serious',
-              tags: [
-                'cat.aria',
-                'wcag2a',
-                'wcag412',
-                'TTv5',
-                'TT6.a',
-                'EN-301-549',
-                'EN-9.4.1.2',
-                'ACT',
-              ],
-              description: 'Ensures every ARIA button, link and menuitem has an accessible name',
-              help: 'ARIA commands must have an accessible name',
-              helpUrl:
-                'https://dequeuniversity.com/rules/axe/4.8/aria-command-name?application=axeAPI',
-              nodes: [
-                {
-                  any: [
-                    {
-                      id: 'has-visible-text',
-                      data: null,
-                      relatedNodes: [],
-                      impact: 'serious',
-                      message: 'Element does not have text that is visible to screen readers',
-                    },
-                    {
-                      id: 'aria-label',
-                      data: null,
-                      relatedNodes: [],
-                      impact: 'serious',
-                      message: 'aria-label attribute does not exist or is empty',
-                    },
-                    {
-                      id: 'aria-labelledby',
-                      data: null,
-                      relatedNodes: [],
-                      impact: 'serious',
-                      message:
-                        'aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty',
-                    },
-                    {
-                      id: 'non-empty-title',
-                      data: {
-                        messageKey: 'noAttr',
-                      },
-                      relatedNodes: [],
-                      impact: 'serious',
-                      message: 'Element has no title attribute',
-                    },
-                  ],
-                  all: [],
-                  none: [],
-                  impact: 'serious',
-                  html: '<div role="button" class="css-12jpz5t">',
-                  target: ['.css-12jpz5t'],
-                  failureSummary:
-                    'Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
-                },
-              ],
-            },
-          ],
+          violations,
         }}
         status="ready"
         error={null}
+        discrepancy={null}
+      />
+    );
+  },
+};
+
+export const ReadyWithResultsDiscrepancyCLIPassedBrowserFailed: Story = {
+  render: () => {
+    return (
+      <Template
+        results={{
+          passes: [],
+          incomplete: [],
+          violations,
+        }}
+        status="ready"
+        error={null}
+        discrepancy={'cliPassedBrowserFailed'}
       />
     );
   },
@@ -164,6 +202,7 @@ export const Error: Story = {
         results={{ passes: [], incomplete: [], violations: [] }}
         status="error"
         error="Test error message"
+        discrepancy={null}
       />
     );
   },
@@ -176,6 +215,7 @@ export const ErrorStateWithObject: Story = {
         results={{ passes: [], incomplete: [], violations: [] }}
         status="error"
         error={{ message: 'Test error object message' }}
+        discrepancy={null}
       />
     );
   },

--- a/code/addons/a11y/template/stories/TestDiscrepancyMessage.stories.tsx
+++ b/code/addons/a11y/template/stories/TestDiscrepancyMessage.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { ManagerContext } from 'storybook/internal/manager-api';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import { TestDiscrepancyMessage } from '../../src/components/TestDiscrepancyMessage';
+
+type Story = StoryObj<typeof TestDiscrepancyMessage>;
+
+const managerContext: any = {
+  state: {},
+  api: {
+    getDocsUrl: fn().mockName('api::getDocsUrl'),
+  },
+};
+
+export default {
+  title: 'TestDiscrepancyMessage',
+  component: TestDiscrepancyMessage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    storyId: 'story-id',
+  },
+  decorators: [
+    (storyFn) => (
+      <ManagerContext.Provider value={managerContext}>{storyFn()}</ManagerContext.Provider>
+    ),
+  ],
+} as Meta<typeof TestDiscrepancyMessage>;
+
+export const BrowserPassedCliFailed: Story = {
+  args: {
+    discrepancy: 'browserPassedCliFailed',
+  },
+};
+
+export const CliPassedBrowserFailed: Story = {
+  args: {
+    discrepancy: 'cliPassedBrowserFailed',
+  },
+};
+
+export const CliFailedButModeManual: Story = {
+  args: {
+    discrepancy: 'cliFailedButModeManual',
+  },
+};

--- a/code/core/src/manager-api/modules/stories.ts
+++ b/code/core/src/manager-api/modules/stories.ts
@@ -7,6 +7,7 @@ import type {
   API_LeafEntry,
   API_LoadedRefData,
   API_PreparedStoryIndex,
+  API_StatusObject,
   API_StatusState,
   API_StatusUpdate,
   API_StoryEntry,
@@ -268,6 +269,12 @@ export interface SubAPI {
    * @returns {Promise<void>} A promise that resolves when the preview has been set as initialized.
    */
   setPreviewInitialized: (ref?: ComposedRef) => Promise<void>;
+  /**
+   * Returns the current status of the stories.
+   *
+   * @returns {API_StatusState} The current status of the stories.
+   */
+  getCurrentStoryStatus: () => Record<string, API_StatusObject>;
   /**
    * Updates the status of a collection of stories.
    *
@@ -628,6 +635,11 @@ export const init: ModuleFn<SubAPI, SubState> = ({
       } else {
         fullAPI.updateRef(ref.id, { previewInitialized: true });
       }
+    },
+
+    getCurrentStoryStatus: () => {
+      const { status, storyId } = store.getState();
+      return status[storyId as StoryId];
     },
 
     /* EXPERIMENTAL APIs */


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29661-sha-2eebee12`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29661-sha-2eebee12 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29661-sha-2eebee12 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29661-sha-2eebee12`](https://npmjs.com/package/storybook/v/0.0.0-pr-29661-sha-2eebee12) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/add-a11y-discrepancy-handling`](https://github.com/storybookjs/storybook/tree/valentin/add-a11y-discrepancy-handling) |
| **Commit** | [`2eebee12`](https://github.com/storybookjs/storybook/commit/2eebee1264ecfead76a5fd6818f61bad84a2de26) |
| **Datetime** | Tue Nov 19 15:05:09 UTC 2024 (`1732028709`) |
| **Workflow run** | [11915852041](https://github.com/storybookjs/storybook/actions/runs/11915852041) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29661`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added discrepancy handling to the A11YPanel component to detect and display messages when accessibility test results differ between CLI and browser environments.

- Added new `TestDiscrepancyMessage` component in `/code/addons/a11y/src/components/TestDiscrepancyMessage.tsx` to display environment-specific test result differences
- Added `discrepancy` field to A11yContext in `/code/addons/a11y/src/components/A11yContext.tsx` to track test result mismatches
- Added comprehensive test coverage in `/code/addons/a11y/src/components/A11yContext.test.tsx` for discrepancy scenarios
- Added documentation links in `/code/addons/a11y/src/constants.ts` for explaining discrepancy cases
- Added new stories in `/code/addons/a11y/template/stories/TestDiscrepancyMessage.stories.tsx` to showcase different discrepancy states

<!-- /greptile_comment -->