### PR TITLE
Telemetry: Don't count example stories towards CSF feature stats

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -345,6 +345,19 @@ describe('StoryIndexGenerator', () => {
                 "title": "D",
                 "type": "story",
               },
+              "example-button--story-one": {
+                "componentPath": undefined,
+                "id": "example-button--story-one",
+                "importPath": "./src/Button.stories.ts",
+                "name": "Story One",
+                "tags": [
+                  "dev",
+                  "test",
+                  "foobar",
+                ],
+                "title": "Example/Button",
+                "type": "story",
+              },
               "first-nested-deeply-f--story-one": {
                 "componentPath": undefined,
                 "id": "first-nested-deeply-f--story-one",
@@ -599,6 +612,19 @@ describe('StoryIndexGenerator', () => {
                 "title": "D",
                 "type": "story",
               },
+              "example-button--story-one": {
+                "componentPath": undefined,
+                "id": "example-button--story-one",
+                "importPath": "./src/Button.stories.ts",
+                "name": "Story One",
+                "tags": [
+                  "dev",
+                  "test",
+                  "foobar",
+                ],
+                "title": "Example/Button",
+                "type": "story",
+              },
               "first-nested-deeply-f--story-one": {
                 "componentPath": undefined,
                 "id": "first-nested-deeply-f--story-one",
@@ -767,6 +793,8 @@ describe('StoryIndexGenerator', () => {
             "a--story-one",
             "b--docs",
             "b--story-one",
+            "example-button--docs",
+            "example-button--story-one",
             "d--docs",
             "d--story-one",
             "h--docs",
@@ -809,6 +837,8 @@ describe('StoryIndexGenerator', () => {
             "a--story-one",
             "b--docs",
             "b--story-one",
+            "example-button--docs",
+            "example-button--story-one",
             "d--docs",
             "d--story-one",
             "h--docs",
@@ -1797,6 +1827,7 @@ describe('StoryIndexGenerator', () => {
           "second-nested-g--story-one",
           "componentreference--docs",
           "notitle--docs",
+          "example-button--story-one",
           "h--story-one",
           "componentpath-extension--story-one",
           "componentpath-noextension--story-one",
@@ -1825,7 +1856,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([specifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(readCsfMock).toHaveBeenCalledTimes(11);
+        expect(readCsfMock).toHaveBeenCalledTimes(12);
 
         readCsfMock.mockClear();
         await generator.getIndex();
@@ -1883,7 +1914,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([specifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(readCsfMock).toHaveBeenCalledTimes(11);
+        expect(readCsfMock).toHaveBeenCalledTimes(12);
 
         generator.invalidate(specifier, './src/B.stories.ts', false);
 
@@ -1968,7 +1999,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([specifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(readCsfMock).toHaveBeenCalledTimes(11);
+        expect(readCsfMock).toHaveBeenCalledTimes(12);
 
         generator.invalidate(specifier, './src/B.stories.ts', true);
 
@@ -2007,7 +2038,7 @@ describe('StoryIndexGenerator', () => {
         const generator = new StoryIndexGenerator([specifier], options);
         await generator.initialize();
         await generator.getIndex();
-        expect(readCsfMock).toHaveBeenCalledTimes(11);
+        expect(readCsfMock).toHaveBeenCalledTimes(12);
 
         generator.invalidate(specifier, './src/B.stories.ts', true);
 

--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -5,6 +5,7 @@ import { dirname, extname, join, normalize, relative, resolve, sep } from 'node:
 
 import { commonGlobOptions, normalizeStoryPath } from '@storybook/core/common';
 import { combineTags, storyNameFromExport, toId } from '@storybook/core/csf';
+import { isExampleStoryId } from '@storybook/core/telemetry';
 import type {
   DocsIndexEntry,
   DocsOptions,
@@ -269,7 +270,10 @@ export class StoryIndexGenerator {
             return item;
           }
 
-          addStats(item.extra.stats, statsSummary);
+          // don't count example stories towards feature usage stats
+          if (!isExampleStoryId(item.id)) {
+            addStats(item.extra.stats, statsSummary);
+          }
 
           // Drop extra data used for internal bookkeeping
           const { extra, ...existing } = item;

--- a/code/core/src/core-server/utils/__mockdata__/src/Button.stories.ts
+++ b/code/core/src/core-server/utils/__mockdata__/src/Button.stories.ts
@@ -1,0 +1,8 @@
+const component = {};
+export default {
+  title: 'Example/Button',
+  component,
+  tags: ['foobar'],
+};
+
+export const StoryOne = {};

--- a/code/core/src/core-server/utils/stories-json.test.ts
+++ b/code/core/src/core-server/utils/stories-json.test.ts
@@ -255,6 +255,18 @@ describe('useStoriesJson', () => {
               "title": "docs2/Yabbadabbadooo",
               "type": "docs",
             },
+            "example-button--story-one": {
+              "id": "example-button--story-one",
+              "importPath": "./src/Button.stories.ts",
+              "name": "Story One",
+              "tags": [
+                "dev",
+                "test",
+                "foobar",
+              ],
+              "title": "Example/Button",
+              "type": "story",
+            },
             "first-nested-deeply-f--story-one": {
               "id": "first-nested-deeply-f--story-one",
               "importPath": "./src/first-nested/deeply/F.stories.js",


### PR DESCRIPTION
Closes N/A

## What I did

We shouldn't count example stories since they are not for "real" components

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 77 B | 1.11 | 0% |
| initSize |  80.6 MB | 80.6 MB | 77 B | 1.11 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | 0.31 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.25 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 0.71 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | 0.27 | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | 0.32 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.9s | 22.8s | 13.8s | 0.52 | 60.7% |
| generateTime |  22.6s | 19.5s | -3s -70ms | -0.04 | -15.7% |
| initTime |  5s | 5s | 40ms | **1.56** | 0.8% |
| buildTime |  9s | 11.6s | 2.6s | **2.9** | 🔺22.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.2s | 5.1s | -2s -89ms | -0.49 | -40.7% |
| devManagerResponsive |  5.2s | 3.7s | -1s -515ms | -0.7 | -40.5% |
| devManagerHeaderVisible |  1s | 703ms | -347ms | -0.72 | -49.4% |
| devManagerIndexVisible |  1.1s | 787ms | -318ms | -0.35 | -40.4% |
| devStoryVisibleUncached |  4.5s | 2.5s | -1s -988ms | **-2** | 🔰-76.9% |
| devStoryVisible |  1.1s | 788ms | -375ms | -0.53 | -47.6% |
| devAutodocsVisible |  1s | 727ms | -284ms | -0.44 | -39.1% |
| devMDXVisible |  991ms | 750ms | -241ms | -0.25 | -32.1% |
| buildManagerHeaderVisible |  1s | 799ms | -202ms | -0.22 | -25.3% |
| buildManagerIndexVisible |  1s | 814ms | -196ms | -0.36 | -24.1% |
| buildStoryVisible |  949ms | 771ms | -178ms | -0.23 | -23.1% |
| buildAutodocsVisible |  840ms | 959ms | 119ms | 0.41 | 12.4% |
| buildMDXVisible |  689ms | 645ms | -44ms | 0.04 | -6.8% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Modified StoryIndexGenerator to exclude example stories from feature usage statistics, ensuring more accurate metrics by only counting stories from real components.

- Added `isExampleStoryId()` check in `StoryIndexGenerator.ts` before adding stats to summary
- Prevents example stories from affecting feature usage metrics in `summarizeIndex.ts`
- Maintains existing functionality while filtering out non-production stories
- Improves accuracy of telemetry data by focusing on actual component usage



<!-- /greptile_comment -->