### PR TITLE
Core: Don't set process.env.NODE_ENV and process.env.DEV

### DIFF
--- a/code/core/scripts/prep.ts
+++ b/code/core/scripts/prep.ts
@@ -124,10 +124,6 @@ async function run() {
       platform: 'neutral',
       mainFields: ['main', 'module', 'node'],
       conditions: ['node', 'module', 'import', 'require'],
-      define: {
-        'process.env.NODE_ENV': '"production"',
-        'process.env.DEV': '"false"',
-      },
     } satisfies EsbuildContextOptions;
 
     const browserAliases = {


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have removed setting `process.env.NODE_ENV` to `production` when building packages since it causes issues of loading, e.g., production builds of React into Storybook while running in `dev` mode. These settings have caused loading production builds of `react-refresh` during development, leading to failures in Next.js Webpack projects.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.6 MB | 79.7 MB | 37.5 kB | **-2.84** | 0% |
| initSize |  79.6 MB | 79.7 MB | 37.5 kB | **-2.84** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.29 MB | 7.29 MB | 392 B | **-1.91** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | 1.11 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | 1.11 | 0% |
| buildPreviewSize |  3.32 MB | 3.32 MB | 392 B | **-1.96** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.4s | 7.4s | 24ms | -0.77 | 0.3% |
| generateTime |  19.5s | 22s | 2.4s | 0.88 | 11.3% |
| initTime |  5.4s | 4.6s | -799ms | -0.39 | -17.1% |
| buildTime |  8.6s | 9.5s | 909ms | 0.04 | 9.6% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.5s | 4.6s | -915ms | -0.96 | -19.9% |
| devManagerResponsive |  5.3s | 4.4s | -893ms | -0.96 | -20.2% |
| devManagerHeaderVisible |  916ms | 651ms | -265ms | **-1.55** | 🔰-40.7% |
| devManagerIndexVisible |  925ms | 684ms | -241ms | **-1.59** | 🔰-35.2% |
| devStoryVisibleUncached |  2.2s | 1.7s | -538ms | -0.28 | -30.8% |
| devStoryVisible |  1s | 710ms | -299ms | **-1.75** | 🔰-42.1% |
| devAutodocsVisible |  866ms | 690ms | -176ms | -0.97 | -25.5% |
| devMDXVisible |  794ms | 731ms | -63ms | -0.09 | -8.6% |
| buildManagerHeaderVisible |  696ms | 614ms | -82ms | -1.12 | -13.4% |
| buildManagerIndexVisible |  709ms | 691ms | -18ms | -0.81 | -2.6% |
| buildStoryVisible |  684ms | 602ms | -82ms | -1.05 | -13.6% |
| buildAutodocsVisible |  589ms | 505ms | -84ms | -1.11 | -16.6% |
| buildMDXVisible |  601ms | 489ms | -112ms | -1.2 | -22.9% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR removes the setting of `process.env.NODE_ENV` and `process.env.DEV` during the build step to prevent issues with loading production builds in development mode.

- Removed environment variable settings from the node esbuild options in `code/core/scripts/prep.ts`
- Maintains `process.env.NODE_ENV` settings for browser and finals build configurations
- Fixes issues with loading production builds of React in development mode
- Addresses failures in Next.js Webpack projects caused by production builds of react-refresh loading during development



<!-- /greptile_comment -->