### PR TITLE
fix (Svelte): adjust type

### DIFF
--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -5,7 +5,7 @@ import { satisfies } from 'storybook/internal/common';
 import type { Canvas, ComponentAnnotations, StoryAnnotations } from 'storybook/internal/types';
 
 import { expectTypeOf } from 'expect-type';
-import type { Component, ComponentProps, SvelteComponent } from 'svelte';
+import { SvelteComponent, type Component, type ComponentProps } from 'svelte';
 
 import Button from './__test__/Button.svelte';
 import ButtonV5 from './__test__/ButtonV5.svelte';
@@ -100,6 +100,28 @@ describe('Meta', () => {
 
 describe('StoryObj', () => {
   it('✅ Required args may be provided partial in meta and the story', () => {
+    const meta = satisfies<Meta<Button>>()({
+      component: Button,
+      args: { label: 'good' },
+    });
+
+    type Actual = StoryObj<typeof meta>;
+    type Expected = SvelteStory<
+      Button,
+      { disabled: boolean; label: string },
+      { disabled: boolean; label?: string }
+    >;
+    expectTypeOf<Actual>().toMatchTypeOf<Expected>();
+  });
+
+  it('✅ Required args may be provided partial in meta and the story (Svelte 4, non-isomorphic type)', () => {
+    // The imported Svelte component in Svelte 5 has an isomorphic type (both function and class).
+    // In order to test how it would look like for real Svelte 4 components, we need to create the class type manually.
+    class Button extends SvelteComponent<{
+      disabled: boolean;
+      label: string;
+    }> {}
+
     const meta = satisfies<Meta<Button>>()({
       component: Button,
       args: { label: 'good' },

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -1,11 +1,17 @@
+/* eslint-disable @typescript-eslint/no-shadow */
 // this file tests Typescript types that's why there are no assertions
 import { describe, it } from 'vitest';
 
 import { satisfies } from 'storybook/internal/common';
-import type { Canvas, ComponentAnnotations, StoryAnnotations } from 'storybook/internal/types';
+import type {
+  Args,
+  Canvas,
+  ComponentAnnotations,
+  StoryAnnotations,
+} from 'storybook/internal/types';
 
 import { expectTypeOf } from 'expect-type';
-import { SvelteComponent, type Component, type ComponentProps } from 'svelte';
+import { type Component, type ComponentProps, SvelteComponent } from 'svelte';
 
 import Button from './__test__/Button.svelte';
 import ButtonV5 from './__test__/ButtonV5.svelte';
@@ -314,4 +320,16 @@ it('mount accepts a Svelte 5 Component and props', () => {
     },
   };
   expectTypeOf(Basic).toMatchTypeOf<StoryObj<typeof ButtonV5>>();
+});
+
+it('StoryObj can accept args directly', () => {
+  const Story: StoryObj<Args> = {
+    args: {},
+  };
+
+  const Story2: StoryObj<{ args: { prop: boolean } }> = {
+    args: {
+      prop: true,
+    },
+  };
 });

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -48,7 +48,7 @@ export type StoryFn<TCmpOrArgs = Args> = TCmpOrArgs extends
  */
 export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
   render?: ArgsStoryFn<SvelteRenderer, any>;
-  component?: infer Comp extends ComponentType | Svelte5ComponentType;
+  component?: infer Comp; // We cannot use "extends ComponentType | Svelte5ComponentType" here, because TypeScript for some reason then refuses to ever enter the true branch
   args?: infer DefaultArgs;
 }
   ? Simplify<

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -48,7 +48,7 @@ export type StoryFn<TCmpOrArgs = Args> = TCmpOrArgs extends
  */
 export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
   render?: ArgsStoryFn<SvelteRenderer, any>;
-  component?: infer Comp extends SvelteComponent | Svelte5ComponentType;
+  component?: infer Comp extends ComponentType | Svelte5ComponentType;
   args?: infer DefaultArgs;
 }
   ? Simplify<


### PR DESCRIPTION
follow-up to #30812 which came in through https://github.com/storybookjs/storybook/pull/30812/commits/8dc2d4ea22ee6f4ccd7860e99f684bb6b99368bb

For some TypeScript-heuristic-fails-here-reason we cannot narrow the type in that position. I added a comment and a regression test.

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

fixed a type bug in the other PR

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This pull request makes targeted adjustments to Svelte renderer types to fix a TypeScript inference issue. Here's a concise summary:

Updates Svelte renderer types to fix a TypeScript inference limitation when handling component types in the StoryObj definition, with improved test coverage for both Svelte 4 and 5 components.

- Removed type constraint in `StoryObj` that was causing TypeScript inference issues
- Added test case for Svelte 4 non-isomorphic component types
- Added explanatory comment about TypeScript limitation in `public-types.ts`
- Maintains backward compatibility while supporting both class and function components

The changes are focused on fixing a specific type inference edge case while ensuring proper typing works for both traditional Svelte components and Svelte 5's function components.



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->