### PR TITLE
UI: Fix test provider event handling on startup

### DIFF
--- a/code/core/src/manager/components/sidebar/SidebarBottom.tsx
+++ b/code/core/src/manager/components/sidebar/SidebarBottom.tsx
@@ -1,7 +1,7 @@
-import React, { Fragment, useEffect, useRef, useState } from 'react';
+import React, { Fragment, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { styled } from '@storybook/core/theming';
-import { type API_FilterFunction, type API_StatusValue } from '@storybook/core/types';
+import { type API_FilterFunction } from '@storybook/core/types';
 
 import {
   TESTING_MODULE_CRASH_REPORT,
@@ -119,7 +119,8 @@ export const SidebarBottomBase = ({
     api.experimental_setFilter('sidebar-bottom-filter', filter);
   }, [api, hasWarnings, hasErrors, warningsActive, errorsActive]);
 
-  useEffect(() => {
+  // Register listeners before the first render
+  useLayoutEffect(() => {
     const onCrashReport = ({ providerId, ...details }: TestingModuleCrashReportPayload) => {
       api.updateTestProviderState(providerId, {
         error: { name: 'Crashed!', message: details.error.message },

--- a/code/package.json
+++ b/code/package.json
@@ -90,7 +90,7 @@
     "type-fest": "~2.19"
   },
   "dependencies": {
-    "@chromatic-com/storybook": "^3.2.0",
+    "@chromatic-com/storybook": "^3.2.2",
     "@happy-dom/global-registrator": "^14.12.0",
     "@nx/eslint": "20.2.2",
     "@nx/vite": "20.2.2",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2532,21 +2532,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chromatic-com/storybook@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@chromatic-com/storybook@npm:3.2.0"
+"@chromatic-com/storybook@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@chromatic-com/storybook@npm:3.2.2"
   dependencies:
-    "@storybook/channels": "npm:^8.3.0"
-    "@storybook/telemetry": "npm:^8.3.0"
-    "@storybook/types": "npm:^8.3.0"
     chromatic: "npm:^11.15.0"
     filesize: "npm:^10.0.12"
     jsonfile: "npm:^6.1.0"
     react-confetti: "npm:^6.1.0"
     strip-ansi: "npm:^7.1.0"
   peerDependencies:
-    storybook: "*"
-  checksum: 10c0/59485e69a55df6b1998e19bf0e129fa1f9a86d3ae541f4dcb6f6dd945e7b9a6258ce75e244aaa73821039cef8c57424402a3c0bf63a66b4511a2ac0b5611103b
+    storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+  checksum: 10c0/7b8da1ddb399c804337ff28a28594b548392b7bead52f66615b98e201cdeb4d31184b9e355791ba5d0d8cfdd2bea7d38355ecd0058f26f4790f9a887107bde0f
   languageName: node
   linkType: hard
 
@@ -6037,15 +6034,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/channels@npm:^8.3.0":
-  version: 8.3.6
-  resolution: "@storybook/channels@npm:8.3.6"
-  peerDependencies:
-    storybook: ^8.3.6
-  checksum: 10c0/3c34ed2b03c60c6ed1160d9a0efdb836be892e333556848ff492c16ab6d92521207512670d42f69d681f521e50f130a00f692610a3ca63228a8d2b49be57f4fa
-  languageName: node
-  linkType: hard
-
 "@storybook/channels@workspace:deprecated/channels":
   version: 0.0.0-use.local
   resolution: "@storybook/channels@workspace:deprecated/channels"
@@ -7035,7 +7023,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/root@workspace:."
   dependencies:
-    "@chromatic-com/storybook": "npm:^3.2.0"
+    "@chromatic-com/storybook": "npm:^3.2.2"
     "@happy-dom/global-registrator": "npm:^14.12.0"
     "@nx/eslint": "npm:20.2.2"
     "@nx/vite": "npm:20.2.2"
@@ -7325,15 +7313,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/telemetry@npm:^8.3.0":
-  version: 8.3.6
-  resolution: "@storybook/telemetry@npm:8.3.6"
-  peerDependencies:
-    storybook: ^8.3.6
-  checksum: 10c0/b4fd8d0e238335249aa82dea49bde56813e0c771e67dd7110fb9e038d1e2bd64aa03e76ee865ef6a7f0fd5220d02bd7bcf3273bb4c19403e3d527d9dd7a258d4
-  languageName: node
-  linkType: hard
-
 "@storybook/telemetry@workspace:deprecated/telemetry":
   version: 0.0.0-use.local
   resolution: "@storybook/telemetry@workspace:deprecated/telemetry"
@@ -7382,15 +7361,6 @@ __metadata:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
   languageName: unknown
   linkType: soft
-
-"@storybook/types@npm:^8.3.0":
-  version: 8.3.6
-  resolution: "@storybook/types@npm:8.3.6"
-  peerDependencies:
-    storybook: ^8.3.6
-  checksum: 10c0/482f55e34877f9eb94a8ff4627a254f3b5442f91f13363e6837e3a9c220a369be1c6ce4652b870b7fa4e522c3365825651f9e04a21bda76b104a6c1f7435e274
-  languageName: node
-  linkType: hard
 
 "@storybook/types@workspace:*, @storybook/types@workspace:deprecated/types":
   version: 0.0.0-use.local


### PR DESCRIPTION
## What I did

Replaced `useEffect` with `useLayoutEffect` in order to have event listeners registered before rendering the test providers' UI. This is necessary because the VTA emits a progress report event when it has a warning (e.g. when not logged in to Chromatic), which happens on first render of its Description. The event is used to set `runnable: false` on the VTA, and if we miss this event, the VTA will have a Run button and respond to "Run all", which results in the addon getting stuck in "pending" state.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 0.7 | 0% |
| initSize |  136 MB | 136 MB | -203 B | 0.5 | 0% |
| diffSize |  58.4 MB | 58.4 MB | -203 B | 0.5 | 0% |
| buildSize |  7.24 MB | 7.24 MB | 1 B | 0.33 | 0% |
| buildSbAddonsSize |  1.88 MB | 1.88 MB | 0 B | 0.33 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 1 B | 0.36 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.93 MB | 3.93 MB | 1 B | 0.33 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | -0.07 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.7s | 9s | 2.3s | -0.6 | 25.9% |
| generateTime |  19.2s | 20.5s | 1.3s | 0.26 | 6.4% |
| initTime |  12.8s | 14s | 1.2s | -0.1 | 8.9% |
| buildTime |  12.8s | 10s | -2s -755ms | 0.02 | -27.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.5s | 4.7s | -803ms | -0.5 | -16.8% |
| devManagerResponsive |  4s | 3.5s | -432ms | -0.48 | -12% |
| devManagerHeaderVisible |  651ms | 636ms | -15ms | 0.55 | -2.4% |
| devManagerIndexVisible |  723ms | 664ms | -59ms | 0.42 | -8.9% |
| devStoryVisibleUncached |  1.7s | 1.8s | 132ms | 0.36 | 7.2% |
| devStoryVisible |  720ms | 663ms | -57ms | 0.37 | -8.6% |
| devAutodocsVisible |  578ms | 524ms | -54ms | -0.08 | -10.3% |
| devMDXVisible |  676ms | 529ms | -147ms | -0.08 | -27.8% |
| buildManagerHeaderVisible |  694ms | 567ms | -127ms | -0.56 | -22.4% |
| buildManagerIndexVisible |  780ms | 648ms | -132ms | -0.65 | -20.4% |
| buildStoryVisible |  652ms | 525ms | -127ms | -0.58 | -24.2% |
| buildAutodocsVisible |  551ms | 413ms | -138ms | -0.79 | -33.4% |
| buildMDXVisible |  586ms | 455ms | -131ms | -0.13 | -28.8% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR changes the event listener registration timing in SidebarBottom from useEffect to useLayoutEffect to prevent the Visual Testing Addon (VTA) from missing critical initial render events.

- Changed `useEffect` to `useLayoutEffect` in `code/core/src/manager/components/sidebar/SidebarBottom.tsx` to register event listeners before UI rendering
- Updated `@chromatic-com/storybook` dependency from 3.2.0 to 3.2.2 in `code/package.json`
- Fixes VTA getting stuck in 'pending' state when warnings occur during initial render (e.g., when not logged into Chromatic)



<!-- /greptile_comment -->