### PR TITLE
Addon A11y: Add conditional rendering for a11y violation number in Testing Module

### DIFF
--- a/code/addons/test/src/components/TestProviderRender.tsx
+++ b/code/addons/test/src/components/TestProviderRender.tsx
@@ -114,6 +114,8 @@ export const TestProviderRender: FC<
     state.config || { a11y: false, coverage: false }
   );
 
+  const isStoryEntry = entryId?.includes('--') ?? false;
+
   const a11yResults = useMemo(() => {
     if (!isA11yAddon) {
       return [];
@@ -156,7 +158,7 @@ export const TestProviderRender: FC<
     (result) => result?.status === 'failed' || result?.status === 'warning'
   ).length;
 
-  const storyId = entryId?.includes('--') ? entryId : undefined;
+  const storyId = isStoryEntry ? entryId : undefined;
   const results = (state.details?.testResults || [])
     .flatMap((test) => {
       if (!entryId) {
@@ -340,7 +342,7 @@ export const TestProviderRender: FC<
                   : null
               }
               icon={<TestStatusIcon status={a11yStatus} aria-label={`status: ${a11yStatus}`} />}
-              right={a11yNotPassedAmount || null}
+              right={isStoryEntry ? null : a11yNotPassedAmount || null}
             />
           )}
         </Extras>


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have removed the a11y violation count on a story in the sidebar because in the case of a a11y violation, it was always showing `1`. The status icon on the left already indicates whether the story has a11y violations.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 1.11 | 0% |
| initSize |  136 MB | 136 MB | 0 B | 1.11 | 0% |
| diffSize |  58.4 MB | 58.4 MB | 0 B | 1.11 | 0% |
| buildSize |  7.24 MB | 7.24 MB | 0 B | 0.9 | 0% |
| buildSbAddonsSize |  1.88 MB | 1.88 MB | 0 B | 0.9 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 0.83 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.93 MB | 3.93 MB | 0 B | 0.9 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | 0.89 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8s | 7.8s | -145ms | -0.84 | -1.8% |
| generateTime |  20.2s | 22s | 1.7s | **1.33** | 🔺8.1% |
| initTime |  14.5s | 14.7s | 169ms | 0.4 | 1.1% |
| buildTime |  11.9s | 10s | -1s -855ms | 0.25 | -18.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.6s | 4.8s | -759ms | -0.41 | -15.5% |
| devManagerResponsive |  4.1s | 3.7s | -420ms | -0.25 | -11.2% |
| devManagerHeaderVisible |  748ms | 599ms | -149ms | 0.08 | -24.9% |
| devManagerIndexVisible |  770ms | 629ms | -141ms | -0.18 | -22.4% |
| devStoryVisibleUncached |  1.9s | 1.9s | -59ms | 0.53 | -3.1% |
| devStoryVisible |  792ms | 630ms | -162ms | -0.18 | -25.7% |
| devAutodocsVisible |  501ms | 423ms | -78ms | **-1.71** | 🔰-18.4% |
| devMDXVisible |  578ms | 552ms | -26ms | 0.29 | -4.7% |
| buildManagerHeaderVisible |  642ms | 655ms | 13ms | 0.86 | 2% |
| buildManagerIndexVisible |  744ms | 779ms | 35ms | 1.12 | 4.5% |
| buildStoryVisible |  603ms | 617ms | 14ms | 1.1 | 2.3% |
| buildAutodocsVisible |  504ms | 443ms | -61ms | -0.14 | -13.8% |
| buildMDXVisible |  475ms | 477ms | 2ms | 0.35 | 0.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR modifies the TestProviderRender component to conditionally hide accessibility test counts when viewing individual stories in Storybook.

- Added conditional check in `code/addons/test/src/components/TestProviderRender.tsx` to hide a11y test counts when entryId contains '--'
- Potential code duplication in story entry detection logic (lines 117 and 161)
- Missing test coverage for new conditional rendering behavior
- Could impact accessibility issue tracking workflow for individual story views



<!-- /greptile_comment -->