### PR TITLE
Angular: Add `@angular-devkit/build-angular` to installed packages

### DIFF
--- a/code/core/src/common/js-package-manager/JsPackageManager.test.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.test.ts
@@ -43,12 +43,12 @@ describe('JsPackageManager', () => {
       expect(result).toEqual(['@storybook/react@8.3.0']);
     });
 
-    it('should return the latest stable release version when there is no current version', async () => {
+    it('should get the requested version when the package is not in the monorepo', async () => {
       mockLatestVersion.mockResolvedValue('2.0.0');
 
-      const result = await jsPackageManager.getVersionedPackages(['@storybook/new-addon@^8.3.0']);
+      const result = await jsPackageManager.getVersionedPackages(['@storybook/new-addon@^next']);
 
-      expect(result).toEqual(['@storybook/new-addon@^2.0.0']);
+      expect(result).toEqual(['@storybook/new-addon@^next']);
     });
   });
 });

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -333,6 +333,13 @@ export abstract class JsPackageManager {
     return Promise.all(
       packages.map(async (pkg) => {
         const [packageName, packageVersion] = getPackageDetails(pkg);
+
+        // If the packageVersion is specified and we are not dealing with a storybook package,
+        // just return the requested version.
+        if (packageVersion && !(packageName in storybookPackagesVersions)) {
+          return pkg;
+        }
+
         const latestInRange = await this.latestVersion(packageName, packageVersion);
 
         const k = packageName as keyof typeof storybookPackagesVersions;

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -499,6 +499,9 @@ export const baseTemplates = {
       renderer: '@storybook/angular',
       builder: '@storybook/builder-webpack5',
     },
+    modifications: {
+      extraDependencies: ['@angular-devkit/build-angular@next'],
+    },
     skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
   },
   'angular-cli/default-ts': {

--- a/code/lib/create-storybook/src/generators/ANGULAR/index.ts
+++ b/code/lib/create-storybook/src/generators/ANGULAR/index.ts
@@ -73,7 +73,10 @@ const generator: Generator<{ projectName: string }> = async (
     'angular',
     {
       extraAddons: [`@storybook/addon-onboarding`],
-      ...(useCompodoc && { extraPackages: ['@compodoc/compodoc', '@storybook/addon-docs'] }),
+      extraPackages: [
+        '@angular-devkit/build-angular',
+        ...(useCompodoc ? ['@compodoc/compodoc', '@storybook/addon-docs'] : []),
+      ],
       addScripts: false,
       componentsDestinationPath: root ? `${root}/src/stories` : undefined,
       storybookConfigFolder: storybookFolder,

--- a/code/nx.json
+++ b/code/nx.json
@@ -1,7 +1,6 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "extends": "nx/presets/npm.json",
-  "nxCloudAccessToken": "NGVmYTkxMmItYzY3OS00MjkxLTk1ZDktZDFmYTFmNmVlNGY4fHJlYWQ=",
   "defaultBase": "next",
   "useLegacyCache": true,
   "parallel": 8,

--- a/code/nx.json
+++ b/code/nx.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "extends": "nx/presets/npm.json",
+  "nxCloudAccessToken": "NGVmYTkxMmItYzY3OS00MjkxLTk1ZDktZDFmYTFmNmVlNGY4fHJlYWQ=",
   "defaultBase": "next",
   "useLegacyCache": true,
   "parallel": 8,


### PR DESCRIPTION
## What I did

Add @angular-devkit/build-angular to default installed pacakages in angular. As it is not installed by default anymore by angular.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added '@angular-devkit/build-angular' as a default package in the Angular generator for Storybook since it's no longer included by default in Angular installations.

- Added `@angular-devkit/build-angular` to default packages in `code/lib/create-storybook/src/generators/ANGULAR/index.ts`
- Maintains backward compatibility with existing Compodoc package handling
- No breaking changes introduced



<!-- /greptile_comment -->