### PR TITLE
CI: Disable test-runner for Svelte 4 sandboxes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -846,7 +846,7 @@ workflows:
           requires:
             - create-sandboxes
       - test-runner-production:
-          parallelism: 9
+          parallelism: 8
           requires:
             - create-sandboxes
       - vitest-integration:
@@ -918,7 +918,7 @@ workflows:
           requires:
             - create-sandboxes
       - test-runner-production:
-          parallelism: 15
+          parallelism: 14
           requires:
             - create-sandboxes
       - vitest-integration:
@@ -991,7 +991,7 @@ workflows:
           requires:
             - create-sandboxes
       - test-runner-production:
-          parallelism: 32
+          parallelism: 30
           requires:
             - create-sandboxes
       - vitest-integration:

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -538,7 +538,7 @@ const baseTemplates = {
       renderer: '@storybook/svelte',
       builder: '@storybook/builder-vite',
     },
-    skipTasks: ['e2e-tests-dev', 'bench'],
+    skipTasks: ['e2e-tests-dev', 'bench', 'test-runner'],
   },
   'svelte-kit/skeleton-ts': {
     name: 'SvelteKit Latest (Vite | TypeScript)',
@@ -549,7 +549,7 @@ const baseTemplates = {
       renderer: '@storybook/svelte',
       builder: '@storybook/builder-vite',
     },
-    skipTasks: ['e2e-tests-dev', 'bench'],
+    skipTasks: ['e2e-tests-dev', 'bench', 'test-runner'],
   },
   'svelte-kit/prerelease-ts': {
     name: 'SvelteKit Prerelease (Vite | TypeScript)',


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

[Test runner in CI has been failing for a couple of days now with a flaky, hard to track error.
](https://app.circleci.com/pipelines/github/storybookjs/storybook/91431/workflows/8171bfc6-eab4-461f-a59b-f7da6b133172/jobs/770065)

This solution just disables the test runner for the two offending Svelte sandboxes, and leaves it enabled for the 3 others. What's noticeable about the two failing is that they are using Svelte 4 + SvelteKit.

The timing of the flaky failures aligns with the release of [SvelteKit 2.17.0](https://github.com/sveltejs/kit/releases/tag/%40sveltejs%2Fkit%402.17.0) so that could be the reason, but I haven't confirmed this.

FYI @benmccann, not something you need to worry about, but might worth knowing for you if you get other user reports about similar issues. The failures indicate that for some reason the browser _sometimes_ navigates when/after rendering a story, which causes the Playwright tests to fail. But only for SvelteKit+Svelte 4.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.4 MB | 80.4 MB | 2.1 MB | **13.73** | 2.6% |
| initSize |  78.4 MB | 80.4 MB | 2.1 MB | **-1.9** | 2.6% |
| diffSize |  97 B | 97 B | 0 B | **-2** | 0% |
| buildSize |  7.22 MB | 7.25 MB | 29.6 kB | **2.87** | 0.4% |
| buildSbAddonsSize |  1.87 MB | 1.87 MB | -1.17 kB | **1.43** | -0.1% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | **1.53** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.95 MB | 3.94 MB | -1.17 kB | **1.46** | 0% |
| buildPreviewSize |  3.27 MB | 3.3 MB | 30.8 kB | **9.41** | 0.9% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  14.5s | 14.8s | 326ms | -0.17 | 2.2% |
| generateTime |  20s | 22s | 1.9s | **1.3** | 🔺8.9% |
| initTime |  4.7s | 5s | 327ms | **-1.68** | 🔺6.5% |
| buildTime |  8.5s | 9.7s | 1.1s | 0.5 | 12.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.8s | 4.9s | 112ms | -0.54 | 2.2% |
| devManagerResponsive |  3.6s | 3.6s | -5ms | -0.83 | -0.1% |
| devManagerHeaderVisible |  705ms | 716ms | 11ms | -0.58 | 1.5% |
| devManagerIndexVisible |  713ms | 797ms | 84ms | -0.28 | 10.5% |
| devStoryVisibleUncached |  3.7s | 3.9s | 116ms | -0.36 | 3% |
| devStoryVisible |  734ms | 798ms | 64ms | -0.32 | 8% |
| devAutodocsVisible |  784ms | 691ms | -93ms | -0.61 | -13.5% |
| devMDXVisible |  676ms | 694ms | 18ms | -0.34 | 2.6% |
| buildManagerHeaderVisible |  660ms | 978ms | 318ms | **1.48** | 🔺32.5% |
| buildManagerIndexVisible |  795ms | 1s | 210ms | 0.97 | 20.9% |
| buildStoryVisible |  646ms | 843ms | 197ms | 0.94 | 23.4% |
| buildAutodocsVisible |  512ms | 666ms | 154ms | -0.03 | 23.1% |
| buildMDXVisible |  589ms | 655ms | 66ms | 0.24 | 10.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and context, I'll create a concise summary of the changes in this PR:

Disabled test runner for specific Svelte 4 sandboxes and adjusted CI parallelism to address flaky test failures.

- Disabled test runner for `svelte-kit/skeleton-js` and `svelte-kit/skeleton-ts` sandboxes in `code/lib/cli-storybook/src/sandbox-templates.ts`
- Reduced test-runner-production parallelism from 9 to 8 in `.circleci/config.yml` normal workflow
- Reduced parallelism in merged workflow (15 to 14) and daily workflow (32 to 30)
- Issue appears related to browser navigation problems specific to SvelteKit+Svelte 4 combinations



<!-- /greptile_comment -->