### PR TITLE
CLI: Corrected Next.js createScript for pnpm.

### DIFF
--- a/code/lib/create-storybook/src/scaffold-new-project.ts
+++ b/code/lib/create-storybook/src/scaffold-new-project.ts
@@ -49,7 +49,7 @@ const SUPPORTED_PROJECTS: Record<string, SupportedProject> = {
       npm: 'npm create next-app@^14 . -- --typescript --use-npm --eslint --tailwind --no-app --import-alias="@/*" --src-dir',
       // yarn doesn't support version ranges, so we have to use npx
       yarn: 'npx create-next-app@^14 . --typescript --use-yarn --eslint --tailwind --no-app --import-alias="@/*" --src-dir',
-      pnpm: 'pnpm create next-app^14 . --typescript --use-pnpm --eslint --tailwind --no-app --import-alias="@/*" --src-dir',
+      pnpm: 'pnpm create next-app@^14 . --typescript --use-pnpm --eslint --tailwind --no-app --import-alias="@/*" --src-dir',
     },
   },
   'vue-vite-ts': {


### PR DESCRIPTION
Closes #30291

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->
```bash
pnpm create next-app@^14 . --typescript --use-pnpm --eslint --tailwind --no-app --import-alias="@/*" --src-dir
```
<img width="415" alt="Screenshot 2025-01-18 at 21 40 29" src="https://github.com/user-attachments/assets/db486ee2-f114-4f3a-9575-05c84f15638c" />

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 77.9 MB | 298 B | 1.11 | 0% |
| initSize |  131 MB | 131 MB | 412 B | 1.2 | 0% |
| diffSize |  53 MB | 53 MB | 114 B | **1.25** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | 0.82 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.82 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.82 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | 0.82 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | 0.82 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  26.1s | 24s | -2s -176ms | **1.44** | 🔰-9.1% |
| generateTime |  18.6s | 19.8s | 1.1s | -0.64 | 5.9% |
| initTime |  12.5s | 14.4s | 1.8s | -0.12 | 13.2% |
| buildTime |  10.2s | 8.7s | -1s -469ms | -0.68 | -16.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.6s | 5.3s | 657ms | 0.94 | 12.3% |
| devManagerResponsive |  3.3s | 3.8s | 430ms | 1.22 | 11.3% |
| devManagerHeaderVisible |  519ms | 641ms | 122ms | 1.16 | 19% |
| devManagerIndexVisible |  527ms | 672ms | 145ms | 0.78 | 21.6% |
| devStoryVisibleUncached |  1.8s | 1s | -785ms | **-3.25** | 🔰-72% |
| devStoryVisible |  590ms | 673ms | 83ms | 1.14 | 12.3% |
| devAutodocsVisible |  508ms | 624ms | 116ms | **1.93** | 🔺18.6% |
| devMDXVisible |  494ms | 569ms | 75ms | 0.65 | 13.2% |
| buildManagerHeaderVisible |  552ms | 720ms | 168ms | **3.36** | 🔺23.3% |
| buildManagerIndexVisible |  654ms | 737ms | 83ms | **1.78** | 🔺11.3% |
| buildStoryVisible |  538ms | 697ms | 159ms | **3.53** | 🔺22.8% |
| buildAutodocsVisible |  439ms | 517ms | 78ms | 0.87 | 15.1% |
| buildMDXVisible |  420ms | 533ms | 113ms | **2.15** | 🔺21.2% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixed incorrect version specifier format in Next.js project creation command for pnpm, resolving a 404 error during project initialization.

- Changed version specifier from `next-app^14` to `next-app@^14` in `code/lib/create-storybook/src/scaffold-new-project.ts`
- Fixed pnpm trying to fetch non-existent package 'create-next-app14'
- Aligned pnpm command syntax with npm/yarn version specifier format



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->