### PR TITLE
Build: Set TypeScript resolution for sandbox generation

### DIFF
--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -94,6 +94,7 @@ export const addWorkaroundResolutions = async ({
     '@testing-library/dom': '^9.3.4',
     '@testing-library/jest-dom': '^6.5.0',
     '@testing-library/user-event': '^14.5.2',
+    typescript: '^5.7.3',
   };
 
   await writeJSON(packageJsonPath, packageJson, { spaces: 2 });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Due to non-overlapping versions of `typescript` in the monorepo and in sandboxes, I was not able to create a vue3 sandbox due to the `YN0071: NM_CANT_INSTALL_EXTERNAL_SOFT_LINK` error. This PR makes sure that the same Typescript version is used in the sandbox as like the one in the monorepo.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78 MB | 78.3 MB | 309 kB | **10.69** | 0.4% |
| initSize |  131 MB | 131 MB | 309 kB | **6.18** | 0.2% |
| diffSize |  53 MB | 53 MB | 0 B | 0.91 | 0% |
| buildSize |  7.17 MB | 7.17 MB | 0 B | 0.67 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | 0.58 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | -0.9 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | 0 B | 0.55 | 0% |
| buildPreviewSize |  3.26 MB | 3.26 MB | 0 B | 0.65 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  11.1s | 35.8s | 24.7s | **2.65** | 🔺69% |
| generateTime |  23.7s | 21.6s | -2s -144ms | 0.86 | -9.9% |
| initTime |  16.7s | 15.4s | -1s -265ms | 1.09 | -8.2% |
| buildTime |  9.3s | 8.2s | -1s -86ms | -0.61 | -13.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.8s | 5.4s | 595ms | -0.04 | 10.9% |
| devManagerResponsive |  3.6s | 4s | 482ms | 0.01 | 11.8% |
| devManagerHeaderVisible |  707ms | 859ms | 152ms | 0.75 | 17.7% |
| devManagerIndexVisible |  734ms | 889ms | 155ms | 0.56 | 17.4% |
| devStoryVisibleUncached |  4s | 2.7s | -1s -326ms | -0.78 | -49% |
| devStoryVisible |  734ms | 889ms | 155ms | 0.52 | 17.4% |
| devAutodocsVisible |  680ms | 897ms | 217ms | **1.33** | 🔺24.2% |
| devMDXVisible |  646ms | 749ms | 103ms | 0.53 | 13.8% |
| buildManagerHeaderVisible |  789ms | 1.3s | 606ms | **2.06** | 🔺43.4% |
| buildManagerIndexVisible |  892ms | 1.4s | 606ms | **1.96** | 🔺40.5% |
| buildStoryVisible |  779ms | 1.3s | 527ms | **1.87** | 🔺40.4% |
| buildAutodocsVisible |  890ms | 1.3s | 493ms | 0.52 | 35.6% |
| buildMDXVisible |  575ms | 692ms | 117ms | 0.66 | 16.9% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of this PR's changes:

Added TypeScript version resolution to sandbox generation to ensure consistent versioning between monorepo and sandboxes, fixing YN0071 errors during Vue3 sandbox creation.

- Added `typescript: '^5.7.3'` to package resolutions in `scripts/utils/yarn.ts`
- Ensures sandbox environments use same TypeScript version as monorepo
- Resolves YN0071 error during Vue3 sandbox generation
- Maintains version consistency across development environments



<!-- /greptile_comment -->