### PR TITLE
CLI: Fix test install in RNW projects

### DIFF
--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -224,6 +224,7 @@ export async function baseGenerator(
       ProjectType.SVELTE,
       ProjectType.SVELTEKIT,
       ProjectType.WEB_COMPONENTS,
+      ProjectType.REACT_NATIVE_WEB,
     ];
     const supportsTestAddon =
       projectType === ProjectType.NEXTJS ||


### PR DESCRIPTION
Closes N/A

## What I did

Currently the CLI does not install testing functionality in RNW projects. This fixes it.

## Checklist for Contributors

### Testing

#### Manual testing

```
pnpm create expo empty-expo
cd empty-expo
pnpm create storybook 
```
1. Select all the features (default selection)
2. Select RNW

This will skep testing in `storybook@latest` but will install it in this updated version.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added React Native Web (RNW) to the list of supported frameworks for test addon installation in the Storybook CLI, enabling test functionality to be included during initialization of RNW projects.

- Added `ProjectType.REACT_NATIVE_WEB` to `supportedFrameworks` array in `code/lib/create-storybook/src/generators/baseGenerator.ts`
- Ensures test addon is installed when initializing Storybook in RNW projects
- Fixes current behavior where testing functionality was being skipped for RNW



<!-- /greptile_comment -->