### PR TITLE
Addon Test: Fix indexing behavior

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,7 @@
 <h1>Migration</h1>
 
+- [From version 8.4.x to 8.5.x](#from-version-84x-to-85x)
+  - [Indexing behavior of @storybook/experimental-addon-test is changed](#indexing-behavior-of-storybookexperimental-addon-test-is-changed)
 - [From version 8.2.x to 8.3.x](#from-version-82x-to-83x)
   - [Removed `experimental_SIDEBAR_BOTTOM` and deprecated `experimental_SIDEBAR_TOP` addon types](#removed-experimental_sidebar_bottom-and-deprecated-experimental_sidebar_top-addon-types)
   - [New parameters format for addon backgrounds](#new-parameters-format-for-addon-backgrounds)
@@ -105,17 +107,17 @@
     - [Tab addons cannot manually route, Tool addons can filter their visibility via tabId](#tab-addons-cannot-manually-route-tool-addons-can-filter-their-visibility-via-tabid)
     - [Removed `config` preset](#removed-config-preset-1)
 - [From version 7.5.0 to 7.6.0](#from-version-750-to-760)
-  - [CommonJS with Vite is deprecated](#commonjs-with-vite-is-deprecated)
-  - [Using implicit actions during rendering is deprecated](#using-implicit-actions-during-rendering-is-deprecated)
-  - [typescript.skipBabel deprecated](#typescriptskipbabel-deprecated)
-  - [Primary doc block accepts of prop](#primary-doc-block-accepts-of-prop)
-  - [Addons no longer need a peer dependency on React](#addons-no-longer-need-a-peer-dependency-on-react)
+    - [CommonJS with Vite is deprecated](#commonjs-with-vite-is-deprecated)
+    - [Using implicit actions during rendering is deprecated](#using-implicit-actions-during-rendering-is-deprecated)
+    - [typescript.skipBabel deprecated](#typescriptskipbabel-deprecated)
+    - [Primary doc block accepts of prop](#primary-doc-block-accepts-of-prop)
+    - [Addons no longer need a peer dependency on React](#addons-no-longer-need-a-peer-dependency-on-react)
 - [From version 7.4.0 to 7.5.0](#from-version-740-to-750)
-  - [`storyStoreV6` and `storiesOf` is deprecated](#storystorev6-and-storiesof-is-deprecated)
-  - [`storyIndexers` is replaced with `experimental_indexers`](#storyindexers-is-replaced-with-experimental_indexers)
+    - [`storyStoreV6` and `storiesOf` is deprecated](#storystorev6-and-storiesof-is-deprecated)
+    - [`storyIndexers` is replaced with `experimental_indexers`](#storyindexers-is-replaced-with-experimental_indexers)
 - [From version 7.0.0 to 7.2.0](#from-version-700-to-720)
-  - [Addon API is more type-strict](#addon-api-is-more-type-strict)
-  - [Addon-controls hideNoControlsWarning parameter is deprecated](#addon-controls-hidenocontrolswarning-parameter-is-deprecated)
+    - [Addon API is more type-strict](#addon-api-is-more-type-strict)
+    - [Addon-controls hideNoControlsWarning parameter is deprecated](#addon-controls-hidenocontrolswarning-parameter-is-deprecated)
 - [From version 6.5.x to 7.0.0](#from-version-65x-to-700)
   - [7.0 breaking changes](#70-breaking-changes)
     - [Dropped support for Node 15 and below](#dropped-support-for-node-15-and-below)
@@ -141,7 +143,7 @@
     - [Deploying build artifacts](#deploying-build-artifacts)
       - [Dropped support for file URLs](#dropped-support-for-file-urls)
       - [Serving with nginx](#serving-with-nginx)
-      - [Ignore story files from node_modules](#ignore-story-files-from-node_modules)
+      - [Ignore story files from node\_modules](#ignore-story-files-from-node_modules)
   - [7.0 Core changes](#70-core-changes)
     - [7.0 feature flags removed](#70-feature-flags-removed)
     - [Story context is prepared before for supporting fine grained updates](#story-context-is-prepared-before-for-supporting-fine-grained-updates)
@@ -155,7 +157,7 @@
     - [Addon-interactions: Interactions debugger is now default](#addon-interactions-interactions-debugger-is-now-default)
   - [7.0 Vite changes](#70-vite-changes)
     - [Vite builder uses Vite config automatically](#vite-builder-uses-vite-config-automatically)
-    - [Vite cache moved to node_modules/.cache/.vite-storybook](#vite-cache-moved-to-node_modulescachevite-storybook)
+    - [Vite cache moved to node\_modules/.cache/.vite-storybook](#vite-cache-moved-to-node_modulescachevite-storybook)
   - [7.0 Webpack changes](#70-webpack-changes)
     - [Webpack4 support discontinued](#webpack4-support-discontinued)
     - [Babel mode v7 exclusively](#babel-mode-v7-exclusively)
@@ -167,7 +169,7 @@
     - [Angular: Drop support for calling Storybook directly](#angular-drop-support-for-calling-storybook-directly)
     - [Angular: Application providers and ModuleWithProviders](#angular-application-providers-and-modulewithproviders)
     - [Angular: Removed legacy renderer](#angular-removed-legacy-renderer)
-    - [Angular: initializer functions](#angular-initializer-functions)
+    - [Angular: Initializer functions](#angular-initializer-functions)
     - [Next.js: use the `@storybook/nextjs` framework](#nextjs-use-the-storybooknextjs-framework)
     - [SvelteKit: needs the `@storybook/sveltekit` framework](#sveltekit-needs-the-storybooksveltekit-framework)
     - [Vue3: replaced app export with setup](#vue3-replaced-app-export-with-setup)
@@ -206,7 +208,7 @@
     - [Dropped addon-docs manual babel configuration](#dropped-addon-docs-manual-babel-configuration)
     - [Dropped addon-docs manual configuration](#dropped-addon-docs-manual-configuration)
     - [Autoplay in docs](#autoplay-in-docs)
-    - [Removed STORYBOOK_REACT_CLASSES global](#removed-storybook_react_classes-global)
+    - [Removed STORYBOOK\_REACT\_CLASSES global](#removed-storybook_react_classes-global)
   - [7.0 Deprecations and default changes](#70-deprecations-and-default-changes)
     - [storyStoreV7 enabled by default](#storystorev7-enabled-by-default)
     - [`Story` type deprecated](#story-type-deprecated)
@@ -418,6 +420,12 @@
   - [Webpack upgrade](#webpack-upgrade)
   - [Packages renaming](#packages-renaming)
   - [Deprecated embedded addons](#deprecated-embedded-addons)
+
+## From version 8.4.x to 8.5.x
+
+### Indexing behavior of @storybook/experimental-addon-test is changed
+
+The Storybook test addon used to index stories based on the `test.include` field in the Vitest config file. This caused indexing issues with Storybook, because stories could have been indexed by Storybook and not Vitest, and vice versa. Starting in Storybook 8.5.0-alpha.18, we changed the indexing behavior so that it always uses the globs defined in the `stories` field in `.storybook/main.js` for a more consistent experience. It is now discouraged to use `test.include`, please remove it.
 
 ## From version 8.2.x to 8.3.x
 


### PR DESCRIPTION
Closes #

## What I did

- [x] filter mdx files without setting the `test.exclude`, because that causes us to remove all `vitest`'s default.
- [x] ignore `test.include`from the user, and log a warning prompting them to remove it from the config

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | **-1.68** | 0% |
| initSize |  130 MB | 130 MB | 0 B | -0.8 | 0% |
| diffSize |  52.5 MB | 52.5 MB | 0 B | **1.47** | 0% |
| buildSize |  6.75 MB | 6.75 MB | 0 B | -0.33 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **1.77** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | -0.33 | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | -0.33 | 0% |
| buildPreviewSize |  3.19 MB | 3.19 MB | 0 B | 0.33 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.8s | 6.7s | -1s -96ms | -0.8 | -16.3% |
| generateTime |  24.5s | 18.8s | -5s -632ms | -0.99 | -29.8% |
| initTime |  13.8s | 12.1s | -1s -718ms | -1.04 | -14.1% |
| buildTime |  8s | 9.6s | 1.6s | 0.7 | 16.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.3s | 4.5s | 159ms | -0.92 | 3.5% |
| devManagerResponsive |  3.3s | 3.3s | 15ms | -0.71 | 0.4% |
| devManagerHeaderVisible |  546ms | 508ms | -38ms | -0.78 | -7.5% |
| devManagerIndexVisible |  607ms | 537ms | -70ms | -1.16 | -13% |
| devStoryVisibleUncached |  928ms | 1.7s | 793ms | -0.14 | 46.1% |
| devStoryVisible |  578ms | 575ms | -3ms | -0.65 | -0.5% |
| devAutodocsVisible |  444ms | 497ms | 53ms | -0.42 | 10.7% |
| devMDXVisible |  439ms | 491ms | 52ms | -0.21 | 10.6% |
| buildManagerHeaderVisible |  504ms | 501ms | -3ms | -0.69 | -0.6% |
| buildManagerIndexVisible |  574ms | 584ms | 10ms | -0.47 | 1.7% |
| buildStoryVisible |  460ms | 466ms | 6ms | -0.66 | 1.3% |
| buildAutodocsVisible |  405ms | 402ms | -3ms | -0.67 | -0.7% |
| buildMDXVisible |  390ms | 437ms | 47ms | 0.14 | 10.8% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Here's my expert review of the pull request:

Changes the indexing behavior in Storybook's test addon to use the stories field from .storybook/main.js instead of Vitest's test.include option, ensuring consistent story indexing between Storybook and Vitest.

- Added warning message in `code/addons/test/src/vitest-plugin/index.ts` when test.include is used
- Removed support for Vitest's test.include option in favor of Storybook's stories field
- Updated MIGRATION.md to document the deprecation of test.include configuration
- Simplified story file filtering by combining MDX exclusion with initial file selection
- Added dependencies (picocolors, ts-dedent) for warning message formatting



<!-- /greptile_comment -->