### PR TITLE
Tests: Disable flaky test-runner tests

### DIFF
--- a/code/core/template/stories/args.stories.ts
+++ b/code/core/template/stories/args.stories.ts
@@ -92,5 +92,6 @@ export const Events = {
     await new Promise((resolve) => channel.once(STORY_ARGS_UPDATED, resolve));
     await within(canvasElement).findByText(/updated/);
   },
-  tags: ['!vitest'],
+  // this story can't be reliably tested because the args changes results in renderPhases disrupting test runs
+  tags: ['!vitest', '!test'],
 };

--- a/code/core/template/stories/decorators.stories.ts
+++ b/code/core/template/stories/decorators.stories.ts
@@ -67,5 +67,6 @@ export const Hooks = {
     });
     await new Promise((resolve) => channel.once(STORY_ARGS_UPDATED, resolve));
   },
-  tags: ['!vitest'],
+  // this story can't be reliably tested because the args changes results in renderPhases disrupting test runs
+  tags: ['!vitest', '!test'],
 };

--- a/code/core/template/stories/globals.stories.ts
+++ b/code/core/template/stories/globals.stories.ts
@@ -44,7 +44,8 @@ export const Events = {
     await channel.emit('updateGlobals', { globals: { foo: 'fooValue' } });
     await within(canvasElement).findByText('fooValue');
   },
-  tags: ['!vitest'],
+  // this story can't be reliably tested because the globals changes results in renderPhases disrupting test runs
+  tags: ['!vitest', '!test'],
 };
 
 export const Overrides1 = {

--- a/code/core/template/stories/rendering.stories.ts
+++ b/code/core/template/stories/rendering.stories.ts
@@ -105,4 +105,6 @@ export const ChangeArgs = {
     await within(canvasElement).findByText(/New Text/);
     await expect(button).toHaveFocus();
   },
+  // this story can't be reliably tested because the args changes results in renderPhases disrupting test runs
+  tags: ['!vitest', '!test'],
 };

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/CustomRenderOptionsArgsFromData.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/CustomRenderOptionsArgsFromData.stories.ts
@@ -34,6 +34,8 @@ const meta = {
                   </div>`,
     });
   },
+  // this story can't be reliably tested because the (inherited) args changes results in renderPhases disrupting test runs
+  tags: ['!vitest', '!test'],
 } satisfies Meta<typeof Reactivity>;
 
 export default meta;


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Disabled the handful of stories that were more or less consistently failing in the test-runner. The one thing they all have in common, is that they emit events to change args/globals _during playing_, which is not supported, because doing that will mess up the render phases and cause any tests to prematurely end at the first event emitted.

There are about 10 more stories that exhibits this behavior without being flaky, and I don't know why.

These stories have all (except for the Vue specfic one) been flaky in the `svelte-vite/default-ts` sandbox for a while, and I can't explain why it is exactly that. Even the JS one is never failing. 🤷

I could do this less dramatically, by only disabling the stories in that specific Svelte sandbox. I could also do it _more_ dramatically, by disabling _all_ stories that changes args/globals during play, because it really doesn't work. Adding console logs to trace what happens, it clearly shows that every single run will end the play function after the first event, so we're not really testing anything, the assertions are never reached. (they are valuable for manual validation though)

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 77.9 MB | 0 B | **3.64** | 0% |
| initSize |  131 MB | 131 MB | 0 B | **3.26** | 0% |
| diffSize |  52.9 MB | 52.9 MB | 0 B | **1.5** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | **1.73** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | **-1.73** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | **1.73** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | **1.73** | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | **1.73** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  30.1s | 11.7s | -18s -471ms | -0.17 | -157.5% |
| generateTime |  18.8s | 22.3s | 3.5s | 0.9 | 15.8% |
| initTime |  13.2s | 14.1s | 884ms | -0.04 | 6.3% |
| buildTime |  9.5s | 9.6s | 110ms | -0.03 | 1.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.9s | 4.5s | -482ms | -1.04 | -10.7% |
| devManagerResponsive |  3.6s | 3.2s | -397ms | **-1.27** | 🔰-12.3% |
| devManagerHeaderVisible |  520ms | 570ms | 50ms | -0.66 | 8.8% |
| devManagerIndexVisible |  525ms | 582ms | 57ms | -0.86 | 9.8% |
| devStoryVisibleUncached |  1.8s | 1.9s | 69ms | 0.35 | 3.6% |
| devStoryVisible |  603ms | 601ms | -2ms | -0.83 | -0.3% |
| devAutodocsVisible |  383ms | 381ms | -2ms | **-1.92** | -0.5% |
| devMDXVisible |  452ms | 546ms | 94ms | 0.01 | 17.2% |
| buildManagerHeaderVisible |  489ms | 567ms | 78ms | 0.03 | 13.8% |
| buildManagerIndexVisible |  579ms | 659ms | 80ms | 0.12 | 12.1% |
| buildStoryVisible |  482ms | 548ms | 66ms | -0.02 | 12% |
| buildAutodocsVisible |  405ms | 419ms | 14ms | -0.86 | 3.3% |
| buildMDXVisible |  390ms | 424ms | 34ms | -0.54 | 8% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR disables flaky tests in Storybook's test runner by adding exclusion tags to stories that modify args/globals during play functions.

- Added `!test` tag to `Events` stories in `args.stories.ts` and `globals.stories.ts` to prevent premature test termination
- Added `!test` tag to `Hooks` story in `decorators.stories.ts` due to args changes disrupting render phases
- Added `!test` and `!vitest` tags to `ChangeArgs` story in `rendering.stories.ts` to address test reliability
- Added `!test` and `!vitest` tags to Vue3 story in `CustomRenderOptionsArgsFromData.stories.ts` to handle render lifecycle issues

The changes focus on consistently failing tests in the svelte-vite/default-ts sandbox, where emitting events to change args/globals during play functions disrupts the render phases and causes tests to end prematurely.



<!-- /greptile_comment -->