### PR TITLE
Nextjs-Vite: Add TS docgen support

### DIFF
--- a/code/frameworks/experimental-nextjs-vite/package.json
+++ b/code/frameworks/experimental-nextjs-vite/package.json
@@ -97,6 +97,7 @@
   "dependencies": {
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",
+    "@storybook/react-vite": "workspace:*",
     "@storybook/test": "workspace:*",
     "styled-jsx": "5.1.6",
     "vite-plugin-storybook-nextjs": "^1.1.0"

--- a/code/frameworks/experimental-nextjs-vite/src/preset.ts
+++ b/code/frameworks/experimental-nextjs-vite/src/preset.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import type { PresetProperty } from 'storybook/internal/types';
 
 import type { StorybookConfigVite } from '@storybook/builder-vite';
+import { viteFinal as reactViteFinal } from '@storybook/react-vite/preset';
 
 import { dirname, join } from 'path';
 import vitePluginStorybookNextjs from 'vite-plugin-storybook-nextjs';
@@ -34,11 +35,13 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entry =
 };
 
 export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, options) => {
-  config.plugins = config.plugins || [];
+  const reactConfig = await reactViteFinal(config, options);
+  const { plugins = [] } = reactConfig;
+
   const { nextConfigPath } = await options.presets.apply<FrameworkOptions>('frameworkOptions');
 
   const nextDir = nextConfigPath ? path.dirname(nextConfigPath) : undefined;
-  config.plugins.push(vitePluginStorybookNextjs({ dir: nextDir }));
+  plugins.push(vitePluginStorybookNextjs({ dir: nextDir }));
 
-  return config;
+  return reactConfig;
 };

--- a/code/frameworks/react-native-web-vite/src/preset.ts
+++ b/code/frameworks/react-native-web-vite/src/preset.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error FIXME
 import { viteFinal as reactViteFinal } from '@storybook/react-vite/preset';
 
 import { esbuildFlowPlugin, flowPlugin } from '@bunchtogether/vite-plugin-flow';

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -32,6 +32,16 @@
     },
     "./package.json": "./package.json"
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/index.d.ts"
+      ],
+      "preset": [
+        "dist/preset.d.ts"
+      ]
+    }
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/code/frameworks/react-vite/src/preset.ts
+++ b/code/frameworks/react-vite/src/preset.ts
@@ -12,7 +12,7 @@ export const core: PresetProperty<'core'> = {
   renderer: getAbsolutePath('@storybook/react'),
 };
 
-export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets }) => {
+export const viteFinal: NonNullable<StorybookConfig['viteFinal']> = async (config, { presets }) => {
   const { plugins = [] } = config;
 
   // Add docgen plugin

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6658,6 +6658,7 @@ __metadata:
   dependencies:
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": "workspace:*"
+    "@storybook/react-vite": "workspace:*"
     "@storybook/test": "workspace:*"
     "@types/node": "npm:^18.0.0"
     next: "npm:^15.0.3"


### PR DESCRIPTION
Closes https://github.com/storybookjs/vite-plugin-storybook-nextjs/issues/22

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR modifies the experimental-nextjs-vite framework to support react-docgen-typescript. It does so by adding react-vite as a dependency, similarly to how it was done in react-native-web-vite.

before:
![image](https://github.com/user-attachments/assets/c44705aa-cae2-49cc-9cd5-ae2f11dbdeaf)

after:
![image](https://github.com/user-attachments/assets/ea776de5-0b2a-43f9-a65e-eb19fb795364)


## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Make a sandbox and add this to its main.js:

```ts
  typescript: {
    reactDocgen: 'react-docgen-typescript'
  },
```

Then look at stories which should contain richer docgen metadata

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29824-sha-bac7061d`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29824-sha-bac7061d sandbox` or in an existing project with `npx storybook@0.0.0-pr-29824-sha-bac7061d upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29824-sha-bac7061d`](https://npmjs.com/package/storybook/v/0.0.0-pr-29824-sha-bac7061d) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/add-ts-docgen-support-next-vite`](https://github.com/storybookjs/storybook/tree/yann/add-ts-docgen-support-next-vite) |
| **Commit** | [`bac7061d`](https://github.com/storybookjs/storybook/commit/bac7061dcdf17148b88976730734b3a98b30e4fe) |
| **Datetime** | Thu Dec  5 15:08:51 UTC 2024 (`1733411331`) |
| **Workflow run** | [12182518539](https://github.com/storybookjs/storybook/actions/runs/12182518539) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29824`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 292 B | **1.75** | 0% |
| initSize |  130 MB | 130 MB | 449 B | 1.02 | 0% |
| diffSize |  52.4 MB | 52.4 MB | 157 B | 0.12 | 0% |
| buildSize |  6.75 MB | 6.75 MB | 0 B | -0.73 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 1.11 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | -0.73 | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | -0.73 | 0% |
| buildPreviewSize |  3.19 MB | 3.19 MB | 0 B | 0.73 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.9s | 11.9s | 5s | -0.41 | 42.2% |
| generateTime |  21.6s | 22.4s | 869ms | **1.53** | 3.9% |
| initTime |  14.8s | 15.1s | 255ms | 0.75 | 1.7% |
| buildTime |  8.5s | 11.2s | 2.7s | **2.01** | 🔺24.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5s | 6s | 970ms | **1.46** | 🔺16.1% |
| devManagerResponsive |  3.8s | 4.1s | 319ms | 0.92 | 7.7% |
| devManagerHeaderVisible |  539ms | 927ms | 388ms | **3.95** | 🔺41.9% |
| devManagerIndexVisible |  610ms | 938ms | 328ms | **3.04** | 🔺35% |
| devStoryVisibleUncached |  1.6s | 1.7s | 46ms | -0.29 | 2.7% |
| devStoryVisible |  607ms | 1s | 422ms | **3.66** | 🔺41% |
| devAutodocsVisible |  484ms | 716ms | 232ms | **2.45** | 🔺32.4% |
| devMDXVisible |  509ms | 706ms | 197ms | **1.85** | 🔺27.9% |
| buildManagerHeaderVisible |  618ms | 744ms | 126ms | 1.22 | 16.9% |
| buildManagerIndexVisible |  693ms | 833ms | 140ms | **1.3** | 🔺16.8% |
| buildStoryVisible |  556ms | 675ms | 119ms | 0.99 | 17.6% |
| buildAutodocsVisible |  418ms | 1s | 593ms | **6.61** | 🔺58.7% |
| buildMDXVisible |  436ms | 590ms | 154ms | **1.81** | 🔺26.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and context, I'll create a concise summary of the key changes in this pull request:

Adds TypeScript documentation generation (docgen) support to the experimental Next.js Vite framework by leveraging existing react-vite functionality.

- Modified `experimental-nextjs-vite/preset.ts` to use `reactViteFinal` from `@storybook/react-vite/preset` for TypeScript docgen support
- Added `@storybook/react-vite` as a dependency in `experimental-nextjs-vite/package.json` to enable docgen functionality
- Updated plugin handling in `react-vite/preset.ts` to properly integrate `react-docgen-typescript` via `@joshwooding/vite-plugin-react-docgen-typescript`
- Configured docgen plugin to save prop values as strings for compatibility with react-docgen format



<!-- /greptile_comment -->