### PR TITLE
Addon Test: Fix duplicate `test.include` patterns

### DIFF
--- a/code/addons/test/src/vitest-plugin/index.ts
+++ b/code/addons/test/src/vitest-plugin/index.ts
@@ -124,7 +124,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin> => {
         .replace('</head>', `${headHtmlSnippet ?? ''}</head>`)
         .replace('<body>', `<body>${bodyHtmlSnippet ?? ''}`);
     },
-    async config(inputConfig_DoNotMutate) {
+    async config(inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED) {
       // ! We're not mutating the input config, instead we're returning a new partial config
       // ! see https://vite.dev/guide/api-plugin.html#config
       try {
@@ -148,8 +148,9 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin> => {
           setupFiles: [
             '@storybook/experimental-addon-test/internal/setup-file',
             // if the existing setupFiles is a string, we have to include it otherwise we're overwriting it
-            typeof inputConfig_DoNotMutate.test?.setupFiles === 'string' &&
-              inputConfig_DoNotMutate.test?.setupFiles,
+            typeof inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test
+              ?.setupFiles === 'string' &&
+              inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test?.setupFiles,
           ].filter(Boolean),
 
           ...(finalOptions.storybookScript
@@ -175,7 +176,8 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin> => {
             .map((path) => convertPathToPattern(path)),
 
           // if the existing deps.inline is true, we keep it as-is, because it will inline everything
-          ...(inputConfig_DoNotMutate.test?.server?.deps?.inline !== true
+          ...(inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test?.server?.deps
+            ?.inline !== true
             ? {
                 server: {
                   deps: {
@@ -186,7 +188,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin> => {
             : {}),
 
           browser: {
-            ...inputConfig_DoNotMutate.test?.browser,
+            ...inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test?.browser,
             commands: {
               getInitialGlobals: () => {
                 const envConfig = JSON.parse(process.env.VITEST_STORYBOOK_CONFIG ?? '{}');
@@ -203,8 +205,9 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin> => {
               },
             },
             // if there is a test.browser config AND test.browser.screenshotFailures is not explicitly set, we set it to false
-            ...(inputConfig_DoNotMutate.test?.browser &&
-            inputConfig_DoNotMutate.test.browser.screenshotFailures === undefined
+            ...(inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test?.browser &&
+            inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test.browser
+              .screenshotFailures === undefined
               ? {
                   screenshotFailures: false,
                 }
@@ -213,7 +216,11 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin> => {
         },
 
         envPrefix: Array.from(
-          new Set([...(inputConfig_DoNotMutate.envPrefix || []), 'STORYBOOK_', 'VITE_'])
+          new Set([
+            ...(inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.envPrefix || []),
+            'STORYBOOK_',
+            'VITE_',
+          ])
         ),
 
         resolve: {
@@ -254,8 +261,12 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin> => {
       );
 
       // alert the user of problems
-      if (inputConfig_DoNotMutate.test.include?.length > 0) {
-        console.warn(
+      if (
+        inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test.include?.length > 0
+      ) {
+        // remove the user's existing include, because we're replacing it with our own heuristic based on main.ts#stories
+        inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test.include = [];
+        console.log(
           picocolors.yellow(dedent`
             Warning: Starting in Storybook 8.5.0-alpha.18, the "test.include" option in Vitest is discouraged in favor of just using the "stories" field in your Storybook configuration.
 

--- a/test-storybooks/portable-stories-kitchen-sink/react/vitest.workspace.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/vitest.workspace.ts
@@ -10,9 +10,6 @@ export default defineWorkspace([
     test: {
       name: "storybook",
       pool: "threads",
-      include: [
-        "stories/AddonTest.stories.?(c|m)[jt]s?(x)",
-      ],
       deps: {
         optimizer: {
           web: { 


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

https://github.com/storybookjs/storybook/pull/29806 introduced a regression, where we wouldn't correctly remove any user-defined patterns in the Vitest workspace config, but just add our `stories` based on on top. That meant that if user's include patterns already included stories, they would be included and counted twice.

This fixes that, by removing the user's `test.include` config correctly.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. In the React kitchen sink:
2. Run all tests from the Storybook UI, _twice_. See that it should report the correct number of tests (12 at the time of writing).
3. Add back the `test.include` configuration that was removed here: https://github.com/storybookjs/storybook/pull/30029/files#diff-ac98573544572f4f674f737551c9bc27cd63113cc15d5b3fcd6f05a3f5ed62f3L13-L15
4. Restart Storybook, run tests
5. See a warning in the terminal with _"Warning: Starting in Storybook 8.5.0-alpha.18, the "test.include" option in Vitest is discouraged..."_
6. Run tests twice again, and see that even with the bad `include`, tests are still counted correctly.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
7. Open Storybook in your browser
8. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 0.86 | 0% |
| initSize |  133 MB | 133 MB | 0 B | **2.49** | 0% |
| diffSize |  55.3 MB | 55.3 MB | 0 B | **2.64** | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | **-2.01** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | **-2** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **-2.38** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | **-2.01** | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | **-2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.4s | 7.5s | -903ms | -0.68 | -12% |
| generateTime |  24.1s | 20.3s | -3s -765ms | -0.39 | -18.5% |
| initTime |  15.5s | 14.4s | -1s -114ms | -0.21 | -7.7% |
| buildTime |  10.3s | 7.7s | -2s -599ms | **-2.39** | 🔰-33.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.2s | 6.2s | 1s | **1.95** | 🔺16.4% |
| devManagerResponsive |  3.9s | 4s | 168ms | 0.9 | 4.1% |
| devManagerHeaderVisible |  654ms | 686ms | 32ms | **1.42** | 4.7% |
| devManagerIndexVisible |  693ms | 725ms | 32ms | **1.25** | 4.4% |
| devStoryVisibleUncached |  2.1s | 1.9s | -225ms | 0.22 | -11.6% |
| devStoryVisible |  694ms | 723ms | 29ms | **1.24** | 4% |
| devAutodocsVisible |  469ms | 662ms | 193ms | **1.82** | 🔺29.2% |
| devMDXVisible |  582ms | 529ms | -53ms | -0.1 | -10% |
| buildManagerHeaderVisible |  728ms | 556ms | -172ms | -0.34 | -30.9% |
| buildManagerIndexVisible |  741ms | 635ms | -106ms | -0.44 | -16.7% |
| buildStoryVisible |  600ms | 500ms | -100ms | -0.38 | -20% |
| buildAutodocsVisible |  512ms | 435ms | -77ms | -0.35 | -17.7% |
| buildMDXVisible |  465ms | 450ms | -15ms | 0.01 | -3.3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixed a regression in the Vitest workspace configuration where user-defined test patterns were causing duplicate test counts by properly handling the test.include configuration.

- Modified `code/addons/test/src/vitest-plugin/index.ts` to clear user's test.include array when detected
- Added warning message in console for deprecated test.include usage starting from v8.5.0-alpha.18
- Removed explicit test.include patterns from `test-storybooks/portable-stories-kitchen-sink/react/vitest.workspace.ts`
- Ensured backward compatibility while preventing duplicate story counting



<!-- /greptile_comment -->