### PR TITLE
Build: Temporarily downgrade Vite to v5 in sandboxes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -986,22 +986,22 @@ workflows:
           requires:
             - build
       - create-sandboxes:
-          parallelism: 37
+          parallelism: 38
           requires:
             - build
       # - smoke-test-sandboxes: # disabled for now
       #     requires:
       #       - create-sandboxes
       - build-sandboxes:
-          parallelism: 37
+          parallelism: 38
           requires:
             - create-sandboxes
       - chromatic-sandboxes:
-          parallelism: 34
+          parallelism: 35
           requires:
             - build-sandboxes
       - e2e-production:
-          parallelism: 32
+          parallelism: 33
           requires:
             - build-sandboxes
       - e2e-dev:
@@ -1009,7 +1009,7 @@ workflows:
           requires:
             - create-sandboxes
       - test-runner-production:
-          parallelism: 32
+          parallelism: 33
           requires:
             - build-sandboxes
       - vitest-integration:

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -853,8 +853,7 @@ export const daily: TemplateKey[] = [
   'html-vite/default-js',
   'internal/react16-webpack',
   'internal/react18-webpack-babel',
-  // TODO: bring this back once ts-docgen supports Vite 6
-  // 'react-native-web-vite/expo-ts',
+  'react-native-web-vite/expo-ts',
   // 'react-native-web-vite/rn-cli-ts',
 ];
 

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -109,9 +109,10 @@ export const install: Task['run'] = async ({ sandboxDir, key }, { link, dryRun, 
       'svelte-vite/default-ts',
       'vue3-vite/default-js',
       'vue3-vite/default-ts',
+      'svelte-kit/skeleton-ts',
     ];
-    if (sandboxesNeedingWorkarounds.includes(key)) {
-      await addWorkaroundResolutions({ cwd, dryRun, debug });
+    if (sandboxesNeedingWorkarounds.includes(key) || key.includes('vite')) {
+      await addWorkaroundResolutions({ cwd, dryRun, debug, key });
     }
 
     await exec(

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -67,7 +67,11 @@ export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
   );
 };
 
-export const addWorkaroundResolutions = async ({ cwd, dryRun }: YarnOptions) => {
+export const addWorkaroundResolutions = async ({
+  cwd,
+  dryRun,
+  key,
+}: YarnOptions & { key?: TemplateKey }) => {
   logger.info(`🔢 Adding resolutions for workarounds`);
 
   if (dryRun) {
@@ -81,10 +85,19 @@ export const addWorkaroundResolutions = async ({ cwd, dryRun }: YarnOptions) => 
     // Due to our support of older vite versions
     '@vitejs/plugin-react': '4.2.0',
     '@vitejs/plugin-vue': '4.5.0',
+    // TODO: Remove this once we figure out how to properly test Vite 4, 5 and 6 in our sandboxes
+    vite: '^5.0.0',
+    // We need to downgrade the plugin so that it works with Vite 5 projects
+    '@sveltejs/vite-plugin-svelte': '4.0.2',
     '@testing-library/dom': '^9.3.4',
     '@testing-library/jest-dom': '^6.5.0',
     '@testing-library/user-event': '^14.5.2',
   };
+
+  if (key.includes('svelte-kit')) {
+    packageJson.resolutions['@sveltejs/vite-plugin-svelte'] = '^3.0.0';
+  }
+
   await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
 };
 


### PR DESCRIPTION
This reverts commit bb0fd7e.Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | **-1.53** | 0% |
| initSize |  143 MB | 143 MB | 0 B | **-1.52** | 0% |
| diffSize |  65.2 MB | 65.2 MB | 0 B | **1.42** | 0% |
| buildSize |  6.83 MB | 6.83 MB | 0 B | 0.91 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | **1.65** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 0.49 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | **1.65** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.84 MB | 3.84 MB | 0 B | 0.9 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.9 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  26.1s | 13.3s | -12s -848ms | -0.31 | -96.4% |
| generateTime |  22.8s | 20.5s | -2s -324ms | -0.19 | -11.3% |
| initTime |  16.1s | 15.2s | -906ms | -0.02 | -5.9% |
| buildTime |  8.8s | 7.6s | -1s -266ms | -1.1 | -16.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.1s | 5.9s | -191ms | -0.07 | -3.2% |
| devManagerResponsive |  3.8s | 4s | 224ms | 0.52 | 5.5% |
| devManagerHeaderVisible |  495ms | 627ms | 132ms | -0.03 | 21.1% |
| devManagerIndexVisible |  523ms | 700ms | 177ms | 0 | 25.3% |
| devStoryVisibleUncached |  876ms | 1.3s | 503ms | 0.36 | 36.5% |
| devStoryVisible |  522ms | 655ms | 133ms | -0.18 | 20.3% |
| devAutodocsVisible |  464ms | 387ms | -77ms | -0.91 | -19.9% |
| devMDXVisible |  435ms | 537ms | 102ms | -0.28 | 19% |
| buildManagerHeaderVisible |  488ms | 589ms | 101ms | -0.24 | 17.1% |
| buildManagerIndexVisible |  511ms | 616ms | 105ms | -0.21 | 17% |
| buildStoryVisible |  486ms | 587ms | 101ms | -0.25 | 17.2% |
| buildAutodocsVisible |  417ms | 491ms | 74ms | -0.21 | 15.1% |
| buildMDXVisible |  392ms | 492ms | 100ms | -0.19 | 20.3% |

<!-- BENCHMARK_SECTION -->
This reverts commit bb0fd7e.This reverts commit bb0fd7e.