### PR TITLE
Build: Fix test command in CircleCI config to use multiple reporters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ jobs:
           name: Test
           command: |
             cd code
-            SHARD="$((${CIRCLE_NODE_INDEX}+1))"; yarn test --reporter=blob --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+            SHARD="$((${CIRCLE_NODE_INDEX}+1))"; yarn test --reporter=blob --reporter=default --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
       # TODO: bring coverage back later. This has caused flakiness in the tests because
       # Somehow Vitest reports coverage while some tests are still running,
       # then it tries to report coverage again and as result it crashes like this:


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 77.9 MB | 0 B | 0.91 | 0% |
| initSize |  131 MB | 131 MB | -114 B | 0.98 | 0% |
| diffSize |  53 MB | 53 MB | -114 B | 1 | 0% |
| buildSize |  7.19 MB | 7.19 MB | 0 B | 0.65 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | -0.65 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | 0.65 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | 0.65 | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 0 B | 0.65 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  9.6s | 8.3s | -1s -309ms | -0.62 | -15.6% |
| generateTime |  22.1s | 22.2s | 108ms | 0.77 | 0.5% |
| initTime |  20.8s | 13.8s | -7s -33ms | -0.46 | -50.9% |
| buildTime |  9.6s | 8.9s | -746ms | -0.43 | -8.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.2s | 4.3s | -814ms | -1.15 | -18.5% |
| devManagerResponsive |  3.7s | 3.2s | -457ms | -0.92 | -13.9% |
| devManagerHeaderVisible |  648ms | 541ms | -107ms | -0.81 | -19.8% |
| devManagerIndexVisible |  683ms | 566ms | -117ms | -0.63 | -20.7% |
| devStoryVisibleUncached |  2s | 661ms | -1s -396ms | **-5.04** | 🔰-211.2% |
| devStoryVisible |  684ms | 567ms | -117ms | -1.19 | -20.6% |
| devAutodocsVisible |  588ms | 519ms | -69ms | 0.07 | -13.3% |
| devMDXVisible |  617ms | 444ms | -173ms | -1.06 | -39% |
| buildManagerHeaderVisible |  583ms | 512ms | -71ms | -0.92 | -13.9% |
| buildManagerIndexVisible |  672ms | 623ms | -49ms | -0.44 | -7.9% |
| buildStoryVisible |  564ms | 476ms | -88ms | **-1.52** | 🔰-18.5% |
| buildAutodocsVisible |  478ms | 421ms | -57ms | -0.79 | -13.5% |
| buildMDXVisible |  480ms | 468ms | -12ms | 0.59 | -2.6% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Modified CircleCI configuration to use multiple test reporters, combining both blob and default reporters for improved test output visibility in the CI pipeline.

- Updated `.circleci/config.yml` to add default reporter while maintaining existing blob reporter in unit-tests job
- Test output will now be displayed in both formats for better debugging and readability

Note: This is a focused CI configuration change that only affects test output formatting, with no impact on test execution or functionality.



<!-- /greptile_comment -->