### PR TITLE
Core: Fix flaky unit tests related to stores

### DIFF
--- a/code/addons/test/src/node/boot-test-runner.test.ts
+++ b/code/addons/test/src/node/boot-test-runner.test.ts
@@ -90,6 +90,7 @@ describe('bootTestRunner', () => {
         NODE_ENV: 'test',
         TEST: 'true',
         VITEST: 'true',
+        VITEST_CHILD_PROCESS: 'true',
       },
       extendEnv: true,
     });

--- a/code/addons/test/src/node/boot-test-runner.ts
+++ b/code/addons/test/src/node/boot-test-runner.ts
@@ -69,7 +69,12 @@ const bootTestRunner = async (channel: Channel, store: Store) => {
   const startChildProcess = () =>
     new Promise<void>((resolve, reject) => {
       child = execaNode(vitestModulePath, {
-        env: { VITEST: 'true', TEST: 'true', NODE_ENV: process.env.NODE_ENV ?? 'test' },
+        env: {
+          VITEST: 'true',
+          TEST: 'true',
+          VITEST_CHILD_PROCESS: 'true',
+          NODE_ENV: process.env.NODE_ENV ?? 'test',
+        },
         extendEnv: true,
       });
       stderr = [];

--- a/code/core/src/core-server/stores/status.ts
+++ b/code/core/src/core-server/stores/status.ts
@@ -12,7 +12,7 @@ const statusStore = createStatusStore({
       before it was ready.
       This will be fixed when we do the planned UniversalStore v0.2.
     */
-    leader: process.env.VITEST !== 'true',
+    leader: process.env.VITEST_CHILD_PROCESS !== 'true',
   }),
   environment: 'server',
 });

--- a/code/core/src/core-server/stores/test-provider.ts
+++ b/code/core/src/core-server/stores/test-provider.ts
@@ -12,7 +12,7 @@ const testProviderStore = createTestProviderStore({
             before it was ready.
             This will be fixed when we do the planned UniversalStore v0.2.
           */
-    leader: process.env.VITEST !== 'true',
+    leader: process.env.VITEST_CHILD_PROCESS !== 'true',
   }),
 });
 


### PR DESCRIPTION
so that our internal unit tests which also has VITEST and TEST env vars doesn't make the store get created as followers, but only the actual vitest child process does.

Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

In `core-server`, we have logic that determines if the status and test provider stores should be leaders or followers, dependning on if they run in the preset (leader) or the Vitest child process (follower). That logic looked at the `VITEST` env variable, because that was set in the child process. However that is also set when we run our own internal unit tests, so in those tests, it would also get created as a follower, which would cause it to timeout.

Now we use a custom env var, that is something we _only_ set in the Vitest child process, and that won't be set automatically in our unit tests, so our unit tests will always create leaders, not timing out.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR updates the store creation logic to distinguish clearly between internal unit tests and actual Vitest child processes by switching the environment key from VITEST to VITEST_CHILD_PROCESS.

- In /code/core/src/core-server/stores/status.ts, updated the leader check to use VITEST_CHILD_PROCESS.
- In /code/core/src/core-server/stores/test-provider.ts, changed the environment variable check to ensure proper leader/follower assignment.
- In /code/addons/test/src/node/boot-test-runner.ts, modified the execaNode spawn configuration to set VITEST_CHILD_PROCESS for actual Vitest processes.



<!-- /greptile_comment -->