### PR TITLE
Docs: Rename `a11ytest` tag to `a11y-test`

### DIFF
--- a/docs/_snippets/addon-a11y-meta-tag.md
+++ b/docs/_snippets/addon-a11y-meta-tag.md
@@ -5,8 +5,8 @@ import { Button } from './button.component';
 
 const meta: Meta<Button> = {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 
 export default meta;
@@ -14,8 +14,8 @@ export default meta;
 
 ```js filename="Button.stories.js" renderer="html" language="js"
 export default {
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 ```
 
@@ -24,8 +24,8 @@ import { Button } from './Button';
 
 export default {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 ```
 
@@ -37,8 +37,8 @@ import { Button } from './Button';
 
 const meta = {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 } satisfies Meta<typeof Button>;
 
 export default meta;
@@ -52,8 +52,8 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 
 export default meta;
@@ -64,8 +64,8 @@ import { Button } from './Button';
 
 export default {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 ```
 
@@ -76,8 +76,8 @@ import { Button } from './Button';
 
 const meta = {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 } satisfies Meta<typeof Button>;
 
 export default meta;
@@ -90,8 +90,8 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 
 export default meta;
@@ -105,8 +105,8 @@ export default meta;
 
   const { Story } = defineMeta({
     component: Button,
-    // 👇 Re-apply the a11ytest tag for this component's stories
-    tags: ['a11ytest'],
+    // 👇 Re-apply the a11y-test tag for this component's stories
+    tags: ['a11y-test'],
   });
 </script>
 ```
@@ -116,8 +116,8 @@ import Button from './Button.svelte';
 
 export default {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 ```
 
@@ -129,8 +129,8 @@ export default {
 
   const { Story } = defineMeta({
     component: Button,
-    // 👇 Re-apply the a11ytest tag for this component's stories
-    tags: ['a11ytest'],
+    // 👇 Re-apply the a11y-test tag for this component's stories
+    tags: ['a11y-test'],
   });
 </script>
 ```
@@ -142,8 +142,8 @@ import Button from './Button.svelte';
 
 const meta = {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 } satisfies Meta<typeof Button>;
 
 export default meta;
@@ -157,8 +157,8 @@ export default meta;
 
   const { Story } = defineMeta({
     component: Button,
-    // 👇 Re-apply the a11ytest tag for this component's stories
-    tags: ['a11ytest'],
+    // 👇 Re-apply the a11y-test tag for this component's stories
+    tags: ['a11y-test'],
   });
 </script>
 ```
@@ -170,8 +170,8 @@ import Button from './Button.svelte';
 
 const meta: Meta<typeof Button> = {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 
 export default meta;
@@ -182,8 +182,8 @@ import Button from './Button.vue';
 
 export default {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 ```
 
@@ -194,8 +194,8 @@ import Button from './Button.vue';
 
 const meta = {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 } satisfies Meta<typeof Button>;
 
 export default meta;
@@ -208,8 +208,8 @@ import Button from './Button.vue';
 
 const meta: Meta<typeof Button> = {
   component: Button,
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 
 export default meta;
@@ -218,8 +218,8 @@ export default meta;
 ```js filename="Button.stories.js" renderer="web-components" language="js"
 export default {
   component: 'demo-button',
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 ```
 
@@ -228,8 +228,8 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'demo-button',
-  // 👇 Re-apply the a11ytest tag for this component's stories
-  tags: ['a11ytest'],
+  // 👇 Re-apply the a11y-test tag for this component's stories
+  tags: ['a11y-test'],
 };
 
 export default meta;

--- a/docs/_snippets/storybook-test-addon-disable-tests.md
+++ b/docs/_snippets/storybook-test-addon-disable-tests.md
@@ -7,9 +7,9 @@ const meta: Meta<typeof Button> = {
   component: Button,
   /*
    * Enable accessibility checks for all stories in this component
-   * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+   * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
    */
-  tags: ['a11ytest'],
+  tags: ['a11y-test'],
 };
 
 export default meta;
@@ -24,7 +24,7 @@ export const Accessible: Story = {
 
 export const Inaccessible: Story = {
   // Turn off accessibility tests for this story using the tag's configuration option
-  tags: ['!a11ytest'],
+  tags: ['!a11y-test'],
   args: {
     ...Accessible.args,
     backgroundColor: 'red',
@@ -39,9 +39,9 @@ export default {
   component: Button,
   /*
    * Enable accessibility checks for all stories in this component
-   * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+   * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
    */
-  tags: ['a11ytest'],
+  tags: ['a11y-test'],
 };
 
 export const Accessible = {
@@ -53,7 +53,7 @@ export const Accessible = {
 
 export const Inaccessible = {
   // Turn off accessibility tests for this story using the tag's configuration option
-  tags: ['!a11ytest'],
+  tags: ['!a11y-test'],
   args: {
     ...Accessible.args,
     backgroundColor: 'red',
@@ -70,9 +70,9 @@ const meta = {
   component: Button,
   /*
    * Enable accessibility checks for all stories in this component
-   * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+   * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
    */
-  tags: ['a11ytest'],
+  tags: ['a11y-test'],
 } satisfies Meta<typeof Button>;
 
 export default meta;
@@ -87,7 +87,7 @@ export const Accessible: Story = {
 
 export const Inaccessible: Story = {
   // Turn off accessibility tests for this story using the tag's configuration option
-  tags: ['!a11ytest'],
+  tags: ['!a11y-test'],
   args: {
     ...Accessible.args,
     backgroundColor: 'red',
@@ -103,11 +103,11 @@ export const Inaccessible: Story = {
 
   /*
   * Enable accessibility checks for all stories in this component
-  * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+  * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
   */
   const { Story } = defineMeta({
     component: Button,
-    tags: ['a11ytest'],
+    tags: ['a11y-test'],
   });
 
   const AccessibleArgs = {
@@ -121,7 +121,7 @@ export const Inaccessible: Story = {
 <!-- Turn off accessibility tests for this story using the tag's configuration option -->
 <Story
   name="Inaccessible"
-  tags={['!a11ytest']}
+  tags={['!a11y-test']}
   args={{
     ...AccessibleArgs,
     backgroundColor: 'red',
@@ -136,9 +136,9 @@ export default {
   component: Button,
   /*
    * Enable accessibility checks for all stories in this component
-   * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+   * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
    */
-  tags: ['a11ytest'],
+  tags: ['a11y-test'],
 };
 
 export const Accessible = {
@@ -150,7 +150,7 @@ export const Accessible = {
 
 export const Inaccessible = {
   // Turn off accessibility tests for this story using the tag's configuration option
-  tags: ['!a11ytest'],
+  tags: ['!a11y-test'],
   args: {
     ...Accessible.args,
     backgroundColor: 'red',
@@ -166,11 +166,11 @@ export const Inaccessible = {
 
   /*
   * Enable accessibility checks for all stories in this component
-  * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+  * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
   */
   const { Story } = defineMeta({
     component: Button,
-    tags: ['a11ytest'],
+    tags: ['a11y-test'],
   });
 
   const AccessibleArgs = {
@@ -184,7 +184,7 @@ export const Inaccessible = {
 <!-- Turn off accessibility tests for this story using the tag's configuration option -->
 <Story
   name="Inaccessible"
-  tags={['!a11ytest']}
+  tags={['!a11y-test']}
   args={{
     ...AccessibleArgs,
     backgroundColor: 'red',
@@ -201,9 +201,9 @@ const meta = {
   component: Button,
   /*
    * Enable accessibility checks for all stories in this component
-   * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+   * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
    */
-  tags: ['a11ytest'],
+  tags: ['a11y-test'],
 } satisfies Meta<typeof Button>;
 
 export default meta;
@@ -218,7 +218,7 @@ export const Accessible: Story = {
 
 export const Inaccessible: Story = {
   // Turn off accessibility tests for this story using the tag's configuration option
-  tags: ['!a11ytest'],
+  tags: ['!a11y-test'],
   args: {
     ...Accessible.args,
     backgroundColor: 'red',
@@ -234,11 +234,11 @@ export const Inaccessible: Story = {
 
   /*
   * Enable accessibility checks for all stories in this component
-  * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+  * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
   */
   const { Story } = defineMeta({
     component: Button,
-    tags: ['a11ytest'],
+    tags: ['a11y-test'],
   });
 
   const AccessibleArgs = {
@@ -252,7 +252,7 @@ export const Inaccessible: Story = {
 <!-- Turn off accessibility tests for this story using the tag's configuration option -->
 <Story
   name="Inaccessible"
-  tags={['!a11ytest']}
+  tags={['!a11y-test']}
   args={{
     ...AccessibleArgs,
     backgroundColor: 'red',
@@ -269,9 +269,9 @@ const meta: Meta<typeof Button> = {
   component: Button,
   /*
    * Enable accessibility checks for all stories in this component
-   * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+   * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
    */
-  tags: ['a11ytest'],
+  tags: ['a11y-test'],
 };
 
 export default meta;
@@ -286,7 +286,7 @@ export const Accessible: Story = {
 
 export const Inaccessible: Story = {
   // Turn off accessibility tests for this story using the tag's configuration option
-  tags: ['!a11ytest'],
+  tags: ['!a11y-test'],
   args: {
     ...Accessible.args,
     backgroundColor: 'red',
@@ -301,9 +301,9 @@ export default {
   component: Button,
   /*
    * Enable accessibility checks for all stories in this component
-   * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+   * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
    */
-  tags: ['a11ytest'],
+  tags: ['a11y-test'],
 };
 
 export const Accessible = {
@@ -315,7 +315,7 @@ export const Accessible = {
 
 export const Inaccessible = {
   // Turn off accessibility tests for this story using the tag's configuration option
-  tags: ['!a11ytest'],
+  tags: ['!a11y-test'],
   args: {
     ...Accessible.args,
     backgroundColor: 'red',
@@ -332,9 +332,9 @@ const meta = {
   component: Button,
   /*
    * Enable accessibility checks for all stories in this component
-   * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+   * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
    */
-  tags: ['a11ytest'],
+  tags: ['a11y-test'],
 } satisfies Meta<typeof Button>;
 
 export default meta;
@@ -349,7 +349,7 @@ export const Accessible: Story = {
 
 export const Inaccessible: Story = {
   // Turn off accessibility tests for this story using the tag's configuration option
-  tags: ['!a11ytest'],
+  tags: ['!a11y-test'],
   args: {
     ...Accessible.args,
     backgroundColor: 'red',
@@ -366,9 +366,9 @@ const meta: Meta<typeof Button> = {
   component: Button,
   /*
    * Enable accessibility checks for all stories in this component
-   * This is only necessary if you have set the `!a11ytest` tag in your preview file, otherwise `a11ytest` is enabled by default
+   * This is only necessary if you have set the `!a11y-test` tag in your preview file, otherwise `a11y-test` is enabled by default
    */
-  tags: ['a11ytest'],
+  tags: ['a11y-test'],
 };
 
 export default meta;
@@ -383,7 +383,7 @@ export const Accessible: Story = {
 
 export const Inaccessible: Story = {
   // Turn off accessibility tests for this story using the tag's configuration option
-  tags: ['!a11ytest'],
+  tags: ['!a11y-test'],
   args: {
     ...Accessible.args,
     backgroundColor: 'red',

--- a/docs/writing-tests/accessibility-testing.mdx
+++ b/docs/writing-tests/accessibility-testing.mdx
@@ -132,7 +132,7 @@ If you enabled the addon and you're manually upgrading to Storybook 8.5 or later
 
 ### Configure accessibility tests with the test addon
 
-Like the Test addon, the accessibility addon also supports [tags](../writing-stories/tags.mdx) to filter the tests you want to run. By default, the addon applies the `a11ytest` tag to all stories. If you need to exclude a story from being accessibility tested, you can remove that tag by applying the `!a11ytest` tag to the story. This also works at the project (in `.storybook/preview.js|ts`) or component level (default export in the story file).
+Like the Test addon, the accessibility addon also supports [tags](../writing-stories/tags.mdx) to filter the tests you want to run. By default, the addon applies the `a11y-test` tag to all stories. If you need to exclude a story from being accessibility tested, you can remove that tag by applying the `!a11y-test` tag to the story. This also works at the project (in `.storybook/preview.js|ts`) or component level (default export in the story file).
 
 You can use tags to progressively work toward a more accessible UI by enabling accessibility tests for a subset of stories and gradually increasing the coverage. For example, a typical workflow might look like this:
 
@@ -146,8 +146,8 @@ You can use tags to progressively work toward a more accessible UI by enabling a
 
    const preview: Preview = {
      // ...
-     // 👇 Temporarily remove the a11ytest tag from all stories
-     tags: ['!a11ytest'],
+     // 👇 Temporarily remove the a11y-test tag from all stories
+     tags: ['!a11y-test'],
    };
 
    export default preview;


### PR DESCRIPTION
## What I did

See title

## Checklist for Contributors

### Testing

N/A — Find/replace in docs only

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Renamed accessibility test tag from 'a11ytest' to 'a11y-test' across documentation files to improve readability while maintaining functionality.

- Updated tag name in `docs/writing-tests/accessibility-testing.mdx` for main accessibility testing documentation
- Changed tag references in `docs/_snippets/addon-a11y-meta-tag.md` across multiple framework examples
- Updated both positive ('a11y-test') and negative ('!a11y-test') tag references in `docs/_snippets/storybook-test-addon-disable-tests.md`



<sub>💡 (5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->