### PR TITLE
Csf Tools: Allow ConfigFile to create more import syntaxes

### DIFF
--- a/code/core/src/csf-tools/ConfigFile.test.ts
+++ b/code/core/src/csf-tools/ConfigFile.test.ts
@@ -1146,6 +1146,24 @@ describe('ConfigFile', () => {
         export default config;
       `);
     });
+
+    it(`supports setting a namespaced import`, () => {
+      const config = loadConfig('').parse();
+      config.setImport({ namespace: 'path' }, 'path');
+
+      const parsed = babelPrint(config._ast);
+
+      expect(parsed).toMatchInlineSnapshot(`import * as path from 'path';`);
+    });
+
+    it(`supports setting import without specifier`, () => {
+      const config = loadConfig('').parse();
+      config.setImport(null, 'path');
+
+      const parsed = babelPrint(config._ast);
+
+      expect(parsed).toMatchInlineSnapshot(`import 'path';`);
+    });
   });
 
   describe('setRequireImport', () => {


### PR DESCRIPTION
Relates to #30203

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR allows the ConfigFile to create two new syntaxes of import:

```ts
import 'side-effect'
import * as annotations from 'some-addon'
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 590 B | 0.47 | 0% |
| initSize |  131 MB | 131 MB | 2.28 kB | **-1.36** | 0% |
| diffSize |  53 MB | 53 MB | 1.69 kB | **-1.36** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | -0.33 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.31 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.14 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | -0.31 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | **-2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.6s | 6.9s | -16s -698ms | -0.81 | -240.2% |
| generateTime |  21.9s | 18.8s | -3s -92ms | -0.91 | -16.4% |
| initTime |  15.5s | 12.7s | -2s -854ms | -0.73 | -22.4% |
| buildTime |  8.7s | 11.8s | 3.1s | **2.4** | 🔺26.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.1s | 4.2s | -931ms | **-1.81** | 🔰-22.1% |
| devManagerResponsive |  3.7s | 3.1s | -532ms | **-1.78** | 🔰-16.8% |
| devManagerHeaderVisible |  605ms | 557ms | -48ms | **-1.24** | 🔰-8.6% |
| devManagerIndexVisible |  635ms | 562ms | -73ms | **-1.61** | 🔰-13% |
| devStoryVisibleUncached |  2s | 1.7s | -388ms | -0.67 | -22.8% |
| devStoryVisible |  636ms | 589ms | -47ms | **-1.37** | 🔰-8% |
| devAutodocsVisible |  491ms | 472ms | -19ms | **-1.46** | -4% |
| devMDXVisible |  525ms | 435ms | -90ms | **-1.8** | 🔰-20.7% |
| buildManagerHeaderVisible |  519ms | 508ms | -11ms | **-1.44** | -2.2% |
| buildManagerIndexVisible |  610ms | 611ms | 1ms | **-1.29** | 0.2% |
| buildStoryVisible |  510ms | 495ms | -15ms | **-1.48** | -3% |
| buildAutodocsVisible |  427ms | 425ms | -2ms | **-1.3** | -0.5% |
| buildMDXVisible |  485ms | 413ms | -72ms | **-1.53** | 🔰-17.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Here's my concise summary of the pull request:

Enhanced ConfigFile class to support additional import syntaxes in Storybook configuration files, specifically adding support for namespace imports and side-effect imports.

- Added support for side-effect imports (`import 'foo'`) in `ConfigFile.ts`
- Added support for namespace imports (`import * as foo from 'bar'`) in `ConfigFile.ts`
- Added comprehensive test coverage for new import syntaxes in `ConfigFile.test.ts`
- Maintained backward compatibility with existing import handling functionality
- Implemented proper type checking and error handling for new import cases



<!-- /greptile_comment -->