### PR TITLE
Addon-vitest: Fix coverage when restarting Vitest due to config change

### DIFF
--- a/code/addons/vitest/src/node/vitest-manager.ts
+++ b/code/addons/vitest/src/node/vitest-manager.ts
@@ -53,7 +53,7 @@ export class VitestManager {
 
   constructor(private testManager: TestManager) {}
 
-  async startVitest({ coverage = false } = {}) {
+  async startVitest({ coverage }: { coverage: boolean }) {
     const { createVitest } = await import('vitest/node');
 
     const storybookCoverageReporter: [string, StorybookCoverageReporterOptions] = [
@@ -206,7 +206,6 @@ export class VitestManager {
     if (!this.vitest) {
       await this.startVitest({ coverage: coverageShouldBeEnabled });
     } else if (currentCoverage !== coverageShouldBeEnabled) {
-      await this.vitestRestartPromise;
       await this.restartVitest({ coverage: coverageShouldBeEnabled });
     } else {
       await this.vitestRestartPromise;
@@ -391,8 +390,8 @@ export class VitestManager {
       const isConfig = file === this.vitest?.vite?.config.configFile;
       if (isConfig) {
         log('Restarting Vitest due to config change');
-        await this.closeVitest();
-        await this.startVitest();
+        const { watching, config } = this.testManager.store.getState();
+        await this.restartVitest({ coverage: config.coverage && !watching });
       }
     });
   }


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/30900

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The issue was technically already fixed in #30875, where coverage mode became more resilient and always restarted Vitest when a run was triggered with coverage mode that didn't match the currently running mode: 

https://github.com/storybookjs/storybook/blob/71a080ba529e0bb4277d5ae3d68187d28d3a928b/code/addons/vitest/src/node/vitest-manager.ts#L201-L213

However restarting Vitest due to config change didn't correctly set coverage mode, so it could result in:

1. Enable coverage
2. Run all tests
3. (This restarts Vitest with coverage enabled)
4. Change Vitest config
5. (This restarts Vitest with coverage _disabled_)
6. Run all tests
7. (This restarts Vitest _again_ to enable coverage)

This PR eliminates step 7, because step 5 will have the correct coverage mode.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
9. Open Storybook in your browser
10. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updated the VitestManager in `/code/addons/vitest/src/node/vitest-manager.ts` to correctly apply the coverage mode when restarting Vitest after configuration changes.

- Modified `startVitest` to require an explicit `coverage` boolean.
- Removed redundant waiting on the prior restart promise in `restartVitest`.
- Updated the config change listener to fetch the current coverage state from the test manager store.
- Ensured the correct coverage mode is maintained post-config change, preventing unnecessary restarts.



<!-- /greptile_comment -->