### PR TITLE
Core: Experimental llms.txt support

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -1,5 +1,7 @@
 import { join } from 'node:path';
 
+import dedent from 'ts-dedent';
+
 import { defineMain } from '../frameworks/react-vite/src/node';
 
 const componentsPath = join(__dirname, '../core/src/components');
@@ -134,6 +136,14 @@ const config = defineMain({
     viewportStoryGlobals: true,
     backgroundsStoryGlobals: true,
     developmentModeForBuild: true,
+    experimentalLlmsTxt: true,
+  },
+  llms: {
+    title: 'Storybook UI',
+    description: dedent`
+      Storybook's UI components, its test cases, and addon examples, all in one place.
+    `,
+    includeDocs: true,
   },
   viteFinal: async (viteConfig, { configType }) => {
     const { mergeConfig } = await import('vite');

--- a/code/core/src/core-server/utils/llms.test.ts
+++ b/code/core/src/core-server/utils/llms.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import type { StoryIndex } from '../../types';
+import { createDocsSections, formatLlmsTxt } from './llms';
+
+describe('llms', () => {
+  it('full', async () => {
+    const links = [
+      {
+        title: 'link1',
+        href: 'href1',
+        description: 'description1',
+      },
+      {
+        title: 'link2',
+        href: 'href2',
+        description: 'description2',
+      },
+    ];
+    const config = {
+      title: 'title',
+      description: 'description',
+      details: 'details',
+      sections: [
+        {
+          title: 'section1',
+          links,
+        },
+        {
+          title: 'section2',
+          links,
+        },
+      ],
+    };
+    await expect(formatLlmsTxt(config)).resolves.toMatchInlineSnapshot(`
+      "# title
+
+      > description
+
+      details
+
+      ## section1
+
+      - [link1](href1) description1
+      - [link2](href2) description2
+
+      ## section2
+
+      - [link1](href1) description1
+      - [link2](href2) description2"
+    `);
+  });
+
+  it('optional', async () => {
+    const config = {
+      title: 'title',
+      sections: [
+        {
+          title: 'section1',
+        },
+      ],
+    };
+    await expect(formatLlmsTxt(config)).resolves.toMatchInlineSnapshot(`
+      "# title
+
+      ## section1"
+    `);
+  });
+
+  it('string', async () => {
+    const config = 'custom string';
+    await expect(formatLlmsTxt(config)).resolves.toMatchInlineSnapshot(`"custom string"`);
+  });
+
+  it.only('docs', async () => {
+    const index: StoryIndex = {
+      entries: {
+        docs1: {
+          type: 'docs',
+          id: 'docs1--docs',
+          name: 'docs1',
+          title: 'Docs 1',
+          importPath: 'asdf',
+          storiesImports: [],
+        },
+        docs2: {
+          type: 'docs',
+          id: 'docs2--docs',
+          name: 'docs2',
+          title: 'Docs 2',
+          importPath: 'asdf',
+          storiesImports: [],
+        },
+      },
+      v: 5,
+    };
+    expect(createDocsSections(index)).toMatchInlineSnapshot(`
+      [
+        {
+          "links": [
+            {
+              "href": "?id=docs1--docs",
+              "title": "Docs 1 docs1",
+            },
+            {
+              "href": "?id=docs2--docs",
+              "title": "Docs 2 docs2",
+            },
+          ],
+          "title": "Docs",
+        },
+      ]
+    `);
+  });
+
+  describe('errors', () => {
+    it('no title', async () => {
+      const noTitle = {
+        description: 'description',
+      };
+      // @ts-expect-error testing error case
+      await expect(formatLlmsTxt(noTitle)).resolves.toMatchInlineSnapshot(`"> description"`);
+    });
+
+    it('no section title', async () => {
+      const noSectionTitle = {
+        title: 'title',
+        sections: [
+          {
+            links: [],
+          },
+        ],
+      };
+      // @ts-expect-error testing error case
+      await expect(formatLlmsTxt(noSectionTitle)).resolves.toMatchInlineSnapshot(`"# title"`);
+    });
+
+    it('no links', async () => {
+      const noLinks = {
+        title: 'title',
+        sections: [
+          {
+            title: 'section1',
+            links: [{}],
+          },
+        ],
+      };
+      // @ts-expect-error testing error case
+      await expect(formatLlmsTxt(noLinks)).resolves.toMatchInlineSnapshot(`
+        "# title
+
+        ## section1"
+      `);
+    });
+  });
+});

--- a/code/core/src/core-server/utils/llms.ts
+++ b/code/core/src/core-server/utils/llms.ts
@@ -1,0 +1,73 @@
+import { writeFile } from 'node:fs/promises';
+
+import type { Polka } from 'polka';
+
+import { toStartCaseStr } from '../../csf/toStartCaseStr';
+import type { LlmsLink, LlmsOptions, LlmsSection, StoryIndex } from '../../types';
+
+const formatLlmsLink = ({ title, description, href }: LlmsLink) =>
+  [title && href && `- [${title}](${href})`, description].filter(Boolean).join(' ');
+
+const formatLlmsSection = ({ title, links }: LlmsSection) =>
+  [title && `## ${title}`, '', ...(links ? links.map(formatLlmsLink) : [])].join('\n').trim();
+
+const formatLlmsOptions = ({ title, description, details, sections }: LlmsOptions) =>
+  [
+    title && `# ${title}`,
+    description && `> ${description}`,
+    details,
+    ...(sections ? sections.map(formatLlmsSection) : []),
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+
+export const createDocsSections = (indexJson?: StoryIndex) => {
+  const sections = Object.values(indexJson?.entries ?? {}).reduce(
+    (acc, { type, title, name, id }) => {
+      if (type === 'docs') {
+        const parts = title.split('/');
+        const href = `?path=/${type}/${id}`;
+        const sectionTitle = parts.length > 1 ? toStartCaseStr(parts[0]) : 'Docs';
+        const section = (acc[sectionTitle] = acc[sectionTitle] ?? {
+          title: sectionTitle,
+          links: [],
+        });
+        section.links!.push({ title: `${title} ${name}`.trim(), href });
+      }
+      return acc;
+    },
+    {} as Record<string, LlmsSection>
+  );
+  return Object.values(sections);
+};
+
+export const formatLlmsTxt = async (options: LlmsOptions | string, indexJson?: StoryIndex) => {
+  if (typeof options === 'string') {
+    return options;
+  }
+
+  const docsSections = options.includeDocs && indexJson ? createDocsSections(indexJson) : [];
+  return formatLlmsOptions({
+    ...options,
+    sections: [...(options.sections ?? []), ...docsSections],
+  });
+};
+
+export async function extractLlmsTxt(
+  outputFile: string,
+  options: LlmsOptions | string,
+  indexJson?: StoryIndex
+) {
+  const llmsTxt = await formatLlmsTxt(options, indexJson);
+
+  await writeFile(outputFile, llmsTxt);
+}
+
+export function useLlmsTxt(app: Polka, options: LlmsOptions | string, indexJson?: StoryIndex) {
+  app.use('/llms.txt', async (req, res) => {
+    const llmsTxt = await formatLlmsTxt(options, indexJson);
+    res.setHeader('Content-Type', 'text/markdown');
+    res.write(llmsTxt);
+    res.end();
+  });
+}

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -105,6 +105,11 @@ export interface Presets {
     config?: StorybookConfigRaw['staticDirs'],
     args?: any
   ): Promise<StorybookConfigRaw['staticDirs']>;
+  apply(
+    extension: 'llms',
+    config?: StorybookConfigRaw['llms'],
+    args?: any
+  ): Promise<StorybookConfigRaw['llms']>;
   apply<T>(extension: string, config?: T, args?: unknown): Promise<T>;
 }
 
@@ -304,6 +309,25 @@ export type DocsOptions = {
   docsMode?: boolean;
 };
 
+export interface LlmsLink {
+  title: string;
+  href: string;
+  description?: string;
+}
+
+export interface LlmsSection {
+  title: string;
+  links?: LlmsLink[];
+}
+
+export interface LlmsOptions {
+  title: string;
+  description?: string;
+  details?: string;
+  sections?: LlmsSection[];
+  includeDocs?: boolean;
+}
+
 export interface TestBuildFlags {
   /**
    * The package @storybook/blocks will be excluded from the bundle, even when imported in e.g. the
@@ -381,6 +405,9 @@ export interface StorybookConfigRaw {
     backgroundsStoryGlobals?: boolean;
     /** Set NODE_ENV to development in built Storybooks for better testability and debuggability */
     developmentModeForBuild?: boolean;
+
+    /** Enable experimental llms.txt support */
+    experimentalLlmsTxt?: boolean;
   };
 
   build?: TestBuildConfig;
@@ -418,6 +445,8 @@ export interface StorybookConfigRaw {
   managerHead?: string;
 
   tags?: TagsOptions;
+
+  llms?: LlmsOptions | string;
 }
 
 /**
@@ -523,6 +552,9 @@ export interface StorybookConfig {
 
   /** Configure non-standard tag behaviors */
   tags?: PresetValue<StorybookConfigRaw['tags']>;
+
+  /** Configure llms.txt metadata */
+  llms?: PresetValue<StorybookConfigRaw['llms']>;
 }
 
 export type PresetValue<T> = T | ((config: T, options: Options) => T | Promise<T>);


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30636-sha-c6ea358f`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30636-sha-c6ea358f sandbox` or in an existing project with `npx storybook@0.0.0-pr-30636-sha-c6ea358f upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30636-sha-c6ea358f`](https://npmjs.com/package/storybook/v/0.0.0-pr-30636-sha-c6ea358f) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/experimental-llms-txt`](https://github.com/storybookjs/storybook/tree/shilman/experimental-llms-txt) |
| **Commit** | [`c6ea358f`](https://github.com/storybookjs/storybook/commit/c6ea358faec105c79ecb28357b2315104f3120b1) |
| **Datetime** | Sun Feb 23 10:23:05 UTC 2025 (`1740306185`) |
| **Workflow run** | [13482107774](https://github.com/storybookjs/storybook/actions/runs/13482107774) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30636`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
