### PR TITLE
Csf-Tools: Enhance setFieldNode logic to handle variable declarations

### DIFF
--- a/code/core/src/csf-tools/ConfigFile.test.ts
+++ b/code/core/src/csf-tools/ConfigFile.test.ts
@@ -519,6 +519,55 @@ describe('ConfigFile', () => {
           export { core };
         `);
       });
+
+      it('sets nested field in parameters variable', () => {
+        expect(
+          setField(
+            ['parameters', 'a11y'],
+            'todo',
+            dedent`
+              const parameters = { foo: 'bar' };
+              const preview = {
+                parameters,
+              }
+              export default preview;
+            `
+          )
+        ).toMatchInlineSnapshot(`
+          const parameters = {
+            foo: 'bar',
+            a11y: 'todo'
+          };
+          const preview = {
+            parameters,
+          }
+          export default preview;
+        `);
+      });
+
+      it('sets nested field when parameters exists as both variable and direct object', () => {
+        expect(
+          setField(
+            ['parameters', 'a11y'],
+            'todo',
+            dedent`
+              const parameters = { foo: 'bar' };
+              const preview = {
+                parameters: {},
+              }
+              export default preview;
+            `
+          )
+        ).toMatchInlineSnapshot(`
+          const parameters = { foo: 'bar' };
+          const preview = {
+            parameters: {
+              a11y: 'todo'
+            },
+          }
+          export default preview;
+        `);
+      });
     });
 
     describe('factory config', () => {

--- a/code/core/src/csf-tools/ConfigFile.ts
+++ b/code/core/src/csf-tools/ConfigFile.ts
@@ -380,18 +380,46 @@ export class ConfigFile {
   setFieldNode(path: string[], expr: t.Expression) {
     const [first, ...rest] = path;
     const exportNode = this._exports[first];
+
+    // First check if we have a direct path in the exports
     if (this._exportsObject) {
+      const properties = this._exportsObject.properties as t.ObjectProperty[];
+      const existingProp = properties.find((p) => propKey(p) === first);
+
+      // If the property exists and is an identifier, follow the reference
+      if (existingProp && t.isIdentifier(existingProp.value)) {
+        const varDecl = _findVarDeclarator(existingProp.value.name, this._ast.program);
+        if (varDecl && t.isObjectExpression(varDecl.init)) {
+          _updateExportNode(rest, expr, varDecl.init);
+          return;
+        }
+      }
+
+      // Otherwise update the export object directly
       _updateExportNode(path, expr, this._exportsObject);
       this._exports[path[0]] = expr;
-    } else if (exportNode && t.isObjectExpression(exportNode) && rest.length > 0) {
+      return;
+    }
+
+    if (exportNode && t.isObjectExpression(exportNode) && rest.length > 0) {
       _updateExportNode(rest, expr, exportNode);
-    } else if (exportNode && rest.length === 0 && this._exportDecls[path[0]]) {
+      return;
+    }
+
+    // If no direct path found, try variable declarations
+    const varDecl = _findVarDeclarator(first, this._ast.program);
+    if (varDecl && t.isObjectExpression(varDecl.init)) {
+      _updateExportNode(rest, expr, varDecl.init);
+      return;
+    }
+
+    if (exportNode && rest.length === 0 && this._exportDecls[path[0]]) {
       const decl = this._exportDecls[path[0]];
       if (t.isVariableDeclarator(decl)) {
         decl.init = _makeObjectExpression([], expr);
       }
     } else if (this.hasDefaultExport) {
-      // This means the main.js of the user has a default export that is not an object expression, therefore we can'types change the AST.
+      // This means the main.js of the user has a default export that is not an object expression, therefore we can't change the AST.
       throw new Error(
         `Could not set the "${path.join(
           '.'
@@ -527,7 +555,7 @@ export class ConfigFile {
         properties.splice(index, 1);
       }
     };
-    // the structure of this._exports doesn'types work for this use case
+    // the structure of this._exports doesn't work for this use case
     // so we have to manually bypass it here
     if (path.length === 1) {
       let removedRootProperty = false;
@@ -777,10 +805,10 @@ export class ConfigFile {
 
       if (requireDeclaration) {
         if (!hasDefaultRequireSpecifier(requireDeclaration, importSpecifier)) {
-          // If the import declaration hasn'types the specified default identifier, we add a new variable declaration
+          // If the import declaration hasn't the specified default identifier, we add a new variable declaration
           addDefaultRequireSpecifier();
         }
-        // If the import declaration with the given source doesn'types exist
+        // If the import declaration with the given source doesn't exist
       } else {
         // Add the import declaration to the top of the file
         addDefaultRequireSpecifier();

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts
@@ -766,5 +766,32 @@ describe('addonA11yAddonTest', () => {
         };"
       `);
     });
+
+    it('should handle const parameters with preview object', async () => {
+      const source = dedent`
+        const parameters = {};
+        const preview = {
+          parameters,
+        };
+        export default preview;
+      `;
+
+      const transformed = await transformPreviewFile(source, process.cwd());
+
+      expect(transformed).toMatchInlineSnapshot(`
+        "const parameters = {
+          a11y: {
+            // 'todo' - show a11y violations in the test UI only
+            // 'error' - fail CI on a11y violations
+            // 'off' - skip a11y checks entirely
+            test: "todo"
+          }
+        };
+        const preview = {
+          parameters,
+        };
+        export default preview;"
+      `);
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31052

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Enhance setFieldNode logic to handle variable declarations and direct object updates more effectively.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhances transformation logic for configuration file exports, especially for variable declarations and merging nested fields.  
- Updated **code/core/src/csf-tools/ConfigFile.ts** to resolve variable declarations when setting field nodes.  
- Modified **code/core/src/csf-tools/ConfigFile.test.ts** to verify correct merging of nested fields.  
- Added a new test case in **code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.test.ts** covering const parameters transformation.



<!-- /greptile_comment -->