### PR TITLE
[doc] Disable auto-included `addon-docs` when adding GFM plugin

### DIFF
--- a/docs/_snippets/storybook-main-config-remark-options.md
+++ b/docs/_snippets/storybook-main-config-remark-options.md
@@ -7,6 +7,17 @@ export default {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
     // Other addons go here
+
+    // If you have @storybook/addon-essentials enabled, change it to the following:
+    /*
+    {
+      name: "@storybook/addon-essentials",
+      options: {
+        docs: false,
+      },
+    },
+    */
+
     {
       name: '@storybook/addon-docs',
       options: {
@@ -32,6 +43,17 @@ const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
     // Other addons go here
+
+    // If you have @storybook/addon-essentials enabled, change it to the following:
+    /*
+    {
+      name: "@storybook/addon-essentials",
+      options: {
+        docs: false,
+      },
+    },
+    */
+
     {
       name: '@storybook/addon-docs',
       options: {


### PR DESCRIPTION
Related to #24718 (could close it if I get some help haha), related to 24743

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This fixes a confusing issue when you try to add the GFM plugin, when using `addon-essentials` (AFAIK, that's the default?): Storybook ignores the new plugin because the `docs` add-on was already included. Changing code order doesn't seem to help, either.

I only found the solution after digging through this old issue: https://github.com/storybookjs/storybook/issues/20091#issuecomment-1526908505

### What's missing
This should also be fixed for [v7](https://storybook.js.org/docs/7/writing-docs/mdx#anatomy-of-mdx), but I didn't find the correct branch to edit that - the "edit on GitHub" link simply takes me to `next`, where the v7 files don't exist anymore.
 
If someone can point me in the correct direct to fix that, I can also add a note about the requirement of `remark-gfm@v3`, as pointed at https://github.com/storybookjs/storybook/issues/24743#issuecomment-1799810754 - this is also an issue I faced on v7. Then, I guess we could auto-close #24718.

## Checklist for Contributors

### Testing
This is just a documentation change, so no testing?

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updated the documentation snippet to clarify GFM plugin configuration with Storybook when using auto-included addon-docs from addon-essentials.

- Updated `docs/_snippets/storybook-main-config-remark-options.md` to include clear JavaScript and TypeScript examples.
- Added commented configuration instructions to disable addon-docs to prevent plugin conflicts.
- Highlighted potential version issues with remark-gfm to aid user troubleshooting.



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->
>Actually, Greptile is incorrect on the version issues, as I don't mention version changes (yet) on the code changes.