### PR TITLE
React: Upgrade react-docgen-typescript to support Vite 6

### DIFF
--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -53,7 +53,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.0",
+    "@joshwooding/vite-plugin-react-docgen-typescript": "0.4.2",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -47,7 +47,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.0",
+    "@joshwooding/vite-plugin-react-docgen-typescript": "0.4.2",
     "@rollup/pluginutils": "^5.0.2",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -4041,21 +4041,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.0":
-  version: 0.3.0
-  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.3.0"
+"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.4.2"
   dependencies:
-    glob: "npm:^7.2.0"
-    glob-promise: "npm:^4.2.0"
     magic-string: "npm:^0.27.0"
     react-docgen-typescript: "npm:^2.2.2"
   peerDependencies:
     typescript: ">= 4.3.x"
-    vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+    vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/31098ad8fcc2440437534599c111d9f2951dd74821e8ba46c521b969bae4c918d830b7bb0484efbad29a51711bb62d3bc623d5a1ed5b1695b5b5594ea9dd4ca0
+  checksum: 10c0/355d13ad92a9da786b561a25250e6c94a8e51d235ced345e54ebfe709abc45ab60c2a8d06599df6ec0441fba01720f189883429943cb62dff9a4c31b59f0939c
   languageName: node
   linkType: hard
 
@@ -7099,7 +7097,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/react-native-web-vite@workspace:frameworks/react-native-web-vite"
   dependencies:
-    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.3.0"
+    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.4.2"
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": "workspace:*"
     "@storybook/react-vite": "workspace:*"
@@ -7120,7 +7118,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/react-vite@workspace:frameworks/react-vite"
   dependencies:
-    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.3.0"
+    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.4.2"
     "@rollup/pluginutils": "npm:^5.0.2"
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": "workspace:*"
@@ -8292,7 +8290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/glob@npm:^7.1.1, @types/glob@npm:^7.1.3":
+"@types/glob@npm:^7.1.1":
   version: 7.2.0
   resolution: "@types/glob@npm:7.2.0"
   dependencies:
@@ -16676,17 +16674,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-promise@npm:^4.2.0":
-  version: 4.2.2
-  resolution: "glob-promise@npm:4.2.2"
-  dependencies:
-    "@types/glob": "npm:^7.1.3"
-  peerDependencies:
-    glob: ^7.1.6
-  checksum: 10c0/3eb01bed2901539365df6a4d27800afb8788840647d01f9bf3500b3de756597f2ff4b8c823971ace34db228c83159beca459dc42a70968d4e9c8200ed2cc96bd
-  languageName: node
-  linkType: hard
-
 "glob-to-regexp@npm:^0.4.1":
   version: 0.4.1
   resolution: "glob-to-regexp@npm:0.4.1"
@@ -16723,7 +16710,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.2.0":
+"glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -109,10 +109,9 @@ export const install: Task['run'] = async ({ sandboxDir, key }, { link, dryRun, 
       'svelte-vite/default-ts',
       'vue3-vite/default-js',
       'vue3-vite/default-ts',
-      'svelte-kit/skeleton-ts',
     ];
     if (sandboxesNeedingWorkarounds.includes(key) || key.includes('vite')) {
-      await addWorkaroundResolutions({ cwd, dryRun, debug, key });
+      await addWorkaroundResolutions({ cwd, dryRun, debug });
     }
 
     await exec(

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -70,7 +70,6 @@ export const installYarn2 = async ({ cwd, dryRun, debug }: YarnOptions) => {
 export const addWorkaroundResolutions = async ({
   cwd,
   dryRun,
-  key,
 }: YarnOptions & { key?: TemplateKey }) => {
   logger.info(`🔢 Adding resolutions for workarounds`);
 
@@ -82,21 +81,10 @@ export const addWorkaroundResolutions = async ({
   const packageJson = await readJSON(packageJsonPath);
   packageJson.resolutions = {
     ...packageJson.resolutions,
-    // Due to our support of older vite versions
-    '@vitejs/plugin-react': '4.2.0',
-    '@vitejs/plugin-vue': '4.5.0',
-    // TODO: Remove this once we figure out how to properly test Vite 4, 5 and 6 in our sandboxes
-    vite: '^5.0.0',
-    // We need to downgrade the plugin so that it works with Vite 5 projects
-    '@sveltejs/vite-plugin-svelte': '4.0.2',
     '@testing-library/dom': '^9.3.4',
     '@testing-library/jest-dom': '^6.5.0',
     '@testing-library/user-event': '^14.5.2',
   };
-
-  if (key?.includes('svelte-kit')) {
-    packageJson.resolutions['@sveltejs/vite-plugin-svelte'] = '^3.0.0';
-  }
 
   await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
 };


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This will only pass once https://github.com/joshwooding/vite-plugin-react-docgen-typescript/pull/40 is released

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 17.2 kB | -0.77 | 0% |
| initSize |  143 MB | 130 MB | -12.8 MB | **-37.86** | 🔰-9.8% |
| diffSize |  65.2 MB | 52.4 MB | -12.8 MB | **-582.97** | 🔰-24.4% |
| buildSize |  6.83 MB | 6.83 MB | 953 B | **2.72** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 1.02 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **1.3** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | 0.9 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.84 MB | 3.84 MB | 0 B | **1.24** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 953 B | **27.33** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  18.3s | 11.9s | -6s -489ms | -0.58 | -54.5% |
| generateTime |  24s | 24s | -60ms | 0.49 | -0.2% |
| initTime |  15.1s | 16.2s | 1.1s | 0.21 | 6.8% |
| buildTime |  11.2s | 8.3s | -2s -910ms | -0.52 | -34.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.1s | 5.2s | -897ms | -0.67 | -17.2% |
| devManagerResponsive |  3.6s | 3.9s | 214ms | 0.28 | 5.5% |
| devManagerHeaderVisible |  634ms | 643ms | 9ms | 0.12 | 1.4% |
| devManagerIndexVisible |  657ms | 713ms | 56ms | 0.17 | 7.9% |
| devStoryVisibleUncached |  1s | 1.9s | 952ms | **1.29** | 🔺48.8% |
| devStoryVisible |  655ms | 711ms | 56ms | 0.21 | 7.9% |
| devAutodocsVisible |  510ms | 525ms | 15ms | -0.07 | 2.9% |
| devMDXVisible |  591ms | 569ms | -22ms | -0.02 | -3.9% |
| buildManagerHeaderVisible |  511ms | 539ms | 28ms | -0.36 | 5.2% |
| buildManagerIndexVisible |  523ms | 562ms | 39ms | -0.34 | 6.9% |
| buildStoryVisible |  513ms | 540ms | 27ms | -0.35 | 5% |
| buildAutodocsVisible |  450ms | 596ms | 146ms | 0.59 | 24.5% |
| buildMDXVisible |  446ms | 457ms | 11ms | -0.3 | 2.4% |

<!-- BENCHMARK_SECTION -->
