### PR TITLE
Angular: Fix @angular/platform-browser/animations never available

### DIFF
--- a/code/frameworks/angular/src/server/framework-preset-angular-cli.ts
+++ b/code/frameworks/angular/src/server/framework-preset-angular-cli.ts
@@ -41,7 +41,7 @@ export async function webpackFinal(baseConfig: webpack.Configuration, options: P
   );
 
   try {
-    await import('@angular/platform-browser/animations');
+    require.resolve('@angular/platform-browser/animations');
   } catch (e) {
     webpackConfig.plugins.push(
       new WebpackIgnorePlugin({


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- Fixed an issue where `@angular/platform-browser/animations` was always ignored by Webpack.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 0 B | **2.42** | 0% |
| initSize |  80.6 MB | 80.6 MB | 0 B | **2.42** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | 1.02 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | -0.56 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 0.82 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | 0.96 | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | 0.88 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  24.8s | 8.6s | -16s -135ms | -0.46 | -186.1% |
| generateTime |  19.2s | 26.8s | 7.6s | **2.46** | 🔺28.5% |
| initTime |  5.1s | 5.6s | 470ms | **1.69** | 🔺8.3% |
| buildTime |  8.7s | 12s | 3.2s | **2.55** | 🔺27.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.8s | 5.2s | 411ms | -0.4 | 7.9% |
| devManagerResponsive |  4.6s | 4.9s | 332ms | 0.11 | 6.7% |
| devManagerHeaderVisible |  658ms | 806ms | 148ms | 0.25 | 18.4% |
| devManagerIndexVisible |  737ms | 812ms | 75ms | 0.02 | 9.2% |
| devStoryVisibleUncached |  1.8s | 1.9s | 63ms | -0.76 | 3.3% |
| devStoryVisible |  738ms | 895ms | 157ms | 0.57 | 17.5% |
| devAutodocsVisible |  655ms | 845ms | 190ms | 0.58 | 22.5% |
| devMDXVisible |  758ms | 788ms | 30ms | 0.29 | 3.8% |
| buildManagerHeaderVisible |  621ms | 724ms | 103ms | -0.39 | 14.2% |
| buildManagerIndexVisible |  628ms | 771ms | 143ms | -0.24 | 18.5% |
| buildStoryVisible |  592ms | 703ms | 111ms | -0.33 | 15.8% |
| buildAutodocsVisible |  547ms | 675ms | 128ms | 0.22 | 19% |
| buildMDXVisible |  510ms | 603ms | 93ms | -0.21 | 15.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Modified the Angular framework preset to fix the handling of '@angular/platform-browser/animations' package by using require.resolve instead of import statements for proper Webpack integration.

- Changed package detection in `code/frameworks/angular/src/server/framework-preset-angular-cli.ts` from import to `require.resolve('@angular/platform-browser/animations')`
- Added WebpackIgnorePlugin only when animations package is not available
- Ensures animations package is properly detected and loaded in Angular Storybook projects

The changes are focused and minimal, addressing a specific issue with animations package detection. No automated tests were included which could be beneficial for such a core functionality change.



<!-- /greptile_comment -->