### PR TITLE
Nextjs-Vite: Fix docgen types in main config

### DIFF
--- a/code/frameworks/experimental-nextjs-vite/src/types.ts
+++ b/code/frameworks/experimental-nextjs-vite/src/types.ts
@@ -1,9 +1,12 @@
 import type {
   CompatibleString,
   StorybookConfig as StorybookConfigBase,
+  TypescriptOptions as TypescriptOptionsBase,
 } from 'storybook/internal/types';
 
 import type { BuilderOptions, StorybookConfigVite } from '@storybook/builder-vite';
+
+import type docgenTypescript from '@joshwooding/vite-plugin-react-docgen-typescript';
 
 type FrameworkName = CompatibleString<'@storybook/experimental-nextjs-vite'>;
 type BuilderName = CompatibleString<'@storybook/builder-vite'>;
@@ -31,10 +34,23 @@ type StorybookConfigFramework = {
   };
 };
 
+type TypescriptOptions = TypescriptOptionsBase & {
+  /**
+   * Sets the type of Docgen when working with React and TypeScript
+   *
+   * @default `'react-docgen'`
+   */
+  reactDocgen: 'react-docgen-typescript' | 'react-docgen' | false;
+  /** Configures `@joshwooding/vite-plugin-react-docgen-typescript` */
+  reactDocgenTypescriptOptions: Parameters<typeof docgenTypescript>[0];
+};
+
 /** The interface for Storybook configuration in `main.ts` files. */
 export type StorybookConfig = Omit<
   StorybookConfigBase,
-  keyof StorybookConfigVite | keyof StorybookConfigFramework
+  keyof StorybookConfigVite | keyof StorybookConfigFramework | 'typescript'
 > &
   StorybookConfigVite &
-  StorybookConfigFramework & {};
+  StorybookConfigFramework & {
+    typescript?: Partial<TypescriptOptions>;
+  };

--- a/code/frameworks/experimental-nextjs-vite/src/types.ts
+++ b/code/frameworks/experimental-nextjs-vite/src/types.ts
@@ -1,12 +1,7 @@
-import type {
-  CompatibleString,
-  StorybookConfig as StorybookConfigBase,
-  TypescriptOptions as TypescriptOptionsBase,
-} from 'storybook/internal/types';
+import type { CompatibleString } from 'storybook/internal/types';
 
-import type { BuilderOptions, StorybookConfigVite } from '@storybook/builder-vite';
-
-import type docgenTypescript from '@joshwooding/vite-plugin-react-docgen-typescript';
+import type { BuilderOptions } from '@storybook/builder-vite';
+import type { StorybookConfig as StorybookConfigReactVite } from '@storybook/react-vite';
 
 type FrameworkName = CompatibleString<'@storybook/experimental-nextjs-vite'>;
 type BuilderName = CompatibleString<'@storybook/builder-vite'>;
@@ -24,7 +19,7 @@ type StorybookConfigFramework = {
         name: FrameworkName;
         options: FrameworkOptions;
       };
-  core?: StorybookConfigBase['core'] & {
+  core?: StorybookConfigReactVite['core'] & {
     builder?:
       | BuilderName
       | {
@@ -34,23 +29,6 @@ type StorybookConfigFramework = {
   };
 };
 
-type TypescriptOptions = TypescriptOptionsBase & {
-  /**
-   * Sets the type of Docgen when working with React and TypeScript
-   *
-   * @default `'react-docgen'`
-   */
-  reactDocgen: 'react-docgen-typescript' | 'react-docgen' | false;
-  /** Configures `@joshwooding/vite-plugin-react-docgen-typescript` */
-  reactDocgenTypescriptOptions: Parameters<typeof docgenTypescript>[0];
-};
-
 /** The interface for Storybook configuration in `main.ts` files. */
-export type StorybookConfig = Omit<
-  StorybookConfigBase,
-  keyof StorybookConfigVite | keyof StorybookConfigFramework | 'typescript'
-> &
-  StorybookConfigVite &
-  StorybookConfigFramework & {
-    typescript?: Partial<TypescriptOptions>;
-  };
+export type StorybookConfig = Omit<StorybookConfigReactVite, keyof StorybookConfigFramework> &
+  StorybookConfigFramework;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR is a followup to #29824 to add types in StorybookConfig for `typescript` and docgen options

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 0.9 | 0% |
| initSize |  133 MB | 133 MB | -775 B | 0.91 | 0% |
| diffSize |  55.3 MB | 55.3 MB | -775 B | 0.91 | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | -0.32 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | -0.65 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **2.37** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | -0.31 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | -0.73 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.5s | 6.9s | -632ms | -1.01 | -9.1% |
| generateTime |  21.6s | 19.5s | -2s -84ms | -0.61 | -10.7% |
| initTime |  15.2s | 12.4s | -2s -746ms | -0.9 | -22% |
| buildTime |  9.3s | 9.9s | 575ms | 1.07 | 5.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.8s | 4.9s | -886ms | -0.33 | -18% |
| devManagerResponsive |  4.3s | 3.7s | -633ms | -0.23 | -17% |
| devManagerHeaderVisible |  717ms | 533ms | -184ms | -0.5 | -34.5% |
| devManagerIndexVisible |  803ms | 601ms | -202ms | -0.45 | -33.6% |
| devStoryVisibleUncached |  2.2s | 1.8s | -405ms | 0.02 | -21.6% |
| devStoryVisible |  801ms | 562ms | -239ms | -0.78 | -42.5% |
| devAutodocsVisible |  605ms | 463ms | -142ms | -0.65 | -30.7% |
| devMDXVisible |  667ms | 466ms | -201ms | -0.61 | -43.1% |
| buildManagerHeaderVisible |  583ms | 717ms | 134ms | 1.11 | 18.7% |
| buildManagerIndexVisible |  694ms | 843ms | 149ms | **1.31** | 🔺17.7% |
| buildStoryVisible |  539ms | 656ms | 117ms | 1.1 | 17.8% |
| buildAutodocsVisible |  430ms | 575ms | 145ms | 1.04 | 25.2% |
| buildMDXVisible |  435ms | 581ms | 146ms | **1.49** | 🔺25.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the key changes in this pull request:

Adds TypeScript docgen configuration support to the experimental Next.js Vite framework by extending the StorybookConfig type system.

- Added `TypescriptOptions` type in `experimental-nextjs-vite/src/types.ts` with `reactDocgen` and `reactDocgenTypescriptOptions` fields
- Added import for `docgenTypescript` plugin type from `@joshwooding/vite-plugin-react-docgen-typescript`
- Extended `StorybookConfig` type to include optional typescript configuration for docgen settings
- Configured type definitions to support both `react-docgen` and `react-docgen-typescript` options

The changes enable proper TypeScript type checking when configuring documentation generation options in the Storybook main configuration file.



<!-- /greptile_comment -->