### PR TITLE
Build: Fix sandbox generation in linked mode

### DIFF
--- a/code/lib/cli-storybook/src/link.ts
+++ b/code/lib/cli-storybook/src/link.ts
@@ -114,7 +114,6 @@ export const link = async ({ target, local, start }: LinkOptions) => {
       ...reproPackageJson.devDependencies,
       'webpack-hot-middleware': '*',
     };
-    await exec(`yarn add -D webpack-hot-middleware`, { cwd: reproDir });
   }
 
   // ensure that linking is possible

--- a/code/lib/cli-storybook/src/link.ts
+++ b/code/lib/cli-storybook/src/link.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 
 import { logger } from 'storybook/internal/node-logger';
@@ -108,14 +108,24 @@ export const link = async ({ target, local, start }: LinkOptions) => {
   await exec(`yarn link --all --relative ${storybookDir}`, { cwd: reproDir });
 
   logger.info(`Installing ${reproName}`);
-  await exec(`yarn install`, { cwd: reproDir });
 
   if (!reproPackageJson.devDependencies?.vite) {
+    reproPackageJson.devDependencies = {
+      ...reproPackageJson.devDependencies,
+      'webpack-hot-middleware': '*',
+    };
     await exec(`yarn add -D webpack-hot-middleware`, { cwd: reproDir });
   }
 
   // ensure that linking is possible
-  await exec(`yarn add @types/node@22`, { cwd: reproDir });
+  reproPackageJson.devDependencies = {
+    ...reproPackageJson.devDependencies,
+    '@types/node': '^22',
+  };
+
+  await writeFile(join(reproDir, 'package.json'), JSON.stringify(reproPackageJson, null, 2));
+
+  await exec(`yarn install`, { cwd: reproDir });
 
   if (start) {
     logger.info(`Running ${reproName} storybook`);

--- a/code/lib/create-storybook/src/generators/NUXT/index.ts
+++ b/code/lib/create-storybook/src/generators/NUXT/index.ts
@@ -4,7 +4,9 @@ import type { Generator } from '../types';
 const generator: Generator = async (packageManager, npmOptions, options) => {
   await baseGenerator(
     packageManager,
-    npmOptions,
+    {
+      ...npmOptions,
+    },
     options,
     'vue3',
     {
@@ -19,6 +21,14 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
     },
     'nuxt'
   );
+
+  if (npmOptions.skipInstall === true) {
+    console.log(
+      'The --skip-install flag is not supported for generating Storybook for Nuxt. We will continue to install dependencies.'
+    );
+    await packageManager.installDependencies();
+  }
+
   // Add nuxtjs/storybook to nuxt.config.js
   await packageManager.runPackageCommand('nuxi', [
     'module',

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -13,6 +13,7 @@ import {
   writeFile,
   writeJson,
 } from 'fs-extra';
+import { readFile } from 'fs/promises';
 import JSON5 from 'json5';
 import { createRequire } from 'module';
 import { join, relative, resolve, sep } from 'path';
@@ -144,7 +145,7 @@ export const init: Task['run'] = async (
 
   await executeCLIStep(steps.init, {
     cwd,
-    optionValues: { debug, yes: true, ...extra },
+    optionValues: { debug, yes: true, 'skip-install': true, ...extra },
     dryRun,
     debug,
   });
@@ -538,17 +539,24 @@ export async function addExtraDependencies({
     return;
   }
 
+  const packageJson = JSON.parse(await readFile(join(cwd, 'package.json'), { encoding: 'utf8' }));
+
   const packageManager = JsPackageManagerFactory.getPackageManager({}, cwd);
-  await packageManager.addDependencies({ installAsDevDependencies: true }, extraDevDeps);
+  await packageManager.addDependencies(
+    { installAsDevDependencies: true, skipInstall: true, packageJson },
+    extraDevDeps
+  );
 
   if (extraDeps) {
     const versionedExtraDeps = await packageManager.getVersionedPackages(extraDeps);
     if (debug) {
       logger.log('\uD83C\uDF81 Adding extra deps', versionedExtraDeps);
     }
-    await packageManager.addDependencies({ installAsDevDependencies: true }, versionedExtraDeps);
+    await packageManager.addDependencies(
+      { installAsDevDependencies: true, skipInstall: true, packageJson },
+      versionedExtraDeps
+    );
   }
-  await packageManager.installDependencies();
 }
 
 export const addStories: Task['run'] = async (

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -4,6 +4,7 @@ import { pathExists, remove } from 'fs-extra';
 import { join } from 'path';
 import { promisify } from 'util';
 
+import { JsPackageManagerFactory } from '../../code/core/src/common';
 import { now, saveBench } from '../bench/utils';
 import type { Task, TaskKey } from '../task';
 
@@ -146,6 +147,10 @@ export const sandbox: Task = {
     await extendPreview(details, options);
 
     await setImportMap(details.sandboxDir);
+
+    const packageManager = JsPackageManagerFactory.getPackageManager({}, details.sandboxDir);
+
+    await packageManager.installDependencies();
 
     logger.info(`✅ Storybook sandbox created at ${details.sandboxDir}`);
   },

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -4,7 +4,6 @@ import { pathExists, remove } from 'fs-extra';
 import { join } from 'path';
 import { promisify } from 'util';
 
-import { JsPackageManagerFactory } from '../../code/core/src/common';
 import { now, saveBench } from '../bench/utils';
 import type { Task, TaskKey } from '../task';
 
@@ -147,6 +146,8 @@ export const sandbox: Task = {
     await extendPreview(details, options);
 
     await setImportMap(details.sandboxDir);
+
+    const { JsPackageManagerFactory } = await import('../../code/core/src/common');
 
     const packageManager = JsPackageManagerFactory.getPackageManager({}, details.sandboxDir);
 

--- a/scripts/utils/cli-step.ts
+++ b/scripts/utils/cli-step.ts
@@ -40,6 +40,7 @@ export const steps = {
       yes: { type: 'boolean' },
       type: { type: 'string' },
       debug: { type: 'boolean' },
+      'skip-install': { type: 'boolean' },
     }),
   },
   add: {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Locally generated sandboxes in linked mode sometimes had corrupted sandboxes. This issue is now fixed by only running installs when necessary.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.3 MB | 78.3 MB | 0 B | **1.51** | 0% |
| initSize |  132 MB | 78.3 MB | -53.2 MB | **-270.62** | 🔰-67.9% |
| diffSize |  53.2 MB | 97 B | -53.2 MB | **-983.77** | 🔰-54839826.8% |
| buildSize |  7.22 MB | 7.22 MB | 0 B | **3** | 0% |
| buildSbAddonsSize |  1.87 MB | 1.87 MB | 0 B | **3** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | **3** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.95 MB | 3.95 MB | 0 B | **3** | 0% |
| buildPreviewSize |  3.27 MB | 3.27 MB | 0 B | **2.99** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.9s | 8s | -907ms | **-1.55** | 🔰-11.3% |
| generateTime |  17.9s | 21.1s | 3.1s | 0.81 | 14.9% |
| initTime |  11.4s | 5.3s | -6s -175ms | **-4.29** | 🔰-116% |
| buildTime |  8.6s | 9.9s | 1.2s | 0.9 | 12.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.6s | 4.9s | 253ms | -0.52 | 5.2% |
| devManagerResponsive |  3.6s | 3.6s | 26ms | -0.67 | 0.7% |
| devManagerHeaderVisible |  658ms | 838ms | 180ms | 0.52 | 21.5% |
| devManagerIndexVisible |  718ms | 911ms | 193ms | 0.77 | 21.2% |
| devStoryVisibleUncached |  3.6s | 4s | 419ms | 0.41 | 10.3% |
| devStoryVisible |  720ms | 912ms | 192ms | 0.64 | 21.1% |
| devAutodocsVisible |  653ms | 829ms | 176ms | 1.01 | 21.2% |
| devMDXVisible |  643ms | 756ms | 113ms | 0.53 | 14.9% |
| buildManagerHeaderVisible |  744ms | 825ms | 81ms | 0.33 | 9.8% |
| buildManagerIndexVisible |  843ms | 990ms | 147ms | 1.01 | 14.8% |
| buildStoryVisible |  672ms | 807ms | 135ms | 0.77 | 16.7% |
| buildAutodocsVisible |  570ms | 645ms | 75ms | -0.21 | 11.6% |
| buildMDXVisible |  544ms | 750ms | 206ms | **1.78** | 🔺27.5% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Here's my concise review of the pull request:

Fixes sandbox generation in linked mode by improving dependency management and installation processes across multiple files to prevent sandbox corruption.

- Added `skip-install` option to `init` CLI step in `scripts/utils/cli-step.ts` to prevent duplicate installations
- Modified `scripts/tasks/sandbox-parts.ts` to handle package.json updates directly instead of relying on package manager state
- Updated `code/lib/cli-storybook/src/link.ts` to write package.json changes before running yarn install
- Added final dependency installation step using JsPackageManagerFactory in `scripts/tasks/sandbox.ts` to ensure proper installation

The changes focus on making dependency management more controlled and predictable to prevent sandbox corruption issues in linked mode.



<!-- /greptile_comment -->