### PR TITLE
Build: Fix infinite reloading of internal storybook

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -160,6 +160,12 @@ const config: StorybookConfig = {
         // disable sourcemaps in CI to not run out of memory
         sourcemap: process.env.CI !== 'true',
       },
+      server: {
+        watch: {
+          // Something odd happens with tsconfig and nx which causes Storybook to keep reloading, so we ignore them
+          ignored: ['**/.nx/cache/**', '**/tsconfig.json'],
+        },
+      },
     } satisfies typeof viteConfig);
   },
   // logLevel: 'debug',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes this annoying behavior in `yarn storybook:ui` in the internal storybook

<img width="606" alt="image" src="https://github.com/user-attachments/assets/a74e4f78-6b32-4b48-8494-84e7d90202b0" />

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 692 B | -0.31 | 0% |
| initSize |  131 MB | 131 MB | 692 B | -0.65 | 0% |
| diffSize |  53 MB | 53 MB | 0 B | -0.65 | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | **1.67** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | -1.22 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | -1.22 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | **1.7** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.6s | 7.6s | 1s | -1.09 | 13.2% |
| generateTime |  19.2s | 23.5s | 4.2s | **2.09** | 🔺18.2% |
| initTime |  13.7s | 15.9s | 2.1s | **1.55** | 🔺13.6% |
| buildTime |  9s | 8.4s | -630ms | **-1.35** | 🔰-7.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.9s | 4.5s | -410ms | **-1.3** | 🔰-9% |
| devManagerResponsive |  3.7s | 3.4s | -262ms | -1.16 | -7.6% |
| devManagerHeaderVisible |  586ms | 679ms | 93ms | 0.64 | 13.7% |
| devManagerIndexVisible |  617ms | 755ms | 138ms | **1.24** | 🔺18.3% |
| devStoryVisibleUncached |  2s | 2s | -53ms | -0.21 | -2.6% |
| devStoryVisible |  618ms | 752ms | 134ms | 1.12 | 17.8% |
| devAutodocsVisible |  444ms | 563ms | 119ms | -0.18 | 21.1% |
| devMDXVisible |  502ms | 573ms | 71ms | 0.24 | 12.4% |
| buildManagerHeaderVisible |  642ms | 579ms | -63ms | -0.66 | -10.9% |
| buildManagerIndexVisible |  741ms | 689ms | -52ms | -0.58 | -7.5% |
| buildStoryVisible |  610ms | 558ms | -52ms | -0.72 | -9.3% |
| buildAutodocsVisible |  548ms | 447ms | -101ms | -1.1 | -22.6% |
| buildMDXVisible |  487ms | 454ms | -33ms | -0.81 | -7.3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request changes:

Fixed infinite reloading issue in internal Storybook setup by modifying the Vite server watch configuration in code/.storybook/main.ts.

- Added `server.watch.ignored` patterns in Vite config to exclude `.nx/cache` and `tsconfig.json` files
- Prevents unnecessary reloading triggered by build cache and TypeScript config changes
- Improves development workflow by eliminating disruptive reload loops
- Change is specific to internal Storybook development environment

The changes are focused and minimal, addressing a specific development workflow issue without impacting the core functionality or addons.



<!-- /greptile_comment -->