### PR TITLE
Builder-Vite: Fix allowedHosts handling for custom hosts

### DIFF
--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -29790,8 +29790,8 @@ __metadata:
   linkType: hard
 
 "vite@npm:^4.0.0, vite@npm:^4.0.4":
-  version: 4.5.1
-  resolution: "vite@npm:4.5.1"
+  version: 4.5.9
+  resolution: "vite@npm:4.5.9"
   dependencies:
     esbuild: "npm:^0.18.10"
     fsevents: "npm:~2.3.2"
@@ -29825,7 +29825,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/352a94b13f793e4bcbc424d680a32507343223eeda8917fde0f23c1fa1ba3db7c806dade8461ca5cfb270154ddb8895a219fdd4384519fe9b8e46d1cf491a890
+  checksum: 10c0/d51b9da32fddc6079333a16306c4c70d6ea6b253267931b5cd5d1c521bcfbee926297dc6878da79b0f1e058b7eef72555226be701fae376c2dfae9f83bc5699a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update yarn lock to use version of `vite` that has `allowedHosts` in `ServerOptions`.
Add logic to pass forward `server.allowedHosts` from user's vite config, otherwise check if server is bound to value that should default `allowedHosts` to `true`, otherwise use set `allowedHosts` to contain specified `host`.

Closes #30338

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->
Add logic to define `allowedHosts` either by passing forward config from user's vite config, or setting default. This required updating some of the yarn lock to use a version that contained the type for `allowedHosts`, but remained in respected semver range. This change should have no impact on prior versions because the `allowedHosts` value will be ignored by vite.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. -->

1. Run a sandbox for a vite based template, e.g. `yarn task --task sandbox --start-from auto --template lit-vite/default-ts`
2. Open Storybook in your browser, using your system's `hostname` instead of `localhost`, by default this should load as expected.
3. Update the sandbox vite.config.js to contain: `{ server: { allowedHosts: ['localhost'] } }`
4. Restart the storybook `yarn run storybook` from your sandbox
5. Reload browser with your `hostname` as the URL and the preview should fail to load, as expected, since it is no longer an allowed hostname.
6. Reload browser with `localhost` as the URL and the preview should load.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.3 MB | 78.3 MB | 0 B | **2.85** | 0% |
| initSize |  131 MB | 131 MB | 436 B | **2.66** | 0% |
| diffSize |  53 MB | 53 MB | 436 B | 0.59 | 0% |
| buildSize |  7.17 MB | 7.17 MB | 0 B | 0.35 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | 0.23 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | -0.58 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | 0.18 | 0% |
| buildPreviewSize |  3.26 MB | 3.26 MB | 0 B | 0.35 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  22.4s | 24.2s | 1.8s | 0.86 | 7.6% |
| generateTime |  19.4s | 17.7s | -1s -683ms | -1.13 | -9.5% |
| initTime |  12.6s | 11.5s | -1s -173ms | -0.83 | -10.2% |
| buildTime |  9.9s | 7.9s | -2s -80ms | -0.92 | -26.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.8s | 6.5s | 1.6s | 0.59 | 25.6% |
| devManagerResponsive |  3.5s | 4.9s | 1.3s | 0.77 | 28% |
| devManagerHeaderVisible |  816ms | 1s | 234ms | **1.83** | 🔺22.3% |
| devManagerIndexVisible |  852ms | 1.1s | 330ms | **2.49** | 🔺27.9% |
| devStoryVisibleUncached |  3.8s | 2.9s | -883ms | **-1.55** | 🔰-30.1% |
| devStoryVisible |  853ms | 1.1s | 330ms | **2.45** | 🔺27.9% |
| devAutodocsVisible |  850ms | 957ms | 107ms | **1.8** | 🔺11.2% |
| devMDXVisible |  724ms | 975ms | 251ms | **2.22** | 🔺25.7% |
| buildManagerHeaderVisible |  847ms | 3s | 2.1s | **7.94** | 🔺72.2% |
| buildManagerIndexVisible |  941ms | 3.1s | 2.2s | **7.56** | 🔺70.1% |
| buildStoryVisible |  836ms | 2.8s | 1.9s | **7.41** | 🔺70.5% |
| buildAutodocsVisible |  608ms | 2.7s | 2.1s | **1.85** | 🔺77.6% |
| buildMDXVisible |  669ms | 1.3s | 640ms | **5.06** | 🔺48.9% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Let me provide a clear and concise summary of this pull request:

This PR fixes an issue where Storybook was not accessible via local hostnames after upgrading to Vite 6. The key changes include:

- Added proper handling of `allowedHosts` configuration in Vite server setup
- Preserves user-defined `allowedHosts` settings from vite config
- Automatically sets `allowedHosts: true` for common local addresses (`::`/`0.0.0.0`/`127.0.0.1`)
- Falls back to including specific host address in `allowedHosts` array when not using common local addresses
- Updates dependencies and documentation to support these changes

Key files changed:
- `code/builders/builder-vite/src/vite-server.ts`: Main implementation of `allowedHosts` handling
- `CHANGELOG.md`: Documents the fix for hostname accessibility issues
- Various framework documentation files: Updated sidebar ordering

The changes are focused and minimal, addressing issue #30338 where Storybook became inaccessible via local hostnames after the Vite 6 upgrade. The implementation properly handles backward compatibility and provides secure defaults for development environments.



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->