### PR TITLE
Composition: Hide contextMenu on composed storybooks

### DIFF
--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -273,7 +273,10 @@ const Node = React.memo<NodeProps>(function Node({
   ]);
 
   const id = createId(item.id, refId);
-  const contextMenu = useContextMenu(item, statusLinks, api);
+  const contextMenu =
+    refId === 'storybook_internal'
+      ? useContextMenu(item, statusLinks, api)
+      : { node: null, onMouseEnter: () => {} };
 
   if (item.type === 'story' || item.type === 'docs') {
     const LeafNode = item.type === 'docs' ? DocumentNode : StoryNode;


### PR DESCRIPTION
Closes #29686

## What I did

I ensured that the code for creating the contextMenu never runs for refs

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I manually verified the UI looks correct by:

- Starting the monorepo storybook in dev-mode after building this change.

It looked like this (icons are from a reffed storybook):
![Screenshot 2024-12-04 at 11 21 29](https://github.com/user-attachments/assets/5dde5020-4202-4ec9-ab6b-325be2a27ed1)

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 0.75 | 0% |
| initSize |  130 MB | 130 MB | 108 B | 0.13 | 0% |
| diffSize |  52.4 MB | 52.4 MB | 108 B | -0.01 | 0% |
| buildSize |  6.75 MB | 6.75 MB | 108 B | **-1.52** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 108 B | 1 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | **-1.53** | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.56 MB | 3.57 MB | 108 B | **-1.53** | 0% |
| buildPreviewSize |  3.19 MB | 3.19 MB | 0 B | **1.53** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.5s | 27s | 20.4s | **1.5** | 🔺75.7% |
| generateTime |  18.8s | 20.8s | 1.9s | 0.1 | 9.4% |
| initTime |  12.2s | 14s | 1.7s | 0.14 | 12.7% |
| buildTime |  8s | 8.2s | 127ms | -1.05 | 1.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4s | 4.5s | 492ms | -0.81 | 10.8% |
| devManagerResponsive |  3s | 3.4s | 420ms | -0.56 | 12.2% |
| devManagerHeaderVisible |  468ms | 554ms | 86ms | -0.42 | 15.5% |
| devManagerIndexVisible |  497ms | 590ms | 93ms | -0.66 | 15.8% |
| devStoryVisibleUncached |  1.7s | 1.2s | -509ms | **-2.69** | 🔰-42.1% |
| devStoryVisible |  497ms | 591ms | 94ms | -0.57 | 15.9% |
| devAutodocsVisible |  477ms | 497ms | 20ms | -0.49 | 4% |
| devMDXVisible |  455ms | 549ms | 94ms | 0.15 | 17.1% |
| buildManagerHeaderVisible |  479ms | 546ms | 67ms | -0.4 | 12.3% |
| buildManagerIndexVisible |  554ms | 630ms | 76ms | -0.07 | 12.1% |
| buildStoryVisible |  444ms | 508ms | 64ms | -0.61 | 12.6% |
| buildAutodocsVisible |  361ms | 450ms | 89ms | -0.3 | 19.8% |
| buildMDXVisible |  372ms | 463ms | 91ms | -0.12 | 19.7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Implemented a fix to prevent context menu from appearing in referenced (composed) Storybooks by modifying the sidebar Tree component's menu behavior.

- Modified `code/core/src/manager/components/sidebar/Tree.tsx` to check for `refId === 'storybook_internal'` before showing context menu
- Returns empty object with null node when story is from a referenced Storybook
- Fixes issue #29686 where context menu incorrectly appeared for referenced stories
- Prevents invariant failures when accessing non-existent entries in composed Storybooks



<!-- /greptile_comment -->