### PR TITLE
UI: Fix default selected addon panel

### DIFF
--- a/code/core/src/manager-api/modules/layout.ts
+++ b/code/core/src/manager-api/modules/layout.ts
@@ -100,7 +100,7 @@ export const defaultLayoutState: SubState = {
     panelPosition: 'bottom',
     showTabs: true,
   },
-  selectedPanel: 'chromaui/addon-visual-tests/panel',
+  selectedPanel: undefined,
   theme: create(),
 };
 


### PR DESCRIPTION
Closes  N/A

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.3 MB | 78.3 MB | 168 B | **2.85** | 0% |
| initSize |  131 MB | 131 MB | 3.01 kB | **2.68** | 0% |
| diffSize |  53 MB | 53 MB | 2.84 kB | 0.67 | 0% |
| buildSize |  7.17 MB | 7.17 MB | -29 B | 0.26 | 0% |
| buildSbAddonsSize |  1.85 MB | 1.85 MB | 0 B | 0.23 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | -29 B | **-6.16** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.91 MB | 3.91 MB | -29 B | -0.32 | 0% |
| buildPreviewSize |  3.26 MB | 3.26 MB | 0 B | 0.35 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  22.4s | 10.2s | -12s -180ms | **-1.27** | 🔰-119% |
| generateTime |  19.4s | 26.4s | 6.9s | **4** | 🔺26.2% |
| initTime |  12.6s | 17.4s | 4.7s | **2.45** | 🔺27.3% |
| buildTime |  9.9s | 11.7s | 1.7s | **2.94** | 🔺15% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.8s | 6s | 1.1s | 0.29 | 19.6% |
| devManagerResponsive |  3.5s | 4.3s | 753ms | 0.18 | 17.4% |
| devManagerHeaderVisible |  816ms | 797ms | -19ms | -0.06 | -2.4% |
| devManagerIndexVisible |  852ms | 890ms | 38ms | 0.26 | 4.3% |
| devStoryVisibleUncached |  3.8s | 4s | 225ms | 0.25 | 5.6% |
| devStoryVisible |  853ms | 889ms | 36ms | 0.2 | 4% |
| devAutodocsVisible |  850ms | 825ms | -25ms | 0.61 | -3% |
| devMDXVisible |  724ms | 859ms | 135ms | 1.15 | 15.7% |
| buildManagerHeaderVisible |  847ms | 1s | 165ms | 0.65 | 16.3% |
| buildManagerIndexVisible |  941ms | 1.1s | 197ms | 0.67 | 17.3% |
| buildStoryVisible |  836ms | 972ms | 136ms | 0.61 | 14% |
| buildAutodocsVisible |  608ms | 716ms | 108ms | -0.18 | 15.1% |
| buildMDXVisible |  669ms | 739ms | 70ms | 0.81 | 9.5% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR modifies the default selected panel behavior in Storybook's UI initialization, removing the ChromaUI addon panel as the default selection.

- Modified `defaultLayoutState.selectedPanel` in `code/core/src/manager-api/modules/layout.ts` from 'chromaui/addon-visual-tests/panel' to undefined
- Change ensures no specific addon panel is selected by default, improving compatibility for users without ChromaUI addon
- User-selected panel preferences are still preserved through the setOptions API



<!-- /greptile_comment -->