### PR TITLE
Upgrade image-size to 2.0

### DIFF
--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -161,7 +161,7 @@
     "babel-loader": "^9.1.3",
     "css-loader": "^6.7.3",
     "find-up": "^5.0.0",
-    "image-size": "^1.0.0",
+    "image-size": "^2.0.0",
     "loader-utils": "^3.2.1",
     "node-polyfill-webpack-plugin": "^2.0.1",
     "pnp-webpack-plugin": "^1.7.0",
@@ -203,9 +203,6 @@
     "webpack": {
       "optional": true
     }
-  },
-  "optionalDependencies": {
-    "sharp": "^0.33.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/code/frameworks/nextjs/src/next-image-loader-stub.ts
+++ b/code/frameworks/nextjs/src/next-image-loader-stub.ts
@@ -1,8 +1,4 @@
-import { cpus } from 'node:os';
-
-import { NextJsSharpError } from 'storybook/internal/preview-errors';
-
-import imageSizeOf from 'image-size';
+import { imageSize } from 'image-size';
 import { interpolateName } from 'loader-utils';
 import type { NextConfig } from 'next';
 import type { RawLoaderDefinition } from 'webpack';
@@ -10,21 +6,6 @@ import type { RawLoaderDefinition } from 'webpack';
 interface LoaderOptions {
   filename: string;
   nextConfig: NextConfig;
-}
-
-let sharp: typeof import('sharp') | undefined;
-
-try {
-  sharp = require('sharp');
-  if (sharp && sharp.concurrency() > 1) {
-    // Reducing concurrency reduces the memory usage too.
-    const divisor = process.env.NODE_ENV === 'development' ? 4 : 2;
-    sharp.concurrency(Math.floor(Math.max(cpus().length / divisor, 1)));
-  }
-} catch (e) {
-  console.warn(
-    'You have to install sharp in order to use image optimization features in Next.js. AVIF support is also disabled.'
-  );
 }
 
 const nextImageLoaderStub: RawLoaderDefinition<LoaderOptions> = async function NextImageLoader(
@@ -36,7 +17,6 @@ const nextImageLoaderStub: RawLoaderDefinition<LoaderOptions> = async function N
     content,
   };
   const outputPath = interpolateName(this, filename.replace('[ext]', '.[ext]'), opts);
-  const extension = interpolateName(this, '[ext]', opts);
 
   this.emitFile(outputPath, content);
 
@@ -44,23 +24,7 @@ const nextImageLoaderStub: RawLoaderDefinition<LoaderOptions> = async function N
     return `const src = '${outputPath}'; export default src;`;
   }
 
-  let width;
-  let height;
-
-  if (extension === 'avif') {
-    if (sharp) {
-      const transformer = sharp(content);
-      const result = await transformer.metadata();
-      width = result.width;
-      height = result.height;
-    } else {
-      throw new NextJsSharpError();
-    }
-  } else {
-    const result = imageSizeOf(this.resourcePath);
-    width = result.width;
-    height = result.height;
-  }
+  const { width, height } = imageSize(content as Uint8Array);
 
   return `export default ${JSON.stringify({
     src: outputPath,

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -8047,7 +8047,7 @@ __metadata:
     babel-loader: "npm:^9.1.3"
     css-loader: "npm:^6.7.3"
     find-up: "npm:^5.0.0"
-    image-size: "npm:^1.0.0"
+    image-size: "npm:^2.0.0"
     loader-utils: "npm:^3.2.1"
     next: "npm:^15.0.3"
     node-polyfill-webpack-plugin: "npm:^2.0.1"
@@ -19547,7 +19547,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"image-size@npm:^1.0.0, image-size@npm:^1.1.1":
+"image-size@npm:^1.1.1":
   version: 1.1.1
   resolution: "image-size@npm:1.1.1"
   dependencies:
@@ -19555,6 +19555,15 @@ __metadata:
   bin:
     image-size: bin/image-size.js
   checksum: 10c0/2660470096d12be82195f7e80fe03274689fbd14184afb78eaf66ade7cd06352518325814f88af4bde4b26647889fe49e573129f6e7ba8f5ff5b85cc7f559000
+  languageName: node
+  linkType: hard
+
+"image-size@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "image-size@npm:2.0.0"
+  bin:
+    image-size: bin/image-size.js
+  checksum: 10c0/c73cfc9006a5b5d500b455f5aed161eadc450a60c548becee93205d17864d18e8c442932ab1acb29bde92a177b154b3835fdf3b26eb84f881772421b6825f72e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What I did
This PR upgrades `image-size` to `2.0.0`, and removed the dependency on `sharp` for avif files.

Related PR https://github.com/storybookjs/vite-plugin-storybook-nextjs/pull/32

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR upgrades the `image-size` package to version 2.0.0 and removes the `sharp` dependency, simplifying AVIF image handling in the Next.js framework integration.

- Upgraded `image-size` to 2.0.0 in `code/frameworks/nextjs/package.json` for native AVIF support
- Removed `sharp` from optionalDependencies as it's no longer needed
- Simplified `code/frameworks/nextjs/src/next-image-loader-stub.ts` by removing special AVIF handling code
- Updated import from `imageSizeOf` to `imageSize` to match new API



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->