### PR TITLE
Csf: Support named exports as functions

### DIFF
--- a/code/core/src/csf-tools/ConfigFile.test.ts
+++ b/code/core/src/csf-tools/ConfigFile.test.ts
@@ -1466,5 +1466,16 @@ describe('ConfigFile', () => {
       expect(config._exportDecls['path']).toBe(undefined);
       expect(config._exports['path']).toBe(undefined);
     });
+
+    it('detects const and function export declarations', () => {
+      const source = dedent`
+        export function normalFunction() { };
+        export const value = ['@storybook/addon-essentials'];
+        export async function asyncFunction() { };
+        `;
+      const config = loadConfig(source).parse();
+
+      expect(Object.keys(config._exportDecls)).toHaveLength(3);
+    });
   });
 });

--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
@@ -58,10 +58,12 @@ describe('main/preview codemod: general parsing functionality', () => {
       });
     `);
   });
+
   it('should wrap defineMain call from const declared default export and default export mix', async () => {
     await expect(
       transform(dedent`
         export const tags = [];
+        export async function viteFinal(config) { return config };
         const config = {
           framework: '@storybook/react-vite',
         };
@@ -74,6 +76,9 @@ describe('main/preview codemod: general parsing functionality', () => {
       const config = {
         framework: '@storybook/react-vite',
         tags: [],
+        viteFinal: () => {
+          return config;
+        },
       };
 
       export default config;
@@ -82,16 +87,22 @@ describe('main/preview codemod: general parsing functionality', () => {
   it('should wrap defineMain call from named exports format', async () => {
     await expect(
       transform(dedent`
-        export const stories = ['../src/**/*.stories.@(js|jsx|ts|tsx)'];
+        export function stories() { return ['../src/**/*.stories.@(js|jsx|ts|tsx)'] };
         export const addons = ['@storybook/addon-essentials'];
+        export async function viteFinal(config) { return config };
         export const framework = '@storybook/react-vite';
       `)
     ).resolves.toMatchInlineSnapshot(`
       import { defineMain } from '@storybook/react-vite';
 
       export default defineMain({
-        stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+        stories: () => {
+          return ['../src/**/*.stories.@(js|jsx|ts|tsx)'];
+        },
         addons: ['@storybook/addon-essentials'],
+        viteFinal: () => {
+          return config;
+        },
         framework: '@storybook/react-vite',
       });
     `);

--- a/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.ts
@@ -35,7 +35,7 @@ export function cleanupTypeImports(programNode: t.Program, disallowList: string[
 export function removeExportDeclarations(
   programNode: t.Program,
   exportDecls: Record<string, t.VariableDeclarator | t.FunctionDeclaration>
-): t.Statement[] {
+) {
   return programNode.body.filter((node) => {
     if (t.isExportNamedDeclaration(node) && node.declaration) {
       if (t.isVariableDeclaration(node.declaration)) {
@@ -51,7 +51,9 @@ export function removeExportDeclarations(
       }
     }
     return true;
-  });
+    // @TODO adding any for now, unsure how to fix the following error:
+    // error TS4058: Return type of exported function has or is using name 'ObjectProperty' from external module "/tmp/storybook/code/core/dist/babel/index" but cannot be named.
+  }) as any;
 }
 
 export function getConfigProperties(
@@ -70,5 +72,7 @@ export function getConfigProperties(
     }
   }
 
-  return properties;
+  // @TODO adding any for now, unsure how to fix the following error:
+  // error TS4058: Return type of exported function has or is using name 'ObjectProperty' from external module "/tmp/storybook/code/core/dist/babel/index" but cannot be named.
+  return properties as any;
 }

--- a/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.ts
@@ -31,3 +31,44 @@ export function cleanupTypeImports(programNode: t.Program, disallowList: string[
     // error TS4058: Return type of exported function has or is using name 'BlockStatement' from external module "/code/core/dist/babel/index" but cannot be named
   }) as any;
 }
+
+export function removeExportDeclarations(
+  programNode: t.Program,
+  exportDecls: Record<string, t.VariableDeclarator | t.FunctionDeclaration>
+): t.Statement[] {
+  return programNode.body.filter((node) => {
+    if (t.isExportNamedDeclaration(node) && node.declaration) {
+      if (t.isVariableDeclaration(node.declaration)) {
+        // Handle variable declarations
+        node.declaration.declarations = node.declaration.declarations.filter(
+          (decl) => t.isIdentifier(decl.id) && !exportDecls[decl.id.name]
+        );
+        return node.declaration.declarations.length > 0;
+      } else if (t.isFunctionDeclaration(node.declaration)) {
+        // Handle function declarations
+        const funcDecl = node.declaration;
+        return t.isIdentifier(funcDecl.id) && !exportDecls[funcDecl.id.name];
+      }
+    }
+    return true;
+  });
+}
+
+export function getConfigProperties(
+  exportDecls: Record<string, t.VariableDeclarator | t.FunctionDeclaration>
+) {
+  const properties = [];
+
+  // Collect properties from named exports
+  for (const [name, decl] of Object.entries(exportDecls)) {
+    if (t.isVariableDeclarator(decl) && decl.init) {
+      properties.push(t.objectProperty(t.identifier(name), decl.init));
+    } else if (t.isFunctionDeclaration(decl)) {
+      properties.push(
+        t.objectProperty(t.identifier(name), t.arrowFunctionExpression([], decl.body))
+      );
+    }
+  }
+
+  return properties;
+}


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When running a codemod against our own snippets, we realized that this snippet from our docs wasn't being transformed:

```
// main.js
export async function webpack(baseConfig, options) {
  const { module = {} } = baseConfig;
  return {
    // ...
  }
}
```

That showed that ConfigFile, when taking into account named exports, only collects const declared exports, and not function declared exports. This PR fixes that but only makes changes necessary for the csf factory codemod to work well, it won't change the functionality of other places using ConfigFile.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 77.9 MB | 298 B | **1.93** | 0% |
| initSize |  131 MB | 131 MB | 938 B | **-1.5** | 0% |
| diffSize |  53.4 MB | 53.4 MB | 640 B | **-1.52** | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | 0.33 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | **-2.07** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | **2.38** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | **2.38** | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | 0.26 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  27.1s | 26.3s | -839ms | 1.12 | -3.2% |
| generateTime |  22.9s | 21.4s | -1s -543ms | -0.02 | -7.2% |
| initTime |  17.4s | 15s | -2s -335ms | 0.44 | -15.5% |
| buildTime |  10.8s | 9.3s | -1s -507ms | -0.25 | -16.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.3s | 5.3s | -39ms | 1 | -0.7% |
| devManagerResponsive |  3.8s | 3.9s | 100ms | **1.54** | 2.5% |
| devManagerHeaderVisible |  668ms | 648ms | -20ms | 0.79 | -3.1% |
| devManagerIndexVisible |  694ms | 683ms | -11ms | 0.83 | -1.6% |
| devStoryVisibleUncached |  2.1s | 2.1s | 90ms | **1.91** | 4.1% |
| devStoryVisible |  695ms | 684ms | -11ms | 0.85 | -1.6% |
| devAutodocsVisible |  513ms | 656ms | 143ms | **2.15** | 🔺21.8% |
| devMDXVisible |  666ms | 554ms | -112ms | 0.4 | -20.2% |
| buildManagerHeaderVisible |  774ms | 602ms | -172ms | 0.48 | -28.6% |
| buildManagerIndexVisible |  776ms | 604ms | -172ms | 0.44 | -28.5% |
| buildStoryVisible |  763ms | 590ms | -173ms | 0.46 | -29.3% |
| buildAutodocsVisible |  515ms | 534ms | 19ms | **1.42** | 3.6% |
| buildMDXVisible |  595ms | 496ms | -99ms | 0.33 | -20% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR enhances the ConfigFile module to properly handle function exports in Storybook configuration files. Here's a concise summary of the key changes:

- Added support for function declarations in named exports within the ConfigFile module, particularly for CSF factory codemod functionality
- Modified ExportNamedDeclaration visitor to properly collect and store function declarations in _exportDecls map
- Added utility functions in csf-factories-utils.ts to handle transformation of both variable and function declarations
- Updated test coverage to verify handling of async functions and mixed export types

Key changes:
- Added function declaration support in `code/core/src/csf-tools/ConfigFile.ts` ExportNamedDeclaration visitor
- Created `getConfigProperties` and `removeExportDeclarations` utilities in `code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.ts`
- Added safety check in setFieldNode method for VariableDeclarator type
- Updated test files to verify function export handling in various scenarios

The changes are focused on enabling proper transformation of function exports in configuration files while maintaining backward compatibility.



<!-- /greptile_comment -->