### PR TITLE
CLI: Add detection for the storybook package being behind any other core packages

### DIFF
--- a/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.test.ts
+++ b/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.test.ts
@@ -147,7 +147,7 @@ describe('getIncompatiblePackagesSummary', () => {
     ];
     const summary = getIncompatiblePackagesSummary(analysedPackages, '8.0.0');
     expect(summary).toMatchInlineSnapshot(`
-      "The following packages are incompatible with Storybook 8.0.0 as they depend on different major versions of Storybook packages:
+      "You are currently using Storybook 8.0.0 but you have packages which are incompatible with it:
       - storybook-react@1.0.0
       - @storybook/addon-essentials@7.0.0 (8.0.0 available!)
 

--- a/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.ts
+++ b/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.ts
@@ -66,12 +66,12 @@ export const checkPackageCompatibility = async (
 
     // For now, we notify about updates only for core packages (which will match the currently installed storybook version)
     // In the future, we can use packageManager.latestVersion(name, constraint) for all packages
-    if (isCorePackage && semver.gt(currentStorybookVersion, packageVersion!)) {
+    if (isCorePackage && packageVersion && semver.gt(currentStorybookVersion, packageVersion)) {
       availableUpdate = currentStorybookVersion;
     }
 
     // If the package is greater than the current version, this means a core update is available.
-    if (isCorePackage && semver.gt(packageVersion!, currentStorybookVersion)) {
+    if (isCorePackage && packageVersion && semver.gt(packageVersion, currentStorybookVersion)) {
       availableCoreUpdate = packageVersion;
     }
 

--- a/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.ts
+++ b/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.ts
@@ -14,6 +14,8 @@ export type AnalysedPackage = {
   homepage?: string;
   hasIncompatibleDependencies?: boolean;
   availableUpdate?: string;
+  availableCoreUpdate?: string;
+  packageStorybookVersion?: string;
 };
 
 type Context = {
@@ -23,7 +25,10 @@ type Context = {
   skipErrors?: boolean;
 };
 
-export const checkPackageCompatibility = async (dependency: string, context: Context) => {
+export const checkPackageCompatibility = async (
+  dependency: string,
+  context: Context
+): Promise<AnalysedPackage> => {
   const { currentStorybookVersion, skipErrors, packageManager } = context;
   try {
     const dependencyPackageJson = await packageManager.getPackageJSON(dependency);
@@ -39,12 +44,13 @@ export const checkPackageCompatibility = async (dependency: string, context: Con
       homepage,
     } = dependencyPackageJson;
 
-    const hasIncompatibleDependencies = !!Object.entries({
+    const packageStorybookVersion = Object.entries({
       ...dependencies,
       ...peerDependencies,
     })
       .filter(([dep]) => storybookCorePackages[dep as keyof typeof storybookCorePackages])
-      .find(([_, versionRange]) => {
+      .map(([_, versionRange]) => versionRange)
+      .find((versionRange) => {
         // prevent issues with "tag" based versions e.g. "latest" or "next" instead of actual numbers
         return (
           versionRange &&
@@ -56,6 +62,7 @@ export const checkPackageCompatibility = async (dependency: string, context: Con
     const isCorePackage = storybookCorePackages[name as keyof typeof storybookCorePackages];
 
     let availableUpdate;
+    let availableCoreUpdate;
 
     // For now, we notify about updates only for core packages (which will match the currently installed storybook version)
     // In the future, we can use packageManager.latestVersion(name, constraint) for all packages
@@ -63,12 +70,19 @@ export const checkPackageCompatibility = async (dependency: string, context: Con
       availableUpdate = currentStorybookVersion;
     }
 
+    // If the package is greater than the current version, this means a core update is available.
+    if (isCorePackage && semver.gt(packageVersion!, currentStorybookVersion)) {
+      availableCoreUpdate = packageVersion;
+    }
+
     return {
       packageName: name,
       packageVersion,
       homepage,
-      hasIncompatibleDependencies,
+      hasIncompatibleDependencies: packageStorybookVersion != null,
+      packageStorybookVersion,
       availableUpdate,
+      availableCoreUpdate,
     };
   } catch (err) {
     if (!skipErrors) {
@@ -112,12 +126,24 @@ export const getIncompatiblePackagesSummary = (
       )} as they depend on different major versions of Storybook packages:`
     );
     incompatiblePackages.forEach(
-      ({ packageName: addonName, packageVersion: addonVersion, homepage, availableUpdate }) => {
+      ({
+        packageName: addonName,
+        packageVersion: addonVersion,
+        homepage,
+        availableUpdate,
+        packageStorybookVersion,
+      }) => {
         const packageDescription = `${picocolors.cyan(addonName)}@${picocolors.cyan(addonVersion)}`;
         const updateMessage = availableUpdate ? ` (${availableUpdate} available!)` : '';
+        const dependsOnStorybook =
+          packageStorybookVersion != null
+            ? ` which depends on ${picocolors.red(packageStorybookVersion)}`
+            : '';
         const packageRepo = homepage ? `\n Repo: ${picocolors.yellow(homepage)}` : '';
 
-        summaryMessage.push(`- ${packageDescription}${updateMessage}${packageRepo}`);
+        summaryMessage.push(
+          `- ${packageDescription}${updateMessage}${dependsOnStorybook}${packageRepo}`
+        );
       }
     );
 
@@ -127,6 +153,22 @@ export const getIncompatiblePackagesSummary = (
       'For more on Storybook 8 compatibility, see the linked GitHub issue:',
       picocolors.yellow('https://github.com/storybookjs/storybook/issues/26031')
     );
+
+    if (incompatiblePackages.some((dep) => dep.availableCoreUpdate)) {
+      summaryMessage.push(
+        '\n',
+        `The version of ${picocolors.blue(`storybook@${currentStorybookVersion}`)} is behind the following core packages:`,
+        `${incompatiblePackages
+          .filter((dep) => dep.availableCoreUpdate)
+          .map(
+            ({ packageName, packageVersion }) =>
+              `- ${picocolors.blue(`${packageName}@${packageVersion}`)}`
+          )
+          .join('\n')}`,
+        `Upgrade storybook with:`,
+        picocolors.blue('npx storybook@latest upgrade')
+      );
+    }
   }
 
   return summaryMessage.join('\n');

--- a/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.ts
+++ b/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.ts
@@ -121,9 +121,9 @@ export const getIncompatiblePackagesSummary = (
 
   if (incompatiblePackages.length > 0) {
     summaryMessage.push(
-      `The following packages are incompatible with Storybook ${picocolors.bold(
+      `You are currently using Storybook ${picocolors.bold(
         currentStorybookVersion
-      )} as they depend on different major versions of Storybook packages:`
+      )} but you have packages which are incompatible with it:`
     );
     incompatiblePackages.forEach(
       ({


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This adds a message when the storybook package is behind any other core packages.

![image](https://github.com/user-attachments/assets/2a3363c5-b4a3-4859-8e99-b40bad48bf8a)

Also added the red depends on constraints, so that it is easier to find out why a package is incompatible.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhanced Storybook's CLI doctor functionality to detect and warn when the main Storybook package version lags behind other core package versions.

- Added version compatibility checks in `code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.ts` to detect mismatched core package versions
- Updated `AnalysedPackage` type with `availableCoreUpdate` and `packageStorybookVersion` fields for better version tracking
- Enhanced error messaging in `getIncompatiblePackagesSummary` to provide clear upgrade instructions
- Added documentation for sandbox templates in `code/lib/cli-storybook/src/sandbox-templates.ts` to clarify testing configurations



<!-- /greptile_comment -->