### PR TITLE
Build: Fix Angular sandbox generation in no-link mode

### DIFF
--- a/code/core/src/manager-api/modules/stories.ts
+++ b/code/core/src/manager-api/modules/stories.ts
@@ -345,7 +345,7 @@ export const init: ModuleFn<SubAPI, SubState> = ({
         return undefined;
       }
       if (refId) {
-        return refs[refId].index ? refs[refId].index[storyId] : undefined;
+        return refs?.[refId]?.index?.[storyId] ?? undefined;
       }
       return index ? index[storyId] : undefined;
     },

--- a/scripts/combine-compodoc.ts
+++ b/scripts/combine-compodoc.ts
@@ -42,7 +42,7 @@ async function run(cwd: string) {
       const outputDir = await temporaryDirectory();
       const resolvedDir = await realpath(dir);
       await execaCommand(
-        `yarn compodoc ${resolvedDir} -p ./tsconfig.json -e json -d ${outputDir}`,
+        `yarn --cwd ${cwd} compodoc ${resolvedDir} -p ./tsconfig.json -e json -d ${outputDir}`,
         { cwd }
       );
       const contents = await readFile(join(outputDir, 'documentation.json'), 'utf8');

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -845,7 +845,7 @@ async function prepareAngularSandbox(cwd: string, templateName: string) {
 
   packageJson.scripts = {
     ...packageJson.scripts,
-    'docs:json': 'DIR=$PWD; cd ../../scripts; jiti combine-compodoc $DIR',
+    'docs:json': 'DIR=$PWD; yarn --cwd ../../scripts jiti combine-compodoc $DIR',
     storybook: `yarn docs:json && ${packageJson.scripts.storybook}`,
     'build-storybook': `yarn docs:json && ${packageJson.scripts['build-storybook']}`,
   };


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.3 MB | 78 MB | -309 kB | 0.34 | -0.4% |
| initSize |  131 MB | 131 MB | -309 kB | 0.5 | -0.2% |
| diffSize |  53 MB | 53 MB | -21 B | 0.66 | 0% |
| buildSize |  7.17 MB | 7.17 MB | -7 B | 0.42 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | 0.33 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | -7 B | **-1.93** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | -7 B | 0.21 | 0% |
| buildPreviewSize |  3.26 MB | 3.26 MB | 0 B | 0.43 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  10s | 12.5s | 2.5s | -0.93 | 20% |
| generateTime |  21.5s | 18.8s | -2s -648ms | -0.5 | -14% |
| initTime |  13.4s | 12.2s | -1s -226ms | -0.45 | -10% |
| buildTime |  9s | 8.2s | -838ms | -0.59 | -10.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5s | 4.9s | -87ms | -0.38 | -1.8% |
| devManagerResponsive |  3.7s | 3.7s | -4ms | -0.35 | -0.1% |
| devManagerHeaderVisible |  952ms | 846ms | -106ms | 0.36 | -12.5% |
| devManagerIndexVisible |  956ms | 876ms | -80ms | 0.22 | -9.1% |
| devStoryVisibleUncached |  4.3s | 3.7s | -632ms | -0.07 | -16.9% |
| devStoryVisible |  983ms | 877ms | -106ms | 0.17 | -12.1% |
| devAutodocsVisible |  854ms | 796ms | -58ms | 0.46 | -7.3% |
| devMDXVisible |  870ms | 836ms | -34ms | 0.95 | -4.1% |
| buildManagerHeaderVisible |  907ms | 754ms | -153ms | -0.23 | -20.3% |
| buildManagerIndexVisible |  1s | 888ms | -145ms | -0.14 | -16.3% |
| buildStoryVisible |  889ms | 739ms | -150ms | -0.2 | -20.3% |
| buildAutodocsVisible |  743ms | 701ms | -42ms | -0.19 | -6% |
| buildMDXVisible |  637ms | 630ms | -7ms | 0.08 | -1.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR focuses on fixing Angular sandbox generation issues in no-link mode by improving command execution and property access safety. Here's a concise summary:

- Modifies compodoc command execution in `scripts/combine-compodoc.ts` to use `--cwd ${cwd}` flag for proper directory context
- Updates `sandbox-parts.ts` to use yarn's `--cwd` flag instead of directory changes for docs:json script execution
- Adds safer property access in `stories.ts` using optional chaining and nullish coalescing for story resolution
- Improves reliability of documentation generation for Angular projects in no-link mode
- Prevents potential runtime errors when accessing nested properties of refs

The changes are focused on making Angular sandbox generation more robust by ensuring proper path resolution and command execution context, particularly when working with symlinks and documentation generation.



<!-- /greptile_comment -->