### PR TITLE
Preview API: Add csf factory utilities

### DIFF
--- a/code/addons/test/src/vitest-plugin/test-utils.ts
+++ b/code/addons/test/src/vitest-plugin/test-utils.ts
@@ -3,7 +3,11 @@
 /* eslint-disable no-underscore-dangle */
 import { type RunnerTask, type TaskMeta, type TestContext } from 'vitest';
 
-import { type Report, composeStory } from 'storybook/internal/preview-api';
+import {
+  type Report,
+  composeStory,
+  getCsfFactoryAnnotations,
+} from 'storybook/internal/preview-api';
 import type { ComponentAnnotations, ComposedStoryFn } from 'storybook/internal/types';
 
 import { server } from '@vitest/browser/context';
@@ -26,11 +30,12 @@ export const testStory = (
   skipTags: string[]
 ) => {
   return async (context: TestContext & { story: ComposedStoryFn }) => {
+    const annotations = getCsfFactoryAnnotations(story, meta);
     const composedStory = composeStory(
-      'isCSFFactory' in story ? (story as any).input : story,
-      'isCSFFactory' in story ? (meta as any).input : meta,
+      annotations.story,
+      annotations.meta,
       { initialGlobals: (await getInitialGlobals?.()) ?? {}, tags: await getTags?.() },
-      'isCSFFactory' in story ? (story as any).config?.input : undefined,
+      annotations.preview,
       exportName
     );
 

--- a/code/builders/builder-vite/src/codegen-modern-iframe-script.ts
+++ b/code/builders/builder-vite/src/codegen-modern-iframe-script.ts
@@ -24,9 +24,7 @@ export async function generateModernIframeScriptCode(options: Options, projectRo
   const getPreviewAnnotationsFunction = `
   const getProjectAnnotations = async (hmrPreviewAnnotationModules = []) => {
     const preview = await import('${previewFileUrl}');
-    const csfFactoryPreview = Object.values(preview).find(module => {
-      return 'isCSFFactoryPreview' in module
-    });
+    const csfFactoryPreview = getCsfFactoryPreview(preview);
     
     if (csfFactoryPreview) {
       return csfFactoryPreview.input;
@@ -81,7 +79,7 @@ export async function generateModernIframeScriptCode(options: Options, projectRo
 
   setup();
  
-  import { composeConfigs, PreviewWeb, ClientApi } from 'storybook/internal/preview-api';
+  import { composeConfigs, PreviewWeb, ClientApi, getCsfFactoryPreview } from 'storybook/internal/preview-api';
   import { importFn } from '${SB_VIRTUAL_FILES.VIRTUAL_STORIES_FILE}';
   
   

--- a/code/core/src/preview-api/index.ts
+++ b/code/core/src/preview-api/index.ts
@@ -56,7 +56,13 @@ export {
   normalizeProjectAnnotations,
 } from './store';
 
-export { createPlaywrightTest } from './modules/store/csf/portable-stories';
+/** CSF API */
+export {
+  createPlaywrightTest,
+  getCsfFactoryPreview,
+  getCsfFactoryAnnotations,
+  isCsfFactory,
+} from './modules/store/csf';
 
 export type { PropDescriptor } from './store';
 

--- a/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.ts
+++ b/code/core/src/preview-api/modules/preview-web/docs-context/DocsContext.ts
@@ -13,7 +13,7 @@ import type {
 
 import { dedent } from 'ts-dedent';
 
-import type { StoryStore } from '../../store';
+import { type StoryStore, isCsfFactory } from '../../store';
 import type { DocsContextProps } from './DocsContextProps';
 
 export class DocsContext<TRenderer extends Renderer> implements DocsContextProps<TRenderer> {
@@ -163,7 +163,8 @@ export class DocsContext<TRenderer extends Renderer> implements DocsContextProps
     }
 
     const story = this.exportToStory.get(
-      'isCSFFactory' in moduleExportOrType ? moduleExportOrType.input : moduleExportOrType
+      // TODO: @kasperpeulen will fix this once csf factory types are defined
+      isCsfFactory(moduleExportOrType) ? (moduleExportOrType as any).input : moduleExportOrType
     );
 
     if (story) {

--- a/code/core/src/preview-api/modules/store/csf/csf-factory-utils.ts
+++ b/code/core/src/preview-api/modules/store/csf/csf-factory-utils.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+/* eslint-disable no-underscore-dangle */
+import type {
+  Args,
+  ComponentAnnotations,
+  LegacyStoryAnnotationsOrFn,
+  ModuleExports,
+  ProjectAnnotations,
+  Renderer,
+  StoryAnnotations,
+} from '@storybook/types';
+
+export function getCsfFactoryPreview(preview: ModuleExports): ProjectAnnotations<any> | null {
+  return Object.values(preview).find(isCsfFactory) ?? null;
+}
+
+export function isCsfFactory(target: StoryAnnotations | ProjectAnnotations<any>) {
+  return (
+    target != null &&
+    typeof target === 'object' &&
+    ('isCSFFactory' in target || 'isCSFFactoryPreview' in target)
+  );
+}
+
+export function getCsfFactoryAnnotations<
+  TRenderer extends Renderer = Renderer,
+  TArgs extends Args = Args,
+>(
+  story: LegacyStoryAnnotationsOrFn<TRenderer>,
+  meta?: ComponentAnnotations<TRenderer, TArgs>,
+  projectAnnotations?: ProjectAnnotations<TRenderer>
+) {
+  const _isCsfFactory = isCsfFactory(story);
+
+  return {
+    // TODO: @kasperpeulen will fix this once csf factory types are defined
+    story: _isCsfFactory ? (story as any)?.input : story,
+    meta: _isCsfFactory ? (story as any)?.meta?.input : meta,
+    preview: _isCsfFactory ? (story as any)?.config?.input : projectAnnotations,
+  };
+}

--- a/code/core/src/preview-api/modules/store/csf/index.ts
+++ b/code/core/src/preview-api/modules/store/csf/index.ts
@@ -8,3 +8,4 @@ export * from './getValuesFromArgTypes';
 export * from './composeConfigs';
 export * from './stepRunners';
 export * from './portable-stories';
+export * from './csf-factory-utils';

--- a/code/core/src/preview-api/modules/store/csf/portable-stories.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.ts
@@ -28,6 +28,7 @@ import { dedent } from 'ts-dedent';
 import { HooksContext } from '../../../addons';
 import { ReporterAPI } from '../reporter-api';
 import { composeConfigs } from './composeConfigs';
+import { getCsfFactoryAnnotations } from './csf-factory-utils';
 import { getValuesFromArgTypes } from './getValuesFromArgTypes';
 import { normalizeComponentAnnotations } from './normalizeComponentAnnotations';
 import { normalizeProjectAnnotations } from './normalizeProjectAnnotations';
@@ -88,21 +89,6 @@ export function setProjectAnnotations<TRenderer extends Renderer = Renderer>(
 }
 
 const cleanups: CleanupCallback[] = [];
-
-export function getAnnotations<TRenderer extends Renderer = Renderer, TArgs extends Args = Args>(
-  story: LegacyStoryAnnotationsOrFn<TRenderer>,
-  meta?: ComponentAnnotations<TRenderer, TArgs>,
-  projectAnnotations?: ProjectAnnotations<TRenderer>
-) {
-  const isCsfFactory =
-    (typeof story === 'function' || typeof story === 'object') && 'isCSFFactory' in story;
-
-  return {
-    storyAnnotations: isCsfFactory ? (story as any)?.input : story,
-    componentAnnotations: isCsfFactory ? (story as any)?.meta?.input : meta,
-    projectAnnotations: isCsfFactory ? (story as any)?.config?.input : projectAnnotations,
-  };
-}
 
 export function composeStory<TRenderer extends Renderer = Renderer, TArgs extends Args = Args>(
   storyAnnotations: LegacyStoryAnnotationsOrFn<TRenderer>,
@@ -295,7 +281,8 @@ export function composeStories<TModule extends Store_CSFExports>(
 
   const composedStories = Object.entries(stories).reduce(
     (storiesMap, [exportsName, story]: [string, any]) => {
-      const { storyAnnotations, componentAnnotations } = getAnnotations(story);
+      const { story: storyAnnotations, meta: componentAnnotations } =
+        getCsfFactoryAnnotations(story);
       if (!meta && componentAnnotations) {
         meta = componentAnnotations;
       }

--- a/code/core/src/preview-api/modules/store/csf/processCSFFile.ts
+++ b/code/core/src/preview-api/modules/store/csf/processCSFFile.ts
@@ -48,6 +48,7 @@ export function processCSFFile<TRenderer extends Renderer>(
 
   const firstStory: any = Object.values(namedExports)[0];
   // CSF4
+  // TODO: @kasperpeulen will fix this once csf factory types are defined
   if (!defaultExport && 'isCSFFactory' in firstStory) {
     const meta: NormalizedComponentAnnotations<TRenderer> =
       normalizeComponentAnnotations<TRenderer>(firstStory.meta.input, title, importPath);


### PR DESCRIPTION
Closes #30236

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR introduces base utilities to use when it comes to dealing with stories, meta or preview annotations and either checking or extracting the proper anotations whether they're in csf factory format or not

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 77.9 MB | 17.5 kB | **1.86** | 0% |
| initSize |  132 MB | 132 MB | 28 kB | -0.68 | 0% |
| diffSize |  53.8 MB | 53.8 MB | 10.5 kB | -0.72 | 0% |
| buildSize |  7.19 MB | 7.19 MB | 385 B | **1.66** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 234 B | 0.04 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.87 MB | 1.87 MB | 0 B | **1.36** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 234 B | **1.59** | 0% |
| buildPreviewSize |  3.28 MB | 3.28 MB | 151 B | **1.78** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  24.2s | 18.4s | -5s -787ms | 0.07 | -31.4% |
| generateTime |  18.3s | 21.4s | 3.1s | 0.07 | 14.5% |
| initTime |  12.7s | 16.5s | 3.7s | **1.47** | 🔺22.8% |
| buildTime |  10.4s | 12.2s | 1.8s | **2.44** | 🔺15.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.8s | 5.1s | 302ms | 0.27 | 5.8% |
| devManagerResponsive |  3.2s | 3.5s | 270ms | -0.44 | 7.6% |
| devManagerHeaderVisible |  645ms | 835ms | 190ms | **3.74** | 🔺22.8% |
| devManagerIndexVisible |  672ms | 848ms | 176ms | **3.13** | 🔺20.8% |
| devStoryVisibleUncached |  1.9s | 1.8s | -47ms | -0.55 | -2.5% |
| devStoryVisible |  674ms | 871ms | 197ms | **3.65** | 🔺22.6% |
| devAutodocsVisible |  539ms | 560ms | 21ms | 0.52 | 3.8% |
| devMDXVisible |  508ms | 583ms | 75ms | 0.72 | 12.9% |
| buildManagerHeaderVisible |  521ms | 609ms | 88ms | 0.46 | 14.4% |
| buildManagerIndexVisible |  523ms | 614ms | 91ms | 0.45 | 14.8% |
| buildStoryVisible |  514ms | 600ms | 86ms | 0.48 | 14.3% |
| buildAutodocsVisible |  433ms | 451ms | 18ms | -0.32 | 4% |
| buildMDXVisible |  481ms | 467ms | -14ms | -0.25 | -3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR introduces new CSF (Component Story Format) factory utilities to improve handling of story annotations and previews in Storybook's preview API.

- Added new `csf-factory-utils.ts` with core functions `getCsfFactoryPreview`, `isCsfFactory`, and `getCsfFactoryAnnotations` for standardized CSF factory handling
- Modified `processCSFFile.ts` to support CSF4 factory types by extracting metadata from `firstStory.meta.input` and `firstStory.config.input`
- Updated `DocsContext` class to use `isCsfFactory` utility for proper CSF factory story handling
- Refactored `testStory` function in `test-utils.ts` to use new `getCsfFactoryAnnotations` utility for improved type safety
- TODO noted for proper CSF factory type definitions that need to be implemented



<!-- /greptile_comment -->