### PR TITLE
Build: Fix sandbox annotations for CSF4 example

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -95,6 +95,7 @@ describe('StoryIndexGenerator', () => {
         expect(stats).toMatchInlineSnapshot(`
           {
             "beforeEach": 0,
+            "factory": 0,
             "globals": 0,
             "loaders": 0,
             "moduleMock": 0,
@@ -463,6 +464,7 @@ describe('StoryIndexGenerator', () => {
         expect(stats).toMatchInlineSnapshot(`
           {
             "beforeEach": 1,
+            "factory": 0,
             "globals": 0,
             "loaders": 1,
             "moduleMock": 0,
@@ -728,6 +730,7 @@ describe('StoryIndexGenerator', () => {
         expect(stats).toMatchInlineSnapshot(`
           {
             "beforeEach": 1,
+            "factory": 0,
             "globals": 0,
             "loaders": 1,
             "moduleMock": 0,

--- a/code/core/src/csf-tools/ConfigFile.test.ts
+++ b/code/core/src/csf-tools/ConfigFile.test.ts
@@ -1242,6 +1242,24 @@ describe('ConfigFile', () => {
         export default config;
       `);
     });
+
+    it(`supports setting a namespaced import`, () => {
+      const config = loadConfig('').parse();
+      config.setImport({ namespace: 'path' }, 'path');
+
+      const parsed = babelPrint(config._ast);
+
+      expect(parsed).toMatchInlineSnapshot(`import * as path from 'path';`);
+    });
+
+    it(`supports setting import without specifier`, () => {
+      const config = loadConfig('').parse();
+      config.setImport(null, 'path');
+
+      const parsed = babelPrint(config._ast);
+
+      expect(parsed).toMatchInlineSnapshot(`import 'path';`);
+    });
   });
 
   describe('setRequireImport', () => {

--- a/code/core/src/csf-tools/ConfigFile.ts
+++ b/code/core/src/csf-tools/ConfigFile.ts
@@ -817,16 +817,21 @@ export class ConfigFile {
    *
    * // import foo from 'bar';
    * setImport('foo', 'bar');
+   *
+   * // import * as foo from 'bar';
+   * setImport({ namespace: 'foo' }, 'bar');
+   *
+   * // import 'bar';
+   * setImport(null, 'bar');
    * ```
    *
    * @param importSpecifiers - The import specifiers to set. If a string is passed in, a default
    *   import will be set. Otherwise, an array of named imports will be set
    * @param fromImport - The module to import from
    */
-  setImport(importSpecifier: string[] | string, fromImport: string) {
+  setImport(importSpecifier: string[] | string | { namespace: string } | null, fromImport: string) {
     const getNewImportSpecifier = (specifier: string) =>
       t.importSpecifier(t.identifier(specifier), t.identifier(specifier));
-
     /**
      * Returns true, when the given import declaration has the given import specifier
      *
@@ -855,26 +860,41 @@ export class ConfigFile {
      * hasImportSpecifier(declaration, 'foo');
      * ```
      */
+    const hasNamespaceImportSpecifier = (declaration: t.ImportDeclaration, name: string) =>
+      declaration.specifiers.find(
+        (specifier) =>
+          t.isImportNamespaceSpecifier(specifier) &&
+          t.isIdentifier(specifier.local) &&
+          specifier.local.name === name
+      );
+
+    /** Returns true when the given import declaration has a default import specifier */
     const hasDefaultImportSpecifier = (declaration: t.ImportDeclaration, name: string) =>
-      declaration.specifiers.find((specifier) => t.isImportDefaultSpecifier(specifier));
+      declaration.specifiers.find(
+        (specifier) =>
+          t.isImportDefaultSpecifier(specifier) &&
+          t.isIdentifier(specifier.local) &&
+          specifier.local.name === name
+      );
 
     const importDeclaration = this._ast.program.body.find(
       (node) => t.isImportDeclaration(node) && node.source.value === fromImport
     ) as t.ImportDeclaration | undefined;
 
-    // if the import specifier is a string, we're dealing with default imports
-    if (typeof importSpecifier === 'string') {
-      // If the import declaration with the given source exists
+    // Handle side-effect imports (e.g., import 'foo')
+    if (importSpecifier === null) {
+      if (!importDeclaration) {
+        this._ast.program.body.unshift(t.importDeclaration([], t.stringLiteral(fromImport)));
+      }
+      // Handle default imports e.g. import foo from 'bar'
+    } else if (typeof importSpecifier === 'string') {
       if (importDeclaration) {
         if (!hasDefaultImportSpecifier(importDeclaration, importSpecifier)) {
-          // If the import declaration hasn'types a default specifier, we add it
           importDeclaration.specifiers.push(
             t.importDefaultSpecifier(t.identifier(importSpecifier))
           );
         }
-        // If the import declaration with the given source doesn'types exist
       } else {
-        // Add the import declaration to the top of the file
         this._ast.program.body.unshift(
           t.importDeclaration(
             [t.importDefaultSpecifier(t.identifier(importSpecifier))],
@@ -882,22 +902,38 @@ export class ConfigFile {
           )
         );
       }
-      // if the import specifier is an array, we're dealing with named imports
-    } else if (importDeclaration) {
-      importSpecifier.forEach((specifier) => {
-        if (!hasImportSpecifier(importDeclaration, specifier)) {
-          importDeclaration.specifiers.push(getNewImportSpecifier(specifier));
+      // Handle named imports e.g. import { foo } from 'bar'
+    } else if (Array.isArray(importSpecifier)) {
+      if (importDeclaration) {
+        importSpecifier.forEach((specifier) => {
+          if (!hasImportSpecifier(importDeclaration, specifier)) {
+            importDeclaration.specifiers.push(getNewImportSpecifier(specifier));
+          }
+        });
+      } else {
+        this._ast.program.body.unshift(
+          t.importDeclaration(
+            importSpecifier.map(getNewImportSpecifier),
+            t.stringLiteral(fromImport)
+          )
+        );
+      }
+      // Handle namespace imports e.g. import * as foo from 'bar'
+    } else if (importSpecifier.namespace) {
+      if (importDeclaration) {
+        if (!hasNamespaceImportSpecifier(importDeclaration, importSpecifier.namespace)) {
+          importDeclaration.specifiers.push(
+            t.importNamespaceSpecifier(t.identifier(importSpecifier.namespace))
+          );
         }
-      });
-    } else {
-      this._ast.program.body.unshift(
-        t.importDeclaration(
-          importSpecifier.map((specifier) =>
-            t.importSpecifier(t.identifier(specifier), t.identifier(specifier))
-          ),
-          t.stringLiteral(fromImport)
-        )
-      );
+      } else {
+        this._ast.program.body.unshift(
+          t.importDeclaration(
+            [t.importNamespaceSpecifier(t.identifier(importSpecifier.namespace))],
+            t.stringLiteral(fromImport)
+          )
+        );
+      }
     }
   }
 }

--- a/code/frameworks/react-vite/template/stories/csf4.stories.tsx
+++ b/code/frameworks/react-vite/template/stories/csf4.stories.tsx
@@ -3,10 +3,8 @@ import React from 'react';
 import { config } from '#.storybook/preview';
 
 // eslint-disable-next-line storybook/default-exports
-const Button = ({ label }) => <button>{label}</button>;
-
 const meta = config.meta({
-  component: Button,
+  component: globalThis.Components.Button,
   args: {
     label: 'Hello world!',
   },

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -825,12 +825,43 @@ export const extendPreview: Task['run'] = async ({ template, sandboxDir }) => {
   if (template.expected.framework === '@storybook/react-vite') {
     // add CSF4 style config
     previewConfig.setImport(['defineConfig'], '@storybook/react/preview');
+    // and all of the addons/previewAnnotations that are needed
+    previewConfig.setImport(null, '../src/stories/components');
+    previewConfig.setImport({ namespace: 'addonA11yAnnotations' }, '@storybook/addon-a11y/preview');
+    previewConfig.setImport(
+      { namespace: 'addonActionsAnnotations' },
+      '@storybook/addon-actions/preview'
+    );
+    previewConfig.setImport(
+      { namespace: 'addonTestAnnotations' },
+      '@storybook/experimental-addon-test/preview'
+    );
+    previewConfig.setImport({ namespace: 'coreAnnotations' }, '../template-stories/core/preview');
+    previewConfig.setImport(
+      { namespace: 'toolbarAnnotations' },
+      '../template-stories/addons/toolbars/preview'
+    );
+
     previewConfig.setBodyDeclaration(
       t.exportNamedDeclaration(
         t.variableDeclaration('const', [
           t.variableDeclarator(
             t.identifier('config'),
-            t.callExpression(t.identifier('defineConfig'), [t.identifier('preview')])
+            t.callExpression(t.identifier('defineConfig'), [
+              t.objectExpression([
+                t.spreadElement(t.identifier('preview')),
+                t.objectProperty(
+                  t.identifier('addons'),
+                  t.arrayExpression([
+                    t.identifier('addonA11yAnnotations'),
+                    t.identifier('addonActionsAnnotations'),
+                    t.identifier('addonTestAnnotations'),
+                    t.identifier('coreAnnotations'),
+                    t.identifier('toolbarAnnotations'),
+                  ])
+                ),
+              ]),
+            ])
           ),
         ]),
         []


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the key changes in this pull request:

Updates CSF4 story handling and sandbox configurations, focusing on component references and import management in the Storybook framework.

- Modified `ConfigFile.ts` to support namespace imports and side-effect imports with improved type checking
- Updated `sandbox-parts.ts` to include CSF4 style configuration and addon preview annotations for React Vite template
- Added factory field tracking in `StoryIndexGenerator.test.ts` for CSF4 stories
- Replaced local Button component with `globalThis.Components.Button` reference in React Vite template
- Added test cases in `ConfigFile.test.ts` for namespaced imports and imports without specifiers



<!-- /greptile_comment -->