### PR TITLE
Addon A11y: Change default element selector

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@
   - [Introducing features.developmentModeForBuild](#introducing-featuresdevelopmentmodeforbuild)
   - [Added source code panel to docs](#added-source-code-panel-to-docs)
   - [Addon-a11y: Component test integration](#addon-a11y-component-test-integration)
+  - [Addon-a11y: Changing the default element selector](#addon-a11y-changing-the-default-element-selector)
   - [Addon-a11y: Deprecated `parameters.a11y.manual`](#addon-a11y-deprecated-parametersa11ymanual)
   - [Addon-test: You should no longer copy the content of `viteFinal` to your configuration](#addon-test-you-should-no-longer-copy-the-content-of-vitefinal-to-your-configuration)
   - [Addon-test: Indexing behavior of @storybook/experimental-addon-test is changed](#addon-test-indexing-behavior-of-storybookexperimental-addon-test-is-changed)
@@ -482,11 +483,24 @@ const annotations = setProjectAnnotations([
 beforeAll(annotations.beforeAll);
 ```
 
+### Addon-a11y: Changing the default element selector
+
+In Storybook 8.5, we changed the default element selector used by the Accessibility addon from `#storybook-root` to `body`. This change was made to align with the default element selector used by the Test addon when running accessibility tests via Vitest. Additionally, Tooltips or Popovers that are rendered outside the `#storybook-root` element will now be included in the accessibility tests per default allowing for a more comprehensive test coverage. If you want to fall back to the previous behavior, you can set the `a11y.element` parameter in your `.storybook/preview.<ts|js>` configuration:
+
+```diff
+// .storybook/preview.js
+export const parameters = {
+  a11y: {
++    element: '#storybook-root',
+  },
+};
+```
+
 ### Addon-a11y: Deprecated `parameters.a11y.manual`
 
 We have deprecated `parameters.a11y.manual` in 8.5. Please use `globals.a11y.manual` instead.
 
-### Addon-test: You should no longer copy the content of `viteFinal` to your configuration 
+### Addon-test: You should no longer copy the content of `viteFinal` to your configuration
 
 In version 8.4 of `@storybook/experimental-addon-test`, it was required to copy any custom configuration you had in `viteFinal` in `main.ts`, to the Vitest Storybook project. This is no longer necessary, as the Storybook Test plugin will automatically include your `viteFinal` configuration. You should remove any configurations you might already have in `viteFinal` to remove duplicates.
 

--- a/code/addons/a11y/src/a11yRunner.ts
+++ b/code/addons/a11y/src/a11yRunner.ts
@@ -41,7 +41,7 @@ const runNext = async () => {
 export const run = async (input: A11yParameters = defaultParameters) => {
   const { default: axe } = await import('axe-core');
 
-  const { element = '#storybook-root', config = {}, options = {} } = input;
+  const { element = 'body', config = {}, options = {} } = input;
   const htmlElement = document.querySelector(element as string) ?? document.body;
 
   if (!htmlElement) {

--- a/docs/_snippets/storybook-addon-a11y-component-config.md
+++ b/docs/_snippets/storybook-addon-a11y-component-config.md
@@ -8,7 +8,7 @@ const meta: Meta<MyComponent> = {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -52,7 +52,7 @@ export default meta;
     parameters: {
       a11y: {
         // Optional selector to inspect
-        element: '#storybook-root',
+        element: 'body',
         config: {
           rules: [
             {
@@ -92,7 +92,7 @@ export default {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -131,7 +131,7 @@ export default {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -173,7 +173,7 @@ export default {
     parameters: {
       a11y: {
         // Optional selector to inspect
-        element: '#storybook-root',
+        element: 'body',
         config: {
           rules: [
             {
@@ -215,7 +215,7 @@ const meta = {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -259,7 +259,7 @@ const meta = {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -303,7 +303,7 @@ export default meta;
     parameters: {
       a11y: {
         // Optional selector to inspect
-        element: '#storybook-root',
+        element: 'body',
         config: {
           rules: [
             {
@@ -345,7 +345,7 @@ const meta: Meta<typeof MyComponent> = {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -389,7 +389,7 @@ const meta: Meta<typeof MyComponent> = {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -428,7 +428,7 @@ export default {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -467,7 +467,7 @@ const meta: Meta = {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {

--- a/docs/_snippets/storybook-addon-a11y-global-config.md
+++ b/docs/_snippets/storybook-addon-a11y-global-config.md
@@ -3,7 +3,7 @@ export default {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -43,7 +43,7 @@ const preview: Preview = {
   parameters: {
     a11y: {
       // Optional selector to inspect
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {

--- a/docs/_snippets/storybook-addon-a11y-story-config.md
+++ b/docs/_snippets/storybook-addon-a11y-story-config.md
@@ -13,7 +13,7 @@ type Story = StoryObj<MyComponent>;
 export const ExampleStory: Story = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -55,7 +55,7 @@ export default {
 export const ExampleStory = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -102,7 +102,7 @@ type Story = StoryObj<typeof meta>;
 export const ExampleStory: Story = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -149,7 +149,7 @@ type Story = StoryObj<typeof MyComponent>;
 export const ExampleStory: Story = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -196,7 +196,7 @@ export const ExampleStory: Story = {
   name="ExampleStory"
   parameters={{
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -238,7 +238,7 @@ export default {
 export const ExampleStory = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -285,7 +285,7 @@ export const ExampleStory = {
   name="ExampleStory"
   parameters={{
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -332,7 +332,7 @@ type Story = StoryObj<typeof meta>;
 export const ExampleStory: Story = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -379,7 +379,7 @@ export const ExampleStory: Story = {
   name="ExampleStory"
   parameters={{
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -426,7 +426,7 @@ type Story = StoryObj<typeof meta>;
 export const ExampleStory: Story = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -468,7 +468,7 @@ export default {
 export const ExampleStory = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -515,7 +515,7 @@ type Story = StoryObj<typeof meta>;
 export const ExampleStory = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -562,7 +562,7 @@ type Story = StoryObj<typeof MyComponent>;
 export const ExampleStory = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -602,7 +602,7 @@ export default {
 export const ExampleStory = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {
@@ -647,7 +647,7 @@ type Story = StoryObj;
 export const ExampleStory: Story = {
   parameters: {
     a11y: {
-      element: '#storybook-root',
+      element: 'body',
       config: {
         rules: [
           {

--- a/docs/_snippets/test-runner-a11y-config.md
+++ b/docs/_snippets/test-runner-a11y-config.md
@@ -10,7 +10,7 @@ module.exports = {
     await injectAxe(page);
   },
   async postVisit(page) {
-    await checkA11y(page, '#storybook-root', {
+    await checkA11y(page, 'body', {
       detailedReport: true,
       detailedReportOptions: {
         html: true,
@@ -33,7 +33,7 @@ const config: TestRunnerConfig = {
     await injectAxe(page);
   },
   async postVisit(page) {
-    await checkA11y(page, '#storybook-root', {
+    await checkA11y(page, 'body', {
       detailedReport: true,
       detailedReportOptions: {
         html: true,

--- a/docs/_snippets/test-runner-a11y-configure.md
+++ b/docs/_snippets/test-runner-a11y-configure.md
@@ -20,7 +20,7 @@ module.exports = {
       rules: storyContext.parameters?.a11y?.config?.rules,
     });
 
-    const element = storyContext.parameters?.a11y?.element ?? '#storybook-root';
+    const element = storyContext.parameters?.a11y?.element ?? 'body';
     await checkA11y(page, element, {
       detailedReport: true,
       detailedReportOptions: {
@@ -54,7 +54,7 @@ const config: TestRunnerConfig = {
       rules: storyContext.parameters?.a11y?.config?.rules,
     });
 
-    const element = storyContext.parameters?.a11y?.element ?? '#storybook-root';
+    const element = storyContext.parameters?.a11y?.element ?? 'body';
     await checkA11y(page, element, {
       detailedReport: true,
       detailedReportOptions: {

--- a/docs/_snippets/test-runner-a11y-disable.md
+++ b/docs/_snippets/test-runner-a11y-disable.md
@@ -18,7 +18,7 @@ module.exports = {
     if (storyContext.parameters?.a11y?.disable) {
       return;
     }
-    await checkA11y(page, '#storybook-root', {
+    await checkA11y(page, 'body', {
       detailedReport: true,
       detailedReportOptions: {
         html: true,
@@ -50,7 +50,7 @@ const config: TestRunnerConfig = {
     if (storyContext.parameters?.a11y?.disable) {
       return;
     }
-    await checkA11y(page, '#storybook-root', {
+    await checkA11y(page, 'body', {
       detailedReport: true,
       detailedReportOptions: {
         html: true,


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have changed the default `element` selector of `@storybook/addon-a11y` from `#storybook-root` to `body`. I did this mainly to align an a11y test run in Storybook and within an Addon Test run. 

In portable stories, we don't have a `#storybook-root` element; therefore, a11y tests were always running on the `document.body` element as part of a Vitest run. When a11y tests are running as part of the `@storybook/addon-a11y` panel in the Storybook UI, the tests were running against `#storybook-root`. This difference in element selection leads to discrepancies, where, for example, modals or popovers, which are teleported to the document root, were successfully tested as part of a Vitest a11y test run but weren't taken into account when a11y tests were run via the Storybook UI.

`#storybook-root` was taken as the root element in the past for a11y test runs because it contains other Storybook-specific elements like error-boundary components or addon-docs specific elements. `axe`, though, doesn't run a11y tests on hidden elements by default and therefore we see it as uncritical to run a11y tests on the `document.body` instead.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.8 MB | 0 B | 1.1 | 0% |
| initSize |  131 MB | 131 MB | 0 B | 0.08 | 0% |
| diffSize |  52.9 MB | 52.9 MB | 0 B | **-2** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | **-1.98** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | **-2** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | **-2** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | **-2** | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | **2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.8s | 7.3s | 550ms | -0.84 | 7.4% |
| generateTime |  19.3s | 20.7s | 1.3s | -0.08 | 6.4% |
| initTime |  12.7s | 14.3s | 1.5s | 0.09 | 10.8% |
| buildTime |  9.3s | 8.6s | -730ms | -1 | -8.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6s | 5s | -991ms | -0.12 | -19.6% |
| devManagerResponsive |  4.3s | 3.6s | -640ms | -0.17 | -17.3% |
| devManagerHeaderVisible |  998ms | 601ms | -397ms | -0.52 | -66.1% |
| devManagerIndexVisible |  1s | 642ms | -405ms | -0.53 | -63.1% |
| devStoryVisibleUncached |  2.2s | 2.1s | -153ms | 0.7 | -7.2% |
| devStoryVisible |  1s | 680ms | -357ms | -0.21 | -52.5% |
| devAutodocsVisible |  858ms | 602ms | -256ms | 0.23 | -42.5% |
| devMDXVisible |  779ms | 503ms | -276ms | -0.74 | -54.9% |
| buildManagerHeaderVisible |  801ms | 596ms | -205ms | -0.16 | -34.4% |
| buildManagerIndexVisible |  818ms | 725ms | -93ms | 0.31 | -12.8% |
| buildStoryVisible |  792ms | 567ms | -225ms | -0.31 | -39.7% |
| buildAutodocsVisible |  612ms | 478ms | -134ms | -0.08 | -28% |
| buildMDXVisible |  614ms | 438ms | -176ms | -0.67 | -40.2% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the key changes in this PR:

Changed the default element selector in Storybook's accessibility addon from '#storybook-root' to 'document.body' to ensure consistent testing behavior across environments.

- Modified `code/addons/a11y/src/a11yRunner.ts` to use document.body as default element for a11y testing
- Updated test runner configurations to align with new default element selector
- Changed documentation examples to reflect new default behavior in accessibility testing
- Improved testing coverage for teleported elements like modals and popovers
- Safe change since axe-core ignores hidden elements by default, preventing unwanted testing of Storybook UI elements



<!-- /greptile_comment -->