### PR TITLE
Build: Fix missing tag in registry command

### DIFF
--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -138,7 +138,7 @@ const publish = async (packages: { name: string; location: string }[], url: stri
             const command = `cd ${resolvePath(
               '../code',
               location
-            )} && yarn pack --out=${PACKS_DIRECTORY}/${tarballFilename} && cd ${PACKS_DIRECTORY} && npm publish ./${tarballFilename} --registry ${url} --force --ignore-scripts`;
+            )} && yarn pack --out=${PACKS_DIRECTORY}/${tarballFilename} && cd ${PACKS_DIRECTORY} && npm publish ./${tarballFilename} --registry ${url} --force --tag="xyz" --ignore-scripts`;
             exec(command, (e) => {
               if (e) {
                 rej(e);


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes the compile command not working in --no-link mode with errors like these:

```ts
🛫 publishing @storybook/addon-interactions (addons/interactions)
Error: Command failed: cd /Users/storybook/code/addons/actions && yarn pack --out=/Users/storybook/packs/storybook-addon-actions.tgz && cd /Users/storybook/packs && npm publish ./storybook-addon-actions.tgz --registry http://localhost:6002/ --force --ignore-scripts
npm warn using --force Recommended protections disabled.
npm error You must specify a tag using --tag when publishing a prerelease version.
npm error A complete log of this run can be found in: /Users/.npm/_logs/2025-01-24T16_11_51_082Z-debug-0.log
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 77.9 MB | 0 B | **2.33** | 0% |
| initSize |  131 MB | 131 MB | -1.19 kB | **1.46** | 0% |
| diffSize |  53 MB | 53 MB | -1.19 kB | -0.17 | 0% |
| buildSize |  7.17 MB | 7.17 MB | 0 B | **-2.38** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | **2.38** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **-2.38** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | **-2.38** | 0% |
| buildPreviewSize |  3.26 MB | 3.26 MB | 0 B | **-2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  24.4s | 7.6s | -16s -730ms | -0.87 | -217.9% |
| generateTime |  19.5s | 20.4s | 844ms | -0.33 | 4.1% |
| initTime |  12.7s | 13.6s | 837ms | -0.59 | 6.2% |
| buildTime |  11.8s | 9.1s | -2s -729ms | -0.39 | -29.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 7.2s | 1.7s | **5.15** | 🔺24.1% |
| devManagerResponsive |  3.8s | 5.2s | 1.3s | **6.51** | 🔺25.6% |
| devManagerHeaderVisible |  688ms | 860ms | 172ms | **4.69** | 🔺20% |
| devManagerIndexVisible |  730ms | 896ms | 166ms | **3.23** | 🔺18.5% |
| devStoryVisibleUncached |  2.2s | 2.6s | 319ms | **3.01** | 🔺12.2% |
| devStoryVisible |  728ms | 893ms | 165ms | **4.74** | 🔺18.5% |
| devAutodocsVisible |  605ms | 721ms | 116ms | **2.83** | 🔺16.1% |
| devMDXVisible |  662ms | 710ms | 48ms | **2.21** | 🔺6.8% |
| buildManagerHeaderVisible |  606ms | 757ms | 151ms | **2.92** | 🔺19.9% |
| buildManagerIndexVisible |  709ms | 864ms | 155ms | **3** | 🔺17.9% |
| buildStoryVisible |  584ms | 725ms | 141ms | **2.84** | 🔺19.4% |
| buildAutodocsVisible |  570ms | 600ms | 30ms | **1.61** | 5% |
| buildMDXVisible |  522ms | 572ms | 50ms | **1.93** | 🔺8.7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and context, I'll create a concise review of the changes:

Modified npm publish command in run-registry.ts to include a tag parameter for prerelease versions.

- Added `--tag="xyz"` parameter to npm publish command in `scripts/run-registry.ts` to fix prerelease version publishing errors
- Current implementation uses a hardcoded "xyz" tag value which should be derived from the package version instead
- Change affects local development workflow when testing package publishing through Verdaccio registry
- Modification resolves npm error requiring tag specification for prerelease versions

The implementation fixes the immediate error but should be improved by using a dynamic tag based on the version rather than a hardcoded value.



<!-- /greptile_comment -->