### PR TITLE
Core: Fix bundling of React

### DIFF
--- a/code/core/assets/server/addon.tsconfig.json
+++ b/code/core/assets/server/addon.tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
+    "jsx": "react",
     "jsxImportSource": "react"
   }
 }


### PR DESCRIPTION
Relates to #29805 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR undoes the work done in #28541 which actually caused the react globalization logic to stop working in Storybook 8. This should allow users to use React 19 in preview while React 18 is used in the manager.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- Build a react 19 sandbox
- Add a manager.tsx file with the following content:
```tsx
import React from 'react';
import { addons, types } from '@storybook/manager-api';

addons.register('test', () => {
  addons.add('test', {
    type: types.TOOLEXTRA,
    title: 'test',
    paramKey: 'test',
    render: () => {
      return <>test</>
    },
  });
});
```
- Inspect the generated manager-bundle file, make sure React is globalized and not bundled in

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR reverts changes to JSX compilation settings in the React addon to fix React globalization logic in Storybook 8, enabling React 19 support in preview while maintaining React 18 compatibility in the manager.

- Modified `code/core/assets/server/addon.tsconfig.json` to revert JSX compilation mode from 'react-jsx' back to 'react'
- Maintains `jsxImportSource` setting as 'react' for compatibility
- Undoes changes from PR #28541 that broke React globalization logic
- Enables React 19 support in preview while keeping React 18 in manager



<!-- /greptile_comment -->