### PR TITLE
Revert "CSF: Fix CSF subcomponent type"

### DIFF
--- a/code/core/src/csf/story.ts
+++ b/code/core/src/csf/story.ts
@@ -186,7 +186,7 @@ export interface Renderer {
   // component: (args: this['T']) => string;
   // This generic type will eventually be filled in with TArgs
   // Credits to Michael Arnaldi.
-  T?: any;
+  T?: unknown;
 }
 
 /** @deprecated - Use `Renderer` */


### PR DESCRIPTION
Reverts storybookjs/storybook#30729

CI is erroring for the check command. This PR broke many tests.

<!-- greptile_comment -->

## Greptile Summary

This PR reverts a type parameter change in the Renderer interface from 'unknown' back to 'any' to restore proper functionality for dot-notation subcomponents in Storybook's Component Story Format.

- Reverts change in `code/core/src/csf/story.ts` to fix type errors with subcomponents
- Restores ability to properly assign components with specific props to subcomponents in meta objects
- Prioritizes component functionality over strict type safety for subcomponent use cases
- Enables proper documentation of dot-notation components with their props



<!-- /greptile_comment -->