### PR TITLE
Docs: Fixes found during 8.5 QA, 2

### DIFF
--- a/docs/_snippets/webpack-final-to-vite-final.md
+++ b/docs/_snippets/webpack-final-to-vite-final.md
@@ -4,13 +4,13 @@ export default {
   framework: '@storybook/your-framework',
   stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   async webpackFinal(config) {
-    storybookBaseConfig.module?.rules?.push({
+    config.module?.rules?.push({
       test: /\.(graphql|gql)$/,
       include: [path.resolve('./lib/emails')],
       exclude: /node_modules/,
       loader: 'graphql-tag/loader',
     });
-    storybookBaseConfig.module?.rules?.push({
+    config.module?.rules?.push({
       test: /\.(graphql|gql)$/,
       include: [path.resolve('./lib/schema')],
       exclude: /node_modules/,
@@ -23,6 +23,8 @@ export default {
 ```
 
 ```js filename=".storybook/main.js" renderer="common" language="js" tabTitle="With Vite"
+import graphql from 'vite-plugin-graphql-loader';
+
 export default {
   // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite)
   framework: '@storybook/your-framework',
@@ -44,13 +46,13 @@ const config: StorybookConfig = {
   framework: '@storybook/your-framework',
   stories: ['../src/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   async webpackFinal(config) {
-    storybookBaseConfig.module?.rules?.push({
+    config.module?.rules?.push({
       test: /\.(graphql|gql)$/,
       include: [path.resolve('./lib/emails')],
       exclude: /node_modules/,
       loader: 'graphql-tag/loader',
     });
-    storybookBaseConfig.module?.rules?.push({
+    config.module?.rules?.push({
       test: /\.(graphql|gql)$/,
       include: [path.resolve('./lib/schema')],
       exclude: /node_modules/,
@@ -67,6 +69,7 @@ export default config;
 ```ts filename=".storybook/main.ts" renderer="common" language="ts" tabTitle="With Vite"
 // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite)
 import type { StorybookConfig } from '@storybook/your-framework';
+import graphql from 'vite-plugin-graphql-loader';
 
 const config: StorybookConfig = {
   framework: '@storybook/your-framework',


### PR DESCRIPTION
## What I did

Fix mistakes in #30103

## Checklist for Contributors

### Testing

N/A — Only addressing mistakes from a prior docs-only PR

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>


<!-- greptile_comment -->

## Greptile Summary

Updates documentation for Webpack to Vite migration and test configuration in Storybook 8.5, improving clarity and accuracy of setup instructions.

- Fixed variable naming from `storybookBaseConfig` to `config` in `docs/_snippets/webpack-final-to-vite-final.md` Webpack examples
- Added `graphql()` plugin import examples for Vite configuration
- Added `configDir` option examples in test configuration files
- Moved coverage exclusion config under Setup section and added `**/.storybook/**` pattern



<sub>💡 (4/5) You can add custom instructions or style guidelines for the bot [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->