### PR TITLE
UI: Visual tweaks to badges and improved layout for a11y panel

### DIFF
--- a/code/addons/a11y/src/components/A11YPanel.tsx
+++ b/code/addons/a11y/src/components/A11YPanel.tsx
@@ -56,14 +56,10 @@ const Centered = styled.span(({ theme }) => ({
   },
 }));
 
-const Count = styled(Badge)({
-  padding: 4,
-  minWidth: 24,
-});
-
 export const A11YPanel: React.FC = () => {
   const { manual: manualParameter } = useParameter<A11yParameters>(PARAM_KEY, {} as any);
   const {
+    tab,
     results,
     status,
     handleManual,
@@ -81,7 +77,9 @@ export const A11YPanel: React.FC = () => {
         label: (
           <Tab>
             Violations
-            <Count status="neutral">{violations.length}</Count>
+            <Badge compact status={tab === 'violations' ? 'active' : 'neutral'}>
+              {violations.length}
+            </Badge>
           </Tab>
         ),
         panel: (
@@ -101,7 +99,9 @@ export const A11YPanel: React.FC = () => {
         label: (
           <Tab>
             Passes
-            <Count status="neutral">{passes.length}</Count>
+            <Badge compact status={tab === 'passes' ? 'active' : 'neutral'}>
+              {passes.length}
+            </Badge>
           </Tab>
         ),
         panel: (
@@ -121,7 +121,9 @@ export const A11YPanel: React.FC = () => {
         label: (
           <Tab>
             Inconclusive
-            <Count status="neutral">{incomplete.length}</Count>
+            <Badge compact status={tab === 'incomplete' ? 'active' : 'neutral'}>
+              {incomplete.length}
+            </Badge>
           </Tab>
         ),
         panel: (
@@ -138,7 +140,7 @@ export const A11YPanel: React.FC = () => {
         type: RuleType.INCOMPLETION,
       },
     ];
-  }, [results, handleSelectionChange, selectedItems, toggleOpen]);
+  }, [tab, results, handleSelectionChange, selectedItems, toggleOpen]);
 
   return (
     <>

--- a/code/addons/a11y/src/components/Report/Details.tsx
+++ b/code/addons/a11y/src/components/Report/Details.tsx
@@ -31,12 +31,22 @@ const Info = styled.div({
   flexDirection: 'column',
 });
 
+const RuleId = styled.div(({ theme }) => ({
+  display: 'block',
+  color: theme.textMutedColor,
+  marginTop: -10,
+  marginBottom: 10,
+
+  '@container (min-width: 800px)': {
+    display: 'none',
+  },
+}));
+
 const Description = styled.p({
   margin: 0,
 });
 
 const Wrapper = styled.div({
-  containerType: 'inline-size',
   display: 'flex',
   flexDirection: 'column',
   padding: '0 15px 20px 15px',
@@ -56,7 +66,10 @@ const Content = styled.div<{ side: 'left' | 'right' }>(({ theme, side }) => ({
   display: side === 'left' ? 'flex' : 'none',
   flexDirection: 'column',
   gap: 15,
-  margin: side === 'left' ? '15px 0 20px 0' : 0,
+  margin: side === 'left' ? '15px 0' : 0,
+  padding: side === 'left' ? '0 15px' : 0,
+  borderLeft: side === 'left' ? `1px solid ${theme.color.border}` : 'none',
+
   '&:focus-visible': {
     outline: 'none',
     borderRadius: 4,
@@ -124,12 +137,13 @@ interface DetailsProps {
 export const Details = ({ item, type, selection, handleSelectionChange }: DetailsProps) => (
   <Wrapper>
     <Info>
+      <RuleId>{item.id}</RuleId>
       <Description>
-        {item.description.endsWith('.') ? item.description : `${item.description}.`}
+        {item.description.endsWith('.') ? item.description : `${item.description}.`}{' '}
+        <Link href={item.helpUrl} target="_blank" withArrow>
+          How to resolve this
+        </Link>
       </Description>
-      <Link href={item.helpUrl} target="_blank" withArrow>
-        Learn how to resolve this violation
-      </Link>
     </Info>
 
     <Tabs.Root

--- a/code/addons/a11y/src/components/Report/Report.tsx
+++ b/code/addons/a11y/src/components/Report/Report.tsx
@@ -27,8 +27,8 @@ const HeaderBar = styled.div(({ theme }) => ({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  gap: 5,
-  padding: '6px 5px 6px 15px',
+  gap: 6,
+  padding: '6px 10px 6px 15px',
   minHeight: 40,
   background: 'none',
   color: 'inherit',
@@ -40,26 +40,29 @@ const HeaderBar = styled.div(({ theme }) => ({
   },
 }));
 
-const Title = styled.div(({ theme }) => ({
+const Title = styled.div({
+  display: 'flex',
   flexGrow: 1,
-  fontWeight: theme.typography.weight.bold,
+  gap: 6,
+});
+
+const RuleId = styled.div(({ theme }) => ({
+  display: 'none',
+  color: theme.textMutedColor,
+
+  '@container (min-width: 800px)': {
+    display: 'block',
+  },
 }));
 
-const RuleId = styled.span<{ onClick: (event: React.SyntheticEvent<Element>) => void }>(
-  ({ theme }) => ({
-    display: 'none',
-    whiteSpace: 'nowrap',
-    cursor: 'text',
-    margin: 2,
-    color: theme.textMutedColor,
-    fontSize: theme.typography.size.s1,
-    fontWeight: theme.typography.weight.bold,
-
-    '@container (min-width: 800px)': {
-      display: 'inline-block',
-    },
-  })
-);
+const Count = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: theme.textMutedColor,
+  width: 28,
+  height: 28,
+}));
 
 export interface ReportProps {
   items: Result[];
@@ -90,8 +93,11 @@ export const Report: FC<ReportProps> = ({
               role="button"
               data-active={!!selection}
             >
-              <Title>{item.help}</Title>
-              <RuleId onClick={(event) => event.stopPropagation()}>{item.id}</RuleId>
+              <Title>
+                <strong>{item.help}</strong>
+                <RuleId>{item.id}</RuleId>
+              </Title>
+              <Count>{item.nodes.length}</Count>
               <IconButton onClick={(event) => toggleOpen(event, type, item)}>
                 <Icon style={{ transform: `rotate(${selection ? -180 : 0}deg)` }} />
               </IconButton>

--- a/code/addons/a11y/src/manager.test.tsx
+++ b/code/addons/a11y/src/manager.test.tsx
@@ -10,6 +10,7 @@ import './manager';
 
 vi.mock('storybook/manager-api');
 const mockedApi = vi.mocked<api.API>(api as any);
+mockedApi.useStorybookApi = vi.fn(() => ({ getSelectedPanel: vi.fn() }));
 mockedApi.useAddonState = vi.fn();
 const mockedAddons = vi.mocked(api.addons);
 const registrationImpl = mockedAddons.register.mock.calls[0][1];
@@ -44,21 +45,18 @@ describe('A11yManager', () => {
 
     // when / then
     expect(title()).toMatchInlineSnapshot(`
-      <div>
-        <Spaced
-          col={1}
-        >
-          <span
-            style={
-              {
-                "display": "inline-block",
-                "verticalAlign": "middle",
-              }
-            }
-          >
-            Accessibility
-          </span>
-        </Spaced>
+      <div
+        style={
+          {
+            "alignItems": "center",
+            "display": "flex",
+            "gap": 6,
+          }
+        }
+      >
+        <span>
+          Accessibility
+        </span>
       </div>
     `);
   });
@@ -77,26 +75,24 @@ describe('A11yManager', () => {
 
     // when / then
     expect(title()).toMatchInlineSnapshot(`
-      <div>
-        <Spaced
-          col={1}
+      <div
+        style={
+          {
+            "alignItems": "center",
+            "display": "flex",
+            "gap": 6,
+          }
+        }
+      >
+        <span>
+          Accessibility
+        </span>
+        <Badge
+          compact={true}
+          status="neutral"
         >
-          <span
-            style={
-              {
-                "display": "inline-block",
-                "verticalAlign": "middle",
-              }
-            }
-          >
-            Accessibility
-          </span>
-          <Badge
-            status="neutral"
-          >
-            3
-          </Badge>
-        </Spaced>
+          3
+        </Badge>
       </div>
     `);
   });

--- a/code/addons/a11y/src/manager.tsx
+++ b/code/addons/a11y/src/manager.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Badge, Spaced } from 'storybook/internal/components';
+import { Badge } from 'storybook/internal/components';
 
-import { addons, types, useAddonState } from 'storybook/manager-api';
+import { addons, types, useAddonState, useStorybookApi } from 'storybook/manager-api';
 
 import { A11YPanel } from './components/A11YPanel';
 import type { Results } from './components/A11yContext';
@@ -11,19 +11,24 @@ import { VisionSimulator } from './components/VisionSimulator';
 import { ADDON_ID, PANEL_ID, PARAM_KEY } from './constants';
 
 const Title = () => {
+  const api = useStorybookApi();
+  const selectedPanel = api.getSelectedPanel();
   const [addonState] = useAddonState<Results>(ADDON_ID);
   const violationsNb = addonState?.violations?.length || 0;
   const incompleteNb = addonState?.incomplete?.length || 0;
   const count = violationsNb + incompleteNb;
 
-  const suffix = count === 0 ? '' : <Badge status="neutral">{count}</Badge>;
+  const suffix =
+    count === 0 ? null : (
+      <Badge compact status={selectedPanel === PANEL_ID ? 'active' : 'neutral'}>
+        {count}
+      </Badge>
+    );
 
   return (
-    <div>
-      <Spaced col={1}>
-        <span style={{ display: 'inline-block', verticalAlign: 'middle' }}>Accessibility</span>
-        {suffix}
-      </Spaced>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <span>Accessibility</span>
+      {suffix}
     </div>
   );
 };

--- a/code/core/src/actions/manager.tsx
+++ b/code/core/src/actions/manager.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 
-import { Badge, Spaced } from 'storybook/internal/components';
+import { Badge } from 'storybook/internal/components';
 import { STORY_CHANGED } from 'storybook/internal/core-events';
 
-import { addons, types, useAddonState, useChannel } from 'storybook/manager-api';
+import { addons, types, useAddonState, useChannel, useStorybookApi } from 'storybook/manager-api';
 
 import { ADDON_ID, CLEAR_ID, EVENT_ID, PANEL_ID, PARAM_KEY } from './constants';
 import ActionLogger from './containers/ActionLogger';
 
 function Title() {
+  const api = useStorybookApi();
+  const selectedPanel = api.getSelectedPanel();
   const [{ count }, setCount] = useAddonState(ADDON_ID, { count: 0 });
 
   useChannel({
@@ -23,14 +25,17 @@ function Title() {
     },
   });
 
-  const suffix = count === 0 ? '' : <Badge status="neutral">{count}</Badge>;
+  const suffix =
+    count === 0 ? null : (
+      <Badge compact status={selectedPanel === PANEL_ID ? 'active' : 'neutral'}>
+        {count}
+      </Badge>
+    );
 
   return (
-    <div>
-      <Spaced col={1}>
-        <span style={{ display: 'inline-block', verticalAlign: 'middle' }}>Actions</span>
-        {suffix}
-      </Spaced>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <span>Actions</span>
+      {suffix}
     </div>
   );
 }

--- a/code/core/src/component-testing/components/PanelTitle.tsx
+++ b/code/core/src/component-testing/components/PanelTitle.tsx
@@ -1,24 +1,30 @@
 import React from 'react';
 
-import { Badge, Spaced } from 'storybook/internal/components';
+import { Badge } from 'storybook/internal/components';
 
-import { useAddonState } from 'storybook/manager-api';
+import { useAddonState, useStorybookApi } from 'storybook/manager-api';
 
-import { ADDON_ID } from '../constants';
+import { ADDON_ID, PANEL_ID } from '../constants';
 
 export function PanelTitle() {
+  const api = useStorybookApi();
+  const selectedPanel = api.getSelectedPanel();
   const [addonState = {}] = useAddonState(ADDON_ID);
   const { hasException, interactionsCount } = addonState as any;
 
   return (
-    <div>
-      <Spaced col={1}>
-        <span style={{ display: 'inline-block', verticalAlign: 'middle' }}>Component tests</span>
-        {interactionsCount && !hasException ? (
-          <Badge status="neutral">{interactionsCount}</Badge>
-        ) : null}
-        {hasException ? <Badge status="negative">{interactionsCount}</Badge> : null}
-      </Spaced>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <span>Component tests</span>
+      {interactionsCount && !hasException ? (
+        <Badge compact status={selectedPanel === PANEL_ID ? 'active' : 'neutral'}>
+          {interactionsCount}
+        </Badge>
+      ) : null}
+      {hasException ? (
+        <Badge compact status={selectedPanel === PANEL_ID ? 'active' : 'negative'}>
+          {interactionsCount}
+        </Badge>
+      ) : null}
     </div>
   );
 }

--- a/code/core/src/components/components/Badge/Badge.stories.tsx
+++ b/code/core/src/components/components/Badge/Badge.stories.tsx
@@ -10,8 +10,13 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default = { args: { children: 'Default' } } satisfies Story;
+export const Active = { args: { status: 'active', children: 'Active' } } satisfies Story;
 export const Positive = { args: { status: 'positive', children: 'Positive' } } satisfies Story;
 export const Negative = { args: { status: 'negative', children: 'Negative' } } satisfies Story;
 export const Neutral = { args: { status: 'neutral', children: 'Neutral' } } satisfies Story;
 export const Warning = { args: { status: 'warning', children: 'Warning' } } satisfies Story;
 export const Critical = { args: { status: 'critical', children: 'Critical' } } satisfies Story;
+
+export const Compact = {
+  args: { compact: true, status: 'neutral', children: '12' },
+} satisfies Story;

--- a/code/core/src/components/components/Badge/Badge.tsx
+++ b/code/core/src/components/components/Badge/Badge.tsx
@@ -4,14 +4,16 @@ import { transparentize } from 'polished';
 import { styled } from 'storybook/theming';
 
 const BadgeWrapper = styled.div<BadgeProps>(
-  ({ theme }) => ({
-    display: 'inline-block',
-    fontSize: 11,
-    lineHeight: '12px',
-    alignSelf: 'center',
-    padding: '4px 10px',
-    borderRadius: '3em',
+  ({ theme, compact }) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: theme.typography.size.s1,
     fontWeight: theme.typography.weight.bold,
+    lineHeight: '12px',
+    minWidth: 20,
+    borderRadius: 20,
+    padding: compact ? '4px 7px' : '4px 10px',
   }),
   {
     svg: {
@@ -56,7 +58,7 @@ const BadgeWrapper = styled.div<BadgeProps>(
       case 'neutral': {
         return {
           color: theme.textMutedColor,
-          background: theme.background.app,
+          background: theme.base === 'light' ? theme.background.app : theme.barBg,
           boxShadow: `inset 0 0 0 1px ${transparentize(0.8, theme.textMutedColor)}`,
         };
       }
@@ -70,6 +72,13 @@ const BadgeWrapper = styled.div<BadgeProps>(
               : 'none',
         };
       }
+      case 'active': {
+        return {
+          color: theme.color.secondary,
+          background: theme.background.hoverable,
+          boxShadow: `inset 0 0 0 1px ${transparentize(0.9, theme.color.secondary)}`,
+        };
+      }
       default: {
         return {};
       }
@@ -78,7 +87,8 @@ const BadgeWrapper = styled.div<BadgeProps>(
 );
 
 export interface BadgeProps {
-  status?: 'positive' | 'negative' | 'neutral' | 'warning' | 'critical';
+  compact?: boolean;
+  status?: 'positive' | 'negative' | 'neutral' | 'warning' | 'critical' | 'active';
   children?: React.ReactNode;
 }
 

--- a/code/core/src/components/components/bar/bar.tsx
+++ b/code/core/src/components/components/bar/bar.tsx
@@ -18,7 +18,7 @@ export const Side = styled.div<SideProps>(
     whiteSpace: 'nowrap',
     flexBasis: 'auto',
     marginLeft: 3,
-    marginRight: 3,
+    marginRight: 10,
   },
   ({ scrollable }) => (scrollable ? { flexShrink: 0 } : {}),
   ({ left }) =>
@@ -32,10 +32,7 @@ export const Side = styled.div<SideProps>(
   ({ right }) =>
     right
       ? {
-          marginLeft: 30,
-          '& > *': {
-            marginRight: 4,
-          },
+          gap: 6,
         }
       : {}
 );

--- a/code/core/src/controls/manager.tsx
+++ b/code/core/src/controls/manager.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AddonPanel, Badge, Spaced } from 'storybook/internal/components';
+import { AddonPanel, Badge } from 'storybook/internal/components';
 import type {
   ResponseData,
   SaveStoryRequestPayload,
@@ -10,25 +10,36 @@ import { SAVE_STORY_REQUEST, SAVE_STORY_RESPONSE } from 'storybook/internal/core
 import type { Args } from 'storybook/internal/csf';
 
 import { dequal as deepEqual } from 'dequal';
-import { addons, experimental_requestResponse, types, useArgTypes } from 'storybook/manager-api';
+import {
+  addons,
+  experimental_requestResponse,
+  types,
+  useArgTypes,
+  useStorybookApi,
+} from 'storybook/manager-api';
 import { color } from 'storybook/theming';
 
 import { ControlsPanel } from './components/ControlsPanel';
 import { ADDON_ID, PARAM_KEY } from './constants';
 
 function Title() {
+  const api = useStorybookApi();
+  const selectedPanel = api.getSelectedPanel();
   const rows = useArgTypes();
   const controlsCount = Object.values(rows).filter(
     (argType) => argType?.control && !argType?.table?.disable
   ).length;
-  const suffix = controlsCount === 0 ? '' : <Badge status="neutral">{controlsCount}</Badge>;
+  const suffix =
+    controlsCount === 0 ? null : (
+      <Badge compact status={selectedPanel === ADDON_ID ? 'active' : 'neutral'}>
+        {controlsCount}
+      </Badge>
+    );
 
   return (
-    <div>
-      <Spaced col={1}>
-        <span style={{ display: 'inline-block', verticalAlign: 'middle' }}>Controls</span>
-        {suffix}
-      </Spaced>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <span>Controls</span>
+      {suffix}
     </div>
   );
 }


### PR DESCRIPTION
## What I did

In collaboration with @domyen, this fixes a bunch of minor visual issues such as badge sizing and colors. Of note, this introduces a "compact" badge variant as well as an "active" state for it. Badges on tab bars should use this active state when their tab is active.

<img width="594" alt="Screenshot 2025-03-28 at 00 12 03" src="https://github.com/user-attachments/assets/75336d35-f5f9-4d3d-beaf-227473fa2325" />

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30955-sha-a85a1e39`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30955-sha-a85a1e39 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30955-sha-a85a1e39 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30955-sha-a85a1e39`](https://npmjs.com/package/storybook/v/0.0.0-pr-30955-sha-a85a1e39) |
| **Triggered by** | @ghengeveld |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`visual-tweaks`](https://github.com/storybookjs/storybook/tree/visual-tweaks) |
| **Commit** | [`a85a1e39`](https://github.com/storybookjs/storybook/commit/a85a1e39021a054391664cbabb8546524f8f6cf6) |
| **Datetime** | Thu Mar 27 23:14:03 UTC 2025 (`1743117243`) |
| **Workflow run** | [14118456414](https://github.com/storybookjs/storybook/actions/runs/14118456414) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30955`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

These changes enhance visual consistency in Storybook's a11y panel by introducing a compact badge variant with an active state along with refined layout tweaks across components.

• A11YPanel.tsx now applies compact badges that switch to an active status based on selected tabs.  
• Details.tsx refines the rule display and inline resolution link with improved spacing.  
• Report.tsx streamlines header layout with flex adjustments and updated Count styling.  
• Manager.tsx and controls utilize useStorybookApi for conditional badge styling.  
• Badge.stories.tsx now includes new examples for the active and compact badge variants.



<!-- /greptile_comment -->