### PR TITLE
RNW-Vite: Add tsconfig path aliases support

### DIFF
--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -58,7 +58,8 @@
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",
-    "@vitejs/plugin-react": "^4.3.2"
+    "@vitejs/plugin-react": "^4.3.2",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/code/frameworks/react-native-web-vite/src/preset.ts
+++ b/code/frameworks/react-native-web-vite/src/preset.ts
@@ -4,6 +4,7 @@ import { viteFinal as reactViteFinal } from '@storybook/react-vite/preset';
 import { esbuildFlowPlugin, flowPlugin } from '@bunchtogether/vite-plugin-flow';
 import react from '@vitejs/plugin-react';
 import type { InlineConfig, PluginOption } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 import type { FrameworkOptions, StorybookConfig } from './types';
 
@@ -72,6 +73,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
   const { plugins = [] } = reactConfig;
 
   plugins.unshift(
+    tsconfigPaths(),
     flowPlugin({
       exclude: [],
     }),

--- a/code/frameworks/react-native-web-vite/src/vite-plugin.ts
+++ b/code/frameworks/react-native-web-vite/src/vite-plugin.ts
@@ -1,9 +1,11 @@
 import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 import { reactNativeWeb } from './preset';
 
 export const storybookReactNativeWeb = () => {
   return [
+    tsconfigPaths(),
     react({
       babel: {
         babelrc: false,

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6705,6 +6705,7 @@ __metadata:
     "@types/node": "npm:^22.0.0"
     "@vitejs/plugin-react": "npm:^4.3.2"
     typescript: "npm:^5.3.2"
+    vite-tsconfig-paths: "npm:^5.1.4"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -16523,6 +16524,13 @@ __metadata:
     slash: "npm:^5.1.0"
     unicorn-magic: "npm:^0.1.0"
   checksum: 10c0/749a6be91cf455c161ebb5c9130df3991cb9fd7568425db850a8279a6cf45acd031c5069395beb7aeb4dd606b64f0d6ff8116c93726178d8e6182fee58c2736d
+  languageName: node
+  linkType: hard
+
+"globrex@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "globrex@npm:0.1.2"
+  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
   languageName: node
   linkType: hard
 
@@ -27581,6 +27589,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsconfck@npm:^3.0.3":
+  version: 3.1.4
+  resolution: "tsconfck@npm:3.1.4"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: 10c0/5120e91b3388574b449d57d08f45d05d9966cf4b9d6aa1018652c1fff6d7d37b1ed099b07e6ebf6099aa40b8a16968dd337198c55b7274892849112b942861ed
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths-webpack-plugin@npm:^4.0.1":
   version: 4.1.0
   resolution: "tsconfig-paths-webpack-plugin@npm:4.1.0"
@@ -28696,6 +28718,22 @@ __metadata:
     sharp:
       optional: true
   checksum: 10c0/02761e1074e62a46b30fc5e13b1c7a3bf6047a5736ac17de8e33376a6cff2b1118a48a95d195ddfd37b1e7a55f6eb3385677da9b4d713189c2b68b9f9843906d
+  languageName: node
+  linkType: hard
+
+"vite-tsconfig-paths@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "vite-tsconfig-paths@npm:5.1.4"
+  dependencies:
+    debug: "npm:^4.1.1"
+    globrex: "npm:^0.1.2"
+    tsconfck: "npm:^3.0.3"
+  peerDependencies:
+    vite: "*"
+  peerDependenciesMeta:
+    vite:
+      optional: true
+  checksum: 10c0/6228f23155ea25d92b1e1702284cf8dc52ad3c683c5ca691edd5a4c82d2913e7326d00708cef1cbfde9bb226261df0e0a12e03ef1d43b6a92d8f02b483ef37e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes N/A

## What I did

New Expo projects use tsconfig path aliases by default, so support it out of the box.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Run the expo sandbox and create a story for a component that uses tsconfig path imports, e.g. `import Component from '@/components/Component'`.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29953-sha-bbfabab3`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29953-sha-bbfabab3 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29953-sha-bbfabab3 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29953-sha-bbfabab3`](https://npmjs.com/package/storybook/v/0.0.0-pr-29953-sha-bbfabab3) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/rnw-add-typescript-paths`](https://github.com/storybookjs/storybook/tree/shilman/rnw-add-typescript-paths) |
| **Commit** | [`bbfabab3`](https://github.com/storybookjs/storybook/commit/bbfabab3d6b2679222d9f1e330439340aeb97114) |
| **Datetime** | Sun Dec  8 15:25:23 UTC 2024 (`1733671523`) |
| **Workflow run** | [12223003343](https://github.com/storybookjs/storybook/actions/runs/12223003343) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29953`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | -1.09 | 0% |
| initSize |  130 MB | 130 MB | 0 B | **1.98** | 0% |
| diffSize |  52.7 MB | 52.7 MB | 0 B | **1.98** | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | **2** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 1.16 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | 1.16 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | **2** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.4s | 6.7s | 342ms | -0.78 | 5.1% |
| generateTime |  18.2s | 19s | 793ms | -0.83 | 4.2% |
| initTime |  11.6s | 13.1s | 1.4s | -0.39 | 11.2% |
| buildTime |  8.8s | 8.6s | -174ms | -0.45 | -2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6s | 4.5s | -1s -427ms | -0.7 | -31.1% |
| devManagerResponsive |  4s | 3.3s | -662ms | -0.66 | -19.6% |
| devManagerHeaderVisible |  646ms | 553ms | -93ms | -0.22 | -16.8% |
| devManagerIndexVisible |  718ms | 629ms | -89ms | -0.17 | -14.1% |
| devStoryVisibleUncached |  1.3s | 1.8s | 519ms | 0.39 | 28.2% |
| devStoryVisible |  719ms | 628ms | -91ms | -0.04 | -14.5% |
| devAutodocsVisible |  570ms | 541ms | -29ms | 0.47 | -5.4% |
| devMDXVisible |  425ms | 539ms | 114ms | 0.41 | 21.2% |
| buildManagerHeaderVisible |  629ms | 552ms | -77ms | -0.19 | -13.9% |
| buildManagerIndexVisible |  708ms | 637ms | -71ms | -0.14 | -11.1% |
| buildStoryVisible |  571ms | 508ms | -63ms | -0.16 | -12.4% |
| buildAutodocsVisible |  456ms | 408ms | -48ms | -0.57 | -11.8% |
| buildMDXVisible |  494ms | 384ms | -110ms | -0.94 | -28.6% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Adds TypeScript path alias support for React Native Web Vite projects, enabling default path aliases in new Expo projects through the integration of vite-tsconfig-paths plugin.

- Added `vite-tsconfig-paths` dependency (^5.1.4) in `code/frameworks/react-native-web-vite/package.json`
- Integrated `tsconfigPaths()` plugin in `code/frameworks/react-native-web-vite/src/vite-plugin.ts` and `preset.ts`
- Configured plugin to run before React and React Native Web plugins for proper path resolution



<!-- /greptile_comment -->