### PR TITLE
Svelte: Support `@sveltejs/vite-plugin-svelte` v5

### DIFF
--- a/code/frameworks/svelte-vite/package.json
+++ b/code/frameworks/svelte-vite/package.json
@@ -64,7 +64,7 @@
     "vite": "^4.0.0"
   },
   "peerDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "@sveltejs/vite-plugin-svelte": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
     "storybook": "workspace:^",
     "svelte": "^4.0.0 || ^5.0.0",
     "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7430,7 +7430,7 @@ __metadata:
     typescript: "npm:^5.3.2"
     vite: "npm:^4.0.0"
   peerDependencies:
-    "@sveltejs/vite-plugin-svelte": ^2.0.0 || ^3.0.0 || ^4.0.0
+    "@sveltejs/vite-plugin-svelte": ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
     storybook: "workspace:^"
     svelte: ^4.0.0 || ^5.0.0
     vite: ^4.0.0 || ^5.0.0 || ^6.0.0

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -89,7 +89,7 @@ export const install: Task['run'] = async ({ sandboxDir, key }, { link, dryRun, 
       dryRun,
       debug,
     });
-    await addWorkaroundResolutions({ cwd, dryRun, debug });
+    await addWorkaroundResolutions({ cwd, dryRun, debug, key });
   } else {
     // We need to add package resolutions to ensure that we only ever install the latest version
     // of any storybook packages as verdaccio is not able to both proxy to npm and publish over

--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -94,7 +94,7 @@ export const addWorkaroundResolutions = async ({
     '@testing-library/user-event': '^14.5.2',
   };
 
-  if (key.includes('svelte-kit')) {
+  if (key?.includes('svelte-kit')) {
     packageJson.resolutions['@sveltejs/vite-plugin-svelte'] = '^3.0.0';
   }
 


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

Related: https://github.com/storybookjs/addon-svelte-csf/pull/237

## What I did

Broaden peer dependency range to support the recently released v5 of `@sveltejs/vite-plugin-svelte`
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | -0.9 | 0% |
| initSize |  143 MB | 143 MB | 0 B | -0.9 | 0% |
| diffSize |  65.2 MB | 65.2 MB | 0 B | 0.96 | 0% |
| buildSize |  6.83 MB | 6.83 MB | 0 B | **1.53** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 1.12 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **1.42** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | 0.99 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.84 MB | 3.84 MB | 0 B | **1.37** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **4.31** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  22.5s | 14.2s | -8s -306ms | -0.31 | -58.4% |
| generateTime |  22.4s | 22.2s | -233ms | 0.15 | -1% |
| initTime |  16s | 13.7s | -2s -308ms | -0.31 | -16.8% |
| buildTime |  8.8s | 8.2s | -597ms | -0.56 | -7.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.8s | 5.1s | -640ms | -0.73 | -12.4% |
| devManagerResponsive |  3.3s | 3.5s | 138ms | -0.35 | 3.9% |
| devManagerHeaderVisible |  517ms | 540ms | 23ms | -0.42 | 4.3% |
| devManagerIndexVisible |  588ms | 610ms | 22ms | -0.36 | 3.6% |
| devStoryVisibleUncached |  923ms | 1.1s | 221ms | 0.06 | 19.3% |
| devStoryVisible |  587ms | 608ms | 21ms | -0.32 | 3.5% |
| devAutodocsVisible |  489ms | 481ms | -8ms | -0.32 | -1.7% |
| devMDXVisible |  470ms | 471ms | 1ms | -0.51 | 0.2% |
| buildManagerHeaderVisible |  478ms | 509ms | 31ms | -0.54 | 6.1% |
| buildManagerIndexVisible |  492ms | 521ms | 29ms | -0.57 | 5.6% |
| buildStoryVisible |  473ms | 508ms | 35ms | -0.53 | 6.9% |
| buildAutodocsVisible |  420ms | 439ms | 19ms | -0.44 | 4.3% |
| buildMDXVisible |  391ms | 441ms | 50ms | -0.43 | 11.3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates peer dependency range for @sveltejs/vite-plugin-svelte to include version 5.0.0 and adds sandbox configuration support for Vite 5 compatibility in Svelte templates.

- Updated peerDependencies to include `^5.0.0` for `@sveltejs/vite-plugin-svelte` in `code/frameworks/svelte-vite/package.json`
- Added Svelte templates (`svelte-vite/default-js`, `svelte-vite/default-ts`, `svelte-kit/skeleton-ts`) to `sandboxesNeedingWorkarounds` array
- Added key parameter to `addWorkaroundResolutions` function for sandbox-specific handling
- Extended Vite workarounds to all Vite-based templates via `key.includes('vite')` check



<sub>💡 (3/5) Reply to the bot's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->