### PR TITLE
CSF Factories: Align addon-essentials import with other addons

### DIFF
--- a/code/.storybook/preview.tsx
+++ b/code/.storybook/preview.tsx
@@ -25,7 +25,7 @@ import addonTest from '@storybook/experimental-addon-test';
 import { definePreview } from '@storybook/react-vite';
 
 import addonA11y from '@storybook/addon-a11y';
-import * as addonEssentials from '@storybook/addon-essentials/entry-preview';
+import addonEssentials from '@storybook/addon-essentials';
 import addonThemes from '@storybook/addon-themes';
 
 import * as addonsPreview from '../addons/toolbars/template/stories/preview';
@@ -372,7 +372,7 @@ const parameters = {
 export default definePreview({
   addons: [
     addonThemes(),
-    addonEssentials,
+    addonEssentials(),
     addonA11y(),
     addonTest(),
     addonsPreview,

--- a/code/core/src/common/utils/get-addon-annotations.ts
+++ b/code/core/src/common/utils/get-addon-annotations.ts
@@ -33,7 +33,6 @@ export async function getAddonAnnotations(addon: string) {
     };
 
     if (addon === '@storybook/addon-essentials') {
-      data.importPath = '@storybook/addon-essentials/entry-preview';
       return data;
     } else if (!data.isCoreAddon) {
       // for backwards compatibility, if it's not a core addon we use /preview entrypoint

--- a/code/core/src/common/utils/sync-main-preview-addons.ts
+++ b/code/core/src/common/utils/sync-main-preview-addons.ts
@@ -43,7 +43,7 @@ export async function getSyncedStorybookAddons(
    * This goes through all mainConfig.addons, read their package.json and check whether they have an
    * exports map called preview, if so add to the array
    */
-  await addons.forEach(async (addon) => {
+  for (const addon of addons) {
     const annotations = await getAddonAnnotations(addon);
     if (annotations) {
       const hasAlreadyImportedAddonAnnotations = previewConfig._ast.program.body.find(
@@ -51,7 +51,7 @@ export async function getSyncedStorybookAddons(
       );
 
       if (!!hasAlreadyImportedAddonAnnotations) {
-        return;
+        continue;
       }
 
       if (
@@ -63,7 +63,7 @@ export async function getSyncedStorybookAddons(
       ) {
         syncedAddons.push(addon);
         // addon-essentials is a special use case that won't have /preview entrypoint but rather /entry-preview
-        if (annotations.isCoreAddon && addon !== '@storybook/addon-essentials') {
+        if (annotations.isCoreAddon) {
           // import addonName from 'addon'; + addonName()
           previewConfig.setImport(annotations.importName, annotations.importPath);
           previewConfig.appendNodeToArray(
@@ -77,7 +77,7 @@ export async function getSyncedStorybookAddons(
         }
       }
     }
-  });
+  }
 
   if (syncedAddons.length > 0) {
     logger.info(

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -114,9 +114,11 @@ export async function buildDevStandalone(
     console.warn('Storybook failed to check addon compatibility', e);
   }
 
-  try {
-    await syncStorybookAddons(config, previewConfigPath!);
-  } catch (e) {}
+  // TODO: Bring back in 9.x when we officialy launch CSF4
+  // We need to consider more scenarios in this function, such as removing addons from main.ts
+  // try {
+  //   await syncStorybookAddons(config, previewConfigPath!);
+  // } catch (e) {}
 
   try {
     await warnWhenUsingArgTypesRegex(previewConfigPath, config);


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.7 MB | 79.7 MB | 0 B | 0.42 | 0% |
| initSize |  79.7 MB | 79.7 MB | 0 B | 0.42 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.3 MB | 7.31 MB | 7.03 kB | 0.46 | 0.1% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.44 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.89 MB | 6.48 kB | 0.01 | 0.3% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.98 MB | 6.48 kB | 0.71 | 0.2% |
| buildPreviewSize |  3.33 MB | 3.33 MB | 552 B | 0.25 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.9s | 7s | 74ms | -1 | 1.1% |
| generateTime |  17.8s | 18.4s | 578ms | -0.79 | 3.1% |
| initTime |  4.1s | 4.2s | 130ms | -0.94 | 3.1% |
| buildTime |  8.1s | 8.6s | 563ms | -0.86 | 6.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.6s | 4.9s | -666ms | -0.86 | -13.5% |
| devManagerResponsive |  5.3s | 4.7s | -594ms | -0.84 | -12.5% |
| devManagerHeaderVisible |  837ms | 663ms | -174ms | -1.22 | -26.2% |
| devManagerIndexVisible |  914ms | 728ms | -186ms | -0.97 | -25.5% |
| devStoryVisibleUncached |  2.1s | 1.7s | -354ms | -0.21 | -19.7% |
| devStoryVisible |  941ms | 747ms | -194ms | -1.16 | -26% |
| devAutodocsVisible |  885ms | 717ms | -168ms | -0.57 | -23.4% |
| devMDXVisible |  856ms | 697ms | -159ms | -0.74 | -22.8% |
| buildManagerHeaderVisible |  876ms | 756ms | -120ms | 0.08 | -15.9% |
| buildManagerIndexVisible |  884ms | 772ms | -112ms | -0.12 | -14.5% |
| buildStoryVisible |  852ms | 721ms | -131ms | 0.06 | -18.2% |
| buildAutodocsVisible |  606ms | 585ms | -21ms | -0.55 | -3.6% |
| buildMDXVisible |  787ms | 484ms | -303ms | **-1.24** | 🔰-62.6% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR aligns the import structure of addon-essentials with other addons in CSF4, removing special case handling to make the codebase more consistent.

- Removed special import path override for '@storybook/addon-essentials' in `code/core/src/common/utils/get-addon-annotations.ts`
- Replaced forEach with for...of loop in `code/core/src/common/utils/sync-main-preview-addons.ts` to properly handle async operations
- Changed `return` to `continue` inside the loop for correct iteration skipping behavior
- Removed conditional check `&& addon !== '@storybook/addon-essentials'` to treat addon-essentials like other core addons



<!-- /greptile_comment -->