### PR TITLE
Exclude unnecessarily tracked coverage files

### DIFF
--- a/code/addons/test/src/node/vitest-manager.ts
+++ b/code/addons/test/src/node/vitest-manager.ts
@@ -80,6 +80,16 @@ export class VitestManager {
             reportOnFailure: true,
             reporter: [['html', {}], storybookCoverageReporter],
             reportsDirectory: resolvePathInStorybookCache(COVERAGE_DIRECTORY),
+            exclude: [
+              '**/*.config.*',
+              '**/*.workspace.*',
+              '**/.storybook/**',
+              '**/.yarn/**',
+              '**/src/**/!(stories)/**',
+              '**/src/**/*.stories.*',
+              '**/test/**/*.stories.*',
+              '**/storybook-static/**',
+            ],
           }
         : { enabled: false }
     ) as CoverageOptions;


### PR DESCRIPTION
Closes #30525

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Glob excluded certain files that test coverage was unnecessarily including, which was causing coverage to incorrectly report dramatically lower than its true results.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

Before changes:

1. Run yarn start
2. Open Storybook in your browser
3. Open the test component module
4. Turn on 'coverage' in its settings menu
5. Run tests -> Notice poor coverage rate

After changes:

1. Run yarn start
2. Open Storybook in your browser
3. Open the test component module
4. Turn on 'coverage' in its settings menu
5. Run tests -> Notice 100% coverage rate

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request:

Updates test coverage configuration to exclude non-source files from coverage calculations, providing more accurate coverage metrics in Storybook Test addon.

- Added coverage exclusions in `code/addons/test/src/node/vitest-manager.ts` for `.storybook`, story files, and build artifacts
- Fixes issue #30525 where `storybook-static` was incorrectly included in coverage
- Prevents artificially low coverage numbers caused by including configuration and build files
- Improves accuracy of test coverage reporting in the Storybook UI test module
- Maintains existing test coverage functionality while filtering out irrelevant files



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->