### PR TITLE
Build: Fix CSF sandboxes

### DIFF
--- a/code/frameworks/react-native-web-vite/src/index.ts
+++ b/code/frameworks/react-native-web-vite/src/index.ts
@@ -1,1 +1,3 @@
 export type { FrameworkOptions, StorybookConfig } from './types';
+
+export { definePreview } from '@storybook/react';

--- a/code/lib/cli-storybook/src/codemod/csf-factories.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.ts
@@ -21,7 +21,7 @@ async function runStoriesCodemod(options: {
 }) {
   const { dryRun, packageManager, ...codemodOptions } = options;
   try {
-    let globString = 'src/**/*.stories.*';
+    let globString = '{stories,src}/**/*.stories.*';
     if (!process.env.IN_STORYBOOK_SANDBOX) {
       logger.log('Please enter the glob for your stories to migrate');
       globString = (
@@ -30,7 +30,7 @@ async function runStoriesCodemod(options: {
             type: 'text',
             name: 'glob',
             message: 'glob',
-            initial: globString,
+            initial: 'src/**/*.stories.*',
           },
           {
             onCancel: () => process.exit(0),

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -689,6 +689,9 @@ export const baseTemplates = {
       renderer: '@storybook/react',
       builder: '@storybook/builder-vite',
     },
+    modifications: {
+      useCsfFactory: true,
+    },
     skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
   },
   'react-native-web-vite/rn-cli-ts': {
@@ -727,6 +730,7 @@ const internalTemplates = {
       builder: '@storybook/builder-webpack5',
     },
     modifications: {
+      useCsfFactory: true,
       extraDependencies: ['@storybook/addon-webpack5-compiler-babel', 'prop-types'],
       editAddons: (addons) =>
         [...addons, '@storybook/addon-webpack5-compiler-babel'].filter(
@@ -746,6 +750,7 @@ const internalTemplates = {
       builder: '@storybook/builder-webpack5',
     },
     modifications: {
+      useCsfFactory: true,
       extraDependencies: ['prop-types'],
     },
     skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -145,7 +145,14 @@ export const baseTemplates = {
   'nextjs/13-ts': {
     name: 'Next.js v13.5 (Webpack | TypeScript)',
     script:
-      'yarn create next-app {{beforeDir}} -e https://github.com/vercel/next.js/tree/next-13/examples/hello-world && cd {{beforeDir}} && npm pkg set "dependencies.next"="^13.5.6" && yarn && git add . && git commit --amend --no-edit && cd ..',
+      'yarn create next-app {{beforeDir}} -e https://github.com/vercel/next.js/tree/next-13/examples/hello-world ' +
+      '&& cd {{beforeDir}} ' +
+      'jq \'.compilerOptions.moduleResolution = "bundler"\' tsconfig.json > tmp.json && mv tmp.json tsconfig.json ' +
+      '&& npm pkg set "dependencies.next"="^13.5.6" ' +
+      '&& yarn ' +
+      '&& git add . ' +
+      '&& git commit --amend --no-edit ' +
+      '&& cd ..',
     expected: {
       framework: '@storybook/nextjs',
       renderer: '@storybook/react',

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -902,8 +902,8 @@ export const extendPreview: Task['run'] = async ({ template, sandboxDir }) => {
 
   if (template.modifications?.useCsfFactory) {
     const storiesDir = (await pathExists(join(sandboxDir, 'src/stories')))
-      ? '../src/stories'
-      : '../stories';
+      ? '../src/stories/components'
+      : '../stories/components';
     previewConfig.setImport(null, storiesDir);
     previewConfig.setImport({ namespace: 'coreAnnotations' }, '../template-stories/core/preview');
     previewConfig.setImport(

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -901,7 +901,10 @@ export const extendPreview: Task['run'] = async ({ template, sandboxDir }) => {
   const previewConfig = await readConfig({ cwd: sandboxDir, fileName: 'preview' });
 
   if (template.modifications?.useCsfFactory) {
-    previewConfig.setImport(null, '../src/stories/components');
+    const storiesDir = (await pathExists(join(sandboxDir, 'src/stories')))
+      ? '../src/stories'
+      : '../stories';
+    previewConfig.setImport(null, storiesDir);
     previewConfig.setImport({ namespace: 'coreAnnotations' }, '../template-stories/core/preview');
     previewConfig.setImport(
       { namespace: 'toolbarAnnotations' },


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixing some react sandboxes due to the changes related to CSF4.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.5 MB | 80.5 MB | 0 B | 0.58 | 0% |
| initSize |  80.5 MB | 80.5 MB | 0 B | 0.58 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | **1.68** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | **1.59** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | -0.22 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | **1.58** | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | **1.72** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.7s | 7.5s | -185ms | -0.97 | -2.5% |
| generateTime |  20.2s | 19.5s | -710ms | 0.1 | -3.6% |
| initTime |  4.8s | 4.8s | 79ms | 0.7 | 1.6% |
| buildTime |  9.5s | 10.6s | 1.1s | **1.78** | 🔺10.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.5s | 4.3s | -197ms | **-1.36** | -4.5% |
| devManagerResponsive |  3.6s | 3.3s | -296ms | -1.23 | -8.8% |
| devManagerHeaderVisible |  664ms | 609ms | -55ms | **-1.41** | 🔰-9% |
| devManagerIndexVisible |  671ms | 620ms | -51ms | **-1.6** | 🔰-8.2% |
| devStoryVisibleUncached |  3.6s | 3.9s | 292ms | 0.63 | 7.4% |
| devStoryVisible |  697ms | 691ms | -6ms | -1.21 | -0.9% |
| devAutodocsVisible |  681ms | 605ms | -76ms | -1.2 | -12.6% |
| devMDXVisible |  607ms | 621ms | 14ms | -1.08 | 2.3% |
| buildManagerHeaderVisible |  622ms | 544ms | -78ms | -0.78 | -14.3% |
| buildManagerIndexVisible |  670ms | 583ms | -87ms | -0.89 | -14.9% |
| buildStoryVisible |  608ms | 528ms | -80ms | -0.81 | -15.2% |
| buildAutodocsVisible |  611ms | 518ms | -93ms | -0.37 | -18% |
| buildMDXVisible |  535ms | 441ms | -94ms | **-1.59** | 🔰-21.3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request focusing on the key changes:

Added useCsfFactory flag to sandbox templates to enable Component Story Format (CSF) functionality across React-based templates in Storybook.

- Added `useCsfFactory` flag to CRA templates in `code/lib/cli-storybook/src/sandbox-templates.ts`
- Added `useCsfFactory` flag to React Webpack templates
- Added `useCsfFactory` flag to React Vite templates
- Added `useCsfFactory` flag to Next.js templates
- Added `useCsfFactory` flag to React Native Web templates

The changes systematically update template configurations to support CSF factory functionality, improving the component story creation experience across React-based frameworks.



<!-- /greptile_comment -->