### PR TITLE
Vite: Fix wrong import paths when configDir is not in project root

### DIFF
--- a/code/builders/builder-vite/src/codegen-importfn-script.test.ts
+++ b/code/builders/builder-vite/src/codegen-importfn-script.test.ts
@@ -1,13 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { toImportFn } from './codegen-importfn-script';
 
 describe('toImportFn', () => {
   it('should correctly map story paths to import functions for absolute paths on Linux', async () => {
-    const root = '/absolute/path';
+    vi.spyOn(process, 'cwd').mockReturnValue('/absolute/path');
+
     const stories = ['/absolute/path/to/story1.js', '/absolute/path/to/story2.js'];
 
-    const result = await toImportFn(root, stories);
+    const result = await toImportFn(stories);
 
     expect(result).toMatchInlineSnapshot(`
       "const importers = {
@@ -22,10 +23,10 @@ describe('toImportFn', () => {
   });
 
   it('should correctly map story paths to import functions for absolute paths on Windows', async () => {
-    const root = 'C:\\absolute\\path';
+    vi.spyOn(process, 'cwd').mockReturnValue('C:\\absolute\\path');
     const stories = ['C:\\absolute\\path\\to\\story1.js', 'C:\\absolute\\path\\to\\story2.js'];
 
-    const result = await toImportFn(root, stories);
+    const result = await toImportFn(stories);
 
     expect(result).toMatchInlineSnapshot(`
       "const importers = {
@@ -43,7 +44,7 @@ describe('toImportFn', () => {
     const root = '/absolute/path';
     const stories: string[] = [];
 
-    const result = await toImportFn(root, stories);
+    const result = await toImportFn(stories);
 
     expect(result).toMatchInlineSnapshot(`
       "const importers = {};

--- a/code/builders/builder-vite/src/codegen-importfn-script.ts
+++ b/code/builders/builder-vite/src/codegen-importfn-script.ts
@@ -29,9 +29,9 @@ function toImportPath(relativePath: string) {
  *
  * @param stories An array of absolute story paths.
  */
-export async function toImportFn(root: string, stories: string[]) {
+export async function toImportFn(stories: string[]) {
   const objectEntries = stories.map((file) => {
-    const relativePath = relative(root, file);
+    const relativePath = relative(process.cwd(), file);
 
     return [toImportPath(relativePath), genDynamicImport(normalize(file))] as [string, string];
   });
@@ -51,5 +51,5 @@ export async function generateImportFnScriptCode(options: Options): Promise<stri
 
   // We can then call toImportFn to create a function that can be used to load each story dynamically.
   // eslint-disable-next-line @typescript-eslint/return-await
-  return await toImportFn(options.projectRoot || process.cwd(), stories);
+  return await toImportFn(stories);
 }

--- a/code/builders/builder-vite/src/vite-config.ts
+++ b/code/builders/builder-vite/src/vite-config.ts
@@ -53,18 +53,18 @@ export async function commonConfig(
 
   const { viteConfigPath } = await getBuilderOptions<BuilderOptions>(options);
 
-  options.projectRoot = options.projectRoot || resolve(options.configDir, '..');
+  const projectRoot = resolve(options.configDir, '..');
 
   // I destructure away the `build` property from the user's config object
   // I do this because I can contain config that breaks storybook, such as we had in a lit project.
   // If the user needs to configure the `build` they need to do so in the viteFinal function in main.js.
   const { config: { build: buildProperty = undefined, ...userConfig } = {} } =
-    (await loadConfigFromFile(configEnv, viteConfigPath, options.projectRoot)) ?? {};
+    (await loadConfigFromFile(configEnv, viteConfigPath, projectRoot)) ?? {};
 
   const sbConfig: InlineConfig = {
     configFile: false,
     cacheDir: resolvePathInStorybookCache('sb-vite', options.cacheKey),
-    root: options.projectRoot,
+    root: projectRoot,
     // Allow storybook deployed as subfolder.  See https://github.com/storybookjs/builder-vite/issues/238
     base: './',
     plugins: await pluginConfig(options),

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -195,7 +195,6 @@ export interface BuilderOptions {
   ignorePreview?: boolean;
   cache?: FileSystemCache;
   configDir: string;
-  projectRoot?: string;
   docsMode?: boolean;
   features?: StorybookConfigRaw['features'];
   versionCheck?: VersionCheck;


### PR DESCRIPTION
Closes #30147

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes a regression in https://github.com/storybookjs/storybook/pull/28941, that caused import paths to be relative to the wrong directory if the config directory (aka `.storybook`) was not a direct child of the project root. The problem was originally discussed in https://github.com/storybookjs/storybook/pull/28941#discussion_r1754282965 but was unfortunately missed in the end.

The idea of a custom `projectRoot` was good, but right now there are just a lot of implicit logic that depends on the path being relative to CWD, so the easiest fix was just to more or less revert https://github.com/storybookjs/storybook/pull/28941/commits/c9107a1f0224e070a2865f0badc6a9c0ad95ac50 .

cc @tobiasdiez 

I applied these changes to the reproduction provided in the original issue and confirmed they fix it.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a new Vite-based sandbox
2. Move the `.storybook` directory to a nested one, eg. to `deeply/nested/.storybook`.
3. Fix the `stories` glob in `main.ts` to be correctly relative to the new location
4. Change the `storybook` script in `package.json` to point to the new directory with the flag `-c deeply/nested/.storybook`
5. Run Storybook and ensure that stories correctly render.

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
6. Open Storybook in your browser
7. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 590 B | 0.47 | 0% |
| initSize |  131 MB | 131 MB | 406 B | **-1.36** | 0% |
| diffSize |  53 MB | 53 MB | -184 B | **-1.36** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | -0.33 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.31 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.14 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | -0.31 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | **-2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.6s | 16.3s | -7s -314ms | 0.49 | -44.8% |
| generateTime |  21.9s | 20.6s | -1s -289ms | 0.4 | -6.2% |
| initTime |  15.5s | 14.7s | -815ms | 0.84 | -5.5% |
| buildTime |  8.7s | 7.6s | -1s -23ms | **-1.64** | 🔰-13.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.1s | 4.5s | -635ms | **-1.27** | 🔰-14.1% |
| devManagerResponsive |  3.7s | 3.4s | -272ms | -1.08 | -7.9% |
| devManagerHeaderVisible |  605ms | 541ms | -64ms | **-1.51** | 🔰-11.8% |
| devManagerIndexVisible |  635ms | 567ms | -68ms | **-1.52** | 🔰-12% |
| devStoryVisibleUncached |  2s | 1.9s | -105ms | -0.06 | -5.3% |
| devStoryVisible |  636ms | 568ms | -68ms | **-1.73** | 🔰-12% |
| devAutodocsVisible |  491ms | 447ms | -44ms | **-1.81** | 🔰-9.8% |
| devMDXVisible |  525ms | 487ms | -38ms | -0.95 | -7.8% |
| buildManagerHeaderVisible |  519ms | 548ms | 29ms | -0.87 | 5.3% |
| buildManagerIndexVisible |  610ms | 636ms | 26ms | -0.97 | 4.1% |
| buildStoryVisible |  510ms | 525ms | 15ms | -1.03 | 2.9% |
| buildAutodocsVisible |  427ms | 450ms | 23ms | -0.87 | 5.1% |
| buildMDXVisible |  485ms | 463ms | -22ms | -0.39 | -4.8% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR fixes import path resolution in the Vite builder when the Storybook config directory is not in the project root.

- Removed `projectRoot` parameter from `toImportFn` in `code/builders/builder-vite/src/codegen-importfn-script.ts` to use `process.cwd()` consistently
- Updated tests in `codegen-importfn-script.test.ts` to mock `process.cwd()` instead of passing root parameter
- Reverted changes from PR #28941 in `vite-config.ts` to restore correct path resolution behavior
- Removed `projectRoot` property from `BuilderOptions` interface in `core-common.ts`



<!-- /greptile_comment -->