### PR TITLE
Addon Test: Improve error message on missing coverage package

### DIFF
--- a/code/addons/test/src/node/test-manager.ts
+++ b/code/addons/test/src/node/test-manager.ts
@@ -53,14 +53,7 @@ export class TestManager {
           coverage: this.coverage,
         });
       } catch (e) {
-        const isV8 = e.message?.includes('@vitest/coverage-v8');
-        const isIstanbul = e.message?.includes('@vitest/coverage-istanbul');
-
-        if (e.message?.includes('Error: Failed to load url') && (isIstanbul || isV8)) {
-          const coveragePackage = isIstanbul ? 'coverage-istanbul' : 'coverage-v8';
-          e.message = `Please install the @vitest/${coveragePackage} package to run with coverage`;
-        }
-        this.reportFatalError('Failed to change coverage mode', e);
+        this.reportFatalError('Failed to change coverage configuration', e);
       }
     }
   }

--- a/code/addons/test/src/node/vitest-manager.ts
+++ b/code/addons/test/src/node/vitest-manager.ts
@@ -100,7 +100,7 @@ export class VitestManager {
           e?.message === "Cannot read properties of undefined (reading 'name')")
       ) {
         const coveragePackage = isIstanbul ? 'coverage-istanbul' : 'coverage-v8';
-        message += `\n\nPlease install the @vitest/${coveragePackage} package to run with coverage\n`;
+        message += `\n\nPlease install the @vitest/${coveragePackage} package to collect coverage\n`;
       }
       this.testManager.reportFatalError(message, e);
       return;

--- a/code/addons/test/src/node/vitest-manager.ts
+++ b/code/addons/test/src/node/vitest-manager.ts
@@ -89,15 +89,21 @@ export class VitestManager {
     try {
       await this.vitest.init();
     } catch (e) {
+      let message = 'Failed to initialize Vitest';
       const isV8 = e.message?.includes('@vitest/coverage-v8');
       const isIstanbul = e.message?.includes('@vitest/coverage-istanbul');
 
-      if (e.message?.includes('Error: Failed to load url') && (isIstanbul || isV8)) {
+      if (
+        (e.message?.includes('Failed to load url') && (isIstanbul || isV8)) ||
+        // Vitest will sometimes not throw the correct missing-package-detection error, so we have to check for this as well
+        (e instanceof TypeError &&
+          e?.message === "Cannot read properties of undefined (reading 'name')")
+      ) {
         const coveragePackage = isIstanbul ? 'coverage-istanbul' : 'coverage-v8';
-        e.message = `Please install the @vitest/${coveragePackage} package to run with coverage`;
+        message += `\n\nPlease install the @vitest/${coveragePackage} package to run with coverage\n`;
       }
-
-      this.testManager.reportFatalError('Failed to init Vitest', e);
+      this.testManager.reportFatalError(message, e);
+      return;
     }
 
     await this.setupWatchers();


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Changed the error handling for coverage initialisation, to also catch an internal Vitest error that would sometimes be thrown when the coverage package was missing.

It now shows:

![Screen Shot 2024-12-17 at 14 08 06 PM](https://github.com/user-attachments/assets/761b5f99-20f5-426e-a0d8-c9d026203d79)
![Screen Shot 2024-12-17 at 14 07 25 PM](https://github.com/user-attachments/assets/afaca55b-c5ad-4fe9-a029-ef2d3aa301ae)


<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 0.53 | 0% |
| initSize |  136 MB | 136 MB | 0 B | 0.23 | 0% |
| diffSize |  58.4 MB | 58.4 MB | 0 B | 0.23 | 0% |
| buildSize |  7.24 MB | 7.24 MB | 0 B | **1.95** | 0% |
| buildSbAddonsSize |  1.88 MB | 1.88 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **2.58** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.93 MB | 3.93 MB | 0 B | **2.58** | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | -0.95 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.3s | 6.7s | -618ms | -0.91 | -9.2% |
| generateTime |  20.7s | 19.4s | -1s -333ms | -0.73 | -6.9% |
| initTime |  14.3s | 13.5s | -798ms | -0.56 | -5.9% |
| buildTime |  11.8s | 8.9s | -2s -836ms | -0.68 | -31.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.5s | 5s | -423ms | 0.01 | -8.3% |
| devManagerResponsive |  4.1s | 3.8s | -257ms | 0.12 | -6.7% |
| devManagerHeaderVisible |  643ms | 628ms | -15ms | -0.01 | -2.4% |
| devManagerIndexVisible |  676ms | 700ms | 24ms | 0.34 | 3.4% |
| devStoryVisibleUncached |  1.8s | 1.7s | -143ms | -0.2 | -8.1% |
| devStoryVisible |  674ms | 697ms | 23ms | 0.29 | 3.3% |
| devAutodocsVisible |  544ms | 550ms | 6ms | 0 | 1.1% |
| devMDXVisible |  518ms | 532ms | 14ms | -0.24 | 2.6% |
| buildManagerHeaderVisible |  619ms | 599ms | -20ms | -0.28 | -3.3% |
| buildManagerIndexVisible |  704ms | 682ms | -22ms | -0.39 | -3.2% |
| buildStoryVisible |  579ms | 561ms | -18ms | -0.23 | -3.2% |
| buildAutodocsVisible |  446ms | 479ms | 33ms | 0.32 | 6.9% |
| buildMDXVisible |  439ms | 488ms | 49ms | 0.26 | 10% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and PR information, I'll create a concise summary of the changes:

Improved error handling for missing Vitest coverage packages by adding better detection and more informative error messages.

- Added detection for TypeError when coverage packages are missing in `vitest-manager.ts`
- Enhanced error message to specify which coverage package (@vitest/coverage-v8 or @vitest/coverage-istanbul) needs to be installed
- Moved detailed error handling from `test-manager.ts` to `vitest-manager.ts` for better organization
- Added early return after error reporting to prevent further execution
- Simplified error reporting structure in TestManager class



<!-- /greptile_comment -->