### PR TITLE
Build: Make `nr build storybook` work again

### DIFF
--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -19,9 +19,6 @@ async function run() {
       if (pkg.name === '@storybook/cli') {
         suffix = 'sb-cli';
       }
-      if (pkg.name === 'storybook') {
-        suffix = 'cli';
-      }
       return {
         ...pkg,
         suffix,


### PR DESCRIPTION
## What I did

This pull request includes a small change to the `scripts/build-package.ts` file. The change removes an unnecessary conditional block that assigns a suffix to the `storybook` package. 

Changes in `async function run()`:

* Removed the conditional block that sets the suffix to 'cli' for the `storybook` package.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

running `nr build storybook` should work.

`nr build core` no longer works. FYI

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.7 MB | 79.7 MB | 0 B | **1.49** | 0% |
| initSize |  79.7 MB | 79.7 MB | 0 B | **1.49** | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.3 MB | 7.3 MB | 0 B | -0.58 | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 0 B | 0.43 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | -0.91 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 0 B | -1.22 | 0% |
| buildPreviewSize |  3.33 MB | 3.33 MB | 0 B | -0.03 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  7.5s | 7s | -488ms | -1 | -6.9% |
| generateTime |  19.6s | 18.4s | -1s -248ms | -0.87 | -6.8% |
| initTime |  4.6s | 4.5s | -49ms | -0.44 | -1.1% |
| buildTime |  9.4s | 10.5s | 1s | 0.67 | 10.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.8s | 4.7s | -110ms | -1 | -2.3% |
| devManagerResponsive |  4.6s | 4.6s | -22ms | -0.94 | -0.5% |
| devManagerHeaderVisible |  662ms | 706ms | 44ms | -0.78 | 6.2% |
| devManagerIndexVisible |  724ms | 716ms | -8ms | -0.94 | -1.1% |
| devStoryVisibleUncached |  1.7s | 1.8s | 76ms | -0.21 | 4.2% |
| devStoryVisible |  752ms | 734ms | -18ms | -1.13 | -2.5% |
| devAutodocsVisible |  701ms | 647ms | -54ms | -1.08 | -8.3% |
| devMDXVisible |  804ms | 740ms | -64ms | -0.29 | -8.6% |
| buildManagerHeaderVisible |  641ms | 635ms | -6ms | -0.86 | -0.9% |
| buildManagerIndexVisible |  654ms | 713ms | 59ms | -0.45 | 8.3% |
| buildStoryVisible |  608ms | 616ms | 8ms | -0.77 | 1.3% |
| buildAutodocsVisible |  533ms | 559ms | 26ms | -0.82 | 4.7% |
| buildMDXVisible |  477ms | 508ms | 31ms | -0.87 | 6.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR fixes the `nr build storybook` command by removing special case handling in the build script.

- Removed conditional block in `scripts/build-package.ts` that was incorrectly setting the suffix to 'cli' for the '@storybook/storybook' package
- This change allows the build script to use the default suffix derivation logic, resulting in 'storybook' instead of 'cli'
- The fix enables developers to use the command `yarn build storybook` or `nr build storybook` to build the storybook package directly



<!-- /greptile_comment -->