### PR TITLE
Vue: Properly resolve Vite plugin

### DIFF
--- a/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
@@ -3,7 +3,7 @@ import { dirname, join, parse, relative, resolve } from 'node:path';
 
 import findPackageJson from 'find-package-json';
 import MagicString from 'magic-string';
-import type { ModuleNode, PluginOption } from 'vite';
+import type { ModuleNode, Plugin } from 'vite';
 import {
   type ComponentMeta,
   type MetaCheckerOptions,
@@ -21,7 +21,7 @@ type MetaSource = {
 } & ComponentMeta &
   MetaCheckerOptions['schema'];
 
-export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<PluginOption> {
+export async function vueComponentMeta(tsconfigPath = 'tsconfig.json'): Promise<Plugin> {
   const { createFilter } = await import('vite');
 
   // exclude stories, virtual modules and storybook internals

--- a/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-docgen.ts
@@ -1,8 +1,8 @@
 import MagicString from 'magic-string';
-import type { PluginOption } from 'vite';
+import type { Plugin } from 'vite';
 import { parse } from 'vue-docgen-api';
 
-export async function vueDocgen(): Promise<PluginOption> {
+export async function vueDocgen(): Promise<Plugin> {
   const { createFilter } = await import('vite');
 
   const include = /\.(vue)$/;

--- a/code/frameworks/vue3-vite/src/plugins/vue-template.ts
+++ b/code/frameworks/vue3-vite/src/plugins/vue-template.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite';
 
-export async function templateCompilation() {
+export async function templateCompilation(): Promise<Plugin> {
   return {
     name: 'storybook:vue-template-compilation',
     config: () => ({

--- a/code/frameworks/vue3-vite/src/preset.ts
+++ b/code/frameworks/vue3-vite/src/preset.ts
@@ -2,7 +2,7 @@ import { dirname, join } from 'node:path';
 
 import type { PresetProperty } from 'storybook/internal/types';
 
-import type { PluginOption } from 'vite';
+import type { Plugin } from 'vite';
 
 import { vueComponentMeta } from './plugins/vue-component-meta';
 import { vueDocgen } from './plugins/vue-docgen';
@@ -18,7 +18,7 @@ export const core: PresetProperty<'core'> = {
 };
 
 export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) => {
-  const plugins: PluginOption[] = [templateCompilation()];
+  const plugins: Plugin[] = [await templateCompilation()];
 
   const framework = await options.presets.apply('framework');
   const frameworkOptions: FrameworkOptions =

--- a/code/frameworks/vue3-vite/src/vite-plugin.ts
+++ b/code/frameworks/vue3-vite/src/vite-plugin.ts
@@ -1,5 +1,7 @@
+import type { Plugin } from 'vite';
+
 import { templateCompilation } from './plugins/vue-template';
 
-export const storybookVuePlugin = () => {
+export const storybookVuePlugin = (): Promise<Plugin>[] => {
   return [templateCompilation()];
 };


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Currently, the vue preset adds `storybook:vue-template-compilation` as unresolved `Promise<Plugin>`. This leads to memory issues downstream as analyzed in https://github.com/nuxt-modules/storybook/pull/740#issuecomment-2408305059. This is fixed by awating the promise. Also changed the types of the plugin array to the stronger `Plugin` type, which doesn't admit promises to prevent this from reaccouring the future. 

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 2.48 kB | **2.7** | 0% |
| initSize |  130 MB | 130 MB | 1.27 kB | 0.87 | 0% |
| diffSize |  52.4 MB | 52.4 MB | -1.21 kB | -0.12 | 0% |
| buildSize |  6.75 MB | 6.75 MB | -108 B | -1 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | -108 B | -0.56 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | -1 | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.56 MB | -108 B | -1 | 0% |
| buildPreviewSize |  3.19 MB | 3.19 MB | 0 B | 1 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  13.1s | 24.8s | 11.7s | 1.05 | 47.1% |
| generateTime |  19.2s | 20.7s | 1.5s | 0.18 | 7.3% |
| initTime |  13s | 13.5s | 545ms | -0.04 | 4% |
| buildTime |  9.3s | 9.1s | -223ms | -0.12 | -2.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.6s | 4.7s | -863ms | -0.85 | -18.2% |
| devManagerResponsive |  3.8s | 3.6s | -194ms | -0.3 | -5.3% |
| devManagerHeaderVisible |  562ms | 555ms | -7ms | -0.44 | -1.3% |
| devManagerIndexVisible |  593ms | 591ms | -2ms | -0.82 | -0.3% |
| devStoryVisibleUncached |  1.8s | 1.4s | -384ms | **-1.52** | 🔰-26.2% |
| devStoryVisible |  595ms | 585ms | -10ms | -0.78 | -1.7% |
| devAutodocsVisible |  555ms | 482ms | -73ms | -0.86 | -15.1% |
| devMDXVisible |  555ms | 541ms | -14ms | -0.07 | -2.6% |
| buildManagerHeaderVisible |  559ms | 537ms | -22ms | -0.53 | -4.1% |
| buildManagerIndexVisible |  636ms | 628ms | -8ms | -0.22 | -1.3% |
| buildStoryVisible |  500ms | 495ms | -5ms | -0.68 | -1% |
| buildAutodocsVisible |  448ms | 400ms | -48ms | -0.82 | -12% |
| buildMDXVisible |  424ms | 464ms | 40ms | -0.05 | 8.6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Fixes memory issues in Vue's Vite plugin system by properly resolving plugin promises and enforcing stricter typing for plugin arrays.

- Changed `storybookVuePlugin` in `code/frameworks/vue3-vite/src/vite-plugin.ts` to properly await plugin promises
- Updated plugin array type from `PluginOption[]` to stricter `Plugin[]` type in `code/frameworks/vue3-vite/src/preset.ts`
- Added proper type annotations for `templateCompilation` function in `code/frameworks/vue3-vite/src/plugins/vue-template.ts`
- Strengthened plugin type definitions across vue-docgen and vue-component-meta plugins



<sub>💡 (4/5) You can add custom instructions or style guidelines for the bot [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->