### PR TITLE
Core: Fix undeclared internal dependencies

### DIFF
--- a/code/core/src/types/modules/csf.ts
+++ b/code/core/src/types/modules/csf.ts
@@ -1,6 +1,11 @@
 import type { ViewMode as ViewModeBase } from '@storybook/core/csf';
+import type { Renderer as CSFRenderer } from '@storybook/core/csf';
 
 import type { Addon_OptionsParameter } from './addons';
+
+// Fix https://github.com/storybookjs/storybook/issues/30540
+// Can be removed once @storybook/core and storybook are merged in 9.0
+export interface Renderer extends CSFRenderer {}
 
 export type {
   AfterEach,
@@ -35,7 +40,6 @@ export type {
   PlayFunction,
   PlayFunctionContext,
   ProjectAnnotations as BaseProjectAnnotations,
-  Renderer,
   SBArrayType,
   SBEnumType,
   SBIntersectionType,


### PR DESCRIPTION
Closes #30540

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 0 B | 0.5 | 0% |
| initSize |  80.6 MB | 80.6 MB | 0 B | 0.5 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | 0.49 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 0.58 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | 0.58 | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | 0.48 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.6s | 7.7s | 1s | -1 | 14% |
| generateTime |  17.6s | 19.8s | 2.2s | 0.02 | 11.3% |
| initTime |  4.3s | 4.4s | 179ms | -0.47 | 4% |
| buildTime |  8.3s | 8.7s | 444ms | -0.59 | 5.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.3s | 6.6s | 276ms | **1.56** | 4.2% |
| devManagerResponsive |  4.8s | 4.7s | -159ms | 1.02 | -3.4% |
| devManagerHeaderVisible |  854ms | 867ms | 13ms | 0.54 | 1.5% |
| devManagerIndexVisible |  871ms | 957ms | 86ms | 1.04 | 9% |
| devStoryVisibleUncached |  4.2s | 4.5s | 296ms | 1.05 | 6.6% |
| devStoryVisible |  946ms | 980ms | 34ms | 0.84 | 3.5% |
| devAutodocsVisible |  923ms | 738ms | -185ms | -0.51 | -25.1% |
| devMDXVisible |  837ms | 885ms | 48ms | 0.95 | 5.4% |
| buildManagerHeaderVisible |  880ms | 709ms | -171ms | -0.75 | -24.1% |
| buildManagerIndexVisible |  947ms | 716ms | -231ms | -1 | -32.3% |
| buildStoryVisible |  856ms | 664ms | -192ms | -0.92 | -28.9% |
| buildAutodocsVisible |  845ms | 590ms | -255ms | -0.64 | -43.2% |
| buildMDXVisible |  662ms | 573ms | -89ms | -0.71 | -15.5% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the changes:

Fixed undeclared internal dependencies in Storybook's CSF types module by extending the Renderer interface to maintain compatibility with @storybook/core/csf.

- Added temporary fix for issue #30540 in `code/core/src/types/modules/csf.ts`
- Extended `CSFRenderer` from @storybook/core/csf to create new `Renderer` interface
- Removed direct export of `Renderer` from core/csf exports list
- Changes are backward compatible and will be resolved when @storybook/core and storybook merge in v9.0



<!-- /greptile_comment -->