### PR TITLE
Fix: Updated favicon handling for Storybook

### DIFF
--- a/sandbox/react-vite-default-js/.storybook/manager-head.html
+++ b/sandbox/react-vite-default-js/.storybook/manager-head.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link rel="icon" type="image/png" href="/favicon.ico" />
+
+  </head>
+</html>
+

--- a/sandbox/react-vite-default-js/.storybook/manager-head.html
+++ b/sandbox/react-vite-default-js/.storybook/manager-head.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/png" href="/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
   </head>
 </html>


### PR DESCRIPTION
PR Title: Fix: Ensure Storybook Uses Correct Favicon
Closes #30158
What I Did
Created .storybook/manager-head.html to properly reference the favicon.

Ensured favicon.ico exists in the public/ folder of react-vite-default-js.

Verified that Storybook loads the favicon correctly in the browser.
![Screenshot from 2025-03-23 18-29-53](https://github.com/user-attachments/assets/9297f42f-7715-4dd8-a8e7-85fb0b8d79ff)


Manual Testing Steps
Run Storybook: yarn storybook (in /storybook/sandbox/react-vite-default-js)

Open Storybook in the browser (http://localhost:6007/).

Verify that the favicon is displayed correctly in the browser tab.

Documentation
 No documentation updates necessary

Additional Notes
This fix ensures that Storybook properly loads the favicon.ico file from the public/ directory, improving branding and user experience.

<!-- greptile_comment -->

## Greptile Summary

Added a manager-head.html file to fix favicon handling in Storybook's dev server, but the implementation needs refinement to properly handle favicon loading and HTML structure.

- Remove unnecessary HTML/head tags from `/sandbox/react-vite-default-js/.storybook/manager-head.html` as they conflict with Storybook's head injection
- Fix incorrect MIME type attribute (`type="image/png"`) for .ico favicon
- Consider using `managerHead` config in main.js instead of manager-head.html for better maintainability
- Remove trailing empty lines from manager-head.html



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->