### PR TITLE
Build: Add flag to skip nx cache

### DIFF
--- a/scripts/task.ts
+++ b/scripts/task.ts
@@ -159,6 +159,11 @@ export const options = createOptions({
     description: "Don't execute commands, just list them (dry run)?",
     promptType: false,
   },
+  skipCache: {
+    type: 'boolean',
+    description: 'Skip NX remote cache?',
+    promptType: false,
+  },
   debug: {
     type: 'boolean',
     description: 'Print all the logs to the console',

--- a/scripts/tasks/compile.ts
+++ b/scripts/tasks/compile.ts
@@ -37,9 +37,10 @@ export const compile: Task = {
       return false;
     }
   },
-  async run({ codeDir }, { link, dryRun, debug, prod }) {
+  async run({ codeDir }, { link, dryRun, debug, prod, skipCache }) {
+    const command = link && !prod ? linkCommand : noLinkCommand;
     return exec(
-      link && !prod ? linkCommand : noLinkCommand,
+      `${command} ${skipCache ? '--skip-nx-cache' : ''}`,
       { cwd: codeDir },
       {
         startMessage: '🥾 Bootstrapping',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR introduces a flag to skip nx cache.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 77.9 MB | 0 B | 0.72 | 0% |
| initSize |  131 MB | 131 MB | 0 B | **2.02** | 0% |
| diffSize |  53 MB | 53 MB | 0 B | **2.08** | 0% |
| buildSize |  7.17 MB | 7.17 MB | 0 B | -0.47 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | 1.04 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | -0.58 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | -0.51 | 0% |
| buildPreviewSize |  3.27 MB | 3.27 MB | 0 B | -0.45 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23.5s | 7.9s | -15s -552ms | **-1.44** | 🔰-195% |
| generateTime |  18.3s | 19.5s | 1.1s | -0.44 | 6% |
| initTime |  11.7s | 12.7s | 1s | -0.5 | 8.3% |
| buildTime |  7.8s | 9s | 1.1s | -0.25 | 12.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.5s | 5.8s | 387ms | 0.27 | 6.6% |
| devManagerResponsive |  4s | 4.5s | 508ms | 0.5 | 11.2% |
| devManagerHeaderVisible |  820ms | 762ms | -58ms | 0.43 | -7.6% |
| devManagerIndexVisible |  909ms | 771ms | -138ms | 0.17 | -17.9% |
| devStoryVisibleUncached |  1.9s | 3.4s | 1.4s | 0.76 | 42.7% |
| devStoryVisible |  909ms | 792ms | -117ms | 0.26 | -14.8% |
| devAutodocsVisible |  741ms | 771ms | 30ms | 0.85 | 3.9% |
| devMDXVisible |  697ms | 681ms | -16ms | 0.34 | -2.3% |
| buildManagerHeaderVisible |  759ms | 697ms | -62ms | -0.11 | -8.9% |
| buildManagerIndexVisible |  866ms | 831ms | -35ms | 0 | -4.2% |
| buildStoryVisible |  692ms | 687ms | -5ms | -0.08 | -0.7% |
| buildAutodocsVisible |  607ms | 671ms | 64ms | -0.13 | 9.5% |
| buildMDXVisible |  597ms | 677ms | 80ms | 0.81 | 11.8% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the PR changes focusing on the addition of the NX cache skip functionality:

Added a new `skipCache` flag to bypass NX caching during Storybook builds, with implementation in core task runner scripts.

- Added `skipCache` boolean option in `scripts/task.ts` with description "Skip NX remote cache"
- Modified compile commands in `scripts/tasks/compile.ts` to append `--skip-nx-cache` when flag is enabled
- Integrated flag into both link and no-link command variants for consistent behavior
- Implementation lacks documentation updates and test coverage for verifying cache bypass functionality
- No migration notes provided for this new feature

The changes are focused on build optimization but would benefit from additional documentation and testing to ensure proper usage and reliability.



<!-- /greptile_comment -->