### PR TITLE
Core: Fix `scrollIntoView` behavior and reimplement testing module time rendering

### DIFF
--- a/code/addons/test/src/components/Description.tsx
+++ b/code/addons/test/src/components/Description.tsx
@@ -60,10 +60,10 @@ export function Description({ state, ...props }: DescriptionProps) {
     );
   } else if (state.progress?.finishedAt) {
     description = (
-      <RelativeTime
-        timestamp={new Date(state.progress.finishedAt)}
-        testCount={state.progress.numTotalTests}
-      />
+      <>
+        Ran {state.progress.numTotalTests} ${state.progress.numTotalTests === 1 ? 'test' : 'tests'}{' '}
+        <RelativeTime timestamp={state.progress.finishedAt} />
+      </>
     );
   } else if (state.watching) {
     description = 'Watching for file changes';

--- a/code/addons/test/src/components/Description.tsx
+++ b/code/addons/test/src/components/Description.tsx
@@ -61,7 +61,7 @@ export function Description({ state, ...props }: DescriptionProps) {
   } else if (state.progress?.finishedAt) {
     description = (
       <>
-        Ran {state.progress.numTotalTests} ${state.progress.numTotalTests === 1 ? 'test' : 'tests'}{' '}
+        Ran {state.progress.numTotalTests} {state.progress.numTotalTests === 1 ? 'test' : 'tests'}{' '}
         <RelativeTime timestamp={state.progress.finishedAt} />
       </>
     );

--- a/code/addons/test/src/components/RelativeTime.stories.tsx
+++ b/code/addons/test/src/components/RelativeTime.stories.tsx
@@ -4,9 +4,6 @@ import { RelativeTime } from './RelativeTime';
 
 const meta = {
   component: RelativeTime,
-  args: {
-    testCount: 42,
-  },
 } satisfies Meta<typeof RelativeTime>;
 
 export default meta;
@@ -15,36 +12,36 @@ type Story = StoryObj<typeof meta>;
 
 export const JustNow: Story = {
   args: {
-    timestamp: new Date(),
+    timestamp: Date.now() - 1000 * 10,
   },
 };
 
-export const SecondsAgo: Story = {
+export const AMinuteAgo: Story = {
   args: {
-    timestamp: new Date(Date.now() - 1000 * 15),
+    timestamp: Date.now() - 1000 * 60,
   },
 };
 
 export const MinutesAgo: Story = {
   args: {
-    timestamp: new Date(Date.now() - 1000 * 60 * 2),
+    timestamp: Date.now() - 1000 * 60 * 2,
   },
 };
 
 export const HoursAgo: Story = {
   args: {
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 3),
+    timestamp: Date.now() - 1000 * 60 * 60 * 3,
   },
 };
 
 export const Yesterday: Story = {
   args: {
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24),
+    timestamp: Date.now() - 1000 * 60 * 60 * 24,
   },
 };
 
 export const DaysAgo: Story = {
   args: {
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3),
+    timestamp: Date.now() - 1000 * 60 * 60 * 24 * 3,
   },
 };

--- a/code/addons/test/src/components/RelativeTime.stories.tsx
+++ b/code/addons/test/src/components/RelativeTime.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { RelativeTime } from './RelativeTime';
+
+const meta = {
+  component: RelativeTime,
+  args: {
+    testCount: 42,
+  },
+} satisfies Meta<typeof RelativeTime>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const JustNow: Story = {
+  args: {
+    timestamp: new Date(),
+  },
+};
+
+export const SecondsAgo: Story = {
+  args: {
+    timestamp: new Date(Date.now() - 1000 * 15),
+  },
+};
+
+export const MinutesAgo: Story = {
+  args: {
+    timestamp: new Date(Date.now() - 1000 * 60 * 2),
+  },
+};
+
+export const HoursAgo: Story = {
+  args: {
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 3),
+  },
+};
+
+export const Yesterday: Story = {
+  args: {
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24),
+  },
+};
+
+export const DaysAgo: Story = {
+  args: {
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3),
+  },
+};

--- a/code/addons/test/src/components/RelativeTime.tsx
+++ b/code/addons/test/src/components/RelativeTime.tsx
@@ -1,19 +1,22 @@
 import { useCallback, useEffect, useState } from 'react';
 
 export function getRelativeTimeString(date: Date): string {
-  const delta = Math.round((Date.now() - date.getTime()) / 1000);
-  if (delta < 60) {
+  const seconds = Math.round((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) {
     return 'just now';
   }
-  if (delta < 60 * 60) {
-    const minutes = Math.floor(delta / 60);
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
     return minutes === 1 ? 'a minute ago' : `${minutes} minutes ago`;
   }
-  if (delta < 60 * 60 * 24) {
-    const hours = Math.floor(delta / 60 / 60);
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
     return hours === 1 ? 'an hour ago' : `${hours} hours ago`;
   }
-  const days = Math.floor(delta / 60 / 60 / 24);
+
+  const days = Math.floor(hours / 24);
   return days === 1 ? 'yesterday' : `${days} days ago`;
 }
 

--- a/code/addons/test/src/components/RelativeTime.tsx
+++ b/code/addons/test/src/components/RelativeTime.tsx
@@ -1,40 +1,35 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-export function getRelativeTimeString(date: Date): string {
-  const seconds = Math.round((Date.now() - date.getTime()) / 1000);
+export const RelativeTime = ({ timestamp }: { timestamp?: number }) => {
+  const [timeAgo, setTimeAgo] = useState(null);
+
+  useEffect(() => {
+    if (timestamp) {
+      setTimeAgo(Date.now() - timestamp);
+      const interval = setInterval(() => setTimeAgo(Date.now() - timestamp), 10000);
+      return () => clearInterval(interval);
+    }
+  }, [timestamp]);
+
+  if (timeAgo === null) {
+    return null;
+  }
+
+  const seconds = Math.round(timeAgo / 1000);
   if (seconds < 60) {
-    return 'just now';
+    return `just now`;
   }
 
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) {
-    return minutes === 1 ? 'a minute ago' : `${minutes} minutes ago`;
+    return minutes === 1 ? `a minute ago` : `${minutes} minutes ago`;
   }
 
   const hours = Math.floor(minutes / 60);
   if (hours < 24) {
-    return hours === 1 ? 'an hour ago' : `${hours} hours ago`;
+    return hours === 1 ? `an hour ago` : `${hours} hours ago`;
   }
 
   const days = Math.floor(hours / 24);
-  return days === 1 ? 'yesterday' : `${days} days ago`;
-}
-
-export const RelativeTime = ({ timestamp, testCount }: { timestamp: Date; testCount: number }) => {
-  const [relativeTimeString, setRelativeTimeString] = useState(null);
-  const updateRelativeTimeString = useCallback(
-    () => timestamp && setRelativeTimeString(getRelativeTimeString(timestamp)),
-    [timestamp]
-  );
-
-  useEffect(() => {
-    updateRelativeTimeString();
-    const interval = setInterval(updateRelativeTimeString, 10000);
-    return () => clearInterval(interval);
-  }, [updateRelativeTimeString]);
-
-  return (
-    relativeTimeString &&
-    `Ran ${testCount} ${testCount === 1 ? 'test' : 'tests'} ${relativeTimeString}`
-  );
+  return days === 1 ? `yesterday` : `${days} days ago`;
 };

--- a/code/core/src/manager/components/sidebar/useHighlighted.ts
+++ b/code/core/src/manager/components/sidebar/useHighlighted.ts
@@ -22,6 +22,25 @@ export interface HighlightedProps {
 const fromSelection = (selection: Selection): Highlight =>
   selection ? { itemId: selection.storyId, refId: selection.refId } : null;
 
+const scrollToSelector = (
+  selector: string,
+  options: {
+    containerRef?: RefObject<Element | null>;
+    center?: boolean;
+    attempts?: number;
+    delay?: number;
+  } = {},
+  _attempt = 1
+) => {
+  const { containerRef, center = false, attempts = 3, delay = 500 } = options;
+  const element = (containerRef ? containerRef.current : document)?.querySelector(selector);
+  if (element) {
+    scrollIntoView(element, center);
+  } else if (_attempt <= attempts) {
+    setTimeout(scrollToSelector, delay, selector, options, _attempt + 1);
+  }
+};
+
 export const useHighlighted = ({
   containerRef,
   isLoading,
@@ -65,14 +84,10 @@ export const useHighlighted = ({
     const highlight = fromSelection(selected);
     updateHighlighted(highlight);
     if (highlight) {
-      const { itemId, refId } = highlight;
-      setTimeout(() => {
-        scrollIntoView(
-          // @ts-expect-error (non strict)
-          containerRef.current?.querySelector(`[data-item-id="${itemId}"][data-ref-id="${refId}"]`),
-          true // make sure it's clearly visible by centering it
-        );
-      }, 0);
+      scrollToSelector(`[data-item-id="${highlight.itemId}"][data-ref-id="${highlight.refId}"]`, {
+        containerRef,
+        center: true,
+      });
     }
   }, [containerRef, selected, updateHighlighted]);
 

--- a/code/core/src/manager/utils/tree.ts
+++ b/code/core/src/manager/utils/tree.ts
@@ -85,10 +85,14 @@ export const scrollIntoView = (element: Element, center = false) => {
     return;
   }
   const { top, bottom } = element.getBoundingClientRect();
-  const isInView =
-    top >= 0 && bottom <= (globalWindow.innerHeight || document.documentElement.clientHeight);
-
-  if (!isInView) {
+  if (!top || !bottom) {
+    return;
+  }
+  const bottomOffset =
+    document?.querySelector('#sidebar-bottom-wrapper')?.getBoundingClientRect().top ||
+    globalWindow.innerHeight ||
+    document.documentElement.clientHeight;
+  if (bottom > bottomOffset) {
     element.scrollIntoView({ block: center ? 'center' : 'nearest' });
   }
 };


### PR DESCRIPTION
## What I did

Updated the sidebar's `scrollIntoView` behavior to make the selected story visible when switching stories. It wasn't taking into account the testing module which may overlap the selected story, and wasn't triggering after creating a new story file through the UI.

Updated the RelativeTime logic to be more concise, less technical and more fitting to our use case. I didn't shorten "seconds" or "minutes" to "s" or "m" but instead made it less likely for those to show up.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30044-sha-f88023ad`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30044-sha-f88023ad sandbox` or in an existing project with `npx storybook@0.0.0-pr-30044-sha-f88023ad upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30044-sha-f88023ad`](https://npmjs.com/package/storybook/v/0.0.0-pr-30044-sha-f88023ad) |
| **Triggered by** | @ghengeveld |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`ui-fixes`](https://github.com/storybookjs/storybook/tree/ui-fixes) |
| **Commit** | [`f88023ad`](https://github.com/storybookjs/storybook/commit/f88023addb0978e9112858371d9c2a87f12a664b) |
| **Datetime** | Fri Dec 13 09:05:01 UTC 2024 (`1734080701`) |
| **Workflow run** | [12312680567](https://github.com/storybookjs/storybook/actions/runs/12312680567) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30044`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 1.22 | 0% |
| initSize |  133 MB | 133 MB | -10.5 kB | 0.91 | 0% |
| diffSize |  55.3 MB | 55.3 MB | -10.5 kB | 0.9 | 0% |
| buildSize |  6.87 MB | 6.87 MB | 1.03 kB | **1.49** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 843 B | 1.11 | 0.1% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 175 B | **28.17** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 1.02 kB | **1.49** | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 8 B | 1 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.9s | 23.3s | -590ms | **1.3** | -2.5% |
| generateTime |  18.8s | 19.3s | 526ms | -0.69 | 2.7% |
| initTime |  12.3s | 12.9s | 537ms | -0.76 | 4.2% |
| buildTime |  8.8s | 9.3s | 447ms | 0 | 4.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.9s | 6.3s | 412ms | **1.71** | 🔺6.5% |
| devManagerResponsive |  4.2s | 4.6s | 438ms | **1.89** | 🔺9.3% |
| devManagerHeaderVisible |  582ms | 723ms | 141ms | **1.58** | 🔺19.5% |
| devManagerIndexVisible |  657ms | 768ms | 111ms | **1.51** | 🔺14.5% |
| devStoryVisibleUncached |  2s | 1.9s | -32ms | 0.5 | -1.6% |
| devStoryVisible |  655ms | 824ms | 169ms | **2.11** | 🔺20.5% |
| devAutodocsVisible |  593ms | 555ms | -38ms | 0.33 | -6.8% |
| devMDXVisible |  665ms | 469ms | -196ms | -0.64 | -41.8% |
| buildManagerHeaderVisible |  620ms | 742ms | 122ms | 1.08 | 16.4% |
| buildManagerIndexVisible |  734ms | 767ms | 33ms | 0.49 | 4.3% |
| buildStoryVisible |  556ms | 674ms | 118ms | 1.09 | 17.5% |
| buildAutodocsVisible |  442ms | 595ms | 153ms | 1.14 | 25.7% |
| buildMDXVisible |  458ms | 500ms | 42ms | 0.45 | 8.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Improved sidebar scroll behavior and simplified the RelativeTime component's implementation for the testing module, focusing on better visibility and user-friendly time displays.

- Modified `code/core/src/manager/utils/tree.ts` to check for testing module overlap when scrolling stories into view
- Added retry mechanism in `code/core/src/manager/components/sidebar/useHighlighted.ts` for more reliable story scrolling
- Simplified `code/addons/test/src/components/RelativeTime.tsx` to use direct time calculations instead of Intl.RelativeTimeFormat
- Added comprehensive story coverage in `RelativeTime.stories.tsx` for various time intervals
- Improved error handling with null checks for getBoundingClientRect() values



<!-- /greptile_comment -->