### PR TITLE
Addon Test: Improve support for mono-repos

### DIFF
--- a/code/addons/test/src/node/vitest-manager.ts
+++ b/code/addons/test/src/node/vitest-manager.ts
@@ -25,6 +25,7 @@ import { StorybookReporter } from './reporter';
 import type { TestManager } from './test-manager';
 
 const VITEST_CONFIG_FILE_EXTENSIONS = ['mts', 'mjs', 'cts', 'cjs', 'ts', 'tsx', 'js', 'jsx'];
+const VITEST_WORKSPACE_FILE_EXTENSION = ['ts', 'js', 'json'];
 
 type TagsFilter = {
   include: string[];
@@ -72,9 +73,7 @@ export class VitestManager {
     ) as CoverageOptions;
 
     const vitestWorkspaceConfig = await findUp([
-      'vitest.workspace.ts',
-      'vitest.workspace.js',
-      'vitest.workspace.json',
+      ...VITEST_WORKSPACE_FILE_EXTENSION.map((ext) => `vitest.workspace.${ext}`),
       ...VITEST_CONFIG_FILE_EXTENSIONS.map((ext) => `vitest.config.${ext}`),
     ]);
 

--- a/code/addons/test/src/postinstall.ts
+++ b/code/addons/test/src/postinstall.ts
@@ -419,6 +419,12 @@ export default async function postInstall(options: PostinstallOptions) {
       dedent`
         import { defineWorkspace } from 'vitest/config';
         import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';${vitestInfo.frameworkPluginImport}
+        import path from 'node:path';
+        import { fileURLToPath } from 'node:url';
+
+        const dirname = typeof __dirname !== 'undefined'
+          ? __dirname
+          : path.dirname(fileURLToPath(import.meta.url));
 
         // More info at: https://storybook.js.org/docs/writing-tests/test-addon
         export default defineWorkspace([
@@ -428,7 +434,7 @@ export default async function postInstall(options: PostinstallOptions) {
             plugins: [
               // The plugin will run tests for the stories defined in your Storybook config
               // See options at: https://storybook.js.org/docs/writing-tests/test-addon#storybooktest
-              storybookTest({ configDir: '${options.configDir}' }),${vitestInfo.frameworkPluginDocs + vitestInfo.frameworkPluginCall}
+              storybookTest({ configDir: path.join(dirname, '${options.configDir}') }),${vitestInfo.frameworkPluginDocs + vitestInfo.frameworkPluginCall}
             ],
             test: {
               name: 'storybook',
@@ -459,13 +465,19 @@ export default async function postInstall(options: PostinstallOptions) {
       dedent`
         import { defineConfig } from 'vitest/config';
         import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';${vitestInfo.frameworkPluginImport}
+        import path from 'node:path';
+        import { fileURLToPath } from 'node:url';
+
+        const dirname = typeof __dirname !== 'undefined'
+          ? __dirname
+          : path.dirname(fileURLToPath(import.meta.url));
 
         // More info at: https://storybook.js.org/docs/writing-tests/test-addon
         export default defineConfig({
           plugins: [
             // The plugin will run tests for the stories defined in your Storybook config
             // See options at: https://storybook.js.org/docs/writing-tests/test-addon#storybooktest
-            storybookTest({ configDir: '${options.configDir}' }),${vitestInfo.frameworkPluginDocs + vitestInfo.frameworkPluginCall}
+            storybookTest({ configDir: path.join(dirname, '${options.configDir}') }),${vitestInfo.frameworkPluginDocs + vitestInfo.frameworkPluginCall}
           ],
           test: {
             name: 'storybook',

--- a/docs/_snippets/vitest-plugin-vitest-config.md
+++ b/docs/_snippets/vitest-plugin-vitest-config.md
@@ -1,8 +1,13 @@
 ```ts filename="vitest.config.ts" renderer="react"
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 // 👇 If you're using Next.js, apply this framework plugin as well
 // import { storybookNextJsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 import viteConfig from './vite.config';
 
@@ -12,7 +17,7 @@ export default mergeConfig(
     plugins: [
       storybookTest({
         // The location of your Storybook config, main.js|ts
-        configDir: './.storybook',
+        configDir: path.join(dirname, '.storybook'),
         // This should match your package.json script to run Storybook
         // The --ci flag will skip prompts and not open a browser
         storybookScript: 'yarn storybook --ci',
@@ -38,8 +43,13 @@ export default mergeConfig(
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
 import { storybookVuePlugin } from '@storybook/vue3-vite/vite-plugin';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import viteConfig from './vite.config';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default mergeConfig(
   viteConfig,
@@ -47,7 +57,7 @@ export default mergeConfig(
     plugins: [
       storybookTest({
         // The location of your Storybook config, main.js|ts
-        configDir: './.storybook',
+        configDir: path.join(dirname, '.storybook'),
         // This should match your package.json script to run Storybook
         // The --ci flag will skip prompts and not open a browser
         storybookScript: 'yarn storybook --ci',
@@ -72,8 +82,13 @@ export default mergeConfig(
 ```ts filename="vitest.config.ts" renderer="svelte"
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 // 👇 If you're using Sveltekit, apply this framework plugin as well
 // import { storybookSveltekitPlugin } from '@storybook/sveltekit/vite-plugin';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 import viteConfig from './vite.config';
 
@@ -83,7 +98,7 @@ export default mergeConfig(
     plugins: [
       storybookTest({
         // The location of your Storybook config, main.js|ts
-        configDir: './.storybook',
+        configDir: path.join(dirname, '.storybook'),
         // This should match your package.json script to run Storybook
         // The --ci flag will skip prompts and not open a browser
         storybookScript: 'yarn storybook --ci',

--- a/docs/_snippets/vitest-plugin-vitest-workspace.md
+++ b/docs/_snippets/vitest-plugin-vitest-workspace.md
@@ -63,7 +63,7 @@ export default defineWorkspace([
     plugins: [
       storybookTest({
         // The location of your Storybook config, main.js|ts
-        configDir: path.join(dirname, './.storybook'),
+        configDir: path.join(dirname, '.storybook'),
         // This should match your package.json script to run Storybook
         // The --ci flag will skip prompts and not open a browser
         storybookScript: 'yarn storybook --ci',
@@ -109,7 +109,7 @@ export default defineWorkspace([
     plugins: [
       storybookTest({
         // The location of your Storybook config, main.js|ts
-        configDir: path.join(dirname, './.storybook'),
+        configDir: path.join(dirname, '.storybook'),
         // This should match your package.json script to run Storybook
         // The --ci flag will skip prompts and not open a browser
         storybookScript: 'yarn storybook --ci',

--- a/docs/_snippets/vitest-plugin-vitest-workspace.md
+++ b/docs/_snippets/vitest-plugin-vitest-workspace.md
@@ -1,8 +1,14 @@
 ```ts filename="vitest.workspace.ts" renderer="react"
 import { defineWorkspace } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 // 👇 If you're using Next.js, apply this framework plugin as well
 // import { storybookNextJsPlugin } from '@storybook/experimental-nextjs-vite/vite-plugin';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineWorkspace([
   // This is the path to your existing Vitest config file
@@ -13,7 +19,7 @@ export default defineWorkspace([
     plugins: [
       storybookTest({
         // The location of your Storybook config, main.js|ts
-        configDir: './.storybook',
+        configDir: path.join(dirname, '.storybook'),
         // This should match your package.json script to run Storybook
         // The --ci flag will skip prompts and not open a browser
         storybookScript: 'yarn storybook --ci',
@@ -40,8 +46,13 @@ export default defineWorkspace([
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
 import { storybookVuePlugin } from '@storybook/vue3-vite/vite-plugin';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import viteConfig from './vite.config';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineWorkspace([
   // This is the path to your existing Vitest config file
@@ -52,7 +63,7 @@ export default defineWorkspace([
     plugins: [
       storybookTest({
         // The location of your Storybook config, main.js|ts
-        configDir: './.storybook',
+        configDir: path.join(dirname, './.storybook'),
         // This should match your package.json script to run Storybook
         // The --ci flag will skip prompts and not open a browser
         storybookScript: 'yarn storybook --ci',
@@ -78,10 +89,16 @@ export default defineWorkspace([
 ```ts filename="vitest.config.ts" renderer="svelte"
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 // 👇 If you're using Sveltekit, apply this framework plugin as well
 // import { storybookSveltekitPlugin } from '@storybook/sveltekit/vite-plugin';
 
 import viteConfig from './vite.config';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineWorkspace([
   // This is the path to your existing Vitest config file
@@ -92,7 +109,7 @@ export default defineWorkspace([
     plugins: [
       storybookTest({
         // The location of your Storybook config, main.js|ts
-        configDir: './.storybook',
+        configDir: path.join(dirname, './.storybook'),
         // This should match your package.json script to run Storybook
         // The --ci flag will skip prompts and not open a browser
         storybookScript: 'yarn storybook --ci',

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -480,13 +480,22 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
     dedent`
       import { defineWorkspace, defaultExclude } from "vitest/config";
       import { storybookTest } from "@storybook/experimental-addon-test/vitest-plugin";
+      import path from 'node:path';
+      import { fileURLToPath } from 'node:url';
+
+      import viteConfig from './vite.config';
+
       ${frameworkPluginImport}
+
+      const dirname =
+        typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
       export default defineWorkspace([
         {
           ${!isNextjs ? `extends: "${viteConfigPath}",` : ''}
           plugins: [
             storybookTest({
+              configDir: path.join(dirname, '.storybook'),
               storybookScript: "yarn storybook --ci",
               tags: {
                 include: ["vitest"],


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR improves the compatibility of `@storybook/experimental-addon-test` in mono repos.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30216-sha-fd79fd61`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30216-sha-fd79fd61 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30216-sha-fd79fd61 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30216-sha-fd79fd61`](https://npmjs.com/package/storybook/v/0.0.0-pr-30216-sha-fd79fd61) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/improve-monorepo-support-for-addon-test`](https://github.com/storybookjs/storybook/tree/valentin/improve-monorepo-support-for-addon-test) |
| **Commit** | [`fd79fd61`](https://github.com/storybookjs/storybook/commit/fd79fd61c3f07e027cd959d57030c4364ecd1fa3) |
| **Datetime** | Wed Jan  8 13:37:21 UTC 2025 (`1736343441`) |
| **Workflow run** | [12671715430](https://github.com/storybookjs/storybook/actions/runs/12671715430) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30216`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 692 B | -0.31 | 0% |
| initSize |  131 MB | 131 MB | 692 B | -0.65 | 0% |
| diffSize |  53 MB | 53 MB | 0 B | -0.65 | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | **1.67** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | -1.22 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | -1.22 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | **1.7** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.6s | 23.9s | 17.3s | **1.27** | 🔺72.3% |
| generateTime |  19.2s | 20.6s | 1.3s | -0.02 | 6.5% |
| initTime |  13.7s | 13.8s | 13ms | -0.17 | 0.1% |
| buildTime |  9s | 9.6s | 519ms | -0.12 | 5.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.9s | 5s | 73ms | -0.43 | 1.5% |
| devManagerResponsive |  3.7s | 3.6s | -86ms | -0.67 | -2.4% |
| devManagerHeaderVisible |  586ms | 722ms | 136ms | **1.38** | 🔺18.8% |
| devManagerIndexVisible |  617ms | 748ms | 131ms | 1.12 | 17.5% |
| devStoryVisibleUncached |  2s | 1.6s | -380ms | -0.97 | -22.7% |
| devStoryVisible |  618ms | 746ms | 128ms | 1.02 | 17.2% |
| devAutodocsVisible |  444ms | 697ms | 253ms | **1.41** | 🔺36.3% |
| devMDXVisible |  502ms | 663ms | 161ms | **1.56** | 🔺24.3% |
| buildManagerHeaderVisible |  642ms | 604ms | -38ms | -0.4 | -6.3% |
| buildManagerIndexVisible |  741ms | 695ms | -46ms | -0.52 | -6.6% |
| buildStoryVisible |  610ms | 585ms | -25ms | -0.39 | -4.3% |
| buildAutodocsVisible |  548ms | 574ms | 26ms | 1.13 | 4.5% |
| buildMDXVisible |  487ms | 541ms | 54ms | 0.89 | 10% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Improved path resolution and configuration handling for the Storybook test addon to better support monorepo setups.

- Added `findUp` utility to locate Vitest config files in parent directories in `code/addons/test/src/node/vitest-manager.ts`
- Updated path resolution in postinstall script using `path.join()` with proper `dirname` handling for ESM/CJS compatibility
- Added support for multiple Vitest config file extensions (`.ts`, `.js`, `.json`) in workspace configurations
- Updated documentation with proper path resolution examples for React, Vue, and Svelte configurations in monorepos



<!-- /greptile_comment -->