### PR TITLE
Addon Test: Enable strict mode

### DIFF
--- a/code/addons/test/src/components/Interaction.tsx
+++ b/code/addons/test/src/components/Interaction.tsx
@@ -23,7 +23,7 @@ const MethodCallWrapper = styled.div(() => ({
 
 const RowContainer = styled('div', {
   shouldForwardProp: (prop) => !['call', 'pausedAt'].includes(prop.toString()),
-})<{ call: Call; pausedAt: Call['id'] }>(
+})<{ call: Call; pausedAt: Call['id'] | undefined }>(
   ({ theme, call }) => ({
     position: 'relative',
     display: 'flex',
@@ -117,6 +117,9 @@ const RowMessage = styled('div')(({ theme }) => ({
 
 export const Exception = ({ exception }: { exception: Call['exception'] }) => {
   const filter = useAnsiToHtmlFilter();
+  if (!exception) {
+    return null;
+  }
   if (isJestError(exception)) {
     return <MatcherResult {...exception} />;
   }
@@ -187,7 +190,7 @@ export const Interaction = ({
           </MethodCallWrapper>
         </RowLabel>
         <RowActions>
-          {childCallIds?.length > 0 && (
+          {(childCallIds?.length ?? 0) > 0 && (
             <WithTooltip
               hasChrome={false}
               tooltip={<Note note={`${isCollapsed ? 'Show' : 'Hide'} interactions`} />}

--- a/code/addons/test/src/components/MatcherResult.tsx
+++ b/code/addons/test/src/components/MatcherResult.tsx
@@ -74,10 +74,10 @@ export const MatcherResult = ({
       {lines.flatMap((line: string, index: number) => {
         if (line.startsWith('expect(')) {
           const received = getParams(line, 7);
-          const remainderIndex = received && 7 + received.length;
+          const remainderIndex = received ? 7 + received.length : 0;
           const matcher = received && line.slice(remainderIndex).match(/\.(to|last|nth)[A-Z]\w+\(/);
           if (matcher) {
-            const expectedIndex = remainderIndex + matcher.index + matcher[0].length;
+            const expectedIndex = remainderIndex + (matcher.index ?? 0) + matcher[0].length;
             const expected = getParams(line, expectedIndex);
             if (expected) {
               return [

--- a/code/addons/test/src/components/MethodCall.tsx
+++ b/code/addons/test/src/components/MethodCall.tsx
@@ -139,7 +139,7 @@ export const Node = ({
     case Object.prototype.hasOwnProperty.call(value, '__class__'):
       return <ClassNode {...props} {...value.__class__} />;
     case Object.prototype.hasOwnProperty.call(value, '__callId__'):
-      return <MethodCall call={callsById.get(value.__callId__)} callsById={callsById} />;
+      return <MethodCall call={callsById?.get(value.__callId__)} callsById={callsById} />;
     /* eslint-enable no-underscore-dangle */
 
     case Object.prototype.toString.call(value) === '[object Object]':
@@ -418,7 +418,7 @@ export const MethodCall = ({
   callsById,
 }: {
   call?: Call;
-  callsById: Map<Call['id'], Call>;
+  callsById?: Map<Call['id'], Call>;
 }) => {
   // Call might be undefined during initial render, can be safely ignored.
   if (!call) {
@@ -434,7 +434,7 @@ export const MethodCall = ({
     const callId = (elem as CallRef).__callId__;
     return [
       callId ? (
-        <MethodCall key={`elem${index}`} call={callsById.get(callId)} callsById={callsById} />
+        <MethodCall key={`elem${index}`} call={callsById?.get(callId)} callsById={callsById} />
       ) : (
         <span key={`elem${index}`}>{elem as any}</span>
       ),

--- a/code/addons/test/src/components/RelativeTime.tsx
+++ b/code/addons/test/src/components/RelativeTime.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 export const RelativeTime = ({ timestamp }: { timestamp?: number }) => {
-  const [timeAgo, setTimeAgo] = useState(null);
+  const [timeAgo, setTimeAgo] = useState<number | null>(null);
 
   useEffect(() => {
     if (timestamp) {

--- a/code/addons/test/src/components/StatusBadge.tsx
+++ b/code/addons/test/src/components/StatusBadge.tsx
@@ -14,7 +14,7 @@ const StyledBadge = styled.div<StatusBadgeProps>(({ theme, status }) => {
     [CallStates.ERROR]: theme.color.negative,
     [CallStates.ACTIVE]: theme.color.warning,
     [CallStates.WAITING]: theme.color.warning,
-  }[status];
+  }[status!];
   return {
     padding: '4px 6px 4px 8px;',
     borderRadius: '4px',
@@ -36,7 +36,7 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
     [CallStates.ERROR]: 'Fail',
     [CallStates.ACTIVE]: 'Runs',
     [CallStates.WAITING]: 'Runs',
-  }[status];
+  }[status!];
   return (
     <StyledBadge aria-label="Status of the test run" status={status}>
       {badgeText}

--- a/code/addons/test/src/components/Subnav.tsx
+++ b/code/addons/test/src/components/Subnav.tsx
@@ -109,7 +109,7 @@ const RerunButton = styled(StyledIconButton)<
 >(({ theme, animating, disabled }) => ({
   opacity: disabled ? 0.5 : 1,
   svg: {
-    animation: animating && `${theme.animation.rotate360} 200ms ease-out`,
+    animation: animating ? `${theme.animation.rotate360} 200ms ease-out` : undefined,
   },
 }));
 

--- a/code/addons/test/src/components/TestDiscrepancyMessage.tsx
+++ b/code/addons/test/src/components/TestDiscrepancyMessage.tsx
@@ -1,13 +1,12 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { Link } from 'storybook/internal/components';
 import { useStorybookApi } from 'storybook/internal/manager-api';
 import { styled } from 'storybook/internal/theming';
-import type { StoryId } from 'storybook/internal/types';
 
 import { CallStates } from '@storybook/instrumenter';
 
-import { DOCUMENTATION_DISCREPANCY_LINK, STORYBOOK_ADDON_TEST_CHANNEL } from '../constants';
+import { DOCUMENTATION_DISCREPANCY_LINK } from '../constants';
 
 const Wrapper = styled.div(({ theme: { color, typography, background } }) => ({
   textAlign: 'start',
@@ -32,7 +31,7 @@ const Wrapper = styled.div(({ theme: { color, typography, background } }) => ({
 }));
 
 interface TestDiscrepancyMessageProps {
-  browserTestStatus: CallStates;
+  browserTestStatus?: CallStates;
 }
 
 export const TestDiscrepancyMessage = ({ browserTestStatus }: TestDiscrepancyMessageProps) => {

--- a/code/addons/test/src/components/TestProviderRender.stories.tsx
+++ b/code/addons/test/src/components/TestProviderRender.stories.tsx
@@ -43,7 +43,7 @@ const baseState: TestProviderState<Details, Config> = {
   cancellable: true,
   cancelling: false,
   crashed: false,
-  error: null,
+  error: undefined,
   failed: false,
   running: false,
   watching: false,

--- a/code/addons/test/src/components/TestProviderRender.tsx
+++ b/code/addons/test/src/components/TestProviderRender.tsx
@@ -162,7 +162,7 @@ export const TestProviderRender: FC<
     : undefined;
 
   const a11ySkippedAmount =
-    state.running || !state?.details.config?.a11y || !state.config.a11y
+    state.running || !state?.details.config?.a11y || !state.config?.a11y
       ? null
       : a11yResults?.filter((result) => !result).length;
 
@@ -304,9 +304,11 @@ export const TestProviderRender: FC<
                     const firstNotPassed = results.find(
                       (r) => r.status === 'failed' || r.status === 'warning'
                     );
-                    openPanel(firstNotPassed.storyId, PANEL_ID);
+                    if (firstNotPassed) {
+                      openPanel(firstNotPassed.storyId, PANEL_ID);
+                    }
                   }
-                : null
+                : undefined
             }
             icon={
               state.crashed ? (
@@ -359,9 +361,11 @@ export const TestProviderRender: FC<
                             (report) => report.status === 'failed' || report.status === 'warning'
                           )
                       );
-                      openPanel(firstNotPassed.storyId, A11y_ADDON_PANEL_ID);
+                      if (firstNotPassed) {
+                        openPanel(firstNotPassed.storyId, A11y_ADDON_PANEL_ID);
+                      }
                     }
-                  : null
+                  : undefined
               }
               icon={<TestStatusIcon status={a11yStatus} aria-label={`status: ${a11yStatus}`} />}
               right={isStoryEntry ? null : a11yNotPassedAmount || null}

--- a/code/addons/test/src/manager.tsx
+++ b/code/addons/test/src/manager.tsx
@@ -38,6 +38,7 @@ addons.register(ADDON_ID, (api) => {
       runnable: true,
       watchable: true,
       name: 'Component tests',
+      // @ts-expect-error: TODO: Fix types
       render: (state) => {
         const [isModalOpen, setModalOpen] = useState(false);
         return (
@@ -55,6 +56,7 @@ addons.register(ADDON_ID, (api) => {
         );
       },
 
+      // @ts-expect-error: TODO: Fix types
       sidebarContextMenu: ({ context, state }) => {
         if (context.type === 'docs') {
           return null;
@@ -72,6 +74,7 @@ addons.register(ADDON_ID, (api) => {
         );
       },
 
+      // @ts-expect-error: TODO: Fix types
       stateUpdater: (state, update) => {
         const updated = {
           ...state,
@@ -89,6 +92,7 @@ addons.register(ADDON_ID, (api) => {
             await api.experimental_updateStatus(
               TEST_PROVIDER_ID,
               Object.fromEntries(
+                // @ts-expect-error: TODO: Fix types
                 update.details.testResults.flatMap((testResult) =>
                   testResult.results
                     .filter(({ storyId }) => storyId)
@@ -113,6 +117,7 @@ addons.register(ADDON_ID, (api) => {
             await api.experimental_updateStatus(
               'storybook/addon-a11y/test-provider',
               Object.fromEntries(
+                // @ts-expect-error: TODO: Fix types
                 update.details.testResults.flatMap((testResult) =>
                   testResult.results
                     .filter(({ storyId }) => storyId)
@@ -143,7 +148,7 @@ addons.register(ADDON_ID, (api) => {
 
         return updated;
       },
-    } as Addon_TestProviderType<Details, Config>);
+    } satisfies Omit<Addon_TestProviderType<Details, Config>, 'id'>);
   }
 
   const filter = ({ state }: Combo) => {
@@ -158,7 +163,7 @@ addons.register(ADDON_ID, (api) => {
     match: ({ viewMode }) => viewMode === 'story',
     render: ({ active }) => {
       return (
-        <AddonPanel active={active}>
+        <AddonPanel active={!!active}>
           <Consumer filter={filter}>{({ storyId }) => <Panel storyId={storyId} />}</Consumer>
         </AddonPanel>
       );

--- a/code/addons/test/src/node/boot-test-runner.ts
+++ b/code/addons/test/src/node/boot-test-runner.ts
@@ -24,7 +24,7 @@ const MAX_START_TIME = 30000;
 const vitestModulePath = join(__dirname, 'node', 'vitest.mjs');
 
 // Events that were triggered before Vitest was ready are queued up and resent once it's ready
-const eventQueue: { type: string; args: any[] }[] = [];
+const eventQueue: { type: string; args?: any[] }[] = [];
 
 let child: null | ChildProcess;
 let ready = false;
@@ -87,7 +87,7 @@ const bootTestRunner = async (channel: Channel) => {
         if (result.type === 'ready') {
           // Resend events that triggered (during) the boot sequence, now that Vitest is ready
           while (eventQueue.length) {
-            const { type, args } = eventQueue.shift();
+            const { type, args } = eventQueue.shift()!;
             child?.send({ type, args, from: 'server' });
           }
 

--- a/code/addons/test/src/node/reporter.ts
+++ b/code/addons/test/src/node/reporter.ts
@@ -220,7 +220,7 @@ export class StorybookReporter implements Reporter {
       (t) => t.status === 'failed' && t.results.length === 0
     );
 
-    const reducedTestSuiteFailures = new Set<string>();
+    const reducedTestSuiteFailures = new Set<string | undefined>();
 
     testSuiteFailures.forEach((t) => {
       reducedTestSuiteFailures.add(t.message);
@@ -240,7 +240,7 @@ export class StorybookReporter implements Reporter {
               message: Array.from(reducedTestSuiteFailures).reduce(
                 (acc, curr) => `${acc}\n${curr}`,
                 ''
-              ),
+              )!,
             }
           : {
               name: `${unhandledErrors.length} unhandled error${unhandledErrors?.length > 1 ? 's' : ''}`,

--- a/code/addons/test/src/node/test-manager.test.ts
+++ b/code/addons/test/src/node/test-manager.test.ts
@@ -22,10 +22,11 @@ const vitest = vi.hoisted(() => ({
   configOverride: {
     actualTestNamePattern: undefined,
     get testNamePattern() {
-      return this.actualTestNamePattern;
+      return this.actualTestNamePattern!;
     },
     set testNamePattern(value: string) {
       setTestNamePattern(value);
+      // @ts-expect-error Ignore for testing
       this.actualTestNamePattern = value;
     },
   },

--- a/code/addons/test/src/node/vitest-manager.ts
+++ b/code/addons/test/src/node/vitest-manager.ts
@@ -88,7 +88,7 @@ export class VitestManager {
 
     try {
       await this.vitest.init();
-    } catch (e) {
+    } catch (e: any) {
       let message = 'Failed to initialize Vitest';
       const isV8 = e.message?.includes('@vitest/coverage-v8');
       const isIstanbul = e.message?.includes('@vitest/coverage-istanbul');
@@ -148,7 +148,7 @@ export class VitestManager {
       ])) as StoryIndex;
       const storyIds = requestStoryIds || Object.keys(index.entries);
       return storyIds.map((id) => index.entries[id]).filter((story) => story.type === 'story');
-    } catch (e) {
+    } catch (e: any) {
       log('Failed to fetch story index: ' + e.message);
       return [];
     }
@@ -330,7 +330,7 @@ export class VitestManager {
   async registerVitestConfigListener() {
     this.vitest?.server?.watcher.on('change', async (file) => {
       file = normalize(file);
-      const isConfig = file === this.vitest.server.config.configFile;
+      const isConfig = file === this.vitest?.server.config.configFile;
       if (isConfig) {
         log('Restarting Vitest due to config change');
         await this.closeVitest();

--- a/code/addons/test/src/vitest-plugin/global-setup.ts
+++ b/code/addons/test/src/vitest-plugin/global-setup.ts
@@ -74,13 +74,15 @@ export const teardown = async () => {
   logger.verbose('Stopping Storybook process');
   await new Promise<void>((resolve, reject) => {
     // Storybook starts multiple child processes, so we need to kill the whole tree
-    treeKill(storybookProcess.pid, 'SIGTERM', (error) => {
-      if (error) {
-        logger.error('Failed to stop Storybook process:');
-        reject(error);
-        return;
-      }
-      resolve();
-    });
+    if (storybookProcess?.pid) {
+      treeKill(storybookProcess.pid, 'SIGTERM', (error) => {
+        if (error) {
+          logger.error('Failed to stop Storybook process:');
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    }
   });
 };

--- a/code/addons/test/src/vitest-plugin/index.ts
+++ b/code/addons/test/src/vitest-plugin/index.ts
@@ -193,6 +193,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin> => {
               }
             : {}),
 
+          // @ts-expect-error: TODO
           browser: {
             ...inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test?.browser,
             commands: {
@@ -266,9 +267,11 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin> => {
 
       // alert the user of problems
       if (
-        inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test.include?.length > 0
+        (inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test?.include?.length ??
+          0) > 0
       ) {
         // remove the user's existing include, because we're replacing it with our own heuristic based on main.ts#stories
+        // @ts-expect-error: Ignore
         inputConfig_ONLY_MUTATE_WHEN_STRICTLY_NEEDED_OR_YOU_WILL_BE_FIRED.test.include = [];
         console.log(
           picocolors.yellow(dedent`
@@ -285,19 +288,21 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin> => {
       return config;
     },
     async configureServer(server) {
-      for (const staticDir of staticDirs) {
-        try {
-          const { staticPath, targetEndpoint } = mapStaticDir(staticDir, directories.configDir);
-          server.middlewares.use(
-            targetEndpoint,
-            sirv(staticPath, {
-              dev: true,
-              etag: true,
-              extensions: [],
-            })
-          );
-        } catch (e) {
-          console.warn(e);
+      if (staticDirs) {
+        for (const staticDir of staticDirs) {
+          try {
+            const { staticPath, targetEndpoint } = mapStaticDir(staticDir, directories.configDir);
+            server.middlewares.use(
+              targetEndpoint,
+              sirv(staticPath, {
+                dev: true,
+                etag: true,
+                extensions: [],
+              })
+            );
+          } catch (e) {
+            console.warn(e);
+          }
         }
       }
     },

--- a/code/addons/test/src/vitest-plugin/viewports.ts
+++ b/code/addons/test/src/vitest-plugin/viewports.ts
@@ -85,7 +85,7 @@ export const setViewport = async (parameters: Parameters = {}, globals: Globals 
   let viewportWidth = DEFAULT_VIEWPORT_DIMENSIONS.width;
   let viewportHeight = DEFAULT_VIEWPORT_DIMENSIONS.height;
 
-  if (defaultViewport in viewports) {
+  if (defaultViewport && defaultViewport in viewports) {
     const styles = viewports[defaultViewport].styles as ViewportStyles;
     if (styles?.width && styles?.height) {
       const { width, height } = styles;

--- a/code/addons/test/tsconfig.json
+++ b/code/addons/test/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "Preserve",
     "moduleResolution": "Bundler",
     "types": ["vitest"],
-    "strict": false
+    "strict": true
   },
   "include": ["src/**/*", "./typings.d.ts"]
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Enable Typescript's strict mode for @storybook/experimental-addon-test package.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 0 B | **1.62** | 0% |
| initSize |  143 MB | 143 MB | 0 B | **1.46** | 0% |
| diffSize |  65.6 MB | 65.6 MB | 0 B | **1.45** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | -1.07 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.88 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.42 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.92 MB | 3.92 MB | 0 B | -0.9 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | -1.11 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  11.4s | 24.5s | 13.1s | **1.65** | 🔺53.5% |
| generateTime |  21.3s | 20.8s | -566ms | 0.04 | -2.7% |
| initTime |  15.3s | 15.5s | 131ms | 0.44 | 0.8% |
| buildTime |  8.8s | 8.9s | 136ms | -0.47 | 1.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.8s | 5.7s | 916ms | 0.42 | 15.9% |
| devManagerResponsive |  3.6s | 4.2s | 533ms | 0.32 | 12.7% |
| devManagerHeaderVisible |  562ms | 690ms | 128ms | 0.28 | 18.6% |
| devManagerIndexVisible |  574ms | 713ms | 139ms | 0.23 | 19.5% |
| devStoryVisibleUncached |  2s | 2.1s | 91ms | 0.44 | 4.3% |
| devStoryVisible |  593ms | 712ms | 119ms | 0.19 | 16.7% |
| devAutodocsVisible |  457ms | 595ms | 138ms | 0.18 | 23.2% |
| devMDXVisible |  485ms | 585ms | 100ms | 0.03 | 17.1% |
| buildManagerHeaderVisible |  637ms | 627ms | -10ms | -0.11 | -1.6% |
| buildManagerIndexVisible |  730ms | 725ms | -5ms | -0.11 | -0.7% |
| buildStoryVisible |  626ms | 608ms | -18ms | -0.04 | -3% |
| buildAutodocsVisible |  453ms | 557ms | 104ms | 0.43 | 18.7% |
| buildMDXVisible |  459ms | 530ms | 71ms | 0.38 | 13.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Here's my analysis of the PR enabling TypeScript's strict mode for the @storybook/experimental-addon-test package:

Enables TypeScript's strict mode for the test addon package, improving type safety through proper null checks, type assertions, and better handling of optional values across multiple components.

- Added proper null checks and optional chaining in `TestProviderRender.tsx` and `vitest-manager.ts` for safer property access
- Fixed type definitions in components like `Panel.tsx` and `MethodCall.tsx` to handle optional/nullable values
- Added non-null assertions in `StatusBadge.tsx` and `boot-test-runner.ts` where values are guaranteed to exist
- Several @ts-expect-error comments added that need proper follow-up fixes
- Set `strict: true` in tsconfig.json to enforce stricter type checking project-wide

The changes improve type safety but some concerning @ts-expect-error suppressions should be properly addressed rather than bypassed.



<!-- /greptile_comment -->