### PR TITLE
Next: Support Next 15.2

### DIFF
--- a/code/frameworks/experimental-nextjs-vite/src/preview.tsx
+++ b/code/frameworks/experimental-nextjs-vite/src/preview.tsx
@@ -25,7 +25,8 @@ function addNextHeadCount() {
 function isAsyncClientComponentError(error: unknown) {
   return (
     typeof error === 'string' &&
-    (error.includes('A component was suspended by an uncached promise.') ||
+    (error.includes('Only Server Components can be async at the moment.') ||
+      error.includes('A component was suspended by an uncached promise.') ||
       error.includes('async/await is not yet supported in Client Components'))
   );
 }

--- a/code/frameworks/nextjs/src/preview.tsx
+++ b/code/frameworks/nextjs/src/preview.tsx
@@ -30,7 +30,8 @@ function addNextHeadCount() {
 function isAsyncClientComponentError(error: unknown) {
   return (
     typeof error === 'string' &&
-    (error.includes('A component was suspended by an uncached promise.') ||
+    (error.includes('Only Server Components can be async at the moment.') ||
+      error.includes('A component was suspended by an uncached promise.') ||
       error.includes('async/await is not yet supported in Client Components'))
   );
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.7 MB | 79.7 MB | 0 B | -0.2 | 0% |
| initSize |  79.7 MB | 79.7 MB | 0 B | -0.2 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.31 MB | 7.31 MB | 0 B | 0.71 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.43 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.89 MB | 1.89 MB | 0 B | 0.17 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.98 MB | 3.98 MB | 0 B | 0.94 | 0% |
| buildPreviewSize |  3.33 MB | 3.33 MB | 0 B | 0.53 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  20.2s | 27.3s | 7s | **1.49** | 🔺25.8% |
| generateTime |  22.6s | 23.9s | 1.2s | **1.44** | 🔺5.1% |
| initTime |  5.1s | 5s | -102ms | 0.24 | -2% |
| buildTime |  11s | 10.2s | -738ms | 0.26 | -7.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.6s | 5.7s | 1s | 0.53 | 18.3% |
| devManagerResponsive |  4.4s | 5.3s | 875ms | 0.31 | 16.3% |
| devManagerHeaderVisible |  750ms | 867ms | 117ms | 0.24 | 13.5% |
| devManagerIndexVisible |  757ms | 968ms | 211ms | 0.67 | 21.8% |
| devStoryVisibleUncached |  1.6s | 2.1s | 528ms | 0.72 | 24.8% |
| devStoryVisible |  844ms | 955ms | 111ms | 0.28 | 11.6% |
| devAutodocsVisible |  559ms | 841ms | 282ms | 0.43 | 33.5% |
| devMDXVisible |  626ms | 778ms | 152ms | -0.02 | 19.5% |
| buildManagerHeaderVisible |  562ms | 940ms | 378ms | 1.16 | 40.2% |
| buildManagerIndexVisible |  604ms | 1s | 420ms | **1.26** | 🔺41% |
| buildStoryVisible |  550ms | 917ms | 367ms | **1.24** | 🔺40% |
| buildAutodocsVisible |  485ms | 706ms | 221ms | 0.37 | 31.3% |
| buildMDXVisible |  449ms | 933ms | 484ms | **3.15** | 🔺51.9% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR adds error handling for a new React Server Components error message in Next.js 15.2, ensuring it's suppressed in the Storybook UI for a cleaner development experience.

- Added detection for "Only Server Components can be async at the moment" error message in `code/frameworks/nextjs/src/preview.tsx`
- Added the same error message handling in `code/frameworks/experimental-nextjs-vite/src/preview.tsx`
- Both implementations extend the existing `isAsyncClientComponentError` function that already filters other RSC-related errors
- The change maintains consistency with Storybook's approach to handling framework-specific errors

Greptile AI



<!-- /greptile_comment -->