### PR TITLE
Instrumenter: Fix `preview-api` import for react-native

### DIFF
--- a/code/core/src/instrumenter/instrumenter.test.ts
+++ b/code/core/src/instrumenter/instrumenter.test.ts
@@ -7,10 +7,9 @@ import { SET_CURRENT_STORY, STORY_RENDER_PHASE_CHANGED } from 'storybook/interna
 
 import { global } from '@storybook/global';
 
-import { addons } from 'storybook/preview-api';
-
 import { EVENTS } from './EVENTS';
 import { Instrumenter, isClass } from './instrumenter';
+import { addons } from './preview-api';
 import type { Options } from './types';
 
 const mocks = await vi.hoisted(async () => {
@@ -37,13 +36,13 @@ const mocks = await vi.hoisted(async () => {
     callSpy,
     syncSpy,
     forceRemountSpy,
-    ready: vi.fn().mockResolvedValue(Promise.resolve()),
+    ready: vi.fn().mockResolvedValue(Promise.resolve(true)),
     channel,
   };
 });
 
 vi.mock('storybook/internal/client-logger');
-vi.mock('storybook/preview-api', () => {
+vi.mock('./preview-api', () => {
   return {
     addons: {
       ready: mocks.ready,

--- a/code/core/src/instrumenter/instrumenter.ts
+++ b/code/core/src/instrumenter/instrumenter.ts
@@ -11,9 +11,9 @@ import type { StoryId } from 'storybook/internal/types';
 import { global } from '@storybook/global';
 
 import { processError } from '@vitest/utils/error';
-import { addons } from 'storybook/preview-api';
 
 import { EVENTS } from './EVENTS';
+import { addons } from './preview-api';
 import type { Call, CallRef, ControlStates, LogItem, Options, State, SyncPayload } from './types';
 import { CallStates } from './types';
 import './typings.d.ts';

--- a/code/core/src/instrumenter/instrumenter.ts
+++ b/code/core/src/instrumenter/instrumenter.ts
@@ -11,6 +11,7 @@ import type { StoryId } from 'storybook/internal/types';
 import { global } from '@storybook/global';
 
 import { processError } from '@vitest/utils/error';
+import { addons } from 'storybook/preview-api';
 
 import { EVENTS } from './EVENTS';
 import type { Call, CallRef, ControlStates, LogItem, Options, State, SyncPayload } from './types';
@@ -235,9 +236,8 @@ export class Instrumenter {
     };
 
     // Support portable stories where addons are not available
-    // This is a workaround to avoid circular dependency
-    import('storybook/preview-api').then(({ addons }) => {
-      (addons ? addons.ready() : Promise.resolve()).then(() => {
+    if (addons) {
+      addons.ready().then(() => {
         this.channel = addons.getChannel();
 
         // A forceRemount might be triggered for debugging (on `start`), or elsewhere in Storybook.
@@ -261,7 +261,7 @@ export class Instrumenter {
         this.channel.on(EVENTS.NEXT, next(this.channel));
         this.channel.on(EVENTS.END, end);
       });
-    });
+    }
   }
 
   getState(storyId: StoryId) {

--- a/code/core/src/instrumenter/preview-api.ts
+++ b/code/core/src/instrumenter/preview-api.ts
@@ -1,0 +1,7 @@
+/**
+ * We do this for mocking purposes, it's a lot easier to mock the a module than the addons channel
+ * than it is to mock a globalThis property.
+ */
+
+// eslint-disable-next-line no-underscore-dangle
+export const addons = globalThis.__STORYBOOK_ADDONS_PREVIEW;

--- a/code/core/src/typings.d.ts
+++ b/code/core/src/typings.d.ts
@@ -17,7 +17,7 @@ declare var __STORYBOOK_ADDON_INTERACTIONS_INSTRUMENTER__: any;
 declare var __STORYBOOK_ADDON_INTERACTIONS_INSTRUMENTER_STATE__: any;
 declare var __STORYBOOK_ADDONS_CHANNEL__: any;
 declare var __STORYBOOK_ADDONS_MANAGER: any;
-declare var __STORYBOOK_ADDONS_PREVIEW: any;
+declare var __STORYBOOK_ADDONS_PREVIEW: import('./preview-api/modules/addons/main').AddonStore;
 declare var __STORYBOOK_PREVIEW__: import('./preview-api/modules/preview-web/PreviewWeb').PreviewWeb<any>;
 declare var __STORYBOOK_STORY_STORE__: any;
 declare var __STORYBOOK_TEST__: any;


### PR DESCRIPTION
## What I did

This pull request includes changes to the `Instrumenter` class in the `code/core/src/instrumenter/instrumenter.ts` file, aimed at improving the handling of the `addons` module by removing a workaround for circular dependencies. The most important changes include importing the `addons` module directly and simplifying the initialization process.

Changes to `Instrumenter` class:

* [`code/core/src/instrumenter/instrumenter.ts`](diffhunk://#diff-77bf3d8fb7717af04c8444372dd25f994b817828cfb2449146a35b42292b2e41R14): Imported the `addons` module directly from `storybook/preview-api` instead of using a dynamic import to avoid circular dependencies.
* [`code/core/src/instrumenter/instrumenter.ts`](diffhunk://#diff-77bf3d8fb7717af04c8444372dd25f994b817828cfb2449146a35b42292b2e41L238-R240): Simplified the initialization of the `addons` module by checking if `addons` is available and then calling `addons.ready()` directly. [[1]](diffhunk://#diff-77bf3d8fb7717af04c8444372dd25f994b817828cfb2449146a35b42292b2e41L238-R240) [[2]](diffhunk://#diff-77bf3d8fb7717af04c8444372dd25f994b817828cfb2449146a35b42292b2e41L264-R264)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31057-sha-a4eda8b5`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31057-sha-a4eda8b5 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31057-sha-a4eda8b5 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31057-sha-a4eda8b5`](https://npmjs.com/package/storybook/v/0.0.0-pr-31057-sha-a4eda8b5) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/intrumenter-fix`](https://github.com/storybookjs/storybook/tree/norbert/intrumenter-fix) |
| **Commit** | [`a4eda8b5`](https://github.com/storybookjs/storybook/commit/a4eda8b5ee21af0b866563a0df8165964fef9743) |
| **Datetime** | Fri Apr  4 06:39:10 UTC 2025 (`1743748750`) |
| **Workflow run** | [14259555721](https://github.com/storybookjs/storybook/actions/runs/14259555721) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31057`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Improved the Instrumenter initialization by replacing dynamic imports with direct imports for the addons module and tightening type safety in the typings file.  

- Updated `code/core/src/instrumenter/instrumenter.ts` to directly import and initialize the addons module, removing circular dependency workarounds.  
- Modified `code/core/src/typings.d.ts` to explicitly type `__STORYBOOK_ADDONS_PREVIEW` using the `AddonStore` type.  
- Simplified initialization by calling `addons.ready()` directly once addons are available.



<!-- /greptile_comment -->