### PR TITLE
Codemod: Only remove types when they are unused

### DIFF
--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
@@ -129,7 +129,7 @@ describe('main/preview codemod: general parsing functionality', () => {
     expect(transformed).toEqual(original);
   });
 
-  it('should remove legacy main config type imports', async () => {
+  it('should remove legacy main config type imports if unused', async () => {
     await expect(
       transform(dedent`
         import { type StorybookConfig } from '@storybook/react-vite'
@@ -141,6 +141,35 @@ describe('main/preview codemod: general parsing functionality', () => {
       `)
     ).resolves.toMatchInlineSnapshot(`
       import { defineMain } from '@storybook/react-vite/node';
+
+      export default defineMain({
+        stories: [],
+      });
+    `);
+  });
+
+  it('should not remove legacy main config type imports if used', async () => {
+    await expect(
+      transform(dedent`
+        import { type StorybookConfig } from '@storybook/react-vite'
+
+        const config: StorybookConfig = {
+          stories: []
+        };
+
+        const features: StorybookConfig['features'] = {
+          foo: true,
+        };
+
+        export default config;
+      `)
+    ).resolves.toMatchInlineSnapshot(`
+      import { type StorybookConfig } from '@storybook/react-vite';
+      import { defineMain } from '@storybook/react-vite/node';
+
+      const features: StorybookConfig['features'] = {
+        foo: true,
+      };
 
       export default defineMain({
         stories: [],

--- a/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+
+import { types as t } from 'storybook/internal/babel';
+import { generate, parser } from 'storybook/internal/babel';
+
+import {
+  cleanupTypeImports,
+  getConfigProperties,
+  removeExportDeclarations,
+} from './csf-factories-utils';
+
+expect.addSnapshotSerializer({
+  serialize: (val: any) => {
+    if (typeof val === 'string') {
+      return val;
+    }
+    if (typeof val === 'object' && val !== null) {
+      return JSON.stringify(val, null, 2);
+    }
+    return String(val);
+  },
+  test: (_val) => true,
+});
+
+function parseCodeToProgramNode(code: string): t.Program {
+  return parser.parse(code, { sourceType: 'module', plugins: ['typescript'] }).program;
+}
+
+function generateCodeFromAST(node: t.Program) {
+  return generate(node).code;
+}
+
+describe('cleanupTypeImports', () => {
+  it('removes disallowed imports from @storybook/*', () => {
+    const code = `
+      import { Story, SomethingElse } from '@storybook/react';
+      import { Other } from 'some-other-package';
+    `;
+
+    const programNode = parseCodeToProgramNode(code);
+    const cleanedNodes = cleanupTypeImports(programNode, ['Story']);
+
+    expect(generateCodeFromAST({ ...programNode, body: cleanedNodes })).toMatchInlineSnapshot(`
+      import { SomethingElse } from '@storybook/react';
+      import { Other } from 'some-other-package';
+    `);
+  });
+
+  it('removes entire import if all specifiers are removed', () => {
+    const code = `
+      import { Story, Meta } from '@storybook/react';
+    `;
+
+    const programNode = parseCodeToProgramNode(code);
+    const cleanedNodes = cleanupTypeImports(programNode, ['Story', 'Meta']);
+
+    expect(generateCodeFromAST({ ...programNode, body: cleanedNodes })).toMatchInlineSnapshot(``);
+  });
+
+  it('retains non storybook imports', () => {
+    const code = `
+      import { Preview } from 'internal-types';
+    `;
+
+    const programNode = parseCodeToProgramNode(code);
+    const cleanedNodes = cleanupTypeImports(programNode, ['Preview']);
+
+    expect(generateCodeFromAST({ ...programNode, body: cleanedNodes })).toMatchInlineSnapshot(
+      `import { Preview } from 'internal-types';`
+    );
+  });
+
+  it('retains namespace imports', () => {
+    const code = `
+      import * as Storybook from '@storybook/react';
+    `;
+
+    const programNode = parseCodeToProgramNode(code);
+    const cleanedNodes = cleanupTypeImports(programNode, ['Preview']);
+
+    expect(generateCodeFromAST({ ...programNode, body: cleanedNodes })).toMatchInlineSnapshot(
+      `import * as Storybook from '@storybook/react';`
+    );
+  });
+
+  it('retains imports if they are used', () => {
+    const code = `
+      import { Type1, type Type2 } from '@storybook/react';
+      import type { Type3, ShouldBeRemoved, Type4 } from '@storybook/react';
+
+      const example: Type1 = {};
+      const example2 = {} as Type2;
+      const example3 = {} satisfies Type3;
+      const example4 = {
+        render: (args: Type4['args']) => {}
+      };
+    `;
+
+    const programNode = parseCodeToProgramNode(code);
+    const cleanedNodes = cleanupTypeImports(programNode, [
+      'Type1',
+      'Type2',
+      'Type3',
+      'Type4',
+      'ShouldBeRemoved',
+    ]);
+
+    const result = generateCodeFromAST({ ...programNode, body: cleanedNodes });
+
+    expect(result).toMatchInlineSnapshot(`
+      import { Type1, type Type2 } from '@storybook/react';
+      import type { Type3, Type4 } from '@storybook/react';
+      const example: Type1 = {};
+      const example2 = {} as Type2;
+      const example3 = {} satisfies Type3;
+      const example4 = {
+        render: (args: Type4['args']) => {}
+      };
+    `);
+
+    expect(result).not.toContain('ShouldBeRemoved');
+  });
+});
+
+describe('removeExportDeclarations', () => {
+  it('removes specified variable export declarations', () => {
+    const code = `
+      export const foo = 'foo';
+      export const bar = 'bar';
+      export const baz = 'baz';
+    `;
+
+    const programNode = parseCodeToProgramNode(code);
+    const exportDecls = {
+      foo: t.variableDeclarator(t.identifier('foo')),
+      baz: t.variableDeclarator(t.identifier('baz')),
+    };
+
+    const cleanedNodes = removeExportDeclarations(programNode, exportDecls);
+    const cleanedCode = generateCodeFromAST({ ...programNode, body: cleanedNodes });
+
+    expect(cleanedCode).toMatchInlineSnapshot(`export const bar = 'bar';`);
+  });
+
+  it('removes specified function export declarations', () => {
+    const code = `
+      export function foo() { return 'foo'; }
+      export function bar() { return 'bar'; }
+    `;
+
+    const programNode = parseCodeToProgramNode(code);
+    const exportDecls = {
+      foo: t.functionDeclaration(t.identifier('foo'), [], t.blockStatement([])),
+    };
+
+    const cleanedNodes = removeExportDeclarations(programNode, exportDecls);
+    const cleanedCode = generateCodeFromAST({ ...programNode, body: cleanedNodes });
+
+    expect(cleanedCode).toMatchInlineSnapshot(`
+      export function bar() {
+        return 'bar';
+      }
+    `);
+  });
+
+  it('retains exports not in the disallow list', () => {
+    const code = `
+      export const foo = 'foo';
+      export const bar = 'bar';
+    `;
+
+    const programNode = parseCodeToProgramNode(code);
+    const exportDecls = {
+      nonExistent: t.variableDeclarator(t.identifier('nonExistent')),
+    };
+
+    const cleanedNodes = removeExportDeclarations(programNode, exportDecls);
+    const cleanedCode = generateCodeFromAST({ ...programNode, body: cleanedNodes });
+
+    expect(cleanedCode).toMatchInlineSnapshot(`
+      export const foo = 'foo';
+      export const bar = 'bar';
+    `);
+  });
+});
+
+describe('getConfigProperties', () => {
+  it('returns object properties from variable declarations', () => {
+    const exportDecls = {
+      foo: t.variableDeclarator(t.identifier('foo'), t.stringLiteral('fooValue')),
+      bar: t.variableDeclarator(t.identifier('bar'), t.numericLiteral(42)),
+    };
+
+    const properties = getConfigProperties(exportDecls);
+
+    expect(properties).toHaveLength(2);
+    expect(properties[0].key.name).toBe('foo');
+    expect(properties[0].value.value).toBe('fooValue');
+    expect(properties[1].key.name).toBe('bar');
+    expect(properties[1].value.value).toBe(42);
+  });
+
+  it('returns object properties from function declarations', () => {
+    const exportDecls = {
+      foo: t.functionDeclaration(t.identifier('foo'), [], t.blockStatement([])),
+    };
+
+    const properties = getConfigProperties(exportDecls);
+
+    expect(properties).toHaveLength(1);
+    expect(properties[0].key.name).toBe('foo');
+    expect(properties[0].value.type).toBe('ArrowFunctionExpression');
+  });
+});

--- a/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
@@ -267,9 +267,6 @@ export async function storyToCsfFactory(
     programNode.body.unshift(configImport);
   }
 
-  // Remove type imports – now inferred – from @storybook/* packages
-  programNode.body = cleanupTypeImports(programNode, typesDisallowList);
-
   // Remove unused type aliases e.g. `type Story = StoryObj<typeof meta>;`
   programNode.body.forEach((node, index) => {
     if (t.isTSTypeAliasDeclaration(node)) {
@@ -288,6 +285,9 @@ export async function storyToCsfFactory(
       }
     }
   });
+
+  // Remove type imports – now inferred – from @storybook/* packages
+  programNode.body = cleanupTypeImports(programNode, typesDisallowList);
 
   return printCsf(csf).code;
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds extra logic to type removal so that the AST is traversed first to check whether the types are being used.
Additionally it adds unit tests to functions which didn't have tests before.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 0 B | **1.45** | 0% |
| initSize |  80.6 MB | 80.6 MB | 0 B | **1.45** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.32 MB | 7.32 MB | 0 B | **2.98** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | -0.06 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | **2.97** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | **2.99** | 0% |
| buildPreviewSize |  3.34 MB | 3.34 MB | 0 B | 0.5 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  10.1s | 8.5s | -1s -560ms | -0.57 | -18.2% |
| generateTime |  20.4s | 17.5s | -2s -835ms | -1.2 | -16.1% |
| initTime |  4.5s | 4.6s | 174ms | -0.03 | 3.7% |
| buildTime |  9.1s | 8.3s | -760ms | -1.04 | -9.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 5.7s | 301ms | 0.24 | 5.3% |
| devManagerResponsive |  5.2s | 5.4s | 259ms | 0.43 | 4.7% |
| devManagerHeaderVisible |  756ms | 852ms | 96ms | 0.83 | 11.3% |
| devManagerIndexVisible |  764ms | 939ms | 175ms | **1.47** | 🔺18.6% |
| devStoryVisibleUncached |  1.8s | 2.1s | 285ms | 0 | 13.4% |
| devStoryVisible |  851ms | 941ms | 90ms | **1.29** | 🔺9.6% |
| devAutodocsVisible |  756ms | 868ms | 112ms | 1.21 | 12.9% |
| devMDXVisible |  697ms | 821ms | 124ms | 1 | 15.1% |
| buildManagerHeaderVisible |  760ms | 753ms | -7ms | -0.16 | -0.9% |
| buildManagerIndexVisible |  831ms | 756ms | -75ms | -0.31 | -9.9% |
| buildStoryVisible |  745ms | 737ms | -8ms | -0.06 | -1.1% |
| buildAutodocsVisible |  558ms | 667ms | 109ms | 0.6 | 16.3% |
| buildMDXVisible |  616ms | 656ms | 40ms | 0.57 | 6.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of this PR's changes focusing on the type management improvements in Storybook's codemod utilities.

Improved type import management in Storybook's codemod utilities by adding AST traversal to only remove unused type imports.

- Added `csf-factories-utils.test.ts` with comprehensive test coverage for type import cleanup and export declarations
- Modified `cleanupTypeImports` in `csf-factories-utils.ts` to track used identifiers before removing imports
- Reordered type cleanup operations in `story-to-csf-factory.ts` to check type usage before removal
- Added error handling for unsupported TypeScript syntax patterns in AST traversal



<!-- /greptile_comment -->