### PR TITLE
Docs: Fix `test` tags description

### DIFF
--- a/docs/writing-stories/tags.mdx
+++ b/docs/writing-stories/tags.mdx
@@ -11,11 +11,11 @@ Tags allow you to control which stories are included in your Storybook, enabling
 
 The following tags are available in every Storybook project:
 
-| Tag        | Applied by default?           | Description                                                                                                                                                                                                               |
-| ---------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `autodocs` | No                            | Stories tagged with `autodocs` will be included in the [docs page](../writing-docs/autodocs.mdx). If a CSF file does not contain at least one story tagged with `autodocs`, that component will not generate a docs page. |
-| `dev`      | Yes                           | Stories tagged with `dev` are rendered in Storybook's sidebar.                                                                                                                                                            |
-| `test`     | Yes                           | Stories tagged with `test` do not currently affect Storybook's UI, but can be used to filter the [test runner](../writing-tests/test-runner.mdx#run-tests-for-a-subset-of-stories).                                       |
+| Tag        | Applied by default? | Description                                                                                                                                                                                                              |
+| ---------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `autodocs` | No                  | Stories tagged with `autodocs` are included in the [docs page](../writing-docs/autodocs.mdx). If a CSF file does not contain at least one story tagged with `autodocs`, that component will not generate a docs page.    |
+| `dev`      | Yes                 | Stories tagged with `dev` are rendered in Storybook's sidebar.                                                                                                                                                           |
+| `test`     | Yes                 | Stories tagged with `test` are included in [test runner](../writing-tests/test-runner.mdx#run-tests-for-a-subset-of-stories) or [test addon](../writing-tests/test-addon.mdxincluding-excluding-or-skipping-tests) runs. |
 
 The `dev` and `test` tags are automatically, implicitly applied to every story in your Storybook project.
 
@@ -56,6 +56,7 @@ Tags can be removed for all stories in your project (in `.storybook/preview.js|t
 Custom tags enable a flexible layer of categorization on top of Storybook's sidebar hierarchy. In the example above, we created an `experimental` tag to indicate that a story is not yet stable.
 
 You can create custom tags for any purpose. Sample uses might include:
+
 - Status, such as `experimental`, `new`, `stable`, or `deprecated`
 - User persona, such as `admin`, `user`, or `developer`
 - Component/code ownership

--- a/docs/writing-stories/tags.mdx
+++ b/docs/writing-stories/tags.mdx
@@ -15,7 +15,7 @@ The following tags are available in every Storybook project:
 | ---------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `autodocs` | No                  | Stories tagged with `autodocs` are included in the [docs page](../writing-docs/autodocs.mdx). If a CSF file does not contain at least one story tagged with `autodocs`, that component will not generate a docs page.    |
 | `dev`      | Yes                 | Stories tagged with `dev` are rendered in Storybook's sidebar.                                                                                                                                                           |
-| `test`     | Yes                 | Stories tagged with `test` are included in [test runner](../writing-tests/test-runner.mdx#run-tests-for-a-subset-of-stories) or [test addon](../writing-tests/test-addon.mdxincluding-excluding-or-skipping-tests) runs. |
+| `test`     | Yes                 | Stories tagged with `test` are included in [test runner](../writing-tests/test-runner.mdx#run-tests-for-a-subset-of-stories) or [test addon](../writing-tests/test-addon.mdx#including-excluding-or-skipping-tests) runs. |
 
 The `dev` and `test` tags are automatically, implicitly applied to every story in your Storybook project.
 


### PR DESCRIPTION

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updated documentation for tags in Storybook, focusing on clarifying the test tag description and improving overall readability.

- Clarified `test` tag description to better explain its impact on test runner and addon functionality
- Improved wording of `autodocs` tag description for clarity
- Enhanced table layout formatting in `docs/writing-stories/tags.mdx`
- Added newline spacing in custom tags section for better readability



<!-- /greptile_comment -->