### PR TITLE
Build: Pin typescript to avoid version conflicts with eslint-typescript

### DIFF
--- a/scripts/utils/yarn.ts
+++ b/scripts/utils/yarn.ts
@@ -94,7 +94,7 @@ export const addWorkaroundResolutions = async ({
     '@testing-library/dom': '^9.3.4',
     '@testing-library/jest-dom': '^6.5.0',
     '@testing-library/user-event': '^14.5.2',
-    typescript: '^5.7.3',
+    typescript: '~5.7.3',
   };
 
   await writeJSON(packageJsonPath, packageJson, { spaces: 2 });


### PR DESCRIPTION
Closes N/A

## What I did

Try to fix this CI error:

![image](https://github.com/user-attachments/assets/e2f80e2d-db82-4d5d-ba49-6bc3656b21bd)

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.8 MB | 79.9 MB | 69.8 kB | **7.31** | 0.1% |
| initSize |  79.8 MB | 79.9 MB | 69.8 kB | **7.31** | 0.1% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.45 MB | 7.45 MB | 32 B | **4.29** | 0% |
| buildSbAddonsSize |  1.9 MB | 1.9 MB | 32 B | 0.44 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | -0.96 | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.97 MB | 3.97 MB | 32 B | **-1.4** | 0% |
| buildPreviewSize |  3.47 MB | 3.47 MB | 0 B | **4.33** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  18.9s | 24.7s | 5.8s | **1.41** | 🔺23.7% |
| generateTime |  19.8s | 20.1s | 278ms | 0 | 1.4% |
| initTime |  4.4s | 4.5s | 148ms | -0.41 | 3.2% |
| buildTime |  9.8s | 8.8s | -981ms | -0.83 | -11.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.7s | 5.1s | 348ms | -0.16 | 6.8% |
| devManagerResponsive |  4.5s | 4.8s | 290ms | -0.22 | 6% |
| devManagerHeaderVisible |  722ms | 744ms | 22ms | -0.39 | 3% |
| devManagerIndexVisible |  800ms | 750ms | -50ms | -0.59 | -6.7% |
| devStoryVisibleUncached |  2.4s | 2.8s | 426ms | **3.27** | 🔺14.9% |
| devStoryVisible |  1.1s | 1.1s | 33ms | **1.73** | 2.9% |
| devAutodocsVisible |  1s | 1.1s | 48ms | **2.72** | 4.2% |
| devMDXVisible |  1.1s | 1.1s | -7ms | **2.61** | -0.6% |
| buildManagerHeaderVisible |  754ms | 844ms | 90ms | 1.13 | 10.7% |
| buildManagerIndexVisible |  761ms | 861ms | 100ms | 0.89 | 11.6% |
| buildStoryVisible |  746ms | 834ms | 88ms | **1.35** | 🔺10.6% |
| buildAutodocsVisible |  682ms | 769ms | 87ms | **1.48** | 🔺11.3% |
| buildMDXVisible |  649ms | 754ms | 105ms | **1.93** | 🔺13.9% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR pins the TypeScript version more strictly to resolve CI errors related to version conflicts with eslint-typescript.

- Changed TypeScript version specification in `scripts/utils/yarn.ts` from `^5.7.3` to `~5.7.3`
- Restricts TypeScript updates to patch versions only (5.7.x) rather than allowing minor version updates
- Prevents potential compatibility issues between TypeScript and eslint-typescript in CI builds
- Implements a more conservative dependency management approach for better stability

Greptile AI: This PR pins the TypeScript version more strictly to resolve CI errors related to version conflicts with eslint-typescript.

- Changed TypeScript version specification in `scripts/utils/yarn.ts` from `^5.7.3` to `~5.7.3`
- Restricts TypeScript updates to patch versions only (5.7.x) rather than allowing minor version updates
- Prevents potential compatibility issues between TypeScript and eslint-typescript in CI builds
- Implements a more conservative dependency management approach for better stability



<!-- /greptile_comment -->