### PR TITLE
Angular: Make sure that polyfills are loaded before the storybook is loaded

### DIFF
--- a/code/frameworks/angular/src/server/angular-cli-webpack.js
+++ b/code/frameworks/angular/src/server/angular-cli-webpack.js
@@ -87,9 +87,9 @@ exports.getWebpackConfig = async (baseConfig, { builderOptions, builderContext }
 
   /** Merge baseConfig Webpack with angular-cli Webpack */
   const entry = [
+    ...(cliConfig.entry.polyfills ?? []),
     ...baseConfig.entry,
     ...(cliConfig.entry.styles ?? []),
-    ...(cliConfig.entry.polyfills ?? []),
   ];
 
   // Don't use storybooks styling rules because we have to use rules created by @angular-devkit/build-angular


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR removed the default zone.js polyfill because it was loaded twice:
https://github.com/storybookjs/storybook/pull/28657

However, the polyfills were loaded after the storybook preview entry is loaded, causing regressions.
For example, the XHR mock of `storybook-addon-mock` would execute with errors, because of a missing method:

```
ERROR TypeError: Illegal invocation
    at sr.ue [as scheduleFn] (68141.ddd3846e.iframe.bundle.js:1684:28318)
    at ir.scheduleTask (68141.ddd3846e.iframe.bundle.js:1684:7320)
    at Object.onScheduleTask (68141.ddd3846e.iframe.bundle.js:1684:4321)
    at ir.scheduleTask (68141.ddd3846e.iframe.bundle.js:1684:7211)
    at zt.scheduleTask (68141.ddd3846e.iframe.bundle.js:1684:3175)
    at zt.scheduleMacroTask (68141.ddd3846e.iframe.bundle.js:1684:3516)
    at L (68141.ddd3846e.iframe.bundle.js:1684:11263)
    at 68141.ddd3846e.iframe.bundle.js:1684:28819
    at Yt.zt.<computed> (68141.ddd3846e.iframe.bundle.js:1684:14770)
    at R._subscribe (68141.ddd3846e.iframe.bundle.js:34:25400)
```

Changing the order, fixes this.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
