### PR TITLE
Addon-Test: Add telemetry data for Focused Tests

### DIFF
--- a/code/addons/test/src/preset.ts
+++ b/code/addons/test/src/preset.ts
@@ -146,6 +146,7 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
             numTotalTests: progress?.numTotalTests,
             numFailedTests: progress?.numFailedTests,
             numPassedTests: progress?.numPassedTests,
+            numSelectedStories: payload.details?.selectedStoryCount ?? 0,
           });
         }
 
@@ -157,6 +158,7 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
             ...(options.enableCrashReports && {
               error: error && sanitizeError(error),
             }),
+            numSelectedStories: payload.details?.selectedStoryCount ?? 0,
           });
         }
       }


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds data about how many stories were selected for the run, when sending telemetry on completed test runs.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 0 B | 0.5 | 0% |
| initSize |  80.6 MB | 80.6 MB | 0 B | 0.5 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | 0.49 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 0.58 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | 0.58 | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | 0.48 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.6s | 21.6s | 14.9s | 0.82 | 69.2% |
| generateTime |  17.6s | 23.9s | 6.3s | **2.34** | 🔺26.4% |
| initTime |  4.3s | 5.1s | 821ms | 1.11 | 16% |
| buildTime |  8.3s | 12.2s | 3.9s | **3.16** | 🔺32% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.3s | 5s | -1s -286ms | -0.78 | -25.5% |
| devManagerResponsive |  4.8s | 3.7s | -1s -154ms | -1.02 | -31% |
| devManagerHeaderVisible |  854ms | 712ms | -142ms | -0.75 | -19.9% |
| devManagerIndexVisible |  871ms | 780ms | -91ms | -0.4 | -11.7% |
| devStoryVisibleUncached |  4.2s | 4s | -217ms | 0.22 | -5.4% |
| devStoryVisible |  946ms | 804ms | -142ms | -0.44 | -17.7% |
| devAutodocsVisible |  923ms | 697ms | -226ms | -0.89 | -32.4% |
| devMDXVisible |  837ms | 684ms | -153ms | -0.96 | -22.4% |
| buildManagerHeaderVisible |  880ms | 589ms | -291ms | **-1.7** | 🔰-49.4% |
| buildManagerIndexVisible |  947ms | 602ms | -345ms | **-1.9** | 🔰-57.3% |
| buildStoryVisible |  856ms | 555ms | -301ms | **-1.85** | 🔰-54.2% |
| buildAutodocsVisible |  845ms | 473ms | -372ms | **-1.39** | 🔰-78.6% |
| buildMDXVisible |  662ms | 503ms | -159ms | **-1.63** | 🔰-31.6% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added telemetry tracking to capture the number of selected stories during test runs in the Storybook test addon.

- Added `selectedStoryCountForLastestRun` property in `code/addons/test/src/node/test-manager.ts` to track focused test count
- Added `numSelectedStories` field to telemetry data in `code/addons/test/src/preset.ts` for completed and failed test runs
- Reset story count after test runs complete in test manager
- Included selected story count in progress report details



<!-- /greptile_comment -->