### PR TITLE
Telemetry: Improve anonymous id calculation

### DIFF
--- a/code/core/src/telemetry/anonymous-id.test.ts
+++ b/code/core/src/telemetry/anonymous-id.test.ts
@@ -93,6 +93,13 @@ describe('normalizeGitUrl', () => {
 });
 
 describe('unhashedProjectId', () => {
+    it('does not touch unix paths', () => {
+    expect(
+      unhashedProjectId('https://github.com/storybookjs/storybook.git\n', 'path/to/storybook')
+    ).toBe('github.com/storybookjs/storybook.gitpath/to/storybook');
+  });
+
+
   it('normalizes windows paths', () => {
     expect(
       unhashedProjectId('https://github.com/storybookjs/storybook.git\n', 'path\\to\\storybook')

--- a/code/core/src/telemetry/anonymous-id.test.ts
+++ b/code/core/src/telemetry/anonymous-id.test.ts
@@ -93,12 +93,11 @@ describe('normalizeGitUrl', () => {
 });
 
 describe('unhashedProjectId', () => {
-    it('does not touch unix paths', () => {
+  it('does not touch unix paths', () => {
     expect(
       unhashedProjectId('https://github.com/storybookjs/storybook.git\n', 'path/to/storybook')
     ).toBe('github.com/storybookjs/storybook.gitpath/to/storybook');
   });
-
 
   it('normalizes windows paths', () => {
     expect(

--- a/code/core/src/telemetry/anonymous-id.test.ts
+++ b/code/core/src/telemetry/anonymous-id.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeGitUrl } from './anonymous-id';
+import { normalizeGitUrl, unhashedProjectId } from './anonymous-id';
 
 describe('normalizeGitUrl', () => {
   it('trims off https://', () => {
@@ -69,6 +69,12 @@ describe('normalizeGitUrl', () => {
     );
   });
 
+  it('adds .git if missing', () => {
+    expect(normalizeGitUrl('https://github.com/storybookjs/storybook')).toEqual(
+      'github.com/storybookjs/storybook.git'
+    );
+  });
+
   it('trims off #hash', () => {
     expect(normalizeGitUrl('https://github.com/storybookjs/storybook.git#next')).toEqual(
       'github.com/storybookjs/storybook.git'
@@ -83,5 +89,13 @@ describe('normalizeGitUrl', () => {
     expect(normalizeGitUrl('https://github.com/storybookjs/storybook.git\n')).toEqual(
       'github.com/storybookjs/storybook.git'
     );
+  });
+});
+
+describe('unhashedProjectId', () => {
+  it('normalizes windows paths', () => {
+    expect(
+      unhashedProjectId('https://github.com/storybookjs/storybook.git\n', 'path\\to\\storybook')
+    ).toBe('github.com/storybookjs/storybook.gitpath/to/storybook');
   });
 });

--- a/code/deprecated/telemetry/package.json
+++ b/code/deprecated/telemetry/package.json
@@ -38,6 +38,9 @@
     "*.cjs",
     "*.d.ts"
   ],
+  "devDependencies": {
+    "slash": "^5.0.0"
+  },
   "peerDependencies": {
     "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
   },

--- a/code/deprecated/telemetry/package.json
+++ b/code/deprecated/telemetry/package.json
@@ -38,9 +38,6 @@
     "*.cjs",
     "*.d.ts"
   ],
-  "devDependencies": {
-    "slash": "^5.0.0"
-  },
   "peerDependencies": {
     "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
   },


### PR DESCRIPTION
- Paths were not stable between windows + unix
- Remote URLs can be specified without the `.git` extension

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29736-sha-1cc488e7`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29736-sha-1cc488e7 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29736-sha-1cc488e7 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29736-sha-1cc488e7`](https://npmjs.com/package/storybook/v/0.0.0-pr-29736-sha-1cc488e7) |
| **Triggered by** | @tmeasday |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`tmeasday/anonymous-id-tweaks`](https://github.com/storybookjs/storybook/tree/tmeasday/anonymous-id-tweaks) |
| **Commit** | [`1cc488e7`](https://github.com/storybookjs/storybook/commit/1cc488e7e065bb02017a781112d2f6cda00f44ab) |
| **Datetime** | Fri Nov 29 03:14:35 UTC 2024 (`1732850075`) |
| **Workflow run** | [12078375772](https://github.com/storybookjs/storybook/actions/runs/12078375772) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29736`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 222 B | -0.61 | 0% |
| initSize |  130 MB | 130 MB | 767 B | **-2.99** | 0% |
| diffSize |  52.4 MB | 52.4 MB | 545 B | **-3** | 0% |
| buildSize |  6.83 MB | 6.83 MB | 59 B | **1.91** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 36 B | 0.86 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 1.11 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 23 B | 0.76 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.84 MB | 3.84 MB | 59 B | 1.05 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **2.98** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.7s | 17.5s | 8.8s | 0.32 | 50.4% |
| generateTime |  28.8s | 19.7s | -9s -149ms | -0.47 | -46.4% |
| initTime |  19.7s | 15.6s | -4s -95ms | 0 | -26.2% |
| buildTime |  10s | 8.7s | -1s -234ms | -0.15 | -14% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.4s | 5.1s | 708ms | -0.59 | 13.7% |
| devManagerResponsive |  3.3s | 3.8s | 548ms | 0.25 | 14.2% |
| devManagerHeaderVisible |  539ms | 532ms | -7ms | -0.47 | -1.3% |
| devManagerIndexVisible |  601ms | 590ms | -11ms | -0.45 | -1.9% |
| devStoryVisibleUncached |  1.7s | 1.8s | 65ms | 0.98 | 3.5% |
| devStoryVisible |  566ms | 559ms | -7ms | -0.55 | -1.3% |
| devAutodocsVisible |  493ms | 604ms | 111ms | 0.33 | 18.4% |
| devMDXVisible |  482ms | 609ms | 127ms | 0.19 | 20.9% |
| buildManagerHeaderVisible |  476ms | 523ms | 47ms | -0.38 | 9% |
| buildManagerIndexVisible |  486ms | 545ms | 59ms | -0.36 | 10.8% |
| buildStoryVisible |  470ms | 522ms | 52ms | -0.38 | 10% |
| buildAutodocsVisible |  417ms | 449ms | 32ms | -0.3 | 7.1% |
| buildMDXVisible |  387ms | 424ms | 37ms | -0.41 | 8.7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Improved anonymous ID calculation in Storybook's telemetry by normalizing paths across operating systems and standardizing git remote URL handling.

- Added path normalization using `slash` library in `code/core/src/telemetry/anonymous-id.ts` for consistent IDs between Windows and Unix
- Added automatic `.git` extension appending in `normalizeGitUrl()` for remote URLs missing the extension
- Added comprehensive test coverage in `anonymous-id.test.ts` for URL normalization and cross-platform path handling
- Extracted `unhashedProjectId` function for better testability and cleaner code organization



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->