### PR TITLE
Addon Test: Show sub test provider toggle state in main testing module

### DIFF
--- a/code/addons/test/src/components/ContextMenuItem.tsx
+++ b/code/addons/test/src/components/ContextMenuItem.tsx
@@ -67,7 +67,7 @@ export const ContextMenuItem: FC<{
             padding="small"
             disabled={state.crashed || isDisabled}
           >
-            <Icon fill={theme.barTextColor} />
+            <Icon fill={theme.textMutedColor} />
           </Button>
         }
       />

--- a/code/addons/test/src/components/Description.tsx
+++ b/code/addons/test/src/components/Description.tsx
@@ -12,7 +12,7 @@ export const Wrapper = styled.div(({ theme }) => ({
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',
   fontSize: theme.typography.size.s1,
-  color: theme.barTextColor,
+  color: theme.textMutedColor,
 }));
 
 const PositiveText = styled.span(({ theme }) => ({

--- a/code/addons/test/src/components/TestProviderRender.tsx
+++ b/code/addons/test/src/components/TestProviderRender.tsx
@@ -76,6 +76,16 @@ const StopIcon = styled(StopAltIcon)({
   width: 10,
 });
 
+const ItemTitle = styled.span<{ enabled?: boolean }>(
+  ({ enabled, theme }) =>
+    !enabled && {
+      color: theme.textMutedColor,
+      '&:after': {
+        content: '" (disabled)"',
+      },
+    }
+);
+
 const statusOrder: TestStatus[] = ['failed', 'warning', 'pending', 'passed', 'skipped'];
 const statusMap: Record<TestStatus, ComponentProps<typeof TestStatusIcon>['status']> = {
   failed: 'negative',
@@ -233,7 +243,7 @@ export const TestProviderRender: FC<
           />
           <ListItem
             as="label"
-            title="Coverage"
+            title={<ItemTitle enabled={config.coverage}>Coverage</ItemTitle>}
             icon={<ShieldIcon color={theme.textMutedColor} />}
             right={
               <Checkbox
@@ -247,7 +257,7 @@ export const TestProviderRender: FC<
           {isA11yAddon && (
             <ListItem
               as="label"
-              title="Accessibility"
+              title={<ItemTitle enabled={config.a11y}>Accessibility</ItemTitle>}
               icon={<AccessibilityIcon color={theme.textMutedColor} />}
               right={
                 <Checkbox
@@ -285,7 +295,7 @@ export const TestProviderRender: FC<
           />
           {coverageSummary ? (
             <ListItem
-              title="Coverage"
+              title={<ItemTitle enabled={config.coverage}>Coverage</ItemTitle>}
               href={'/coverage/index.html'}
               // @ts-expect-error ListItem doesn't include all anchor attributes in types, but it is an achor element
               target="_blank"
@@ -300,13 +310,13 @@ export const TestProviderRender: FC<
             />
           ) : (
             <ListItem
-              title="Coverage"
+              title={<ItemTitle enabled={config.coverage}>Coverage</ItemTitle>}
               icon={<TestStatusIcon status="unknown" aria-label={`status: unknown`} />}
             />
           )}
           {isA11yAddon && (
             <ListItem
-              title="Accessibility"
+              title={<ItemTitle enabled={config.a11y}>Accessibility</ItemTitle>}
               onClick={
                 (a11yStatus === 'negative' || a11yStatus === 'warning') && a11yResults.length
                   ? () => {

--- a/code/core/src/components/components/Loader/Loader.tsx
+++ b/code/core/src/components/components/Loader/Loader.tsx
@@ -63,7 +63,7 @@ const ProgressBar = styled.div(({ theme }) => ({
 const ProgressMessage = styled.div(({ theme }) => ({
   minHeight: '2em',
   fontSize: `${theme.typography.size.s1}px`,
-  color: theme.barTextColor,
+  color: theme.textMutedColor,
 }));
 
 const ErrorIcon = styled(LightningOffIcon)(({ theme }) => ({

--- a/code/core/src/components/components/tooltip/ListItem.tsx
+++ b/code/core/src/components/components/tooltip/ListItem.tsx
@@ -40,7 +40,7 @@ const Title = styled(({ active, loading, disabled, ...rest }: TitleProps) => <sp
   ({ disabled, theme }) =>
     disabled
       ? {
-          color: transparentize(0.7, theme.color.defaultText),
+          color: theme.textMutedColor,
         }
       : {}
 );

--- a/code/core/src/manager/components/sidebar/LegacyRender.tsx
+++ b/code/core/src/manager/components/sidebar/LegacyRender.tsx
@@ -32,7 +32,7 @@ const TitleWrapper = styled.div<{ crashed?: boolean }>(({ crashed, theme }) => (
 
 const DescriptionWrapper = styled.div(({ theme }) => ({
   fontSize: theme.typography.size.s1,
-  color: theme.barTextColor,
+  color: theme.textMutedColor,
 }));
 
 const Progress = styled(ProgressSpinner)({

--- a/code/core/src/manager/components/sidebar/SearchResults.tsx
+++ b/code/core/src/manager/components/sidebar/SearchResults.tsx
@@ -70,7 +70,7 @@ const NoResults = styled.div(({ theme }) => ({
   lineHeight: `18px`,
   color: theme.color.defaultText,
   small: {
-    color: theme.barTextColor,
+    color: theme.textMutedColor,
     fontSize: `${theme.typography.size.s1}px`,
   },
 }));


### PR DESCRIPTION
Closes #30009

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Muted the disabled options and adds a (disabled) suffix:

<img width="315" alt="Screenshot 2024-12-11 at 10 55 29" src="https://github.com/user-attachments/assets/b9eace33-598b-49f7-8bd4-a3d7ff7e5f87">

While I was implementing this, I noticed a discrepancy in the color between the muted option and the description text above ("Starting..."). This prompted me to review what color variable was being used. I found a bunch of places where `barTextColor` was being used while `textMutedColor` is more appropriate (because it's not in a bar and the intent is muted text) so I've corrected those places as well.

Note that the color difference between `defaultText` and `textMutedColor` is pretty minimal, but I've verified these are the exact colors used in Figma.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | **2.91** | 0% |
| initSize |  133 MB | 133 MB | -69 B | 0.84 | 0% |
| diffSize |  55.1 MB | 55.1 MB | -69 B | 0.82 | 0% |
| buildSize |  6.87 MB | 6.87 MB | -20 B | 0.36 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.85 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | -12 B | 0.99 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | -12 B | 0.95 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | -8 B | 0.28 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.6s | 7.6s | -964ms | -0.21 | -12.5% |
| generateTime |  20s | 21.5s | 1.5s | 0.66 | 7.3% |
| initTime |  13.6s | 14.8s | 1.1s | 0.75 | 8% |
| buildTime |  9.9s | 8.6s | -1s -290ms | -0.75 | -14.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.1s | 4.8s | -1s -330ms | -0.74 | -27.4% |
| devManagerResponsive |  4.3s | 3.4s | -864ms | -1.1 | -25% |
| devManagerHeaderVisible |  659ms | 567ms | -92ms | -0.28 | -16.2% |
| devManagerIndexVisible |  668ms | 615ms | -53ms | -0.25 | -8.6% |
| devStoryVisibleUncached |  1.9s | 1.7s | -282ms | -0.05 | -16.5% |
| devStoryVisible |  741ms | 609ms | -132ms | -0.33 | -21.7% |
| devAutodocsVisible |  514ms | 492ms | -22ms | -0.67 | -4.5% |
| devMDXVisible |  502ms | 463ms | -39ms | -0.97 | -8.4% |
| buildManagerHeaderVisible |  661ms | 588ms | -73ms | -0.18 | -12.4% |
| buildManagerIndexVisible |  685ms | 665ms | -20ms | -0.3 | -3% |
| buildStoryVisible |  532ms | 536ms | 4ms | -0.11 | 0.7% |
| buildAutodocsVisible |  414ms | 447ms | 33ms | -0.21 | 7.4% |
| buildMDXVisible |  524ms | 414ms | -110ms | -0.69 | -26.6% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Here's my summary of the PR changes:

Improves visual feedback for disabled test providers and standardizes muted text colors across the UI components in Storybook's testing module.

- Added `(disabled)` suffix and muted text color for disabled test options in `code/addons/test/src/components/TestProviderRender.tsx`
- Replaced `barTextColor` with `textMutedColor` in multiple components for better semantic meaning and consistency
- Added new `ItemTitle` styled component to handle disabled state styling
- Updated `ListItem` component to use theme's `textMutedColor` directly instead of transparentized text
- Fixed color inconsistency between disabled options and description text in test provider UI



<!-- /greptile_comment -->