### PR TITLE
Buid: Remove tailwind for now as it is failing vite postcss in experimental-nextjs-vite/default-ts

### DIFF
--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -235,7 +235,7 @@ export const baseTemplates = {
   'experimental-nextjs-vite/default-ts': {
     name: 'Next.js Latest (Vite | TypeScript)',
     script:
-      'npx create-next-app {{beforeDir}} --eslint --tailwind --app --import-alias="@/*" --src-dir',
+      'npx create-next-app {{beforeDir}} --eslint --no-tailwind --app --import-alias="@/*" --src-dir',
     expected: {
       framework: '@storybook/experimental-nextjs-vite',
       renderer: '@storybook/react',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.7 MB | 79.7 MB | 0 B | -0.64 | 0% |
| initSize |  79.7 MB | 79.7 MB | 0 B | -0.64 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | 0.54 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.43 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.89 MB | 1.89 MB | 0 B | 0.41 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.98 MB | 3.98 MB | 0 B | **1.61** | 0% |
| buildPreviewSize |  3.33 MB | 3.33 MB | 0 B | 0.04 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.7s | 7.2s | -488ms | -0.88 | -6.7% |
| generateTime |  21.4s | 19.8s | -1s -542ms | -0.24 | -7.8% |
| initTime |  5.2s | 4.8s | -409ms | -0.11 | -8.5% |
| buildTime |  8.9s | 9.6s | 669ms | 0 | 6.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.2s | 5.2s | 34ms | -0.57 | 0.6% |
| devManagerResponsive |  5s | 5s | 78ms | -0.49 | 1.5% |
| devManagerHeaderVisible |  673ms | 823ms | 150ms | -0.06 | 18.2% |
| devManagerIndexVisible |  680ms | 891ms | 211ms | 0.23 | 23.7% |
| devStoryVisibleUncached |  1.9s | 1.8s | -141ms | -0.21 | -7.6% |
| devStoryVisible |  755ms | 922ms | 167ms | 0.15 | 18.1% |
| devAutodocsVisible |  643ms | 767ms | 124ms | -0.55 | 16.2% |
| devMDXVisible |  687ms | 791ms | 104ms | -0.02 | 13.1% |
| buildManagerHeaderVisible |  701ms | 917ms | 216ms | 0.98 | 23.6% |
| buildManagerIndexVisible |  715ms | 967ms | 252ms | 0.84 | 26.1% |
| buildStoryVisible |  643ms | 895ms | 252ms | 1.05 | 28.2% |
| buildAutodocsVisible |  610ms | 771ms | 161ms | 0.99 | 20.9% |
| buildMDXVisible |  539ms | 666ms | 127ms | 0.39 | 19.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR removes Tailwind CSS from the experimental Next.js Vite template configuration to address PostCSS issues.

- Modified `code/lib/cli-storybook/src/sandbox-templates.ts` to use `--no-tailwind` flag instead of `--tailwind` when creating Next.js app in the experimental-nextjs-vite/default-ts template
- The change only affects the experimental Next.js with Vite TypeScript template
- The regular Next.js v14 template with Vite still includes Tailwind
- This change addresses PostCSS compatibility issues between Tailwind and Vite in the experimental integration



<!-- /greptile_comment -->