### PR TITLE
Tags: Add story/meta usage telemetry

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -103,6 +103,7 @@ describe('StoryIndexGenerator', () => {
             "play": 0,
             "render": 0,
             "storyFn": 0,
+            "tags": 1,
           }
         `);
       });
@@ -472,6 +473,7 @@ describe('StoryIndexGenerator', () => {
             "play": 2,
             "render": 1,
             "storyFn": 1,
+            "tags": 5,
           }
         `);
       });
@@ -738,6 +740,7 @@ describe('StoryIndexGenerator', () => {
             "play": 2,
             "render": 1,
             "storyFn": 1,
+            "tags": 5,
           }
         `);
       });

--- a/code/core/src/csf-tools/CsfFile.test.ts
+++ b/code/core/src/csf-tools/CsfFile.test.ts
@@ -92,6 +92,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -106,6 +107,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -137,6 +139,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -169,6 +172,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -199,6 +203,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -227,6 +232,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -256,6 +262,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -268,6 +275,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -297,6 +305,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -309,6 +318,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -338,6 +348,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -350,6 +361,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -380,6 +392,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -392,6 +405,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -426,6 +440,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -441,6 +456,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -475,6 +491,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -490,6 +507,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -521,6 +539,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -533,6 +552,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -564,6 +584,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -576,6 +597,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -605,6 +627,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -617,6 +640,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -650,6 +674,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -682,6 +707,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -715,6 +741,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -753,6 +780,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -786,6 +814,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -801,6 +830,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -829,6 +859,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -841,6 +872,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -874,6 +906,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -889,6 +922,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -923,6 +957,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -1004,6 +1039,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -1016,6 +1052,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -1070,6 +1107,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -1082,6 +1120,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: true
               mount: false
               moduleMock: false
@@ -1160,6 +1199,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1193,6 +1233,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1224,6 +1265,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1257,6 +1299,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -1339,6 +1382,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: true
               storyFn: true
               mount: false
               moduleMock: false
@@ -1373,6 +1417,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: true
               storyFn: false
               mount: false
               moduleMock: false
@@ -1409,6 +1454,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: true
               storyFn: false
               mount: false
               moduleMock: false
@@ -1470,6 +1516,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: true
               storyFn: true
               mount: false
               moduleMock: false
@@ -1506,6 +1553,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: true
               storyFn: false
               mount: false
               moduleMock: false
@@ -1538,6 +1586,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: true
               moduleMock: false
@@ -1569,6 +1618,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: true
               moduleMock: false
@@ -1603,6 +1653,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: true
               moduleMock: false
@@ -1637,6 +1688,7 @@ describe('CsfFile', () => {
               loaders: true
               beforeEach: false
               globals: false
+              tags: true
               storyFn: false
               mount: false
               moduleMock: false
@@ -1670,6 +1722,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: true
               storyFn: true
               mount: false
               moduleMock: false
@@ -1721,6 +1774,7 @@ describe('CsfFile', () => {
             loaders: false
             beforeEach: false
             globals: false
+            tags: true
             storyFn: false
             mount: false
             moduleMock: false
@@ -1742,6 +1796,7 @@ describe('CsfFile', () => {
             loaders: false
             beforeEach: false
             globals: false
+            tags: true
             storyFn: false
             mount: false
             moduleMock: false
@@ -1781,6 +1836,7 @@ describe('CsfFile', () => {
             loaders: false
             beforeEach: false
             globals: false
+            tags: true
             storyFn: false
             mount: false
             moduleMock: false
@@ -1825,6 +1881,7 @@ describe('CsfFile', () => {
             loaders: false
             beforeEach: false
             globals: false
+            tags: true
             storyFn: false
             mount: false
             moduleMock: false
@@ -1884,6 +1941,7 @@ describe('CsfFile', () => {
             loaders: false
             beforeEach: false
             globals: false
+            tags: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1922,6 +1980,7 @@ describe('CsfFile', () => {
             loaders: false
             beforeEach: false
             globals: false
+            tags: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1960,6 +2019,7 @@ describe('CsfFile', () => {
             loaders: false
             beforeEach: false
             globals: false
+            tags: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -1998,6 +2058,7 @@ describe('CsfFile', () => {
             loaders: false
             beforeEach: false
             globals: false
+            tags: false
             storyFn: false
             mount: false
             moduleMock: false
@@ -2029,6 +2090,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: true
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -2060,6 +2122,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: true
+              tags: false
               storyFn: false
               mount: false
               moduleMock: false
@@ -2090,6 +2153,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: true
@@ -2117,6 +2181,7 @@ describe('CsfFile', () => {
               loaders: false
               beforeEach: false
               globals: false
+              tags: false
               storyFn: false
               mount: false
               moduleMock: true
@@ -2150,6 +2215,7 @@ describe('CsfFile', () => {
                 loaders: false
                 beforeEach: false
                 globals: false
+                tags: false
                 storyFn: false
                 mount: false
                 moduleMock: false
@@ -2162,6 +2228,7 @@ describe('CsfFile', () => {
                 loaders: false
                 beforeEach: false
                 globals: false
+                tags: false
                 storyFn: false
                 mount: false
                 moduleMock: false
@@ -2191,6 +2258,7 @@ describe('CsfFile', () => {
                 loaders: false
                 beforeEach: false
                 globals: false
+                tags: false
                 storyFn: false
                 mount: false
                 moduleMock: false
@@ -2222,6 +2290,7 @@ describe('CsfFile', () => {
                 loaders: false
                 beforeEach: false
                 globals: false
+                tags: false
                 storyFn: false
                 mount: false
                 moduleMock: false
@@ -2234,6 +2303,7 @@ describe('CsfFile', () => {
                 loaders: false
                 beforeEach: false
                 globals: false
+                tags: false
                 storyFn: false
                 mount: false
                 moduleMock: false
@@ -2263,6 +2333,7 @@ describe('CsfFile', () => {
                 loaders: false
                 beforeEach: false
                 globals: false
+                tags: false
                 storyFn: false
                 mount: false
                 moduleMock: false
@@ -2297,6 +2368,7 @@ describe('CsfFile', () => {
                 loaders: false
                 beforeEach: false
                 globals: false
+                tags: false
                 storyFn: false
                 mount: false
                 moduleMock: false
@@ -2331,6 +2403,7 @@ describe('CsfFile', () => {
                 loaders: false
                 beforeEach: false
                 globals: false
+                tags: false
                 storyFn: false
                 mount: false
                 moduleMock: false

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -765,7 +765,7 @@ export class CsfFile {
           acc[key].tags = [...(acc[key].tags || []), 'play-fn'];
         }
         const stats = acc[key].__stats;
-        ['play', 'render', 'loaders', 'beforeEach', 'globals'].forEach((annotation) => {
+        ['play', 'render', 'loaders', 'beforeEach', 'globals', 'tags'].forEach((annotation) => {
           stats[annotation as keyof IndexInputStats] =
             !!storyAnnotations[annotation] || !!self._metaAnnotations[annotation];
         });

--- a/code/core/src/types/modules/indexer.ts
+++ b/code/core/src/types/modules/indexer.ts
@@ -92,6 +92,7 @@ export interface IndexInputStats {
   moduleMock?: boolean;
   globals?: boolean;
   factory?: boolean;
+  tags?: boolean;
 }
 
 /** The base input for indexing a story or docs entry. */


### PR DESCRIPTION
Closes N/A

## What I did

Count the number of stories/meta that use tags. Does not include the implicit `dev`/`test` tags or tags that are added in `preview.js`.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 32 B | **1.39** | 0% |
| initSize |  80.6 MB | 80.6 MB | 32 B | **1.39** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | 0.51 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.45 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 0.53 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | 0.45 | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | 0.54 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.1s | 19.2s | 11.1s | 0.07 | 57.9% |
| generateTime |  19.7s | 18s | -1s -656ms | **-1.48** | 🔰-9.2% |
| initTime |  4.7s | 4.3s | -480ms | -1.19 | -11.2% |
| buildTime |  9.9s | 9.2s | -620ms | -0.01 | -6.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.3s | 5.7s | 420ms | 0.18 | 7.3% |
| devManagerResponsive |  3.9s | 4.2s | 291ms | -0.06 | 6.9% |
| devManagerHeaderVisible |  985ms | 845ms | -140ms | 0.2 | -16.6% |
| devManagerIndexVisible |  997ms | 915ms | -82ms | 0.47 | -9% |
| devStoryVisibleUncached |  4.4s | 4.2s | -196ms | 0.96 | -4.6% |
| devStoryVisible |  1s | 939ms | -125ms | 0.29 | -13.3% |
| devAutodocsVisible |  841ms | 894ms | 53ms | 1.11 | 5.9% |
| devMDXVisible |  899ms | 806ms | -93ms | 0.25 | -11.5% |
| buildManagerHeaderVisible |  795ms | 779ms | -16ms | -0.35 | -2.1% |
| buildManagerIndexVisible |  870ms | 784ms | -86ms | -0.57 | -11% |
| buildStoryVisible |  772ms | 765ms | -7ms | -0.24 | -0.9% |
| buildAutodocsVisible |  662ms | 639ms | -23ms | -0.33 | -3.6% |
| buildMDXVisible |  750ms | 625ms | -125ms | -0.12 | -20% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added telemetry tracking for tags usage in Storybook stories by implementing tag counting across story and meta annotations.

- Added `tags` boolean property to `IndexInputStats` interface in `code/core/src/types/modules/indexer.ts`
- Added `tags` to tracked annotations in `code/core/src/csf-tools/CsfFile.ts` for story stats
- Added test coverage in `StoryIndexGenerator.test.ts` for tags counting across different scenarios
- Added test cases in `CsfFile.test.ts` for tag handling in CSF2/CSF3 formats

The changes are minimal and focused on adding telemetry capabilities without modifying existing functionality. The implementation appears thorough with good test coverage for various tag usage scenarios.



<!-- /greptile_comment -->