### PR TITLE
Addon Test: Fix environment variable for Vitest Storybook integration

### DIFF
--- a/code/addons/test/src/node/vitest-manager.ts
+++ b/code/addons/test/src/node/vitest-manager.ts
@@ -31,6 +31,9 @@ type TagsFilter = {
 
 const packageDir = dirname(require.resolve('@storybook/experimental-addon-test/package.json'));
 
+// We have to tell Vitest that it runs as part of Storybook
+process.env.VITEST_STORYBOOK = 'true';
+
 export class VitestManager {
   vitest: Vitest | null = null;
 
@@ -65,31 +68,17 @@ export class VitestManager {
         : { enabled: false }
     ) as CoverageOptions;
 
-    this.vitest = await createVitest(
-      'test',
-      {
-        watch: true,
-        passWithNoTests: false,
-        // TODO:
-        // Do we want to enable Vite's default reporter?
-        // The output in the terminal might be too spamy and it might be better to
-        // find a way to just show errors and warnings for example
-        // Otherwise it might be hard for the user to discover Storybook related logs
-        reporters: ['default', new StorybookReporter(this.testManager)],
-        coverage: coverageOptions,
-      },
-      {
-        define: {
-          // polyfilling process.env.VITEST_STORYBOOK to 'true' in the browser
-          'process.env.VITEST_STORYBOOK': 'true',
-        },
-      }
-    );
-
-    this.vitest.configOverride.env = {
-      // We signal to the test runner that we are running it via Storybook
-      VITEST_STORYBOOK: 'true',
-    };
+    this.vitest = await createVitest('test', {
+      watch: true,
+      passWithNoTests: false,
+      // TODO:
+      // Do we want to enable Vite's default reporter?
+      // The output in the terminal might be too spamy and it might be better to
+      // find a way to just show errors and warnings for example
+      // Otherwise it might be hard for the user to discover Storybook related logs
+      reporters: ['default', new StorybookReporter(this.testManager)],
+      coverage: coverageOptions,
+    });
 
     if (this.vitest) {
       this.vitest.onCancel(() => {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The `process.env.VITEST_STORYBOOK` variable wasn't set properly by the vitest process. This was causing component tests failures as soon as a11y tests were failing.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30054-sha-fb986dc5`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30054-sha-fb986dc5 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30054-sha-fb986dc5 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30054-sha-fb986dc5`](https://npmjs.com/package/storybook/v/0.0.0-pr-30054-sha-fb986dc5) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-environment-detection-for-vitest`](https://github.com/storybookjs/storybook/tree/valentin/fix-environment-detection-for-vitest) |
| **Commit** | [`fb986dc5`](https://github.com/storybookjs/storybook/commit/fb986dc5e4ae6c6c729b8069930e7914ab489081) |
| **Datetime** | Fri Dec 13 08:54:23 UTC 2024 (`1734080063`) |
| **Workflow run** | [12312532319](https://github.com/storybookjs/storybook/actions/runs/12312532319) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30054`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 1.22 | 0% |
| initSize |  133 MB | 133 MB | 8.18 kB | 1.23 | 0% |
| diffSize |  55.3 MB | 55.3 MB | 8.18 kB | 1.22 | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | -0.91 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | -0.9 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | -1 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | -0.91 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | -1 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.9s | 22s | -1s -936ms | 1.11 | -8.8% |
| generateTime |  18.8s | 29.8s | 11s | 1.15 | 37% |
| initTime |  12.3s | 17.5s | 5.2s | 0.52 | 29.6% |
| buildTime |  8.8s | 9s | 196ms | -0.36 | 2.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.9s | 4.4s | -1s -451ms | -1.09 | -32.6% |
| devManagerResponsive |  4.2s | 3.4s | -812ms | -0.84 | -23.6% |
| devManagerHeaderVisible |  582ms | 521ms | -61ms | -0.7 | -11.7% |
| devManagerIndexVisible |  657ms | 554ms | -103ms | -0.97 | -18.6% |
| devStoryVisibleUncached |  2s | 1.7s | -246ms | -0.32 | -13.8% |
| devStoryVisible |  655ms | 559ms | -96ms | -0.82 | -17.2% |
| devAutodocsVisible |  593ms | 490ms | -103ms | -0.38 | -21% |
| devMDXVisible |  665ms | 451ms | -214ms | -0.81 | -47.5% |
| buildManagerHeaderVisible |  620ms | 562ms | -58ms | -0.36 | -10.3% |
| buildManagerIndexVisible |  734ms | 642ms | -92ms | -0.44 | -14.3% |
| buildStoryVisible |  556ms | 503ms | -53ms | -0.4 | -10.5% |
| buildAutodocsVisible |  442ms | 408ms | -34ms | -0.58 | -8.3% |
| buildMDXVisible |  458ms | 402ms | -56ms | -0.64 | -13.9% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the changes:

Sets the VITEST_STORYBOOK environment variable directly at module level to simplify Vitest integration with Storybook's testing environment.

- Modified `code/addons/test/src/node/vitest-manager.ts` to set `VITEST_STORYBOOK` environment variable at module level
- Removed redundant environment variable definitions from browser context (`define`)
- Removed redundant environment variable definitions from test runner context (`configOverride.env`)
- Simplified configuration by consolidating environment variable declaration to a single location

The changes make the code cleaner and more maintainable while preserving the same functionality for Vitest integration in Storybook.



<!-- /greptile_comment -->