### PR TITLE
Automigrations: Skip vite config file migration for react native web

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/vite-config-file.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/vite-config-file.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import type { StorybookConfig } from 'storybook/internal/types';
+
+import { viteConfigFile } from './vite-config-file';
+
+const check = async ({
+  packageManager,
+  main: mainConfig,
+  storybookVersion = '8.0.0',
+}: {
+  packageManager: any;
+  main: Partial<StorybookConfig> & Record<string, unknown>;
+  storybookVersion?: string;
+}) => {
+  return viteConfigFile.check({
+    packageManager,
+    configDir: '',
+    mainConfig: mainConfig as any,
+    storybookVersion,
+  });
+};
+
+describe('no-ops', () => {
+  it('skips when react-native-web-vite', async () => {
+    await expect(
+      check({
+        packageManager: {},
+        main: {
+          framework: '@storybook/react-native-web-vite',
+        },
+      })
+    ).resolves.toBeFalsy();
+  });
+});
+
+describe('continue', () => {
+  it('executes for vite framework', async () => {
+    await expect(
+      check({
+        packageManager: {},
+        main: {
+          framework: '@storybook/react-vite',
+        },
+      })
+    ).resolves.toBeTruthy();
+  });
+});

--- a/code/lib/cli-storybook/src/automigrate/fixes/vite-config-file.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/vite-config-file.ts
@@ -42,6 +42,12 @@ export const viteConfigFile = {
       return null;
     }
     const frameworkName = frameworkPackages[frameworkPackageName];
+
+    if (frameworkName === 'react-native-web-vite') {
+      // we don't expect a vite config file for this framework
+      return null;
+    }
+
     const isUsingViteBuilder =
       mainConfig.core?.builder === 'vite' ||
       frameworkPackageName?.includes('vite') ||


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

changed it to skip the vite config migration if the framework is react native web vite

this is because we don't expect a vite config in these projects since they usually rely on metro and storybook runs separately

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | -3.23 kB | 0.81 | 0% |
| initSize |  131 MB | 131 MB | -3.23 kB | -1.01 | 0% |
| diffSize |  53 MB | 53 MB | 0 B | -1.01 | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | -0.63 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.63 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.4 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | -0.63 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | - | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  24.8s | 8.5s | -16s -296ms | -0.56 | -190.3% |
| generateTime |  18.5s | 21.7s | 3.2s | 1.05 | 14.7% |
| initTime |  11.9s | 14.2s | 2.3s | 0.3 | 16.5% |
| buildTime |  8.7s | 8.3s | -398ms | -0.85 | -4.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.5s | 4.2s | -294ms | **-1.44** | 🔰-6.9% |
| devManagerResponsive |  3.3s | 3.2s | -131ms | **-1.29** | -4% |
| devManagerHeaderVisible |  574ms | 1s | 517ms | **3.67** | 🔺47.4% |
| devManagerIndexVisible |  608ms | 1s | 487ms | **3.34** | 🔺44.5% |
| devStoryVisibleUncached |  2s | 1.7s | -329ms | -0.65 | -19.1% |
| devStoryVisible |  609ms | 1s | 484ms | **3.27** | 🔺44.3% |
| devAutodocsVisible |  543ms | 939ms | 396ms | **3.75** | 🔺42.2% |
| devMDXVisible |  515ms | 858ms | 343ms | **2.41** | 🔺40% |
| buildManagerHeaderVisible |  549ms | 556ms | 7ms | -0.65 | 1.3% |
| buildManagerIndexVisible |  647ms | 636ms | -11ms | -0.75 | -1.7% |
| buildStoryVisible |  534ms | 538ms | 4ms | -0.7 | 0.7% |
| buildAutodocsVisible |  483ms | 705ms | 222ms | **2.32** | 🔺31.5% |
| buildMDXVisible |  521ms | 565ms | 44ms | 0.82 | 7.8% |

<!-- BENCHMARK_SECTION -->
