### PR TITLE
Build: Fix eslint plugin checks for storybook cli packages

### DIFF
--- a/scripts/eslint-plugin-local-rules/storybook-monorepo-imports.js
+++ b/scripts/eslint-plugin-local-rules/storybook-monorepo-imports.js
@@ -16,7 +16,7 @@ module.exports = {
     return {
       ImportDeclaration: (node) => {
         const fileName = context.getPhysicalFilename();
-        const isInCLI = !!fileName.includes(path.join('code', 'lib', 'cli'));
+        const isInCLI = !!fileName.endsWith(path.join('code', 'lib', 'cli'));
         const isInCodeod = !!fileName.includes(path.join('code', 'lib', 'codemod'));
         const isInCore = !!fileName.includes(path.join('code', 'core'));
 

--- a/scripts/eslint-plugin-local-rules/storybook-monorepo-imports.js
+++ b/scripts/eslint-plugin-local-rules/storybook-monorepo-imports.js
@@ -16,7 +16,7 @@ module.exports = {
     return {
       ImportDeclaration: (node) => {
         const fileName = context.getPhysicalFilename();
-        const isInCLI = !!fileName.endsWith(path.join('code', 'lib', 'cli'));
+        const isInCLI = !!fileName.includes(path.join('code', 'lib', 'cli') + path.sep);
         const isInCodeod = !!fileName.includes(path.join('code', 'lib', 'codemod'));
         const isInCore = !!fileName.includes(path.join('code', 'core'));
 

--- a/scripts/eslint-plugin-local-rules/storybook-monorepo-imports.js
+++ b/scripts/eslint-plugin-local-rules/storybook-monorepo-imports.js
@@ -17,14 +17,14 @@ module.exports = {
       ImportDeclaration: (node) => {
         const fileName = context.getPhysicalFilename();
         const isInCLI = !!fileName.includes(path.join('code', 'lib', 'cli') + path.sep);
-        const isInCodeod = !!fileName.includes(path.join('code', 'lib', 'codemod'));
+        const isInCodemod = !!fileName.includes(path.join('code', 'lib', 'codemod'));
         const isInCore = !!fileName.includes(path.join('code', 'core'));
 
         if (
           node.source.value.startsWith('@storybook/core/') &&
           !isInCLI &&
           !isInCore &&
-          !isInCodeod
+          !isInCodemod
         ) {
           const newPath = node.source.value
             .replace('@storybook/core', 'storybook/internal')


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

There was an issue where the local rules eslint plugin was not taking into account a refactor we did where we moved the cli packages around. This resulted in the plugin not being applied in cli-storybook.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and context, I'll create a concise summary of the pull request changes:

Makes ESLint import path detection more precise for Storybook CLI packages by using stricter path matching logic.

- Modified `scripts/eslint-plugin-local-rules/storybook-monorepo-imports.js` to use `endsWith()` instead of `includes()` for CLI path validation
- Ensures import paths must exactly match 'code/lib/cli' rather than just containing it
- Maintains existing import rules for '@storybook/core' and 'storybook/internal' paths
- Improves consistency of monorepo imports by preventing partial path matches



<!-- /greptile_comment -->