### PR TITLE
Manager: Optimize getPanels function with memoization

### DIFF
--- a/code/core/src/manager/container/Panel.tsx
+++ b/code/core/src/manager/container/Panel.tsx
@@ -16,7 +16,7 @@ const createPanelActions = memoize(1)((api) => ({
   togglePosition: () => api.togglePanelPosition(),
 }));
 
-const getPanels = (api: API) => {
+const getPanels = memoize(1)((api: API) => {
   const allPanels = api.getElements(Addon_TypesEnum.PANEL);
   const story = api.getCurrentStoryData();
 
@@ -42,7 +42,7 @@ const getPanels = (api: API) => {
   });
 
   return filteredPanels;
-};
+});
 
 const mapper = ({ state, api }: Combo) => ({
   panels: getPanels(api),


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixed an issue where the addon panel was indefinitely rerendering due to missing memoization.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 4.31 kB | **1.26** | 0% |
| initSize |  131 MB | 131 MB | 4.3 kB | **-2** | 0% |
| diffSize |  53 MB | 53 MB | -12 B | **-2** | 0% |
| buildSize |  7.19 MB | 7.19 MB | -46 B | -0.57 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.56 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | -12 B | 0.26 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | -12 B | -0.56 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | -34 B | **-Infinity** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  20.1s | 25s | 4.9s | **1.92** | 🔺19.6% |
| generateTime |  21.1s | 21s | -128ms | 0.5 | -0.6% |
| initTime |  14.4s | 14s | -379ms | 0.15 | -2.7% |
| buildTime |  8.4s | 9.3s | 877ms | -0.07 | 9.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.5s | 5.3s | 871ms | 0.12 | 16.2% |
| devManagerResponsive |  3.4s | 3.8s | 466ms | -0.01 | 12% |
| devManagerHeaderVisible |  604ms | 638ms | 34ms | -0.1 | 5.3% |
| devManagerIndexVisible |  614ms | 653ms | 39ms | -0.2 | 6% |
| devStoryVisibleUncached |  1.8s | 2.1s | 372ms | 0.32 | 17.1% |
| devStoryVisible |  635ms | 682ms | 47ms | -0.06 | 6.9% |
| devAutodocsVisible |  580ms | 628ms | 48ms | 0.46 | 7.6% |
| devMDXVisible |  507ms | 554ms | 47ms | -0.1 | 8.5% |
| buildManagerHeaderVisible |  546ms | 620ms | 74ms | -0.13 | 11.9% |
| buildManagerIndexVisible |  644ms | 701ms | 57ms | -0.26 | 8.1% |
| buildStoryVisible |  534ms | 591ms | 57ms | -0.23 | 9.6% |
| buildAutodocsVisible |  429ms | 466ms | 37ms | -0.55 | 7.9% |
| buildMDXVisible |  421ms | 594ms | 173ms | 1.21 | 29.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the PR changes focusing on the Panel.tsx modifications:

Optimizes the addon panel rendering performance by adding memoization to the getPanels function, preventing unnecessary re-calculations when the API state hasn't changed.

- Added memoization to `getPanels` function in `code/core/src/manager/container/Panel.tsx` using `memoizerific`
- Removed unused `useCallback` import
- Function now caches panel calculations with a cache size of 1
- Filters panels based on story parameters and disabled state
- Potential improvement needed for stricter typing of `paramKey` destructuring



<!-- /greptile_comment -->