### PR TITLE
ReactVite: Add `@storybook/test` as optional peer dependency

### DIFF
--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -63,10 +63,16 @@
     "vite": "^4.0.0"
   },
   "peerDependencies": {
+    "@storybook/test": "workspace:*",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
     "storybook": "workspace:^",
     "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@storybook/test": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7133,10 +7133,14 @@ __metadata:
     typescript: "npm:^5.3.2"
     vite: "npm:^4.0.0"
   peerDependencies:
+    "@storybook/test": "workspace:*"
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     storybook: "workspace:^"
     vite: ^4.0.0 || ^5.0.0 || ^6.0.0
+  peerDependenciesMeta:
+    "@storybook/test":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Closes #29169

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

`@storybook/react` has a peer dependency of `@storybook/test`, however, `@storybook/react-vite`, which has a direct dependency of `@storybook/react`, doesn't have a peer dependency of `@storybook/test`, thus breaking this chain.

This PR tries to fix that chain.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29754-sha-834368b9`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29754-sha-834368b9 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29754-sha-834368b9 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29754-sha-834368b9`](https://npmjs.com/package/storybook/v/0.0.0-pr-29754-sha-834368b9) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/fix-npm-resolution-error`](https://github.com/storybookjs/storybook/tree/yann/fix-npm-resolution-error) |
| **Commit** | [`834368b9`](https://github.com/storybookjs/storybook/commit/834368b965d9aa9710a6f71fab7ea20f32dc8005) |
| **Datetime** | Fri Nov 29 16:25:11 UTC 2024 (`1732897511`) |
| **Workflow run** | [12087989373](https://github.com/storybookjs/storybook/actions/runs/12087989373) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29754`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | -0.46 | 0% |
| initSize |  130 MB | 130 MB | 128 B | **-2** | 0% |
| diffSize |  52.4 MB | 52.4 MB | 128 B | **-2** | 0% |
| buildSize |  6.83 MB | 6.83 MB | 0 B | **1.63** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.49 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **1.33** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | 0.4 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.84 MB | 3.84 MB | 0 B | 1.11 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **1.99** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  13.2s | 23.8s | 10.6s | 1.22 | 44.5% |
| generateTime |  26.5s | 23.3s | -3s -176ms | 0.11 | -13.6% |
| initTime |  16.7s | 15.3s | -1s -364ms | -0.12 | -8.9% |
| buildTime |  10.9s | 10.4s | -489ms | **1.61** | -4.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.7s | 5.2s | 464ms | -0.43 | 8.9% |
| devManagerResponsive |  3.3s | 3.7s | 339ms | 0.05 | 9.2% |
| devManagerHeaderVisible |  599ms | 582ms | -17ms | -0.14 | -2.9% |
| devManagerIndexVisible |  627ms | 606ms | -21ms | -0.31 | -3.5% |
| devStoryVisibleUncached |  1.6s | 1.2s | -427ms | -0.01 | -35.6% |
| devStoryVisible |  626ms | 605ms | -21ms | -0.27 | -3.5% |
| devAutodocsVisible |  575ms | 557ms | -18ms | 0.07 | -3.2% |
| devMDXVisible |  565ms | 470ms | -95ms | -0.45 | -20.2% |
| buildManagerHeaderVisible |  626ms | 537ms | -89ms | -0.29 | -16.6% |
| buildManagerIndexVisible |  633ms | 547ms | -86ms | -0.33 | -15.7% |
| buildStoryVisible |  619ms | 532ms | -87ms | -0.31 | -16.4% |
| buildAutodocsVisible |  509ms | 479ms | -30ms | -0.04 | -6.3% |
| buildMDXVisible |  530ms | 524ms | -6ms | 0.27 | -1.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added @storybook/test as an optional peer dependency to @storybook/react-vite to fix dependency chain resolution with @storybook/react.

- Added `@storybook/test` to `peerDependencies` in `code/frameworks/react-vite/package.json`
- Added `@storybook/test` to `peerDependenciesMeta` as optional in `code/frameworks/react-vite/package.json`
- Uses `workspace:*` version specifier consistent with other internal dependencies



<!-- /greptile_comment -->