### PR TITLE
Addon Test: Use local storybook binary instead

### DIFF
--- a/code/addons/test/src/postinstall.ts
+++ b/code/addons/test/src/postinstall.ts
@@ -16,7 +16,7 @@ import { readConfig, writeConfig } from 'storybook/internal/csf-tools';
 import { colors, logger } from 'storybook/internal/node-logger';
 
 // eslint-disable-next-line depend/ban-dependencies
-import { execa } from 'execa';
+import { $ } from 'execa';
 import { findUp } from 'find-up';
 import { dirname, extname, join, relative, resolve } from 'pathe';
 import picocolors from 'picocolors';
@@ -227,22 +227,9 @@ export default async function postInstall(options: PostinstallOptions) {
     }
 
     if (shouldUninstall) {
-      await execa(
-        packageManager.getRemoteRunCommand(),
-        [
-          'storybook',
-          'remove',
-          addonInteractionsName,
-          '--package-manager',
-          options.packageManager,
-          '--config-dir',
-          options.configDir,
-        ],
-        {
-          shell: true,
-          stdio: 'inherit',
-        }
-      );
+      await $({
+        stdio: 'inherit',
+      })`storybook remove ${addonInteractionsName} --package-manager ${options.packageManager} --config-dir ${options.configDir}`;
     }
   }
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Use local storybook binary instead for remove command

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30021-sha-b1cc74da`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30021-sha-b1cc74da sandbox` or in an existing project with `npx storybook@0.0.0-pr-30021-sha-b1cc74da upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30021-sha-b1cc74da`](https://npmjs.com/package/storybook/v/0.0.0-pr-30021-sha-b1cc74da) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/use-local`](https://github.com/storybookjs/storybook/tree/kasper/use-local) |
| **Commit** | [`b1cc74da`](https://github.com/storybookjs/storybook/commit/b1cc74dac1d86c517cdc50d2bb3bd83c8554bcaa) |
| **Datetime** | Wed Dec 11 11:33:45 UTC 2024 (`1733916825`) |
| **Workflow run** | [12275506540](https://github.com/storybookjs/storybook/actions/runs/12275506540) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30021`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | **1.71** | 0% |
| initSize |  133 MB | 133 MB | 0 B | 0.6 | 0% |
| diffSize |  55.1 MB | 55.1 MB | 0 B | 0.58 | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | 0.69 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.6 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 0.73 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | 0.7 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | 0.69 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.5s | 22.5s | 14.9s | **3.3** | 🔺66.6% |
| generateTime |  22.5s | 21.6s | -928ms | 0.39 | -4.3% |
| initTime |  16.7s | 16.5s | -161ms | **1.4** | -1% |
| buildTime |  9.2s | 8.8s | -398ms | -0.88 | -4.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 5.8s | 367ms | 0.56 | 6.3% |
| devManagerResponsive |  3.9s | 3.8s | -64ms | -0.27 | -1.7% |
| devManagerHeaderVisible |  603ms | 676ms | 73ms | 0.93 | 10.8% |
| devManagerIndexVisible |  671ms | 749ms | 78ms | 1.11 | 10.4% |
| devStoryVisibleUncached |  2.2s | 2s | -224ms | 0.5 | -11.2% |
| devStoryVisible |  635ms | 712ms | 77ms | 0.69 | 10.8% |
| devAutodocsVisible |  694ms | 557ms | -137ms | -0.14 | -24.6% |
| devMDXVisible |  684ms | 585ms | -99ms | 0.38 | -16.9% |
| buildManagerHeaderVisible |  642ms | 660ms | 18ms | 0.34 | 2.7% |
| buildManagerIndexVisible |  733ms | 770ms | 37ms | 0.47 | 4.8% |
| buildStoryVisible |  581ms | 589ms | 8ms | 0.32 | 1.4% |
| buildAutodocsVisible |  535ms | 433ms | -102ms | -0.58 | -23.6% |
| buildMDXVisible |  463ms | 411ms | -52ms | -0.87 | -12.7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the PR changes:

Simplified the postinstall script in addon-test by refactoring how the interactions addon removal command is executed, using execa's template literal syntax instead of direct command execution.

- Modified `code/addons/test/src/postinstall.ts` to use `$` template literal syntax from execa for cleaner command execution
- Maintains same functionality of removing `@storybook/addon-interactions` during installation
- Keeps all existing package manager and config directory options intact
- Uses local storybook binary instead of remote execution for better reliability



<sub>💡 (4/5) You can add custom instructions or style guidelines for the bot [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->