### PR TITLE
Builder-Vite: Fix resolve id warning

### DIFF
--- a/code/builders/builder-vite/input/iframe.html
+++ b/code/builders/builder-vite/input/iframe.html
@@ -64,6 +64,6 @@
     <!-- [BODY HTML SNIPPET HERE] -->
     <div id="storybook-root"></div>
     <div id="storybook-docs"></div>
-    <script type="module" src="/virtual:/@storybook/builder-vite/vite-app.js"></script>
+    <script type="module" src="virtual:@storybook/builder-vite/vite-app.js"></script>
   </body>
 </html>

--- a/code/builders/builder-vite/src/codegen-modern-iframe-script.ts
+++ b/code/builders/builder-vite/src/codegen-modern-iframe-script.ts
@@ -45,7 +45,7 @@ export async function generateModernIframeScriptCode(options: Options, projectRo
 
     return `
     if (import.meta.hot) {
-      import.meta.hot.accept('${getResolvedVirtualModuleId(SB_VIRTUAL_FILES.VIRTUAL_STORIES_FILE)}', (newModule) => {
+      import.meta.hot.accept('${SB_VIRTUAL_FILES.VIRTUAL_STORIES_FILE}', (newModule) => {
       // importFn has changed so we need to patch the new one in
       window.__STORYBOOK_PREVIEW__.onStoriesChanged({ importFn: newModule.importFn });
       });

--- a/code/builders/builder-vite/src/index.ts
+++ b/code/builders/builder-vite/src/index.ts
@@ -35,8 +35,7 @@ function iframeMiddleware(options: Options, server: ViteDevServer): Middleware {
     const indexHtml = await readFile(require.resolve('@storybook/builder-vite/input/iframe.html'), {
       encoding: 'utf8',
     });
-    const generated = await transformIframeHtml(indexHtml, options);
-    const transformed = await server.transformIndexHtml('/iframe.html', generated);
+    const transformed = await server.transformIndexHtml('/iframe.html', indexHtml);
     res.setHeader('Content-Type', 'text/html');
     res.statusCode = 200;
     res.write(transformed);

--- a/code/builders/builder-vite/src/plugins/webpack-stats-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/webpack-stats-plugin.ts
@@ -63,15 +63,23 @@ export function pluginWebpackStats({ workingDir }: WebpackStatsPluginOptions): W
   /** Convert an absolute path name to a path relative to the vite root, with a starting `./` */
   function normalize(filename: string) {
     // Do not try to resolve virtual files
-    if (filename.startsWith('/virtual:')) {
-      return filename;
+    if (filename.startsWith('virtual:')) {
+      // We have to append a forward slash because otherwise we break turbosnap.
+      // As soon as the chromatic-cli supports `virtual:` id's without a starting forward slash,
+      // we can remove adding the forward slash here
+      // Reference: https://github.com/chromaui/chromatic-cli/blob/v11.25.2/node-src/lib/getDependentStoryFiles.ts#L53
+      return `/${filename}`;
     }
     // ! Maintain backwards compatibility with the old virtual file names
     // ! to ensure that the stats file doesn't change between the versions
     // ! Turbosnap is also only compatible with the old virtual file names
     // ! the old virtual file names did not start with the obligatory \0 character
     if (Object.values(SB_VIRTUAL_FILES).includes(getOriginalVirtualModuleId(filename))) {
-      return getOriginalVirtualModuleId(filename);
+      // We have to append a forward slash because otherwise we break turbosnap.
+      // As soon as the chromatic-cli supports `virtual:` id's without a starting forward slash,
+      // we can remove adding the forward slash here
+      // Reference: https://github.com/chromaui/chromatic-cli/blob/v11.25.2/node-src/lib/getDependentStoryFiles.ts#L53
+      return `/${getOriginalVirtualModuleId(filename)}`;
     }
 
     // Otherwise, we need them in the format `./path/to/file.js`.

--- a/code/builders/builder-vite/src/transform-iframe-html.ts
+++ b/code/builders/builder-vite/src/transform-iframe-html.ts
@@ -1,6 +1,8 @@
 import { normalizeStories } from 'storybook/internal/common';
 import type { DocsOptions, Options, TagsOptions } from 'storybook/internal/types';
 
+import { SB_VIRTUAL_FILES } from './virtual-file-names';
+
 export type PreviewHtml = string | undefined;
 
 export async function transformIframeHtml(html: string, options: Options) {
@@ -26,7 +28,7 @@ export async function transformIframeHtml(html: string, options: Options) {
     ...(build?.test?.disableBlocks ? { __STORYBOOK_BLOCKS_EMPTY_MODULE__: {} } : {}),
   };
 
-  return html
+  const transformedHtml = html
     .replace('[CONFIG_TYPE HERE]', configType || '')
     .replace('[LOGLEVEL HERE]', logLevel || '')
     .replace(`'[FRAMEWORK_OPTIONS HERE]'`, JSON.stringify(frameworkOptions))
@@ -46,4 +48,13 @@ export async function transformIframeHtml(html: string, options: Options) {
     .replace(`'[TAGS_OPTIONS HERE]'`, JSON.stringify(tagsOptions || {}))
     .replace('<!-- [HEAD HTML SNIPPET HERE] -->', headHtmlSnippet || '')
     .replace('<!-- [BODY HTML SNIPPET HERE] -->', bodyHtmlSnippet || '');
+
+  if (configType === 'DEVELOPMENT') {
+    return transformedHtml.replace(
+      'virtual:@storybook/builder-vite/vite-app.js',
+      `/@id/__x00__${SB_VIRTUAL_FILES.VIRTUAL_APP_FILE}`
+    );
+  }
+
+  return transformedHtml;
 }

--- a/code/builders/builder-vite/src/virtual-file-names.ts
+++ b/code/builders/builder-vite/src/virtual-file-names.ts
@@ -1,8 +1,8 @@
 export const SB_VIRTUAL_FILES = {
-  VIRTUAL_APP_FILE: '/virtual:/@storybook/builder-vite/vite-app.js',
-  VIRTUAL_STORIES_FILE: '/virtual:/@storybook/builder-vite/storybook-stories.js',
-  VIRTUAL_PREVIEW_FILE: '/virtual:/@storybook/builder-vite/preview-entry.js',
-  VIRTUAL_ADDON_SETUP_FILE: '/virtual:/@storybook/builder-vite/setup-addons.js',
+  VIRTUAL_APP_FILE: 'virtual:@storybook/builder-vite/vite-app.js',
+  VIRTUAL_STORIES_FILE: 'virtual:@storybook/builder-vite/storybook-stories.js',
+  VIRTUAL_PREVIEW_FILE: 'virtual:@storybook/builder-vite/preview-entry.js',
+  VIRTUAL_ADDON_SETUP_FILE: 'virtual:@storybook/builder-vite/setup-addons.js',
 };
 
 export function getResolvedVirtualModuleId(virtualModuleId: string) {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/30480

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

`import.meta.hot.accept` calls in Vite are supposed to only accept module ids. Since our virtual file namings contain a leading forward slash, the virtual id which we were passing to `import.meta.hot.accept` was interpreted as an url, leading to the warning described in the linked issue. Additionally, we have applied a workaround to not break Chromatic's Turbosnap implementation in the Chromatic CLI.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.5 MB | 80.5 MB | 0 B | **1.26** | 0% |
| initSize |  80.5 MB | 80.5 MB | 0 B | -0.79 | 0% |
| diffSize |  97 B | 97 B | 0 B | -0.82 | 0% |
| buildSize |  7.24 MB | 7.24 MB | 0 B | 0.93 | 0% |
| buildSbAddonsSize |  1.87 MB | 1.87 MB | 0 B | 0.54 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 0.33 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.94 MB | 3.94 MB | 0 B | 0.47 | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | 1.2 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.6s | 6.6s | -1s -14ms | -0.96 | -15.3% |
| generateTime |  18.7s | 16.9s | -1s -809ms | **-2.16** | 🔰-10.7% |
| initTime |  4.7s | 4.1s | -551ms | -0.93 | -13.2% |
| buildTime |  8.7s | 8s | -716ms | **-1.24** | 🔰-8.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.1s | 5.5s | 417ms | 0.24 | 7.5% |
| devManagerResponsive |  3.8s | 4.2s | 404ms | 0.54 | 9.5% |
| devManagerHeaderVisible |  761ms | 924ms | 163ms | 1.07 | 17.6% |
| devManagerIndexVisible |  829ms | 965ms | 136ms | 1.13 | 14.1% |
| devStoryVisibleUncached |  4.1s | 3.1s | -1s -61ms | **-2.78** | 🔰-34.2% |
| devStoryVisible |  828ms | 966ms | 138ms | 0.94 | 14.3% |
| devAutodocsVisible |  778ms | 773ms | -5ms | 0.16 | -0.6% |
| devMDXVisible |  643ms | 736ms | 93ms | -0.05 | 12.6% |
| buildManagerHeaderVisible |  859ms | 717ms | -142ms | -0.43 | -19.8% |
| buildManagerIndexVisible |  982ms | 742ms | -240ms | -0.58 | -32.3% |
| buildStoryVisible |  793ms | 641ms | -152ms | -0.49 | -23.7% |
| buildAutodocsVisible |  619ms | 640ms | 21ms | -0.25 | 3.3% |
| buildMDXVisible |  625ms | 777ms | 152ms | 0.83 | 19.6% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR addresses a warning in Vite's hot module replacement system by fixing virtual module ID resolution in the Storybook Vite builder.

- Modified virtual file paths in `code/builders/builder-vite/src/virtual-file-names.ts` to remove leading forward slashes, preventing incorrect URL interpretation
- Updated `code/builders/builder-vite/src/codegen-modern-iframe-script.ts` to properly handle virtual module IDs in HMR calls
- Adjusted `code/builders/builder-vite/input/iframe.html` script path format for proper module resolution
- Added compatibility handling in `code/builders/builder-vite/src/plugins/webpack-stats-plugin.ts` to maintain Chromatic's TurboSnap functionality



<!-- /greptile_comment -->