### PR TITLE
Autoblock: Add autoblocker for addon-test

### DIFF
--- a/code/lib/cli-storybook/src/autoblock/block-experimental-addon-test.test.ts
+++ b/code/lib/cli-storybook/src/autoblock/block-experimental-addon-test.test.ts
@@ -7,6 +7,17 @@ import { blocker } from './block-experimental-addon-test';
 
 vi.mock('semver');
 
+vi.mock('picocolors', async (importOriginal) => {
+  const mod = (await importOriginal()) as any;
+  return {
+    ...mod,
+    default: {
+      bold: (s: string) => s,
+      magenta: (s: string) => s,
+    },
+  };
+});
+
 describe('experimentalAddonTestVitest blocker', () => {
   const mockPackageManager = {
     getInstalledVersion: vi.fn(),

--- a/code/lib/cli-storybook/src/autoblock/block-experimental-addon-test.test.ts
+++ b/code/lib/cli-storybook/src/autoblock/block-experimental-addon-test.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import semver from 'semver';
+import dedent from 'ts-dedent';
 
 import { blocker } from './block-experimental-addon-test';
 
@@ -101,7 +102,7 @@ describe('experimentalAddonTestVitest blocker', () => {
 
   test('log should return correct message', () => {
     const message = blocker.log({} as any, true);
-    expect(message).toMatchInlineSnapshot(`
+    expect(message).toMatchInlineSnapshot(dedent`
       "@storybook/experimental-addon-test is being stabilized in Storybook 9.
 
       The addon will be renamed to @storybook/addon-vitest and as part of this stabilization, we have dropped support for Vitest 2.

--- a/code/lib/cli-storybook/src/autoblock/block-experimental-addon-test.ts
+++ b/code/lib/cli-storybook/src/autoblock/block-experimental-addon-test.ts
@@ -1,0 +1,43 @@
+import picocolors from 'picocolors';
+import semver from 'semver';
+import { dedent } from 'ts-dedent';
+
+import { createBlocker } from './types';
+
+export const blocker = createBlocker({
+  id: 'experimentalAddonTestVitest',
+  async check({ packageJson, packageManager }) {
+    const dependencies = {
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+    };
+
+    // Check if @storybook/experimental-addon-test is installed
+    const hasExperimentalAddon = '@storybook/experimental-addon-test' in dependencies;
+
+    if (!hasExperimentalAddon) {
+      return false;
+    }
+
+    const vitestVersion = await packageManager.getInstalledVersion('vitest');
+
+    if (!vitestVersion) {
+      return false;
+    }
+
+    return semver.lt(vitestVersion, '3.0.0');
+  },
+  log() {
+    return dedent`
+      ${picocolors.bold('@storybook/experimental-addon-test')} is being stabilized in Storybook 9.
+      
+      The addon will be renamed to ${picocolors.bold('@storybook/addon-vitest')} and as part of this stabilization, we have dropped support for Vitest 2.
+      
+      You have two options to proceed:
+      1. Remove ${picocolors.bold('@storybook/experimental-addon-test')} if you don't need it
+      2. Upgrade to ${picocolors.bold('Vitest 3')} to continue using the addon
+      
+      After addressing this, you can try running the upgrade command again.
+    `;
+  },
+});

--- a/code/lib/cli-storybook/src/autoblock/block-experimental-addon-test.ts
+++ b/code/lib/cli-storybook/src/autoblock/block-experimental-addon-test.ts
@@ -29,12 +29,12 @@ export const blocker = createBlocker({
   },
   log() {
     return dedent`
-      ${picocolors.bold('@storybook/experimental-addon-test')} is being stabilized in Storybook 9.
+      ${picocolors.magenta('@storybook/experimental-addon-test')} is being stabilized in Storybook 9.
       
-      The addon will be renamed to ${picocolors.bold('@storybook/addon-vitest')} and as part of this stabilization, we have dropped support for Vitest 2.
+      The addon will be renamed to ${picocolors.magenta('@storybook/addon-vitest')} and as part of this stabilization, we have dropped support for Vitest 2.
       
       You have two options to proceed:
-      1. Remove ${picocolors.bold('@storybook/experimental-addon-test')} if you don't need it
+      1. Remove ${picocolors.magenta('@storybook/experimental-addon-test')} if you don't need it
       2. Upgrade to ${picocolors.bold('Vitest 3')} to continue using the addon
       
       After addressing this, you can try running the upgrade command again.

--- a/code/lib/cli-storybook/src/autoblock/index.ts
+++ b/code/lib/cli-storybook/src/autoblock/index.ts
@@ -14,6 +14,7 @@ const blockers: () => BlockerModule<any>[] = () => [
   import('./block-node-version'),
   import('./block-svelte-webpack5'),
   import('./block-major-version'),
+  import('./block-experimental-addon-test'),
 ];
 
 type BlockerModule<T> = Promise<{ blocker: Blocker<T> }>;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds a new autoblock that prevents users from upgrading to Storybook 9 if they have `@storybook/experimental-addon-test` installed and are using Vitest < 3. This is necessary because in Storybook 9, the experimental addon is being stabilized (renamed to `@storybook/addon-vitest`) and as part of this stabilization, we've dropped support for Vitest 2.

### Changes
- Added new autoblock `block-experimental-addon-test.ts` that:
  - Checks for presence of `@storybook/experimental-addon-test` in dependencies
  - Verifies Vitest version using package manager
  - Blocks upgrade if Vitest < 3.0.0 is detected
- Added comprehensive test suite covering all scenarios
- Added clear user messaging explaining the required actions

### Testing
The changes include a test suite that verifies:
- ✅ Returns false when experimental addon is not installed
- ✅ Returns false when Vitest is not installed
- ✅ Returns true (blocks) when Vitest < 3.0.0 is detected
- ✅ Returns false when Vitest >= 3.0.0 is detected
- ✅ Checks both dependencies and devDependencies
- ✅ Provides clear user guidance in the log message

### User Impact
When users with `@storybook/experimental-addon-test` and Vitest < 3 attempt to upgrade to Storybook 9, they will see a message explaining:
- That the addon is being stabilized in Storybook 9
- The new name of the addon (`@storybook/addon-vitest`)
- Their options:
  1. Remove the experimental addon if not needed
  2. Upgrade to Vitest 3 to continue using the addon

![image](https://github.com/user-attachments/assets/3e8edcb0-9699-4cc5-afa2-4234ee17be44)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31068-sha-6e3bb0f4`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31068-sha-6e3bb0f4 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31068-sha-6e3bb0f4 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31068-sha-6e3bb0f4`](https://npmjs.com/package/storybook/v/0.0.0-pr-31068-sha-6e3bb0f4) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/introduce-experimental-addon-test-autoblock`](https://github.com/storybookjs/storybook/tree/valentin/introduce-experimental-addon-test-autoblock) |
| **Commit** | [`6e3bb0f4`](https://github.com/storybookjs/storybook/commit/6e3bb0f4dea76a91d545fc5da620bd6c9b04a26d) |
| **Datetime** | Fri Apr  4 09:22:54 UTC 2025 (`1743758574`) |
| **Workflow run** | [14262219854](https://github.com/storybookjs/storybook/actions/runs/14262219854) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31068`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
