### PR TITLE
Build: Improve task command and error message

### DIFF
--- a/scripts/task.ts
+++ b/scripts/task.ts
@@ -3,6 +3,7 @@ import { outputFile, pathExists, readFile } from 'fs-extra';
 import type { TestCase } from 'junit-xml';
 import { getJunitXml } from 'junit-xml';
 import { join, resolve } from 'path';
+import picocolors from 'picocolors';
 import { prompt } from 'prompts';
 import invariant from 'tiny-invariant';
 import { dedent } from 'ts-dedent';
@@ -101,7 +102,7 @@ export const tasks = {
   bench,
   'vitest-integration': vitestTests,
 };
-type TaskKey = keyof typeof tasks;
+export type TaskKey = keyof typeof tasks;
 
 function isSandboxTask(taskKey: TaskKey) {
   return !['install', 'compile', 'publish', 'run-registry', 'check', 'sync-docs'].includes(taskKey);
@@ -179,7 +180,7 @@ export const options = createOptions({
   },
 });
 
-export type PassedOptionValues = Omit<OptionValues<typeof options>, 'task' | 'startFrom' | 'junit'>;
+export type PassedOptionValues = Omit<OptionValues<typeof options>, 'startFrom' | 'junit'>;
 
 const logger = console;
 
@@ -347,7 +348,8 @@ async function run() {
 
   const allOptionValues = await getOptionsOrPrompt('yarn task', options);
 
-  const { task: taskKey, startFrom, junit, ...optionValues } = allOptionValues;
+  const { junit, startFrom, ...optionValues } = allOptionValues;
+  const taskKey = optionValues.task;
 
   const finalTask = tasks[taskKey];
   const { template: templateKey } = optionValues;
@@ -363,7 +365,6 @@ async function run() {
     builtSandboxDir: templateKey && join(templateSandboxDir, 'storybook-static'),
     junitFilename: junit && getJunitFilename(taskKey),
   };
-
   const { sortedTasks, tasksThatDepend } = getTaskList(finalTask, details, optionValues);
   const sortedTasksReady = await Promise.all(
     sortedTasks.map((t) => t.ready(details, optionValues))
@@ -482,27 +483,29 @@ async function run() {
         }
       } catch (err) {
         invariant(err instanceof Error);
-        logger.error(`Error running task ${getTaskKey(task)}:`);
+        logger.error(
+          `Error running task ${picocolors.bold(getTaskKey(task))} for ${picocolors.bgMagenta(picocolors.bold(details.key))}:`
+        );
         logger.error(JSON.stringify(err, null, 2));
 
         if (process.env.CI) {
-          logger.error(
-            dedent`
-              To reproduce this error locally, run:
+          const separator = '\n--------------------------------------------\n';
+          const reproduceMessage = dedent`
+            To reproduce this error locally, run:
 
-              ${getCommand('yarn task', options, {
+            ${picocolors.bold(
+              getCommand('yarn task', options, {
                 ...allOptionValues,
                 link: true,
                 startFrom: 'auto',
-              })}
-              
-              Note this uses locally linking which in rare cases behaves differently to CI. For a closer match, run:
-              
-              ${getCommand('yarn task', options, {
-                ...allOptionValues,
-                startFrom: 'auto',
-              })}`
-          );
+              })
+            )}
+            
+            Note this uses locally linking which in rare cases behaves differently to CI.
+            For a closer match, add ${picocolors.bold('--no-link')} to the command above.
+          `;
+
+          err.message += `\n${separator}${reproduceMessage}${separator}\n`;
         }
 
         controllers.forEach((controller) => {

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { promisify } from 'util';
 
 import { now, saveBench } from '../bench/utils';
-import type { Task } from '../task';
+import type { Task, TaskKey } from '../task';
 
 const logger = console;
 
@@ -22,8 +22,24 @@ export const sandbox: Task = {
 
     return ['run-registry'];
   },
-  async ready({ sandboxDir }) {
-    return pathExists(sandboxDir);
+  async ready({ sandboxDir }, { task: selectedTask }) {
+    // If the selected task requires the sandbox to exist, we check it. Else we always assume it needs to be created
+    // This avoids issues where you want to overwrite a sandbox and it will stop because it already exists
+    const tasksAfterSandbox: TaskKey[] = [
+      'vitest-integration',
+      'test-runner',
+      'test-runner-dev',
+      'e2e-tests',
+      'e2e-tests-dev',
+      'smoke-test',
+      'dev',
+      'build',
+      'serve',
+      'chromatic',
+      'bench',
+    ];
+    const isSelectedTaskAfterSandboxCreation = tasksAfterSandbox.includes(selectedTask);
+    return isSelectedTaskAfterSandboxCreation && pathExists(sandboxDir);
   },
   async run(details, options) {
     if (options.link && details.template.inDevelopment) {
@@ -33,7 +49,7 @@ export const sandbox: Task = {
 
       options.link = false;
     }
-    if (await this.ready(details)) {
+    if (await this.ready(details, options)) {
       logger.info('🗑  Removing old sandbox dir');
       await remove(details.sandboxDir);
     }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR does the following improvements:
- The sandbox task will not be ready by default if the selected task is (in order) before sandbox. This fixes the issue where recreating a sandbox using --no-link always just stops with no reason when there was already an existing sandbox
- The error message is improved so it's clear which sandbox failed, making it easier to inspect in Circle CI

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | **2.91** | 0% |
| initSize |  133 MB | 133 MB | 0 B | 0.84 | 0% |
| diffSize |  55.1 MB | 55.1 MB | 0 B | 0.82 | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | 0.36 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.85 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 1 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | 0.95 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | 0.28 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.6s | 6.7s | -1s -922ms | -0.42 | -28.5% |
| generateTime |  20s | 19.1s | -878ms | -0.74 | -4.6% |
| initTime |  13.6s | 13.1s | -486ms | -0.35 | -3.7% |
| buildTime |  9.9s | 8.5s | -1s -428ms | -0.92 | -16.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.1s | 4.2s | -1s -974ms | **-1.63** | 🔰-46.9% |
| devManagerResponsive |  4.3s | 3.2s | -1s -47ms | **-1.51** | 🔰-32% |
| devManagerHeaderVisible |  659ms | 501ms | -158ms | -1.08 | -31.5% |
| devManagerIndexVisible |  668ms | 531ms | -137ms | -1.11 | -25.8% |
| devStoryVisibleUncached |  1.9s | 1.7s | -267ms | -0.02 | -15.5% |
| devStoryVisible |  741ms | 529ms | -212ms | -1.14 | -40.1% |
| devAutodocsVisible |  514ms | 460ms | -54ms | -1.04 | -11.7% |
| devMDXVisible |  502ms | 475ms | -27ms | -0.81 | -5.7% |
| buildManagerHeaderVisible |  661ms | 538ms | -123ms | -0.69 | -22.9% |
| buildManagerIndexVisible |  685ms | 618ms | -67ms | -0.77 | -10.8% |
| buildStoryVisible |  532ms | 492ms | -40ms | -0.65 | -8.1% |
| buildAutodocsVisible |  414ms | 373ms | -41ms | **-1.39** | 🔰-11% |
| buildMDXVisible |  524ms | 371ms | -153ms | **-1.47** | 🔰-41.2% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Here's my concise review of the PR's changes:

Improves task command error handling and sandbox task behavior in Storybook CLI, focusing on better developer experience and debugging capabilities.

- Added clearer error messages in `scripts/task.ts` that highlight which sandbox failed using picocolors formatting
- Modified sandbox task's ready check in `scripts/tasks/sandbox.ts` to only verify sandbox existence for relevant tasks (e.g. test-runner, e2e-tests)
- Simplified CI reproduction instructions by suggesting `--no-link` flag instead of showing multiple commands
- Fixed issue where recreating sandboxes with `--no-link` would stop unexpectedly when sandbox already existed
- Improved type safety by updating PassedOptionValues to retain 'task' in options object



<!-- /greptile_comment -->