### PR TITLE
Addon Test: Fix printing Date object in MethodCall for test/interactions log

### DIFF
--- a/code/addons/interactions/src/components/MethodCall.stories.tsx
+++ b/code/addons/interactions/src/components/MethodCall.stories.tsx
@@ -70,7 +70,7 @@ export const Args = () => (
       value={{ __date__: { value: new Date(Date.UTC(2012, 11, 20, 0, 0, 0)).toISOString() } }}
     />
     <Node value={{ __date__: { value: new Date(1600000000000).toISOString() } }} />
-    <Node value={{ __date__: { value: new Date(1600000000123).toISOString() } }} />
+    <Node value={{ __date__: { value: new Date(1600000000123) } }} />
     <Node value={{ __error__: { name: 'EvalError', message: '' } }} />
     <Node value={{ __error__: { name: 'SyntaxError', message: "Can't do that" } }} />
     <Node

--- a/code/addons/interactions/src/components/MethodCall.tsx
+++ b/code/addons/interactions/src/components/MethodCall.tsx
@@ -344,8 +344,9 @@ export const ElementNode = ({
   );
 };
 
-export const DateNode = ({ value }: { value: string }) => {
-  const [date, time, ms] = value.split(/[T.Z]/);
+export const DateNode = ({ value }: { value: string | Date }) => {
+  const string = value instanceof Date ? value.toISOString() : value;
+  const [date, time, ms] = string.split(/[T.Z]/);
   const colors = useThemeColors();
   return (
     <span style={{ whiteSpace: 'nowrap', color: colors.date }}>

--- a/code/addons/test/src/components/MethodCall.stories.tsx
+++ b/code/addons/test/src/components/MethodCall.stories.tsx
@@ -70,7 +70,7 @@ export const Args = () => (
       value={{ __date__: { value: new Date(Date.UTC(2012, 11, 20, 0, 0, 0)).toISOString() } }}
     />
     <Node value={{ __date__: { value: new Date(1600000000000).toISOString() } }} />
-    <Node value={{ __date__: { value: new Date(1600000000123).toISOString() } }} />
+    <Node value={{ __date__: { value: new Date(1600000000123) } }} />
     <Node value={{ __error__: { name: 'EvalError', message: '' } }} />
     <Node value={{ __error__: { name: 'SyntaxError', message: "Can't do that" } }} />
     <Node

--- a/code/addons/test/src/components/MethodCall.tsx
+++ b/code/addons/test/src/components/MethodCall.tsx
@@ -344,8 +344,9 @@ export const ElementNode = ({
   );
 };
 
-export const DateNode = ({ value }: { value: string }) => {
-  const [date, time, ms] = value.split(/[T.Z]/);
+export const DateNode = ({ value }: { value: string | Date }) => {
+  const string = value instanceof Date ? value.toISOString() : value;
+  const [date, time, ms] = string.split(/[T.Z]/);
   const colors = useThemeColors();
   return (
     <span style={{ whiteSpace: 'nowrap', color: colors.date }}>


### PR DESCRIPTION
Closes #30503

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Likely due to a change in channel serialization behavior, dates are deserialized back into Date objects which causes the test/interactions log to crash because it expects a date string. I've updated the addons to handle Date objects as well.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.5 MB | 80.5 MB | 0 B | **1.4** | 0% |
| initSize |  80.5 MB | 80.5 MB | 0 B | -0.87 | 0% |
| diffSize |  97 B | 97 B | 0 B | -0.9 | 0% |
| buildSize |  7.24 MB | 7.24 MB | 39 B | 1.03 | 0% |
| buildSbAddonsSize |  1.87 MB | 1.87 MB | 39 B | 0.62 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 0.4 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.94 MB | 3.94 MB | 39 B | 0.54 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | **1.34** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.2s | 7.1s | -138ms | -0.94 | -1.9% |
| generateTime |  18.8s | 18.6s | -166ms | -0.58 | -0.9% |
| initTime |  4.8s | 4.6s | -230ms | -0.9 | -5% |
| buildTime |  8.6s | 9.1s | 493ms | -0.16 | 5.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.7s | 5.9s | 1.1s | 0.85 | 19% |
| devManagerResponsive |  3.6s | 4.1s | 495ms | 0.27 | 12.1% |
| devManagerHeaderVisible |  656ms | 783ms | 127ms | -0.05 | 16.2% |
| devManagerIndexVisible |  667ms | 842ms | 175ms | 0.12 | 20.8% |
| devStoryVisibleUncached |  3.7s | 3.7s | 6ms | -0.84 | 0.2% |
| devStoryVisible |  687ms | 879ms | 192ms | 0.29 | 21.8% |
| devAutodocsVisible |  636ms | 825ms | 189ms | 0.63 | 22.9% |
| devMDXVisible |  580ms | 737ms | 157ms | -0.04 | 21.3% |
| buildManagerHeaderVisible |  665ms | 755ms | 90ms | -0.36 | 11.9% |
| buildManagerIndexVisible |  750ms | 898ms | 148ms | -0.3 | 16.5% |
| buildStoryVisible |  585ms | 733ms | 148ms | -0.29 | 20.2% |
| buildAutodocsVisible |  614ms | 668ms | 54ms | -0.25 | 8.1% |
| buildMDXVisible |  562ms | 706ms | 144ms | 0.33 | 20.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR fixes the handling of Date objects in Storybook's test/interactions log to prevent crashes during test assertions.

- Modified `DateNode` component in `code/addons/test/src/components/MethodCall.tsx` to handle both Date objects and strings
- Updated `DateNode` component in `code/addons/interactions/src/components/MethodCall.tsx` for consistent Date handling
- Added direct Date object support in test stories at `code/addons/test/src/components/MethodCall.stories.tsx`
- Fixed serialization behavior to properly handle Date objects in test assertions



<!-- /greptile_comment -->