### PR TITLE
Addon-docs: Add explicit type to default export

### DIFF
--- a/code/addons/actions/src/index.ts
+++ b/code/addons/actions/src/index.ts
@@ -1,4 +1,5 @@
 import { definePreview } from 'storybook/internal/preview-api';
+import type { ProjectAnnotations, Renderer } from 'storybook/internal/types';
 
 import * as addonAnnotations from './preview';
 
@@ -6,6 +7,6 @@ export * from './constants';
 export * from './models';
 export * from './runtime';
 
-export default () => definePreview(addonAnnotations);
+export default (): ProjectAnnotations<Renderer> => definePreview(addonAnnotations);
 
 export type { ActionsParameters } from './types';


### PR DESCRIPTION
Closes #30540

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Add explicit type annotation to default export of @storybook/addon-docs

Enabling the eslint rule [explicit-module-boundary-types](https://typescript-eslint.io/rules/explicit-module-boundary-types/) would probably help catch these in the future.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:
Not required
-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 0 B | **1.24** | 0% |
| initSize |  80.6 MB | 80.6 MB | 0 B | **1.24** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | -1.46 kB | 0.37 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.36 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | -27 B | 0.17 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | -27 B | 0.36 | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | -1.43 kB | 0.36 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  24.4s | 22.3s | -2s -140ms | 0.37 | -9.6% |
| generateTime |  18.4s | 18.6s | 167ms | -0.91 | 0.9% |
| initTime |  4.4s | 4s | -469ms | **-2.25** | 🔰-11.6% |
| buildTime |  9.7s | 8.1s | -1s -688ms | **-1.46** | 🔰-20.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.3s | 4.5s | -825ms | -1.2 | -18.2% |
| devManagerResponsive |  4s | 3.4s | -665ms | -1.21 | -19.4% |
| devManagerHeaderVisible |  860ms | 604ms | -256ms | **-1.48** | 🔰-42.4% |
| devManagerIndexVisible |  871ms | 632ms | -239ms | **-1.5** | 🔰-37.8% |
| devStoryVisibleUncached |  4.1s | 3.3s | -752ms | -0.47 | -22.2% |
| devStoryVisible |  897ms | 659ms | -238ms | **-1.45** | 🔰-36.1% |
| devAutodocsVisible |  773ms | 613ms | -160ms | **-1.53** | 🔰-26.1% |
| devMDXVisible |  793ms | 599ms | -194ms | **-1.51** | 🔰-32.4% |
| buildManagerHeaderVisible |  721ms | 575ms | -146ms | **-1.37** | 🔰-25.4% |
| buildManagerIndexVisible |  807ms | 613ms | -194ms | **-1.44** | 🔰-31.6% |
| buildStoryVisible |  703ms | 561ms | -142ms | **-1.34** | 🔰-25.3% |
| buildAutodocsVisible |  578ms | 476ms | -102ms | -0.72 | -21.4% |
| buildMDXVisible |  597ms | 485ms | -112ms | **-1.34** | 🔰-23.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR adds explicit type annotations to the default export in addon-actions to prevent incorrect type inference and dependency leakage during compilation.

- Added `ProjectAnnotations<Renderer>` return type to default export in `/code/addons/actions/src/index.ts`
- Fixes issue #30540 where internal dependencies were being incorrectly inferred as `@storybook/core/csf`
- Prevents compilation errors in yarn pnp environments by properly declaring types



<sub>💡 (4/5) You can add custom instructions or style guidelines for the bot [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->