### PR TITLE
Builder-Vite: Fix Turbosnap

### DIFF
--- a/code/builders/builder-vite/input/iframe.html
+++ b/code/builders/builder-vite/input/iframe.html
@@ -64,6 +64,6 @@
     <!-- [BODY HTML SNIPPET HERE] -->
     <div id="storybook-root"></div>
     <div id="storybook-docs"></div>
-    <script type="module" src="virtual:@storybook/builder-vite/vite-app.js"></script>
+    <script type="module" src="virtual:/@storybook/builder-vite/vite-app.js"></script>
   </body>
 </html>

--- a/code/builders/builder-vite/src/transform-iframe-html.ts
+++ b/code/builders/builder-vite/src/transform-iframe-html.ts
@@ -51,7 +51,7 @@ export async function transformIframeHtml(html: string, options: Options) {
 
   if (configType === 'DEVELOPMENT') {
     return transformedHtml.replace(
-      'virtual:@storybook/builder-vite/vite-app.js',
+      'virtual:/@storybook/builder-vite/vite-app.js',
       `/@id/__x00__${SB_VIRTUAL_FILES.VIRTUAL_APP_FILE}`
     );
   }

--- a/code/builders/builder-vite/src/virtual-file-names.ts
+++ b/code/builders/builder-vite/src/virtual-file-names.ts
@@ -1,8 +1,8 @@
 export const SB_VIRTUAL_FILES = {
-  VIRTUAL_APP_FILE: 'virtual:@storybook/builder-vite/vite-app.js',
-  VIRTUAL_STORIES_FILE: 'virtual:@storybook/builder-vite/storybook-stories.js',
-  VIRTUAL_PREVIEW_FILE: 'virtual:@storybook/builder-vite/preview-entry.js',
-  VIRTUAL_ADDON_SETUP_FILE: 'virtual:@storybook/builder-vite/setup-addons.js',
+  VIRTUAL_APP_FILE: 'virtual:/@storybook/builder-vite/vite-app.js',
+  VIRTUAL_STORIES_FILE: 'virtual:/@storybook/builder-vite/storybook-stories.js',
+  VIRTUAL_PREVIEW_FILE: 'virtual:/@storybook/builder-vite/preview-entry.js',
+  VIRTUAL_ADDON_SETUP_FILE: 'virtual:/@storybook/builder-vite/setup-addons.js',
 };
 
 export function getResolvedVirtualModuleId(virtualModuleId: string) {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/30521

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Re-added the slash after `virtual:` for some virtual ids to not break Chromatic's Turbosnap

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.5 MB | 80.5 MB | 0 B | 0.68 | 0% |
| initSize |  80.5 MB | 80.5 MB | 0 B | -0.3 | 0% |
| diffSize |  97 B | 97 B | 0 B | -0.33 | 0% |
| buildSize |  7.24 MB | 7.27 MB | 26 kB | **2.75** | 0.4% |
| buildSbAddonsSize |  1.87 MB | 1.89 MB | 17.1 kB | **15.75** | 0.9% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 204 B | -0.76 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.94 MB | 3.96 MB | 17.3 kB | **6.18** | 0.4% |
| buildPreviewSize |  3.3 MB | 3.31 MB | 8.71 kB | **1.28** | 0.3% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  14.3s | 25s | 10.6s | 0.51 | 42.5% |
| generateTime |  20.8s | 22.9s | 2s | **3.42** | 🔺9% |
| initTime |  4.9s | 5s | 69ms | -0.16 | 1.4% |
| buildTime |  9.9s | 11.8s | 1.9s | **3.16** | 🔺16.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 5s | -430ms | -0.77 | -8.6% |
| devManagerResponsive |  4.3s | 3.9s | -356ms | -0.34 | -9% |
| devManagerHeaderVisible |  1s | 976ms | -98ms | **1.49** | 🔰-10% |
| devManagerIndexVisible |  1.1s | 998ms | -158ms | **1.31** | 🔰-15.8% |
| devStoryVisibleUncached |  2.9s | 2.7s | -204ms | **-1.32** | 🔰-7.3% |
| devStoryVisible |  1.1s | 1s | -130ms | **1.37** | 🔰-12.3% |
| devAutodocsVisible |  868ms | 772ms | -96ms | 0.13 | -12.4% |
| devMDXVisible |  831ms | 885ms | 54ms | **1.52** | 🔺6.1% |
| buildManagerHeaderVisible |  796ms | 784ms | -12ms | -0.32 | -1.5% |
| buildManagerIndexVisible |  895ms | 902ms | 7ms | -0.3 | 0.8% |
| buildStoryVisible |  710ms | 721ms | 11ms | -0.31 | 1.5% |
| buildAutodocsVisible |  720ms | 623ms | -97ms | -0.26 | -15.6% |
| buildMDXVisible |  575ms | 637ms | 62ms | -0.17 | 9.7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and context, I'll provide a concise summary of the changes:

Fixed TurboSnap functionality in the Vite builder by modifying virtual module path handling in development mode.

- Modified virtual path prefix in `code/builders/builder-vite/src/transform-iframe-html.ts` to include forward slash
- Updated script source path in `code/builders/builder-vite/input/iframe.html` for proper virtual module resolution
- Standardized virtual file paths in `code/builders/builder-vite/src/virtual-file-names.ts` with consistent forward slash usage
- Fixed issue where TurboSnap failed to detect CSF globs when no changes were present

The changes are focused on path resolution for virtual modules to ensure proper functionality of TurboSnap in the Vite builder.



<!-- /greptile_comment -->