### PR TITLE
CLI: Make telemetry data an object

### DIFF
--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -338,9 +338,9 @@ export async function doInitiate(options: CommandOptions): Promise<
   }
 
   const telemetryFeatures = {
+    dev: true,
     docs: selectedFeatures.has('docs'),
     test: selectedFeatures.has('test'),
-    dev: true,
   };
 
   // Check if the current directory is empty.

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -337,7 +337,11 @@ export async function doInitiate(options: CommandOptions): Promise<
     selectedFeatures = new Set(out.features);
   }
 
-  const telemetryFeatures = ['dev', ...selectedFeatures];
+  const telemetryFeatures = {
+    docs: selectedFeatures.has('docs'),
+    test: selectedFeatures.has('test'),
+    dev: true,
+  };
 
   // Check if the current directory is empty.
   if (options.force !== true && currentDirectoryIsEmpty(packageManager.type)) {


### PR DESCRIPTION
## What I did

Make telemetry data an object

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.5 MB | 80.5 MB | 29 kB | **-1.4** | 0% |
| initSize |  80.5 MB | 80.5 MB | 29 kB | **-1.4** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | **4.35** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | **-4.36** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | **4.36** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | **4.36** | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | **-1.36** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  15.9s | 14.2s | -1s -649ms | -0.02 | -11.6% |
| generateTime |  20.8s | 18.2s | -2s -563ms | -0.99 | -14% |
| initTime |  4.7s | 4.2s | -455ms | -1.01 | -10.6% |
| buildTime |  10.5s | 8.2s | -2s -252ms | -1.18 | -27.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.1s | 5s | -65ms | -0.77 | -1.3% |
| devManagerResponsive |  3.8s | 3.8s | -33ms | -0.69 | -0.9% |
| devManagerHeaderVisible |  871ms | 692ms | -179ms | -0.95 | -25.9% |
| devManagerIndexVisible |  907ms | 697ms | -210ms | -1.11 | -30.1% |
| devStoryVisibleUncached |  4.1s | 3.9s | -183ms | 0.08 | -4.6% |
| devStoryVisible |  907ms | 715ms | -192ms | -1.13 | -26.9% |
| devAutodocsVisible |  841ms | 689ms | -152ms | -0.95 | -22.1% |
| devMDXVisible |  823ms | 699ms | -124ms | -0.93 | -17.7% |
| buildManagerHeaderVisible |  683ms | 778ms | 95ms | -0.02 | 12.2% |
| buildManagerIndexVisible |  695ms | 787ms | 92ms | -0.32 | 11.7% |
| buildStoryVisible |  667ms | 736ms | 69ms | -0.16 | 9.4% |
| buildAutodocsVisible |  620ms | 584ms | -36ms | -0.47 | -6.2% |
| buildMDXVisible |  571ms | 541ms | -30ms | -1.06 | -5.5% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Refactored telemetry data structure in Storybook's initialization process from an array to an object-based format for clearer feature tracking.

- Changed `telemetryFeatures` in `code/lib/create-storybook/src/initiate.ts` to use boolean flags instead of array entries
- Features now tracked as `{ docs: boolean, test: boolean, dev: true }` for more explicit state management
- Maintains backward compatibility with existing telemetry system while providing more structured data



<!-- /greptile_comment -->