### PR TITLE
React-Native: Update config directory to .rnstorybook

### DIFF
--- a/code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts
+++ b/code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts
@@ -23,9 +23,9 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
 
   const packagesToResolve = [
     ...peerDependencies,
-    '@storybook/addon-ondevice-controls',
-    '@storybook/addon-ondevice-actions',
-    '@storybook/react-native',
+    '@storybook/addon-ondevice-controls@next',
+    '@storybook/addon-ondevice-actions@next',
+    '@storybook/react-native@next',
   ];
 
   const packagesWithFixedVersion: string[] = [];

--- a/code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts
+++ b/code/lib/create-storybook/src/generators/REACT_NATIVE/index.ts
@@ -52,7 +52,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
     'storybook-generate': 'sb-rn-get-stories',
   });
 
-  const storybookConfigFolder = '.storybook';
+  const storybookConfigFolder = '.rnstorybook';
 
   await copyTemplateFiles({
     packageManager: packageManager as any,

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -499,7 +499,7 @@ export async function doInitiate(options: CommandOptions): Promise<
 
       1. Replace the contents of your app entry with the following
 
-      ${picocolors.inverse(' ' + "export {default} from './.storybook';" + ' ')}
+      ${picocolors.inverse(' ' + "export {default} from './.rnstorybook';" + ' ')}
 
       2. Wrap your metro config with the withStorybook enhancer function like this:
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

As part of v9 react native will use a different config directory name to simplify running  react-native and the react-native-web-vite storybook framework along side each other

This pr updates the package name to get things started on the v9 alpha

also updates to use the @next version whilst we are in alpha

this follows the work done so far to get react native working with the alpha https://github.com/storybookjs/react-native/pull/698

(note that right now only alpha.3 is working and not alpha.4)

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30819-sha-ee05e620`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30819-sha-ee05e620 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30819-sha-ee05e620 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30819-sha-ee05e620`](https://npmjs.com/package/storybook/v/0.0.0-pr-30819-sha-ee05e620) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`dannyhw/feat-rnstorybook-folder`](https://github.com/storybookjs/storybook/tree/dannyhw/feat-rnstorybook-folder) |
| **Commit** | [`ee05e620`](https://github.com/storybookjs/storybook/commit/ee05e620eff331b5b3fb3186bd7b51586e5175c0) |
| **Datetime** | Sun Mar 16 15:27:39 UTC 2025 (`1742138859`) |
| **Workflow run** | [13884826940](https://github.com/storybookjs/storybook/actions/runs/13884826940) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30819`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
