### PR TITLE
Addon-Test: Automatically load before all

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -691,7 +691,22 @@ export const MyStory = {
 
 #### Experimental Test Addon: Stabilized and renamed
 
-In Storybook 9.0, we've officially stabilized the Test addon. The package has been renamed from `@storybook/experimental-addon-test` to `@storybook/addon-vitest`, reflecting its production-ready status. If you were using the experimental addon, you'll need to update your dependencies and imports:
+In Storybook 9.0, we've officially stabilized the Test addon. The package has been renamed from `@storybook/experimental-addon-test` to `@storybook/addon-vitest`, reflecting its production-ready status. If you were using the experimental addon, you'll need to update your dependencies and imports.
+
+The vitest addon automatically loads storybook's beforeAll, so that you can remove the following line in your vitest.setup.ts file:
+
+```diff
+// .storybook/vitest.setup.ts
+import { setProjectAnnotations } from '@storybook/react-vite';
+import * as addonAnnotations from 'my-addon/preview';
+import * as previewAnnotations from './.storybook/preview';
+
+- const project = setProjectAnnotations([previewAnnotations, addonAnnotations]);
++ setProjectAnnotations([previewAnnotations, addonAnnotations]);
+
+// the vitest addon automatically loads beforeAll
+- beforeAll(project.beforeAll);
+```
 
 #### Vitest Addon (former @storybook/experimental-addon-test): Vitest 2.0 support is dropped
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -693,7 +693,7 @@ export const MyStory = {
 
 In Storybook 9.0, we've officially stabilized the Test addon. The package has been renamed from `@storybook/experimental-addon-test` to `@storybook/addon-vitest`, reflecting its production-ready status. If you were using the experimental addon, you'll need to update your dependencies and imports.
 
-The vitest addon automatically loads storybook's beforeAll, so that you can remove the following line in your vitest.setup.ts file:
+The vitest addon automatically loads Storybook's `beforeAll` hook, so that you can remove the following line in your vitest.setup.ts file:
 
 ```diff
 // .storybook/vitest.setup.ts

--- a/code/.storybook/storybook.setup.ts
+++ b/code/.storybook/storybook.setup.ts
@@ -1,4 +1,4 @@
-import { beforeAll, vi, expect as vitestExpect } from 'vitest';
+import { vi, expect as vitestExpect } from 'vitest';
 
 import { setProjectAnnotations } from '@storybook/react';
 
@@ -8,7 +8,7 @@ import preview from './preview';
 
 vi.spyOn(console, 'warn').mockImplementation((...args) => console.log(...args));
 
-const annotations = setProjectAnnotations([
+setProjectAnnotations([
   preview.composed,
   {
     // experiment with injecting Vitest's interactivity API over our userEvent while tests run in browser mode
@@ -26,5 +26,3 @@ const annotations = setProjectAnnotations([
     },
   },
 ]);
-
-beforeAll(annotations.beforeAll);

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -305,9 +305,7 @@ export default async function postInstall(options: PostinstallOptions) {
     existsSync
   );
 
-  const imports = [
-    `import { setProjectAnnotations } from '${annotationsImport}';`,
-  ];
+  const imports = [`import { setProjectAnnotations } from '${annotationsImport}';`];
 
   const projectAnnotations = [];
 

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -306,7 +306,6 @@ export default async function postInstall(options: PostinstallOptions) {
   );
 
   const imports = [
-    `import { beforeAll } from 'vitest';`,
     `import { setProjectAnnotations } from '${annotationsImport}';`,
   ];
 
@@ -324,9 +323,7 @@ export default async function postInstall(options: PostinstallOptions) {
 
       // This is an important step to apply the right configuration when testing your stories.
       // More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
-      const project = setProjectAnnotations([${projectAnnotations.join(', ')}]);
-
-      beforeAll(project.beforeAll);
+      setProjectAnnotations([${projectAnnotations.join(', ')}]);
     `
   );
 

--- a/code/addons/vitest/src/vitest-plugin/setup-file.ts
+++ b/code/addons/vitest/src/vitest-plugin/setup-file.ts
@@ -1,4 +1,4 @@
-import { afterEach, vi } from 'vitest';
+import { afterEach, beforeAll, vi } from 'vitest';
 import type { RunnerTask } from 'vitest';
 
 import { Channel } from 'storybook/internal/channels';
@@ -34,11 +34,10 @@ export const modifyErrorMessage = ({ task }: { task: Task }) => {
   }
 };
 
-// Enable this in 9.0
-// beforeAll(() => {
-//   if (globalThis.globalProjectAnnotations) {
-//     return globalThis.globalProjectAnnotations.beforeAll();
-//   }
-// });
+beforeAll(() => {
+  if (globalThis.globalProjectAnnotations) {
+    return globalThis.globalProjectAnnotations.beforeAll();
+  }
+});
 
 afterEach(modifyErrorMessage);

--- a/code/core/src/preview-api/modules/store/csf/portable-stories.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.ts
@@ -82,13 +82,6 @@ export function setProjectAnnotations<TRenderer extends Renderer = Renderer>(
     composeConfigs(annotations.map(extractAnnotation)),
   ]);
 
-  /*
-    We must return the composition of default and global annotations here
-    To ensure that the user has the full project annotations, eg. when running
-
-    const projectAnnotations = setProjectAnnotations(...);
-    beforeAll(projectAnnotations.beforeAll)
-  */
   return globalThis.globalProjectAnnotations ?? {};
 }
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
@@ -416,7 +416,7 @@ describe('addonA11yAddonTest', () => {
         ...   
         + import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
 
-        const annotations = setProjectAnnotations([
+        setProjectAnnotations([
           ...
         + a11yAddonAnnotations,
         ]);

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
@@ -98,13 +98,10 @@ describe('addonA11yAddonTest', () => {
         if (p.toString().includes('vitest.setup')) {
           return `
             import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
-            import { beforeAll } from 'vitest';
             import { setProjectAnnotations } from 'storybook';
             import * as projectAnnotations from './preview';
 
-            const project = setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
-
-            beforeAll(project.beforeAll);
+            setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
           `;
         } else {
           return `
@@ -281,13 +278,10 @@ describe('addonA11yAddonTest', () => {
       vi.mocked(readFileSync).mockImplementation((p) => {
         if (p.toString().includes('vitest.setup')) {
           return `
-            import { beforeAll } from 'vitest';
             import { setProjectAnnotations } from 'storybook';
             import * as projectAnnotations from './preview';
 
-            const project = setProjectAnnotations([projectAnnotations]);
-
-            beforeAll(project.beforeAll);
+            setProjectAnnotations([projectAnnotations]);
           `;
         } else {
           return `
@@ -328,13 +322,10 @@ describe('addonA11yAddonTest', () => {
         if (p.toString().includes('vitest.setup')) {
           return `
             import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
-            import { beforeAll } from 'vitest';
             import { setProjectAnnotations } from 'storybook';
             import * as projectAnnotations from './preview';
 
-            const project = setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
-
-            beforeAll(project.beforeAll);
+            setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
           `;
         } else {
           return `
@@ -388,8 +379,6 @@ describe('addonA11yAddonTest', () => {
         + a11yAddonAnnotations,
         ]);
 
-        beforeAll(annotations.beforeAll);
-
         2) We couldn't find or automatically update your .storybook/preview.<ts|js> in your project to smoothly set up parameters.a11y.test from @storybook/addon-a11y. 
         Please manually update your .storybook/preview.<ts|js> file to include the following:
 
@@ -431,8 +420,6 @@ describe('addonA11yAddonTest', () => {
           ...
         + a11yAddonAnnotations,
         ]);
-
-        beforeAll(annotations.beforeAll);
 
         2) We have to update your .storybook/preview.js file to set up parameters.a11y.test from @storybook/addon-a11y.
 
@@ -581,9 +568,7 @@ describe('addonA11yAddonTest', () => {
         import { setProjectAnnotations } from 'storybook';
         import * as projectAnnotations from './preview';
 
-        const project = setProjectAnnotations([projectAnnotations]);
-
-        beforeAll(project.beforeAll);
+        setProjectAnnotations([projectAnnotations]);
       `;
       vi.mocked(readFileSync).mockReturnValue(source);
 
@@ -591,28 +576,23 @@ describe('addonA11yAddonTest', () => {
       const transformedCode = transformSetupFile(s);
       expect(transformedCode).toMatchInlineSnapshot(`
         "import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
-        import { beforeAll } from 'vitest';
         import { setProjectAnnotations } from 'storybook';
         import * as projectAnnotations from './preview';
 
-        const project = setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
-
-        beforeAll(project.beforeAll);"
+        setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
+        "
       `);
     });
 
     it('should transform setup file correctly - 2 (different format)', () => {
       const setupFile = '/path/to/vitest.setup.ts';
       const source = dedent`
-        import { beforeAll } from 'vitest';
         import { setProjectAnnotations } from 'storybook';
         import * as projectAnnotations from './preview';
 
-        const project = setProjectAnnotations([
+        setProjectAnnotations([
           projectAnnotations
         ]);
-
-        beforeAll(project.beforeAll);
       `;
       vi.mocked(readFileSync).mockReturnValue(source);
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
@@ -550,10 +550,7 @@ describe('addonA11yAddonTest', () => {
     it('should throw', async () => {
       const setupFile = '/path/to/vitest.setup.ts';
       const source = dedent`
-        import { beforeAll } from 'vitest';
         import { setProjectAnnotations } from 'storybook';
-
-        beforeAll(project.beforeAll);
       `;
 
       vi.mocked(readFileSync).mockReturnValue(source);
@@ -564,7 +561,6 @@ describe('addonA11yAddonTest', () => {
     it('should transform setup file correctly - 1', () => {
       const setupFile = '/path/to/vitest.setup.ts';
       const source = dedent`
-        import { beforeAll } from 'vitest';
         import { setProjectAnnotations } from 'storybook';
         import * as projectAnnotations from './preview';
 
@@ -579,8 +575,7 @@ describe('addonA11yAddonTest', () => {
         import { setProjectAnnotations } from 'storybook';
         import * as projectAnnotations from './preview';
 
-        setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
-        "
+        setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);"
       `);
     });
 
@@ -599,14 +594,12 @@ describe('addonA11yAddonTest', () => {
       const s = readFileSync(setupFile, 'utf8');
       const transformedCode = transformSetupFile(s);
       expect(transformedCode).toMatchInlineSnapshot(`
-          "import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
-          import { beforeAll } from 'vitest';
-          import { setProjectAnnotations } from 'storybook';
-          import * as projectAnnotations from './preview';
+        "import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
+        import { setProjectAnnotations } from 'storybook';
+        import * as projectAnnotations from './preview';
 
-          setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
-          "
-        `);
+        setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);"
+      `);
     });
 
     it('should transform setup file correctly - project annotation is not an array', () => {
@@ -626,7 +619,7 @@ describe('addonA11yAddonTest', () => {
         import { setProjectAnnotations } from 'storybook';
         import * as projectAnnotations from './preview';
 
-        setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
+        setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);"
       `);
     });
   });

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
@@ -374,7 +374,7 @@ describe('addonA11yAddonTest', () => {
         ...   
         + import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
 
-        const annotations = setProjectAnnotations([
+        setProjectAnnotations([
           ...
         + a11yAddonAnnotations,
         ]);
@@ -604,22 +604,18 @@ describe('addonA11yAddonTest', () => {
           import { setProjectAnnotations } from 'storybook';
           import * as projectAnnotations from './preview';
 
-          const project = setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
-
-          beforeAll(project.beforeAll);"
+          setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
+          "
         `);
     });
 
     it('should transform setup file correctly - project annotation is not an array', () => {
       const setupFile = '/path/to/vitest.setup.ts';
       const source = dedent`
-        import { beforeAll } from 'vitest';
         import { setProjectAnnotations } from 'storybook';
         import * as projectAnnotations from './preview';
 
-        const project = setProjectAnnotations(projectAnnotations);
-
-        beforeAll(project.beforeAll);
+        setProjectAnnotations(projectAnnotations);
       `;
       vi.mocked(readFileSync).mockReturnValue(source);
 
@@ -627,13 +623,10 @@ describe('addonA11yAddonTest', () => {
       const transformedCode = transformSetupFile(s);
       expect(transformedCode).toMatchInlineSnapshot(dedent`
         "import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
-        import { beforeAll } from 'vitest';
         import { setProjectAnnotations } from 'storybook';
         import * as projectAnnotations from './preview';
 
-        const project = setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
-
-        beforeAll(project.beforeAll);"
+        setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
       `);
     });
   });

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
@@ -155,12 +155,10 @@ export const addonA11yAddonTest: Fix<AddonA11yAddonTestOptions> = {
           ${picocolors.gray('...')}   
           ${picocolors.green('+ import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";')}
 
-          ${picocolors.gray('const annotations = setProjectAnnotations([')}
+          ${picocolors.gray('setProjectAnnotations([')}
           ${picocolors.gray('  ...')}
           ${picocolors.green('+ a11yAddonAnnotations,')}
           ${picocolors.gray(']);')}
-
-          ${picocolors.gray('beforeAll(annotations.beforeAll);')}
         `);
       } else {
         const fileExtensionSetupFile = path.extname(setupFile!);

--- a/docs/_snippets/storybook-addon-a11y-test-setup.md
+++ b/docs/_snippets/storybook-addon-a11y-test-setup.md
@@ -1,6 +1,4 @@
 ```ts filename=".storybook/vitest.setup.ts" renderer="react" language="ts"
-import { beforeAll } from 'vitest';
-
 import { setProjectAnnotations } from '@storybook/react';
 
 // Import the a11y addon annotations
@@ -9,18 +7,14 @@ import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview';
 // Optionally import your own annotations
 import * as projectAnnotations from './preview';
 
-const project = setProjectAnnotations([
+setProjectAnnotations([
   // Add the a11y addon annotations
   a11yAddonAnnotations,
   projectAnnotations,
 ]);
-
-beforeAll(project.beforeAll);
 ```
 
 ```js filename=".storybook/vitest.setup.js" renderer="react" language="js"
-import { beforeAll } from 'vitest';
-
 import { setProjectAnnotations } from '@storybook/react';
 
 // Import the a11y addon annotations
@@ -29,18 +23,14 @@ import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview';
 // Optionally import your own annotations
 import * as projectAnnotations from './preview';
 
-const project = setProjectAnnotations([
+setProjectAnnotations([
   // Add the a11y addon annotations
   a11yAddonAnnotations,
   projectAnnotations,
 ]);
-
-beforeAll(project.beforeAll);
 ```
 
 ```ts filename=".storybook/vitest.setup.ts" renderer="svelte" language="ts"
-import { beforeAll } from 'vitest';
-
 // Replace @storybook/svelte with @storybook/sveltekit if you are using SvelteKit
 import { setProjectAnnotations } from '@storybook/svelte';
 
@@ -50,18 +40,14 @@ import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview';
 // Optionally import your own annotations
 import * as projectAnnotations from './preview';
 
-const project = setProjectAnnotations([
+setProjectAnnotations([
   // Add the a11y addon annotations
   a11yAddonAnnotations,
   projectAnnotations,
 ]);
-
-beforeAll(project.beforeAll);
 ```
 
 ```js filename=".storybook/vitest.setup.js" renderer="svelte" language="js"
-import { beforeAll } from 'vitest';
-
 // Replace @storybook/svelte with @storybook/sveltekit if you are using SvelteKit
 import { setProjectAnnotations } from '@storybook/svelte';
 
@@ -71,18 +57,14 @@ import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview';
 // Optionally import your own annotations
 import * as projectAnnotations from './preview';
 
-const project = setProjectAnnotations([
+setProjectAnnotations([
   // Add the a11y addon annotations
   a11yAddonAnnotations,
   projectAnnotations,
 ]);
-
-beforeAll(project.beforeAll);
 ```
 
 ```ts filename=".storybook/vitest.setup.ts" renderer="vue" language="ts"
-import { beforeAll } from 'vitest';
-
 import { setProjectAnnotations } from '@storybook/vue3';
 
 // Import the a11y addon annotations
@@ -91,18 +73,14 @@ import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview';
 // Optionally import your own annotations
 import * as projectAnnotations from './preview';
 
-const project = setProjectAnnotations([
+setProjectAnnotations([
   // Add the a11y addon annotations
   a11yAddonAnnotations,
   projectAnnotations,
 ]);
-
-beforeAll(project.beforeAll);
 ```
 
 ```js filename=".storybook/vitest.setup.js" renderer="vue" language="js"
-import { beforeAll } from 'vitest';
-
 import { setProjectAnnotations } from '@storybook/vue3';
 
 // Import the a11y addon annotations
@@ -111,11 +89,9 @@ import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview';
 // Optionally import your own annotations
 import * as projectAnnotations from './preview';
 
-const project = setProjectAnnotations([
+setProjectAnnotations([
   // Add the a11y addon annotations
   a11yAddonAnnotations,
   projectAnnotations,
 ]);
-
-beforeAll(project.beforeAll);
 ```

--- a/docs/api/csf/csf-factories.mdx
+++ b/docs/api/csf/csf-factories.mdx
@@ -74,7 +74,7 @@ export default definePreview({
 
 ### `preview.meta`
 
-The `meta` function on the `preview` object is used to define the [metadata for your stories](./index.mdx#default-export). It accepts an object containing the `component`, `title`, `parameters`, and other story properties. 
+The `meta` function on the `preview` object is used to define the [metadata for your stories](./index.mdx#default-export). It accepts an object containing the `component`, `title`, `parameters`, and other story properties.
 
 ```ts title="Button.stories.js|ts"
 // Learn about the # subpath import: https://storybook.js.org/docs/api/csf/csf-factories#subpath-imports
@@ -164,7 +164,7 @@ Update your `.storybook/preview.js|ts` file to use the new [`definePreview`](#de
 <details>
 <summary>Which addons should be specified in `preview`?</summary>
 
-The ability for an addon to provide annotation types (`parameters`, `globals`, etc.) is new and not all addons support it yet. 
+The ability for an addon to provide annotation types (`parameters`, `globals`, etc.) is new and not all addons support it yet.
 
 If an addon provides annotations (i.e. it distributes a `./preview` export), it can be imported in two ways:
 
@@ -264,7 +264,9 @@ All of the story properties are now contained within a new property called `comp
 
 ### 5. Update your Vitest setup file
 
-Whether you're using [Storybook's Vitest addon](../../writing-tests/vitest-addon.mdx) or [portable stories in Vitest](../portable-stories/portable-stories-vitest.mdx), you may use a Vitest setup file to configure your stories. This file must be updated to use the new CSF Factories format.
+If you're using the [Storybook's Vitest addon](../../writing-tests/vitest-addon.mdx) you can remove your vitest setup file.
+
+If you are using [portable stories in Vitest](../portable-stories/portable-stories-vitest.mdx), you may use a Vitest setup file to configure your stories. This file must be updated to use the new CSF Factories format.
 
 <Callout variant="warning">
 Note that this only applies if you use CSF Factories for all your tested stories. If you use a mix of CSF 1, 2, or 3 and CSF Factories, you must maintain two separate setup files.
@@ -280,7 +282,7 @@ import { beforeAll } from 'vitest';
 
 // No longer necessary
 - const annotations = setProjectAnnotations([previewAnnotations, addonAnnotations]);
- 
+
 // Run Storybook's beforeAll hook
 + beforeAll(preview.composed.beforeAll);
 - beforeAll(annotations.beforeAll);
@@ -296,13 +298,13 @@ If you cannot use Storybook Test, you can still reuse the stories in your test f
 import { test, expect } from 'vitest';
 import { screen } from '@testing-library/react';
 - import { composeStories } from '@storybook/react-vite';
- 
+
 // Import all stories from the stories file
 import * as stories from './Button.stories';
- 
+
 + const { Primary } = stories;
 - const { Primary } = composeStories(stories);
- 
+
 test('renders primary button with default args', async () => {
   // The run function will mount the component and run all of Storybook's lifecycle hooks
   await Primary.run();


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.7 MB | 79.7 MB | 0 B | **-1.94** | 0% |
| initSize |  79.7 MB | 79.7 MB | 0 B | **-1.94** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.29 MB | 7.29 MB | -84 B | **-1.49** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | -7 B | 0.9 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | -7 B | 0.9 | 0% |
| buildPreviewSize |  3.32 MB | 3.32 MB | -77 B | **-1.51** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.5s | 21.6s | 14s | **1.24** | 🔺65.2% |
| generateTime |  24.7s | 19.2s | -5s -577ms | -0.45 | -29% |
| initTime |  4.5s | 4.5s | 0ms | -0.5 | 0% |
| buildTime |  9.2s | 8.3s | -975ms | -1.1 | -11.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.3s | 5.5s | 243ms | 0.02 | 4.3% |
| devManagerResponsive |  5.1s | 5.3s | 269ms | 0.09 | 5% |
| devManagerHeaderVisible |  778ms | 744ms | -34ms | -0.36 | -4.6% |
| devManagerIndexVisible |  781ms | 759ms | -22ms | -0.55 | -2.9% |
| devStoryVisibleUncached |  1.6s | 1.8s | 195ms | 0 | 10.6% |
| devStoryVisible |  811ms | 776ms | -35ms | -0.8 | -4.5% |
| devAutodocsVisible |  754ms | 764ms | 10ms | -0.18 | 1.3% |
| devMDXVisible |  756ms | 765ms | 9ms | 0.37 | 1.2% |
| buildManagerHeaderVisible |  669ms | 992ms | 323ms | 1.07 | 32.6% |
| buildManagerIndexVisible |  737ms | 1s | 350ms | **1.24** | 🔺32.2% |
| buildStoryVisible |  653ms | 913ms | 260ms | 0.8 | 28.5% |
| buildAutodocsVisible |  549ms | 774ms | 225ms | 1.16 | 29.1% |
| buildMDXVisible |  546ms | 704ms | 158ms | 0.94 | 22.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR enables the `beforeAll` lifecycle hook in the Vitest setup file for Storybook's test addon, ensuring proper initialization of global project annotations before test execution.

- Added support for `beforeAll` hook in `code/addons/test/src/vitest-plugin/setup-file.ts`
- Uncommented code that was previously marked with "Enable this in 9.0" comment
- Checks for existence of `globalThis.globalProjectAnnotations` and calls its `beforeAll` method if available
- Aligns with documented preview lifecycle hooks in Storybook
- Ensures proper initialization before running test suites



<!-- /greptile_comment -->