### PR TITLE
Core: Fix invalid Websocket termination

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -90,7 +90,7 @@
     "type-fest": "~2.19"
   },
   "dependencies": {
-    "@chromatic-com/storybook": "^3.2.2",
+    "@chromatic-com/storybook": "^3.2.4",
     "@happy-dom/global-registrator": "^14.12.0",
     "@nx/eslint": "20.2.2",
     "@nx/vite": "20.2.2",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -3256,9 +3256,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chromatic-com/storybook@npm:^3.2.2":
-  version: 3.2.2
-  resolution: "@chromatic-com/storybook@npm:3.2.2"
+"@chromatic-com/storybook@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "@chromatic-com/storybook@npm:3.2.4"
   dependencies:
     chromatic: "npm:^11.15.0"
     filesize: "npm:^10.0.12"
@@ -3267,7 +3267,7 @@ __metadata:
     strip-ansi: "npm:^7.1.0"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 10c0/7b8da1ddb399c804337ff28a28594b548392b7bead52f66615b98e201cdeb4d31184b9e355791ba5d0d8cfdd2bea7d38355ecd0058f26f4790f9a887107bde0f
+  checksum: 10c0/57d466644d859ca58a853cc8316d3b0a64c617216ccf30d743c5fbf24c90859271a5708f05253a3b48c9ce64bc12749dd5a5b00fd1310f5d8a2ee64da9ceebe3
   languageName: node
   linkType: hard
 
@@ -8739,7 +8739,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/root@workspace:."
   dependencies:
-    "@chromatic-com/storybook": "npm:^3.2.2"
+    "@chromatic-com/storybook": "npm:^3.2.4"
     "@happy-dom/global-registrator": "npm:^14.12.0"
     "@nx/eslint": "npm:20.2.2"
     "@nx/vite": "npm:20.2.2"


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The server sometimes wrongfully terminated its client's WS connection. The server now just sends a heartbeat event to the client, and it is only about the client checking whether the connection is still established. If it isn't it shows an error message to the user (two cases: server closed, server timed out)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 77.9 MB | 0 B | **1.75** | 0% |
| initSize |  131 MB | 131 MB | -614 B | 1.21 | 0% |
| diffSize |  53 MB | 53 MB | -614 B | -0.28 | 0% |
| buildSize |  7.17 MB | 7.17 MB | 0 B | **-1.53** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | **1.53** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **-1.53** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | **-1.53** | 0% |
| buildPreviewSize |  3.26 MB | 3.26 MB | 0 B | **-1.53** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.8s | 23.5s | -259ms | 1.06 | -1.1% |
| generateTime |  21.7s | 24.7s | 2.9s | **2.45** | 🔺12% |
| initTime |  14.3s | 16.1s | 1.7s | 0.61 | 11% |
| buildTime |  9.4s | 10.5s | 1s | 0.89 | 10.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.3s | 4.4s | -1s -890ms | **-1.24** | 🔰-42.8% |
| devManagerResponsive |  4.5s | 3.1s | -1s -321ms | **-1.51** | 🔰-41.5% |
| devManagerHeaderVisible |  774ms | 556ms | -218ms | -0.61 | -39.2% |
| devManagerIndexVisible |  822ms | 561ms | -261ms | -0.84 | -46.5% |
| devStoryVisibleUncached |  2.5s | 1.5s | -1s -29ms | **-1.68** | 🔰-68.1% |
| devStoryVisible |  830ms | 631ms | -199ms | -0.2 | -31.5% |
| devAutodocsVisible |  775ms | 517ms | -258ms | -0.26 | -49.9% |
| devMDXVisible |  679ms | 483ms | -196ms | -0.67 | -40.6% |
| buildManagerHeaderVisible |  799ms | 509ms | -290ms | -0.9 | -57% |
| buildManagerIndexVisible |  823ms | 605ms | -218ms | -0.85 | -36% |
| buildStoryVisible |  789ms | 502ms | -287ms | -0.85 | -57.2% |
| buildAutodocsVisible |  625ms | 401ms | -224ms | -1.21 | -55.9% |
| buildMDXVisible |  650ms | 405ms | -245ms | -0.94 | -60.5% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR implements a simplified WebSocket heartbeat mechanism to improve connection stability in Storybook's manager interface.

- Removed server-side connection state tracking in `code/core/src/core-server/utils/get-server-channel.ts`, eliminating `isAlive` flag and `heartbeat()` method
- Implemented one-way ping system where server sends periodic heartbeats without expecting responses
- Shifted connection monitoring responsibility to client-side for better error handling and user messaging
- Updated `@chromatic-com/storybook` dependency from 3.2.2 to 3.2.4 in `package.json`
- Added client-side error states for server closure and timeout scenarios



<!-- /greptile_comment -->