### PR TITLE
Build: Add addon a11y to sandbox tests

### DIFF
--- a/code/addons/a11y/src/components/A11YPanel.stories.tsx
+++ b/code/addons/a11y/src/components/A11YPanel.stories.tsx
@@ -8,9 +8,9 @@ import { fn } from '@storybook/test';
 
 import type axe from 'axe-core';
 
-import { A11YPanel } from '../../src/components/A11YPanel';
-import { A11yContext } from '../../src/components/A11yContext';
-import type { A11yContextStore } from '../../src/components/A11yContext';
+import { A11YPanel } from './A11YPanel';
+import { A11yContext } from './A11yContext';
+import type { A11yContextStore } from './A11yContext';
 
 const managerContext: any = {
   state: {},

--- a/code/addons/a11y/src/components/TestDiscrepancyMessage.stories.tsx
+++ b/code/addons/a11y/src/components/TestDiscrepancyMessage.stories.tsx
@@ -5,7 +5,7 @@ import { ManagerContext } from 'storybook/internal/manager-api';
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 
-import { TestDiscrepancyMessage } from '../../src/components/TestDiscrepancyMessage';
+import { TestDiscrepancyMessage } from './TestDiscrepancyMessage';
 
 type Story = StoryObj<typeof TestDiscrepancyMessage>;
 

--- a/code/frameworks/angular/template/components/button.css
+++ b/code/frameworks/angular/template/components/button.css
@@ -8,7 +8,7 @@
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .storybook-button--primary {
-  background-color: #1ea7fd;
+  background-color: #555ab9;
   color: white;
 }
 .storybook-button--secondary {

--- a/code/frameworks/angular/template/stories_angular-cli-default-ts/signal/button.css
+++ b/code/frameworks/angular/template/stories_angular-cli-default-ts/signal/button.css
@@ -8,7 +8,7 @@
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .storybook-button--primary {
-  background-color: #1ea7fd;
+  background-color: #555ab9;
   color: white;
 }
 .storybook-button--secondary {

--- a/code/frameworks/angular/template/stories_angular-cli-prerelease/signal/button.css
+++ b/code/frameworks/angular/template/stories_angular-cli-prerelease/signal/button.css
@@ -8,7 +8,7 @@
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .storybook-button--primary {
-  background-color: #1ea7fd;
+  background-color: #555ab9;
   color: white;
 }
 .storybook-button--secondary {

--- a/code/lib/create-storybook/rendererAssets/common/button.css
+++ b/code/lib/create-storybook/rendererAssets/common/button.css
@@ -8,7 +8,7 @@
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .storybook-button--primary {
-  background-color: #1ea7fd;
+  background-color: #555ab9;
   color: white;
 }
 .storybook-button--secondary {

--- a/code/lib/create-storybook/rendererAssets/common/page.css
+++ b/code/lib/create-storybook/rendererAssets/common/page.css
@@ -22,8 +22,7 @@
 }
 
 .storybook-page a {
-  color: #1ea7fd;
-  text-decoration: none;
+  color: inherit;
 }
 
 .storybook-page ul {
@@ -42,7 +41,7 @@
   border-radius: 1em;
   background: #e7fdd8;
   padding: 4px 12px;
-  color: #66bf3c;
+  color: #357a14;
   font-weight: 700;
   font-size: 11px;
   line-height: 12px;

--- a/code/renderers/react/src/__test__/button.css
+++ b/code/renderers/react/src/__test__/button.css
@@ -8,7 +8,7 @@
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .storybook-button--primary {
-  background-color: #1ea7fd;
+  background-color: #555ab9;
   color: white;
 }
 .storybook-button--secondary {

--- a/code/renderers/svelte/template/components/button.css
+++ b/code/renderers/svelte/template/components/button.css
@@ -8,7 +8,7 @@
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .storybook-button--primary {
-  background-color: #1ea7fd;
+  background-color: #555ab9;
   color: white;
 }
 .storybook-button--secondary {

--- a/code/renderers/vue3/src/__tests__/button.css
+++ b/code/renderers/vue3/src/__tests__/button.css
@@ -8,7 +8,7 @@
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .storybook-button--primary {
-  background-color: #1ea7fd;
+  background-color: #555ab9;
   color: white;
 }
 .storybook-button--secondary {

--- a/code/renderers/vue3/template/components/button.css
+++ b/code/renderers/vue3/template/components/button.css
@@ -8,7 +8,7 @@
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .storybook-button--primary {
-  background-color: #1ea7fd;
+  background-color: #555ab9;
   color: white;
 }
 .storybook-button--secondary {

--- a/code/renderers/web-components/template/components/button.css
+++ b/code/renderers/web-components/template/components/button.css
@@ -8,7 +8,7 @@
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .storybook-button--primary {
-  background-color: #1ea7fd;
+  background-color: #555ab9;
   color: white;
 }
 .storybook-button--secondary {

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -439,6 +439,7 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
     dedent`import { beforeAll } from 'vitest'
     import { setProjectAnnotations } from '${storybookPackage}'
     import * as rendererDocsAnnotations from '${template.expected.renderer}/dist/entry-preview-docs.mjs'
+    import * as addonA11yAnnotations from '@storybook/addon-a11y/preview'
     import * as addonActionsAnnotations from '@storybook/addon-actions/preview'
     import * as addonTestAnnotations from '@storybook/experimental-addon-test/preview'
     import '../src/stories/components'
@@ -448,13 +449,14 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
     ${isVue ? 'import * as vueAnnotations from "../src/stories/renderers/vue3/preview.js"' : ''}
 
     const annotations = setProjectAnnotations([
+      ${isVue ? 'vueAnnotations,' : ''}
       rendererDocsAnnotations,
-      projectAnnotations,
       coreAnnotations,
       toolbarAnnotations,
       addonActionsAnnotations,
       addonTestAnnotations,
-      ${isVue ? 'vueAnnotations,' : ''}
+      addonA11yAnnotations,
+      projectAnnotations,
     ])
 
     beforeAll(annotations.beforeAll)`
@@ -808,6 +810,11 @@ export const extendPreview: Task['run'] = async ({ template, sandboxDir }) => {
 
   if (template.expected.builder.includes('vite')) {
     previewConfig.setFieldValue(['tags'], ['vitest']);
+    // TODO: Remove this once the starter components + test stories have proper accessibility
+    previewConfig.setFieldValue(
+      ['parameters', 'a11y'],
+      ['minor', 'moderate', 'serious', 'critical']
+    );
   }
 
   await writeConfig(previewConfig);

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -812,7 +812,7 @@ export const extendPreview: Task['run'] = async ({ template, sandboxDir }) => {
     previewConfig.setFieldValue(['tags'], ['vitest']);
     // TODO: Remove this once the starter components + test stories have proper accessibility
     previewConfig.setFieldValue(
-      ['parameters', 'a11y'],
+      ['parameters', 'a11y', 'warnings'],
       ['minor', 'moderate', 'serious', 'critical']
     );
   }

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -74,7 +74,11 @@ export const sandbox: Task = {
       //   extraDeps.push('@testing-library/angular', '@analogjs/vitest-angular');
       // }
 
-      options.addon = [...options.addon, '@storybook/experimental-addon-test'];
+      options.addon = [
+        ...options.addon,
+        '@storybook/experimental-addon-test',
+        '@storybook/addon-a11y',
+      ];
     }
 
     let startTime = now();


### PR DESCRIPTION
Building on top of #29643

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | -0.45 | 0% |
| initSize |  130 MB | 130 MB | 0 B | -1 | 0% |
| diffSize |  52.5 MB | 52.5 MB | 0 B | -0.99 | 0% |
| buildSize |  6.76 MB | 6.76 MB | 37 B | **-2.38** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.88 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | -0.23 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | **-2.38** | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | **-2.38** | 0% |
| buildPreviewSize |  3.19 MB | 3.19 MB | 37 B | **2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  27.3s | 15.4s | -11s -899ms | -0.06 | -77.1% |
| generateTime |  20.4s | 21s | 657ms | -0.11 | 3.1% |
| initTime |  13.9s | 13.8s | -44ms | -0.44 | -0.3% |
| buildTime |  9.5s | 8.2s | -1s -304ms | -0.54 | -15.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.6s | 5.4s | -215ms | -0.02 | -3.9% |
| devManagerResponsive |  4s | 3.8s | -122ms | 0.7 | -3.1% |
| devManagerHeaderVisible |  609ms | 638ms | 29ms | 0.29 | 4.5% |
| devManagerIndexVisible |  717ms | 675ms | -42ms | 0 | -6.2% |
| devStoryVisibleUncached |  2s | 1.8s | -236ms | 1.01 | -12.9% |
| devStoryVisible |  716ms | 673ms | -43ms | 0.06 | -6.4% |
| devAutodocsVisible |  544ms | 587ms | 43ms | 0.49 | 7.3% |
| devMDXVisible |  533ms | 709ms | 176ms | **1.99** | 🔺24.8% |
| buildManagerHeaderVisible |  603ms | 557ms | -46ms | -0.17 | -8.3% |
| buildManagerIndexVisible |  692ms | 628ms | -64ms | 0.31 | -10.2% |
| buildStoryVisible |  548ms | 510ms | -38ms | -0.55 | -7.5% |
| buildAutodocsVisible |  523ms | 456ms | -67ms | -0.03 | -14.7% |
| buildMDXVisible |  492ms | 432ms | -60ms | -0.38 | -13.9% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR reorganizes accessibility testing files by moving a11y stories to their proper location and integrates the a11y addon into sandbox testing configurations.

- Relocated `A11YPanel.stories.tsx` and `TestDiscrepancyMessage.stories.tsx` from template directory to `code/addons/a11y/src/components/`
- Updated import paths in stories files to use relative paths
- Added `@storybook/addon-a11y` to sandbox setup when Vitest integration is enabled
- Added a11y parameters in preview config for vite-based projects



<!-- /greptile_comment -->