### PR TITLE
Codemod: Always get real path of files

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/codemod.ts
+++ b/code/lib/cli-storybook/src/automigrate/codemod.ts
@@ -69,9 +69,7 @@ export async function runCodemod(
           try {
             let filePath = file;
             try {
-              if ((await fs.lstat(file)).isSymbolicLink()) {
-                filePath = await fs.realpath(file);
-              }
+              filePath = await fs.realpath(file);
             } catch (err) {
               // if anything goes wrong when resolving the file, fallback to original path as is set above
             }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Somehow some files, even though symlinked, would return `false` in `fs.lstat(file)).isSymbolicLink()` so the code now always just gets the real path to be safe.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.6 MB | 79.7 MB | 37.5 kB | **-2.84** | 0% |
| initSize |  79.6 MB | 79.7 MB | 37.5 kB | **-2.84** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.29 MB | 7.29 MB | 392 B | **-1.91** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 1.11 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | 1.11 | 0% |
| buildPreviewSize |  3.32 MB | 3.32 MB | 392 B | **-1.96** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.4s | 24.8s | 17.4s | **1.75** | 🔺70.1% |
| generateTime |  19.5s | 18.3s | -1s -221ms | -0.91 | -6.6% |
| initTime |  5.4s | 4.2s | -1s -212ms | **-1.32** | 🔰-28.4% |
| buildTime |  8.6s | 8.7s | 111ms | -0.84 | 1.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.5s | 5.6s | 131ms | 0.1 | 2.3% |
| devManagerResponsive |  5.3s | 5.4s | 117ms | 0.16 | 2.2% |
| devManagerHeaderVisible |  916ms | 888ms | -28ms | **1.47** | -3.2% |
| devManagerIndexVisible |  925ms | 899ms | -26ms | 1.23 | -2.9% |
| devStoryVisibleUncached |  2.2s | 1.5s | -688ms | -0.75 | -43.1% |
| devStoryVisible |  1s | 971ms | -38ms | **1.92** | -3.9% |
| devAutodocsVisible |  866ms | 844ms | -22ms | 0.87 | -2.6% |
| devMDXVisible |  794ms | 757ms | -37ms | 0.31 | -4.9% |
| buildManagerHeaderVisible |  696ms | 901ms | 205ms | 0.51 | 22.8% |
| buildManagerIndexVisible |  709ms | 912ms | 203ms | 0.33 | 22.3% |
| buildStoryVisible |  684ms | 886ms | 202ms | 0.61 | 22.8% |
| buildAutodocsVisible |  589ms | 631ms | 42ms | -0.09 | 6.7% |
| buildMDXVisible |  601ms | 888ms | 287ms | **2.63** | 🔺32.3% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR simplifies the symlink path resolution logic in the `runCodemod` function by always resolving to the real path of files rather than conditionally doing so only for detected symbolic links.

- Modified `code/lib/cli-storybook/src/automigrate/codemod.ts` to always call `fs.realpathSync` on files regardless of symlink status
- Addresses an edge case where some symlinked files were not being properly detected with `fs.lstat(file).isSymbolicLink()`
- Ensures consistent file path resolution behavior across different environments
- Maintains the existing error handling approach while making the code more robust

Greptile AI



<!-- /greptile_comment -->