### PR TITLE
Maintenance: Support storysort in csf factories

### DIFF
--- a/code/.storybook/preview.tsx
+++ b/code/.storybook/preview.tsx
@@ -321,10 +321,6 @@ const decorators = [
 ] satisfies Decorator[];
 
 const parameters = {
-  options: {
-    storySort: (a, b) =>
-      a.title === b.title ? 0 : a.id.localeCompare(b.id, undefined, { numeric: true }),
-  },
   docs: {
     theme: themes.light,
     toc: {},
@@ -373,7 +369,7 @@ const parameters = {
   },
 };
 
-export const config = definePreview({
+export default definePreview({
   addons: [
     addonThemes(),
     addonEssentials(),
@@ -382,8 +378,8 @@ export const config = definePreview({
     addonsPreview,
     templatePreview,
   ],
-  parameters,
   decorators,
   loaders,
   tags: ['test', 'vitest'],
+  parameters,
 });

--- a/code/.storybook/storybook.setup.ts
+++ b/code/.storybook/storybook.setup.ts
@@ -3,12 +3,12 @@ import { beforeAll, vi, expect as vitestExpect } from 'vitest';
 import { setProjectAnnotations } from '@storybook/react';
 import { userEvent as storybookEvent, expect as storybookExpect } from '@storybook/test';
 
-import { config } from './preview';
+import previw from './preview';
 
 vi.spyOn(console, 'warn').mockImplementation((...args) => console.log(...args));
 
 const annotations = setProjectAnnotations([
-  config.input,
+  previw.input,
   {
     // experiment with injecting Vitest's interactivity API over our userEvent while tests run in browser mode
     // https://vitest.dev/guide/browser/interactivity-api.html

--- a/code/core/src/components/components/Button/Button.stories.tsx
+++ b/code/core/src/components/components/Button/Button.stories.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 
 import { FaceHappyIcon } from '@storybook/icons';
 
-import { config } from '../../../../../.storybook/preview';
+import preview from '../../../../../.storybook/preview';
 import { Button } from './Button';
 
-const meta = config.meta({
+const meta = preview.meta({
   id: 'button-component',
   title: 'Button',
   component: Button,

--- a/code/core/src/core-server/utils/save-story/mocks/csf4-variances.stories.tsx
+++ b/code/core/src/core-server/utils/save-story/mocks/csf4-variances.stories.tsx
@@ -1,7 +1,7 @@
 // @ts-expect-error this is just a mock file
-import { config } from '#.storybook/preview';
+import preview from '#.storybook/preview';
 
-const meta = config.meta({
+const meta = preview.meta({
   title: 'MyComponent',
   args: {
     initial: 'foo',

--- a/code/core/src/csf-tools/getStorySortParameter.test.ts
+++ b/code/core/src/csf-tools/getStorySortParameter.test.ts
@@ -477,6 +477,51 @@ export default {
           }
         `);
       });
+      describe('csf factories', () => {
+        it('inline storysort in default export', () => {
+          expect(
+            getStorySortParameter(dedent`
+              export default definePreview({
+                parameters: {
+                  options: {
+                    storySort: {
+                      order: ['General']
+                    }
+                  },
+                },
+              });
+          `)
+          ).toMatchInlineSnapshot(`
+            {
+              "order": [
+                "General",
+              ],
+            }
+          `);
+        });
+        it('variable reference in default export', () => {
+          expect(
+            getStorySortParameter(dedent`
+              const parameters = {
+                options: {
+                  storySort: {
+                    order: ['General']
+                  }
+                },
+              };
+              export default definePreview({
+                parameters,
+              });
+          `)
+          ).toMatchInlineSnapshot(`
+            {
+              "order": [
+                "General",
+              ],
+            }
+          `);
+        });
+      });
     });
     describe('unsupported', () => {
       it('bad default export', () => {

--- a/code/core/src/csf-tools/getStorySortParameter.ts
+++ b/code/core/src/csf-tools/getStorySortParameter.ts
@@ -131,7 +131,10 @@ export const getStorySortParameter = (previewCode: string) => {
           defaultObj = findVarInitialization(defaultObj.name, ast.program);
         }
         defaultObj = stripTSModifiers(defaultObj);
-        if (t.isObjectExpression(defaultObj)) {
+        // parse the call arg when using definePreview({ ... })
+        if (t.isCallExpression(defaultObj) && t.isObjectExpression(defaultObj.arguments?.[0])) {
+          storySort = parseDefault(defaultObj.arguments[0], ast.program);
+        } else if (t.isObjectExpression(defaultObj)) {
           storySort = parseDefault(defaultObj, ast.program);
         } else {
           unsupported('default', false);

--- a/code/frameworks/react-vite/template/stories/csf4.stories.tsx
+++ b/code/frameworks/react-vite/template/stories/csf4.stories.tsx
@@ -1,7 +1,7 @@
 // @ts-expect-error this will be part of the package.json of the sandbox
-import config from '#.storybook/preview';
+import preview from '#.storybook/preview';
 
-const meta = config.meta({
+const meta = preview.meta({
   component: globalThis.Components.Button,
   args: {
     label: 'Hello world!',

--- a/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
@@ -34,7 +34,7 @@ export async function storyToCsfFactory(info: FileInfo) {
   /**
    * Add the preview import if it doesn't exist yet:
    *
-   * `import { config } from '#.storybook/preview'`;
+   * `import preview from '#.storybook/preview'`;
    */
   const programNode = csf._ast.program;
   let foundConfigImport = false;
@@ -196,7 +196,7 @@ export async function storyToCsfFactory(info: FileInfo) {
        *
        * Into a meta call:
        *
-       * `const meta = config.meta({ title: 'A' });`
+       * `const meta = preview.meta({ title: 'A' });`
        */
       const binding = csf._metaPath.scope.getBinding(declaration.name);
       if (binding && binding.path.isVariableDeclarator()) {

--- a/code/renderers/react/src/__test__/Button.csf4.stories.tsx
+++ b/code/renderers/react/src/__test__/Button.csf4.stories.tsx
@@ -8,9 +8,9 @@ import { action } from '@storybook/addon-actions';
 import { definePreview } from '../preview';
 import { Button } from './Button';
 
-const config = definePreview({});
+const preview = definePreview({});
 
-const meta = config.meta({
+const meta = preview.meta({
   id: 'button-component',
   title: 'Example/CSF4/Button',
   component: Button,


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.9 MB | 78 MB | 67.1 kB | **3.27** | 0.1% |
| initSize |  132 MB | 132 MB | 67.3 kB | -0.33 | 0.1% |
| diffSize |  53.9 MB | 53.9 MB | 225 B | -0.46 | 0% |
| buildSize |  7.2 MB | 7.2 MB | -296 B | **3.63** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | **-4.19** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **-3.28** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | **-3.83** | 0% |
| buildPreviewSize |  3.29 MB | 3.29 MB | -296 B | **4.24** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.5s | 28.8s | 20.2s | **1.56** | 🔺70.2% |
| generateTime |  19s | 22.1s | 3.1s | 0.42 | 14.3% |
| initTime |  12s | 13.1s | 1.1s | -0.6 | 8.5% |
| buildTime |  8.4s | 8.6s | 280ms | -1.08 | 3.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 6.8s | 1.3s | **4.27** | 🔺20.3% |
| devManagerResponsive |  4s | 5s | 994ms | **4.21** | 🔺19.7% |
| devManagerHeaderVisible |  775ms | 966ms | 191ms | **4.98** | 🔺19.8% |
| devManagerIndexVisible |  801ms | 1s | 232ms | **5.15** | 🔺22.5% |
| devStoryVisibleUncached |  4.1s | 4.4s | 306ms | **4.81** | 🔺6.9% |
| devStoryVisible |  803ms | 1s | 253ms | **5.73** | 🔺24% |
| devAutodocsVisible |  688ms | 853ms | 165ms | **4.83** | 🔺19.3% |
| devMDXVisible |  643ms | 814ms | 171ms | **4** | 🔺21% |
| buildManagerHeaderVisible |  774ms | 780ms | 6ms | **2.43** | 0.8% |
| buildManagerIndexVisible |  778ms | 783ms | 5ms | **2.37** | 0.6% |
| buildStoryVisible |  759ms | 767ms | 8ms | **2.44** | 1% |
| buildAutodocsVisible |  677ms | 589ms | -88ms | **1.67** | 🔰-14.9% |
| buildMDXVisible |  601ms | 668ms | 67ms | **2.59** | 🔺10% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR updates the CSF (Component Story Format) factory implementation to support story sorting functionality, with changes focused on standardizing the preview configuration pattern.

- Added support for `storySort` parameter extraction in `code/core/src/csf-tools/getStorySortParameter.ts` for CSF factories
- Changed imports from named `{ config }` to default `preview` across multiple files for consistency
- Updated `code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts` to handle root-level preview constants and TypeScript annotations
- Removed story sorting configuration from `code/.storybook/preview.tsx` while maintaining core functionality
- Added test coverage in `getStorySortParameter.test.ts` for both inline and variable reference sorting patterns



<!-- /greptile_comment -->