### PR TITLE
UI: Support CSF factories when creating story files from UI

### DIFF
--- a/code/core/src/common/utils/sync-main-preview-addons.ts
+++ b/code/core/src/common/utils/sync-main-preview-addons.ts
@@ -2,7 +2,12 @@
 import { types as t } from '@storybook/core/babel';
 import type { StorybookConfig } from '@storybook/types';
 
-import { type ConfigFile, readConfig, writeConfig } from '@storybook/core/csf-tools';
+import {
+  type ConfigFile,
+  isCsfFactoryPreview,
+  readConfig,
+  writeConfig,
+} from '@storybook/core/csf-tools';
 
 import picocolors from 'picocolors';
 
@@ -22,22 +27,9 @@ export async function getSyncedStorybookAddons(
   mainConfig: StorybookConfig,
   previewConfig: ConfigFile
 ): Promise<ConfigFile> {
-  const program = previewConfig._ast.program;
-  const isCsfFactoryPreview = !!program.body.find((node) => {
-    return (
-      t.isImportDeclaration(node) &&
-      node.source.value.includes('@storybook') &&
-      node.specifiers.some((specifier) => {
-        return (
-          t.isImportSpecifier(specifier) &&
-          t.isIdentifier(specifier.imported) &&
-          specifier.imported.name === 'definePreview'
-        );
-      })
-    );
-  });
+  const isCsfFactory = isCsfFactoryPreview(previewConfig);
 
-  if (!isCsfFactoryPreview) {
+  if (!isCsfFactory) {
     return previewConfig;
   }
 

--- a/code/core/src/core-server/utils/new-story-templates/csf-factory-template.test.ts
+++ b/code/core/src/core-server/utils/new-story-templates/csf-factory-template.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCsfFactoryTemplateForNewStoryFile } from './csf-factory-template';
+
+describe('csf-factories', () => {
+  it('should return a CSF factories template with a default import', async () => {
+    const result = await getCsfFactoryTemplateForNewStoryFile({
+      basenameWithoutExtension: 'foo',
+      componentExportName: 'default',
+      componentIsDefaultExport: true,
+      exportedStoryName: 'Default',
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      "import preview from '#.storybook/preview';
+
+      import Foo from './foo';
+
+      const meta = preview.meta({
+        component: Foo,
+      });
+
+      export const Default = meta.story({});"
+    `);
+  });
+});

--- a/code/core/src/core-server/utils/new-story-templates/csf-factory-template.ts
+++ b/code/core/src/core-server/utils/new-story-templates/csf-factory-template.ts
@@ -1,0 +1,33 @@
+import { dedent } from 'ts-dedent';
+
+import { getComponentVariableName } from '../get-component-variable-name';
+
+interface CsfFactoryTemplateData {
+  /** The components file name without the extension */
+  basenameWithoutExtension: string;
+  componentExportName: string;
+  componentIsDefaultExport: boolean;
+  /** The exported name of the default story */
+  exportedStoryName: string;
+}
+
+export async function getCsfFactoryTemplateForNewStoryFile(data: CsfFactoryTemplateData) {
+  const importName = data.componentIsDefaultExport
+    ? await getComponentVariableName(data.basenameWithoutExtension)
+    : data.componentExportName;
+  const importStatement = data.componentIsDefaultExport
+    ? `import ${importName} from './${data.basenameWithoutExtension}';`
+    : `import { ${importName} } from './${data.basenameWithoutExtension}';`;
+  const previewImport = `import preview from '#.storybook/preview';`;
+  return dedent`
+  ${previewImport}
+  
+  ${importStatement}
+
+  const meta = preview.meta({
+    component: ${importName},
+  });
+  
+  export const ${data.exportedStoryName} = meta.story({});
+  `;
+}

--- a/code/core/src/csf-tools/ConfigFile.ts
+++ b/code/core/src/csf-tools/ConfigFile.ts
@@ -970,3 +970,20 @@ export const writeConfig = async (config: ConfigFile, fileName?: string) => {
   }
   await writeFile(fname, formatConfig(config));
 };
+
+export const isCsfFactoryPreview = (previewConfig: ConfigFile) => {
+  const program = previewConfig._ast.program;
+  return !!program.body.find((node) => {
+    return (
+      t.isImportDeclaration(node) &&
+      node.source.value.includes('@storybook') &&
+      node.specifiers.some((specifier) => {
+        return (
+          t.isImportSpecifier(specifier) &&
+          t.isIdentifier(specifier.imported) &&
+          specifier.imported.name === 'definePreview'
+        );
+      })
+    );
+  });
+};


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR introduces a check when creating stories so that if the project uses CSF Factories, the newly created story will also use the CSF Factory format

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78 MB | 78 MB | 0 B | **2.56** | 0% |
| initSize |  132 MB | 132 MB | 39.5 kB | -0.22 | 0% |
| diffSize |  53.9 MB | 53.9 MB | 39.5 kB | -0.35 | 0.1% |
| buildSize |  7.2 MB | 7.2 MB | 0 B | **2.71** | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | **-2.94** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **-2.56** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | **-2.8** | 0% |
| buildPreviewSize |  3.29 MB | 3.29 MB | 0 B | **2.96** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  25.8s | 9.2s | -16s -580ms | -1 | -178.4% |
| generateTime |  19.8s | 22.7s | 2.9s | 0.63 | 12.9% |
| initTime |  12.9s | 13.6s | 734ms | -0.24 | 5.4% |
| buildTime |  8.2s | 8.6s | 388ms | -1.04 | 4.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.5s | 5.8s | 1.3s | **1.95** | 🔺23% |
| devManagerResponsive |  3.4s | 4.2s | 891ms | **1.89** | 🔺20.8% |
| devManagerHeaderVisible |  695ms | 792ms | 97ms | **2.41** | 🔺12.2% |
| devManagerIndexVisible |  721ms | 804ms | 83ms | **2.02** | 🔺10.3% |
| devStoryVisibleUncached |  3.6s | 4.1s | 505ms | **3.33** | 🔺12.2% |
| devStoryVisible |  722ms | 824ms | 102ms | **2.36** | 🔺12.4% |
| devAutodocsVisible |  607ms | 732ms | 125ms | **2.95** | 🔺17.1% |
| devMDXVisible |  666ms | 710ms | 44ms | **2.31** | 🔺6.2% |
| buildManagerHeaderVisible |  613ms | 757ms | 144ms | **2.14** | 🔺19% |
| buildManagerIndexVisible |  615ms | 771ms | 156ms | **2.22** | 🔺20.2% |
| buildStoryVisible |  605ms | 742ms | 137ms | **2.11** | 🔺18.5% |
| buildAutodocsVisible |  510ms | 679ms | 169ms | **2.99** | 🔺24.9% |
| buildMDXVisible |  480ms | 600ms | 120ms | **1.6** | 🔺20% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR adds support for CSF (Component Story Format) factories when generating story files through Storybook's UI, enabling automatic template generation that aligns with the new factory pattern.

- Added `code/core/src/core-server/utils/new-story-templates/csf-factory-template.ts` to generate CSF factory-based story templates
- Added test coverage in `csf-factory-template.test.ts` to verify template generation for default exports
- Modified `get-new-story-file.ts` to detect and support CSF factory usage with fallback to CSF3
- Added `isCsfFactoryPreview` function in `ConfigFile.ts` to detect if a project uses CSF factories
- Updated addon synchronization in `sync-main-preview-addons.ts` to properly handle CSF factory format



<!-- /greptile_comment -->