### PR TITLE
Addon Test: Remove a11y placeholder

### DIFF
--- a/code/addons/test/src/components/TestProviderRender.tsx
+++ b/code/addons/test/src/components/TestProviderRender.tsx
@@ -166,19 +166,6 @@ export const TestProviderRender: FC<{
               />
             }
           />
-          <ListItem
-            as="label"
-            title="Accessibility"
-            icon={<AccessibilityIcon color={theme.textMutedColor} />}
-            right={
-              <Checkbox
-                type="checkbox"
-                disabled // TODO: Implement a11y
-                checked={config.a11y}
-                onChange={() => updateConfig({ a11y: !config.a11y })}
-              />
-            }
-          />
         </Extras>
       ) : (
         <Extras>
@@ -207,11 +194,6 @@ export const TestProviderRender: FC<{
               icon={<TestStatusIcon status="unknown" aria-label={`status: unknown`} />}
             />
           )}
-          <ListItem
-            title="Accessibility"
-            icon={<TestStatusIcon status="negative" aria-label="status: failed" />}
-            right={73}
-          />
         </Extras>
       )}
 


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Removed the temporary a11y placeholder in the testing module.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | **1.3** | 0% |
| initSize |  130 MB | 130 MB | 2.86 kB | -0.49 | 0% |
| diffSize |  52.5 MB | 52.5 MB | 2.86 kB | -0.49 | 0% |
| buildSize |  6.83 MB | 6.83 MB | 0 B | 0.41 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | -0.58 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 0.22 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | -0.58 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.84 MB | 3.84 MB | 0 B | 0.17 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.5 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.7s | 24.5s | 16.7s | **1.38** | 🔺68.4% |
| generateTime |  21.4s | 22.7s | 1.3s | 0.25 | 5.9% |
| initTime |  13.4s | 15.6s | 2.1s | 0.46 | 14.1% |
| buildTime |  8.6s | 8.8s | 252ms | -0.26 | 2.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.6s | 4.8s | 246ms | -0.3 | 5.1% |
| devManagerResponsive |  3.5s | 3.4s | -24ms | -0.21 | -0.7% |
| devManagerHeaderVisible |  521ms | 551ms | 30ms | -0.26 | 5.4% |
| devManagerIndexVisible |  607ms | 634ms | 27ms | 0.12 | 4.3% |
| devStoryVisibleUncached |  1.6s | 1.7s | 87ms | 0.33 | 5% |
| devStoryVisible |  552ms | 583ms | 31ms | -0.48 | 5.3% |
| devAutodocsVisible |  505ms | 500ms | -5ms | -0.23 | -1% |
| devMDXVisible |  446ms | 521ms | 75ms | -0.01 | 14.4% |
| buildManagerHeaderVisible |  511ms | 507ms | -4ms | -0.53 | -0.8% |
| buildManagerIndexVisible |  537ms | 532ms | -5ms | -0.45 | -0.9% |
| buildStoryVisible |  509ms | 502ms | -7ms | -0.59 | -1.4% |
| buildAutodocsVisible |  439ms | 435ms | -4ms | -0.4 | -0.9% |
| buildMDXVisible |  426ms | 397ms | -29ms | -0.77 | -7.3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Removed accessibility (a11y) placeholder UI elements from the testing module's TestProviderRender component while maintaining core functionality.

- Removed a11y checkbox from settings panel in `code/addons/test/src/components/TestProviderRender.tsx`
- Removed a11y status display from main view in `code/addons/test/src/components/TestProviderRender.tsx`
- Retained `a11y: false` in initial config object for backward compatibility



<sub>💡 (5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->