### PR TITLE
CLI: Don't initially select Documentation and Testing features

### DIFF
--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -331,7 +331,6 @@ export async function doInitiate(options: CommandOptions): Promise<
       choices: Object.entries(selectableFeatures).map(([value, { name, description }]) => ({
         title: `${name}: ${description}`,
         value,
-        selected: true,
       })),
     });
     selectedFeatures = new Set(out.features);


### PR DESCRIPTION
## What I did

Changed the initial selected state for features from Documentation and Testing to none. This means users will have to explicitly opt-in to install these features, giving us better signal on whether they are desired.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.5 MB | 80.5 MB | 0 B | -0.94 | 0% |
| initSize |  80.5 MB | 80.5 MB | 0 B | -0.94 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | **2.49** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | -1.16 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | **1.73** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | **2.18** | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | **1.58** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.3s | 6.9s | -445ms | -0.77 | -6.4% |
| generateTime |  19s | 17.9s | -1s -180ms | -1.07 | -6.6% |
| initTime |  4.4s | 4.2s | -245ms | -1.09 | -5.8% |
| buildTime |  8.9s | 8.2s | -698ms | -1.21 | -8.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.6s | 5.4s | 869ms | -0.05 | 15.8% |
| devManagerResponsive |  4.4s | 5.2s | 820ms | **1.57** | 🔺15.6% |
| devManagerHeaderVisible |  685ms | 787ms | 102ms | -0.2 | 13% |
| devManagerIndexVisible |  692ms | 802ms | 110ms | -0.24 | 13.7% |
| devStoryVisibleUncached |  1.8s | 2.1s | 228ms | **-1.47** | 🔺10.8% |
| devStoryVisible |  715ms | 822ms | 107ms | -0.35 | 13% |
| devAutodocsVisible |  661ms | 691ms | 30ms | -1.07 | 4.3% |
| devMDXVisible |  643ms | 689ms | 46ms | -1.08 | 6.7% |
| buildManagerHeaderVisible |  664ms | 928ms | 264ms | **1.25** | 🔺28.4% |
| buildManagerIndexVisible |  675ms | 1s | 338ms | **1.51** | 🔺33.4% |
| buildStoryVisible |  650ms | 912ms | 262ms | **1.43** | 🔺28.7% |
| buildAutodocsVisible |  587ms | 705ms | 118ms | 0.37 | 16.7% |
| buildMDXVisible |  524ms | 646ms | 122ms | 0.13 | 18.9% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR modifies Storybook's initialization behavior to make Documentation and Testing features opt-in rather than enabled by default.

- Modified feature selection in `code/lib/create-storybook/src/initiate.ts` to remove auto-selection of docs and test features
- Features must now be explicitly selected in interactive mode rather than pre-selected
- Maintains existing behavior of auto-adding docs in CI and both docs/test with --yes flag
- Aims to gather better signal on feature adoption by requiring explicit opt-in
- Affects only new Storybook installations, not existing ones



<!-- /greptile_comment -->