### PR TITLE
CLI: Fix peer dep issues for npm users during upgrade

### DIFF
--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -254,36 +254,47 @@ export const doUpgrade = async ({
     // GitHub Issue: https://github.com/storybookjs/storybook/issues/30306
     // Solution: Remove all Storybook packages (except 'storybook') from the package.json and install them again
     if (packageManager.type === 'npm') {
+      const getPackageName = (dep: string) => {
+        const lastAtIndex = dep.lastIndexOf('@');
+        return lastAtIndex > 0 ? dep.slice(0, lastAtIndex) : dep;
+      };
+
+      // Remove all Storybook packages except 'storybook'
       await packageManager.removeDependencies(
-        {
-          skipInstall: false,
-        },
+        { skipInstall: false },
         [...upgradedDependencies, ...upgradedDevDependencies]
-          .map((dep) => {
-            const lastAtIndex = dep.lastIndexOf('@');
-            return lastAtIndex > 0 ? dep.slice(0, lastAtIndex) : dep;
-          })
-          // We don't want to remove the storybook package from the package.json
-          // because third-party packages which we don't remove may depend on it via peer-dependency requirements
+          .map(getPackageName)
           .filter((dep) => dep !== 'storybook')
       );
 
-      await packageManager.installDependencies();
+      // Handle 'storybook' package separately to maintain peer dependencies
+      const findStorybookPackage = (deps: string[]) =>
+        deps.find((dep) => getPackageName(dep) === 'storybook');
+
+      const storybookDep = findStorybookPackage(upgradedDependencies);
+      const storybookDevDep = findStorybookPackage(upgradedDevDependencies);
+
+      if (storybookDep) {
+        await packageManager.addDependencies({ installAsDevDependencies: false }, [storybookDep]);
+      }
+      if (storybookDevDep) {
+        await packageManager.addDependencies({ installAsDevDependencies: true }, [storybookDevDep]);
+      }
     }
 
+    // Update all dependencies
     logger.info(`Updating dependencies in ${picocolors.cyan('package.json')}..`);
-    if (upgradedDependencies.length > 0) {
-      await packageManager.addDependencies(
-        { installAsDevDependencies: false, skipInstall: true, packageJson },
-        upgradedDependencies
-      );
-    }
-    if (upgradedDevDependencies.length > 0) {
-      await packageManager.addDependencies(
-        { installAsDevDependencies: true, skipInstall: true, packageJson },
-        upgradedDevDependencies
-      );
-    }
+    const addDeps = async (deps: string[], isDev: boolean) => {
+      if (deps.length > 0) {
+        await packageManager.addDependencies(
+          { installAsDevDependencies: isDev, skipInstall: true, packageJson },
+          deps
+        );
+      }
+    };
+
+    await addDeps(upgradedDependencies, false);
+    await addDeps(upgradedDevDependencies, true);
     await packageManager.installDependencies();
   }
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- Fixed an issue for npm users related to peer dependency conflicts during upgrade

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.5 MB | 80.6 MB | 65.6 kB | **2.9** | 0.1% |
| initSize |  80.5 MB | 80.6 MB | 65.6 kB | **2.9** | 0.1% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | 1.13 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | -0.63 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 0.9 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | 1.06 | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | 0.95 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.3s | 18.1s | 10.7s | **1.35** | 🔺59.2% |
| generateTime |  18.6s | 22.1s | 3.4s | 0.52 | 15.8% |
| initTime |  4.5s | 5.3s | 801ms | 1.17 | 14.9% |
| buildTime |  8.9s | 11.4s | 2.5s | **1.88** | 🔺22.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.8s | 4.9s | 167ms | -0.71 | 3.3% |
| devManagerResponsive |  4.6s | 4.7s | 169ms | -0.05 | 3.5% |
| devManagerHeaderVisible |  682ms | 667ms | -15ms | **-1.42** | -2.2% |
| devManagerIndexVisible |  694ms | 758ms | 64ms | -0.65 | 8.4% |
| devStoryVisibleUncached |  1.7s | 957ms | -834ms | **-1.66** | 🔰-87.1% |
| devStoryVisible |  766ms | 757ms | -9ms | -1.03 | -1.2% |
| devAutodocsVisible |  668ms | 658ms | -10ms | **-1.5** | -1.5% |
| devMDXVisible |  715ms | 754ms | 39ms | -0.28 | 5.2% |
| buildManagerHeaderVisible |  668ms | 1s | 427ms | **2.59** | 🔺39% |
| buildManagerIndexVisible |  678ms | 1.1s | 426ms | **2.05** | 🔺38.6% |
| buildStoryVisible |  642ms | 1s | 421ms | **2.63** | 🔺39.6% |
| buildAutodocsVisible |  575ms | 2.2s | 1.6s | **13.04** | 🔺73.9% |
| buildMDXVisible |  523ms | 751ms | 228ms | **1.44** | 🔺30.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR improves the upgrade process for npm users by implementing a new strategy to handle peer dependency conflicts during Storybook package updates.

- Added package removal step in `code/lib/cli-storybook/src/upgrade.ts` to clean up existing Storybook packages before reinstallation
- Implemented separate handling for 'storybook' package to maintain peer dependencies
- Added `getPackageName` helper function to extract package names from dependency strings
- Modified dependency installation process to use two-phase approach: remove then reinstall
- Added npm-specific upgrade path to prevent dependency conflicts during installation



<!-- /greptile_comment -->