### PR TITLE
Telemetry: Add metadata distinguishing "apps" from "design systems"

### DIFF
--- a/code/core/src/__mocks__/page.ts
+++ b/code/core/src/__mocks__/page.ts
@@ -1,0 +1,1 @@
+// empty file only matched on path

--- a/code/core/src/__mocks__/path/to/Screens/index.jsx
+++ b/code/core/src/__mocks__/path/to/Screens/index.jsx
@@ -1,0 +1,1 @@
+// empty file only matched on path

--- a/code/core/src/manager-api/modules/layout.ts
+++ b/code/core/src/manager-api/modules/layout.ts
@@ -100,7 +100,7 @@ export const defaultLayoutState: SubState = {
     panelPosition: 'bottom',
     showTabs: true,
   },
-  selectedPanel: undefined,
+  selectedPanel: 'chromaui/addon-visual-tests/panel',
   theme: create(),
 };
 

--- a/code/core/src/manager/components/panel/Panel.tsx
+++ b/code/core/src/manager/components/panel/Panel.tsx
@@ -60,7 +60,7 @@ export const AddonPanel = React.memo<{
     return (
       <Tabs
         absolute={absolute}
-        {...(selectedPanel ? { selected: selectedPanel } : {})}
+        {...(selectedPanel && panels[selectedPanel] ? { selected: selectedPanel } : {})}
         menuName="Addons"
         actions={actions}
         showToolsWhenEmpty

--- a/code/core/src/telemetry/exec-command-count-lines.test.ts
+++ b/code/core/src/telemetry/exec-command-count-lines.test.ts
@@ -1,0 +1,71 @@
+import type { Transform } from 'node:stream';
+import { PassThrough } from 'node:stream';
+
+import { beforeEach, describe, expect, it, vitest } from 'vitest';
+
+// eslint-disable-next-line depend/ban-dependencies
+import { execaCommand as rawExecaCommand } from 'execa';
+
+import { execCommandCountLines } from './exec-command-count-lines';
+
+vitest.mock('execa');
+
+const execaCommand = vitest.mocked(rawExecaCommand);
+beforeEach(() => {
+  execaCommand.mockReset();
+});
+
+type ExecaStreamer = typeof Promise & {
+  stdout: Transform;
+  kill: () => void;
+};
+
+function createExecaStreamer() {
+  let resolver: () => void;
+  const promiseLike: ExecaStreamer = new Promise<void>((aResolver, aRejecter) => {
+    resolver = aResolver;
+  }) as any;
+
+  promiseLike.stdout = new PassThrough();
+  // @ts-expect-error technically it is invalid to use resolver "before" it is assigned (but not really)
+  promiseLike.kill = resolver;
+  return promiseLike;
+}
+
+describe('execCommandCountLines', () => {
+  it('counts lines, many', async () => {
+    const streamer = createExecaStreamer();
+    execaCommand.mockReturnValue(streamer as any);
+
+    const promise = execCommandCountLines('some command');
+
+    streamer.stdout.write('First line\n');
+    streamer.stdout.write('Second line\n');
+    streamer.kill();
+
+    expect(await promise).toEqual(2);
+  });
+
+  it('counts lines, one', async () => {
+    const streamer = createExecaStreamer();
+    execaCommand.mockReturnValue(streamer as any);
+
+    const promise = execCommandCountLines('some command');
+
+    streamer.stdout.write('First line\n');
+    streamer.kill();
+
+    expect(await promise).toEqual(1);
+  });
+
+  it('counts lines, none', async () => {
+    const streamer = createExecaStreamer();
+    execaCommand.mockReturnValue(streamer as any);
+
+    const promise = execCommandCountLines('some command');
+
+    streamer.kill();
+
+    expect(await promise).toEqual(0);
+  });
+});

--- a/code/core/src/telemetry/exec-command-count-lines.ts
+++ b/code/core/src/telemetry/exec-command-count-lines.ts
@@ -16,8 +16,8 @@ export async function execCommandCountLines(
 ) {
   const process = execaCommand(command, { shell: true, buffer: false, ...options });
   if (!process.stdout) {
-    // Return null rather than throwing an error
-    return null;
+    // Return undefined rather than throwing an error
+    return undefined;
   }
 
   let lineCount = 0;

--- a/code/core/src/telemetry/exec-command-count-lines.ts
+++ b/code/core/src/telemetry/exec-command-count-lines.ts
@@ -16,8 +16,8 @@ export async function execCommandCountLines(
 ) {
   const process = execaCommand(command, { shell: true, buffer: false, ...options });
   if (!process.stdout) {
-    // Return undefined rather than throwing an error
-    return undefined;
+    // eslint-disable-next-line local-rules/no-uncategorized-errors
+    throw new Error('Unexpected missing stdout');
   }
 
   let lineCount = 0;
@@ -28,6 +28,8 @@ export async function execCommandCountLines(
 
   // If the process errors, this will throw
   await process;
+
+  rl.close();
 
   return lineCount;
 }

--- a/code/core/src/telemetry/exec-command-count-lines.ts
+++ b/code/core/src/telemetry/exec-command-count-lines.ts
@@ -1,0 +1,33 @@
+import { createInterface } from 'node:readline';
+
+// eslint-disable-next-line depend/ban-dependencies
+import { execaCommand } from 'execa';
+
+/**
+ * Execute a command in the local terminal and count the lines in the result
+ *
+ * @param command The command to execute.
+ * @param options Execa options
+ * @returns The number of lines the command returned
+ */
+export async function execCommandCountLines(
+  command: string,
+  options?: Parameters<typeof execaCommand>[1]
+) {
+  const process = execaCommand(command, { shell: true, buffer: false, ...options });
+  if (!process.stdout) {
+    // Return null rather than throwing an error
+    return null;
+  }
+
+  let lineCount = 0;
+  const rl = createInterface(process.stdout);
+  rl.on('line', () => {
+    lineCount += 1;
+  });
+
+  // If the process errors, this will throw
+  await process;
+
+  return lineCount;
+}

--- a/code/core/src/telemetry/get-application-file-count.test.ts
+++ b/code/core/src/telemetry/get-application-file-count.test.ts
@@ -1,0 +1,14 @@
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { getApplicationFilesCountUncached } from './get-application-file-count';
+
+const mocksDir = join(__dirname, '..', '__mocks__');
+
+describe('getApplicationFilesCount', () => {
+  it('should find files with correct names', async () => {
+    const files = await getApplicationFilesCountUncached(mocksDir);
+    expect(files).toMatchInlineSnapshot(`2`);
+  });
+});

--- a/code/core/src/telemetry/get-application-file-count.ts
+++ b/code/core/src/telemetry/get-application-file-count.ts
@@ -1,0 +1,30 @@
+import { execCommandCountLines } from './exec-command-count-lines';
+import { runTelemetryOperation } from './run-telemetry-operation';
+
+// We are looking for files with the word "page" or "screen" somewhere in them with these exts
+const nameMatches = ['page', 'screen'];
+const extensions = ['js', 'jsx', 'ts', 'tsx'];
+
+export const getApplicationFilesCountUncached = async (basePath: string) => {
+  const bothCasesNameMatches = nameMatches.flatMap((match) => [
+    match,
+    [match[0].toUpperCase(), ...match.slice(1)].join(''),
+  ]);
+
+  const globs = bothCasesNameMatches.flatMap((match) =>
+    extensions.map((extension) => `"${basePath}*${match}*.${extension}"`)
+  );
+
+  try {
+    const command = `git ls-files -- ${globs.join(' ')}`;
+    return await execCommandCountLines(command);
+  } catch {
+    return undefined;
+  }
+};
+
+export const getApplicationFileCount = async (path: string) => {
+  return runTelemetryOperation('applicationFiles', async () =>
+    getApplicationFilesCountUncached(path)
+  );
+};

--- a/code/core/src/telemetry/get-application-file-count.ts
+++ b/code/core/src/telemetry/get-application-file-count.ts
@@ -1,3 +1,5 @@
+import { sep } from 'node:path';
+
 import { execCommandCountLines } from './exec-command-count-lines';
 import { runTelemetryOperation } from './run-telemetry-operation';
 
@@ -12,7 +14,7 @@ export const getApplicationFilesCountUncached = async (basePath: string) => {
   ]);
 
   const globs = bothCasesNameMatches.flatMap((match) =>
-    extensions.map((extension) => `"${basePath}*${match}*.${extension}"`)
+    extensions.map((extension) => `"${basePath}${sep}*${match}*.${extension}"`)
   );
 
   try {

--- a/code/core/src/telemetry/get-has-router-package.test.ts
+++ b/code/core/src/telemetry/get-has-router-package.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from 'vitest';
+
+import { getHasRouterPackage } from './get-has-router-package';
+
+it('returns true if there is a routing package in package.json', async () => {
+  expect(
+    getHasRouterPackage({
+      dependencies: {
+        react: '^18',
+        'react-dom': '^18',
+        'react-router': '^6',
+      },
+    })
+  ).toBe(true);
+});
+
+it('returns false if there is a routing package in package.json dependenices', async () => {
+  expect(
+    getHasRouterPackage({
+      dependencies: {
+        react: '^18',
+        'react-dom': '^18',
+      },
+      devDependencies: {
+        'react-router': '^6',
+      },
+    })
+  ).toBe(false);
+});

--- a/code/core/src/telemetry/get-has-router-package.test.ts
+++ b/code/core/src/telemetry/get-has-router-package.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from 'vitest';
 
 import { getHasRouterPackage } from './get-has-router-package';
 
-it('returns true if there is a routing package in package.json', async () => {
+it('returns true if there is a routing package in package.json', () => {
   expect(
     getHasRouterPackage({
       dependencies: {
@@ -14,7 +14,7 @@ it('returns true if there is a routing package in package.json', async () => {
   ).toBe(true);
 });
 
-it('returns false if there is a routing package in package.json dependenices', async () => {
+it('returns false if there is a routing package in package.json dependencies', () => {
   expect(
     getHasRouterPackage({
       dependencies: {

--- a/code/core/src/telemetry/get-has-router-package.ts
+++ b/code/core/src/telemetry/get-has-router-package.ts
@@ -1,0 +1,37 @@
+import type { PackageJson } from '../types';
+
+const routerPackages = new Set([
+  'react-router',
+  'react-router-dom',
+  'remix',
+  '@tanstack/react-router',
+  'expo-router',
+  '@reach/router',
+  'react-easy-router',
+  '@remix-run/router',
+  'wouter',
+  'wouter-preact',
+  'preact-router',
+  'vue-router',
+  'unplugin-vue-router',
+  '@angular/router',
+  '@solidjs/router',
+
+  // metaframeworks that imply routing
+  'next',
+  'react-scripts',
+  'gatsby',
+  'nuxt',
+  '@sveltejs/kit',
+]);
+
+/**
+ * @param packageJson The package JSON of the project
+ * @returns Boolean Does this project use a routing package?
+ */
+export function getHasRouterPackage(packageJson: PackageJson) {
+  // NOTE: we just check real dependencies; if it is in dev dependencies, it may just be an example
+  return Object.keys(packageJson?.dependencies ?? {}).some((depName) =>
+    routerPackages.has(depName)
+  );
+}

--- a/code/core/src/telemetry/get-portable-stories-usage.ts
+++ b/code/core/src/telemetry/get-portable-stories-usage.ts
@@ -1,7 +1,5 @@
-// eslint-disable-next-line depend/ban-dependencies
-import { execaCommand } from 'execa';
-
 import { createFileSystemCache, resolvePathInStorybookCache } from '../common';
+import { execCommandCountLines } from './exec-command-count-lines';
 
 const cache = createFileSystemCache({
   basePath: resolvePathInStorybookCache('portable-stories'),
@@ -11,12 +9,7 @@ const cache = createFileSystemCache({
 
 export const getPortableStoriesFileCountUncached = async (path?: string) => {
   const command = `git grep -l composeStor` + (path ? ` -- ${path}` : '');
-  const { stdout } = await execaCommand(command, {
-    cwd: process.cwd(),
-    shell: true,
-  });
-
-  return stdout.split('\n').filter(Boolean).length;
+  return execCommandCountLines(command);
 };
 
 const CACHE_KEY = 'portableStories';

--- a/code/core/src/telemetry/get-portable-stories-usage.ts
+++ b/code/core/src/telemetry/get-portable-stories-usage.ts
@@ -1,30 +1,18 @@
-import { createFileSystemCache, resolvePathInStorybookCache } from '../common';
 import { execCommandCountLines } from './exec-command-count-lines';
-
-const cache = createFileSystemCache({
-  basePath: resolvePathInStorybookCache('portable-stories'),
-  ns: 'storybook',
-  ttl: 24 * 60 * 60 * 1000, // 24h
-});
+import { runTelemetryOperation } from './run-telemetry-operation';
 
 export const getPortableStoriesFileCountUncached = async (path?: string) => {
-  const command = `git grep -l composeStor` + (path ? ` -- ${path}` : '');
-  return execCommandCountLines(command);
+  try {
+    const command = `git grep -l composeStor` + (path ? ` -- ${path}` : '');
+    return await execCommandCountLines(command);
+  } catch (err: any) {
+    // exit code 1 if no matches are found
+    return err.exitCode === 1 ? 0 : undefined;
+  }
 };
 
-const CACHE_KEY = 'portableStories';
 export const getPortableStoriesFileCount = async (path?: string) => {
-  let cached = await cache.get(CACHE_KEY);
-  if (!cached) {
-    try {
-      const count = await getPortableStoriesFileCountUncached();
-      cached = { count };
-      await cache.set(CACHE_KEY, cached);
-    } catch (err: any) {
-      // exit code 1 if no matches are found
-      const count = err.exitCode === 1 ? 0 : null;
-      cached = { count };
-    }
-  }
-  return cached.count;
+  return runTelemetryOperation('portableStories', async () =>
+    getPortableStoriesFileCountUncached(path)
+  );
 };

--- a/code/core/src/telemetry/run-telemetry-operation.ts
+++ b/code/core/src/telemetry/run-telemetry-operation.ts
@@ -1,0 +1,22 @@
+import { createFileSystemCache, resolvePathInStorybookCache } from '../common';
+
+const cache = createFileSystemCache({
+  basePath: resolvePathInStorybookCache('telemetry'),
+  ns: 'storybook',
+  ttl: 24 * 60 * 60 * 1000, // 24h
+});
+
+/**
+ * Run an (expensive) operation, caching the result in a FS cache for 24 hours.
+ *
+ * NOTE: if the operation returns `undefined` the value will not be cached. Use this to indicate
+ * that the operation failed.
+ */
+export const runTelemetryOperation = async <T>(cacheKey: string, operation: () => Promise<T>) => {
+  let cached = await cache.get<T>(cacheKey);
+  if (cached === undefined) {
+    cached = await operation();
+    await cache.set(cacheKey, cached);
+  }
+  return cached;
+};

--- a/code/core/src/telemetry/run-telemetry-operation.ts
+++ b/code/core/src/telemetry/run-telemetry-operation.ts
@@ -16,7 +16,10 @@ export const runTelemetryOperation = async <T>(cacheKey: string, operation: () =
   let cached = await cache.get<T>(cacheKey);
   if (cached === undefined) {
     cached = await operation();
-    await cache.set(cacheKey, cached);
+    // Undefined indicates an error, setting isn't really valuable.
+    if (cached !== undefined) {
+      await cache.set(cacheKey, cached);
+    }
   }
   return cached;
 };

--- a/code/core/src/telemetry/storybook-metadata.test.ts
+++ b/code/core/src/telemetry/storybook-metadata.test.ts
@@ -12,6 +12,8 @@ const packageJsonMock: PackageJson = {
   version: 'x.x.x',
 };
 
+const packageJsonPath = process.cwd();
+
 const mainJsMock: StorybookConfig = {
   stories: [],
 };
@@ -126,6 +128,7 @@ describe('storybook-metadata', () => {
       it('should parse pnp paths for known frameworks', async () => {
         const unixResult = await computeStorybookMetadata({
           packageJson: packageJsonMock,
+          packageJsonPath,
           mainConfig: {
             ...mainJsMock,
             framework: {
@@ -144,6 +147,7 @@ describe('storybook-metadata', () => {
 
         const windowsResult = await computeStorybookMetadata({
           packageJson: packageJsonMock,
+          packageJsonPath,
           mainConfig: {
             ...mainJsMock,
             framework: {
@@ -164,6 +168,7 @@ describe('storybook-metadata', () => {
       it('should parse pnp paths for unknown frameworks', async () => {
         const unixResult = await computeStorybookMetadata({
           packageJson: packageJsonMock,
+          packageJsonPath,
           mainConfig: {
             ...mainJsMock,
             framework: {
@@ -178,6 +183,7 @@ describe('storybook-metadata', () => {
 
         const windowsResult = await computeStorybookMetadata({
           packageJson: packageJsonMock,
+          packageJsonPath,
           mainConfig: {
             ...mainJsMock,
             framework: {
@@ -198,6 +204,7 @@ describe('storybook-metadata', () => {
 
         const unixResult = await computeStorybookMetadata({
           packageJson: packageJsonMock,
+          packageJsonPath,
           mainConfig: {
             ...mainJsMock,
             framework: {
@@ -215,6 +222,7 @@ describe('storybook-metadata', () => {
         cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('C:\\Users\\foo\\my-project');
         const windowsResult = await computeStorybookMetadata({
           packageJson: packageJsonMock,
+          packageJsonPath,
           mainConfig: {
             ...mainJsMock,
             framework: {
@@ -232,6 +240,7 @@ describe('storybook-metadata', () => {
     it('should return frameworkOptions from mainjs', async () => {
       const reactResult = await computeStorybookMetadata({
         packageJson: packageJsonMock,
+        packageJsonPath,
         mainConfig: {
           ...mainJsMock,
           framework: {
@@ -250,6 +259,7 @@ describe('storybook-metadata', () => {
 
       const angularResult = await computeStorybookMetadata({
         packageJson: packageJsonMock,
+        packageJsonPath,
         mainConfig: {
           ...mainJsMock,
           framework: {
@@ -279,6 +289,7 @@ describe('storybook-metadata', () => {
             'storybook-addon-deprecated': 'x.x.z',
           },
         } as PackageJson,
+        packageJsonPath,
         mainConfig: {
           ...mainJsMock,
           addons: [
@@ -319,6 +330,7 @@ describe('storybook-metadata', () => {
 
       const result = await computeStorybookMetadata({
         packageJson: packageJsonMock,
+        packageJsonPath,
         mainConfig: {
           ...mainJsMock,
           features,
@@ -332,6 +344,7 @@ describe('storybook-metadata', () => {
       expect(
         await computeStorybookMetadata({
           packageJson: packageJsonMock,
+          packageJsonPath,
           mainConfig: {
             ...mainJsMock,
             framework: '@storybook/react-vite',
@@ -347,6 +360,7 @@ describe('storybook-metadata', () => {
     it('should return the number of refs', async () => {
       const res = await computeStorybookMetadata({
         packageJson: packageJsonMock,
+        packageJsonPath,
         mainConfig: {
           ...mainJsMock,
           refs: {
@@ -361,6 +375,7 @@ describe('storybook-metadata', () => {
     it('only reports addon options for addon-essentials', async () => {
       const res = await computeStorybookMetadata({
         packageJson: packageJsonMock,
+        packageJsonPath,
         mainConfig: {
           ...mainJsMock,
           addons: [
@@ -395,6 +410,7 @@ describe('storybook-metadata', () => {
               [metaFramework]: 'x.x.x',
             },
           } as PackageJson,
+          packageJsonPath,
           mainConfig: mainJsMock,
         });
         expect(res.metaFramework).toEqual({

--- a/code/core/src/telemetry/storybook-metadata.ts
+++ b/code/core/src/telemetry/storybook-metadata.ts
@@ -1,3 +1,5 @@
+import { dirname } from 'node:path';
+
 import {
   getProjectRoot,
   getStorybookConfiguration,
@@ -9,8 +11,9 @@ import type { PackageJson, StorybookConfig } from '@storybook/core/types';
 import { readConfig } from '@storybook/core/csf-tools';
 
 import { detect, getNpmVersion } from 'detect-package-manager';
-import { findPackage } from 'fd-package-json';
+import { findPackage, findPackagePath } from 'fd-package-json';
 
+import { getApplicationFileCount } from './get-application-file-count';
 import { getChromaticVersionSpecifier } from './get-chromatic-version';
 import { getFrameworkInfo } from './get-framework-info';
 import { getHasRouterPackage } from './get-has-router-package';
@@ -42,9 +45,11 @@ export const sanitizeAddonName = (name: string) => {
 // Analyze a combination of information from main.js and package.json
 // to provide telemetry over a Storybook project
 export const computeStorybookMetadata = async ({
+  packageJsonPath,
   packageJson,
   mainConfig,
 }: {
+  packageJsonPath: string;
   packageJson: PackageJson;
   mainConfig: StorybookConfig & Record<string, any>;
 }): Promise<StorybookMetadata> => {
@@ -212,11 +217,13 @@ export const computeStorybookMetadata = async ({
 
   const storybookVersion = storybookPackages[storybookInfo.frameworkPackage]?.version;
   const portableStoriesFileCount = await getPortableStoriesFileCount();
+  const applicationFileCount = await getApplicationFileCount(dirname(packageJsonPath));
 
   return {
     ...metadata,
     ...frameworkInfo,
     portableStoriesFileCount,
+    applicationFileCount,
     storybookVersion,
     storybookVersionSpecifier: storybookInfo.version,
     language,
@@ -226,13 +233,29 @@ export const computeStorybookMetadata = async ({
   };
 };
 
+async function getPackageJsonDetails() {
+  const packageJsonPath = await findPackagePath(process.cwd());
+  if (packageJsonPath) {
+    return {
+      packageJsonPath,
+      packageJson: (await findPackage(packageJsonPath)) || {},
+    };
+  }
+
+  // If we don't find a `package.json`, we assume it "would have" been in the current working directory
+  return {
+    packageJsonPath: process.cwd(),
+    packageJson: {},
+  };
+}
+
 let cachedMetadata: StorybookMetadata;
 export const getStorybookMetadata = async (_configDir?: string) => {
   if (cachedMetadata) {
     return cachedMetadata;
   }
 
-  const packageJson = (await findPackage(process.cwd())) || {};
+  const { packageJson, packageJsonPath } = await getPackageJsonDetails();
   // TODO: improve the way configDir is extracted, as a "storybook" script might not be present
   // Scenarios:
   // 1. user changed it to something else e.g. "storybook:dev"
@@ -246,6 +269,6 @@ export const getStorybookMetadata = async (_configDir?: string) => {
       ) as string)) ??
     '.storybook';
   const mainConfig = await loadMainConfig({ configDir });
-  cachedMetadata = await computeStorybookMetadata({ mainConfig, packageJson });
+  cachedMetadata = await computeStorybookMetadata({ mainConfig, packageJson, packageJsonPath });
   return cachedMetadata;
 };

--- a/code/core/src/telemetry/storybook-metadata.ts
+++ b/code/core/src/telemetry/storybook-metadata.ts
@@ -13,6 +13,7 @@ import { findPackage } from 'fd-package-json';
 
 import { getChromaticVersionSpecifier } from './get-chromatic-version';
 import { getFrameworkInfo } from './get-framework-info';
+import { getHasRouterPackage } from './get-has-router-package';
 import { getMonorepoType } from './get-monorepo-type';
 import { getPortableStoriesFileCount } from './get-portable-stories-usage';
 import { getActualPackageVersion, getActualPackageVersions } from './package-json';
@@ -99,6 +100,8 @@ export const computeStorybookMetadata = async ({
       testPackageDeps.map(async (dep) => [dep, (await getActualPackageVersion(dep))?.version])
     )
   );
+
+  metadata.hasRouterPackage = getHasRouterPackage(packageJson);
 
   const monorepoType = getMonorepoType();
   if (monorepoType) {

--- a/code/core/src/telemetry/types.ts
+++ b/code/core/src/telemetry/types.ts
@@ -70,6 +70,7 @@ export type StorybookMetadata = {
     usesGlobals?: boolean;
   };
   portableStoriesFileCount?: number;
+  applicationFileCount?: number;
 };
 
 export interface Payload {

--- a/code/core/src/telemetry/types.ts
+++ b/code/core/src/telemetry/types.ts
@@ -59,6 +59,7 @@ export type StorybookMetadata = {
     version: string;
   };
   testPackages?: Record<string, string | undefined>;
+  hasRouterPackage?: boolean;
   hasStorybookEslint?: boolean;
   hasStaticDirs?: boolean;
   hasCustomWebpack?: boolean;

--- a/code/e2e-tests/preview-api.spec.ts
+++ b/code/e2e-tests/preview-api.spec.ts
@@ -65,6 +65,7 @@ test.describe('preview-api', () => {
 
     const root = sbPage.previewRoot();
 
+    await sbPage.viewAddonPanel('Controls');
     const labelControl = sbPage.page.locator('#control-label');
 
     await expect(root.getByText('Loaded. Click me')).toBeVisible();


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Create a project with a router and some pages and install Storybook with STORYBOOK_TELEMETRY_DEBUG=1. Bonus points if it's in a monorepo.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30070-sha-0b45cb37`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30070-sha-0b45cb37 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30070-sha-0b45cb37 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30070-sha-0b45cb37`](https://npmjs.com/package/storybook/v/0.0.0-pr-30070-sha-0b45cb37) |
| **Triggered by** | @tmeasday |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`tom/metadata-tweaks`](https://github.com/storybookjs/storybook/tree/tom/metadata-tweaks) |
| **Commit** | [`0b45cb37`](https://github.com/storybookjs/storybook/commit/0b45cb37bdd850cd5555eb3ea51162bfe9dea918) |
| **Datetime** | Mon Dec 16 05:52:50 UTC 2024 (`1734328370`) |
| **Workflow run** | [12346768870](https://github.com/storybookjs/storybook/actions/runs/12346768870) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30070`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 48 B | 1.11 | 0% |
| initSize |  136 MB | 136 MB | 4.41 kB | 1.11 | 0% |
| diffSize |  58.4 MB | 58.4 MB | 4.37 kB | 1.11 | 0% |
| buildSize |  7.24 MB | 7.24 MB | 87 B | 0.91 | 0% |
| buildSbAddonsSize |  1.88 MB | 1.88 MB | 0 B | 0.9 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 37 B | 0.9 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.93 MB | 3.93 MB | 37 B | 0.9 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 50 B | **1.55** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8s | 6.7s | -1s -280ms | -0.98 | -18.9% |
| generateTime |  20.2s | 19.2s | -1s -32ms | -1.03 | -5.4% |
| initTime |  14.5s | 13.3s | -1s -267ms | -0.75 | -9.5% |
| buildTime |  11.9s | 10s | -1s -824ms | 0.27 | -18.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.6s | 5.2s | -357ms | 0.26 | -6.8% |
| devManagerResponsive |  4.1s | 3.8s | -301ms | 0.02 | -7.8% |
| devManagerHeaderVisible |  748ms | 559ms | -189ms | -0.42 | -33.8% |
| devManagerIndexVisible |  770ms | 584ms | -186ms | -0.75 | -31.8% |
| devStoryVisibleUncached |  1.9s | 1.1s | -883ms | **-2.63** | 🔰-80.2% |
| devStoryVisible |  792ms | 585ms | -207ms | -0.73 | -35.4% |
| devAutodocsVisible |  501ms | 535ms | 34ms | 0.21 | 6.4% |
| devMDXVisible |  578ms | 522ms | -56ms | -0.08 | -10.7% |
| buildManagerHeaderVisible |  642ms | 564ms | -78ms | -0.46 | -13.8% |
| buildManagerIndexVisible |  744ms | 651ms | -93ms | -0.54 | -14.3% |
| buildStoryVisible |  603ms | 529ms | -74ms | -0.31 | -14% |
| buildAutodocsVisible |  504ms | 457ms | -47ms | 0.14 | -10.3% |
| buildMDXVisible |  475ms | 444ms | -31ms | -0.16 | -7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhanced Storybook's telemetry system to distinguish between applications and design systems by adding metrics for router package detection and application file counting.

- Added `getApplicationFileCount.ts` to detect files with 'page' or 'screen' patterns using git ls-files
- Added `getHasRouterPackage.ts` to identify routing dependencies across major frameworks
- Added filesystem caching in `runTelemetryOperation.ts` with 24-hour TTL for expensive operations
- Updated `StorybookMetadata` type with new `hasRouterPackage` and `applicationFileCount` fields
- Changed default selected panel to 'chromaui/addon-visual-tests/panel' in layout module



<sub>💡 (3/5) Reply to the bot's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->