### PR TITLE
Build: Improve waiting detection on E2E to fix flake

### DIFF
--- a/code/e2e-tests/util.ts
+++ b/code/e2e-tests/util.ts
@@ -112,6 +112,10 @@ export class SbPage {
     const storyLoadingPage = root.locator('.sb-preparing-story');
     await docsLoadingPage.waitFor({ state: 'hidden' });
     await storyLoadingPage.waitFor({ state: 'hidden' });
+    await this.page.waitForFunction(() => {
+      const storybookRoot = document.querySelector('#storybook-root');
+      return storybookRoot && storybookRoot.children.length > 0;
+    });
   }
 
   previewIframe() {

--- a/code/e2e-tests/util.ts
+++ b/code/e2e-tests/util.ts
@@ -1,3 +1,4 @@
+/* eslint-disable local-rules/no-uncategorized-errors */
 import { toId } from '@storybook/csf';
 
 import type { Expect, Page } from '@playwright/test';
@@ -61,6 +62,7 @@ export class SbPage {
     await this.expect(selected).toHaveAttribute('data-selected', 'true');
 
     await this.previewRoot();
+    await this.waitUntilLoaded();
   }
 
   async navigateToUnattachedDocs(title: string, name = 'docs') {
@@ -80,7 +82,25 @@ export class SbPage {
     const selected = storyLink;
     await this.expect(selected).toHaveAttribute('data-selected', 'true');
 
-    await this.previewRoot();
+    await this.waitForStoryLoaded();
+  }
+
+  async waitForStoryLoaded() {
+    try {
+      const root = this.previewRoot();
+      // Wait until there is at least one child (a story element) in the preview iframe
+      await root.locator(':scope > *').first().waitFor({
+        state: 'attached',
+        timeout: 10000,
+      });
+    } catch (error: any) {
+      if (error.name === 'TimeoutError') {
+        throw new Error(
+          'The Storybook iframe did not have children within the specified timeout. Did the story load correctly?'
+        );
+      }
+      throw error;
+    }
   }
 
   async waitUntilLoaded() {
@@ -112,10 +132,8 @@ export class SbPage {
     const storyLoadingPage = root.locator('.sb-preparing-story');
     await docsLoadingPage.waitFor({ state: 'hidden' });
     await storyLoadingPage.waitFor({ state: 'hidden' });
-    await this.page.waitForFunction(() => {
-      const storybookRoot = document.querySelector('#storybook-root');
-      return storybookRoot && storybookRoot.children.length > 0;
-    });
+
+    await this.waitForStoryLoaded();
   }
 
   previewIframe() {
@@ -146,6 +164,30 @@ export class SbPage {
 
   getCanvasBodyElement() {
     return this.previewIframe().locator('body');
+  }
+
+  // utility to try and decrease flake
+  async retryTimes(
+    fn: () => Promise<void>,
+    options?: {
+      retries?: number;
+      delay?: number;
+    }
+  ): Promise<void> {
+    let attempts = 0;
+    const { retries = 3, delay = 0 } = options || {};
+    while (attempts < retries) {
+      try {
+        await fn();
+        return;
+      } catch (error) {
+        attempts++;
+        if (attempts === retries) {
+          throw error;
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, delay));
+      }
+    }
   }
 }
 

--- a/test-storybooks/portable-stories-kitchen-sink/react/.storybook/main.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/.storybook/main.ts
@@ -12,9 +12,21 @@ const config: StorybookConfig = {
     options: {},
   },
   core: {
-    disableWhatsNewNotifications: true
+    disableWhatsNewNotifications: true,
   },
-  previewHead: (head = '') => `${head}
+  viteFinal: (config) => ({
+    ...config,
+    optimizeDeps: {
+      ...config.optimizeDeps,
+      include: [
+        ...(config.optimizeDeps?.include || []),
+        "react-dom/test-utils",
+        "@storybook/react/**",
+        "@storybook/experimental-addon-test/preview",
+      ],
+    },
+  }),
+  previewHead: (head = "") => `${head}
   <style>
     body {
       border: 1px solid red;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Ongoing effort to fix E2E tests flake

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | -15 B | 0.32 | 0% |
| initSize |  133 MB | 133 MB | -5.99 kB | 1.04 | 0% |
| diffSize |  55.3 MB | 55.3 MB | -5.98 kB | 1.08 | 0% |
| buildSize |  7.24 MB | 6.87 MB | -364 kB | -0.33 | -5.3% |
| buildSbAddonsSize |  1.88 MB | 1.51 MB | -363 kB | -0.33 | -24% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | -960 B | -0.16 | -0.1% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.93 MB | 3.57 MB | -364 kB | -0.33 | -10.2% |
| buildPreviewSize |  3.3 MB | 3.3 MB | -168 B | -0.97 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7s | 27s | 19.9s | **1.81** | 🔺73.8% |
| generateTime |  19.5s | 20.1s | 574ms | -0.65 | 2.9% |
| initTime |  12.4s | 15.2s | 2.8s | 0.3 | 18.8% |
| buildTime |  8.7s | 10.6s | 1.9s | **2.56** | 🔺18.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.6s | 4.8s | 127ms | -0.65 | 2.6% |
| devManagerResponsive |  3.6s | 3.6s | 12ms | -0.66 | 0.3% |
| devManagerHeaderVisible |  605ms | 551ms | -54ms | -0.39 | -9.8% |
| devManagerIndexVisible |  631ms | 858ms | 227ms | **2.28** | 🔺26.5% |
| devStoryVisibleUncached |  1.7s | 1.7s | 8ms | -0.06 | 0.4% |
| devStoryVisible |  629ms | 580ms | -49ms | -0.7 | -8.4% |
| devAutodocsVisible |  604ms | 494ms | -110ms | -0.37 | -22.3% |
| devMDXVisible |  491ms | 488ms | -3ms | -0.42 | -0.6% |
| buildManagerHeaderVisible |  573ms | 508ms | -65ms | -0.89 | -12.8% |
| buildManagerIndexVisible |  665ms | 601ms | -64ms | -0.88 | -10.6% |
| buildStoryVisible |  535ms | 473ms | -62ms | -0.78 | -13.1% |
| buildAutodocsVisible |  443ms | 431ms | -12ms | -0.35 | -2.8% |
| buildMDXVisible |  431ms | 401ms | -30ms | -0.64 | -7.5% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhanced the waiting detection in Storybook's E2E test utility to ensure UI elements are fully rendered before test interactions begin, reducing test flakiness particularly in Vite projects.

- Modified `waitUntilLoaded` method in `code/e2e-tests/util.ts` to verify `#storybook-root` has child elements
- Added additional wait condition to ensure complete UI rendering before test execution
- Targets specifically flaky behavior in Vite project tests
- Maintains minimal, focused change to core E2E test infrastructure



<!-- /greptile_comment -->