### PR TITLE
Vite: Fix not stripping all HMR boundaries

### DIFF
--- a/code/builders/builder-vite/src/codegen-importfn-script.ts
+++ b/code/builders/builder-vite/src/codegen-importfn-script.ts
@@ -1,6 +1,6 @@
 import type { Options } from 'storybook/internal/types';
 
-import { genDynamicImport, genImport, genObjectFromRawEntries } from 'knitwork';
+import { genDynamicImport, genObjectFromRawEntries } from 'knitwork';
 import { normalize, relative } from 'pathe';
 import { dedent } from 'ts-dedent';
 

--- a/code/builders/builder-vite/src/plugins/strip-story-hmr-boundaries.ts
+++ b/code/builders/builder-vite/src/plugins/strip-story-hmr-boundaries.ts
@@ -9,17 +9,17 @@ import type { Plugin } from 'vite';
 export async function stripStoryHMRBoundary(): Promise<Plugin> {
   const { createFilter } = await import('vite');
 
-  const filter = createFilter(/\.stories\.([tj])sx?$/);
+  const filter = createFilter(/\.stories\.\w+$/);
   return {
     name: 'storybook:strip-hmr-boundary-plugin',
     enforce: 'post',
-    async transform(src: string, id: string) {
+    async transform(src, id) {
       if (!filter(id)) {
         return undefined;
       }
 
       const s = new MagicString(src);
-      s.replace(/import\.meta\.hot\.accept\(\);/, '');
+      s.replace(/import\.meta\.hot\.accept\w*/, '(function hmrBoundaryNoop(){})');
 
       return {
         code: s.toString(),


### PR DESCRIPTION
Closes https://github.com/storybookjs/addon-svelte-csf/issues/280

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

See https://github.com/storybookjs/addon-svelte-csf/issues/280#issuecomment-2664081468

Improved the HMR boundary stripping, by targetting any `X.stories.Y` files and replacing any `import.meta.hot.acceptX` instead of only `import.meta.hot.accept();`.

HMR boundaries in stories files causes the parent module to not invalidate on those file changes, resulting in `importFn`'s returning stale modules.

### Some more details

- before it only replaced `import.meta.hot.accept();`, which was very restricted. Ie. it wouldn't replace `import.meta.hot.accept((module) => {...})`, it also wouldn't replace the (undocumented) `import.meta.hot.acceptExports(...)` that Svelte uses. By just replacing the variable without the parentheses, we're able to hit anything import.meta.hot.acceptX
- But not replacing parentheses means that the function will still be "called", so we replace it with a dummy no op function.
replacing:

```js
import.meta.hot.acceptExports(["default"],(module) => {
  module.default[$.HMR].source = Button_stories[$.HMR].source;
  $.set(Button_stories[$.HMR].source, module.default[$.HMR].original);
});
```

with:

```js
(function hmrBoundaryNoop(){})(["default"],(module) => {
  module.default[$.HMR].source = Button_stories[$.HMR].source;
  $.set(Button_stories[$.HMR].source, module.default[$.HMR].original);
});
```

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30562-sha-f0b573b7`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30562-sha-f0b573b7 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30562-sha-f0b573b7 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30562-sha-f0b573b7`](https://npmjs.com/package/storybook/v/0.0.0-pr-30562-sha-f0b573b7) |
| **Triggered by** | @JReinhold |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`jeppe/fix-hmr-stripping`](https://github.com/storybookjs/storybook/tree/jeppe/fix-hmr-stripping) |
| **Commit** | [`f0b573b7`](https://github.com/storybookjs/storybook/commit/f0b573b78b76549f40c09ba99082340509f2ffda) |
| **Datetime** | Tue Feb 18 10:31:20 UTC 2025 (`1739874680`) |
| **Workflow run** | [13388519251](https://github.com/storybookjs/storybook/actions/runs/13388519251) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30562`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | -1.97 kB | 0.82 | 0% |
| initSize |  80.6 MB | 80.6 MB | -1.97 kB | 0.82 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | -10 B | 0.8 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.33 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 0.9 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | 0.47 | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | -10 B | 0.8 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  25s | 20.6s | -4s -443ms | 0.6 | -21.5% |
| generateTime |  20.4s | 19.8s | -573ms | 0.23 | -2.9% |
| initTime |  5.2s | 4.6s | -533ms | 0.2 | -11.4% |
| buildTime |  10s | 8.9s | -1s -43ms | -0.27 | -11.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5s | 5.3s | 228ms | -0.18 | 4.3% |
| devManagerResponsive |  3.7s | 3.9s | 223ms | -0.23 | 5.6% |
| devManagerHeaderVisible |  708ms | 789ms | 81ms | 0.04 | 10.3% |
| devManagerIndexVisible |  736ms | 793ms | 57ms | -0.18 | 7.2% |
| devStoryVisibleUncached |  4.1s | 2.8s | -1s -358ms | **-1.6** | 🔰-47.9% |
| devStoryVisible |  737ms | 858ms | 121ms | 0.09 | 14.1% |
| devAutodocsVisible |  693ms | 812ms | 119ms | 0.53 | 14.7% |
| devMDXVisible |  711ms | 774ms | 63ms | 0.13 | 8.1% |
| buildManagerHeaderVisible |  797ms | 944ms | 147ms | 0.68 | 15.6% |
| buildManagerIndexVisible |  805ms | 978ms | 173ms | 0.67 | 17.7% |
| buildStoryVisible |  774ms | 931ms | 157ms | 0.79 | 16.9% |
| buildAutodocsVisible |  595ms | 862ms | 267ms | 0.23 | 31% |
| buildMDXVisible |  697ms | 780ms | 83ms | **1.34** | 🔺10.6% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request changes focusing on the Vite builder's HMR boundary handling improvements.

Improves HMR boundary stripping in Storybook's Vite builder to prevent stale modules from being returned when story files are updated.

- Modified regex in `strip-story-hmr-boundaries.ts` to catch all story file extensions with `.stories.\w+$` pattern
- Enhanced HMR accept pattern to catch all variations with `import.meta.hot.accept\w*`
- Replaced HMR accept calls with `(function hmrBoundaryNoop(){})` instead of removing them entirely
- Improved code formatting in `codegen-modern-iframe-script.ts` using `dedent` for better template string readability
- Removed unused imports from `codegen-importfn-script.ts` and `codegen-modern-iframe-script.ts`



<!-- /greptile_comment -->