### PR TITLE
Build: Fix local sandbox generation in linked mode

### DIFF
--- a/code/lib/cli-storybook/src/link.ts
+++ b/code/lib/cli-storybook/src/link.ts
@@ -86,10 +86,6 @@ export const link = async ({ target, local, start }: LinkOptions) => {
     reproDir = join(reprosDir, reproName);
   }
 
-  const reproPackageJson = JSON.parse(
-    await readFile(join(reproDir, 'package.json'), { encoding: 'utf8' })
-  );
-
   const version = spawnSync('yarn', ['--version'], {
     cwd: reproDir,
     stdio: 'pipe',
@@ -108,6 +104,10 @@ export const link = async ({ target, local, start }: LinkOptions) => {
   await exec(`yarn link --all --relative ${storybookDir}`, { cwd: reproDir });
 
   logger.info(`Installing ${reproName}`);
+
+  const reproPackageJson = JSON.parse(
+    await readFile(join(reproDir, 'package.json'), { encoding: 'utf8' })
+  );
 
   if (!reproPackageJson.devDependencies?.vite) {
     reproPackageJson.devDependencies = {

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import dirSize from 'fast-folder-size';
 // eslint-disable-next-line depend/ban-dependencies
 import { pathExists, remove } from 'fs-extra';
@@ -49,7 +51,8 @@ export const sandbox: Task = {
 
       options.link = false;
     }
-    if (await this.ready(details, options)) {
+
+    if (!(await this.ready(details, options))) {
       logger.info('🗑  Removing old sandbox dir');
       await remove(details.sandboxDir);
     }
@@ -151,6 +154,7 @@ export const sandbox: Task = {
 
     const packageManager = JsPackageManagerFactory.getPackageManager({}, details.sandboxDir);
 
+    await remove(path.join(details.sandboxDir, 'node_modules'));
     await packageManager.installDependencies();
 
     logger.info(`✅ Storybook sandbox created at ${details.sandboxDir}`);


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.3 MB | 78.3 MB | 18 kB | **1.32** | 0% |
| initSize |  78.3 MB | 78.3 MB | 18 kB | **-3** | 0% |
| diffSize |  97 B | 97 B | 0 B | **-3** | 0% |
| buildSize |  7.22 MB | 7.22 MB | 0 B | **2** | 0% |
| buildSbAddonsSize |  1.87 MB | 1.87 MB | 0 B | **2** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | **2** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.95 MB | 3.95 MB | 0 B | **2** | 0% |
| buildPreviewSize |  3.27 MB | 3.27 MB | 0 B | **2** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.4s | 20s | 12.6s | 0.48 | 63% |
| generateTime |  19.1s | 20.9s | 1.8s | 0.65 | 8.8% |
| initTime |  5.1s | 5.4s | 233ms | **-2.25** | 4.3% |
| buildTime |  10.6s | 9.6s | -998ms | 0.52 | -10.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.3s | 5s | -1s -297ms | -0.41 | -25.6% |
| devManagerResponsive |  4.7s | 3.8s | -942ms | -0.38 | -24.6% |
| devManagerHeaderVisible |  761ms | 671ms | -90ms | -1.04 | -13.4% |
| devManagerIndexVisible |  784ms | 681ms | -103ms | **-1.54** | 🔰-15.1% |
| devStoryVisibleUncached |  4.1s | 4s | -105ms | 0.37 | -2.6% |
| devStoryVisible |  785ms | 700ms | -85ms | **-1.28** | 🔰-12.1% |
| devAutodocsVisible |  815ms | 646ms | -169ms | -1.08 | -26.2% |
| devMDXVisible |  791ms | 623ms | -168ms | -1.19 | -27% |
| buildManagerHeaderVisible |  769ms | 807ms | 38ms | 0.01 | 4.7% |
| buildManagerIndexVisible |  928ms | 928ms | 0ms | 0.24 | 0% |
| buildStoryVisible |  745ms | 751ms | 6ms | -0.06 | 0.8% |
| buildAutodocsVisible |  701ms | 624ms | -77ms | -0.51 | -12.3% |
| buildMDXVisible |  581ms | 750ms | 169ms | **1.33** | 🔺22.5% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR improves sandbox generation in linked mode by addressing dependency installation issues and cleanup processes, particularly focusing on the Nuxt generator and linking functionality.

- Modified `code/lib/create-storybook/src/generators/NUXT/index.ts` to force node_modules removal before dependency installation
- Updated `scripts/tasks/sandbox.ts` to properly handle sandbox directory cleanup and dependency installation in linked mode
- Enhanced `code/lib/cli-storybook/src/link.ts` with improved error handling and added webpack-hot-middleware dependencies
- Added safety checks for package.json parsing after yarn version verification



<!-- /greptile_comment -->