### PR TITLE
Docs: Set init/upgrade snippets to latest on latest

### DIFF
--- a/docs/_snippets/init-command.md
+++ b/docs/_snippets/init-command.md
@@ -1,11 +1,11 @@
 ```shell renderer="common" language="js" packageManager="npm"
-npx storybook@next init
+npx storybook@latest init
 ```
 
 ```shell renderer="common" language="js" packageManager="pnpm"
-pnpm dlx storybook@next init
+pnpm dlx storybook@latest init
 ```
 
 ```shell renderer="common" language="js" packageManager="yarn"
-yarn dlx storybook@next init
+yarn dlx storybook@latest init
 ```

--- a/docs/_snippets/storybook-upgrade.md
+++ b/docs/_snippets/storybook-upgrade.md
@@ -1,11 +1,11 @@
 ```shell renderer="common" language="js" packageManager="npm"
-npx storybook@next upgrade
+npx storybook@latest upgrade
 ```
 
 ```shell renderer="common" language="js" packageManager="pnpm"
-pnpm dlx storybook@next upgrade
+pnpm dlx storybook@latest upgrade
 ```
 
 ```shell renderer="common" language="js" packageManager="yarn"
-yarn dlx storybook@next upgrade
+yarn dlx storybook@latest upgrade
 ```


### PR DESCRIPTION
## What I did

Reverts changes in #29696, on `main`. Those changes only applied to `next`, which were then mistakenly carried over when `next` was copied to `main` in the release process.

Longer term, this situation will be fixed by https://linear.app/chromaui/issue/SB-1283/[docs]-issue-with-prereleases-and-snippet-package-labels

(Yes, this is another round of #30364)

## Checklist for Contributors

### Testing

N/A - docs-only change

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- greptile_comment -->

## Greptile Summary

# Greptile Summary

This PR updates documentation snippets to use `@latest` tag instead of `@next` for Storybook initialization and upgrade commands on the main branch.

- Changed commands in `docs/_snippets/init-command.md` from `storybook@next` to `storybook@latest` for npm, pnpm, and yarn
- Updated commands in `docs/_snippets/storybook-upgrade.md` from `storybook@next` to `storybook@latest` for all package managers
- Reverts changes from PR #29696 that were mistakenly carried over from the next branch during release
- Ensures users following main branch documentation install stable releases rather than prerelease versions



<!-- /greptile_comment -->