### PR TITLE
Manager: Escape single quotes in dynamic import paths in wrapManagerEntries function

### DIFF
--- a/code/core/src/builder-manager/utils/managerEntries.ts
+++ b/code/core/src/builder-manager/utils/managerEntries.ts
@@ -60,7 +60,8 @@ export async function wrapManagerEntries(entrypoints: string[], uniqueId?: strin
         const directory = dirname(location);
         await mkdir(directory, { recursive: true });
       }
-      await writeFile(location, `import '${slash(entry)}';`);
+
+      await writeFile(location, `import '${slash(entry).replaceAll(/'/g, "\\'")}';`);
 
       return location;
     })


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/29701

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Escaped single quotes in dynamic import paths in wrapManagerEntries function

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Change the parent folder to contain an apostrophe (')
3. Run Storybook

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 0 B | **1.33** | 0% |
| initSize |  143 MB | 143 MB | 48 B | 1.18 | 0% |
| diffSize |  65.6 MB | 65.6 MB | 48 B | 1.18 | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | -0.88 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.72 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.23 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.92 MB | 3.92 MB | 0 B | -0.73 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | -0.9 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.2s | 24.4s | 17.2s | **1.85** | 🔺70.5% |
| generateTime |  21.1s | 21.3s | 183ms | 0.14 | 0.9% |
| initTime |  14.6s | 16.5s | 1.8s | 1.04 | 11% |
| buildTime |  11.5s | 8.9s | -2s -547ms | -0.51 | -28.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.5s | 5.2s | -375ms | -0.16 | -7.2% |
| devManagerResponsive |  4.1s | 3.8s | -275ms | -0.23 | -7.2% |
| devManagerHeaderVisible |  755ms | 663ms | -92ms | 0.07 | -13.9% |
| devManagerIndexVisible |  799ms | 702ms | -97ms | 0.14 | -13.8% |
| devStoryVisibleUncached |  2s | 1.9s | -104ms | 0.08 | -5.2% |
| devStoryVisible |  800ms | 703ms | -97ms | 0.1 | -13.8% |
| devAutodocsVisible |  711ms | 600ms | -111ms | 0.16 | -18.5% |
| devMDXVisible |  577ms | 570ms | -7ms | -0.1 | -1.2% |
| buildManagerHeaderVisible |  595ms | 669ms | 74ms | 0.19 | 11.1% |
| buildManagerIndexVisible |  682ms | 762ms | 80ms | 0.14 | 10.5% |
| buildStoryVisible |  575ms | 650ms | 75ms | 0.29 | 11.5% |
| buildAutodocsVisible |  562ms | 554ms | -8ms | 0.35 | -1.4% |
| buildMDXVisible |  545ms | 495ms | -50ms | -0.09 | -10.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request:

Fixes an issue where single quotes in file paths cause syntax errors in dynamic imports for Storybook manager entries.

- Modified `code/core/src/builder-manager/utils/managerEntries.ts` to escape single quotes in import paths
- Addresses issue #29701 where paths containing apostrophes (e.g. in usernames) break manager imports
- Critical fix for Windows users who have single quotes in their file paths or usernames
- Simple implementation using `replaceAll` to properly escape quotes with backslashes



<!-- /greptile_comment -->