### PR TITLE
CI: Increase sharding for unit-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,9 +314,9 @@ jobs:
       - cancel-workflow-on-failure
   unit-tests:
     executor:
-      class: large
+      class: xlarge
       name: sb_playwright
-    parallelism: 6
+    parallelism: 2
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ jobs:
     executor:
       class: large
       name: sb_playwright
-    parallelism: 4
+    parallelism: 6
     steps:
       - git-shallow-clone/checkout_advanced:
           clone_options: "--depth 1 --verbose"


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Increased the sharding for unit tests on CI because they regularly were hitting the maximum of RAM usage, leading to a 129 error.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.5 MB | 80.5 MB | 190 B | 0.27 | 0% |
| initSize |  80.5 MB | 80.5 MB | 190 B | 0.27 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | **1.89** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | **1.81** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | -0.32 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | **1.79** | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | **1.84** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.6s | 8s | 394ms | -0.98 | 4.9% |
| generateTime |  18.5s | 23.8s | 5.2s | **4.13** | 🔺22.1% |
| initTime |  4.4s | 5.6s | 1.1s | **3.09** | 🔺20.1% |
| buildTime |  8.8s | 12s | 3.2s | **3.58** | 🔺26.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.5s | 4.9s | -2s -578ms | -0.69 | -51.6% |
| devManagerResponsive |  5.9s | 3.8s | -2s -138ms | -0.52 | -55.8% |
| devManagerHeaderVisible |  851ms | 716ms | -135ms | -0.67 | -18.9% |
| devManagerIndexVisible |  866ms | 726ms | -140ms | -0.87 | -19.3% |
| devStoryVisibleUncached |  3.4s | 2.4s | -1s -27ms | **-1.6** | 🔰-41.7% |
| devStoryVisible |  944ms | 746ms | -198ms | -0.88 | -26.5% |
| devAutodocsVisible |  869ms | 755ms | -114ms | -0.04 | -15.1% |
| devMDXVisible |  784ms | 692ms | -92ms | -0.55 | -13.3% |
| buildManagerHeaderVisible |  1.3s | 840ms | -507ms | -0.28 | -60.4% |
| buildManagerIndexVisible |  1.3s | 848ms | -541ms | -0.45 | -63.8% |
| buildStoryVisible |  1.3s | 827ms | -488ms | -0.2 | -59% |
| buildAutodocsVisible |  2.5s | 798ms | -1s -723ms | -0.22 | -215.9% |
| buildMDXVisible |  897ms | 747ms | -150ms | 0.51 | -20.1% |

<!-- BENCHMARK_SECTION -->
