### PR TITLE
Angular: Default to standalone components in Angular v19

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/utils/PropertyExtractor.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/PropertyExtractor.ts
@@ -11,6 +11,7 @@ import {
   Provider,
   ɵReflectionCapabilities as ReflectionCapabilities,
   importProvidersFrom,
+  VERSION,
 } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import {
@@ -176,15 +177,20 @@ export class PropertyExtractor implements NgModuleMetadata {
     const isDeclarable = isComponent || isDirective || isPipe;
 
     // Check if the hierarchically lowest Component or Directive decorator (the only relevant for importing dependencies) is standalone.
-    const isStandalone = !!(
+
+    let isStandalone =
       (isComponent || isDirective) &&
       [...decorators]
         .reverse() // reflectionCapabilities returns decorators in a hierarchically top-down order
         .find(
           (d) =>
             this.isDecoratorInstanceOf(d, 'Component') || this.isDecoratorInstanceOf(d, 'Directive')
-        )?.standalone
-    );
+        )?.standalone;
+
+    //Starting in Angular 19 the default (in case it's undefined) value for standalone is true
+    if (isStandalone === undefined) {
+      isStandalone = !!(VERSION.major && Number(VERSION.major) >= 19);
+    }
 
     return { isDeclarable, isStandalone };
   };


### PR DESCRIPTION
Closes #29671

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.4 MB | 78.4 MB | 0 B | -0.22 | 0% |
| initSize |  144 MB | 144 MB | 0 B | -0.64 | 0% |
| diffSize |  65.1 MB | 65.1 MB | 0 B | -0.83 | 0% |
| buildSize |  6.83 MB | 6.83 MB | 0 B | -1.05 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | -1.09 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.83 MB | 3.83 MB | 0 B | -1.09 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.95 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  15.5s | 6.6s | -8s -879ms | **-1.7** | 🔰-134.1% |
| generateTime |  19.4s | 19.4s | -24ms | -0.55 | -0.1% |
| initTime |  13.3s | 13.1s | -211ms | -1.01 | -1.6% |
| buildTime |  7.7s | 7.5s | -179ms | **-1.33** | -2.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.8s | 7.5s | 1.6s | **2.84** | 🔺22.4% |
| devManagerResponsive |  3.5s | 4.6s | 1.1s | **3.34** | 🔺24% |
| devManagerHeaderVisible |  587ms | 736ms | 149ms | **2.6** | 🔺20.2% |
| devManagerIndexVisible |  668ms | 832ms | 164ms | **2.41** | 🔺19.7% |
| devStoryVisibleUncached |  1.2s | 1.1s | -108ms | 0.54 | -9.5% |
| devStoryVisible |  624ms | 824ms | 200ms | **2.6** | 🔺24.3% |
| devAutodocsVisible |  542ms | 739ms | 197ms | **4.73** | 🔺26.7% |
| devMDXVisible |  701ms | 674ms | -27ms | **2.22** | -4% |
| buildManagerHeaderVisible |  584ms | 850ms | 266ms | **4.68** | 🔺31.3% |
| buildManagerIndexVisible |  603ms | 910ms | 307ms | **5.08** | 🔺33.7% |
| buildStoryVisible |  583ms | 849ms | 266ms | **4.6** | 🔺31.3% |
| buildAutodocsVisible |  479ms | 608ms | 129ms | **2.34** | 🔺21.2% |
| buildMDXVisible |  478ms | 611ms | 133ms | **3.23** | 🔺21.8% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR modifies the standalone component behavior in Angular's PropertyExtractor to align with Angular 19's new default where components are standalone by default unless explicitly specified otherwise.

- Added version check using `VERSION.major` to determine default `isStandalone` value in `PropertyExtractor.analyzeDecorators`
- Set `isStandalone` to `true` by default for Angular >= 19 when undefined
- Set `isStandalone` to `false` by default for Angular < 19 when undefined
- Maintains existing decorator analysis logic for explicitly defined standalone values

<!-- /greptile_comment -->