### PR TITLE
Automigrations: Re-add renderer-to-framework and fix issue in monorepositories

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
@@ -114,6 +114,7 @@ export const consolidatedImports: Fix<ConsolidatedOptions> = {
       ignore: ['**/node_modules/**'],
       cwd: projectRoot,
       gitignore: true,
+      absolute: true,
     });
 
     const consolidatedDeps = new Set<keyof typeof consolidatedPackages>();
@@ -203,6 +204,7 @@ export const consolidatedImports: Fix<ConsolidatedOptions> = {
       ignore: ['**/node_modules/**'],
       dot: true,
       cwd: projectRoot,
+      absolute: true,
     });
 
     const importErrors = await transformImportFiles(sourceFiles, dryRun);

--- a/code/lib/cli-storybook/src/automigrate/fixes/index.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/index.ts
@@ -6,6 +6,7 @@ import { consolidatedImports } from './consolidated-imports';
 import { eslintPlugin } from './eslint-plugin';
 import { initialGlobals } from './initial-globals';
 import { removeAddonInteractions } from './remove-addon-interactions';
+import { rendererToFramework } from './renderer-to-framework';
 import { rnstorybookConfig } from './rnstorybook-config';
 import { upgradeStorybookRelatedDependencies } from './upgrade-storybook-related-dependencies';
 import { wrapRequire } from './wrap-require';
@@ -22,6 +23,7 @@ export const allFixes: Fix[] = [
   addonExperimentalTest,
   rnstorybookConfig,
   removeAddonInteractions,
+  rendererToFramework,
 ];
 
 export const initFixes: Fix[] = [eslintPlugin];

--- a/code/lib/cli-storybook/src/automigrate/fixes/renderer-to-framework.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/renderer-to-framework.test.ts
@@ -1,0 +1,255 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { dedent } from 'ts-dedent';
+
+import { removeRenderersInPackageJson, transformSourceFiles } from './renderer-to-framework';
+import { rendererToFramework } from './renderer-to-framework';
+
+vi.mock('node:fs/promises');
+vi.mock('globby', () => ({
+  globby: vi.fn(),
+}));
+vi.mock('storybook/internal/common', () => ({
+  commonGlobOptions: () => ({}),
+  frameworkPackages: {
+    '@storybook/react-vite': 'react-vite',
+    '@storybook/vue3-vite': 'vue3-vite',
+  },
+  getProjectRoot: vi.fn().mockResolvedValue('/project/root'),
+  rendererPackages: {
+    '@storybook/react': 'react',
+    '@storybook/vue3': 'vue3',
+  },
+}));
+
+const mockPackageJson = {
+  dependencies: {
+    '@storybook/react': '^9.0.0',
+    '@storybook/react-vite': '^9.0.0',
+    react: '^18.0.0',
+  },
+  devDependencies: {
+    '@storybook/addon-essentials': '^9.0.0',
+    '@storybook/manager-api': '^9.0.0',
+    typescript: '^5.0.0',
+  },
+};
+
+describe('transformSourceFiles', () => {
+  it('should transform multiple files', async () => {
+    const sourceContents = dedent`
+      import { something } from '@storybook/react';
+      import { other } from '@storybook/react-vite';
+    `;
+    const sourceFiles = [join('src', 'test1.ts'), join('src', 'test2.ts')];
+
+    vi.mocked(readFile).mockResolvedValue(sourceContents);
+
+    const errors = await transformSourceFiles(
+      sourceFiles,
+      '@storybook/react',
+      '@storybook/react-vite',
+      false
+    );
+
+    expect(errors).toHaveLength(0);
+    expect(writeFile).toHaveBeenCalledTimes(2);
+    expect(writeFile).toHaveBeenCalledWith(
+      sourceFiles[0],
+      expect.stringContaining('@storybook/react-vite')
+    );
+  });
+
+  it('should not write files in dry run mode', async () => {
+    const sourceContents = dedent`
+      import { something } from '@storybook/react';
+    `;
+    const sourceFiles = [join('src', 'test.ts')];
+
+    vi.mocked(readFile).mockResolvedValue(sourceContents);
+
+    const errors = await transformSourceFiles(
+      sourceFiles,
+      '@storybook/react',
+      '@storybook/react-vite',
+      true
+    );
+
+    expect(errors).toHaveLength(0);
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('should handle file read errors', async () => {
+    const sourceFiles = [join('src', 'test.ts')];
+    vi.mocked(readFile).mockRejectedValueOnce(new Error('Failed to read file'));
+
+    const errors = await transformSourceFiles(
+      sourceFiles,
+      '@storybook/react',
+      '@storybook/react-vite',
+      false
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      file: sourceFiles[0],
+      error: expect.any(Error),
+    });
+  });
+});
+
+describe('removeRenderersInPackageJson', () => {
+  it('should remove renderer packages from dependencies', async () => {
+    const contents = JSON.stringify(mockPackageJson);
+    const filePath = 'test/package.json';
+
+    vi.mocked(readFile).mockResolvedValueOnce(contents);
+
+    const hasChanges = await removeRenderersInPackageJson(filePath, ['@storybook/react'], false);
+
+    expect(hasChanges).toBe(true);
+    expect(writeFile).toHaveBeenCalledWith(
+      filePath,
+      expect.not.stringContaining('"@storybook/react": "^9.0.0"')
+    );
+  });
+
+  it('should remove renderer packages from devDependencies', async () => {
+    const contents = JSON.stringify({
+      ...mockPackageJson,
+      dependencies: {},
+      devDependencies: {
+        '@storybook/react': '^9.0.0',
+      },
+    });
+    const filePath = 'test/package.json';
+
+    vi.mocked(readFile).mockResolvedValueOnce(contents);
+
+    const hasChanges = await removeRenderersInPackageJson(filePath, ['@storybook/react'], false);
+
+    expect(hasChanges).toBe(true);
+    expect(writeFile).toHaveBeenCalledWith(
+      filePath,
+      expect.not.stringContaining('"@storybook/react": "^9.0.0"')
+    );
+  });
+
+  it('should not write files in dry run mode', async () => {
+    const contents = JSON.stringify(mockPackageJson);
+    const filePath = 'test/package.json';
+
+    vi.mocked(readFile).mockResolvedValueOnce(contents);
+
+    const hasChanges = await removeRenderersInPackageJson(filePath, ['@storybook/react'], true);
+
+    expect(hasChanges).toBe(true);
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('should handle file read errors', async () => {
+    const filePath = 'test/package.json';
+    vi.mocked(readFile).mockRejectedValueOnce(new Error('Failed to read file'));
+
+    await expect(
+      removeRenderersInPackageJson(filePath, ['@storybook/react'], false)
+    ).rejects.toThrow('Failed to update package.json');
+  });
+});
+
+describe('check', () => {
+  it('should detect frameworks and renderers in package.json', async () => {
+    const packageJsonFiles = ['package.json'];
+    const contents = JSON.stringify(mockPackageJson);
+
+    vi.mocked(readFile).mockResolvedValue(contents);
+    // eslint-disable-next-line depend/ban-dependencies
+    const { globby } = await import('globby');
+    vi.mocked(globby).mockResolvedValue(packageJsonFiles);
+
+    const result = await rendererToFramework.check({} as any);
+
+    expect(result).toEqual({
+      frameworks: ['@storybook/react-vite'],
+      renderers: ['@storybook/react'],
+      packageJsonFiles: ['package.json'],
+    });
+  });
+
+  it('should handle multiple package.json files', async () => {
+    const packageJsonFiles = ['package.json', 'packages/app/package.json'];
+    const contents1 = JSON.stringify(mockPackageJson);
+    const contents2 = JSON.stringify({
+      dependencies: {
+        '@storybook/vue3': '^9.0.0',
+        '@storybook/vue3-vite': '^9.0.0',
+      },
+    });
+
+    vi.mocked(readFile).mockResolvedValueOnce(contents1).mockResolvedValueOnce(contents2);
+    // eslint-disable-next-line depend/ban-dependencies
+    const { globby } = await import('globby');
+    vi.mocked(globby).mockResolvedValue(packageJsonFiles);
+
+    const result = await rendererToFramework.check({} as any);
+
+    expect(result).toEqual({
+      frameworks: ['@storybook/react-vite', '@storybook/vue3-vite'],
+      renderers: ['@storybook/react', '@storybook/vue3'],
+      packageJsonFiles: ['package.json', 'packages/app/package.json'],
+    });
+  });
+
+  it('should return null when no frameworks found', async () => {
+    const packageJsonFiles = ['package.json'];
+    const contents = JSON.stringify({
+      dependencies: {
+        '@storybook/react': '^9.0.0',
+        react: '^18.0.0',
+      },
+    });
+
+    vi.mocked(readFile).mockResolvedValue(contents);
+    // eslint-disable-next-line depend/ban-dependencies
+    const { globby } = await import('globby');
+    vi.mocked(globby).mockResolvedValue(packageJsonFiles);
+
+    const result = await rendererToFramework.check({} as any);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when no renderers found', async () => {
+    const packageJsonFiles = ['package.json'];
+    const contents = JSON.stringify({
+      dependencies: {
+        '@storybook/react-vite': '^9.0.0',
+        react: '^18.0.0',
+      },
+    });
+
+    vi.mocked(readFile).mockResolvedValue(contents);
+    // eslint-disable-next-line depend/ban-dependencies
+    const { globby } = await import('globby');
+    vi.mocked(globby).mockResolvedValue(packageJsonFiles);
+
+    const result = await rendererToFramework.check({} as any);
+
+    expect(result).toBeNull();
+  });
+
+  it('should handle file read errors gracefully', async () => {
+    const packageJsonFiles = ['package.json'];
+    vi.mocked(readFile).mockRejectedValue(new Error('Failed to read file'));
+    // eslint-disable-next-line depend/ban-dependencies
+    const { globby } = await import('globby');
+    vi.mocked(globby).mockResolvedValue(packageJsonFiles);
+
+    const result = await rendererToFramework.check({} as any);
+
+    expect(result).toBeNull();
+  });
+});

--- a/code/lib/cli-storybook/src/automigrate/fixes/renderer-to-framework.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/renderer-to-framework.ts
@@ -1,0 +1,255 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+import {
+  commonGlobOptions,
+  frameworkPackages,
+  getProjectRoot,
+  rendererPackages,
+} from 'storybook/internal/common';
+import type { PackageJson } from 'storybook/internal/types';
+
+import prompts from 'prompts';
+import { dedent } from 'ts-dedent';
+
+import type { Fix, RunOptions } from '../types';
+
+interface MigrationResult {
+  frameworks: string[];
+  renderers: string[];
+  packageJsonFiles: string[];
+}
+
+const getAllDependencies = (packageJson: PackageJson): string[] =>
+  Object.keys({
+    ...(packageJson.dependencies || {}),
+    ...(packageJson.devDependencies || {}),
+  });
+
+const detectFrameworks = (dependencies: string[]): string[] => {
+  return Object.keys(frameworkPackages).filter((pkg) => dependencies.includes(pkg));
+};
+
+const detectRenderers = (dependencies: string[]): string[] => {
+  return Object.keys(rendererPackages).filter((pkg) => dependencies.includes(pkg));
+};
+
+const replaceImports = (source: string, renderer: string, framework: string) => {
+  const regex = new RegExp(`(['"])${renderer}(['"])`, 'g');
+  return regex.test(source) ? source.replace(regex, `$1${framework}$2`) : null;
+};
+
+export const transformSourceFiles = async (
+  files: string[],
+  renderer: string,
+  framework: string,
+  dryRun: boolean
+) => {
+  const errors: Array<{ file: string; error: Error }> = [];
+  const { default: pLimit } = await import('p-limit');
+  const limit = pLimit(10);
+
+  await Promise.all(
+    files.map((file) =>
+      limit(async () => {
+        try {
+          const contents = await readFile(file, 'utf-8');
+          const transformed = replaceImports(contents, renderer, framework);
+          if (!dryRun && transformed) {
+            await writeFile(file, transformed);
+          }
+        } catch (error) {
+          errors.push({ file, error: error as Error });
+        }
+      })
+    )
+  );
+
+  return errors;
+};
+
+export const removeRenderersInPackageJson = async (
+  packageJsonPath: string,
+  renderers: string[],
+  dryRun: boolean
+) => {
+  try {
+    const content = await readFile(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(content);
+    let hasChanges = false;
+
+    renderers.forEach((renderer) => {
+      if (packageJson.dependencies?.[renderer]) {
+        delete packageJson.dependencies[renderer];
+        hasChanges = true;
+      }
+      if (packageJson.devDependencies?.[renderer]) {
+        delete packageJson.devDependencies[renderer];
+        hasChanges = true;
+      }
+    });
+
+    if (!dryRun && hasChanges) {
+      await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+    }
+
+    return hasChanges;
+  } catch (error) {
+    // eslint-disable-next-line local-rules/no-uncategorized-errors
+    throw new Error(`Failed to update package.json: ${error}`);
+  }
+};
+
+const selectFramework = async (frameworks: string[]): Promise<string | null> => {
+  if (frameworks.length === 1) {
+    return frameworks[0];
+  }
+
+  const response = await prompts({
+    type: 'select',
+    name: 'framework',
+    message: 'Which framework would you like to use?',
+    choices: frameworks.map((framework) => ({
+      title: framework,
+      value: framework,
+    })),
+  });
+
+  return response.framework || null;
+};
+
+// Helper to check if a package.json needs migration
+const checkPackageJson = async (
+  packageJsonPath: string
+): Promise<{ frameworks: string[]; renderers: string[] } | null> => {
+  const content = await readFile(packageJsonPath, 'utf-8');
+  const packageJson = JSON.parse(content);
+  const dependencies = getAllDependencies(packageJson);
+
+  const frameworks = detectFrameworks(dependencies);
+  if (frameworks.length === 0) {
+    return null;
+  }
+
+  const renderers = detectRenderers(dependencies);
+  if (renderers.length === 0) {
+    return null;
+  }
+
+  return { frameworks, renderers };
+};
+
+export const rendererToFramework: Fix<MigrationResult> = {
+  id: 'renderer-to-framework',
+  versionRange: ['<9.0.0', '^9.0.0-0'],
+  promptType: 'auto',
+
+  async check(): Promise<MigrationResult | null> {
+    const projectRoot = await getProjectRoot();
+    // eslint-disable-next-line depend/ban-dependencies
+    const { globby } = await import('globby');
+
+    const packageJsonFiles = await globby(['**/package.json'], {
+      ...commonGlobOptions(''),
+      ignore: ['**/node_modules/**'],
+      cwd: projectRoot,
+      gitignore: true,
+      absolute: true,
+    });
+
+    // Check each package.json for migration needs
+    const results = await Promise.all(
+      packageJsonFiles.map(async (file) => {
+        try {
+          return await checkPackageJson(file);
+        } catch (error) {
+          return null;
+        }
+      })
+    );
+    const validResults = results.filter(
+      (r): r is { frameworks: string[]; renderers: string[] } =>
+        r !== null && r.renderers.length > 0
+    );
+
+    if (validResults.length === 0) {
+      return null;
+    }
+
+    return {
+      frameworks: [...new Set(validResults.flatMap((r) => r.frameworks))],
+      renderers: [...new Set(validResults.flatMap((r) => r.renderers))],
+      packageJsonFiles: packageJsonFiles.filter((_, i) => validResults[i] !== null),
+    };
+  },
+
+  prompt(result: MigrationResult): string {
+    if (result.frameworks.length > 1) {
+      return dedent`
+        As part of Storybook's evolution, we're moving from renderer-based to framework-based configuration.
+        We've detected multiple framework packages in your project: ${result.frameworks.join(', ')}.
+        You will be prompted to select which framework to use for your Storybook configuration.
+        This will update your imports and dependencies to use the framework-specific package.
+        Would you like to proceed with the migration?
+      `;
+    }
+
+    return dedent`
+      As part of Storybook's evolution, we're moving from renderer-based to framework-based configuration.
+      We've detected renderer packages (${result.renderers.join(', ')}) that can be replaced with the framework package "${result.frameworks[0]}".
+      
+      This migration will:
+      1. Update your source files to use framework-specific imports
+      2. Remove the renderer packages from your package.json
+      3. Install the necessary framework dependencies
+      Would you like to proceed with these changes?
+    `;
+  },
+
+  async run(options: RunOptions<MigrationResult>) {
+    const { result, dryRun = false } = options;
+    const selectedFramework = await selectFramework(result.frameworks);
+
+    if (!selectedFramework) {
+      console.log('Migration cancelled: No framework selected');
+      return;
+    }
+
+    const defaultGlob = '**/*.{mjs,cjs,js,jsx,ts,tsx}';
+    const { glob } = await prompts({
+      type: 'text',
+      name: 'glob',
+      message: 'Enter a custom glob pattern to scan (or press enter to use default):',
+      initial: defaultGlob,
+    });
+
+    const projectRoot = await getProjectRoot();
+
+    // eslint-disable-next-line depend/ban-dependencies
+    const globby = (await import('globby')).globby;
+
+    const sourceFiles = await globby([glob], {
+      ...commonGlobOptions(''),
+      ignore: ['**/node_modules/**'],
+      dot: true,
+      cwd: projectRoot,
+      absolute: true,
+    });
+
+    // Transform imports for each renderer
+    await Promise.all(
+      result.renderers.map((renderer) =>
+        transformSourceFiles(sourceFiles, renderer, selectedFramework, dryRun)
+      )
+    );
+
+    // Update all package.json files to remove renderers
+    await Promise.all(
+      result.packageJsonFiles.map((file: string) =>
+        removeRenderersInPackageJson(file, result.renderers, dryRun)
+      )
+    );
+
+    // Install dependencies
+    await options.packageManager.installDependencies();
+  },
+};


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31003

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- Re-added the accidentially removed automigration "renderer-to-framework"
- Fixed an issue with the `consolidated-package` automigration in monorepositories, were the project root doesn't equal the cwd.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31011-sha-be27789f`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31011-sha-be27789f sandbox` or in an existing project with `npx storybook@0.0.0-pr-31011-sha-be27789f upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31011-sha-be27789f`](https://npmjs.com/package/storybook/v/0.0.0-pr-31011-sha-be27789f) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-automigrations`](https://github.com/storybookjs/storybook/tree/valentin/fix-automigrations) |
| **Commit** | [`be27789f`](https://github.com/storybookjs/storybook/commit/be27789f0b444255629b9e3f90841bf2e14cec83) |
| **Datetime** | Tue Apr  1 13:20:59 UTC 2025 (`1743513659`) |
| **Workflow run** | [14196734616](https://github.com/storybookjs/storybook/actions/runs/14196734616) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31011`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR re-adds the missing renderer-to-framework automigration and improves monorepo handling by ensuring absolute path resolution in migration scans. 

- Re-imported and included renderer-to-framework in code/lib/cli-storybook/src/automigrate/fixes/index.ts.
- Added comprehensive tests in code/lib/cli-storybook/src/automigrate/fixes/renderer-to-framework.test.ts.
- Updated globby options in code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts with "absolute: true" for monorepository compatibility.
- Reintroduced migration logic with robust error handling and concurrency in code/lib/cli-storybook/src/automigrate/fixes/renderer-to-framework.ts.



<!-- /greptile_comment -->