### PR TITLE
Automigration: Improve setup file transformation and version range handling for a11y migration

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
@@ -141,7 +141,8 @@ describe('addonA11yAddonTest', () => {
       `;
       vi.mocked(readFileSync).mockReturnValue(source);
 
-      const transformedCode = transformSetupFile(setupFile);
+      const s = readFileSync(setupFile, 'utf8');
+      const transformedCode = transformSetupFile(s);
       expect(transformedCode).toMatchInlineSnapshot(`
         "import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
         import { beforeAll } from 'vitest';
@@ -169,7 +170,35 @@ describe('addonA11yAddonTest', () => {
       `;
       vi.mocked(readFileSync).mockReturnValue(source);
 
-      const transformedCode = transformSetupFile(setupFile);
+      const s = readFileSync(setupFile, 'utf8');
+      const transformedCode = transformSetupFile(s);
+      expect(transformedCode).toMatchInlineSnapshot(`
+        "import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
+        import { beforeAll } from 'vitest';
+        import { setProjectAnnotations } from 'storybook';
+        import * as projectAnnotations from './preview';
+
+        const project = setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
+
+        beforeAll(project.beforeAll);"
+      `);
+    });
+
+    it('should transform setup file correctly - project annotation is not an array', () => {
+      const setupFile = '/path/to/vitest.setup.ts';
+      const source = dedent`
+        import { beforeAll } from 'vitest';
+        import { setProjectAnnotations } from 'storybook';
+        import * as projectAnnotations from './preview';
+
+        const project = setProjectAnnotations(projectAnnotations);
+
+        beforeAll(project.beforeAll);
+      `;
+      vi.mocked(readFileSync).mockReturnValue(source);
+
+      const s = readFileSync(setupFile, 'utf8');
+      const transformedCode = transformSetupFile(s);
       expect(transformedCode).toMatchInlineSnapshot(`
         "import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
         import { beforeAll } from 'vitest';

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
@@ -22,8 +22,7 @@ interface AddonA11yAddonTestOptions {
  */
 export const addonA11yAddonTest: Fix<AddonA11yAddonTestOptions> = {
   id: 'addonA11yAddonTest',
-  // TODO: Change to the correct version after testing
-  versionRange: ['<8.5.0', '*'],
+  versionRange: ['<8.5.0', '>=8.5.0'],
 
   promptType(result) {
     if (result.setupFile === null) {
@@ -53,7 +52,11 @@ export const addonA11yAddonTest: Fix<AddonA11yAddonTestOptions> = {
 
     try {
       if (vitestSetupFile) {
-        const transformedSetupCode = transformSetupFile(vitestSetupFile);
+        const source = readFileSync(vitestSetupFile, 'utf8');
+        if (source.includes('@storybook/addon-a11y')) {
+          return null;
+        }
+        const transformedSetupCode = transformSetupFile(source);
         return {
           setupFile: vitestSetupFile,
           transformedSetupCode,
@@ -124,8 +127,7 @@ export const addonA11yAddonTest: Fix<AddonA11yAddonTestOptions> = {
   },
 };
 
-export function transformSetupFile(setupFile: string) {
-  const source = readFileSync(setupFile, 'utf8');
+export function transformSetupFile(source: string) {
   const j = jscodeshift.withParser('ts');
 
   const root = j(source);
@@ -148,9 +150,14 @@ export function transformSetupFile(setupFile: string) {
     throw new Error('Could not find setProjectAnnotations call in vitest.setup file');
   }
 
-  // Add a11yAddonAnnotations to the annotations array
-  setProjectAnnotationsCall.find(j.ArrayExpression).forEach((p) => {
-    p.value.elements.unshift(j.identifier('a11yAddonAnnotations'));
+  // Add a11yAddonAnnotations to the annotations array or create a new array if argument is a string
+  setProjectAnnotationsCall.forEach((p) => {
+    if (p.value.arguments.length === 1 && p.value.arguments[0].type === 'ArrayExpression') {
+      p.value.arguments[0].elements.unshift(j.identifier('a11yAddonAnnotations'));
+    } else if (p.value.arguments.length === 1 && p.value.arguments[0].type === 'Identifier') {
+      const arg = p.value.arguments[0];
+      p.value.arguments[0] = j.arrayExpression([j.identifier('a11yAddonAnnotations'), arg]);
+    }
   });
 
   // Add the import declaration at the top


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- Fixed the version range for the a11y addon automigration
- Added a check whether `setProjectAnnotations` has a string or an array as argument

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | **3** | 0% |
| initSize |  136 MB | 136 MB | 0 B | **3** | 0% |
| diffSize |  58.4 MB | 58.4 MB | 0 B | **3** | 0% |
| buildSize |  7.24 MB | 7.24 MB | 0 B | **2** | 0% |
| buildSbAddonsSize |  1.88 MB | 1.88 MB | 0 B | **2** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **1.74** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.93 MB | 3.93 MB | 0 B | **2** | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | **1.91** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  12.4s | 6.9s | -5s -544ms | -0.77 | -79.9% |
| generateTime |  19.7s | 19.8s | 149ms | -0.66 | 0.7% |
| initTime |  14.5s | 13.5s | -1s -15ms | -0.62 | -7.5% |
| buildTime |  8.3s | 8.4s | 148ms | -0.56 | 1.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.5s | 4.4s | -95ms | -1.21 | -2.1% |
| devManagerResponsive |  3.4s | 3.3s | -73ms | -1.18 | -2.2% |
| devManagerHeaderVisible |  601ms | 518ms | -83ms | -0.81 | -16% |
| devManagerIndexVisible |  634ms | 551ms | -83ms | -1.12 | -15.1% |
| devStoryVisibleUncached |  1.3s | 1.6s | 313ms | -0.26 | 18.5% |
| devStoryVisible |  635ms | 550ms | -85ms | -1.12 | -15.5% |
| devAutodocsVisible |  480ms | 528ms | 48ms | 0.11 | 9.1% |
| devMDXVisible |  549ms | 502ms | -47ms | -0.38 | -9.4% |
| buildManagerHeaderVisible |  568ms | 597ms | 29ms | -0.14 | 4.9% |
| buildManagerIndexVisible |  663ms | 674ms | 11ms | -0.31 | 1.6% |
| buildStoryVisible |  530ms | 544ms | 14ms | -0.17 | 2.6% |
| buildAutodocsVisible |  435ms | 417ms | -18ms | -0.48 | -4.3% |
| buildMDXVisible |  447ms | 393ms | -54ms | -0.76 | -13.7% |

<!-- BENCHMARK_SECTION -->
