### PR TITLE
React: Allow portable stories to be used in SSR

### DIFF
--- a/code/renderers/react/src/act-compat.ts
+++ b/code/renderers/react/src/act-compat.ts
@@ -2,8 +2,6 @@
 // https://github.com/testing-library/react-testing-library/blob/3dcd8a9649e25054c0e650d95fca2317b7008576/src/act-compat.js
 import * as React from 'react';
 
-import * as DeprecatedReactTestUtils from 'react-dom/test-utils';
-
 declare const globalThis: {
   IS_REACT_ACT_ENVIRONMENT: boolean;
 };

--- a/code/renderers/react/src/entry-preview.tsx
+++ b/code/renderers/react/src/entry-preview.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import semver from 'semver';
 
-import { act, getReactActEnvironment, setReactActEnvironment } from './act-compat';
+import { getAct, getReactActEnvironment, setReactActEnvironment } from './act-compat';
 import type { Decorator } from './public-types';
 
 export const parameters = { renderer: 'react' };
@@ -31,6 +31,8 @@ export const beforeAll = async () => {
     // copied from
     // https://github.com/testing-library/react-testing-library/blob/3dcd8a9649e25054c0e650d95fca2317b7008576/src/pure.js
     const { configure } = await import('storybook/test');
+
+    const act = await getAct();
 
     configure({
       unstable_advanceTimersWrapper: (cb) => {

--- a/code/renderers/react/src/renderToCanvas.tsx
+++ b/code/renderers/react/src/renderToCanvas.tsx
@@ -5,7 +5,7 @@ import type { RenderContext } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
 
-import { act } from './act-compat';
+import { getAct } from './act-compat';
 import type { ReactRenderer, StoryContext } from './types';
 
 const { FRAMEWORK_OPTIONS } = global;
@@ -98,6 +98,7 @@ export async function renderToCanvas(
     unmountElement(canvasElement);
   }
 
+  const act = await getAct();
   await new Promise<void>(async (resolve, reject) => {
     actQueue.push(async () => {
       try {


### PR DESCRIPTION
Closes #30245

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30847-sha-82dc8610`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30847-sha-82dc8610 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30847-sha-82dc8610 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30847-sha-82dc8610`](https://npmjs.com/package/storybook/v/0.0.0-pr-30847-sha-82dc8610) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/ssr-portable-stories`](https://github.com/storybookjs/storybook/tree/kasper/ssr-portable-stories) |
| **Commit** | [`82dc8610`](https://github.com/storybookjs/storybook/commit/82dc86105c01d42df8a5f1dc5e33d6a3f9158ad0) |
| **Datetime** | Wed Mar 19 09:35:30 UTC 2025 (`1742376930`) |
| **Workflow run** | [13943280928](https://github.com/storybookjs/storybook/actions/runs/13943280928) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30847`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a summary of the key changes in this PR focused on enabling SSR for portable stories in the React renderer:

Implements server-side rendering (SSR) support for portable stories in the React renderer through dynamic act function loading and rendering optimizations.

- Modified `act-compat.ts` to lazy-load React's act function via new async `getAct` function instead of synchronous initialization
- Updated `renderToCanvas.tsx` to conditionally skip ErrorBoundary wrapper for portable stories and implement act operation queue system
- Adjusted `entry-preview.tsx` to use async `getAct` in beforeAll configuration while maintaining RSC compatibility
- Added isPortableStory flag to control rendering behavior and optimize SSR performance
- Implemented queue system to properly sequence act operations during server-side rendering

The changes focus on making the React renderer SSR-compatible while preserving existing functionality for React Server Components and test infrastructure. The implementation uses dynamic imports and conditional rendering to optimize the SSR experience for portable stories.



<!-- /greptile_comment -->