### PR TITLE
RNW-Vite: Fix flow plugin including too many things

### DIFF
--- a/code/frameworks/react-native-web-vite/src/preset.ts
+++ b/code/frameworks/react-native-web-vite/src/preset.ts
@@ -73,7 +73,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
 
   plugins.unshift(
     flowPlugin({
-      exclude: [],
+      exclude: [/node_modules\/(?!react-native|@react-native)/],
     }),
     react({
       babel: {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Excludes all node modules except for react native packages which are actually causing the issue.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29952-sha-41e4fd31`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29952-sha-41e4fd31 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29952-sha-41e4fd31 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29952-sha-41e4fd31`](https://npmjs.com/package/storybook/v/0.0.0-pr-29952-sha-41e4fd31) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`danny/fix-rnw-flow-plugin-excludes`](https://github.com/storybookjs/storybook/tree/danny/fix-rnw-flow-plugin-excludes) |
| **Commit** | [`41e4fd31`](https://github.com/storybookjs/storybook/commit/41e4fd31a1ff061bd8fcfd55e0609c13fc303491) |
| **Datetime** | Sun Dec  8 15:24:58 UTC 2024 (`1733671498`) |
| **Workflow run** | [12223000941](https://github.com/storybookjs/storybook/actions/runs/12223000941) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29952`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | -1.09 | 0% |
| initSize |  130 MB | 130 MB | 0 B | **1.98** | 0% |
| diffSize |  52.7 MB | 52.7 MB | 0 B | **1.98** | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | **2** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 1.16 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | 1.16 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | **2** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.4s | 19.1s | 12.7s | 1.02 | 66.5% |
| generateTime |  18.2s | 19.2s | 1s | -0.7 | 5.3% |
| initTime |  11.6s | 13.7s | 2.1s | 0.13 | 15.5% |
| buildTime |  8.8s | 8.8s | -15ms | -0.24 | -0.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6s | 4.6s | -1s -400ms | -0.66 | -30.3% |
| devManagerResponsive |  4s | 3.3s | -682ms | -0.71 | -20.3% |
| devManagerHeaderVisible |  646ms | 488ms | -158ms | -0.95 | -32.4% |
| devManagerIndexVisible |  718ms | 518ms | -200ms | -1.2 | -38.6% |
| devStoryVisibleUncached |  1.3s | 1.7s | 449ms | 0.14 | 25.4% |
| devStoryVisible |  719ms | 518ms | -201ms | -1.09 | -38.8% |
| devAutodocsVisible |  570ms | 485ms | -85ms | -0.57 | -17.5% |
| devMDXVisible |  425ms | 433ms | 8ms | -0.82 | 1.8% |
| buildManagerHeaderVisible |  629ms | 508ms | -121ms | -0.68 | -23.8% |
| buildManagerIndexVisible |  708ms | 604ms | -104ms | -0.47 | -17.2% |
| buildStoryVisible |  571ms | 467ms | -104ms | -0.66 | -22.3% |
| buildAutodocsVisible |  456ms | 415ms | -41ms | -0.46 | -9.9% |
| buildMDXVisible |  494ms | 386ms | -108ms | -0.91 | -28% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates the Flow plugin configuration in React Native Web Vite preset to optimize build performance by limiting Flow processing to only React Native related files.

- Modified exclude pattern in `code/frameworks/react-native-web-vite/src/preset.ts` to `/node_modules\/(?!react-native|@react-native)/`
- Added Flow plugin configuration to process only `.flow` and `.jsx` files through esbuild
- Configured React plugin with automatic JSX runtime and disabled babel configuration files
- Maintained proper extension resolution order prioritizing `.web.*` files



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->