### PR TITLE
CLI: Update a11y-test comment with experimental caveat

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
@@ -679,7 +679,8 @@ describe('addonA11yAddonTest', () => {
           },
 
           // The \`a11y-test\` tag controls whether accessibility tests are run as part of a standalone Vitest test run
-          // For more information please visit: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon
+          // The tag and its behavior are experimental and subject to change.
+          // For more information please see: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon
           tags: [/*'a11y-test'*/]
         };
 
@@ -740,7 +741,8 @@ describe('addonA11yAddonTest', () => {
 
         const preview: Preview = {
           // The \`a11y-test\` tag controls whether accessibility tests are run as part of a standalone Vitest test run
-          // For more information please visit: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon
+          // The tag and its behavior are experimental and subject to change.
+          // For more information please see: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon
           tags: ["existingTag"/*, "a11y-test"*/],
           parameters: {
             controls: {
@@ -824,7 +826,8 @@ describe('addonA11yAddonTest', () => {
           },
 
           // The \`a11y-test\` tag controls whether accessibility tests are run as part of a standalone Vitest test run
-          // For more information please visit: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon
+          // The tag and its behavior are experimental and subject to change.
+          // For more information please see: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon
           tags: [/*"a11y-test"*/]
         };"
       `);
@@ -850,7 +853,8 @@ describe('addonA11yAddonTest', () => {
       expect(transformed).toMatchInlineSnapshot(`
         "export default {
           // The \`a11y-test\` tag controls whether accessibility tests are run as part of a standalone Vitest test run
-          // For more information please visit: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon
+          // The tag and its behavior are experimental and subject to change.
+          // For more information please see: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon
           tags: ["existingTag"/*, "a11y-test"*/],
           parameters: {
             controls: {

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
@@ -318,7 +318,7 @@ export async function transformPreviewFile(source: string, filePath: string) {
   const indentation = lines[tagsLineIndex]?.match(/^\s*/)?.[0];
 
   // Add the comment with the same indentation level
-  const comment = `${indentation}// The \`a11y-test\` tag controls whether accessibility tests are run as part of a standalone Vitest test run\n${indentation}The tag and its behavior are experimental and subject to change.\n${indentation}// For more information please see: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon`;
+  const comment = `${indentation}// The \`a11y-test\` tag controls whether accessibility tests are run as part of a standalone Vitest test run\n${indentation}// The tag and its behavior are experimental and subject to change.\n${indentation}// For more information please see: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon`;
   lines.splice(tagsLineIndex, 0, comment);
 
   return formatFileContent(filePath, lines.join('\n'));

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
@@ -318,7 +318,7 @@ export async function transformPreviewFile(source: string, filePath: string) {
   const indentation = lines[tagsLineIndex]?.match(/^\s*/)?.[0];
 
   // Add the comment with the same indentation level
-  const comment = `${indentation}// The \`a11y-test\` tag controls whether accessibility tests are run as part of a standalone Vitest test run\n${indentation}// For more information please visit: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon`;
+  const comment = `${indentation}// The \`a11y-test\` tag controls whether accessibility tests are run as part of a standalone Vitest test run\n${indentation}The tag and its behavior are experimental and subject to change.\n${indentation}// For more information please see: https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon`;
   lines.splice(tagsLineIndex, 0, comment);
 
   return formatFileContent(filePath, lines.join('\n'));


### PR DESCRIPTION
Closes #

## What I did

Update the comment generated by the `a11y-test` automigration to emphasize that it's experimental.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.8 MB | 77.9 MB | 27.9 kB | **2.89** | 0% |
| initSize |  131 MB | 131 MB | 29.3 kB | **2.47** | 0% |
| diffSize |  52.9 MB | 52.9 MB | 1.4 kB | **-1.56** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 12 B | -0.8 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | **-1.73** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 1 B | 0.58 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 1 B | **-1.66** | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 11 B | **29.5** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  21.3s | 18.6s | -2s -711ms | 0.53 | -14.6% |
| generateTime |  22.4s | 21.4s | -949ms | 0.44 | -4.4% |
| initTime |  16.4s | 15.3s | -1s -187ms | 0.79 | -7.8% |
| buildTime |  9.6s | 9s | -669ms | -0.56 | -7.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5s | 4.7s | -267ms | -0.68 | -5.6% |
| devManagerResponsive |  3.5s | 3.4s | -71ms | -0.78 | -2% |
| devManagerHeaderVisible |  579ms | 610ms | 31ms | -0.44 | 5.1% |
| devManagerIndexVisible |  607ms | 641ms | 34ms | -0.52 | 5.3% |
| devStoryVisibleUncached |  1.9s | 2.1s | 103ms | 0.62 | 4.9% |
| devStoryVisible |  608ms | 648ms | 40ms | -0.48 | 6.2% |
| devAutodocsVisible |  398ms | 557ms | 159ms | -0.14 | 28.5% |
| devMDXVisible |  524ms | 538ms | 14ms | -0.38 | 2.6% |
| buildManagerHeaderVisible |  550ms | 692ms | 142ms | 0.91 | 20.5% |
| buildManagerIndexVisible |  650ms | 834ms | 184ms | **1.5** | 🔺22.1% |
| buildStoryVisible |  541ms | 677ms | 136ms | 0.99 | 20.1% |
| buildAutodocsVisible |  466ms | 582ms | 116ms | **1.75** | 🔺19.9% |
| buildMDXVisible |  464ms | 474ms | 10ms | -0.1 | 2.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates the comment generated by the a11y-test automigration to emphasize its experimental nature in the Storybook CLI.

- Modified `code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts` to add experimental status warning for a11y test integration
- Added notice about potential changes in Storybook 9.0 to help set proper expectations for users



<!-- /greptile_comment -->