### PR TITLE
Next.js: Support v15.1.1

### DIFF
--- a/code/frameworks/experimental-nextjs-vite/src/routing/app-router-provider.tsx
+++ b/code/frameworks/experimental-nextjs-vite/src/routing/app-router-provider.tsx
@@ -45,8 +45,6 @@ function getSelectedParams(currentTree: FlightRouterState, params: Params = {}):
     }
 
     // Ensure catchAll and optional catchall are turned into an array
-
-    // Ensure catchAll and optional catchall are turned into an array
     const isCatchAll = isDynamicParameter && (segment[2] === 'c' || segment[2] === 'oc');
 
     if (isCatchAll) {
@@ -82,6 +80,16 @@ export const AppRouterProvider: React.FC<React.PropsWithChildren<AppRouterProvid
     return getSelectedParams(tree);
   }, [tree]);
 
+  const newLazyCacheNode = {
+    lazyData: null,
+    rsc: null,
+    prefetchRsc: null,
+    head: null,
+    prefetchHead: null,
+    parallelRoutes: new Map(),
+    loading: null,
+  };
+
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx#L436
   return (
     <PathParamsContext.Provider value={pathParams}>
@@ -106,10 +114,18 @@ export const AppRouterProvider: React.FC<React.PropsWithChildren<AppRouterProvid
             <AppRouterContext.Provider value={getRouter()}>
               <LayoutRouterContext.Provider
                 value={{
+                  // TODO Remove when dropping Next.js < v15.1.1
                   childNodes: new Map(),
-                  loading: null,
                   tree,
+                  // TODO END
+
+                  // START Next.js v15.2 support
+                  // @ts-expect-error Only available in Next.js >= v15.1.1
+                  parentTree: tree,
+                  parentCacheNode: newLazyCacheNode,
+                  // END
                   url: pathname,
+                  loading: null,
                 }}
               >
                 {children}

--- a/code/frameworks/nextjs/src/routing/app-router-provider.tsx
+++ b/code/frameworks/nextjs/src/routing/app-router-provider.tsx
@@ -80,6 +80,16 @@ export const AppRouterProvider: React.FC<React.PropsWithChildren<AppRouterProvid
     return getSelectedParams(tree);
   }, [tree]);
 
+  const newLazyCacheNode = {
+    lazyData: null,
+    rsc: null,
+    prefetchRsc: null,
+    head: null,
+    prefetchHead: null,
+    parallelRoutes: new Map(),
+    loading: null,
+  };
+
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx#L436
   return (
     <PathParamsContext.Provider value={pathParams}>
@@ -104,8 +114,16 @@ export const AppRouterProvider: React.FC<React.PropsWithChildren<AppRouterProvid
             <AppRouterContext.Provider value={getRouter()}>
               <LayoutRouterContext.Provider
                 value={{
+                  // TODO Remove when dropping Next.js < v15.1.1
                   childNodes: new Map(),
                   tree,
+                  // TODO END
+
+                  // START Next.js v15.2 support
+                  // @ts-expect-error Only available in Next.js >= v15.1.1
+                  parentTree: tree,
+                  parentCacheNode: newLazyCacheNode,
+                  // END
                   url: pathname,
                   loading: null,
                 }}


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added support for the upcoming Next.js v15.1 release

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | **1.53** | 0% |
| initSize |  136 MB | 136 MB | 0 B | **1.53** | 0% |
| diffSize |  58.4 MB | 58.4 MB | 0 B | **1.53** | 0% |
| buildSize |  7.24 MB | 7.24 MB | 0 B | 1.22 | 0% |
| buildSbAddonsSize |  1.88 MB | 1.88 MB | 0 B | 1.22 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 1.11 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.93 MB | 3.93 MB | 0 B | 1.22 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | 1.2 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.9s | 7.2s | 336ms | -0.85 | 4.6% |
| generateTime |  21.5s | 19.4s | -2s -93ms | -0.69 | -10.8% |
| initTime |  14.6s | 14.5s | -147ms | 0.09 | -1% |
| buildTime |  8.8s | 8s | -750ms | -0.91 | -9.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.2s | 5.1s | 891ms | 0.01 | 17.2% |
| devManagerResponsive |  3.3s | 4s | 685ms | 0.32 | 17% |
| devManagerHeaderVisible |  500ms | 618ms | 118ms | 0.3 | 19.1% |
| devManagerIndexVisible |  529ms | 657ms | 128ms | 0.15 | 19.5% |
| devStoryVisibleUncached |  1.7s | 1.9s | 259ms | 0.79 | 13.1% |
| devStoryVisible |  528ms | 656ms | 128ms | 0.13 | 19.5% |
| devAutodocsVisible |  497ms | 578ms | 81ms | 0.72 | 14% |
| devMDXVisible |  456ms | 574ms | 118ms | 0.33 | 20.6% |
| buildManagerHeaderVisible |  520ms | 625ms | 105ms | 0.21 | 16.8% |
| buildManagerIndexVisible |  593ms | 719ms | 126ms | 0.16 | 17.5% |
| buildStoryVisible |  468ms | 585ms | 117ms | 0.28 | 20% |
| buildAutodocsVisible |  404ms | 573ms | 169ms | 1.17 | 29.5% |
| buildMDXVisible |  391ms | 509ms | 118ms | 0.53 | 23.2% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates the AppRouterProvider component in Next.js and experimental-nextjs-vite frameworks to support Next.js v15.2 while maintaining backward compatibility.

- Added `newLazyCacheNode` object for caching in both frameworks
- Added `parentTree` and `parentCacheNode` properties to `LayoutRouterContext.Provider` for v15.2 support
- Maintained backward compatibility with `childNodes` and `tree` properties for Next.js < v15.2
- Added TODO comments to mark code for removal when dropping support for older Next.js versions



<!-- /greptile_comment -->