### PR TITLE
Core: Fix extracting import path when it's not a core addon

### DIFF
--- a/code/core/src/common/utils/get-addon-annotations.ts
+++ b/code/core/src/common/utils/get-addon-annotations.ts
@@ -34,7 +34,7 @@ export async function getAddonAnnotations(addon: string) {
 
     // for backwards compatibility, if it's not a core addon we use /preview entrypoint
     if (!data.isCoreAddon) {
-      data.importPath = `@storybook/${addon}/preview`;
+      data.importPath = `${addon}/preview`;
     }
 
     require.resolve(path.join(addon, 'preview'));


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 0 B | **1.45** | 0% |
| initSize |  80.6 MB | 80.6 MB | 0 B | **1.45** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.32 MB | 7.32 MB | 0 B | **2.98** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | -0.06 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | **2.97** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | **2.99** | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | 0.5 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  10.1s | 16.1s | 5.9s | 0.6 | 37.1% |
| generateTime |  20.4s | 18.6s | -1s -786ms | -0.65 | -9.6% |
| initTime |  4.5s | 4.2s | -240ms | -1.09 | -5.6% |
| buildTime |  9.1s | 8.3s | -737ms | -1.02 | -8.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 5.1s | -287ms | -0.35 | -5.6% |
| devManagerResponsive |  5.2s | 4.8s | -344ms | -0.17 | -7.1% |
| devManagerHeaderVisible |  756ms | 694ms | -62ms | -0.98 | -8.9% |
| devManagerIndexVisible |  764ms | 705ms | -59ms | -1.2 | -8.4% |
| devStoryVisibleUncached |  1.8s | 1.7s | -122ms | -0.51 | -7.1% |
| devStoryVisible |  851ms | 723ms | -128ms | **-1.43** | 🔰-17.7% |
| devAutodocsVisible |  756ms | 668ms | -88ms | -1.05 | -13.2% |
| devMDXVisible |  697ms | 777ms | 80ms | 0.42 | 10.3% |
| buildManagerHeaderVisible |  760ms | 651ms | -109ms | -0.83 | -16.7% |
| buildManagerIndexVisible |  831ms | 710ms | -121ms | -0.59 | -17% |
| buildStoryVisible |  745ms | 637ms | -108ms | -0.75 | -17% |
| buildAutodocsVisible |  558ms | 540ms | -18ms | -1.01 | -3.3% |
| buildMDXVisible |  616ms | 474ms | -142ms | **-1.26** | 🔰-30% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and context, I'll create a concise summary of the pull request changes:

Fixed import path generation for non-core Storybook addons by correctly handling the preview entrypoint resolution in `get-addon-annotations.ts`.

- Modified `getAddonAnnotations()` function to properly handle non-core addon paths
- Aligned with addon package.json exports that define `preview` entrypoints directly
- Affects addons like a11y, links, viewport, controls, docs, and others that follow the standard addon structure
- Ensures consistent import path resolution for both core and non-core addons
- Maintains backward compatibility with existing addon loading patterns



<!-- /greptile_comment -->