### PR TITLE
Update storybook-interactions-play-function.md

### DIFF
--- a/docs/_snippets/storybook-interactions-play-function.md
+++ b/docs/_snippets/storybook-interactions-play-function.md
@@ -8,8 +8,8 @@ import { Form } from './Form.component';
 const meta: Meta<Form> = {
   component: MyComponent,
   args: {
-    // 👇 Use `fn` to spy on the onSubmit arg
-    onSubmit: fn(),
+    // 👇 Use `fn` to spy on the submit output
+    submit: fn(),
   },
 };
 


### PR DESCRIPTION
Replace onSubmit -> submit, and mention it's an output to make things more angulary

https://angular.dev/style-guide#dont-prefix-output-properties

This is purely docs change and shouldn't affect anything outside
  

<!-- greptile_comment -->

## Greptile Summary

Updates documentation to align with Angular's style guide by replacing 'onSubmit' with 'submit' for output properties, but introduces inconsistencies in property naming across examples.

- Inconsistent property naming in `docs/_snippets/storybook-interactions-play-function.md` where 'onSubmit' and 'submit' are used interchangeably
- Property name 'onSubmit' still appears in play function assertions and non-Angular framework examples
- Need to standardize property naming across all code examples to maintain consistency with Angular style guide
- Consider adding a note about framework-specific naming conventions if different patterns are intentional



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->