### PR TITLE
Addon-Test: Fix console error in build mode

### DIFF
--- a/code/addons/test/src/manager-store.ts
+++ b/code/addons/test/src/manager-store.ts
@@ -4,5 +4,5 @@ import { type StoreState, storeOptions } from './constants';
 
 export const store = experimental_UniversalStore.create<StoreState>({
   ...storeOptions,
-  leader: globalThis.CONFIG_TYPE === 'PRODUCTION',
+  leader: (globalThis as any).CONFIG_TYPE === 'PRODUCTION',
 });

--- a/code/addons/test/src/manager-store.ts
+++ b/code/addons/test/src/manager-store.ts
@@ -2,4 +2,7 @@ import { experimental_UniversalStore } from 'storybook/internal/manager-api';
 
 import { type StoreState, storeOptions } from './constants';
 
-export const store = experimental_UniversalStore.create<StoreState>(storeOptions);
+export const store = experimental_UniversalStore.create<StoreState>({
+  ...storeOptions,
+  leader: globalThis.CONFIG_TYPE === 'PRODUCTION',
+});


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Made the manager-side universal store a leader in build mode, since there is no server-side instance to lead.
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 143 B | **2.1** | 0% |
| initSize |  80.6 MB | 80.6 MB | 143 B | **2.1** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | 0.93 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | -0.49 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 0.73 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | 0.86 | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | 0.81 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  24.3s | 24.1s | -170ms | **1.99** | -0.7% |
| generateTime |  19.5s | 18.1s | -1s -463ms | -1.16 | -8.1% |
| initTime |  4.8s | 4.3s | -470ms | -0.98 | -10.8% |
| buildTime |  9.2s | 8.1s | -1s -119ms | **-1.46** | 🔰-13.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6s | 6.8s | 755ms | **1.29** | 🔺11.1% |
| devManagerResponsive |  5.6s | 6.4s | 828ms | **1.44** | 🔺12.8% |
| devManagerHeaderVisible |  837ms | 1.1s | 324ms | **4.32** | 🔺27.9% |
| devManagerIndexVisible |  870ms | 1.1s | 312ms | **4.19** | 🔺26.4% |
| devStoryVisibleUncached |  1.8s | 2.4s | 579ms | -0.2 | 24.1% |
| devStoryVisible |  872ms | 1.2s | 346ms | **4.45** | 🔺28.4% |
| devAutodocsVisible |  769ms | 1s | 284ms | **3.06** | 🔺27% |
| devMDXVisible |  767ms | 999ms | 232ms | **3.53** | 🔺23.2% |
| buildManagerHeaderVisible |  856ms | 1.1s | 315ms | **3.21** | 🔺26.9% |
| buildManagerIndexVisible |  916ms | 1.1s | 266ms | **2.64** | 🔺22.5% |
| buildStoryVisible |  798ms | 979ms | 181ms | **1.94** | 🔺18.5% |
| buildAutodocsVisible |  640ms | 905ms | 265ms | **2.2** | 🔺29.3% |
| buildMDXVisible |  671ms | 814ms | 143ms | **2.27** | 🔺17.6% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR modifies the manager-store in the test addon to ensure it acts as a leader in production build mode, fixing console errors that occur when no server-side instance is available.

- Modified `code/addons/test/src/manager-store.ts` to set `leader: true` when `CONFIG_TYPE === 'PRODUCTION'`
- Leverages `UniversalStore` leader-follower pattern to handle state synchronization appropriately in build environments
- Ensures proper state management when server-side instance is not present during production builds
- Maintains existing store options while adding production-specific leader configuration



<!-- /greptile_comment -->