### PR TITLE
React: Update react-docgen-typescript to fix CI hanging issues

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -465,7 +465,9 @@ Storybook now supports [Angular's experimental zoneless mode](https://angular.de
 
 ### React Vite: react-docgen-typescript is updated
 
-Storybook now uses [react-docgen-typescript](https://github.com/joshwooding/vite-plugin-react-docgen-typescript) v0.5.0 which updates its internal logic on how it parses files. Depending on how big is your codebase and which version of TypeScript you use, you might have performance issues. If that is the case, you can opt-in to a newer implementation under the `EXPERIMENTAL_useWatchProgram` flag. Keep in mind that this flag is experimental and also does not support the `references` field in tsconfig.json files.
+Storybook now uses [react-docgen-typescript](https://github.com/joshwooding/vite-plugin-react-docgen-typescript) v0.5.0 which updates its internal logic on how it parses files, available under an experimental feature flag `EXPERIMENTAL_useWatchProgram`, which is disabled by default.
+
+Previously, once you made changes to a component's props, the controls and args table would not update unless you restarted Storybook. With the `EXPERIMENTAL_useWatchProgram` flag, you do not need to restart Storybook anymore, however you do need to refresh the browser page. Keep in mind that this flag is experimental and also does not support the `references` field in tsconfig.json files. Depending on how big your codebase is, it might have performance issues.
 
 ```ts
 // .storybook/main.ts

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,9 @@
 
 - [From version 8.5.x to 8.6.x](#from-version-85x-to-86x)
   - [Angular: Support experimental zoneless support](#angular-support-experimental-zoneless-support)
+- [From version 8.4.x to 8.5.x](#from-version-84x-to-85x)
+  - [React Vite: react-docgen-typescript is updated](#react-vite-react-docgen-typescript-is-updated)
+  - [Introducing features.developmentModeForBuild](#introducing-featuresdevelopmentmodeforbuild)
   - [Added source code panel to docs](#added-source-code-panel-to-docs)
   - [Addon-a11y: Component test integration](#addon-a11y-component-test-integration)
   - [Addon-a11y: Changing the default element selector](#addon-a11y-changing-the-default-element-selector)
@@ -460,6 +463,24 @@ Storybook now supports [Angular's experimental zoneless mode](https://angular.de
 
 ## From version 8.4.x to 8.5.x
 
+### React Vite: react-docgen-typescript is updated
+
+Storybook now uses [react-docgen-typescript](https://github.com/joshwooding/vite-plugin-react-docgen-typescript) v0.5.0 which updates its internal logic on how it parses files. Depending on how big is your codebase and which version of TypeScript you use, you might have performance issues. If that is the case, you can opt-in to a newer implementation under the `EXPERIMENTAL_useWatchProgram` flag. Keep in mind that this flag is experimental and also does not support the `references` field in tsconfig.json files.
+
+```ts
+// .storybook/main.ts
+const config = {
+  // ...
+  typescript: {
+    reactDocgen: "react-docgen-typescript",
+    reactDocgenTypescriptOptions: {
+      EXPERIMENTAL_useWatchProgram: true,
+    },
+  },
+};
+export default config;
+```
+
 ### Introducing features.developmentModeForBuild
 
 As part of our ongoing efforts to improve the testability and debuggability of Storybook, we are introducing a new feature flag: `developmentModeForBuild`. This feature flag allows you to set `process.env.NODE_ENV` to `development` in built Storybooks, enabling development-related optimizations that are typically disabled in production builds.
@@ -473,7 +494,7 @@ export default {
     developmentModeForBuild: true,
   },
 };
-````
+```
 
 ### Added source code panel to docs
 

--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -56,7 +56,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.26.3",
     "@babel/preset-react": "^7.26.3",
     "@bunchtogether/vite-plugin-flow": "^1.0.2",
-    "@joshwooding/vite-plugin-react-docgen-typescript": "0.4.2",
+    "@joshwooding/vite-plugin-react-docgen-typescript": "0.5.0",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -57,7 +57,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@joshwooding/vite-plugin-react-docgen-typescript": "0.4.2",
+    "@joshwooding/vite-plugin-react-docgen-typescript": "0.5.0",
     "@rollup/pluginutils": "^5.0.2",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -4779,10 +4779,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.4.2":
-  version: 0.4.2
-  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.4.2"
+"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.5.0"
   dependencies:
+    glob: "npm:^10.0.0"
     magic-string: "npm:^0.27.0"
     react-docgen-typescript: "npm:^2.2.2"
   peerDependencies:
@@ -4791,7 +4792,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/355d13ad92a9da786b561a25250e6c94a8e51d235ced345e54ebfe709abc45ab60c2a8d06599df6ec0441fba01720f189883429943cb62dff9a4c31b59f0939c
+  checksum: 10c0/dd5bcd01c685c67bcfb4676639f15319937867ad5af0dc083991fe9ae9e66302c72fec53d12e0616a45eadb0ae715bea144d0302f408a44f1eeab14c5160ad4a
   languageName: node
   linkType: hard
 
@@ -8624,7 +8625,7 @@ __metadata:
     "@babel/plugin-transform-modules-commonjs": "npm:^7.26.3"
     "@babel/preset-react": "npm:^7.26.3"
     "@bunchtogether/vite-plugin-flow": "npm:^1.0.2"
-    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.4.2"
+    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.5.0"
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": "workspace:*"
     "@storybook/react-vite": "workspace:*"
@@ -8648,7 +8649,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/react-vite@workspace:frameworks/react-vite"
   dependencies:
-    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.4.2"
+    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.5.0"
     "@rollup/pluginutils": "npm:^5.0.2"
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": "workspace:*"

--- a/docs/api/main-config/main-config-typescript.mdx
+++ b/docs/api/main-config/main-config-typescript.mdx
@@ -79,7 +79,7 @@ Options to pass to `fork-ts-checker-webpack-plugin`, if [enabled](#check). See [
 
   Type: `ReactDocgenTypescriptOptions`
 
-  Configures the options to pass to `react-docgen-typescript-plugin` if `react-docgen-typescript` is enabled. See [docs for available options](https://github.com/hipstersmoothie/react-docgen-typescript-plugin).
+  Configures the options to pass to `react-docgen-typescript-plugin` if `react-docgen-typescript` is enabled. See docs for available options [for Webpack projects](https://github.com/hipstersmoothie/react-docgen-typescript-plugin) or [for Vite projects](https://github.com/joshwooding/vite-plugin-react-docgen-typescript).
 
   {/* prettier-ignore-start */}
 


### PR DESCRIPTION
Closes #29828

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR updates react-docgen-typescript so that it fixes the ongoing issues. It also adds documentation for users who would like to opt-in to the new behavior, which is now under an experimental flag.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30422-sha-3b8c2a95`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30422-sha-3b8c2a95 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30422-sha-3b8c2a95 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30422-sha-3b8c2a95`](https://npmjs.com/package/storybook/v/0.0.0-pr-30422-sha-3b8c2a95) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/update-react-docgen-typescript`](https://github.com/storybookjs/storybook/tree/yann/update-react-docgen-typescript) |
| **Commit** | [`3b8c2a95`](https://github.com/storybookjs/storybook/commit/3b8c2a958052ac051eac782a739ff471d17ed537) |
| **Datetime** | Thu Jan 30 10:54:14 UTC 2025 (`1738234454`) |
| **Workflow run** | [13050807576](https://github.com/storybookjs/storybook/actions/runs/13050807576) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30422`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 77.9 MB | 119 B | 0.95 | 0% |
| initSize |  131 MB | 134 MB | 3.41 MB | **134.44** | 2.5% |
| diffSize |  53 MB | 56.4 MB | 3.4 MB | **248.37** | 🔺6% |
| buildSize |  7.17 MB | 7.17 MB | 0 B | -0.79 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | **1.4** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | -0.82 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | -0.74 | 0% |
| buildPreviewSize |  3.26 MB | 3.26 MB | 0 B | -0.81 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  15.2s | 21.2s | 6s | 0.57 | 28.4% |
| generateTime |  17.9s | 19.3s | 1.3s | -0.65 | 7.2% |
| initTime |  11.3s | 13s | 1.6s | -0.51 | 12.7% |
| buildTime |  8.4s | 8.2s | -206ms | -1.07 | -2.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.9s | 4.8s | -28ms | -0.35 | -0.6% |
| devManagerResponsive |  3.6s | 3.6s | 15ms | -0.26 | 0.4% |
| devManagerHeaderVisible |  699ms | 756ms | 57ms | 0.53 | 7.5% |
| devManagerIndexVisible |  709ms | 768ms | 59ms | 0.29 | 7.7% |
| devStoryVisibleUncached |  3.9s | 4s | 120ms | **1.54** | 3% |
| devStoryVisible |  730ms | 837ms | 107ms | 0.74 | 12.8% |
| devAutodocsVisible |  644ms | 797ms | 153ms | 1.14 | 19.2% |
| devMDXVisible |  619ms | 805ms | 186ms | **1.43** | 🔺23.1% |
| buildManagerHeaderVisible |  677ms | 793ms | 116ms | 0.28 | 14.6% |
| buildManagerIndexVisible |  768ms | 932ms | 164ms | 0.4 | 17.6% |
| buildStoryVisible |  666ms | 782ms | 116ms | 0.31 | 14.8% |
| buildAutodocsVisible |  683ms | 584ms | -99ms | -0.19 | -17% |
| buildMDXVisible |  534ms | 764ms | 230ms | **1.45** | 🔺30.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request changes:

Updates the @joshwooding/vite-plugin-react-docgen-typescript dependency to version 0.5.0 to resolve CI hanging issues in Storybook's React frameworks.

- Updated dependency in `code/frameworks/react-native-web-vite/package.json` to fix CI build hangs
- Updated dependency in `code/frameworks/react-vite/package.json` for consistent version across frameworks
- Added documentation in `docs/api/main-config/main-config-typescript.mdx` for Vite-specific configuration
- Added migration notes in `MIGRATION.md` for new experimental performance flag and development mode feature



<!-- /greptile_comment -->