### PR TITLE
Addon A11y: Refactor environment variable handling for Vitest integration

### DIFF
--- a/code/addons/a11y/src/utils.ts
+++ b/code/addons/a11y/src/utils.ts
@@ -1,25 +1,17 @@
 export function getIsVitestStandaloneRun() {
   try {
-    return process.env.VITEST_STORYBOOK === 'false';
-  } catch {
-    try {
-      // @ts-expect-error Suppress TypeScript warning about wrong setting. Doesn't matter, because we don't use tsc for bundling.
-      return import.meta.env.VITEST_STORYBOOK === 'false';
-    } catch (e) {
-      return false;
-    }
+    // @ts-expect-error Suppress TypeScript warning about wrong setting. Doesn't matter, because we don't use tsc for bundling.
+    return import.meta.env.VITEST_STORYBOOK === 'false';
+  } catch (e) {
+    return false;
   }
 }
 
 export function getIsVitestRunning() {
   try {
-    return process?.env.MODE === 'test';
-  } catch {
-    try {
-      // @ts-expect-error Suppress TypeScript warning about wrong setting. Doesn't matter, because we don't use tsc for bundling.
-      return import.meta.env.MODE === 'test';
-    } catch (e) {
-      return false;
-    }
+    // @ts-expect-error Suppress TypeScript warning about wrong setting. Doesn't matter, because we don't use tsc for bundling.
+    return import.meta.env.MODE === 'test';
+  } catch (e) {
+    return false;
   }
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Accessibility checks were always running, independently of whether the a11y checkbox was checked in the testing module or not. The applied fix applies environment variables correctly again to avoid the issue.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | **1.71** | 0% |
| initSize |  133 MB | 133 MB | 0 B | 0.6 | 0% |
| diffSize |  55.1 MB | 55.1 MB | 0 B | 0.58 | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | 0.69 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.6 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 0.73 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | 0.7 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | 0.69 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.5s | 7.3s | -146ms | -0.24 | -2% |
| generateTime |  22.5s | 22.9s | 408ms | 0.98 | 1.8% |
| initTime |  16.7s | 17.5s | 852ms | **1.97** | 4.8% |
| buildTime |  9.2s | 9.4s | 283ms | 0.01 | 3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 5.4s | 0ms | 0 | 0% |
| devManagerResponsive |  3.9s | 3.8s | -94ms | -0.35 | -2.5% |
| devManagerHeaderVisible |  603ms | 543ms | -60ms | -0.68 | -11% |
| devManagerIndexVisible |  671ms | 617ms | -54ms | -0.3 | -8.8% |
| devStoryVisibleUncached |  2.2s | 1.8s | -410ms | 0.01 | -22.6% |
| devStoryVisible |  635ms | 617ms | -18ms | -0.32 | -2.9% |
| devAutodocsVisible |  694ms | 468ms | -226ms | -1.14 | -48.3% |
| devMDXVisible |  684ms | 658ms | -26ms | **1.27** | -4% |
| buildManagerHeaderVisible |  642ms | 630ms | -12ms | 0.06 | -1.9% |
| buildManagerIndexVisible |  733ms | 717ms | -16ms | 0 | -2.2% |
| buildStoryVisible |  581ms | 581ms | 0ms | 0.23 | 0% |
| buildAutodocsVisible |  535ms | 521ms | -14ms | 0.73 | -2.7% |
| buildMDXVisible |  463ms | 547ms | 84ms | **1.59** | 🔺15.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and PR context, I'll create a concise summary of the key changes:

Refactored environment variable handling in Storybook's a11y and test addons to fix accessibility checks running unintentionally.

- Simplified environment checks in `code/addons/a11y/src/utils.ts` to directly use `import.meta.env` instead of redundant process.env fallbacks
- Added conditional a11y check enablement in `code/addons/test/src/vitest-plugin/index.ts` based on environment configuration
- Moved `VITEST_STORYBOOK` environment variable definition earlier in the code to avoid duplication
- Removed unused TestManager import and unnecessary process.env polyfill from define section

The changes ensure accessibility checks only run when explicitly enabled through user settings, fixing a bug where they would always execute regardless of configuration.



<!-- /greptile_comment -->