### PR TITLE
Web-components: Export html helper for custom render functions

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,7 @@
 
 - [From version 8.x to 9.0.0](#from-version-8x-to-900)
   - [Package Manager Support](#package-manager-support)
+  - [Web components html helper](#web-components-html-helper)
   - [A11y addon: Removed deprecated manual parameter](#a11y-addon-removed-deprecated-manual-parameter)
   - [Button Component API Changes](#button-component-api-changes)
   - [Documentation Generation Changes](#documentation-generation-changes)
@@ -113,17 +114,17 @@
     - [Tab addons cannot manually route, Tool addons can filter their visibility via tabId](#tab-addons-cannot-manually-route-tool-addons-can-filter-their-visibility-via-tabid)
     - [Removed `config` preset](#removed-config-preset-1)
 - [From version 7.5.0 to 7.6.0](#from-version-750-to-760)
-    - [CommonJS with Vite is deprecated](#commonjs-with-vite-is-deprecated)
-    - [Using implicit actions during rendering is deprecated](#using-implicit-actions-during-rendering-is-deprecated)
-    - [typescript.skipBabel deprecated](#typescriptskipbabel-deprecated)
-    - [Primary doc block accepts of prop](#primary-doc-block-accepts-of-prop)
-    - [Addons no longer need a peer dependency on React](#addons-no-longer-need-a-peer-dependency-on-react)
+  - [CommonJS with Vite is deprecated](#commonjs-with-vite-is-deprecated)
+  - [Using implicit actions during rendering is deprecated](#using-implicit-actions-during-rendering-is-deprecated)
+  - [typescript.skipBabel deprecated](#typescriptskipbabel-deprecated)
+  - [Primary doc block accepts of prop](#primary-doc-block-accepts-of-prop)
+  - [Addons no longer need a peer dependency on React](#addons-no-longer-need-a-peer-dependency-on-react)
 - [From version 7.4.0 to 7.5.0](#from-version-740-to-750)
-    - [`storyStoreV6` and `storiesOf` is deprecated](#storystorev6-and-storiesof-is-deprecated)
-    - [`storyIndexers` is replaced with `experimental_indexers`](#storyindexers-is-replaced-with-experimental_indexers)
+  - [`storyStoreV6` and `storiesOf` is deprecated](#storystorev6-and-storiesof-is-deprecated)
+  - [`storyIndexers` is replaced with `experimental_indexers`](#storyindexers-is-replaced-with-experimental_indexers)
 - [From version 7.0.0 to 7.2.0](#from-version-700-to-720)
-    - [Addon API is more type-strict](#addon-api-is-more-type-strict)
-    - [Addon-controls hideNoControlsWarning parameter is deprecated](#addon-controls-hidenocontrolswarning-parameter-is-deprecated)
+  - [Addon API is more type-strict](#addon-api-is-more-type-strict)
+  - [Addon-controls hideNoControlsWarning parameter is deprecated](#addon-controls-hidenocontrolswarning-parameter-is-deprecated)
 - [From version 6.5.x to 7.0.0](#from-version-65x-to-700)
   - [7.0 breaking changes](#70-breaking-changes)
     - [Dropped support for Node 15 and below](#dropped-support-for-node-15-and-below)
@@ -149,7 +150,7 @@
     - [Deploying build artifacts](#deploying-build-artifacts)
       - [Dropped support for file URLs](#dropped-support-for-file-urls)
       - [Serving with nginx](#serving-with-nginx)
-      - [Ignore story files from node\_modules](#ignore-story-files-from-node_modules)
+      - [Ignore story files from node_modules](#ignore-story-files-from-node_modules)
   - [7.0 Core changes](#70-core-changes)
     - [7.0 feature flags removed](#70-feature-flags-removed)
     - [Story context is prepared before for supporting fine grained updates](#story-context-is-prepared-before-for-supporting-fine-grained-updates)
@@ -163,7 +164,7 @@
     - [Addon-interactions: Interactions debugger is now default](#addon-interactions-interactions-debugger-is-now-default)
   - [7.0 Vite changes](#70-vite-changes)
     - [Vite builder uses Vite config automatically](#vite-builder-uses-vite-config-automatically)
-    - [Vite cache moved to node\_modules/.cache/.vite-storybook](#vite-cache-moved-to-node_modulescachevite-storybook)
+    - [Vite cache moved to node_modules/.cache/.vite-storybook](#vite-cache-moved-to-node_modulescachevite-storybook)
   - [7.0 Webpack changes](#70-webpack-changes)
     - [Webpack4 support discontinued](#webpack4-support-discontinued)
     - [Babel mode v7 exclusively](#babel-mode-v7-exclusively)
@@ -214,7 +215,7 @@
     - [Dropped addon-docs manual babel configuration](#dropped-addon-docs-manual-babel-configuration)
     - [Dropped addon-docs manual configuration](#dropped-addon-docs-manual-configuration)
     - [Autoplay in docs](#autoplay-in-docs)
-    - [Removed STORYBOOK\_REACT\_CLASSES global](#removed-storybook_react_classes-global)
+    - [Removed STORYBOOK_REACT_CLASSES global](#removed-storybook_react_classes-global)
   - [7.0 Deprecations and default changes](#70-deprecations-and-default-changes)
     - [storyStoreV7 enabled by default](#storystorev7-enabled-by-default)
     - [`Story` type deprecated](#story-type-deprecated)
@@ -434,17 +435,29 @@
 Storybook 9.0 drops official support and maintenance for older package manager versions:
 
 - npm v8 and v9 are no longer supported
-- yarn v3 is no longer supported  
+- yarn v3 is no longer supported
 - pnpm v7 and v8 are no longer supported
 
 The minimum supported versions are now:
 
 - npm v10+
-- yarn v4+ 
+- yarn v4+
 - pnpm v9+
 
 While Storybook may still work with older versions, we recommend upgrading to the latest supported versions for the best experience and to ensure compatibility.
 
+### Web components html helper
+
+Storybook re-exports lit-html's `html` tag helper for stories with custom render functions that compose multiple web components. WC stories remain compatible with Lit's `html` helper (or plain strings!), but we recommend the following update to your stories (replace `web-components-vite` with `web-components-webpack5` if you use webpack):
+
+```diff
+- import { html } from 'lit';
++ import { html } from '@storybook/web-components-vite';
+export default { component: 'my-component' };
+export const WithProp = {
+  render: () => html\`<my-component prop="value" />\`,
+};
+```
 
 ### A11y addon: Removed deprecated manual parameter
 
@@ -485,6 +498,7 @@ export const initialGlobals = {
 ### Button Component API Changes
 
 The Button component has been updated to use a more modern props API. The following props have been removed:
+
 - `isLink`
 - `primary`
 - `secondary`
@@ -556,6 +570,7 @@ export default {
 ### Icon System Updates
 
 Several icon-related exports have been removed:
+
 - `IconButtonSkeleton`
 - `Icons`
 - `Symbols`
@@ -587,11 +602,13 @@ The `TESTING_MODULE_RUN_ALL_REQUEST` event has been removed:
 ### Type System Updates
 
 The following types have been removed:
+
 - `Addon_SidebarBottomType`
 - `Addon_SidebarTopType`
 - `DeprecatedState`
 
 Import paths have been updated:
+
 ```diff
 - import { SupportedRenderers } from './project_types';
 + import { SupportedRenderers } from 'storybook/internal/types';
@@ -600,6 +617,7 @@ Import paths have been updated:
 ### Story Store API Changes
 
 Several deprecated methods have been removed from the StoryStore:
+
 - `getSetStoriesPayload`
 - `getStoriesJsonData`
 - `raw`
@@ -608,6 +626,7 @@ Several deprecated methods have been removed from the StoryStore:
 ### CSF File Changes
 
 Deprecated getters have been removed from the CsfFile class:
+
 - `_fileName`
 - `_makeTitle`
 
@@ -789,10 +808,11 @@ To upgrade:
    export default {
      // ... your other config
      // Make sure you're using Vite 5 compatible plugins
-   }
+   };
    ```
 
 If you're using framework-specific Vite plugins, ensure they are compatible with Vite 5:
+
 - `@vitejs/plugin-react`
 - `@vitejs/plugin-vue`
 - `@sveltejs/vite-plugin-svelte`
@@ -809,6 +829,7 @@ Storybook has dropped support for Angular versions 15-17. The minimum supported 
 If you're using an older version of Angular, you'll need to upgrade to Angular 18 or newer to use the latest version of Storybook.
 
 Key changes:
+
 - All Angular packages in peerDependencies now require `>=18.0.0 < 20.0.0`
 - Removed legacy code supporting Angular < 18
 - Standalone components are now the default (can be opted out by explicitly setting `standalone: false` in component decorators)
@@ -838,7 +859,7 @@ Then update your `.storybook/main.js|ts`:
 ```js
 export default {
   framework: {
-    name: '@storybook/preact-vite',
+    name: "@storybook/preact-vite",
     options: {},
   },
   // ... other configurations
@@ -864,7 +885,7 @@ Also update your `.storybook/main.<js|ts>` file accordingly:
 export default {
   addons: [
 -   "@storybook/experimental-nextjs-vite",
-+   "@storybook/nextjs-vite"    
++   "@storybook/nextjs-vite"
   ]
 }
 ```

--- a/code/frameworks/web-components-webpack5/package.json
+++ b/code/frameworks/web-components-webpack5/package.json
@@ -62,11 +62,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "lit": "2.3.1",
     "typescript": "^5.7.3"
   },
   "peerDependencies": {
-    "lit": "^2.0.0 || ^3.0.0",
     "storybook": "workspace:^"
   },
   "engines": {

--- a/code/package.json
+++ b/code/package.json
@@ -87,6 +87,7 @@
     "@types/react": "^18.0.0",
     "@vitest/expect@npm:3.0.9": "patch:@vitest/expect@npm%3A3.0.9#~/.yarn/patches/@vitest-expect-npm-3.0.9-e2a2210fb4.patch",
     "esbuild": "^0.25.0",
+    "lit-html": "^3.0.0",
     "playwright": "1.48.1",
     "playwright-core": "1.48.1",
     "react": "^18.2.0",

--- a/code/renderers/web-components/package.json
+++ b/code/renderers/web-components/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@storybook/global": "^5.0.0",
+    "lit-html": "^3.0.0",
     "tiny-invariant": "^1.3.1",
     "ts-dedent": "^2.0.0"
   },
@@ -57,12 +58,10 @@
     "@types/cross-spawn": "^6.0.2",
     "@types/node": "^22.0.0",
     "cross-spawn": "^7.0.3",
-    "lit": "2.3.1",
     "typescript": "^5.7.3",
     "web-component-analyzer": "^1.1.6"
   },
   "peerDependencies": {
-    "lit": "^2.0.0 || ^3.0.0",
     "storybook": "workspace:^"
   },
   "engines": {

--- a/code/renderers/web-components/src/docs/sourceDecorator.test.ts
+++ b/code/renderers/web-components/src/docs/sourceDecorator.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SNIPPET_RENDERED } from 'storybook/internal/docs-tools';
 
-import { html, render } from 'lit';
+import { html, render } from 'lit-html';
 import { styleMap } from 'lit/directives/style-map.js';
 import { addons, useEffect } from 'storybook/preview-api';
 

--- a/code/renderers/web-components/src/docs/sourceDecorator.ts
+++ b/code/renderers/web-components/src/docs/sourceDecorator.ts
@@ -2,7 +2,7 @@
 import { SNIPPET_RENDERED, SourceType } from 'storybook/internal/docs-tools';
 import type { ArgsStoryFn, PartialStoryFn, StoryContext } from 'storybook/internal/types';
 
-import { render } from 'lit';
+import { render } from 'lit-html';
 import { addons, useEffect } from 'storybook/preview-api';
 
 import type { WebComponentsRenderer } from '../types';

--- a/code/renderers/web-components/src/index.ts
+++ b/code/renderers/web-components/src/index.ts
@@ -5,6 +5,22 @@ import './globals';
 
 const { window, EventSource } = global;
 
+/**
+ * Storybook re-exports lit-html's `html` tag helper for stories stories that compose multiple web
+ * components.
+ *
+ * Import it from the framework package you're using (typically `@storybook/web-components-vite` or
+ * `@storybook/web-components-webpack5`).
+ *
+ * ```js
+ * import { html } from '@storybook/web-components-vite';
+ * export default { component: 'my-component' };
+ * export const WithProp = {
+ *   render: () => html`<my-component prop="value" />`,
+ * };
+ * ```
+ */
+export { html } from 'lit-html';
 export * from './public-types';
 export * from './framework-api';
 export * from './portable-stories';

--- a/code/renderers/web-components/src/index.ts
+++ b/code/renderers/web-components/src/index.ts
@@ -6,8 +6,8 @@ import './globals';
 const { window, EventSource } = global;
 
 /**
- * Storybook re-exports lit-html's `html` tag helper for stories stories that compose multiple web
- * components.
+ * Storybook re-exports lit-html's `html` tag helper for stories with custom render functions that
+ * compose multiple web components.
  *
  * Import it from the framework package you're using (typically `@storybook/web-components-vite` or
  * `@storybook/web-components-webpack5`).

--- a/code/renderers/web-components/src/render.ts
+++ b/code/renderers/web-components/src/render.ts
@@ -3,9 +3,9 @@ import type { ArgsStoryFn, RenderContext } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
 
-import { render as litRender } from 'lit';
+import { render as litRender } from 'lit-html';
 // Keep `.js` extension to avoid issue with Webpack (related to export map?)
-import { isTemplateResult } from 'lit/directive-helpers.js';
+import { isTemplateResult } from 'lit-html/directive-helpers.js';
 import { simulateDOMContentLoaded, simulatePageLoad } from 'storybook/preview-api';
 import { dedent } from 'ts-dedent';
 

--- a/code/renderers/web-components/src/types.ts
+++ b/code/renderers/web-components/src/types.ts
@@ -1,6 +1,6 @@
 import type { StoryContext as StoryContextBase, WebRenderer } from 'storybook/internal/types';
 
-import type { SVGTemplateResult, TemplateResult } from 'lit';
+import type { SVGTemplateResult, TemplateResult } from 'lit-html';
 
 export type StoryFnHtmlReturnType =
   | string

--- a/code/renderers/web-components/template/stories/demo-wc-card.stories.js
+++ b/code/renderers/web-components/template/stories/demo-wc-card.stories.js
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 import './demo-wc-card';
 

--- a/code/renderers/web-components/template/stories/script.stories.js
+++ b/code/renderers/web-components/template/stories/script.stories.js
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: undefined,

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7895,13 +7895,12 @@ __metadata:
     "@types/cross-spawn": "npm:^6.0.2"
     "@types/node": "npm:^22.0.0"
     cross-spawn: "npm:^7.0.3"
-    lit: "npm:2.3.1"
+    lit-html: "npm:^3.0.0"
     tiny-invariant: "npm:^1.3.1"
     ts-dedent: "npm:^2.0.0"
     typescript: "npm:^5.7.3"
     web-component-analyzer: "npm:^1.1.6"
   peerDependencies:
-    lit: ^2.0.0 || ^3.0.0
     storybook: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -20015,6 +20014,15 @@ __metadata:
   dependencies:
     "@types/trusted-types": "npm:^2.0.2"
   checksum: 10c0/90057dee050803823ac884c1355b0213ab8c05fbe2ec63943c694b61aade5d36272068f3925f45a312835e504f9c9784738ef797009f0a756a750351eafb52d5
+  languageName: node
+  linkType: hard
+
+"lit-html@npm:^3.0.0":
+  version: 3.2.1
+  resolution: "lit-html@npm:3.2.1"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.2"
+  checksum: 10c0/31c02df2148bf9a73545570cbe57aae01c4de1d9b44060b6ff13641837d38e39e6b1abcf92e13882cc84f5fee37605ed79602b91ad479728549014462808118e
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -3948,7 +3948,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lit/reactive-element@npm:^1.3.0, @lit/reactive-element@npm:^1.4.0, @lit/reactive-element@npm:^1.6.0":
+"@lit/reactive-element@npm:^1.3.0, @lit/reactive-element@npm:^1.6.0":
   version: 1.6.3
   resolution: "@lit/reactive-element@npm:1.6.3"
   dependencies:
@@ -7879,10 +7879,8 @@ __metadata:
     "@storybook/builder-webpack5": "workspace:*"
     "@storybook/web-components": "workspace:*"
     "@types/node": "npm:^22.0.0"
-    lit: "npm:2.3.1"
     typescript: "npm:^5.7.3"
   peerDependencies:
-    lit: ^2.0.0 || ^3.0.0
     storybook: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -19997,7 +19995,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lit-element@npm:^3.2.0, lit-element@npm:^3.3.0":
+"lit-element@npm:^3.3.0":
   version: 3.3.3
   resolution: "lit-element@npm:3.3.3"
   dependencies:
@@ -20008,7 +20006,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lit-html@npm:^2.3.0, lit-html@npm:^2.8.0":
+"lit-html@npm:^2.8.0":
   version: 2.8.0
   resolution: "lit-html@npm:2.8.0"
   dependencies:
@@ -20023,17 +20021,6 @@ __metadata:
   dependencies:
     "@types/trusted-types": "npm:^2.0.2"
   checksum: 10c0/31c02df2148bf9a73545570cbe57aae01c4de1d9b44060b6ff13641837d38e39e6b1abcf92e13882cc84f5fee37605ed79602b91ad479728549014462808118e
-  languageName: node
-  linkType: hard
-
-"lit@npm:2.3.1":
-  version: 2.3.1
-  resolution: "lit@npm:2.3.1"
-  dependencies:
-    "@lit/reactive-element": "npm:^1.4.0"
-    lit-element: "npm:^3.2.0"
-    lit-html: "npm:^2.3.0"
-  checksum: 10c0/7ca5dde792bd03bf2a1f162f4d376d191913b3e8fc37c7bafb36cdde5c3b81e934a1a9a3c38efd92aacd2ca4858b40434e49c90b370da9802caaa92c05fb3b63
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -20006,15 +20006,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lit-html@npm:^2.8.0":
-  version: 2.8.0
-  resolution: "lit-html@npm:2.8.0"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.2"
-  checksum: 10c0/90057dee050803823ac884c1355b0213ab8c05fbe2ec63943c694b61aade5d36272068f3925f45a312835e504f9c9784738ef797009f0a756a750351eafb52d5
-  languageName: node
-  linkType: hard
-
 "lit-html@npm:^3.0.0":
   version: 3.2.1
   resolution: "lit-html@npm:3.2.1"

--- a/docs/_snippets/arg-types-mapping.md
+++ b/docs/_snippets/arg-types-mapping.md
@@ -81,7 +81,7 @@ export default meta;
 ```
 
 ```js filename="Example.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'demo-example',
@@ -100,7 +100,7 @@ export default {
 ```ts filename="Example.stories.ts" renderer="web-components" language="ts"
 import type { Meta } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'demo-example',

--- a/docs/_snippets/button-story-click-handler-args.md
+++ b/docs/_snippets/button-story-click-handler-args.md
@@ -334,7 +334,7 @@ export const Primary: Story = {
 ```
 
 ```js filename="Button.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 import { action } from 'storybook/actions';
 
@@ -356,7 +356,7 @@ export const Text = {
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { action } from 'storybook/actions';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'custom-button',

--- a/docs/_snippets/button-story-click-handler.md
+++ b/docs/_snippets/button-story-click-handler.md
@@ -277,7 +277,7 @@ export const Text: Story = {
 ```
 
 ```js filename="Button.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 import { action } from 'storybook/actions';
 
@@ -294,7 +294,7 @@ export const Text = {
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { action } from 'storybook/actions';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'custom-button',

--- a/docs/_snippets/button-story-component-decorator.md
+++ b/docs/_snippets/button-story-component-decorator.md
@@ -306,7 +306,7 @@ export default meta;
 ```
 
 ```js filename="Button.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'demo-button',
@@ -319,7 +319,7 @@ export const Example = {};
 ```ts filename="Button.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'demo-button',

--- a/docs/_snippets/button-story-decorator.md
+++ b/docs/_snippets/button-story-decorator.md
@@ -342,7 +342,7 @@ export const Primary: Story = {
 ```
 
 ```js filename="Button.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'demo-button',

--- a/docs/_snippets/button-story-with-addon-example.md
+++ b/docs/_snippets/button-story-with-addon-example.md
@@ -457,7 +457,7 @@ export const Basic: Story = {
 ```
 
 ```js filename="Button.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   title: 'Button',
@@ -483,7 +483,7 @@ export const Basic = {
 ```ts filename="Button.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   title: 'Button',

--- a/docs/_snippets/button-story-with-emojis.md
+++ b/docs/_snippets/button-story-with-emojis.md
@@ -598,7 +598,7 @@ export const Tertiary: Story = {
 ```
 
 ```js filename="Button.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'demo-button',
@@ -625,7 +625,7 @@ export const Tertiary = {
 ```ts filename="Button.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'demo-button',

--- a/docs/_snippets/button-story.md
+++ b/docs/_snippets/button-story.md
@@ -618,7 +618,7 @@ export const Primary: Story = {
 ```
 
 ```js filename="Button.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'demo-button',
@@ -632,7 +632,7 @@ export const Primary = {
 ```ts filename="Button.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'demo-button',

--- a/docs/_snippets/component-story-custom-args-complex.md
+++ b/docs/_snippets/component-story-custom-args-complex.md
@@ -684,7 +684,7 @@ export const ExampleStory: Story = {
 ```
 
 ```js filename="Button.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'custom-component',
@@ -727,7 +727,7 @@ export const ExampleStory = {
 ```ts filename="Button.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'custom-component',

--- a/docs/_snippets/component-story-static-asset-cdn.md
+++ b/docs/_snippets/component-story-static-asset-cdn.md
@@ -301,7 +301,7 @@ export const WithAnImage: Story = {
 ```
 
 ```js filename="MyComponent.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'my-component',
@@ -319,7 +319,7 @@ export const WithAnImage = {
 ```ts filename="MyComponent.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'my-component',

--- a/docs/_snippets/component-story-static-asset-with-import.md
+++ b/docs/_snippets/component-story-static-asset-with-import.md
@@ -393,7 +393,7 @@ export const WithAnImage: Story = {
 ```
 
 ```js filename="MyComponent.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 import imageFile from './static/image.png';
 
@@ -414,7 +414,7 @@ export const WithAnImage = {
 ```ts filename="MyComponent.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 import imageFile from './static/image.png';
 

--- a/docs/_snippets/component-story-static-asset-without-import.md
+++ b/docs/_snippets/component-story-static-asset-without-import.md
@@ -288,7 +288,7 @@ export const WithAnImage: Story = {
 ```
 
 ```js filename="MyComponent.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'my-component',
@@ -303,7 +303,7 @@ export const WithAnImage = {
 ```ts filename="MyComponent.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'my-component',

--- a/docs/_snippets/component-story-with-custom-render-function.md
+++ b/docs/_snippets/component-story-with-custom-render-function.md
@@ -324,7 +324,7 @@ export const Example: Story = {
 ```
 
 ```js filename="MyComponent.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'my-component',
@@ -348,7 +348,7 @@ export const Example = {
 ```ts filename="MyComponent.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'my-component',

--- a/docs/_snippets/csf-2-example-starter.md
+++ b/docs/_snippets/csf-2-example-starter.md
@@ -137,7 +137,7 @@ Primary.args = { primary: true };
 ```
 
 ```js filename="CSF 2 - Button.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   title: 'components/Button',
@@ -153,7 +153,7 @@ Primary.args = {
 ```ts filename="CSF 2 - Button.stories.ts" renderer="web-components" language="ts"
 import type { Meta, Story } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   title: 'components/Button',

--- a/docs/_snippets/list-story-expanded.md
+++ b/docs/_snippets/list-story-expanded.md
@@ -597,7 +597,7 @@ export const ManyItems: Story = {
 ```
 
 ```js filename="List.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'demo-list',
@@ -629,7 +629,7 @@ export const ManyItems = {
 ```ts filename="List.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'demo-list',

--- a/docs/_snippets/list-story-reuse-data.md
+++ b/docs/_snippets/list-story-reuse-data.md
@@ -349,7 +349,7 @@ export const ManyItems: Story = {
 ```
 
 ```js filename="List.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 // 👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';
@@ -371,7 +371,7 @@ export const ManyItems = {
 ```ts filename="List.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 // 👇 We're importing the necessary stories from ListItem
 import { Selected, Unselected } from './ListItem.stories';

--- a/docs/_snippets/list-story-starter.md
+++ b/docs/_snippets/list-story-starter.md
@@ -301,7 +301,7 @@ export const Empty: Story = {
 ```
 
 ```js filename="List.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'demo-list',

--- a/docs/_snippets/list-story-template.md
+++ b/docs/_snippets/list-story-template.md
@@ -516,7 +516,7 @@ export const OneItem: Story = {
 ```
 
 ```js filename="List.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 import { repeat } from 'lit/directives/repeat.js';
 
 import { Unchecked } from './ListItem.stories';
@@ -558,7 +558,7 @@ export const OneItem = {
 ```ts filename="List.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 import { repeat } from 'lit/directives/repeat.js';
 
 const meta: Meta = {

--- a/docs/_snippets/list-story-unchecked.md
+++ b/docs/_snippets/list-story-unchecked.md
@@ -332,7 +332,7 @@ export const OneItem: Story = {
 ```
 
 ```js filename="MyList.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 // 👇 Import the stories of MyListItem
 import { Unchecked } from './MyListItem.stories';
@@ -350,7 +350,7 @@ export const OneItem = {
 ```ts filename="MyList.stories.ts" renderer="web-components" language="ts"
 import { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 // 👇 Import the stories of MyListItem
 import { Unchecked } from './my-list-item.stories';

--- a/docs/_snippets/list-story-with-subcomponents.md
+++ b/docs/_snippets/list-story-with-subcomponents.md
@@ -198,7 +198,7 @@ export const OneItem: Story = {
 ```
 
 ```js filename="List.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   title: 'List',
@@ -220,7 +220,7 @@ export const OneItem = {
 ```ts filename="List.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   title: 'List',

--- a/docs/_snippets/my-component-story-basic-and-props.md
+++ b/docs/_snippets/my-component-story-basic-and-props.md
@@ -344,7 +344,7 @@ export const WithProp: Story = {
 ```
 
 ```js filename="MyComponent.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   title: 'Path/To/MyComponent',
@@ -361,7 +361,7 @@ export const WithProp = {
 ```ts filename="MyComponent.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'my-component',

--- a/docs/_snippets/my-component-story-use-globaltype.md
+++ b/docs/_snippets/my-component-story-use-globaltype.md
@@ -460,7 +460,7 @@ export const MyStory: Story = {
 ```
 
 ```js filename="MyComponent.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'my-component',
@@ -492,7 +492,7 @@ export const StoryWithLocale = {
 ```ts filename="MyComponent.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   component: 'my-component',

--- a/docs/_snippets/page-story-slots.md
+++ b/docs/_snippets/page-story-slots.md
@@ -331,7 +331,7 @@ export const Primary: Story = {
 ```
 
 ```js filename="Page.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   title: 'Page',
@@ -353,7 +353,7 @@ export const CustomFooter = {
 ```ts filename="Page.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
 
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 type CustomArgs = { footer?: string };
 

--- a/docs/_snippets/storybook-preview-global-decorator.md
+++ b/docs/_snippets/storybook-preview-global-decorator.md
@@ -115,7 +115,7 @@ export default preview;
 ```
 
 ```js filename=".storybook/preview.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   decorators: [(story) => html`<div style="margin: 3em">${story()}</div>`],

--- a/docs/_snippets/tags-combo-example.md
+++ b/docs/_snippets/tags-combo-example.md
@@ -448,7 +448,7 @@ export const Combo: Story = {
 ```
 
 ```ts filename="Button.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   title: 'Button',
@@ -481,7 +481,7 @@ export const Combo = {
 
 ```ts filename="Button.stories.ts" renderer="web-components" language="ts"
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 const meta: Meta = {
   title: 'Button',

--- a/docs/_snippets/your-component-with-decorator.md
+++ b/docs/_snippets/your-component-with-decorator.md
@@ -264,7 +264,7 @@ export default meta;
 ```
 
 ```js filename="YourComponent.stories.js" renderer="web-components" language="js"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 export default {
   component: 'demo-your-component',
@@ -273,7 +273,7 @@ export default {
 ```
 
 ```ts filename="YourComponent.stories.ts" renderer="web-components" language="ts"
-import { html } from 'lit';
+import { html } from '@storybook/web-components';
 
 import type { Meta } from '@storybook/web-components';
 


### PR DESCRIPTION
Closes #30979

## What I did

- [x] Re-export `html`
- [x] Update docs
- [ ] Update sample components

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Create a WC sandbox and run it. Add a story with a custom render function.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

**This review covers only the changes made since the last review (commit ba1b8f5), not the entire PR.**

The recent changes address the previous typo feedback and include several additional documentation updates across web-components examples. The main changes include:

- **Fixed documentation typo**: The duplicate "stories" in the JSDoc comment in `index.ts` has been corrected to "stories that compose multiple web components"
- **Comprehensive documentation updates**: Updated import statements across ~25 documentation snippet files to use `import { html } from '@storybook/web-components'` instead of `import { html } from 'lit'`
- **Migration documentation**: Added a new section to `MIGRATION.md` documenting the breaking change for Storybook 9.0
- **Dependency management**: Removed `lit` dependency from `web-components-webpack5` package to avoid conflicts
- **Type imports consistency**: Updated type imports in several files to use `lit-html` consistently

These changes complete the standardization effort by ensuring all documentation examples demonstrate the new import pattern where users import the `html` helper from `@storybook/web-components` rather than directly from `lit`. This provides a more consistent API surface and better encapsulation for the web-components renderer.

## Confidence score: 4/5

- This update is mostly safe with comprehensive documentation fixes and good migration guidance
- Score reflects the thoroughness of documentation updates but notes one critical missing import in a TypeScript example
- Pay close attention to `docs/_snippets/list-story-starter.md` which has a TypeScript example using `html` without importing it

<!-- /greptile_comment -->