### PR TITLE
RNW-Vite: Support requires for images/fonts

### DIFF
--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -62,6 +62,7 @@
     "@storybook/react-vite": "workspace:*",
     "@vitejs/plugin-react": "^4.3.2",
     "vite-plugin-babel": "^1.3.0",
+    "vite-plugin-commonjs": "^0.10.4",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {

--- a/code/frameworks/react-native-web-vite/src/preset.ts
+++ b/code/frameworks/react-native-web-vite/src/preset.ts
@@ -4,6 +4,7 @@ import { esbuildFlowPlugin, flowPlugin } from '@bunchtogether/vite-plugin-flow';
 import react from '@vitejs/plugin-react';
 import type { InlineConfig, PluginOption } from 'vite';
 import babel from 'vite-plugin-babel';
+import commonjs from 'vite-plugin-commonjs';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 import type { FrameworkOptions, StorybookConfig } from './types';
@@ -129,6 +130,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
       }),
       ...plugins,
       reactNativeWeb(),
+      commonjs(),
     ],
     optimizeDeps: {
       esbuildOptions: {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6975,6 +6975,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.2"
     typescript: "npm:^5.3.2"
     vite-plugin-babel: "npm:^1.3.0"
+    vite-plugin-commonjs: "npm:^0.10.4"
     vite-tsconfig-paths: "npm:^5.1.4"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -29220,6 +29221,29 @@ __metadata:
     "@babel/core": ^7.0.0
     vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
   checksum: 10c0/1613c45ee220ffbad18aeacbbe395d4d346cbe7c971c7469b0cd96df422bd9d617821a40bacf3b6ea3e7c4ded43e6ccdfd17ec3c0899fee2835f56e8971c6b57
+  languageName: node
+  linkType: hard
+
+"vite-plugin-commonjs@npm:^0.10.4":
+  version: 0.10.4
+  resolution: "vite-plugin-commonjs@npm:0.10.4"
+  dependencies:
+    acorn: "npm:^8.12.1"
+    magic-string: "npm:^0.30.11"
+    vite-plugin-dynamic-import: "npm:^1.6.0"
+  checksum: 10c0/074e0d7a1e8f20d605f1a02c53867706639ea5a9aac8657e8d90442f13cf86154a6ebc65de1f05eb62e1a98523422d5025f3b7ccaabe88c486bec12b45e5d136
+  languageName: node
+  linkType: hard
+
+"vite-plugin-dynamic-import@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "vite-plugin-dynamic-import@npm:1.6.0"
+  dependencies:
+    acorn: "npm:^8.12.1"
+    es-module-lexer: "npm:^1.5.4"
+    fast-glob: "npm:^3.3.2"
+    magic-string: "npm:^0.30.11"
+  checksum: 10c0/049f953b404157346e06a729eb055bc5b3630ac990bf36d52e6c44b1b223ac8e1f22fa1c44cadea55e7621366a0666439860fd4572f09c87daa45affd5dd15b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

react native uses requires for images and fonts so we need to support requires, I added the commonjs plugin to support this

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30305-sha-c7104654`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30305-sha-c7104654 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30305-sha-c7104654 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30305-sha-c7104654`](https://npmjs.com/package/storybook/v/0.0.0-pr-30305-sha-c7104654) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`dannyhw/fix-rnw-requires-support`](https://github.com/storybookjs/storybook/tree/dannyhw/fix-rnw-requires-support) |
| **Commit** | [`c7104654`](https://github.com/storybookjs/storybook/commit/c71046546572d49d6b1eebaab0e027c2c0cb6970) |
| **Datetime** | Sat Jan 18 16:29:29 UTC 2025 (`1737217769`) |
| **Workflow run** | [12845641313](https://github.com/storybookjs/storybook/actions/runs/12845641313) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30305`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 77.9 MB | 0 B | 0.34 | 0% |
| initSize |  131 MB | 131 MB | 0 B | 0.97 | 0% |
| diffSize |  52.9 MB | 52.9 MB | 0 B | **2.1** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | **3** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | **-3** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | **3** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | **3** | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | **3** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  12.9s | 19.2s | 6.3s | 0.96 | 32.8% |
| generateTime |  23.8s | 19.5s | -4s -312ms | -0.8 | -22.1% |
| initTime |  16.3s | 13.2s | -3s -59ms | -0.73 | -23.1% |
| buildTime |  8.9s | 9.8s | 917ms | 0.2 | 9.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.3s | 5s | 696ms | 0.31 | 13.8% |
| devManagerResponsive |  3.1s | 3.6s | 503ms | 0.37 | 13.7% |
| devManagerHeaderVisible |  546ms | 604ms | 58ms | -0.15 | 9.6% |
| devManagerIndexVisible |  552ms | 614ms | 62ms | -0.34 | 10.1% |
| devStoryVisibleUncached |  1.7s | 1.9s | 123ms | 0.34 | 6.4% |
| devStoryVisible |  603ms | 638ms | 35ms | -0.17 | 5.5% |
| devAutodocsVisible |  453ms | 491ms | 38ms | -0.42 | 7.7% |
| devMDXVisible |  461ms | 505ms | 44ms | -0.55 | 8.7% |
| buildManagerHeaderVisible |  535ms | 585ms | 50ms | 0.23 | 8.5% |
| buildManagerIndexVisible |  622ms | 678ms | 56ms | 0.44 | 8.3% |
| buildStoryVisible |  515ms | 575ms | 60ms | 0.32 | 10.4% |
| buildAutodocsVisible |  432ms | 459ms | 27ms | -0.1 | 5.9% |
| buildMDXVisible |  395ms | 451ms | 56ms | -0.12 | 12.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added support for CommonJS requires in React Native Web Vite framework to handle images and fonts through the vite-plugin-commonjs plugin.

- Added `vite-plugin-commonjs` dependency in `/code/frameworks/react-native-web-vite/package.json`
- Integrated CommonJS plugin in `/code/frameworks/react-native-web-vite/src/preset.ts` viteFinal configuration
- Added plugin to support require statements for asset handling in React Native Web packages



<sub>💡 (5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->