### PR TITLE
React: Force act running always in sequence

### DIFF
--- a/code/renderers/react/src/__test__/portable-stories.test.tsx
+++ b/code/renderers/react/src/__test__/portable-stories.test.tsx
@@ -67,7 +67,7 @@ describe('renders', () => {
   });
 
   it('should throw error when rendering a component with a render error', async () => {
-    await expect(() => ThrowsError.run()).rejects.toThrowError('Error in render');
+    await expect(ThrowsError.run()).rejects.toThrowError('Error in render');
   });
 
   it('should render component mounted in play function', async () => {
@@ -77,8 +77,8 @@ describe('renders', () => {
     expect(screen.getByTestId('loaded-data').textContent).toEqual('loaded data');
   });
 
-  it('should throw an error in play function', () => {
-    expect(() => MountInPlayFunctionThrow.run()).rejects.toThrowError('Error thrown in play');
+  it('should throw an error in play function', async () => {
+    await expect(MountInPlayFunctionThrow.run()).rejects.toThrowError('Error thrown in play');
   });
 
   it('should call and compose loaders data', async () => {

--- a/code/renderers/react/src/renderToCanvas.tsx
+++ b/code/renderers/react/src/renderToCanvas.tsx
@@ -112,8 +112,8 @@ export async function renderToCanvas(
     processActQueue();
   });
 
-  return () => {
-    act(() => {
+  return async () => {
+    await act(() => {
       unmountElement(canvasElement);
     });
   };

--- a/code/renderers/react/src/renderToCanvas.tsx
+++ b/code/renderers/react/src/renderToCanvas.tsx
@@ -98,18 +98,18 @@ export async function renderToCanvas(
     unmountElement(canvasElement);
   }
 
-  await new Promise<void>((resolve, reject) => {
-    try {
-      actQueue.push(async () => {
+  await new Promise<void>(async (resolve, reject) => {
+    actQueue.push(async () => {
+      try {
         await act(async () => {
           await renderElement(element, canvasElement, storyContext?.parameters?.react?.rootOptions);
-          resolve();
         });
-      });
-      processActQueue();
-    } catch (e) {
-      reject(e);
-    }
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+    processActQueue();
   });
 
   return () => {


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

`act` calls are now allowed to run in parallel. The made adjustment makes sure that `act` calls always run in sequence.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 590 B | 0.47 | 0% |
| initSize |  131 MB | 131 MB | 1.53 kB | **-1.36** | 0% |
| diffSize |  53 MB | 53 MB | 943 B | **-1.36** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 194 B | -0.21 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.31 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 12 B | 0.69 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 12 B | -0.3 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 182 B | **12.61** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.6s | 6.8s | -16s -769ms | -0.82 | -243.7% |
| generateTime |  21.9s | 18.8s | -3s -110ms | -0.92 | -16.5% |
| initTime |  15.5s | 12.5s | -3s -34ms | -0.87 | -24.2% |
| buildTime |  8.7s | 9s | 339ms | -0.31 | 3.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.1s | 4.6s | -481ms | -0.99 | -10.3% |
| devManagerResponsive |  3.7s | 3.5s | -191ms | -0.86 | -5.4% |
| devManagerHeaderVisible |  605ms | 547ms | -58ms | **-1.41** | 🔰-10.6% |
| devManagerIndexVisible |  635ms | 560ms | -75ms | **-1.64** | 🔰-13.4% |
| devStoryVisibleUncached |  2s | 1.9s | -163ms | -0.19 | -8.5% |
| devStoryVisible |  636ms | 581ms | -55ms | **-1.5** | 🔰-9.5% |
| devAutodocsVisible |  491ms | 535ms | 44ms | -0.58 | 8.2% |
| devMDXVisible |  525ms | 497ms | -28ms | -0.78 | -5.6% |
| buildManagerHeaderVisible |  519ms | 555ms | 36ms | -0.77 | 6.5% |
| buildManagerIndexVisible |  610ms | 642ms | 32ms | -0.9 | 5% |
| buildStoryVisible |  510ms | 529ms | 19ms | -0.97 | 3.6% |
| buildAutodocsVisible |  427ms | 454ms | 27ms | -0.8 | 5.9% |
| buildMDXVisible |  485ms | 443ms | -42ms | -0.84 | -9.5% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the key changes in this pull request:

Implemented sequential execution of React `act` calls in Storybook's test environment by introducing a queue-based system to prevent parallel execution.

- Added `actQueue` array and `isActing` flag in `code/renderers/react/src/act-compat.ts` to manage task sequencing
- Introduced `withQueuedActEnvironment` wrapper to ensure proper queue processing and environment state management
- Maintains proper error handling and React environment state during async operations
- Prevents potential race conditions when multiple `act` calls occur simultaneously



<!-- /greptile_comment -->