### PR TITLE
Yarn: Update Yarn package command execution to use 'exec'

### DIFF
--- a/code/core/src/common/js-package-manager/Yarn1Proxy.test.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.test.ts
@@ -51,7 +51,10 @@ describe('Yarn 1 Proxy', () => {
       await yarn1Proxy.runPackageCommand('compodoc', ['-e', 'json', '-d', '.']);
 
       expect(executeCommandSpy).toHaveBeenLastCalledWith(
-        expect.objectContaining({ command: 'yarn', args: ['compodoc', '-e', 'json', '-d', '.'] })
+        expect.objectContaining({
+          command: 'yarn',
+          args: ['exec', 'compodoc', '-e', 'json', '-d', '.'],
+        })
       );
     });
   });

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.ts
@@ -67,7 +67,7 @@ export class Yarn1Proxy extends JsPackageManager {
   }
 
   async runPackageCommand(command: string, args: string[], cwd?: string): Promise<string> {
-    return this.executeCommand({ command: `yarn`, args: [command, ...args], cwd });
+    return this.executeCommand({ command: `yarn`, args: ['exec', command, ...args], cwd });
   }
 
   public async getPackageJSON(

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.test.ts
@@ -48,7 +48,7 @@ describe('Yarn 2 Proxy', () => {
       expect(executeCommandSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
           command: 'yarn',
-          args: ['compodoc', '-e', 'json', '-d', '.'],
+          args: ['exec', 'compodoc', '-e', 'json', '-d', '.'],
         })
       );
     });

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.ts
@@ -110,7 +110,7 @@ export class Yarn2Proxy extends JsPackageManager {
   }
 
   async runPackageCommand(command: string, args: string[], cwd?: string) {
-    return this.executeCommand({ command: 'yarn', args: [command, ...args], cwd });
+    return this.executeCommand({ command: 'yarn', args: ['exec', command, ...args], cwd });
   }
 
   public async findInstallations(pattern: string[], { depth = 99 }: { depth?: number } = {}) {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Update Yarn package command execution to use 'exec' for both Yarn1Proxy and Yarn2Proxy classes, ensuring proper command execution context.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR updates the command execution in both Yarn1Proxy and Yarn2Proxy to uniformly use the 'exec' prefix for package commands, with tests adjusted accordingly.

- Updated `code/core/src/common/js-package-manager/Yarn1Proxy.ts` to prepend 'exec' in `runPackageCommand`.
- Modified `code/core/src/common/js-package-manager/Yarn2Proxy.ts` similarly for Yarn Berry.
- Revised tests in both `Yarn1Proxy.test.ts` and `Yarn2Proxy.test.ts` to match the new command format.
- Ensured consistency in command execution context without affecting synchronous flows.



<!-- /greptile_comment -->