### PR TITLE
Automigration: Ensure correct addition of missing dependencies

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 
-import { commonGlobOptions, getProjectRoot } from 'storybook/internal/common';
+import { commonGlobOptions, getProjectRoot, versions } from 'storybook/internal/common';
 
 import picocolors from 'picocolors';
 import prompts from 'prompts';
@@ -18,18 +18,49 @@ function transformPackageJson(content: string): string | null {
   const packageJson = JSON.parse(content);
   let hasChanges = false;
 
+  // Track new packages to add
+  const packagesToAdd = new Set<string>();
+
   // Check both dependencies and devDependencies
   const depTypes = ['dependencies', 'devDependencies'] as const;
+
+  // Determine where storybook is installed and get its version
+  let storybookVersion: string | null = null;
+  let storybookDepType: (typeof depTypes)[number] | null = null;
+
+  for (const depType of depTypes) {
+    if (packageJson[depType]?.storybook) {
+      storybookVersion = packageJson[depType].storybook;
+      storybookDepType = depType;
+      break;
+    }
+  }
 
   for (const depType of depTypes) {
     if (packageJson[depType]) {
       for (const [dep] of Object.entries(packageJson[depType])) {
         if (dep in consolidatedPackages) {
+          const newPackage = consolidatedPackages[dep as keyof typeof consolidatedPackages];
+          // Only add to packagesToAdd if it's not being consolidated into storybook/*
+          if (!newPackage.startsWith('storybook/')) {
+            packagesToAdd.add(newPackage);
+          }
           delete packageJson[depType][dep];
           hasChanges = true;
         }
       }
     }
+  }
+
+  // Add new packages to the same dependency type as storybook
+  if (packagesToAdd.size > 0) {
+    const version = storybookVersion ?? versions['@storybook/nextjs-vite'];
+    const depType = storybookDepType ?? 'devDependencies';
+    packageJson[depType] = packageJson[depType] || {};
+    for (const pkg of packagesToAdd) {
+      packageJson[depType][pkg] = version;
+    }
+    hasChanges = true;
   }
 
   return hasChanges ? JSON.stringify(packageJson, null, 2) : null;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The `consolidated-packages` automigration has installed new packages, but only removed old ones. This has been fixed to take into account package renames like the one `@storybook/experimental-nextjs-vite` to `@storybook/nextjs-vite`

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31023-sha-c1d1c6b4`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31023-sha-c1d1c6b4 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31023-sha-c1d1c6b4 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31023-sha-c1d1c6b4`](https://npmjs.com/package/storybook/v/0.0.0-pr-31023-sha-c1d1c6b4) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-consolidated-imports-automigration`](https://github.com/storybookjs/storybook/tree/valentin/fix-consolidated-imports-automigration) |
| **Commit** | [`c1d1c6b4`](https://github.com/storybookjs/storybook/commit/c1d1c6b4caf37f79442a7dfded2065263d9cf7d3) |
| **Datetime** | Tue Apr  1 18:47:13 UTC 2025 (`1743533233`) |
| **Workflow run** | [14203601832](https://github.com/storybookjs/storybook/actions/runs/14203601832) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31023`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhances the automigration logic for consolidated imports by correctly removing outdated packages and adding new dependencies based on existing Storybook versions.

- Modified code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts to track new packages using a Set and determine versions dynamically.
- Updated code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.test.ts to validate behavior across dependencies and error/dry run conditions.
- Noted potential pitfall: new package check may not correctly handle namespaced packages like '@storybook/'.



<!-- /greptile_comment -->