### PR TITLE
RNW-Vite: Add built-in Flow support

### DIFF
--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -53,6 +53,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
+    "@bunchtogether/vite-plugin-flow": "^1.0.2",
     "@joshwooding/vite-plugin-react-docgen-typescript": "0.4.2",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",

--- a/code/frameworks/react-native-web-vite/src/preset.ts
+++ b/code/frameworks/react-native-web-vite/src/preset.ts
@@ -90,7 +90,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
   return mergeConfig(reactConfig, {
     optimizeDeps: {
       esbuildOptions: {
-        plugins: [esbuildFlowPlugin()],
+        plugins: [esbuildFlowPlugin(new RegExp(/\.(flow|jsx?)$/), (_path: string) => 'jsx')],
       },
     },
   } satisfies InlineConfig);

--- a/code/frameworks/react-native-web-vite/src/preset.ts
+++ b/code/frameworks/react-native-web-vite/src/preset.ts
@@ -1,8 +1,9 @@
 // @ts-expect-error FIXME
 import { viteFinal as reactViteFinal } from '@storybook/react-vite/preset';
 
+import { esbuildFlowPlugin, flowPlugin } from '@bunchtogether/vite-plugin-flow';
 import react from '@vitejs/plugin-react';
-import type { PluginOption } from 'vite';
+import type { InlineConfig, PluginOption } from 'vite';
 
 import type { FrameworkOptions, StorybookConfig } from './types';
 
@@ -61,13 +62,19 @@ export function reactNativeWeb(): PluginOption {
 }
 
 export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) => {
+  const { mergeConfig } = await import('vite');
+
   const { pluginReactOptions = {} } =
     await options.presets.apply<FrameworkOptions>('frameworkOptions');
 
   const reactConfig = await reactViteFinal(config, options);
+
   const { plugins = [] } = reactConfig;
 
   plugins.unshift(
+    flowPlugin({
+      exclude: [],
+    }),
     react({
       babel: {
         babelrc: false,
@@ -77,9 +84,16 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
       ...pluginReactOptions,
     })
   );
+
   plugins.push(reactNativeWeb());
 
-  return reactConfig;
+  return mergeConfig(reactConfig, {
+    optimizeDeps: {
+      esbuildOptions: {
+        plugins: [esbuildFlowPlugin()],
+      },
+    },
+  } satisfies InlineConfig);
 };
 
 export const core = {

--- a/code/frameworks/react-native-web-vite/src/typings.d.ts
+++ b/code/frameworks/react-native-web-vite/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module '@bunchtogether/vite-plugin-flow';

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2501,6 +2501,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bunchtogether/vite-plugin-flow@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@bunchtogether/vite-plugin-flow@npm:1.0.2"
+  dependencies:
+    flow-remove-types: "npm:^2.158.0"
+    rollup-pluginutils: "npm:^2.8.2"
+  checksum: 10c0/84faf014977196470bbeae686b4e167de2805777389f8a0da88647484df7cf39db3da91907d75ea810ea77175c0cdd40a9a3ad92b7c7c44681b0cd1f4156c7b8
+  languageName: node
+  linkType: hard
+
 "@bundled-es-modules/cookie@npm:^2.0.0":
   version: 2.0.0
   resolution: "@bundled-es-modules/cookie@npm:2.0.0"
@@ -7099,6 +7109,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/react-native-web-vite@workspace:frameworks/react-native-web-vite"
   dependencies:
+    "@bunchtogether/vite-plugin-flow": "npm:^1.0.2"
     "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.4.2"
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": "workspace:*"
@@ -15317,6 +15328,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "estree-walker@npm:0.6.1"
+  checksum: 10c0/6dabc855faa04a1ffb17b6a9121b6008ba75ab5a163ad9dc3d7fca05cfda374c5f5e91418d783496620ca75e99a73c40874d8b75f23b4117508cc8bde78e7b41
+  languageName: node
+  linkType: hard
+
 "estree-walker@npm:^2.0.1, estree-walker@npm:^2.0.2":
   version: 2.0.2
   resolution: "estree-walker@npm:2.0.2"
@@ -16025,6 +16043,20 @@ __metadata:
   version: 0.217.2
   resolution: "flow-parser@npm:0.217.2"
   checksum: 10c0/d61127283db052fddf8275b070eea76dda5d2926aea3d8659250e168d69478f4ebdbc2bede83aa05c29f464c420ce1d701691278d3041af0492bfc16193277b5
+  languageName: node
+  linkType: hard
+
+"flow-remove-types@npm:^2.158.0":
+  version: 2.255.0
+  resolution: "flow-remove-types@npm:2.255.0"
+  dependencies:
+    hermes-parser: "npm:0.25.1"
+    pirates: "npm:^3.0.2"
+    vlq: "npm:^0.2.1"
+  bin:
+    flow-node: flow-node
+    flow-remove-types: flow-remove-types
+  checksum: 10c0/080cfab76259e313ac77ebd911528fdc9423446d0c4503b95c9f0beb57fde1143657ac3388110382ddbfdb9b7e8ebc20fe903b14a7de374f53d44d6365e26ae1
   languageName: node
   linkType: hard
 
@@ -17248,6 +17280,22 @@ __metadata:
   dependencies:
     rsvp: "npm:~3.2.1"
   checksum: 10c0/20c9d9cce7983683a6423720387af0701de8c50660734899bf68a2d862535414e463ac69fd6423875ab3ace8f83ae4b490f18e047c5b3db8e5ab64da1b7aedc3
+  languageName: node
+  linkType: hard
+
+"hermes-estree@npm:0.25.1":
+  version: 0.25.1
+  resolution: "hermes-estree@npm:0.25.1"
+  checksum: 10c0/48be3b2fa37a0cbc77a112a89096fa212f25d06de92781b163d67853d210a8a5c3784fac23d7d48335058f7ed283115c87b4332c2a2abaaccc76d0ead1a282ac
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:0.25.1":
+  version: 0.25.1
+  resolution: "hermes-parser@npm:0.25.1"
+  dependencies:
+    hermes-estree: "npm:0.25.1"
+  checksum: 10c0/3abaa4c6f1bcc25273f267297a89a4904963ea29af19b8e4f6eabe04f1c2c7e9abd7bfc4730ddb1d58f2ea04b6fee74053d8bddb5656ec6ebf6c79cc8d14202c
   languageName: node
   linkType: hard
 
@@ -21897,6 +21945,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-modules-regexp@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "node-modules-regexp@npm:1.0.0"
+  checksum: 10c0/d4a9b6425a18e9fadd38f21a7f7820b3bfda4663c7d3b9f80043e3f5f7e27a0a1e04f524077b00a15ae77148cd81319da5772900229d89541062f7e876b36763
+  languageName: node
+  linkType: hard
+
 "node-polyfill-webpack-plugin@npm:^2.0.1":
   version: 2.0.1
   resolution: "node-polyfill-webpack-plugin@npm:2.0.1"
@@ -23153,6 +23208,15 @@ __metadata:
   version: 1.1.0
   resolution: "pinpoint@npm:1.1.0"
   checksum: 10c0/d894d22dd8243623da11b550ee18a5a0aa6db6c3a33ba84b51f55a797257ffc251909d24964a44657a57e7d1b9c567bb4404ab56532f7bb0f9bcb3d9e6edaa2f
+  languageName: node
+  linkType: hard
+
+"pirates@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "pirates@npm:3.0.2"
+  dependencies:
+    node-modules-regexp: "npm:^1.0.0"
+  checksum: 10c0/f71519f64abff750ad00398e7a0f724e7d3af0ce14c0cf149a47dd9e1fae5e9aea24cb3a63b4ce8dce8b051f7d44531af6743078e33f72cb8602c5a7365185d1
   languageName: node
   linkType: hard
 
@@ -25529,6 +25593,15 @@ __metadata:
     hash-base: "npm:^3.0.0"
     inherits: "npm:^2.0.1"
   checksum: 10c0/f6f0df78817e78287c766687aed4d5accbebc308a8e7e673fb085b9977473c1f139f0c5335d353f172a915bb288098430755d2ad3c4f30612f4dd0c901cd2c3a
+  languageName: node
+  linkType: hard
+
+"rollup-pluginutils@npm:^2.8.2":
+  version: 2.8.2
+  resolution: "rollup-pluginutils@npm:2.8.2"
+  dependencies:
+    estree-walker: "npm:^0.6.1"
+  checksum: 10c0/20947bec5a5dd68b5c5c8423911e6e7c0ad834c451f1a929b1f4e2bc08836ad3f1a722ef2bfcbeca921870a0a283f13f064a317dc7a6768496e98c9a641ba290
   languageName: node
   linkType: hard
 
@@ -29218,6 +29291,13 @@ __metadata:
   bin:
     vitest: vitest.mjs
   checksum: 10c0/7688fdce37205e7f3b448039df216e103e3a52994af0201993e22decbb558d129a734001b991f3c3d80bf4a4ef91ca6a5665a7395d5b051249da60a0016eda36
+  languageName: node
+  linkType: hard
+
+"vlq@npm:^0.2.1":
+  version: 0.2.3
+  resolution: "vlq@npm:0.2.3"
+  checksum: 10c0/d1557b404353ca75c7affaaf403d245a3273a7d1c6b3380ed7f04ae3f080e4658f41ac700d6f48acb3cd4875fe7bc7da4924b3572cd5584a5de83b35b1de5e12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added support for flow which is used by some React Native libraries and React Native source code itself.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29756-sha-18442450`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29756-sha-18442450 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29756-sha-18442450 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29756-sha-18442450`](https://npmjs.com/package/storybook/v/0.0.0-pr-29756-sha-18442450) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`dannyhw/fix-rnw-flow-support`](https://github.com/storybookjs/storybook/tree/dannyhw/fix-rnw-flow-support) |
| **Commit** | [`18442450`](https://github.com/storybookjs/storybook/commit/18442450017d77202dc9fd5aa4910af9c192fce4) |
| **Datetime** | Sat Nov 30 13:45:21 UTC 2024 (`1732974321`) |
| **Workflow run** | [12096885441](https://github.com/storybookjs/storybook/actions/runs/12096885441) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29756`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 364 B | -0.37 | 0% |
| initSize |  130 MB | 130 MB | 11.4 kB | **-1.73** | 0% |
| diffSize |  52.4 MB | 52.4 MB | 11 kB | **-1.73** | 0% |
| buildSize |  6.83 MB | 6.83 MB | 0 B | **1.45** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.42 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 1.21 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | 0.35 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.84 MB | 3.84 MB | 0 B | 1.01 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **1.73** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.6s | 23.4s | 16.7s | **1.27** | 🔺71.5% |
| generateTime |  19.8s | 18.2s | -1s -545ms | -0.85 | -8.4% |
| initTime |  13s | 11.8s | -1s -240ms | -0.88 | -10.5% |
| buildTime |  7.9s | 8.5s | 617ms | -0.47 | 7.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.2s | 4.9s | 725ms | -0.59 | 14.7% |
| devManagerResponsive |  3.2s | 3.5s | 379ms | -0.11 | 10.6% |
| devManagerHeaderVisible |  485ms | 596ms | 111ms | -0.04 | 18.6% |
| devManagerIndexVisible |  543ms | 624ms | 81ms | -0.19 | 13% |
| devStoryVisibleUncached |  1.6s | 1.7s | 184ms | 0.77 | 10.3% |
| devStoryVisible |  541ms | 622ms | 81ms | -0.15 | 13% |
| devAutodocsVisible |  419ms | 487ms | 68ms | -0.28 | 14% |
| devMDXVisible |  426ms | 559ms | 133ms | 0.06 | 23.8% |
| buildManagerHeaderVisible |  456ms | 587ms | 131ms | -0.03 | 22.3% |
| buildManagerIndexVisible |  469ms | 602ms | 133ms | -0.04 | 22.1% |
| buildStoryVisible |  456ms | 590ms | 134ms | 0 | 22.7% |
| buildAutodocsVisible |  384ms | 476ms | 92ms | -0.04 | 19.3% |
| buildMDXVisible |  368ms | 447ms | 79ms | -0.2 | 17.7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added Flow support to React Native Web Vite framework in Storybook to handle Flow types used in React Native libraries and source code.

- Added `@bunchtogether/vite-plugin-flow` dependency in `code/frameworks/react-native-web-vite/package.json`
- Configured Flow plugin to run before React plugin in `code/frameworks/react-native-web-vite/src/preset.ts`
- Added esbuild Flow support with JSX transformation for `.flow` and `.jsx` files
- Added module declaration for Flow plugin in `typings.d.ts` for TypeScript compatibility



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->