### PR TITLE
UI: Fix controls and parameters on tag-filtered stories

### DIFF
--- a/code/core/src/manager-api/lib/stories.ts
+++ b/code/core/src/manager-api/lib/stories.ts
@@ -342,6 +342,7 @@ export const transformStoryIndexToStoriesHash = (
     .reduce(addItem, orphanHash);
 };
 
+/** Now we need to patch in the existing prepared stories */
 export const addPreparedStories = (newHash: API_IndexHash, oldHash?: API_IndexHash) => {
   if (!oldHash) {
     return newHash;

--- a/code/core/src/manager-api/modules/stories.ts
+++ b/code/core/src/manager-api/modules/stories.ts
@@ -568,41 +568,61 @@ export const init: ModuleFn<SubAPI, SubState> = ({
     // The story index we receive on fetchStoryIndex is not, but all the prepared fields are optional
     // so we can cast one to the other easily enough
     setIndex: async (input) => {
-      const { index: oldHash, status, filters } = store.getState();
-      const newHash = transformStoryIndexToStoriesHash(input, {
+      const { filteredIndex: oldFilteredHash, index: oldHash, status, filters } = store.getState();
+      const newFilteredHash = transformStoryIndexToStoriesHash(input, {
         provider,
         docsOptions,
         status,
         filters,
       });
+      const newHash = transformStoryIndexToStoriesHash(input, {
+        provider,
+        docsOptions,
+        status,
+        filters: {},
+      });
 
-      // Now we need to patch in the existing prepared stories
-      const output = addPreparedStories(newHash, oldHash);
-
-      await store.setState({ internal_index: input, index: output, indexError: undefined });
+      await store.setState({
+        internal_index: input,
+        filteredIndex: addPreparedStories(newFilteredHash, oldFilteredHash),
+        index: addPreparedStories(newHash, oldHash),
+        indexError: undefined,
+      });
     },
+    // FIXME: is there a bug where filtered stories get added back in on updateStory???
     updateStory: async (
       storyId: StoryId,
       update: StoryUpdate,
       ref?: API_ComposedRef
     ): Promise<void> => {
       if (!ref) {
-        const { index } = store.getState();
-        if (!index) {
-          return;
+        const { index, filteredIndex } = store.getState();
+        if (index) {
+          index[storyId] = {
+            ...index[storyId],
+            ...update,
+          } as API_StoryEntry;
         }
-        index[storyId] = {
-          ...index[storyId],
-          ...update,
-        } as API_StoryEntry;
-        await store.setState({ index });
+        if (filteredIndex) {
+          filteredIndex[storyId] = {
+            ...filteredIndex[storyId],
+            ...update,
+          } as API_StoryEntry;
+        }
+        if (index || filteredIndex) {
+          await store.setState({ index, filteredIndex });
+        }
       } else {
-        const { id: refId, index }: any = ref;
+        const { id: refId, index, filteredIndex }: any = ref;
         index[storyId] = {
           ...index[storyId],
           ...update,
         } as API_StoryEntry;
-        await fullAPI.updateRef(refId, { index });
+        filteredIndex[storyId] = {
+          ...filteredIndex[storyId],
+          ...update,
+        } as API_StoryEntry;
+        await fullAPI.updateRef(refId, { index, filteredIndex });
       }
     },
     updateDocs: async (
@@ -611,22 +631,33 @@ export const init: ModuleFn<SubAPI, SubState> = ({
       ref?: API_ComposedRef
     ): Promise<void> => {
       if (!ref) {
-        const { index } = store.getState();
-        if (!index) {
-          return;
+        const { index, filteredIndex } = store.getState();
+        if (index) {
+          index[docsId] = {
+            ...index[docsId],
+            ...update,
+          } as API_DocsEntry;
         }
-        index[docsId] = {
-          ...index[docsId],
-          ...update,
-        } as API_DocsEntry;
-        await store.setState({ index });
+        if (filteredIndex) {
+          filteredIndex[docsId] = {
+            ...filteredIndex[docsId],
+            ...update,
+          } as API_DocsEntry;
+        }
+        if (index || filteredIndex) {
+          await store.setState({ index, filteredIndex });
+        }
       } else {
-        const { id: refId, index }: any = ref;
+        const { id: refId, index, filteredIndex }: any = ref;
         index[docsId] = {
           ...index[docsId],
           ...update,
         } as API_DocsEntry;
-        await fullAPI.updateRef(refId, { index });
+        filteredIndex[docsId] = {
+          ...filteredIndex[docsId],
+          ...update,
+        } as API_DocsEntry;
+        await fullAPI.updateRef(refId, { index, filteredIndex });
       }
     },
     setPreviewInitialized: async (ref) => {

--- a/code/core/src/manager-api/tests/refs.test.ts
+++ b/code/core/src/manager-api/tests/refs.test.ts
@@ -291,6 +291,7 @@ describe('Refs API', () => {
         {
           "refs": {
             "fake": {
+              "filteredIndex": undefined,
               "id": "fake",
               "index": undefined,
               "indexError": {
@@ -360,6 +361,7 @@ describe('Refs API', () => {
         {
           "refs": {
             "fake": {
+              "filteredIndex": undefined,
               "id": "fake",
               "index": undefined,
               "indexError": {
@@ -504,6 +506,7 @@ describe('Refs API', () => {
         {
           "refs": {
             "fake": {
+              "filteredIndex": {},
               "id": "fake",
               "index": {},
               "internal_index": {
@@ -522,6 +525,7 @@ describe('Refs API', () => {
         {
           "refs": {
             "fake": {
+              "filteredIndex": {},
               "id": "fake",
               "index": {},
               "internal_index": {
@@ -601,6 +605,7 @@ describe('Refs API', () => {
         {
           "refs": {
             "fake": {
+              "filteredIndex": {},
               "id": "fake",
               "index": {},
               "internal_index": {
@@ -682,6 +687,7 @@ describe('Refs API', () => {
         {
           "refs": {
             "fake": {
+              "filteredIndex": {},
               "id": "fake",
               "index": {},
               "internal_index": {
@@ -763,6 +769,7 @@ describe('Refs API', () => {
         {
           "refs": {
             "fake": {
+              "filteredIndex": undefined,
               "id": "fake",
               "index": undefined,
               "internal_index": undefined,
@@ -905,6 +912,7 @@ describe('Refs API', () => {
         {
           "refs": {
             "fake": {
+              "filteredIndex": undefined,
               "id": "fake",
               "index": undefined,
               "internal_index": undefined,
@@ -987,6 +995,7 @@ describe('Refs API', () => {
         {
           "refs": {
             "fake": {
+              "filteredIndex": {},
               "id": "fake",
               "index": {},
               "internal_index": {
@@ -1068,6 +1077,7 @@ describe('Refs API', () => {
         {
           "refs": {
             "fake": {
+              "filteredIndex": {},
               "id": "fake",
               "index": {},
               "internal_index": {
@@ -1227,18 +1237,20 @@ describe('Refs API', () => {
         },
       };
 
+      const transformOptions = {
+        provider: provider as any,
+        docsOptions: {},
+        filters: {},
+        status: {},
+      };
       const initialState: Partial<State> = {
         refs: {
           fake: {
             id: 'fake',
             url: 'https://example.com',
             previewInitialized: true,
-            index: transformStoryIndexToStoriesHash(index, {
-              provider: provider as any,
-              docsOptions: {},
-              filters: {},
-              status: {},
-            }),
+            index: transformStoryIndexToStoriesHash(index, transformOptions),
+            filteredIndex: transformStoryIndexToStoriesHash(index, transformOptions),
             internal_index: index,
           },
         },
@@ -1261,10 +1273,10 @@ describe('Refs API', () => {
 
       await api.setRef('fake', { storyIndex: index });
 
-      await expect(api.getRefs().fake.index).toEqual(
+      await expect(api.getRefs().fake.filteredIndex).toEqual(
         expect.objectContaining({ 'a--1': expect.anything() })
       );
-      await expect(api.getRefs().fake.index).not.toEqual(
+      await expect(api.getRefs().fake.filteredIndex).not.toEqual(
         expect.objectContaining({ 'a--2': expect.anything() })
       );
     });

--- a/code/core/src/manager-api/tests/stories.test.ts
+++ b/code/core/src/manager-api/tests/stories.test.ts
@@ -765,10 +765,15 @@ describe('stories API', () => {
         source: '',
         sourceLocation: '',
         type: '',
-        ref: { id: 'refId', index: { 'a--1': { args: { a: 'b' } } } } as any,
+        ref: {
+          id: 'refId',
+          index: { 'a--1': { args: { a: 'b' } } },
+          filteredIndex: { 'a--1': { args: { a: 'b' } } },
+        } as any,
       });
       provider.channel.emit(STORY_ARGS_UPDATED, { storyId: 'a--1', args: { foo: 'bar' } });
       expect(fullAPI.updateRef).toHaveBeenCalledWith('refId', {
+        filteredIndex: { 'a--1': { args: { foo: 'bar' } } },
         index: { 'a--1': { args: { foo: 'bar' } } },
       });
     });
@@ -1539,6 +1544,7 @@ describe('stories API', () => {
         })
       );
     });
+
     it('updates state', async () => {
       const moduleArgs = createMockModuleArgs({});
       const { api } = initStories(moduleArgs as unknown as ModuleArgs);
@@ -1565,9 +1571,9 @@ describe('stories API', () => {
       await api.setIndex({ v: 5, entries: navigationEntries });
       await api.experimental_setFilter('myCustomFilter', (item: any) => item.id.startsWith('a'));
 
-      const { index } = store.getState();
+      const { filteredIndex } = store.getState();
 
-      expect(index).toMatchInlineSnapshot(`
+      expect(filteredIndex).toMatchInlineSnapshot(`
         {
           "a": {
             "children": [
@@ -1624,7 +1630,7 @@ describe('stories API', () => {
       );
 
       // empty, because there are no stories with status
-      expect(store.getState().index).toMatchInlineSnapshot('{}');
+      expect(store.getState().filteredIndex).toMatchInlineSnapshot('{}');
 
       // setting status should update the index
       await api.experimental_updateStatus('a-addon-id', {
@@ -1636,7 +1642,7 @@ describe('stories API', () => {
         'a--2': { status: 'success', title: 'a addon title', description: '' },
       });
 
-      expect(store.getState().index).toMatchInlineSnapshot(`
+      expect(store.getState().filteredIndex).toMatchInlineSnapshot(`
         {
           "a": {
             "children": [
@@ -1676,9 +1682,9 @@ describe('stories API', () => {
 
       await api.setIndex({ v: 5, entries: navigationEntries });
 
-      const { index } = store.getState();
+      const { filteredIndex } = store.getState();
 
-      expect(index).toMatchInlineSnapshot(`
+      expect(filteredIndex).toMatchInlineSnapshot(`
         {
           "a": {
             "children": [

--- a/code/core/src/manager/components/sidebar/Explorer.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Explorer.stories.tsx
@@ -34,7 +34,7 @@ const simple: Record<string, RefType> = {
     url: 'iframe.html',
     previewInitialized: true,
     // @ts-expect-error (invalid input)
-    index: mockDataset.withRoot,
+    filteredIndex: mockDataset.withRoot,
   },
 };
 
@@ -47,7 +47,7 @@ const withRefs: Record<string, RefType> = {
     previewInitialized: true,
     type: 'auto-inject',
     // @ts-expect-error (invalid input)
-    index: mockDataset.noRoot,
+    filteredIndex: mockDataset.noRoot,
   },
   injected: {
     id: 'injected',
@@ -56,7 +56,7 @@ const withRefs: Record<string, RefType> = {
     previewInitialized: false,
     type: 'auto-inject',
     // @ts-expect-error (invalid input)
-    index: mockDataset.noRoot,
+    filteredIndex: mockDataset.noRoot,
   },
   unknown: {
     id: 'unknown',
@@ -65,7 +65,7 @@ const withRefs: Record<string, RefType> = {
     previewInitialized: true,
     type: 'unknown',
     // @ts-expect-error (invalid input)
-    index: mockDataset.noRoot,
+    filteredIndex: mockDataset.noRoot,
   },
   lazy: {
     id: 'lazy',
@@ -74,7 +74,7 @@ const withRefs: Record<string, RefType> = {
     previewInitialized: false,
     type: 'lazy',
     // @ts-expect-error (invalid input)
-    index: mockDataset.withRoot,
+    filteredIndex: mockDataset.withRoot,
   },
 };
 

--- a/code/core/src/manager/components/sidebar/Refs.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Refs.stories.tsx
@@ -37,11 +37,11 @@ export default {
 };
 
 const { menu } = standardHeaderData;
-const index = mockDataset.withRoot;
+const filteredIndex = mockDataset.withRoot;
 const storyId = '1-12-121';
 
-export const simpleData = { menu, index, storyId };
-export const loadingData = { menu, index: {} };
+export const simpleData = { menu, filteredIndex, storyId };
+export const loadingData = { menu, filteredIndex: {} };
 
 // @ts-expect-error (non strict)
 const indexError: Error = (() => {
@@ -60,14 +60,14 @@ const refs: Record<string, RefType> = {
     previewInitialized: false,
     type: 'lazy',
     // @ts-expect-error (invalid input)
-    index,
+    filteredIndex,
   },
   empty: {
     id: 'empty',
     title: 'It is empty because no stories were loaded',
     url: 'https://example.com',
     type: 'lazy',
-    index: {},
+    filteredIndex: {},
     previewInitialized: false,
   },
   startInjected_unknown: {
@@ -77,7 +77,7 @@ const refs: Record<string, RefType> = {
     type: 'unknown',
     previewInitialized: false,
     // @ts-expect-error (invalid input)
-    index,
+    filteredIndex,
   },
   startInjected_loading: {
     id: 'startInjected_loading',
@@ -86,7 +86,7 @@ const refs: Record<string, RefType> = {
     type: 'auto-inject',
     previewInitialized: false,
     // @ts-expect-error (invalid input)
-    index,
+    filteredIndex,
   },
   startInjected_ready: {
     id: 'startInjected_ready',
@@ -95,7 +95,7 @@ const refs: Record<string, RefType> = {
     type: 'auto-inject',
     previewInitialized: true,
     // @ts-expect-error (invalid input)
-    index,
+    filteredIndex,
   },
   versions: {
     id: 'versions',
@@ -103,7 +103,7 @@ const refs: Record<string, RefType> = {
     url: 'https://example.com',
     type: 'lazy',
     // @ts-expect-error (invalid input)
-    index,
+    filteredIndex,
     versions: { '1.0.0': 'https://example.com/v1', '2.0.0': 'https://example.com' },
     previewInitialized: true,
   },
@@ -113,7 +113,7 @@ const refs: Record<string, RefType> = {
     url: 'https://example.com',
     type: 'lazy',
     // @ts-expect-error (invalid input)
-    index,
+    filteredIndex,
     versions: { '1.0.0': 'https://example.com/v1', '2.0.0': 'https://example.com/v2' },
     previewInitialized: true,
   },
@@ -138,7 +138,7 @@ const refs: Record<string, RefType> = {
     title: 'This storybook has a very very long name for some reason',
     url: 'https://example.com',
     // @ts-expect-error (invalid input)
-    index,
+    filteredIndex,
     type: 'lazy',
     versions: {
       '111.111.888-new': 'https://example.com/new',
@@ -154,7 +154,7 @@ const refs: Record<string, RefType> = {
     previewInitialized: false,
     type: 'lazy',
     // @ts-expect-error (invalid input)
-    index,
+    filteredIndex,
   },
 };
 

--- a/code/core/src/manager/components/sidebar/Refs.tsx
+++ b/code/core/src/manager/components/sidebar/Refs.tsx
@@ -81,7 +81,7 @@ export const Ref: FC<RefType & RefProps & { status?: State['status'] }> = React.
     const { docsOptions } = useStorybookState();
     const api = useStorybookApi();
     const {
-      index,
+      filteredIndex: index,
       id: refId,
       title = refId,
       isLoading: isLoadingMain,

--- a/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
@@ -111,7 +111,7 @@ const refs: Record<string, RefType> = {
     title: 'This is a ref',
     url: 'https://example.com',
     type: 'lazy',
-    index,
+    filteredIndex: index,
     previewInitialized: true,
   },
 };
@@ -123,7 +123,7 @@ const refsError = {
   optimized: {
     ...refs.optimized,
     // @ts-expect-error (non strict)
-    index: undefined as IndexHash,
+    filteredIndex: undefined as IndexHash,
     indexError,
   },
 };
@@ -132,7 +132,7 @@ const refsEmpty = {
   optimized: {
     ...refs.optimized,
     // type: 'auto-inject',
-    index: {} as IndexHash,
+    filteredIndex: {} as IndexHash,
   },
 };
 

--- a/code/core/src/manager/components/sidebar/Sidebar.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.tsx
@@ -93,6 +93,7 @@ const useCombination = (
     () => ({
       [DEFAULT_REF_ID]: {
         index,
+        filteredIndex: index,
         indexError,
         previewInitialized,
         status,

--- a/code/core/src/manager/container/Sidebar.tsx
+++ b/code/core/src/manager/container/Sidebar.tsx
@@ -27,7 +27,7 @@ const Sidebar = React.memo(function Sideber({ onMenuClick }: SidebarProps) {
       // is actually the stories hash. We should fix this up and make it consistent.
       // eslint-disable-next-line @typescript-eslint/naming-convention
       internal_index,
-      index,
+      filteredIndex: index,
       status,
       indexError,
       previewInitialized,

--- a/code/core/src/types/modules/api.ts
+++ b/code/core/src/types/modules/api.ts
@@ -155,6 +155,7 @@ export type API_StoryMapper = (ref: API_ComposedRef, story: SetStoriesStory) => 
 
 export interface API_LoadedRefData {
   index?: API_IndexHash;
+  filteredIndex?: API_IndexHash;
   indexError?: Error;
   previewInitialized: boolean;
 }
@@ -180,6 +181,7 @@ export type API_ComposedRefUpdate = Partial<
     | 'type'
     | 'expanded'
     | 'index'
+    | 'filteredIndex'
     | 'versions'
     | 'loginUrl'
     | 'version'


### PR DESCRIPTION
Closes #29827

## What I did

Refactor the manager to include a full stories hash and a filtered stories hash. Show the filtered hash in the sidebar but use the full stories hash for storing parameters etc.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Start a sandbox
2. Select a story that shows controls
3. Use tags filtering to filter out that story from the sidebar
4. Verify that the controls still render successfully

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 0.65 | 0% |
| initSize |  133 MB | 133 MB | -17 kB | 0.33 | 0% |
| diffSize |  55.3 MB | 55.3 MB | -17 kB | 0.32 | 0% |
| buildSize |  6.87 MB | 6.87 MB | 1.63 kB | **5.31** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 843 B | **2.38** | 0.1% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 734 B | **11.54** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 1.58 kB | **5.33** | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 49 B | 0.8 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.5s | 7.5s | 70ms | -0.84 | 0.9% |
| generateTime |  20.3s | 21.3s | 937ms | -0.3 | 4.4% |
| initTime |  13.1s | 14s | 903ms | -0.44 | 6.4% |
| buildTime |  9.5s | 7.8s | -1s -680ms | **-1.83** | 🔰-21.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5s | 4.3s | -614ms | -1.19 | -14% |
| devManagerResponsive |  3.7s | 3.3s | -387ms | -1.04 | -11.5% |
| devManagerHeaderVisible |  549ms | 521ms | -28ms | -0.69 | -5.4% |
| devManagerIndexVisible |  626ms | 552ms | -74ms | -1.09 | -13.4% |
| devStoryVisibleUncached |  1.8s | 1.5s | -308ms | -1.2 | -20.1% |
| devStoryVisible |  624ms | 553ms | -71ms | -0.98 | -12.8% |
| devAutodocsVisible |  507ms | 520ms | 13ms | 0.1 | 2.5% |
| devMDXVisible |  483ms | 446ms | -37ms | -0.78 | -8.3% |
| buildManagerHeaderVisible |  585ms | 511ms | -74ms | -0.78 | -14.5% |
| buildManagerIndexVisible |  692ms | 603ms | -89ms | -0.78 | -14.8% |
| buildStoryVisible |  534ms | 475ms | -59ms | -0.68 | -12.4% |
| buildAutodocsVisible |  410ms | 431ms | 21ms | -0.35 | 4.9% |
| buildMDXVisible |  415ms | 390ms | -25ms | -0.75 | -6.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR refactors Storybook's manager to maintain both full and filtered story indexes, ensuring Controls panel functionality remains intact when stories are filtered by tags in the sidebar.

- Added `filteredIndex` field to `API_LoadedRefData` interface in `code/core/src/types/modules/api.ts`
- Modified `setIndex` in `code/core/src/manager-api/modules/stories.ts` to maintain both filtered and unfiltered story hashes
- Updated sidebar components to use `filteredIndex` for display while preserving full story data for Controls
- Added test coverage in `code/core/src/manager-api/tests/stories.test.ts` for filtered index functionality
- Modified refs module to handle both indexes in `code/core/src/manager-api/modules/refs.ts`



<!-- /greptile_comment -->