### PR TITLE
UI: Keep failing stories in the sidebar, disregarding filters

### DIFF
--- a/code/core/src/manager-api/lib/stories.ts
+++ b/code/core/src/manager-api/lib/stories.ts
@@ -192,11 +192,17 @@ export const transformStoryIndexToStoriesHash = (
   const entryValues = Object.values(index.entries).filter((entry: any) => {
     let result = true;
 
+    // All stories with a failing status should always show up, regardless of the applied filters
+    const storyStatus = status[entry.id];
+    if (Object.values(storyStatus ?? {}).some(({ status: s }) => s === 'error')) {
+      return result;
+    }
+
     Object.values(filters).forEach((filter: any) => {
       if (result === false) {
         return;
       }
-      result = filter({ ...entry, status: status[entry.id] });
+      result = filter({ ...entry, status: storyStatus });
     });
 
     return result;


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/29653

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Before applying filters to the index, we first check if the entry has a failing status. If it does, always keep it in the filtered index.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 0.63 | 0% |
| initSize |  136 MB | 136 MB | 216 B | 0.42 | 0% |
| diffSize |  58.4 MB | 58.4 MB | 216 B | 0.42 | 0% |
| buildSize |  7.24 MB | 7.24 MB | 72 B | 0.23 | 0% |
| buildSbAddonsSize |  1.88 MB | 1.88 MB | 0 B | 0.23 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 72 B | **3.87** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.93 MB | 3.93 MB | 72 B | 0.23 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | -0.27 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  26.8s | 27s | 219ms | **1.68** | 0.8% |
| generateTime |  19.7s | 27s | 7.2s | **5.74** | 🔺26.9% |
| initTime |  14.8s | 18.5s | 3.6s | **3.64** | 🔺19.7% |
| buildTime |  8.3s | 8.7s | 370ms | -0.7 | 4.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.1s | 4.8s | -267ms | -0.36 | -5.5% |
| devManagerResponsive |  3.9s | 3.7s | -270ms | -0.31 | -7.3% |
| devManagerHeaderVisible |  884ms | 594ms | -290ms | -0.26 | -48.8% |
| devManagerIndexVisible |  973ms | 625ms | -348ms | -0.32 | -55.7% |
| devStoryVisibleUncached |  1.9s | 1.7s | -216ms | -0.21 | -12.3% |
| devStoryVisible |  970ms | 626ms | -344ms | -0.32 | -55% |
| devAutodocsVisible |  679ms | 530ms | -149ms | -0.13 | -28.1% |
| devMDXVisible |  718ms | 522ms | -196ms | -0.33 | -37.5% |
| buildManagerHeaderVisible |  633ms | 584ms | -49ms | -0.47 | -8.4% |
| buildManagerIndexVisible |  753ms | 677ms | -76ms | -0.44 | -11.2% |
| buildStoryVisible |  589ms | 547ms | -42ms | -0.39 | -7.7% |
| buildAutodocsVisible |  485ms | 456ms | -29ms | -0.16 | -6.4% |
| buildMDXVisible |  499ms | 430ms | -69ms | -0.58 | -16% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Modified the story filtering logic to ensure failing stories remain visible in the sidebar regardless of applied filters.

- Added failing story bypass in `code/core/src/manager-api/lib/stories.ts` to preserve stories with error status
- Added test case in `code/core/src/manager-api/lib/stories.test.ts` verifying failing stories remain visible despite filters
- Fixed issue #29653 where failing stories without 'dev' tag were hidden from sidebar



<!-- /greptile_comment -->