### PR TITLE
Addon Test: Always use installed version of vitest

### DIFF
--- a/code/addons/test/src/postinstall.ts
+++ b/code/addons/test/src/postinstall.ts
@@ -56,8 +56,7 @@ export default async function postInstall(options: PostinstallOptions) {
   const allDeps = await packageManager.getAllDependencies();
   // only install these dependencies if they are not already installed
   const dependencies = ['vitest', '@vitest/browser', 'playwright'].filter((p) => !allDeps[p]);
-  const vitestVersionSpecifier =
-    allDeps.vitest || (await packageManager.getInstalledVersion('vitest'));
+  const vitestVersionSpecifier = await packageManager.getInstalledVersion('vitest');
   const coercedVitestVersion = vitestVersionSpecifier ? coerce(vitestVersionSpecifier) : null;
   // if Vitest is installed, we use the same version to keep consistency across Vitest packages
   const vitestVersionToInstall = vitestVersionSpecifier ?? 'latest';


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30134-sha-dcd49108`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30134-sha-dcd49108 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30134-sha-dcd49108 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30134-sha-dcd49108`](https://npmjs.com/package/storybook/v/0.0.0-pr-30134-sha-dcd49108) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/use-installed-version-vitest`](https://github.com/storybookjs/storybook/tree/kasper/use-installed-version-vitest) |
| **Commit** | [`dcd49108`](https://github.com/storybookjs/storybook/commit/dcd49108c917daa707b519a2ff5a95f71fd36d1b) |
| **Datetime** | Tue Dec 24 10:16:08 UTC 2024 (`1735035368`) |
| **Workflow run** | [12480338785](https://github.com/storybookjs/storybook/actions/runs/12480338785) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30134`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 0 B | **1.33** | 0% |
| initSize |  143 MB | 143 MB | 0 B | 1.18 | 0% |
| diffSize |  65.6 MB | 65.6 MB | 0 B | 1.18 | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | -0.88 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.72 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.23 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.92 MB | 3.92 MB | 0 B | -0.73 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | -0.9 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.2s | 24.2s | 17s | **1.83** | 🔺70.3% |
| generateTime |  21.1s | 19.1s | -1s -930ms | -0.92 | -10.1% |
| initTime |  14.6s | 13.2s | -1s -466ms | **-1.33** | 🔰-11.1% |
| buildTime |  11.5s | 8.5s | -3s -1ms | -1.04 | -35.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.5s | 5.3s | -239ms | -0.03 | -4.5% |
| devManagerResponsive |  4.1s | 3.7s | -347ms | -0.33 | -9.2% |
| devManagerHeaderVisible |  755ms | 611ms | -144ms | -0.29 | -23.6% |
| devManagerIndexVisible |  799ms | 640ms | -159ms | -0.27 | -24.8% |
| devStoryVisibleUncached |  2s | 1.5s | -499ms | -0.79 | -31.2% |
| devStoryVisible |  800ms | 641ms | -159ms | -0.32 | -24.8% |
| devAutodocsVisible |  711ms | 553ms | -158ms | -0.16 | -28.6% |
| devMDXVisible |  577ms | 492ms | -85ms | -0.64 | -17.3% |
| buildManagerHeaderVisible |  595ms | 604ms | 9ms | -0.24 | 1.5% |
| buildManagerIndexVisible |  682ms | 700ms | 18ms | -0.24 | 2.6% |
| buildStoryVisible |  575ms | 586ms | 11ms | -0.22 | 1.9% |
| buildAutodocsVisible |  562ms | 482ms | -80ms | -0.24 | -16.6% |
| buildMDXVisible |  545ms | 440ms | -105ms | -0.72 | -23.9% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the changes:

Modified the postinstall script in Storybook's test addon to ensure consistent Vitest versioning across dependencies by using the installed version instead of falling back to default versions.

- Removed fallback to `allDeps.vitest` in favor of using `packageManager.getInstalledVersion('vitest')`
- Added logic to use 'latest' version when Vitest is not installed
- Ensures consistent versioning between Vitest and related packages like `@vitest/browser` and `@vitest/coverage-v8`
- Prevents potential version mismatches between Vitest dependencies during installation



<!-- /greptile_comment -->