### PR TITLE
Core: Fix addon essentials preview preset

### DIFF
--- a/code/addons/essentials/package.json
+++ b/code/addons/essentials/package.json
@@ -27,7 +27,7 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
-    "./preview": {
+    "./entry-preview": {
       "types": "./dist/preview.d.ts",
       "import": "./dist/preview.mjs",
       "require": "./dist/preview.js"
@@ -88,7 +88,7 @@
       "*": [
         "dist/index.d.ts"
       ],
-      "preview": [
+      "entry-preview": [
         "dist/preview.d.ts"
       ]
     }

--- a/code/builders/builder-vite/src/optimizeDeps.ts
+++ b/code/builders/builder-vite/src/optimizeDeps.ts
@@ -17,7 +17,6 @@ const INCLUDE_CANDIDATES = [
   '@storybook/addon-backgrounds/preview',
   '@storybook/addon-designs/blocks',
   '@storybook/addon-docs/preview',
-  '@storybook/addon-essentials/preview',
   '@storybook/addon-essentials/actions/preview',
   '@storybook/addon-essentials/actions/preview',
   '@storybook/addon-essentials/backgrounds/preview',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  80.6 MB | 80.6 MB | 0 B | 1.2 | 0% |
| initSize |  80.6 MB | 80.6 MB | 0 B | 1.2 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.32 MB | 7.29 MB | -26.1 kB | **-11.78** | -0.4% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.42 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | **2** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | **2** | 0% |
| buildPreviewSize |  3.34 MB | 3.32 MB | -26.1 kB | **-638.03** | -0.8% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.7s | 26.5s | 18.7s | **2.21** | 🔺70.7% |
| generateTime |  19.9s | 17.6s | -2s -307ms | **-1.3** | 🔰-13.1% |
| initTime |  4.9s | 4.3s | -676ms | **-1.4** | 🔰-15.7% |
| buildTime |  8.7s | 8.4s | -267ms | -1.06 | -3.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.9s | 4.4s | -475ms | -0.95 | -10.6% |
| devManagerResponsive |  4.7s | 4.3s | -442ms | -0.84 | -10.2% |
| devManagerHeaderVisible |  697ms | 690ms | -7ms | -1.02 | -1% |
| devManagerIndexVisible |  753ms | 758ms | 5ms | -0.54 | 0.7% |
| devStoryVisibleUncached |  2.1s | 1.5s | -569ms | -0.73 | -37.1% |
| devStoryVisible |  773ms | 782ms | 9ms | -0.63 | 1.2% |
| devAutodocsVisible |  722ms | 722ms | 0ms | -0.44 | 0% |
| devMDXVisible |  716ms | 617ms | -99ms | **-1.9** | 🔰-16% |
| buildManagerHeaderVisible |  688ms | 596ms | -92ms | -1.2 | -15.4% |
| buildManagerIndexVisible |  700ms | 606ms | -94ms | -1.22 | -15.5% |
| buildStoryVisible |  656ms | 557ms | -99ms | **-1.33** | 🔰-17.8% |
| buildAutodocsVisible |  556ms | 491ms | -65ms | **-1.72** | 🔰-13.2% |
| buildMDXVisible |  568ms | 516ms | -52ms | -0.79 | -10.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR updates the export path naming in @storybook/addon-essentials and adjusts Vite dependency optimization to improve the addon essentials preview preset implementation.

- Renamed `/preview` to `/entry-preview` in `code/addons/essentials/package.json` exports and typesVersions fields
- Removed `@storybook/addon-essentials/preview` from `INCLUDE_CANDIDATES` array in `code/builders/builder-vite/src/optimizeDeps.ts`
- Individual preview entries for essential addons (actions, backgrounds, docs, etc.) remain in optimization list



<!-- /greptile_comment -->