### PR TITLE
Revert "CLI: Don't initially select Documentation and Testing features"

### DIFF
--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -330,6 +330,7 @@ export async function doInitiate(options: CommandOptions): Promise<
       choices: Object.entries(selectableFeatures).map(([value, { name, description }]) => ({
         title: `${name}: ${description}`,
         value,
+        selected: true,
       })),
     });
     selectedFeatures = new Set(out.features);


### PR DESCRIPTION
Reverts storybookjs/storybook#30599

Reverting this because (1) the CLI prompt is not clear, and (2) the docs-disabled experience needs work (we still add the `.mdx` glob to your main.js, etc.)

Hope to re-enable this change down the road once we tighten this up.

<!-- greptile_comment -->

## Greptile Summary

This PR reverts a change that made Documentation and Testing features opt-in during Storybook initialization, restoring the default behavior where these features are pre-selected.

- Modified `code/lib/create-storybook/src/initiate.ts` to add `selected: true` to Documentation and Testing feature choices
- Features will now be pre-selected by default in the interactive prompt during initialization
- Users must explicitly deselect these features if they don't want them, rather than having to opt-in
- Affects only the default selection state in the initialization UI, not the actual functionality
- Improves initial user experience by enabling commonly used features by default



<!-- /greptile_comment -->