### PR TITLE
Portable stories: Support multiple annotation notations from preview

### DIFF
--- a/code/core/src/preview-api/modules/store/csf/portable-stories.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.test.ts
@@ -77,6 +77,25 @@ describe('composeStory', () => {
     expect(composedStory.parameters.fromAnnotations.asDefaultImport).toEqual(true);
   });
 
+  it('should compose project annotations when used in named and default exports from the same module', () => {
+    setProjectAnnotations([
+      {
+        initialGlobals: { namedExportAnnotation: true },
+        default: {
+          parameters: { defaultExportAnnotation: true },
+        },
+      },
+    ]);
+
+    const Story: Story = {
+      render: () => {},
+    };
+
+    const composedStory = composeStory(Story, meta);
+    expect(composedStory.parameters.defaultExportAnnotation).toEqual(true);
+    expect(composedStory.globals.namedExportAnnotation).toEqual(true);
+  });
+
   it('should return story with composed annotations from story, meta and project', () => {
     const decoratorFromProjectAnnotations = vi.fn((StoryFn) => StoryFn());
     const decoratorFromStoryAnnotations = vi.fn((StoryFn) => StoryFn());

--- a/code/core/src/preview-api/modules/store/csf/portable-stories.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.ts
@@ -61,11 +61,8 @@ function extractAnnotation<TRenderer extends Renderer = Renderer>(
   // import * as annotations from '.storybook/preview'
   // import annotations from '.storybook/preview'
   // in both cases: 1 - the file has a default export; 2 - named exports only
-  // support imports such as
-  // import * as annotations from '.storybook/preview'
-  // import annotations from '.storybook/preview'
-  // in both cases: 1 - the file has a default export; 2 - named exports only
-  return 'default' in annotation ? annotation.default : annotation;
+  // also support when the file has both annotations coming from default and named exports
+  return composeConfigs([annotation]);
 }
 
 export function setProjectAnnotations<TRenderer extends Renderer = Renderer>(


### PR DESCRIPTION
Closes #29732

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR makes it so that portable stories use the same mechanism as Storybook when loading annotations. This allows for supporting both notations at the same time coming from the preview file.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | -0.82 | 0% |
| initSize |  143 MB | 143 MB | -69 B | -0.81 | 0% |
| diffSize |  65.2 MB | 65.2 MB | -69 B | 0.86 | 0% |
| buildSize |  6.83 MB | 6.83 MB | -59 B | **1.3** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | -36 B | 0.77 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **1.3** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | -23 B | 0.66 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.84 MB | 3.84 MB | -59 B | 1.16 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **2.99** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  18.3s | 7s | -11s -353ms | -1.21 | -161.2% |
| generateTime |  24s | 19.4s | -4s -654ms | -0.39 | -24% |
| initTime |  15.1s | 14.7s | -351ms | -0.1 | -2.4% |
| buildTime |  11.2s | 8s | -3s -245ms | -0.94 | -40.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.1s | 5.8s | -288ms | -0.12 | -4.9% |
| devManagerResponsive |  3.6s | 3.4s | -205ms | -0.35 | -5.9% |
| devManagerHeaderVisible |  634ms | 620ms | -14ms | 0 | -2.3% |
| devManagerIndexVisible |  657ms | 654ms | -3ms | -0.13 | -0.5% |
| devStoryVisibleUncached |  1s | 983ms | -17ms | -0.16 | -1.7% |
| devStoryVisible |  655ms | 652ms | -3ms | -0.09 | -0.5% |
| devAutodocsVisible |  510ms | 580ms | 70ms | 0.23 | 12.1% |
| devMDXVisible |  591ms | 553ms | -38ms | -0.1 | -6.9% |
| buildManagerHeaderVisible |  511ms | 549ms | 38ms | -0.31 | 6.9% |
| buildManagerIndexVisible |  523ms | 569ms | 46ms | -0.3 | 8.1% |
| buildStoryVisible |  513ms | 548ms | 35ms | -0.31 | 6.4% |
| buildAutodocsVisible |  450ms | 456ms | 6ms | -0.31 | 1.3% |
| buildMDXVisible |  446ms | 412ms | -34ms | -0.57 | -8.3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhanced portable stories to support simultaneous handling of both named and default export annotations from preview files, matching Storybook's core behavior.

- Modified `code/core/src/preview-api/modules/store/csf/portable-stories.ts` to use `composeConfigs` for combining all module annotations
- Added test cases in `portable-stories.test.ts` to verify proper merging of named exports (e.g. `initialGlobals`) and default exports (e.g. `parameters`)
- Fixed issue #29732 where annotations were being ignored when using both export types
- Maintains backward compatibility while supporting the dual annotation pattern



<!-- /greptile_comment -->