### PR TITLE
Csf Tools: Support CSF factories in enrichCsf source extraction

### DIFF
--- a/code/core/src/csf-tools/enrichCsf.test.ts
+++ b/code/core/src/csf-tools/enrichCsf.test.ts
@@ -149,6 +149,51 @@ describe('enrichCsf', () => {
         };
       `);
     });
+    it('csf4', () => {
+      expect(
+        enrich(
+          dedent`
+          // compiled code
+          import {config} from "/.storybook/preview.ts";
+          const meta = config.meta({
+              args: {
+                label: "Hello world!"
+              }
+          });
+          export const Story = meta.story({});
+        `,
+          dedent`
+          // original code
+          import {config} from "#.storybook/preview.ts";
+          const meta = config.meta({
+              args: {
+                label: "Hello world!"
+              }
+          });
+          export const Story = meta.story({});
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        // compiled code
+        import { config } from "/.storybook/preview.ts";
+        const meta = config.meta({
+          args: {
+            label: "Hello world!"
+          }
+        });
+        export const Story = meta.story({});
+        Story.annotations.parameters = {
+          ...Story.annotations.parameters,
+          docs: {
+            ...Story.annotations.parameters?.docs,
+            source: {
+              originalSource: "meta.story({})",
+              ...Story.annotations.parameters?.docs?.source
+            }
+          }
+        };
+      `);
+    });
     it('multiple stories', () => {
       expect(
         enrich(

--- a/code/core/src/csf-tools/enrichCsf.test.ts
+++ b/code/core/src/csf-tools/enrichCsf.test.ts
@@ -149,7 +149,7 @@ describe('enrichCsf', () => {
         };
       `);
     });
-    it('csf4', () => {
+    it('csf factories', () => {
       expect(
         enrich(
           dedent`

--- a/code/core/src/csf-tools/enrichCsf.ts
+++ b/code/core/src/csf-tools/enrichCsf.ts
@@ -24,7 +24,7 @@ export const enrichCsfStory = (
   const description =
     !options?.disableDescription && extractDescription(csfSource._storyStatements[key]);
   const parameters = [];
-  // in csf1/2/3 we use Story.parameters, in csf4 we use Story.annotations.parameters
+  // in csf 1/2/3 use Story.parameters; CSF factories use Story.annotations.parameters
   const baseStoryObject = isCsfFactory
     ? t.memberExpression(t.identifier(key), t.identifier('annotations'))
     : t.identifier(key);


### PR DESCRIPTION
Closes #30241

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds support for augmenting parameters in CSF factory format (conditionally), useful for docs source extraction. Check the tests for more detail!

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  0 B | 77.8 MB | 77.8 MB | - | 100% |
| initSize |  0 B | 131 MB | 131 MB | - | 100% |
| diffSize |  0 B | 53.4 MB | 53.4 MB | - | 100% |
| buildSize |  0 B | 7.19 MB | 7.19 MB | - | 100% |
| buildSbAddonsSize |  0 B | 1.85 MB | 1.85 MB | - | 100% |
| buildSbCommonSize |  0 B | 195 kB | 195 kB | - | 100% |
| buildSbManagerSize |  0 B | 1.87 MB | 1.87 MB | - | 100% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  0 B | 3.91 MB | 3.91 MB | - | 100% |
| buildPreviewSize |  0 B | 3.28 MB | 3.28 MB | - | 100% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  0ms | 24.2s | 24.2s | - | 100% |
| generateTime |  0ms | 20.1s | 20.1s | - | 100% |
| initTime |  0ms | 14.1s | 14.1s | - | 100% |
| buildTime |  0ms | 9s | 9s | - | 100% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  0ms | 5.1s | 5.1s | - | 100% |
| devManagerResponsive |  0ms | 3.6s | 3.6s | - | 100% |
| devManagerHeaderVisible |  0ms | 588ms | 588ms | - | 100% |
| devManagerIndexVisible |  0ms | 599ms | 599ms | - | 100% |
| devStoryVisibleUncached |  0ms | 2s | 2s | - | 100% |
| devStoryVisible |  0ms | 618ms | 618ms | - | 100% |
| devAutodocsVisible |  0ms | 576ms | 576ms | - | 100% |
| devMDXVisible |  0ms | 508ms | 508ms | - | 100% |
| buildManagerHeaderVisible |  0ms | 492ms | 492ms | - | 100% |
| buildManagerIndexVisible |  0ms | 493ms | 493ms | - | 100% |
| buildStoryVisible |  0ms | 485ms | 485ms | - | 100% |
| buildAutodocsVisible |  0ms | 425ms | 425ms | - | 100% |
| buildMDXVisible |  0ms | 449ms | 449ms | - | 100% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the PR changes:

Added support for CSF4 format in enrichCsf function to properly handle source extraction and parameter augmentation for stories using the new meta.story({}) syntax.

- Added detection of CSF4 factory stories through AST checks in `code/core/src/csf-tools/enrichCsf.ts`
- Modified parameter access path to use `Story.annotations.parameters` for CSF4 and `Story.parameters` for CSF1/2/3
- Added comprehensive test coverage in `code/core/src/csf-tools/enrichCsf.test.ts` for CSF4 format
- Preserved backward compatibility for existing CSF1/2/3 formats



<!-- /greptile_comment -->