### PR TITLE
Core: Fix statically serving single files and multiple dirs on the same endpoint

### DIFF
--- a/code/core/src/core-server/utils/server-statics.ts
+++ b/code/core/src/core-server/utils/server-statics.ts
@@ -27,7 +27,7 @@ export async function useStatics(app: Polka.Polka, options: Options): Promise<vo
       }
 
       if (existsSync(staticPath) && statSync(staticPath).isFile()) {
-        // sirv doesn't support serving single files, so we need to pass the the file's directory to sirv instead
+        // sirv doesn't support serving single files, so we need to pass the file's directory to sirv instead
         const staticPathDir = resolve(staticPath, '..');
         const staticPathFile = basename(staticPath);
         app.use(targetEndpoint, (req, res, next) => {

--- a/code/core/src/core-server/utils/server-statics.ts
+++ b/code/core/src/core-server/utils/server-statics.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { basename, isAbsolute, posix, resolve, sep, win32 } from 'node:path';
 
 import { getDirectoryFromWorkingDir } from '@storybook/core/common';
@@ -26,9 +26,25 @@ export async function useStatics(app: Polka.Polka, options: Options): Promise<vo
         );
       }
 
+      if (existsSync(staticPath) && statSync(staticPath).isFile()) {
+        // sirv doesn't support serving single files, so we need to pass the the file's directory to sirv instead
+        const staticPathDir = resolve(staticPath, '..');
+        const staticPathFile = basename(staticPath);
+        app.use(targetEndpoint, (req, res, next) => {
+          // Rewrite the URL to match the file's name, ensuring that we only ever serve the file
+          // even when sirv is passed the full directory
+          req.url = `/${staticPathFile}`;
+          sirvWorkaround(staticPathDir, {
+            dev: true,
+            etag: true,
+            extensions: [],
+          })(req, res, next);
+        });
+        return;
+      }
       app.use(
         targetEndpoint,
-        sirv(staticPath, {
+        sirvWorkaround(staticPath, {
           dev: true,
           etag: true,
           extensions: [],
@@ -43,13 +59,37 @@ export async function useStatics(app: Polka.Polka, options: Options): Promise<vo
 
   app.get(
     `/${basename(faviconPath)}`,
-    sirv(faviconPath, {
+    sirvWorkaround(faviconPath, {
       dev: true,
       etag: true,
       extensions: [],
     })
   );
 }
+
+/**
+ * This is a workaround for sirv breaking when serving multiple directories on the same endpoint.
+ *
+ * @see https://github.com/lukeed/polka/issues/218
+ */
+const sirvWorkaround: typeof sirv =
+  (...sirvArgs) =>
+  (req, res, next) => {
+    // polka+sirv will modify the request URL, so we need to restore it after sirv is done
+    // req._parsedUrl is an internal construct used by both polka and sirv
+    // eslint-disable-next-line no-underscore-dangle
+    const originalParsedUrl = (req as any)._parsedUrl;
+
+    const maybeNext = next
+      ? () => {
+          // eslint-disable-next-line no-underscore-dangle
+          (req as any)._parsedUrl = originalParsedUrl;
+          next();
+        }
+      : undefined;
+
+    sirv(...sirvArgs)(req, res, maybeNext);
+  };
 
 export const parseStaticDir = (arg: string) => {
   // Split on last index of ':', for Windows compatibility (e.g. 'C:\some\dir:\foo')


### PR DESCRIPTION
Closes #29576

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added two workaround for polka+sirv:

1. sirv doesn't support serving single files, only directories (which is fair). added a workaround to detect when files need to be served, and if so, serve the parent dir instead, but filtering only for that file.

2. sirv+polka has a bug (🤷) where serving multiple dirs on the same endpoint results in only the first sirv instance to work. added a workarund so any number of middlewares will continue to work.

<!-- Briefly describe what your PR does -->

I noticed when testing, that if you serve multiple dirs at the same path with conflicting files, dev and build are inconsistent. (in the testing scenario below, that would be `/my-static/file-b.txt`) dev will serve the file that matches the first staticDir entry with a match, while build will produce the last file that matches.

This is because serving stops at the first sirv that matches, while building copies the files over one by one, and so the last one wins naturally. A solution would be to traverse the `staticDirs` in reverse order in _either_ serve or build, so they match, but I'm not sure if that will break other use cases, so I've opted for just not fixing that here. 🤷 

## Checklist for Contributors

### Testing

@valentinpalkovic I haven't added any tests for this. I don't think this is really unit-testable. Adding a bunch of static dirs to all sandboxes seems a bit too much. I could add some static dirs just for the UI Storybook and have a story show their content. Then it would be tested by Chromatic, but only the built Storybook would be tested, not the dev one which we're fixing here. 🤷

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Add the following to `code/.storybook/main.ts`:

```ts
  staticDirs: [
    {
      from: './some-static/a-dir',
      to: '/my-static',
    },
    {
      from: './some-static/b-dir',
      to: '/my-static',
    },
    {
      from: './some-static/just-a-file.txt',
      to: '/the-file.txt',
    },
    {
      from: './some-static/just-a-file.txt',
      to: '/my-static/the-file.txt',
    },
  ],
```

2. Add the corresponding files to `code/.storybook` with some content:

```ascii
some-static/
├── just-a-file.txt
├── a-dir/
│   ├── file-a.txt
│   └── file-b.txt
└── b-dir/
    ├── file-b.txt
    ├── file-c.txt
    └── sub/
        └── file-d.txt
```

3. Start Storybook dev and visit the following URLs and see that they work:
	1. http://localhost:6006/my-static/file-a.txt
	1. http://localhost:6006/my-static/file-b.txt
	1. http://localhost:6006/my-static/file-c.txt
	1. http://localhost:6006/my-static/sub/file-d.txt
	1. http://localhost:6006/my-static/the-file.txt
	1. http://localhost:6006/the-file.txt

4. Build the storybook and visit the same URLs and see that they work.

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
3. Open Storybook in your browser
5. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.3 MB | 78.3 MB | 0 B | **1.51** | 0% |
| initSize |  132 MB | 132 MB | 955 B | **2.04** | 0% |
| diffSize |  53.2 MB | 53.2 MB | 955 B | **2.89** | 0% |
| buildSize |  7.22 MB | 7.22 MB | 0 B | **3** | 0% |
| buildSbAddonsSize |  1.87 MB | 1.87 MB | 0 B | **3** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | **3** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.95 MB | 3.95 MB | 0 B | **3** | 0% |
| buildPreviewSize |  3.27 MB | 3.27 MB | 0 B | **2.99** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.9s | 9.8s | 921ms | **-1.26** | 🔺9.3% |
| generateTime |  17.9s | 19.8s | 1.9s | 0.08 | 9.6% |
| initTime |  11.4s | 12.6s | 1.1s | -0.27 | 9.1% |
| buildTime |  8.6s | 9.1s | 482ms | 0.17 | 5.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.6s | 7.3s | 2.6s | **3.76** | 🔺36.4% |
| devManagerResponsive |  3.6s | 4.9s | 1.3s | **2.75** | 🔺27.5% |
| devManagerHeaderVisible |  658ms | 1.2s | 543ms | **3.64** | 🔺45.2% |
| devManagerIndexVisible |  718ms | 1.3s | 617ms | **4.6** | 🔺46.2% |
| devStoryVisibleUncached |  3.6s | 4.4s | 796ms | 1.18 | 17.9% |
| devStoryVisible |  720ms | 1.2s | 545ms | **3.65** | 🔺43.1% |
| devAutodocsVisible |  653ms | 1.2s | 589ms | **5.31** | 🔺47.4% |
| devMDXVisible |  643ms | 1.1s | 550ms | **5.73** | 🔺46.1% |
| buildManagerHeaderVisible |  744ms | 1.1s | 373ms | **3.05** | 🔺33.4% |
| buildManagerIndexVisible |  843ms | 1.2s | 409ms | **3.7** | 🔺32.7% |
| buildStoryVisible |  672ms | 1s | 346ms | **3.35** | 🔺34% |
| buildAutodocsVisible |  570ms | 779ms | 209ms | **1.25** | 🔺26.8% |
| buildMDXVisible |  544ms | 798ms | 254ms | **2.35** | 🔺31.8% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the PR changes focusing on the static file serving improvements in Storybook:

This PR adds workarounds for serving static files in Storybook, addressing issues with the sirv and polka middleware stack to improve static file handling.

- Added fix in `code/core/src/core-server/utils/server-statics.ts` to serve single files by using parent directory with filtered access
- Implemented workaround for serving multiple directories at the same endpoint by preserving request URL state
- Fixed regression from Express to Polka migration that prevented serving individual files in staticDirs config
- Maintains backward compatibility with existing staticDirs configurations including single file paths
- Note: Dev and build environments may handle conflicting files from multiple directories differently



<!-- /greptile_comment -->