### PR TITLE
Addon A11y: Make Vitest Axe optional

### DIFF
--- a/code/addons/a11y/package.json
+++ b/code/addons/a11y/package.json
@@ -68,8 +68,7 @@
   "dependencies": {
     "@storybook/addon-highlight": "workspace:*",
     "@storybook/test": "workspace:*",
-    "axe-core": "^4.2.0",
-    "vitest-axe": "^0.1.0"
+    "axe-core": "^4.2.0"
   },
   "devDependencies": {
     "@storybook/global": "^5.0.0",
@@ -82,10 +81,17 @@
     "react-dom": "^18.2.0",
     "react-resize-detector": "^7.1.2",
     "resize-observer-polyfill": "^1.5.1",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest-axe": "^0.1.0"
   },
   "peerDependencies": {
-    "storybook": "workspace:^"
+    "storybook": "workspace:^",
+    "vitest": "^2.1.1 || ^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/code/addons/a11y/package.json
+++ b/code/addons/a11y/package.json
@@ -85,13 +85,7 @@
     "vitest-axe": "^0.1.0"
   },
   "peerDependencies": {
-    "storybook": "workspace:^",
-    "vitest": "^2.1.1 || ^3.0.0"
-  },
-  "peerDependenciesMeta": {
-    "vitest": {
-      "optional": true
-    }
+    "storybook": "workspace:^"
   },
   "publishConfig": {
     "access": "public"

--- a/code/addons/a11y/src/preview.tsx
+++ b/code/addons/a11y/src/preview.tsx
@@ -1,6 +1,3 @@
-// Source: https://github.com/chaance/vitest-axe/blob/main/src/to-have-no-violations.ts
-import * as matchers from 'vitest-axe/matchers';
-
 import type { AfterEach } from 'storybook/internal/types';
 
 import { expect } from '@storybook/test';
@@ -10,7 +7,7 @@ import { A11Y_TEST_TAG } from './constants';
 import type { A11yParameters } from './params';
 import { getIsVitestRunning, getIsVitestStandaloneRun } from './utils';
 
-expect.extend(matchers);
+let vitestMatchersExtended = false;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const experimental_afterEach: AfterEach<any> = async ({
@@ -54,6 +51,12 @@ export const experimental_afterEach: AfterEach<any> = async ({
          */
         if (getIsVitestStandaloneRun()) {
           if (hasViolations) {
+            if (!vitestMatchersExtended) {
+              const { toHaveNoViolations } = await import('vitest-axe/matchers');
+              expect.extend({ toHaveNoViolations });
+              vitestMatchersExtended = true;
+            }
+
             // @ts-expect-error - todo - fix type extension of expect from @storybook/test
             expect(result).toHaveNoViolations();
           }

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5632,6 +5632,10 @@ __metadata:
     vitest-axe: "npm:^0.1.0"
   peerDependencies:
     storybook: "workspace:^"
+    vitest: ^2.1.1 || ^3.0.0
+  peerDependenciesMeta:
+    vitest:
+      optional: true
   languageName: unknown
   linkType: soft
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5632,10 +5632,6 @@ __metadata:
     vitest-axe: "npm:^0.1.0"
   peerDependencies:
     storybook: "workspace:^"
-    vitest: ^2.1.1 || ^3.0.0
-  peerDependenciesMeta:
-    vitest:
-      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Relates https://github.com/storybookjs/storybook/issues/30423

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- made `vitest` in `@storybook/addon-a11y` an optional peer-dependency

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30442-sha-6e0c6f13`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30442-sha-6e0c6f13 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30442-sha-6e0c6f13 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30442-sha-6e0c6f13`](https://npmjs.com/package/storybook/v/0.0.0-pr-30442-sha-6e0c6f13) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/make-vitest-axe-optional`](https://github.com/storybookjs/storybook/tree/valentin/make-vitest-axe-optional) |
| **Commit** | [`6e0c6f13`](https://github.com/storybookjs/storybook/commit/6e0c6f13846c5f18551d757843f8115b54852fe6) |
| **Datetime** | Mon Feb  3 10:00:20 UTC 2025 (`1738576820`) |
| **Workflow run** | [13110891933](https://github.com/storybookjs/storybook/actions/runs/13110891933) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30442`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78 MB | 78 MB | 6.33 kB | **1.93** | 0% |
| initSize |  131 MB | 131 MB | 6.33 kB | **1.57** | 0% |
| diffSize |  53 MB | 53 MB | 0 B | 1 | 0% |
| buildSize |  7.17 MB | 7.17 MB | 37 B | 0.75 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | 0.65 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | -1 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | 0.63 | 0% |
| buildPreviewSize |  3.26 MB | 3.26 MB | 37 B | 0.73 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  19.9s | 11.9s | -8s -33ms | **-1.45** | 🔰-67.2% |
| generateTime |  19.7s | 23.7s | 3.9s | **2.47** | 🔺16.7% |
| initTime |  17.4s | 13.9s | -3s -569ms | 0.4 | -25.6% |
| buildTime |  8.5s | 10.7s | 2.1s | **1.67** | 🔺20.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.9s | 5.1s | -792ms | -0.25 | -15.3% |
| devManagerResponsive |  4.2s | 3.9s | -291ms | -0.09 | -7.3% |
| devManagerHeaderVisible |  801ms | 804ms | 3ms | 0.34 | 0.4% |
| devManagerIndexVisible |  812ms | 839ms | 27ms | 0.2 | 3.2% |
| devStoryVisibleUncached |  4.1s | 3.4s | -697ms | 0.05 | -20.4% |
| devStoryVisible |  830ms | 834ms | 4ms | 0.13 | 0.5% |
| devAutodocsVisible |  774ms | 738ms | -36ms | 0.17 | -4.9% |
| devMDXVisible |  739ms | 744ms | 5ms | 0.48 | 0.7% |
| buildManagerHeaderVisible |  776ms | 716ms | -60ms | -0.25 | -8.4% |
| buildManagerIndexVisible |  908ms | 903ms | -5ms | 0.03 | -0.6% |
| buildStoryVisible |  758ms | 695ms | -63ms | -0.25 | -9.1% |
| buildAutodocsVisible |  669ms | 697ms | 28ms | -0.15 | 4% |
| buildMDXVisible |  683ms | 783ms | 100ms | **1.33** | 🔺12.8% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Makes the Vitest Axe dependency optional in the @storybook/addon-a11y package to prevent errors for users not using Vitest.

- Moved `vitest-axe` from dependencies to devDependencies in `code/addons/a11y/package.json`
- Modified `code/addons/a11y/src/preview.tsx` to dynamically import Vitest Axe matchers only when needed
- Added flag `vitestMatchersExtended` to ensure matchers are only extended once
- Maintains core accessibility testing functionality using axe-core
- Fixes issue #30423 where non-Vitest users encountered errors when upgrading to Storybook 8.5.0



<!-- /greptile_comment -->