### PR TITLE
Svelte: Adjust Svelte typings to include Svelte 5 function components

### DIFF
--- a/code/renderers/svelte/src/__test__/ButtonV5.svelte
+++ b/code/renderers/svelte/src/__test__/ButtonV5.svelte
@@ -2,7 +2,7 @@
   interface Props {
     disabled: boolean;
     label: string;
-    clicked?: (e: MouseEvent) => void
+    clicked?: (e: MouseEvent) => void;
   }
 
   // When a Svelte 5 component only uses runes, it is typed as a function component.

--- a/code/renderers/svelte/src/__test__/ButtonV5.svelte
+++ b/code/renderers/svelte/src/__test__/ButtonV5.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  interface Props {
+    disabled: boolean;
+    label: string;
+    clicked?: (e: MouseEvent) => void
+  }
+
+  // When a Svelte 5 component only uses runes, it is typed as a function component.
+  // Others are typed as class components. Hence we need to have tests for both shapes.
+  let { disabled, label, clicked}: Props = $props();
+</script>
+
+<button onclick={clicked} {disabled}>
+  {label}
+</button>

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -5,7 +5,7 @@ import { satisfies } from 'storybook/internal/common';
 import type { Canvas, ComponentAnnotations, StoryAnnotations } from 'storybook/internal/types';
 
 import { expectTypeOf } from 'expect-type';
-import type { Component, ComponentProps, SvelteComponent } from 'svelte';
+import { SvelteComponent, type Component, type ComponentProps } from 'svelte';
 
 import Button from './__test__/Button.svelte';
 import ButtonV5 from './__test__/ButtonV5.svelte';
@@ -100,6 +100,28 @@ describe('Meta', () => {
 
 describe('StoryObj', () => {
   it('✅ Required args may be provided partial in meta and the story', () => {
+    const meta = satisfies<Meta<Button>>()({
+      component: Button,
+      args: { label: 'good' },
+    });
+
+    type Actual = StoryObj<typeof meta>;
+    type Expected = SvelteStory<
+      Button,
+      { disabled: boolean; label: string },
+      { disabled: boolean; label?: string }
+    >;
+    expectTypeOf<Actual>().toMatchTypeOf<Expected>();
+  });
+
+  it('✅ Required args may be provided partial in meta and the story (Svelte 4, non-isomorphic type)', () => {
+    // The imported Svelte component in Svelte 5 has an isomorphic type (both function and class).
+    // In order to test how it would look like for real Svelte 4 components, we need to create the class type manually.
+    class Button extends SvelteComponent<{
+      disabled: boolean;
+      label: string;
+    }> {}
+
     const meta = satisfies<Meta<Button>>()({
       component: Button,
       args: { label: 'good' },

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -135,7 +135,7 @@ describe('StoryObj', () => {
 
     type Actual = StoryObj<typeof meta>;
     type Expected = SvelteStory<
-    ButtonV4,
+      ButtonV4,
       { disabled: boolean; label: string },
       { disabled: boolean; label?: string }
     >;

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -327,7 +327,7 @@ it('StoryObj can accept args directly', () => {
     args: {},
   };
 
-  const Story2: StoryObj<{ args: { prop: boolean } }> = {
+  const Story2: StoryObj< { prop: boolean }> = {
     args: {
       prop: true,
     },

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -5,19 +5,20 @@ import { satisfies } from 'storybook/internal/common';
 import type { Canvas, ComponentAnnotations, StoryAnnotations } from 'storybook/internal/types';
 
 import { expectTypeOf } from 'expect-type';
-import type { ComponentProps, SvelteComponent } from 'svelte';
+import type { Component, ComponentProps, SvelteComponent } from 'svelte';
 
 import Button from './__test__/Button.svelte';
+import ButtonV5 from './__test__/ButtonV5.svelte';
 import Decorator2 from './__test__/Decorator2.svelte';
 import Decorator1 from './__test__/Decorator.svelte';
 import type { Decorator, Meta, StoryObj } from './public-types';
 import type { SvelteRenderer } from './types';
 
-type SvelteStory<Component extends SvelteComponent, Args, RequiredArgs> = StoryAnnotations<
-  SvelteRenderer<Component>,
+type SvelteStory<
+  Comp extends SvelteComponent | Component<any, any, any>,
   Args,
-  RequiredArgs
->;
+  RequiredArgs,
+> = StoryAnnotations<SvelteRenderer<Comp>, Args, RequiredArgs>;
 
 describe('Meta', () => {
   it('Generic parameter of Meta can be a component', () => {
@@ -31,6 +32,20 @@ describe('Meta', () => {
 
     expectTypeOf(meta).toMatchTypeOf<
       ComponentAnnotations<SvelteRenderer<Button>, { disabled: boolean; label: string }>
+    >();
+  });
+
+  it('Generic parameter of Meta can be a Svelte 5 component', () => {
+    const meta: Meta<typeof ButtonV5> = {
+      component: ButtonV5,
+      args: {
+        label: 'good',
+        disabled: false,
+      },
+    };
+
+    expectTypeOf(meta).toMatchTypeOf<
+      ComponentAnnotations<SvelteRenderer<typeof ButtonV5>, { disabled: boolean; label: string }>
     >();
   });
 
@@ -99,6 +114,21 @@ describe('StoryObj', () => {
     expectTypeOf<Actual>().toMatchTypeOf<Expected>();
   });
 
+  it('✅ Required args may be provided partial in meta and the story (Svelte 5)', () => {
+    const meta = satisfies<Meta<typeof ButtonV5>>()({
+      component: ButtonV5,
+      args: { label: 'good' },
+    });
+
+    type Actual = StoryObj<typeof meta>;
+    type Expected = SvelteStory<
+      typeof ButtonV5,
+      { disabled: boolean; label: string },
+      { disabled: boolean; label?: string }
+    >;
+    expectTypeOf<Actual>().toMatchTypeOf<Expected>();
+  });
+
   it('❌ The combined shape of meta args and story args must match the required args.', () => {
     {
       const meta = satisfies<Meta<Button>>()({ component: Button });
@@ -145,6 +175,16 @@ describe('StoryObj', () => {
     expectTypeOf<StoryObj<Button>>().toMatchTypeOf<
       SvelteStory<
         Button,
+        { disabled: boolean; label: string },
+        { disabled?: boolean; label?: string }
+      >
+    >();
+  });
+
+  it('Svelte 5 Component can be used as generic parameter for StoryObj', () => {
+    expectTypeOf<StoryObj<typeof ButtonV5>>().toMatchTypeOf<
+      SvelteStory<
+        typeof ButtonV5,
         { disabled: boolean; label: string },
         { disabled?: boolean; label?: string }
       >
@@ -242,4 +282,14 @@ it('mount accepts a Component and props', () => {
     },
   };
   expectTypeOf(Basic).toMatchTypeOf<StoryObj<Button>>();
+});
+
+it('mount accepts a Svelte 5 Component and props', () => {
+  const Basic: StoryObj<typeof ButtonV5> = {
+    async play({ mount }) {
+      const canvas = await mount(ButtonV5, { props: { label: 'label', disabled: true } });
+      expectTypeOf(canvas).toMatchTypeOf<Canvas>();
+    },
+  };
+  expectTypeOf(Basic).toMatchTypeOf<StoryObj<typeof ButtonV5>>();
 });

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -1,11 +1,17 @@
+/* eslint-disable @typescript-eslint/no-shadow */
 // this file tests Typescript types that's why there are no assertions
 import { describe, it } from 'vitest';
 
 import { satisfies } from 'storybook/internal/common';
-import type { Canvas, ComponentAnnotations, StoryAnnotations } from 'storybook/internal/types';
+import type {
+  Args,
+  Canvas,
+  ComponentAnnotations,
+  StoryAnnotations,
+} from 'storybook/internal/types';
 
 import { expectTypeOf } from 'expect-type';
-import { SvelteComponent, type Component, type ComponentProps } from 'svelte';
+import { type Component, type ComponentProps, SvelteComponent } from 'svelte';
 
 import Button from './__test__/Button.svelte';
 import ButtonV5 from './__test__/ButtonV5.svelte';
@@ -314,4 +320,16 @@ it('mount accepts a Svelte 5 Component and props', () => {
     },
   };
   expectTypeOf(Basic).toMatchTypeOf<StoryObj<typeof ButtonV5>>();
+});
+
+it('StoryObj can accept args directly', () => {
+  const Story: StoryObj<Args> = {
+    args: {},
+  };
+
+  const Story2: StoryObj<{ args: { prop: boolean } }> = {
+    args: {
+      prop: true,
+    },
+  };
 });

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -123,19 +123,19 @@ describe('StoryObj', () => {
   it('✅ Required args may be provided partial in meta and the story (Svelte 4, non-isomorphic type)', () => {
     // The imported Svelte component in Svelte 5 has an isomorphic type (both function and class).
     // In order to test how it would look like for real Svelte 4 components, we need to create the class type manually.
-    class Button extends SvelteComponent<{
+    class ButtonV4 extends SvelteComponent<{
       disabled: boolean;
       label: string;
     }> {}
 
-    const meta = satisfies<Meta<Button>>()({
-      component: Button,
+    const meta = satisfies<Meta<ButtonV4>>()({
+      component: ButtonV4,
       args: { label: 'good' },
     });
 
     type Actual = StoryObj<typeof meta>;
     type Expected = SvelteStory<
-      Button,
+    ButtonV4,
       { disabled: boolean; label: string },
       { disabled: boolean; label?: string }
     >;
@@ -327,7 +327,7 @@ it('StoryObj can accept args directly', () => {
     args: {},
   };
 
-  const Story2: StoryObj< { prop: boolean }> = {
+  const Story2: StoryObj<{ prop: boolean }> = {
     args: {
       prop: true,
     },

--- a/code/renderers/svelte/src/public-types.test.ts
+++ b/code/renderers/svelte/src/public-types.test.ts
@@ -26,6 +26,13 @@ type SvelteStory<
   RequiredArgs,
 > = StoryAnnotations<SvelteRenderer<Comp>, Args, RequiredArgs>;
 
+// The imported Svelte component in Svelte 5 has an isomorphic type (both function and class).
+// In order to test how it would look like for real Svelte 4 components, we need to create the class type manually.
+declare class ButtonV4 extends SvelteComponent<{
+  disabled: boolean;
+  label: string;
+}> {}
+
 describe('Meta', () => {
   it('Generic parameter of Meta can be a component', () => {
     const meta: Meta<Button> = {
@@ -121,15 +128,8 @@ describe('StoryObj', () => {
   });
 
   it('✅ Required args may be provided partial in meta and the story (Svelte 4, non-isomorphic type)', () => {
-    // The imported Svelte component in Svelte 5 has an isomorphic type (both function and class).
-    // In order to test how it would look like for real Svelte 4 components, we need to create the class type manually.
-    class ButtonV4 extends SvelteComponent<{
-      disabled: boolean;
-      label: string;
-    }> {}
-
     const meta = satisfies<Meta<ButtonV4>>()({
-      component: ButtonV4,
+      component: null as any as typeof ButtonV4,
       args: { label: 'good' },
     });
 

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -48,7 +48,7 @@ export type StoryFn<TCmpOrArgs = Args> = TCmpOrArgs extends
  */
 export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
   render?: ArgsStoryFn<SvelteRenderer, any>;
-  component?: infer Comp; // We cannot use "extends ComponentType | Svelte5ComponentType" here, because TypeScript for some reason then refuses to ever enter the true branch
+  component: infer Comp; // We cannot use "extends ComponentType | Svelte5ComponentType" here, because TypeScript for some reason then refuses to ever enter the true branch
   args?: infer DefaultArgs;
 }
   ? Simplify<

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -48,7 +48,7 @@ export type StoryFn<TCmpOrArgs = Args> = TCmpOrArgs extends
  */
 export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
   render?: ArgsStoryFn<SvelteRenderer, any>;
-  component?: infer Comp extends ComponentType | Svelte5ComponentType;
+  component?: infer Comp; // We cannot use "extends ComponentType | Svelte5ComponentType" here, because TypeScript for some reason then refuses to ever enter the true branch
   args?: infer DefaultArgs;
 }
   ? Simplify<

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -15,7 +15,7 @@ import type {
 import type { ComponentProps, ComponentType, SvelteComponent } from 'svelte';
 import type { SetOptional, Simplify } from 'type-fest';
 
-import type { SvelteRenderer } from './types';
+import type { Svelte5ComponentType, SvelteRenderer } from './types';
 
 export type { Args, ArgTypes, Parameters, StrictArgs } from 'storybook/internal/types';
 
@@ -24,19 +24,22 @@ export type { Args, ArgTypes, Parameters, StrictArgs } from 'storybook/internal/
  *
  * @see [Default export](https://storybook.js.org/docs/api/csf#default-export)
  */
-export type Meta<CmpOrArgs = Args> =
-  CmpOrArgs extends SvelteComponent<infer Props>
-    ? ComponentAnnotations<SvelteRenderer<CmpOrArgs>, Props>
-    : ComponentAnnotations<SvelteRenderer, CmpOrArgs>;
+export type Meta<CmpOrArgs = Args> = CmpOrArgs extends
+  | SvelteComponent<infer Props>
+  | Svelte5ComponentType<infer Props>
+  ? ComponentAnnotations<SvelteRenderer<CmpOrArgs>, Props>
+  : ComponentAnnotations<SvelteRenderer, CmpOrArgs>;
+
 /**
  * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/api/csf#named-story-exports)
  */
-export type StoryFn<TCmpOrArgs = Args> =
-  TCmpOrArgs extends SvelteComponent<infer Props>
-    ? AnnotatedStoryFn<SvelteRenderer, Props>
-    : AnnotatedStoryFn<SvelteRenderer, TCmpOrArgs>;
+export type StoryFn<TCmpOrArgs = Args> = TCmpOrArgs extends
+  | SvelteComponent<infer Props>
+  | Svelte5ComponentType<infer Props>
+  ? AnnotatedStoryFn<SvelteRenderer, Props>
+  : AnnotatedStoryFn<SvelteRenderer, TCmpOrArgs>;
 
 /**
  * Story object that represents a CSFv3 component example.
@@ -45,19 +48,32 @@ export type StoryFn<TCmpOrArgs = Args> =
  */
 export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
   render?: ArgsStoryFn<SvelteRenderer, any>;
-  component?: ComponentType<infer Component>;
+  component?: infer Comp extends SvelteComponent | Svelte5ComponentType;
   args?: infer DefaultArgs;
 }
   ? Simplify<
-      ComponentProps<Component> & ArgsFromMeta<SvelteRenderer, MetaOrCmpOrArgs>
+      ComponentProps<
+        Comp extends ComponentType<infer Component>
+          ? Component
+          : Comp extends Svelte5ComponentType
+            ? Comp
+            : never
+      > &
+        ArgsFromMeta<SvelteRenderer, MetaOrCmpOrArgs>
     > extends infer TArgs
     ? StoryAnnotations<
-        SvelteRenderer<Component>,
+        SvelteRenderer<
+          Comp extends ComponentType<infer Component>
+            ? Component
+            : Comp extends Svelte5ComponentType
+              ? Comp
+              : never
+        >,
         TArgs,
         SetOptional<TArgs, Extract<keyof TArgs, keyof DefaultArgs>>
       >
     : never
-  : MetaOrCmpOrArgs extends SvelteComponent
+  : MetaOrCmpOrArgs extends SvelteComponent | Svelte5ComponentType
     ? StoryAnnotations<SvelteRenderer<MetaOrCmpOrArgs>, ComponentProps<MetaOrCmpOrArgs>>
     : StoryAnnotations<SvelteRenderer, MetaOrCmpOrArgs>;
 

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -48,7 +48,7 @@ export type StoryFn<TCmpOrArgs = Args> = TCmpOrArgs extends
  */
 export type StoryObj<MetaOrCmpOrArgs = Args> = MetaOrCmpOrArgs extends {
   render?: ArgsStoryFn<SvelteRenderer, any>;
-  component?: infer Comp extends SvelteComponent | Svelte5ComponentType;
+  component?: infer Comp extends ComponentType | Svelte5ComponentType;
   args?: infer DefaultArgs;
 }
   ? Simplify<

--- a/code/renderers/svelte/src/types.ts
+++ b/code/renderers/svelte/src/types.ts
@@ -37,14 +37,24 @@ type ComponentType<
   >[P];
 };
 
-export interface SvelteRenderer<C extends SvelteComponent = SvelteComponent> extends WebRenderer {
-  component: ComponentType<this['T'] extends Record<string, any> ? this['T'] : any>;
+export type Svelte5ComponentType<Props extends Record<string, any> = any> =
+  typeof import('svelte') extends { mount: any }
+    ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore svelte.Component doesn't exist in Svelte 4
+      import('svelte').Component<Props, any, any>
+    : never;
+
+export interface SvelteRenderer<C extends SvelteComponent | Svelte5ComponentType = SvelteComponent>
+  extends WebRenderer {
+  component:
+    | ComponentType<this['T'] extends Record<string, any> ? this['T'] : any>
+    | Svelte5ComponentType<this['T'] extends Record<string, any> ? this['T'] : any>;
   storyResult: this['T'] extends Record<string, any>
-    ? SvelteStoryResult<this['T'], ComponentEvents<C>>
+    ? SvelteStoryResult<this['T'], C extends SvelteComponent ? ComponentEvents<C> : {}>
     : SvelteStoryResult;
 
   mount: (
-    Component?: ComponentType,
+    Component?: ComponentType | Svelte5ComponentType,
     // TODO add proper typesafety
     options?: Record<string, any> & { props: Record<string, any> }
   ) => Promise<Canvas>;
@@ -54,10 +64,10 @@ export interface SvelteStoryResult<
   Props extends Record<string, any> = any,
   Events extends Record<string, any> = any,
 > {
-  Component?: ComponentType<Props>;
+  Component?: ComponentType<Props> | Svelte5ComponentType<Props>;
   on?: Record<string, any> extends Events
     ? Record<string, (event: CustomEvent) => void>
     : { [K in keyof Events as string extends K ? never : K]?: (event: Events[K]) => void };
   props?: Props;
-  decorator?: ComponentType<Props>;
+  decorator?: ComponentType<Props> | Svelte5ComponentType<Props>;
 }


### PR DESCRIPTION
Reverts storybookjs/storybook#30851

Closes #29308

## What I did

Svelte 5 components that only use runes and none of the legacy stuff (events, slots) are typed as function components. This adjusts the types to include that shape.

Note that for Svelte 5 components you need to do `Meta<typeof MyComponent>` instead of `Meta<MyComponent>` (similar for other types where you pass the component shape).

This fix, if accepted, should be backported to the last stable version (8 I believe).

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Honestly I'm a bit lost, maybe @benmccann can help me out here, also to check I didn't break anything in the process.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR updates Storybook's Svelte renderer types to properly support both Svelte 5 function components and traditional class-based components.

Key changes:
- Added `Svelte5ComponentType` in `types.ts` to handle Svelte 5's new function component pattern
- Updated `Meta`, `StoryFn`, and `StoryObj` type definitions to support both component styles
- Added `ButtonV5.svelte` test component using runes syntax to validate new typings
- Added comprehensive test cases in `public-types.test.ts` for both component forms
- Fixed type inference for component props and events across Svelte 4 and 5 components

The changes ensure proper typing support for Svelte 5's runes-based components while maintaining backward compatibility with class-based components. The implementation includes thorough test coverage and handles the type differences between Svelte versions appropriately.



<!-- /greptile_comment -->