### PR TITLE
Docs: Set init/upgrade snippets to next on next

### DIFF
--- a/docs/_snippets/init-command.md
+++ b/docs/_snippets/init-command.md
@@ -1,11 +1,11 @@
 ```shell renderer="common" language="js" packageManager="npm"
-npx storybook@latest init
+npx storybook@next init
 ```
 
 ```shell renderer="common" language="js" packageManager="pnpm"
-pnpm dlx storybook@latest init
+pnpm dlx storybook@next init
 ```
 
 ```shell renderer="common" language="js" packageManager="yarn"
-yarn dlx storybook@latest init
+yarn dlx storybook@next init
 ```

--- a/docs/_snippets/storybook-upgrade.md
+++ b/docs/_snippets/storybook-upgrade.md
@@ -1,11 +1,11 @@
 ```shell renderer="common" language="js" packageManager="npm"
-npx storybook@latest upgrade
+npx storybook@next upgrade
 ```
 
 ```shell renderer="common" language="js" packageManager="pnpm"
-pnpm dlx storybook@latest upgrade
+pnpm dlx storybook@next upgrade
 ```
 
 ```shell renderer="common" language="js" packageManager="yarn"
-yarn dlx storybook@latest upgrade
+yarn dlx storybook@next upgrade
 ```


### PR DESCRIPTION
Setting the init/upgrade snippets to `next` so that we can have users test prereleases like `@storybook/react-native-web-vite`. @kylegach / @jonniebigodes we need to add a release checklist item to ensure that these are always `latest` on `main`.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates initialization and upgrade command snippets in documentation to use `@next` tag instead of `@latest`, enabling users to test prerelease versions of Storybook packages.

- Modified `docs/_snippets/init-command.md` to use `@next` tag for npx, pnpm, and yarn initialization commands
- Modified `docs/_snippets/storybook-upgrade.md` to use `@next` tag for upgrade commands across all package managers
- Requires new release checklist item to ensure commands use `@latest` on main branch

<!-- /greptile_comment -->