### PR TITLE
AutoBlocker: Add major version upgrade blocker

### DIFF
--- a/code/lib/cli-storybook/src/autoblock/block-major-version.test.ts
+++ b/code/lib/cli-storybook/src/autoblock/block-major-version.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { versions } from 'storybook/internal/common';
+
+import { blocker, shouldBlockUpgrade } from './block-major-version';
+
+describe('shouldBlockUpgrade', () => {
+  // Test invalid versions
+  it('returns false for invalid versions', () => {
+    expect(shouldBlockUpgrade('', '8.0.0')).toBe(false);
+    expect(shouldBlockUpgrade('7.0.0', '')).toBe(false);
+    expect(shouldBlockUpgrade('invalid', '8.0.0')).toBe(false);
+    expect(shouldBlockUpgrade('7.0.0', 'invalid')).toBe(false);
+  });
+
+  // Test prerelease versions
+  it('returns false when upgrading from a prerelease', () => {
+    expect(shouldBlockUpgrade('6.0.0-canary.1', '8.0.0')).toBe(false);
+    expect(shouldBlockUpgrade('6.0.0-alpha.0', '8.0.0')).toBe(false);
+    expect(shouldBlockUpgrade('6.0.0-beta.1', '8.0.0')).toBe(false);
+    expect(shouldBlockUpgrade('6.0.0-rc.1', '8.0.0')).toBe(false);
+    expect(shouldBlockUpgrade('0.0.0-bla-0', '8.0.0')).toBe(false);
+  });
+
+  it('returns false when upgrading to a prerelease', () => {
+    expect(shouldBlockUpgrade('6.0.0', '8.0.0-alpha.1')).toBe(false);
+    expect(shouldBlockUpgrade('6.0.0', '8.0.0-canary.0')).toBe(false);
+    expect(shouldBlockUpgrade('6.0.0', '8.0.0-beta.1')).toBe(false);
+    expect(shouldBlockUpgrade('6.0.0', '8.0.0-rc.0')).toBe(false);
+    expect(shouldBlockUpgrade('6.0.0', '0.0.0-bla-0')).toBe(false);
+  });
+
+  // Test version gaps
+  it('returns false when versions are one major apart', () => {
+    expect(shouldBlockUpgrade('6.0.0', '7.0.0')).toBe(false);
+    expect(shouldBlockUpgrade('7.0.0', '8.0.0')).toBe(false);
+    expect(shouldBlockUpgrade('6.5.0', '7.0.0')).toBe(false);
+  });
+
+  it('returns true when versions are more than one major apart', () => {
+    expect(shouldBlockUpgrade('6.0.0', '8.0.0')).toBe(true);
+    expect(shouldBlockUpgrade('5.0.0', '7.0.0')).toBe(true);
+    expect(shouldBlockUpgrade('6.5.0', '8.0.0')).toBe(true);
+  });
+
+  // Test with current CLI version
+  it('correctly handles upgrades to current CLI version', () => {
+    const cliVersion = versions.storybook;
+    const cliMajor = parseInt(cliVersion.split('.')[0], 10);
+
+    // Should block if more than one major behind
+    expect(shouldBlockUpgrade(`${cliMajor - 2}.0.0`, cliVersion)).toBe(true);
+    expect(shouldBlockUpgrade(`${cliMajor - 3}.5.0`, cliVersion)).toBe(true);
+
+    // Should not block if one major behind or on same major
+    expect(shouldBlockUpgrade(`${cliMajor - 1}.0.0`, cliVersion)).toBe(false);
+    expect(shouldBlockUpgrade(`${cliMajor}.0.0`, cliVersion)).toBe(false);
+
+    // Should not block if upgrading from a prerelease
+    expect(shouldBlockUpgrade(`${cliMajor - 2}.0.0-canary.1`, cliVersion)).toBe(false);
+    expect(shouldBlockUpgrade(`${cliMajor - 2}.0.0-alpha.0`, cliVersion)).toBe(false);
+    expect(shouldBlockUpgrade(`${cliMajor - 2}.0.0-beta.1`, cliVersion)).toBe(false);
+    expect(shouldBlockUpgrade(`${cliMajor - 2}.0.0-rc.0`, cliVersion)).toBe(false);
+  });
+
+  // Test version zero
+  it('returns false for version zero', () => {
+    expect(shouldBlockUpgrade('0.1.0', '8.0.0')).toBe(false);
+    expect(shouldBlockUpgrade('6.0.0', '0.1.0')).toBe(false);
+    expect(shouldBlockUpgrade('0.0.1', '0.0.2')).toBe(false);
+  });
+});
+
+describe('blocker', () => {
+  const mockPackageManager = {
+    retrievePackageJson: vi.fn(),
+  };
+
+  it('returns false if no version found', async () => {
+    mockPackageManager.retrievePackageJson.mockResolvedValue({});
+    const result = await blocker.check({ packageManager: mockPackageManager } as any);
+    expect(result).toBe(false);
+  });
+
+  it('returns false if version check fails', async () => {
+    mockPackageManager.retrievePackageJson.mockRejectedValue(new Error('test'));
+    const result = await blocker.check({ packageManager: mockPackageManager } as any);
+    expect(result).toBe(false);
+  });
+
+  it('returns version data if upgrade should be blocked', async () => {
+    mockPackageManager.retrievePackageJson.mockResolvedValue({
+      dependencies: {
+        '@storybook/react': '6.0.0',
+      },
+    });
+    versions.storybook = '8.0.0';
+    const result = await blocker.check({ packageManager: mockPackageManager } as any);
+    expect(result).toEqual({ currentVersion: '6.0.0' });
+  });
+
+  describe('log', () => {
+    it('includes upgrade command for valid versions', () => {
+      const message = blocker.log({ packageManager: mockPackageManager } as any, {
+        currentVersion: '6.0.0',
+      });
+      expect(message).toContain('You can upgrade to version 7 by running:');
+      expect(message).toContain('npx storybook@7 upgrade');
+    });
+
+    it('omits upgrade command for invalid versions', () => {
+      const message = blocker.log({ packageManager: mockPackageManager } as any, {
+        currentVersion: 'invalid',
+      });
+      expect(message).not.toContain('You can upgrade to version');
+      expect(message).toContain('Major Version Gap Detected');
+      expect(message).toContain('For more information about upgrading');
+    });
+  });
+});

--- a/code/lib/cli-storybook/src/autoblock/block-major-version.test.ts
+++ b/code/lib/cli-storybook/src/autoblock/block-major-version.test.ts
@@ -52,13 +52,24 @@ describe('checkUpgrade', () => {
     expect(checkUpgrade('6.5.0', '8.0.0')).toBe('gap-too-large');
   });
 
-  it('downgrade - detects all downgrades between stable versions', () => {
-    expect(checkUpgrade('7.0.0', '6.0.0')).toBe('downgrade');
-    expect(checkUpgrade('8.0.0', '7.0.0')).toBe('downgrade');
-    expect(checkUpgrade('7.5.0', '6.0.0')).toBe('downgrade');
-    expect(checkUpgrade('8.0.0', '6.0.0')).toBe('downgrade');
-    expect(checkUpgrade('7.0.0', '5.0.0')).toBe('downgrade');
-    expect(checkUpgrade('8.5.0', '6.0.0')).toBe('downgrade');
+  describe('downgrade', () => {
+    it('detects major version downgrades', () => {
+      expect(checkUpgrade('7.0.0', '6.0.0')).toBe('downgrade');
+      expect(checkUpgrade('8.0.0', '7.0.0')).toBe('downgrade');
+      expect(checkUpgrade('8.0.0', '6.0.0')).toBe('downgrade');
+    });
+
+    it('detects minor version downgrades', () => {
+      expect(checkUpgrade('7.2.0', '7.1.0')).toBe('downgrade');
+      expect(checkUpgrade('7.1.0', '7.0.0')).toBe('downgrade');
+      expect(checkUpgrade('8.5.0', '8.4.9')).toBe('downgrade');
+    });
+
+    it('detects patch version downgrades', () => {
+      expect(checkUpgrade('7.1.2', '7.1.1')).toBe('downgrade');
+      expect(checkUpgrade('7.0.1', '7.0.0')).toBe('downgrade');
+      expect(checkUpgrade('8.0.5', '8.0.4')).toBe('downgrade');
+    });
   });
 
   it('special - allows any version zero upgrades or downgrades', () => {

--- a/code/lib/cli-storybook/src/autoblock/block-major-version.ts
+++ b/code/lib/cli-storybook/src/autoblock/block-major-version.ts
@@ -84,7 +84,7 @@ export const blocker = createBlocker<MajorVersionData>({
         Downgrading is not supported.
 
         For more information about upgrading and version compatibility, visit:
-        ${picocolors.cyan('https://storybook.js.org/docs/react/configure/upgrading')}`;
+        ${picocolors.cyan('https://storybook.js.org/docs/configure/upgrading')}`;
     }
 
     const message = dedent`
@@ -103,13 +103,13 @@ export const blocker = createBlocker<MajorVersionData>({
         ${picocolors.cyan(cmd)}
 
         For more information about upgrading, visit:
-        ${picocolors.cyan('https://storybook.js.org/docs/react/configure/upgrading')}`;
+        ${picocolors.cyan('https://storybook.js.org/docs/configure/upgrading')}`;
     }
 
     return dedent`
       ${message}
 
       For more information about upgrading, visit:
-      ${picocolors.cyan('https://storybook.js.org/docs/react/configure/upgrading')}`;
+      ${picocolors.cyan('https://storybook.js.org/docs/configure/upgrading')}`;
   },
 });

--- a/code/lib/cli-storybook/src/autoblock/block-major-version.ts
+++ b/code/lib/cli-storybook/src/autoblock/block-major-version.ts
@@ -2,7 +2,7 @@ import { getStorybookVersionSpecifier } from 'storybook/internal/cli';
 import { versions } from 'storybook/internal/common';
 
 import picocolors from 'picocolors';
-import { coerce, major, parse, prerelease } from 'semver';
+import { coerce, gt, major, parse, prerelease } from 'semver';
 import { dedent } from 'ts-dedent';
 
 import { createBlocker } from './types';
@@ -37,8 +37,8 @@ export function checkUpgrade(currentVersion: string, targetVersion: string): Upg
     return 'ok';
   }
 
-  // Check for downgrade
-  if (target.major < current.major) {
+  // Check for downgrade (when current version is greater than target)
+  if (gt(currentVersion, targetVersion)) {
     return 'downgrade';
   }
 

--- a/code/lib/cli-storybook/src/autoblock/block-major-version.ts
+++ b/code/lib/cli-storybook/src/autoblock/block-major-version.ts
@@ -1,0 +1,93 @@
+import { getStorybookVersionSpecifier } from 'storybook/internal/cli';
+import { versions } from 'storybook/internal/common';
+
+import picocolors from 'picocolors';
+import { coerce, major, parse, prerelease } from 'semver';
+import { dedent } from 'ts-dedent';
+
+import { createBlocker } from './types';
+
+interface MajorVersionData {
+  currentVersion: string;
+}
+
+/** Returns true if upgrading should be blocked due to major version gap */
+export function shouldBlockUpgrade(currentVersion: string, targetVersion: string): boolean {
+  // Skip check for missing versions
+  if (!currentVersion || !targetVersion) {
+    return false;
+  }
+
+  const current = parse(currentVersion);
+  const target = parse(targetVersion);
+  if (!current || !target) {
+    return false;
+  }
+
+  // Never block if upgrading from or to a prerelease
+  if (prerelease(currentVersion) || prerelease(targetVersion)) {
+    return false;
+  }
+
+  // Never block if upgrading from or to a canary
+  if (current.major === 0 || target.major === 0) {
+    return false;
+  }
+
+  const gap = target.major - current.major;
+  return gap > 1;
+}
+
+export const blocker = createBlocker<MajorVersionData>({
+  id: 'major-version-gap',
+  async check(options) {
+    const { packageManager } = options;
+    const packageJson = await packageManager.retrievePackageJson();
+
+    try {
+      const current = getStorybookVersionSpecifier(packageJson);
+      if (!current) {
+        return false;
+      }
+
+      const target = versions.storybook;
+      if (shouldBlockUpgrade(current, target)) {
+        return {
+          currentVersion: current,
+        };
+      }
+    } catch (e) {
+      // If we can't determine the version, don't block
+      return false;
+    }
+
+    return false;
+  },
+  log(options, data) {
+    const coercedVersion = coerce(data.currentVersion);
+    const message = dedent`
+      ${picocolors.red('Major Version Gap Detected')}
+      Your Storybook version (v${data.currentVersion}) is more than one major version behind the target release (v${versions.storybook}).
+      Please upgrade one major version at a time.`;
+
+    if (coercedVersion) {
+      const currentMajor = major(coercedVersion);
+      const nextMajor = currentMajor + 1;
+      const cmd = `npx storybook@${nextMajor} upgrade`;
+      return dedent`
+        ${message}
+
+        You can upgrade to version ${nextMajor} by running:
+        ${picocolors.cyan(cmd)}
+
+        For more information about upgrading, visit:
+        ${picocolors.cyan('https://storybook.js.org/docs/react/configure/upgrading')}`;
+    }
+
+    return dedent`
+      ${message}
+
+      For more information about upgrading, visit:
+      ${picocolors.cyan('https://storybook.js.org/docs/react/configure/upgrading')}`;
+  },
+});

--- a/code/lib/cli-storybook/src/autoblock/block-major-version.ts
+++ b/code/lib/cli-storybook/src/autoblock/block-major-version.ts
@@ -51,8 +51,8 @@ export const blocker = createBlocker<MajorVersionData>({
   id: 'major-version-gap',
   async check(options) {
     const { packageManager } = options;
-    const packageJson = await packageManager.retrievePackageJson();
 
+    const packageJson = await packageManager.retrievePackageJson();
     try {
       const current = getStorybookVersionSpecifier(packageJson);
       if (!current) {

--- a/code/lib/cli-storybook/src/autoblock/index.ts
+++ b/code/lib/cli-storybook/src/autoblock/index.ts
@@ -12,6 +12,7 @@ const blockers: () => BlockerModule<any>[] = () => [
   import('./block-storystorev6'),
   import('./block-dependencies-versions'),
   import('./block-node-version'),
+  import('./block-major-version'),
 ];
 
 type BlockerModule<T> = Promise<{ blocker: Blocker<T> }>;


### PR DESCRIPTION
## What I did

This commit introduces a new blocker mechanism to prevent users from skipping major version upgrades in Storybook. The implementation includes:

- A new module to check and block upgrades with large major version gaps
- Comprehensive test coverage for version comparison logic
- Integration with existing autoblock system

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

This is going to be rather hard to manual QA, honestly I could use some tips.

This upgrade blocker is explicitly skipped when upgrading from and to canary releases and release-candidates.
So it can ONLY be tested with latest releases; and it will only block the upgrade if the major version difference is more than 1.

I added unit tests to ensure that comparison code is okay, and I left plenty of error handling code, so that the most common failure is to allow the upgrade.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.7 MB | 79.7 MB | 0 B | **1.66** | 0% |
| initSize |  79.7 MB | 79.7 MB | 0 B | **1.66** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.3 MB | 7.3 MB | 0 B | -0.47 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.44 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | -0.89 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | -1.15 | 0% |
| buildPreviewSize |  3.33 MB | 3.33 MB | 0 B | 0.07 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.6s | 7.1s | -495ms | -0.98 | -6.9% |
| generateTime |  20.2s | 19.3s | -953ms | -0.31 | -4.9% |
| initTime |  5.1s | 4.6s | -476ms | -0.27 | -10.3% |
| buildTime |  8.6s | 9.4s | 756ms | -0.22 | 8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.8s | 5.6s | 870ms | 0.51 | 15.3% |
| devManagerResponsive |  4.6s | 5.3s | 763ms | 0.46 | 14.1% |
| devManagerHeaderVisible |  748ms | 782ms | 34ms | -0.35 | 4.3% |
| devManagerIndexVisible |  760ms | 795ms | 35ms | -0.5 | 4.4% |
| devStoryVisibleUncached |  1.9s | 2s | 108ms | 0.48 | 5.4% |
| devStoryVisible |  780ms | 862ms | 82ms | -0.33 | 9.5% |
| devAutodocsVisible |  692ms | 774ms | 82ms | -0.05 | 10.6% |
| devMDXVisible |  702ms | 825ms | 123ms | 0.4 | 14.9% |
| buildManagerHeaderVisible |  646ms | 922ms | 276ms | **1.51** | 🔺29.9% |
| buildManagerIndexVisible |  674ms | 1s | 343ms | **1.82** | 🔺33.7% |
| buildStoryVisible |  614ms | 859ms | 245ms | **1.32** | 🔺28.5% |
| buildAutodocsVisible |  686ms | 584ms | -102ms | -0.64 | -17.5% |
| buildMDXVisible |  526ms | 582ms | 56ms | -0.28 | 9.6% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR adds a major version upgrade blocker to prevent users from skipping versions (e.g., v6 to v8), ensuring smoother migration paths between Storybook releases.

- Added `code/lib/cli-storybook/src/autoblock/block-major-version.ts` implementing version gap detection with special handling for prereleases and canary versions
- Added comprehensive test suite in `block-major-version.test.ts` covering various version scenarios and edge cases
- Modified `code/lib/cli-storybook/src/autoblock/index.ts` to integrate the new blocker into the existing autoblock system
- Implemented fail-safe error handling to allow upgrades when version detection fails
- Included helpful error messages with upgrade instructions when blocking occurs



<!-- /greptile_comment -->