### PR TITLE
Angular: Fix accent character issue

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
@@ -152,7 +152,7 @@ export abstract class AbstractRenderer {
    * https://github.com/storybookjs/storybook/issues/29132
    *
    * This method filters accents from a given raw id. For example, this method converts
-   * 'Example/Button with an "é" accent' into 'Example/Button with an "e" accent'
+   * 'Example/Button with an "é" accent' into 'Example/Button with an "e" accent'.
    *
    * @memberof AbstractRenderer
    * @protected

--- a/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
@@ -143,6 +143,27 @@ export abstract class AbstractRenderer {
     return storyIdIsInvalidHtmlTagName ? `sb-${id.replace(invalidHtmlTag, '')}-component` : id;
   }
 
+  /**
+   * Angular is unable to handle components that have selectors with accented attributes.
+   *
+   * Therefore, stories break when meta's title contains accents.
+   * https://github.com/storybookjs/storybook/issues/29132
+   *
+   * This method filters accents from a given raw id. For example, this method converts
+   * 'Example/Button with an "é" accent' into 'Example/Button with an "e" accent'
+   *
+   * @memberof AbstractRenderer
+   * @protected
+   */
+  protected generateStoryUIdFromRawStoryUid(rawStoryUid: string | null) {
+    if (rawStoryUid === null) {
+      return rawStoryUid;
+    }
+
+    const accentCharacters = /[\u0300-\u036f]/g;
+    return rawStoryUid.normalize('NFD').replace(accentCharacters, '');
+  }
+
   /** Adds DOM element that angular will use as bootstrap component. */
   protected initAngularRootElement(targetDOMNode: HTMLElement, targetSelector: string) {
     targetDOMNode.innerHTML = '';

--- a/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
@@ -96,7 +96,9 @@ export abstract class AbstractRenderer {
 
     const analyzedMetadata = new PropertyExtractor(storyFnAngular.moduleMetadata, component);
 
-    const storyUid = targetDOMNode.getAttribute(STORY_UID_ATTRIBUTE);
+    const storyUid = this.generateStoryUIdFromRawStoryUid(
+      targetDOMNode.getAttribute(STORY_UID_ATTRIBUTE)
+    );
     const componentSelector = storyUid !== null ? `${targetSelector}[${storyUid}]` : targetSelector;
     if (storyUid !== null) {
       const element = targetDOMNode.querySelector(targetSelector);


### PR DESCRIPTION
Closes #29132

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Just filtered accent characters from a story UID, as suggested at https://github.com/storybookjs/storybook/issues/29132#issuecomment-2443772159.
The method defined in this PR could convert `Example/Button with an "é" accent` into `Example/Button with an "e" accent`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 0 B | **1.33** | 0% |
| initSize |  143 MB | 143 MB | -20.6 kB | 1.18 | 0% |
| diffSize |  65.6 MB | 65.6 MB | -20.6 kB | 1.18 | 0% |
| buildSize |  7.19 MB | 7.23 MB | 34.2 kB | 0.83 | 0.5% |
| buildSbAddonsSize |  1.85 MB | 1.86 MB | 7.66 kB | 0.25 | 0.4% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.23 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.92 MB | 3.92 MB | 7.66 kB | 0.29 | 0.2% |
| buildPreviewSize |  3.28 MB | 3.3 MB | 26.5 kB | 1.08 | 0.8% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.2s | 25.7s | 18.5s | **2.07** | 🔺72% |
| generateTime |  21.1s | 20.5s | -613ms | -0.26 | -3% |
| initTime |  14.6s | 15.5s | 867ms | 0.36 | 5.6% |
| buildTime |  11.5s | 8.7s | -2s -720ms | -0.71 | -30.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.5s | 5.6s | 29ms | 0.24 | 0.5% |
| devManagerResponsive |  4.1s | 4.2s | 147ms | 0.37 | 3.5% |
| devManagerHeaderVisible |  755ms | 672ms | -83ms | 0.14 | -12.4% |
| devManagerIndexVisible |  799ms | 702ms | -97ms | 0.14 | -13.8% |
| devStoryVisibleUncached |  2s | 2s | -75ms | 0.14 | -3.7% |
| devStoryVisible |  800ms | 701ms | -99ms | 0.09 | -14.1% |
| devAutodocsVisible |  711ms | 551ms | -160ms | -0.17 | -29% |
| devMDXVisible |  577ms | 597ms | 20ms | 0.09 | 3.4% |
| buildManagerHeaderVisible |  595ms | 682ms | 87ms | 0.27 | 12.8% |
| buildManagerIndexVisible |  682ms | 806ms | 124ms | 0.41 | 15.4% |
| buildStoryVisible |  575ms | 656ms | 81ms | 0.33 | 12.3% |
| buildAutodocsVisible |  562ms | 572ms | 10ms | 0.49 | 1.7% |
| buildMDXVisible |  545ms | 562ms | 17ms | 0.67 | 3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added Unicode normalization for Angular component selectors to prevent errors when using accented characters in story titles, specifically addressing issue #29132.

- Added `generateStoryUIdFromRawStoryUid` method in `code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts` to normalize accented characters
- Implemented Unicode NFD normalization to decompose and remove diacritical marks from story UIDs
- Fixed issue where accented characters in Meta titles were breaking doc pages with NG05104 errors



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->