### PR TITLE
Addon Test: Add prerequisite check for MSW

### DIFF
--- a/code/addons/test/src/postinstall.ts
+++ b/code/addons/test/src/postinstall.ts
@@ -150,8 +150,8 @@ export default async function postInstall(options: PostinstallOptions) {
 
     if (coercedMswVersion && !satisfies(coercedMswVersion, '>=2.0.0')) {
       reasons.push(dedent`
-        • Detected the package MSW installed at version ${picocolors.bold(coercedMswVersion.version)}. To avoid conflicts with Vitest's dependencies, MSW must be version 2.0.0 or later.  
-        Please update to a compatible version.
+        • The addon uses Vitest behind the scenes, which supports only version 2 and above of MSW. However, we have detected version ${picocolors.bold(coercedMswVersion.version)} in this project.
+        Please update the 'msw' package and try again.
       `);
     }
 

--- a/code/addons/test/src/postinstall.ts
+++ b/code/addons/test/src/postinstall.ts
@@ -145,6 +145,16 @@ export default async function postInstall(options: PostinstallOptions) {
       `);
     }
 
+    const mswVersionSpecifier = await packageManager.getInstalledVersion('msw');
+    const coercedMswVersion = mswVersionSpecifier ? coerce(mswVersionSpecifier) : null;
+
+    if (coercedMswVersion && !satisfies(coercedMswVersion, '>=2.0.0')) {
+      reasons.push(dedent`
+        • Detected the package MSW installed at version ${picocolors.bold(coercedMswVersion.version)}. To avoid conflicts with Vitest's dependencies, MSW must be version 2.0.0 or later.  
+        Please update to a compatible version.
+      `);
+    }
+
     if (info.frameworkPackageName === '@storybook/nextjs') {
       const nextVersion = await packageManager.getInstalledVersion('next');
       if (!nextVersion) {
@@ -159,6 +169,7 @@ export default async function postInstall(options: PostinstallOptions) {
       reasons.unshift(
         `Storybook Test's automated setup failed due to the following package incompatibilities:`
       );
+      reasons.push('--------------------------------');
       reasons.push(
         dedent`
           You can fix these issues and rerun the command to reinstall. If you wish to roll back the installation, remove ${picocolors.bold(colors.pink(ADDON_NAME))} from the "addons" array

--- a/code/lib/cli-storybook/src/add.ts
+++ b/code/lib/cli-storybook/src/add.ts
@@ -111,17 +111,19 @@ export async function add(
 
   let shouldAddToMain = true;
   if (checkInstalled(addonName, requireMain(configDir))) {
-    const { shouldForceInstall } = await prompts({
-      type: 'confirm',
-      name: 'shouldForceInstall',
-      message: `The Storybook addon "${addonName}" is already present in ${mainConfig}. Do you wish to install it again?`,
-    });
-
-    if (!shouldForceInstall) {
-      return;
-    }
-
     shouldAddToMain = false;
+    if (!yes) {
+      logger.log(`The Storybook addon "${addonName}" is already present in ${mainConfig}.`);
+      const { shouldForceInstall } = await prompts({
+        type: 'confirm',
+        name: 'shouldForceInstall',
+        message: `Do you wish to install it again?`,
+      });
+
+      if (!shouldForceInstall) {
+        return;
+      }
+    }
   }
 
   const main = await readConfig(mainConfig);


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR does two things:
- Addon Test postinstall: Add prerequisite check for MSW <2.0.0 if it is present in a project
- CLI's add command: respect the --yes flag when addon is already installed

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | -5.16 kB | 0.51 | 0% |
| initSize |  131 MB | 131 MB | -5.16 kB | **-1.73** | 0% |
| diffSize |  53 MB | 53 MB | 0 B | **-1.73** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | -0.49 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.48 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.82 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | -0.47 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | **-4.36** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.5s | 6.6s | 157ms | -0.84 | 2.3% |
| generateTime |  19.2s | 20s | 773ms | -0.05 | 3.9% |
| initTime |  13.2s | 12.7s | -532ms | -0.79 | -4.2% |
| buildTime |  11.1s | 8.1s | -2s -946ms | -1.1 | -36.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.9s | 4.8s | -76ms | -0.57 | -1.6% |
| devManagerResponsive |  3.6s | 3.4s | -171ms | -0.97 | -5% |
| devManagerHeaderVisible |  728ms | 603ms | -125ms | -0.46 | -20.7% |
| devManagerIndexVisible |  768ms | 630ms | -138ms | -0.46 | -21.9% |
| devStoryVisibleUncached |  2s | 1s | -925ms | **-1.94** | 🔰-85.3% |
| devStoryVisible |  767ms | 631ms | -136ms | -0.64 | -21.6% |
| devAutodocsVisible |  599ms | 448ms | -151ms | **-1.75** | 🔰-33.7% |
| devMDXVisible |  567ms | 501ms | -66ms | -0.7 | -13.2% |
| buildManagerHeaderVisible |  553ms | 518ms | -35ms | **-1.35** | 🔰-6.8% |
| buildManagerIndexVisible |  643ms | 602ms | -41ms | **-1.33** | 🔰-6.8% |
| buildStoryVisible |  534ms | 501ms | -33ms | **-1.44** | 🔰-6.6% |
| buildAutodocsVisible |  543ms | 433ms | -110ms | -1.2 | -25.4% |
| buildMDXVisible |  456ms | 444ms | -12ms | -0.82 | -2.7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the PR changes:

Adds MSW version compatibility check to Storybook Test addon installation process and improves the CLI's addon installation behavior with respect to the --yes flag.

- Added prerequisite check in `code/addons/test/src/postinstall.ts` to ensure MSW version ≥2.0.0 if installed
- Modified `code/lib/cli-storybook/src/add.ts` to respect --yes flag when reinstalling existing addons
- Added separator line between error messages for better readability
- Improved error message formatting for package incompatibilities



<!-- /greptile_comment -->