### PR TITLE
Manager: Add Content-Type to fix Cloud IDEs

### DIFF
--- a/code/core/src/builder-manager/index.ts
+++ b/code/core/src/builder-manager/index.ts
@@ -206,6 +206,7 @@ const starter: StarterFunction = async function* starterGeneratorFn({
   router.use('/', ({ url }, res, next) => {
     if (url && isRootPath.test(url)) {
       res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/html');
       res.write(html);
       res.end();
     } else {
@@ -214,6 +215,7 @@ const starter: StarterFunction = async function* starterGeneratorFn({
   });
   router.use(`/index.html`, (req, res) => {
     res.statusCode = 200;
+    res.setHeader('Content-Type', 'text/html');
     res.write(html);
     res.end();
   });


### PR DESCRIPTION
Closes #30453

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Off the back of discussion in #30453, I investigated why the index handler was not getting a content type assigned. After digging through the code, I found the handler that serves the index page, and added a `Content-Type` header. This matches other places in the code where manual handlers are specified and `Content-Type` assigned.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

<!-- Please include the steps to test your changes here. For example:-->

##### To test without using Codespaces (with curl):
1. Run `yarn start`
2. Use `curl` to check that the index has the content type assigned: `curl -v localhost:6006 -o /dev/null`
3. Observe in response header output a line stating `Content-Type: text/html`

Repeat steps above on next if you want to see the difference before this PR, where the `Content-Type` is not present.

##### To test without using Codespaces (with browser):
1. Run `yarn start`
2. Open browser network tab, and refresh page
3. Observe on initial index request, that a `Content-Type: text/html` header is present

Repeat steps above on next if you want to see the difference before this PR, where the `Content-Type` is not present.

##### To test with Codespaces:

Reproduce fault:
1. Open Codespaces on the current `next` branch. Use the Web IDE rather than remoting it to a local VS Code, as otherwise the proxy is bypassed.
2. Install fnm and correct node version per CONTRIBUTING.md
5. Run `yarn start` 
6. Open exposed port in browser
7. Observe that only the HTML is printed
8. Stop `yarn start`

Check fix:
1. Check out this branch
2. Run `yarn start`
5. Open exposed port in browser
6. Observe that Storybook UI now loads successfully

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

@shilman , afraid I cannot seem to mention the above team. Would we be able to have a canary release to test this fix for CodeSpaces etc in #30453 

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.9 MB | 79.9 MB | 0 B | **2.73** | 0% |
| initSize |  79.9 MB | 79.9 MB | 0 B | **2.73** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.45 MB | 7.45 MB | 0 B | **2.37** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.35 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | -0.93 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | **-1.35** | 0% |
| buildPreviewSize |  3.47 MB | 3.47 MB | 0 B | **2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  24.1s | 7.2s | -16s -858ms | -1.05 | -232.3% |
| generateTime |  18.1s | 19.3s | 1.1s | -0.3 | 5.9% |
| initTime |  4s | 4.7s | 718ms | 0.28 | 15% |
| buildTime |  7.9s | 9.1s | 1.1s | -0.32 | 12.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.5s | 4.6s | 125ms | -0.83 | 2.7% |
| devManagerResponsive |  4.3s | 4.4s | 124ms | -0.85 | 2.8% |
| devManagerHeaderVisible |  693ms | 640ms | -53ms | -1.06 | -8.3% |
| devManagerIndexVisible |  702ms | 649ms | -53ms | -1.22 | -8.2% |
| devStoryVisibleUncached |  2.2s | 2.3s | 63ms | **1.5** | 2.7% |
| devStoryVisible |  1s | 1s | -38ms | 1.1 | -3.7% |
| devAutodocsVisible |  953ms | 956ms | 3ms | **1.3** | 0.3% |
| devMDXVisible |  1s | 1.1s | 41ms | **2.01** | 3.7% |
| buildManagerHeaderVisible |  756ms | 745ms | -11ms | 0.11 | -1.5% |
| buildManagerIndexVisible |  773ms | 759ms | -14ms | -0.03 | -1.8% |
| buildStoryVisible |  748ms | 737ms | -11ms | 0.25 | -1.5% |
| buildAutodocsVisible |  679ms | 644ms | -35ms | -0.05 | -5.4% |
| buildMDXVisible |  645ms | 620ms | -25ms | 0.34 | -4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added Content-Type header to the Storybook manager's index handler to ensure proper HTML interpretation, particularly important for cloud IDE environments like GitHub Codespaces.

- Modified `code/core/src/builder-manager/index.ts` to add `Content-Type: text/html` header for both root path and index.html routes
- Prevents content type sniffing issues that were causing HTML to be treated as raw text in cloud IDEs
- Matches content type header implementation with other manual handlers in the codebase



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->