### PR TITLE
Addon Test: Filter out falsy test results in TestProviderRender

### DIFF
--- a/code/addons/test/src/components/TestProviderRender.tsx
+++ b/code/addons/test/src/components/TestProviderRender.tsx
@@ -111,6 +111,7 @@ export const TestProviderRender: FC<
 
     return state.details?.testResults?.flatMap((result) =>
       result.results
+        .filter(Boolean)
         .filter((r) => !entryId || r.storyId === entryId || r.storyId?.startsWith(`${entryId}-`))
         .map((r) => r.reports.find((report) => report.type === 'a11y'))
     );


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | -0.05 | 0% |
| initSize |  133 MB | 133 MB | 0 B | **1.73** | 0% |
| diffSize |  55.1 MB | 55.1 MB | 0 B | **1.72** | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | 0.91 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | **1.82** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **2.36** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | **2.17** | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | 0.85 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7s | 24s | 17s | **2.57** | 🔺70.9% |
| generateTime |  19.6s | 20.2s | 591ms | -0.27 | 2.9% |
| initTime |  13.3s | 17s | 3.7s | **1.98** | 🔺21.8% |
| buildTime |  11.5s | 8.5s | -2s -981ms | -0.49 | -34.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5s | 5.2s | 212ms | 0.14 | 4% |
| devManagerResponsive |  3.7s | 3.9s | 225ms | 0.3 | 5.7% |
| devManagerHeaderVisible |  581ms | 622ms | 41ms | 0.63 | 6.6% |
| devManagerIndexVisible |  619ms | 658ms | 39ms | 0.09 | 5.9% |
| devStoryVisibleUncached |  1.9s | 1.4s | -536ms | -0.9 | -37.3% |
| devStoryVisible |  620ms | 660ms | 40ms | 0.35 | 6.1% |
| devAutodocsVisible |  555ms | 559ms | 4ms | 0.2 | 0.7% |
| devMDXVisible |  538ms | 566ms | 28ms | 0.68 | 4.9% |
| buildManagerHeaderVisible |  572ms | 641ms | 69ms | 0.44 | 10.8% |
| buildManagerIndexVisible |  694ms | 729ms | 35ms | 0.4 | 4.8% |
| buildStoryVisible |  530ms | 581ms | 51ms | 0.48 | 8.8% |
| buildAutodocsVisible |  457ms | 433ms | -24ms | -0.44 | -5.5% |
| buildMDXVisible |  441ms | 402ms | -39ms | -0.81 | -9.7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR adds filtering for falsy test results in the TestProviderRender component to prevent potential undefined/null handling issues in the Storybook test addon.

- Added `.filter(Boolean)` to accessibility test results processing in `code/addons/test/src/components/TestProviderRender.tsx`
- Missing similar filtering for main test results array which could lead to inconsistent handling
- Potential runtime errors in panel opening logic if all results are filtered out
- Consider adding null checks around `firstNotPassed` usage in panel opening code



<!-- /greptile_comment -->