### PR TITLE
Fix storybook mock example

### DIFF
--- a/docs/_snippets/storybook-test-mock-file-example.md
+++ b/docs/_snippets/storybook-test-mock-file-example.md
@@ -1,7 +1,7 @@
 ```ts filename="lib/session.mock.ts" renderer="common" language="ts"
-import { fn } from 'storybook/test';
+import { fn, Mock } from 'storybook/test';
 import * as actual from './session';
 
 export * from './session';
-export const getUserFromSession = fn(actual.getUserFromSession).mockName('getUserFromSession');
+export const getUserFromSession: Mock<typeof actual.getUserFromSession> = fn(actual.getUserFromSession).mockName('getUserFromSession');
 ```


### PR DESCRIPTION
Make example not error out with type cannot be inferred and a type annotation is necessary. This isnt complete everywhere, but at least its in one location

## What I did

Fixed an error I got when using the example verbatim

![image](https://github.com/user-attachments/assets/ffcbecbb-94f9-4f81-abe3-e88b5a3e821a)
![image](https://github.com/user-attachments/assets/22c86621-8a66-4f47-b7bd-a767185400c8)



<!-- greptile_comment -->

## Greptile Summary

Fixed type inference issue in Storybook test mock example by adding explicit type annotations and importing the Mock type, preventing TypeScript errors when users copy the example code.

- Added `Mock` type import from `storybook/test` in `docs/_snippets/storybook-test-mock-file-example.md`
- Added explicit type annotation `Mock<typeof actual.getUserFromSession>` to fix type inference errors
- Improved developer experience by ensuring example code works without modification



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->