### PR TITLE
Automigration: Improve addon-a11y-addon-test

### DIFF
--- a/code/addons/test/src/constants.ts
+++ b/code/addons/test/src/constants.ts
@@ -12,6 +12,13 @@ export const DOCUMENTATION_FATAL_ERROR_LINK = `${DOCUMENTATION_LINK}#what-happen
 
 export const COVERAGE_DIRECTORY = 'coverage';
 
+export const SUPPORTED_FRAMEWORKS = [
+  '@storybook/nextjs',
+  '@storybook/experimental-nextjs-vite',
+  '@storybook/sveltekit',
+];
+
+export const SUPPORTED_RENDERERS = ['@storybook/react', '@storybook/svelte', '@storybook/vue3'];
 export interface Config {
   coverage: boolean;
   a11y: boolean;

--- a/code/addons/test/src/postinstall.ts
+++ b/code/addons/test/src/postinstall.ts
@@ -25,6 +25,7 @@ import { coerce, satisfies } from 'semver';
 import { dedent } from 'ts-dedent';
 
 import { type PostinstallOptions } from '../../../lib/cli-storybook/src/add';
+import { SUPPORTED_FRAMEWORKS, SUPPORTED_RENDERERS } from './constants';
 import { printError, printInfo, printSuccess, step } from './postinstall-logger';
 import { getAddonNames } from './utils';
 
@@ -106,18 +107,11 @@ export default async function postInstall(options: PostinstallOptions) {
     }
   }
 
-  const annotationsImport = [
-    '@storybook/nextjs',
-    '@storybook/experimental-nextjs-vite',
-    '@storybook/sveltekit',
-  ].includes(info.frameworkPackageName)
+  const annotationsImport = SUPPORTED_FRAMEWORKS.includes(info.frameworkPackageName)
     ? info.frameworkPackageName === '@storybook/nextjs'
       ? '@storybook/experimental-nextjs-vite'
       : info.frameworkPackageName
-    : info.rendererPackageName &&
-        ['@storybook/react', '@storybook/svelte', '@storybook/vue3'].includes(
-          info.rendererPackageName
-        )
+    : info.rendererPackageName && SUPPORTED_RENDERERS.includes(info.rendererPackageName)
       ? info.rendererPackageName
       : null;
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
@@ -1,10 +1,17 @@
+import { rendererPackages } from '@storybook/core/common';
+
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import * as jscodeshift from 'jscodeshift';
 import path from 'path';
 import picocolors from 'picocolors';
 import { dedent } from 'ts-dedent';
 
-import { getAddonNames } from '../helpers/mainConfigFile';
+// Relative path import to avoid dependency to @storybook/test
+import {
+  SUPPORTED_FRAMEWORKS,
+  SUPPORTED_RENDERERS,
+} from '../../../../../addons/test/src/constants';
+import { getAddonNames, getFrameworkPackageName, getRendererName } from '../helpers/mainConfigFile';
 import type { Fix } from '../types';
 
 export const vitestFileExtensions = ['.js', '.ts', '.cts', '.mts', '.cjs', '.mjs'] as const;
@@ -35,10 +42,22 @@ export const addonA11yAddonTest: Fix<AddonA11yAddonTestOptions> = {
   async check({ mainConfig, configDir }) {
     const addons = getAddonNames(mainConfig);
 
+    const frameworkPackageName = getFrameworkPackageName(mainConfig);
+    const rendererPackageName = getRendererName(mainConfig);
+
     const hasA11yAddon = !!addons.find((addon) => addon.includes('@storybook/addon-a11y'));
     const hasTestAddon = !!addons.find((addon) =>
       addon.includes('@storybook/experimental-addon-test')
     );
+
+    if (
+      !SUPPORTED_FRAMEWORKS.find((framework) => frameworkPackageName?.includes(framework)) &&
+      !SUPPORTED_RENDERERS.find((renderer) =>
+        rendererPackageName?.includes(rendererPackages[renderer])
+      )
+    ) {
+      return null;
+    }
 
     if (!hasA11yAddon || !hasTestAddon || !configDir) {
       return null;

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
@@ -1,4 +1,4 @@
-import { rendererPackages } from '@storybook/core/common';
+import { rendererPackages } from 'storybook/internal/common';
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import * as jscodeshift from 'jscodeshift';


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have improved the addon-a11y-addon-test automigration to only apply it for supported frameworks and renderers.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30127-sha-cb69dbf6`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30127-sha-cb69dbf6 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30127-sha-cb69dbf6 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30127-sha-cb69dbf6`](https://npmjs.com/package/storybook/v/0.0.0-pr-30127-sha-cb69dbf6) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/improve-a11y-addon-automigration`](https://github.com/storybookjs/storybook/tree/valentin/improve-a11y-addon-automigration) |
| **Commit** | [`cb69dbf6`](https://github.com/storybookjs/storybook/commit/cb69dbf6b3fc73ab53e5c88ab6cb4878a3bf7890) |
| **Datetime** | Mon Dec 23 14:32:34 UTC 2024 (`1734964354`) |
| **Workflow run** | [12468414303](https://github.com/storybookjs/storybook/actions/runs/12468414303) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30127`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 0 B | **1.27** | 0% |
| initSize |  143 MB | 143 MB | 0 B | **2.16** | 0% |
| diffSize |  65.6 MB | 65.6 MB | 0 B | **2.16** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | **-1.47** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -1.17 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.65 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.92 MB | 3.92 MB | 0 B | -1.21 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | **-1.53** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.1s | 25.5s | 18.3s | **1.36** | 🔺72% |
| generateTime |  19s | 23.5s | 4.5s | **1.86** | 🔺19.3% |
| initTime |  13.8s | 17.2s | 3.4s | **2.62** | 🔺19.7% |
| buildTime |  8.8s | 9s | 185ms | -0.45 | 2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.7s | 5.3s | 572ms | -0.07 | 10.7% |
| devManagerResponsive |  3.6s | 3.9s | 333ms | -0.1 | 8.4% |
| devManagerHeaderVisible |  607ms | 794ms | 187ms | 0.88 | 23.6% |
| devManagerIndexVisible |  636ms | 834ms | 198ms | 0.88 | 23.7% |
| devStoryVisibleUncached |  1.9s | 2s | 85ms | 0.2 | 4.2% |
| devStoryVisible |  637ms | 835ms | 198ms | 0.89 | 23.7% |
| devAutodocsVisible |  529ms | 665ms | 136ms | 0.58 | 20.5% |
| devMDXVisible |  569ms | 725ms | 156ms | 0.9 | 21.5% |
| buildManagerHeaderVisible |  619ms | 608ms | -11ms | -0.35 | -1.8% |
| buildManagerIndexVisible |  726ms | 741ms | 15ms | -0.13 | 2% |
| buildStoryVisible |  605ms | 594ms | -11ms | -0.26 | -1.9% |
| buildAutodocsVisible |  422ms | 613ms | 191ms | 0.83 | 31.2% |
| buildMDXVisible |  529ms | 557ms | 28ms | 0.54 | 5% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and changes, I'll create a concise summary of this PR:

Improved the addon-a11y-addon-test automigration to only apply to explicitly supported frameworks and renderers, adding framework compatibility validation.

- Added `SUPPORTED_FRAMEWORKS` and `SUPPORTED_RENDERERS` constants in `code/addons/test/src/constants.ts` to define compatibility
- Updated automigration logic in `addon-a11y-addon-test.ts` to validate framework/renderer support before migration
- Added framework compatibility tests in `addon-a11y-addon-test.test.ts` to verify unsupported frameworks are rejected
- Added `noFallthroughCasesInSwitch` to TypeScript config for better switch statement safety
- Enhanced postinstall script with improved framework detection and prerequisite checks



<!-- /greptile_comment -->