### PR TITLE
Nextjs-Vite: Update vite-plugin-storybook-nextjs version and add optimizeDeps

### DIFF
--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -108,7 +108,7 @@
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",
     "styled-jsx": "5.1.6",
-    "vite-plugin-storybook-nextjs": "2.0.0--canary.33.17a2310.0"
+    "vite-plugin-storybook-nextjs": "2.0.0--canary.33.c17eb1b.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/code/frameworks/nextjs-vite/src/preset.ts
+++ b/code/frameworks/nextjs-vite/src/preset.ts
@@ -34,6 +34,11 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entry =
   return result;
 };
 
+export const optimizeViteDeps = [
+  '@storybook/nextjs-vite/navigation.mock',
+  '@storybook/nextjs-vite/router.mock',
+];
+
 export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, options) => {
   const reactConfig = await reactViteFinal(config, options);
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6997,7 +6997,7 @@ __metadata:
     next: "npm:^15.0.3"
     styled-jsx: "npm:5.1.6"
     typescript: "npm:^5.7.3"
-    vite-plugin-storybook-nextjs: "npm:2.0.0--canary.33.17a2310.0"
+    vite-plugin-storybook-nextjs: "npm:2.0.0--canary.33.c17eb1b.0"
   peerDependencies:
     next: ^14.1.0 || ^15.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -28940,9 +28940,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-storybook-nextjs@npm:2.0.0--canary.33.17a2310.0":
-  version: 2.0.0--canary.33.17a2310.0
-  resolution: "vite-plugin-storybook-nextjs@npm:2.0.0--canary.33.17a2310.0"
+"vite-plugin-storybook-nextjs@npm:2.0.0--canary.33.c17eb1b.0":
+  version: 2.0.0--canary.33.c17eb1b.0
+  resolution: "vite-plugin-storybook-nextjs@npm:2.0.0--canary.33.c17eb1b.0"
   dependencies:
     "@next/env": "npm:^15.0.3"
     image-size: "npm:^2.0.0"
@@ -28953,7 +28953,7 @@ __metadata:
     next: ^14.1.0 || ^15.0.0
     storybook: ^9.0.0-0
     vite: ^5.0.0 || ^6.0.0
-  checksum: 10c0/6882ee982a8865df9a778c10f0efca70c669b0ad050b25f4ceb115e83d00b3f25f59e27d5b84b03bfa517fcd1b9223fff753d971b4fe575bf924e7b493a18342
+  checksum: 10c0/f2679fd3fe931afacf32636bd03e2d8f9846702ca2be32586c1f80c340653ba19ad8a9fd367f712f81179c89c9a12dd8700ee9d6cbd75d5769590ded50d8c8b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31020

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31037-sha-7ccb21c3`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31037-sha-7ccb21c3 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31037-sha-7ccb21c3 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31037-sha-7ccb21c3`](https://npmjs.com/package/storybook/v/0.0.0-pr-31037-sha-7ccb21c3) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-nextjs-vite`](https://github.com/storybookjs/storybook/tree/valentin/fix-nextjs-vite) |
| **Commit** | [`7ccb21c3`](https://github.com/storybookjs/storybook/commit/7ccb21c34f5c9875dbcb49f2f9c12109a7e0905c) |
| **Datetime** | Wed Apr  2 12:43:13 UTC 2025 (`1743597793`) |
| **Workflow run** | [14219893497](https://github.com/storybookjs/storybook/actions/runs/14219893497) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31037`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updated the nextjs-vite framework to improve integration with Next.js and Vite by updating the vite-plugin-storybook-nextjs version and incorporating optimizeDeps.  
- Updated the vite-plugin-storybook-nextjs version in code/frameworks/nextjs-vite/package.json to resolve the Next.js export issue.  
- Added an optimizeDeps array in code/frameworks/nextjs-vite/src/preset.ts with two dependencies to optimize Vite's bundling process.



<!-- /greptile_comment -->