### PR TITLE
Addon Onboarding: Use @neoconfetti/react as alternative

### DIFF
--- a/code/addons/onboarding/package.json
+++ b/code/addons/onboarding/package.json
@@ -45,12 +45,12 @@
     "prep": "jiti ../../../scripts/prepare/addon-bundle.ts"
   },
   "devDependencies": {
+    "@neoconfetti/react": "^1.0.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@storybook/icons": "^1.2.12",
     "@storybook/react": "workspace:*",
     "framer-motion": "^11.0.3",
     "react": "^18.2.0",
-    "react-confetti-boom": "^1.1.0",
     "react-dom": "^18.2.0",
     "react-joyride": "^2.8.2",
     "react-use-measure": "^2.1.1",

--- a/code/addons/onboarding/src/components/Confetti/Confetti.tsx
+++ b/code/addons/onboarding/src/components/Confetti/Confetti.tsx
@@ -1,46 +1,34 @@
-import React, { type ComponentProps, useEffect } from 'react';
-import { useState } from 'react';
+import React, { type ComponentProps } from 'react';
 
 import { styled } from 'storybook/internal/theming';
 
-import ReactConfetti from 'react-confetti-boom';
+import { Confetti as ReactConfetti } from '@neoconfetti/react';
 
 const Wrapper = styled.div({
   zIndex: 9999,
   position: 'fixed',
   top: 0,
-  left: 0,
-  bottom: 0,
-  right: 0,
+  left: '50%',
+  width: '50%',
+  height: '100%',
 });
 
-export function Confetti({
+export const Confetti = React.memo(function Confetti({
   timeToFade = 5000,
   colors = ['#CA90FF', '#FC521F', '#66BF3C', '#FF4785', '#FFAE00', '#1EA7FD'],
   ...confettiProps
 }: ComponentProps<typeof ReactConfetti> & { timeToFade?: number }) {
-  const [particleCount, setParticleCount] = useState(42);
-
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      setParticleCount(0);
-    }, timeToFade);
-
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [timeToFade]);
-
   return (
     <Wrapper>
       <ReactConfetti
-        mode="fall"
         colors={colors}
-        shapeSize={14}
-        particleCount={particleCount}
-        fadeOutHeight={10}
+        particleCount={200}
+        duration={5000}
+        stageHeight={window.innerHeight}
+        stageWidth={window.innerWidth}
+        destroyAfterDone
         {...confettiProps}
       />
     </Wrapper>
   );
-}
+});

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -4118,6 +4118,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@neoconfetti/react@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@neoconfetti/react@npm:1.0.0"
+  checksum: 10c0/dfa487965b69f88b39562ccd910114cd68b00a90c7eb79cfb1a483c7ac717b720f9f095e5aea13cef8a9b9bea05533d380ddff5e44d3bc3f7dc4d5c66716765c
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:15.0.3, @next/env@npm:^15.0.3":
   version: 15.0.3
   resolution: "@next/env@npm:15.0.3"
@@ -5749,12 +5756,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-onboarding@workspace:addons/onboarding"
   dependencies:
+    "@neoconfetti/react": "npm:^1.0.0"
     "@radix-ui/react-dialog": "npm:^1.0.5"
     "@storybook/icons": "npm:^1.2.12"
     "@storybook/react": "workspace:*"
     framer-motion: "npm:^11.0.3"
     react: "npm:^18.2.0"
-    react-confetti-boom: "npm:^1.1.0"
     react-dom: "npm:^18.2.0"
     react-joyride: "npm:^2.8.2"
     react-use-measure: "npm:^2.1.1"
@@ -24224,16 +24231,6 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 10c0/48eb73cf71e10841c2a61b6b06ab81da9fffa9876134c239bfdebcf348ce2a47e56b146338e35dfb03512c85966bfc9a53844fc56bc50154e71f8daee59ff6f0
-  languageName: node
-  linkType: hard
-
-"react-confetti-boom@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "react-confetti-boom@npm:1.1.0"
-  peerDependencies:
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
-  checksum: 10c0/76faf3e5cc3284b7dc0297ab7189ff92bbf74379a9478096bc8c8d7b16a82badea74c2e57f7313cd2a55ccf3c8dc50d51165fbf00c9fee5b9ed241369812d686
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | - | 0% |
| initSize |  136 MB | 136 MB | -2.84 kB | 0.65 | 0% |
| diffSize |  58.4 MB | 58.4 MB | -2.84 kB | 0.65 | 0% |
| buildSize |  7.22 MB | 7.22 MB | -898 B | 0.99 | 0% |
| buildSbAddonsSize |  1.86 MB | 1.86 MB | -898 B | 0.99 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 1 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.92 MB | 3.92 MB | -898 B | 0.99 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | 1 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  25.7s | 24.2s | -1s -518ms | 0.84 | -6.3% |
| generateTime |  23.3s | 21.7s | -1s -577ms | -0.41 | -7.3% |
| initTime |  15.9s | 16.5s | 571ms | **2.18** | 3.4% |
| buildTime |  9s | 11.8s | 2.7s | **6.9** | 🔺23.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.6s | 6s | 1.3s | **2.58** | 🔺22.6% |
| devManagerResponsive |  3.5s | 4.4s | 974ms | **9.18** | 🔺21.7% |
| devManagerHeaderVisible |  551ms | 696ms | 145ms | **4.99** | 🔺20.8% |
| devManagerIndexVisible |  582ms | 760ms | 178ms | **7.92** | 🔺23.4% |
| devStoryVisibleUncached |  1.7s | 2s | 253ms | **1.35** | 🔺12.6% |
| devStoryVisible |  583ms | 761ms | 178ms | **7.82** | 🔺23.4% |
| devAutodocsVisible |  485ms | 668ms | 183ms | **3.29** | 🔺27.4% |
| devMDXVisible |  497ms | 598ms | 101ms | **4.44** | 🔺16.9% |
| buildManagerHeaderVisible |  566ms | 695ms | 129ms | **9.55** | 🔺18.6% |
| buildManagerIndexVisible |  640ms | 796ms | 156ms | **11.01** | 🔺19.6% |
| buildStoryVisible |  525ms | 649ms | 124ms | **9.87** | 🔺19.1% |
| buildAutodocsVisible |  417ms | 548ms | 131ms | **7.33** | 🔺23.9% |
| buildMDXVisible |  423ms | 559ms | 136ms | **8.42** | 🔺24.3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR replaces `react-confetti-boom` with `@neoconfetti/react` in the onboarding addon, simplifying the confetti animation implementation while maintaining core functionality.

- Replaced dependency in `code/addons/onboarding/package.json` with `@neoconfetti/react`
- Modified `code/addons/onboarding/src/components/Confetti/Confetti.tsx` to use half-width positioning and fixed dimensions
- Added React.memo optimization to Confetti component
- Simplified component by removing state management and fade-out logic
- Unused `timeToFade` prop remains in interface despite removal of fade functionality



<!-- /greptile_comment -->