### PR TITLE
Codemod: Use csf-tools in csf factory codemod

### DIFF
--- a/code/lib/codemod/src/transforms/__tests__/csf-3-to-4.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-3-to-4.test.ts
@@ -21,10 +21,9 @@ describe('csf-3-to-4', () => {
           export default meta;
         `)
       ).resolves.toMatchInlineSnapshot(`
-        import { config } from "#.storybook/preview";
-        const meta = config.meta({
-          title: 'Component'
-        });
+        import { config } from '#.storybook/preview';
+
+        const meta = config.meta({ title: 'Component' });
       `);
     });
 
@@ -34,9 +33,10 @@ describe('csf-3-to-4', () => {
           export default { title: 'Component' };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        import { config } from "#.storybook/preview";
+        import { config } from '#.storybook/preview';
+
         const meta = config.meta({
-          title: 'Component'
+          title: 'Component',
         });
       `);
     });
@@ -48,10 +48,9 @@ describe('csf-3-to-4', () => {
           export default componentMeta;
         `)
       ).resolves.toMatchInlineSnapshot(`
-        import { config } from "#.storybook/preview";
-        const meta = config.meta({
-          title: 'Component'
-        });
+        import { config } from '#.storybook/preview';
+
+        const meta = config.meta({ title: 'Component' });
       `);
     });
 
@@ -66,15 +65,12 @@ describe('csf-3-to-4', () => {
           };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        import { config } from "#.storybook/preview";
-        const meta = config.meta({
-          title: 'Component'
-        });
+        import { config } from '#.storybook/preview';
+
+        const meta = config.meta({ title: 'Component' });
         export const A = meta.story({
-          args: {
-            primary: true
-          },
-          render: args => <Component {...args} />
+          args: { primary: true },
+          render: (args) => <Component {...args} />,
         });
       `);
     });
@@ -91,15 +87,12 @@ describe('csf-3-to-4', () => {
           };
         `)
       ).resolves.toMatchInlineSnapshot(`
-        import { decorators, config } from "#.storybook/preview";
-        const meta = config.meta({
-          title: 'Component'
-        });
+        import { config, decorators } from '#.storybook/preview';
+
+        const meta = config.meta({ title: 'Component' });
         export const A = meta.story({
-          args: {
-            primary: true
-          },
-          render: args => <Component {...args} />
+          args: { primary: true },
+          render: (args) => <Component {...args} />,
         });
       `);
     });
@@ -119,17 +112,14 @@ describe('csf-3-to-4', () => {
     `;
     it('meta satisfies syntax', async () => {
       await expect(transform(metaSatisfies)).resolves.toMatchInlineSnapshot(`
-        import { config } from "#.storybook/preview";
-        import { Meta, StoryObj as CSF3 } from '@storybook/react';
+        import { config } from '#.storybook/preview';
+
         import { ComponentProps } from './Component';
-        const meta = config.meta({
-          title: 'Component',
-          component: Component
-        });
+
+        const meta = config.meta({ title: 'Component', component: Component });
+
         export const A = meta.story({
-          args: {
-            primary: true
-          }
+          args: { primary: true },
         });
       `);
     });
@@ -147,17 +137,14 @@ describe('csf-3-to-4', () => {
     `;
     it('meta as syntax', async () => {
       await expect(transform(metaAs)).resolves.toMatchInlineSnapshot(`
-        import { config } from "#.storybook/preview";
-        import { Meta, StoryObj as CSF3 } from '@storybook/react';
+        import { config } from '#.storybook/preview';
+
         import { ComponentProps } from './Component';
-        const meta = config.meta({
-          title: 'Component',
-          component: Component
-        });
+
+        const meta = config.meta({ title: 'Component', component: Component });
+
         export const A = meta.story({
-          args: {
-            primary: true
-          }
+          args: { primary: true },
         });
       `);
     });
@@ -175,17 +162,14 @@ describe('csf-3-to-4', () => {
     `;
     it('story satisfies syntax', async () => {
       await expect(transform(storySatisfies)).resolves.toMatchInlineSnapshot(`
-        import { config } from "#.storybook/preview";
-        import { Meta, StoryObj as CSF3 } from '@storybook/react';
+        import { config } from '#.storybook/preview';
+
         import { ComponentProps } from './Component';
-        const meta = config.meta({
-          title: 'Component',
-          component: Component
-        });
+
+        const meta = config.meta({ title: 'Component', component: Component });
+
         export const A = meta.story({
-          args: {
-            primary: true
-          }
+          args: { primary: true },
         });
       `);
     });
@@ -203,17 +187,14 @@ describe('csf-3-to-4', () => {
     `;
     it('story as syntax', async () => {
       await expect(transform(storyAs)).resolves.toMatchInlineSnapshot(`
-        import { config } from "#.storybook/preview";
-        import { Meta, StoryObj as CSF3 } from '@storybook/react';
+        import { config } from '#.storybook/preview';
+
         import { ComponentProps } from './Component';
-        const meta = config.meta({
-          title: 'Component',
-          component: Component
-        });
+
+        const meta = config.meta({ title: 'Component', component: Component });
+
         export const A = meta.story({
-          args: {
-            primary: true
-          }
+          args: { primary: true },
         });
       `);
     });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR modifies the internals of the csf3 to csf-factory codemod so that it fully uses CsfFile instead of jscodeshift.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  0 B | 77.9 MB | 77.9 MB | - | 100% |
| initSize |  0 B | 131 MB | 131 MB | - | 100% |
| diffSize |  0 B | 53.4 MB | 53.4 MB | - | 100% |
| buildSize |  0 B | 7.19 MB | 7.19 MB | - | 100% |
| buildSbAddonsSize |  0 B | 1.85 MB | 1.85 MB | - | 100% |
| buildSbCommonSize |  0 B | 195 kB | 195 kB | - | 100% |
| buildSbManagerSize |  0 B | 1.87 MB | 1.87 MB | - | 100% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  0 B | 3.91 MB | 3.91 MB | - | 100% |
| buildPreviewSize |  0 B | 3.28 MB | 3.28 MB | - | 100% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  0ms | 24.5s | 24.5s | - | 100% |
| generateTime |  0ms | 20.3s | 20.3s | - | 100% |
| initTime |  0ms | 12.4s | 12.4s | - | 100% |
| buildTime |  0ms | 8.9s | 8.9s | - | 100% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  0ms | 4.7s | 4.7s | - | 100% |
| devManagerResponsive |  0ms | 3.4s | 3.4s | - | 100% |
| devManagerHeaderVisible |  0ms | 633ms | 633ms | - | 100% |
| devManagerIndexVisible |  0ms | 657ms | 657ms | - | 100% |
| devStoryVisibleUncached |  0ms | 1.9s | 1.9s | - | 100% |
| devStoryVisible |  0ms | 656ms | 656ms | - | 100% |
| devAutodocsVisible |  0ms | 692ms | 692ms | - | 100% |
| devMDXVisible |  0ms | 537ms | 537ms | - | 100% |
| buildManagerHeaderVisible |  0ms | 567ms | 567ms | - | 100% |
| buildManagerIndexVisible |  0ms | 569ms | 569ms | - | 100% |
| buildStoryVisible |  0ms | 558ms | 558ms | - | 100% |
| buildAutodocsVisible |  0ms | 484ms | 484ms | - | 100% |
| buildMDXVisible |  0ms | 511ms | 511ms | - | 100% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and pull request information, I'll create a concise summary of the changes:

Refactored the CSF3 to CSF4 codemod to use CsfFile tools instead of direct jscodeshift manipulation, improving maintainability and error handling.

- Added `_storyPaths` and `_metaPath` tracking in `CsfFile.ts` for AST transformations
- Implemented error handling for CSF parsing failures in `csf-3-to-4.ts`
- Added automatic removal of type imports from @storybook/* packages
- Added prettier formatting for transformed code output
- Enhanced TypeScript support for 'as' and 'satisfies' type assertions



<!-- /greptile_comment -->