### PR TITLE
Codemod: Use real path from symbolic links

### DIFF
--- a/code/lib/cli-storybook/src/codemod/csf-factories.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.ts
@@ -39,7 +39,7 @@ async function runStoriesCodemod(options: {
       ).glob;
     }
 
-    logger.log('\n🛠️ Applying codemod on your stories, this might take some time...');
+    logger.log('\n🛠️  Applying codemod on your stories, this might take some time...');
 
     // TODO: Move the csf-2-to-3 codemod into automigrations
     await packageManager.executeCommand({
@@ -125,14 +125,14 @@ export const csfFactories: CommandFix = {
       previewConfigPath: previewConfigPath!,
     });
 
-    logger.log('\n🛠️ Applying codemod on your main config...');
+    logger.log('\n🛠️  Applying codemod on your main config...');
     const frameworkPackage =
       getFrameworkPackageName(mainConfig) || '@storybook/your-framework-here';
     await runCodemod(mainConfigPath, (fileInfo) =>
       configToCsfFactory(fileInfo, { configType: 'main', frameworkPackage }, { dryRun })
     );
 
-    logger.log('\n🛠️ Applying codemod on your preview config...');
+    logger.log('\n🛠️  Applying codemod on your preview config...');
     await runCodemod(previewConfigPath, (fileInfo) =>
       configToCsfFactory(fileInfo, { configType: 'preview', frameworkPackage }, { dryRun })
     );


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes the automigration codemod mechanism to always pass the real path when files are symlinked. Additionally it changes the ignore patterns as they were not ignoring e.g. node_modules when they were placed deeper in the directory tree

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 0 B | **1.45** | 0% |
| initSize |  80.6 MB | 80.6 MB | 0 B | **1.45** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.32 MB | 7.32 MB | 0 B | **2.98** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | -0.06 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | **2.97** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | **2.99** | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | 0.5 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  10.1s | 27.7s | 17.6s | **2.41** | 🔺63.4% |
| generateTime |  20.4s | 19.1s | -1s -224ms | -0.36 | -6.4% |
| initTime |  4.5s | 4.5s | -13ms | -0.51 | -0.3% |
| buildTime |  9.1s | 10.6s | 1.5s | **1.27** | 🔺14.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 4.6s | -757ms | -0.83 | -16.3% |
| devManagerResponsive |  5.2s | 4.4s | -785ms | -0.61 | -17.7% |
| devManagerHeaderVisible |  756ms | 672ms | -84ms | -1.23 | -12.5% |
| devManagerIndexVisible |  764ms | 679ms | -85ms | **-1.5** | 🔰-12.5% |
| devStoryVisibleUncached |  1.8s | 1.8s | -19ms | -0.38 | -1% |
| devStoryVisible |  851ms | 770ms | -81ms | -0.84 | -10.5% |
| devAutodocsVisible |  756ms | 672ms | -84ms | -1 | -12.5% |
| devMDXVisible |  697ms | 607ms | -90ms | **-1.85** | 🔰-14.8% |
| buildManagerHeaderVisible |  760ms | 758ms | -2ms | -0.12 | -0.3% |
| buildManagerIndexVisible |  831ms | 771ms | -60ms | -0.21 | -7.8% |
| buildStoryVisible |  745ms | 723ms | -22ms | -0.16 | -3% |
| buildAutodocsVisible |  558ms | 586ms | 28ms | -0.43 | 4.8% |
| buildMDXVisible |  616ms | 473ms | -143ms | **-1.27** | 🔰-30.2% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Here's my concise review of the pull request:

Updates codemod functionality to properly handle symlinked files and improve ignore pattern matching in the Storybook CLI.

- Resolves symlinks to real file paths before applying transformations in `code/lib/cli-storybook/src/automigrate/codemod.ts`
- Updates ignore patterns from `pattern/**` to `**/pattern/**` to catch matches at any directory depth
- Adds graceful fallback to original path if symlink resolution fails
- Minor formatting improvements to log messages in `code/lib/cli-storybook/src/codemod/csf-factories.ts`

The changes improve reliability when working with symlinked files and provide better control over which files are processed by the codemod system.



<!-- /greptile_comment -->