### PR TITLE
Addon Docs: Make new code panel opt in

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -434,7 +434,7 @@ As part of our ongoing efforts to improve the testability and debuggability of S
 In development mode, React and other libraries often include additional checks and warnings that help catch potential issues early. These checks are usually stripped out in production builds to optimize performance. However, when running tests or debugging issues in a built Storybook, having these additional checks can be incredibly valuable. One such feature is React's `act`, which ensures that all updates related to a test are processed and applied before making assertions. `act` is crucial for reliable and predictable test results, but it only works correctly when `NODE_ENV` is set to `development`.
 
 ```js
-// main.js
+// .storybook/main.js
 export default {
   features: {
     developmentModeForBuild: true,
@@ -444,15 +444,16 @@ export default {
 
 ### Added source code panel to docs
 
-Starting in 8.5, Storybook Docs (`@storybook/addon-docs`) automatically adds a new addon panel to stories that displays a source snippet beneath each story. This works similarly to the existing [source snippet doc block](https://storybook.js.org/docs/writing-docs/doc-blocks#source), but in the story view. It is intended to replace the [Storysource addon](https://storybook.js.org/addons/@storybook/addon-storysource).
+Storybook Docs (`@storybook/addon-docs`) now can automatically add a new addon panel to stories that displays a source snippet beneath each story. This is an experimental feature that works similarly to the existing [source snippet doc block](https://storybook.js.org/docs/writing-docs/doc-blocks#source), but in the story view. It is intended to replace the [Storysource addon](https://storybook.js.org/addons/@storybook/addon-storysource).
 
-If you wish to disable this panel globally, add the following line to your `.storybook/preview.js` project configuration. You can also selectively disable/enable at the story level.
+To enable this globally, add the following line to your project configuration. You can also configure at the component/story level.
 
 ```js
+// .storybook/preview.js
 export default {
   parameters: {
     docs: {
-      codePanel: false,
+      codePanel: true,
     },
   },
 };

--- a/code/addons/docs/src/manager.tsx
+++ b/code/addons/docs/src/manager.tsx
@@ -12,25 +12,19 @@ addons.register(ADDON_ID, (api) => {
     type: types.PANEL,
     paramKey: PARAM_KEY,
     /**
-     * This code panel can be disabled by the user by adding this parameter:
+     * This code panel can be enabled by adding this parameter:
      *
      * @example
      *
      * ```ts
      *  parameters: {
      *    docs: {
-     *      codePanel: false,
+     *      codePanel: true,
      *    },
      *  },
      * ```
      */
-    disabled: (parameters) => {
-      return (
-        !!parameters &&
-        typeof parameters[PARAM_KEY] === 'object' &&
-        parameters[PARAM_KEY].codePanel === false
-      );
-    },
+    disabled: (parameters) => !parameters?.docs?.codePanel,
     match: ({ viewMode }) => viewMode === 'story',
     render: ({ active }) => {
       const [codeSnippet, setSourceCode] = useAddonState<{

--- a/code/core/src/manager/container/Panel.tsx
+++ b/code/core/src/manager/container/Panel.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React from 'react';
 
-import { Addon_TypesEnum } from '@storybook/core/types';
+import { type API_LeafEntry, Addon_TypesEnum } from '@storybook/core/types';
 
 import { Consumer } from '@storybook/core/manager-api';
 import type { API, Combo } from '@storybook/core/manager-api';
@@ -16,9 +16,8 @@ const createPanelActions = memoize(1)((api) => ({
   togglePosition: () => api.togglePanelPosition(),
 }));
 
-const getPanels = memoize(1)((api: API) => {
+const getPanels = memoize(1)((api: API, story: API_LeafEntry) => {
   const allPanels = api.getElements(Addon_TypesEnum.PANEL);
-  const story = api.getCurrentStoryData();
 
   if (!allPanels || !story || story.type !== 'story') {
     return allPanels;
@@ -45,7 +44,7 @@ const getPanels = memoize(1)((api: API) => {
 });
 
 const mapper = ({ state, api }: Combo) => ({
-  panels: getPanels(api),
+  panels: getPanels(api, api.getCurrentStoryData()),
   selectedPanel: api.getSelectedPanel(),
   panelPosition: state.layout.panelPosition,
   actions: createPanelActions(api),


### PR DESCRIPTION
Closes N/A

## What I did

There are some open questions about the new code panel. Since we don't have time to address them before 8.5, making the panel opt in instead of opt out for now.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- Run a storybook on the branch/canary and observe no `Code` panel by default
- Set the `docs.codePanel` parameter to `true` and observe the `Code` panel when you restart your storybook.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 0 B | **1.97** | 0% |
| initSize |  131 MB | 131 MB | -18.9 kB | 0.36 | 0% |
| diffSize |  53 MB | 52.9 MB | -18.9 kB | **-38.14** | 0% |
| buildSize |  7.19 MB | 7.19 MB | -31 B | 0.17 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | -30 B | **-Infinity** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | -1 B | -0.61 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | -31 B | **-8.94** | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | 0.58 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.8s | 25.9s | 19s | **1.28** | 🔺73.5% |
| generateTime |  20.9s | 19.9s | -1s -36ms | -0.7 | -5.2% |
| initTime |  14.2s | 13s | -1s -185ms | -1 | -9.1% |
| buildTime |  10.7s | 10.6s | -131ms | 1.02 | -1.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5s | 5.6s | 586ms | **1.74** | 🔺10.3% |
| devManagerResponsive |  3.9s | 4.2s | 337ms | **2.27** | 🔺7.8% |
| devManagerHeaderVisible |  647ms | 708ms | 61ms | **1.33** | 🔺8.6% |
| devManagerIndexVisible |  724ms | 739ms | 15ms | 1.08 | 2% |
| devStoryVisibleUncached |  1.9s | 2.2s | 262ms | 1.05 | 11.9% |
| devStoryVisible |  722ms | 740ms | 18ms | 1.05 | 2.4% |
| devAutodocsVisible |  525ms | 660ms | 135ms | **1.51** | 🔺20.5% |
| devMDXVisible |  522ms | 632ms | 110ms | **1.37** | 🔺17.4% |
| buildManagerHeaderVisible |  571ms | 761ms | 190ms | **1.51** | 🔺25% |
| buildManagerIndexVisible |  656ms | 892ms | 236ms | **1.88** | 🔺26.5% |
| buildStoryVisible |  553ms | 737ms | 184ms | **1.8** | 🔺25% |
| buildAutodocsVisible |  435ms | 601ms | 166ms | **2.33** | 🔺27.6% |
| buildMDXVisible |  448ms | 568ms | 120ms | **1.7** | 🔺21.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Makes the code panel in Storybook docs addon opt-in rather than opt-out by default, requiring explicit enablement through the `docs.codePanel` parameter.

- Changed `disabled` logic in `code/addons/docs/src/manager.tsx` to disable panel by default
- Panel can be enabled via `parameters.docs.codePanel = true` 
- Replaces previous Storysource addon functionality
- Configurable at both global and story level



<!-- /greptile_comment -->