### PR TITLE
Revert "Build: Add workaround resolution for Angular sandboxes"

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -109,9 +109,6 @@ export const install: Task['run'] = async ({ sandboxDir, key }, { link, dryRun, 
       'svelte-vite/default-ts',
       'vue3-vite/default-js',
       'vue3-vite/default-ts',
-      'angular-cli/15-ts',
-      'angular-cli/default-ts',
-      'angular-cli/prerelease',
     ];
     if (sandboxesNeedingWorkarounds.includes(key)) {
       await addWorkaroundResolutions({ cwd, dryRun, debug });

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -29,7 +29,6 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
   packageJson.resolutions = {
     ...packageJson.resolutions,
     ...storybookVersions,
-    'enhanced-resolve': '~5.10.0', // TODO, remove this
     // this is for our CI test, ensure we use the same version as docker image, it should match version specified in `./code/package.json` and `.circleci/config.yml`
     '@swc/core': '1.5.7',
     playwright: '1.48.1',
@@ -85,8 +84,6 @@ export const addWorkaroundResolutions = async ({ cwd, dryRun }: YarnOptions) => 
     '@testing-library/dom': '^9.3.4',
     '@testing-library/jest-dom': '^6.5.0',
     '@testing-library/user-event': '^14.5.2',
-    // TODO: Remove as soon as @storybook/csf@0.1.10 is released
-    '@storybook/csf': '0.1.10--canary.d841bb4.0',
   };
   await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
 };

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -29,6 +29,7 @@ export const addPackageResolutions = async ({ cwd, dryRun }: YarnOptions) => {
   packageJson.resolutions = {
     ...packageJson.resolutions,
     ...storybookVersions,
+    'enhanced-resolve': '~5.10.0', // TODO, remove this
     // this is for our CI test, ensure we use the same version as docker image, it should match version specified in `./code/package.json` and `.circleci/config.yml`
     '@swc/core': '1.5.7',
     playwright: '1.48.1',
@@ -84,8 +85,8 @@ export const addWorkaroundResolutions = async ({ cwd, dryRun }: YarnOptions) => 
     '@testing-library/dom': '^9.3.4',
     '@testing-library/jest-dom': '^6.5.0',
     '@testing-library/user-event': '^14.5.2',
-    // TODO: Remove this once this issue is fixed https://github.com/thednp/position-observer/issues/1
-    '@thednp/shorty': '2.0.7',
+    // TODO: Remove as soon as @storybook/csf@0.1.10 is released
+    '@storybook/csf': '0.1.10--canary.d841bb4.0',
   };
   await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
 };


### PR DESCRIPTION
Reverts storybookjs/storybook#29690 as it's not needed anymore

<!-- greptile_comment -->

## Greptile Summary

This PR reverts workaround resolutions that were previously added for Angular sandboxes, as they are no longer needed for handling Vite 5 peer dependency errors.

- Removed Angular CLI templates from `sandboxesNeedingWorkarounds` array in `scripts/tasks/sandbox-parts.ts`
- Re-added `enhanced-resolve` resolution (~5.10.0) in `scripts/utils/yarn.ts`
- Replaced `@thednp/shorty` with canary version of `@storybook/csf` in resolutions
- Reverts changes from PR #29690 which originally added these workarounds

<!-- /greptile_comment -->