### PR TITLE
Benchmark: Fix script breaking when base branch has slashes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,8 +256,6 @@ jobs:
                   yarn bench-packages --upload
       - store_artifacts:
           path: bench/packages/results.json
-      - store_artifacts:
-          path: bench/packages/compare-with-<< pipeline.parameters.ghBaseBranch >>.json
       - report-workflow-on-failure
       - cancel-workflow-on-failure
   check:

--- a/docs/writing-tests/test-addon.mdx
+++ b/docs/writing-tests/test-addon.mdx
@@ -434,12 +434,6 @@ If the URLs are not working when running tests in CI, you should ensure the Stor
 
 If your stories use assets in the public directory and you're not using the default public directory location (`public`), you need to adjust the Vitest configuration to include the public directory. You can do this by providing the [`publicDir` option in the Vitest configuration file](https://vitejs.dev/config/shared-options.html#publicdir).
 
-### How do I apply custom Vite configuration?
-
-Your Storybook project's Vite configuration (in [`viteFinal`](../api/main-config/main-config-vite-final.mdx) in your `.storybook/main.js|ts` file) is automatically applied to your Vitest configuration, with one exception: the plugins.
-
-If you are running any plugins in `viteFinal`, you will likely also need to run those in the Vitest configuration.
-
 ### How do I isolate Storybook tests from others?
 
 Some projects might contain a `test` property in their Vite configuration. Because the Vitest configuration used by this plugin extends that Vite config, the `test` properties are merged. This lack of isolation can cause issues with your Storybook tests.

--- a/scripts/bench/bench-packages.ts
+++ b/scripts/bench/bench-packages.ts
@@ -460,16 +460,6 @@ const run = async () => {
   if (options.baseBranch) {
     const comparisonResults = await compareResults({ results, baseBranch: options.baseBranch });
     const resultsAboveThreshold = filterResultsByThresholds(comparisonResults);
-    await saveLocally({
-      filename: `compare-with-${options.baseBranch}.json`,
-      results: comparisonResults,
-      diff: true,
-    });
-    await saveLocally({
-      filename: `comparisons-above-threshold-with-${options.baseBranch}.json`,
-      results: resultsAboveThreshold,
-      diff: true,
-    });
     if (options.pullRequest) {
       await uploadToGithub({
         results: resultsAboveThreshold,


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Disabled saving comparison results to disk, only saving the raw results. They were causing issues when the base branch had a slash in them, because that would lead to mangled file names. No one looks at these files, so let's just stop generating them.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 0 B | **-2.12** | 0% |
| initSize |  131 MB | 131 MB | 0 B | -0.34 | 0% |
| diffSize |  53 MB | 53 MB | 0 B | -0.33 | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | 1.08 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | -0.82 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | -0.82 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | 1.09 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  11.8s | 7.3s | -4s -475ms | **-1.27** | 🔰-60.6% |
| generateTime |  22.5s | 20.6s | -1s -928ms | 0.02 | -9.4% |
| initTime |  15.1s | 13.9s | -1s -204ms | -0.06 | -8.7% |
| buildTime |  8.2s | 8.8s | 553ms | -0.68 | 6.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.2s | 4.2s | -1s -50ms | **-1.63** | 🔰-24.9% |
| devManagerResponsive |  3.9s | 3.1s | -803ms | **-1.63** | 🔰-25.4% |
| devManagerHeaderVisible |  586ms | 551ms | -35ms | -1.19 | -6.4% |
| devManagerIndexVisible |  613ms | 576ms | -37ms | **-1.31** | 🔰-6.4% |
| devStoryVisibleUncached |  2.1s | 1.8s | -369ms | -0.64 | -20.3% |
| devStoryVisible |  614ms | 577ms | -37ms | **-1.4** | 🔰-6.4% |
| devAutodocsVisible |  549ms | 455ms | -94ms | **-1.25** | 🔰-20.7% |
| devMDXVisible |  490ms | 576ms | 86ms | 0.31 | 14.9% |
| buildManagerHeaderVisible |  530ms | 509ms | -21ms | -1.12 | -4.1% |
| buildManagerIndexVisible |  621ms | 618ms | -3ms | -0.92 | -0.5% |
| buildStoryVisible |  519ms | 499ms | -20ms | -1.14 | -4% |
| buildAutodocsVisible |  415ms | 413ms | -2ms | **-1.4** | -0.5% |
| buildMDXVisible |  407ms | 485ms | 78ms | 0.06 | 16.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Simplified benchmarking process by removing storage of comparison results to disk, while maintaining core functionality and raw results storage, to fix issues with base branch names containing slashes.

- Removed comparison results JSON artifact storage in `.circleci/config.yml`
- Removed `saveLocally()` calls for comparison results in `scripts/bench/bench-packages.ts`
- Maintained raw results.json storage as CircleCI artifact
- Preserved core benchmarking functionality including BigQuery and GitHub uploads



<!-- /greptile_comment -->