### PR TITLE
Docs: fix .storybook/main PnP workaround to work in ESM environments

### DIFF
--- a/docs/_snippets/storybook-main-pnpm-with-module-resolution.md
+++ b/docs/_snippets/storybook-main-pnpm-with-module-resolution.md
@@ -1,8 +1,11 @@
 ```js filename=".storybook/main.js" renderer="common" language="js"
 import path from 'path';
 
+const _require = typeof require === 'undefined' ? import.meta : require; 
 const getAbsolutePath = (packageName) =>
-  path.dirname(require.resolve(path.join(packageName, 'package.json')));
+  path
+    .dirname(_require.resolve(path.join(packageName, 'package.json')))
+    .replace(/^file:\/\//, '');
 
 export default {
   framework: {
@@ -24,8 +27,11 @@ import type { StorybookConfig } from '@storybook/your-framework';
 
 import path from 'path';
 
+const _require = typeof require === 'undefined' ? import.meta : require; 
 const getAbsolutePath = (packageName: string): any =>
-  path.dirname(require.resolve(path.join(packageName, 'package.json')));
+  path
+    .dirname(_require.resolve(path.join(packageName, 'package.json')))
+    .replace(/^file:\/\//, '');
 
 const config: StorybookConfig = {
   framework: {


### PR DESCRIPTION
## What I did

the FAQ page in the docs has an item called [“How do I fix module resolution in special environments?”](https://storybook.js.org/docs/faq#how-do-i-fix-module-resolution-in-special-environments). the suggested workaround is the following:

```ts
import path from 'path';
 
const getAbsolutePath = (packageName: string): any =>
  path.dirname(require.resolve(path.join(packageName, 'package.json')));
```

in a fully ESM environment, [there is no `require.resolve`](https://nodejs.org/api/esm.html#no-requireresolve), and the code samples are using ESM imports, so to avoid triggering `ReferenceError: require is not defined`, i adapted the code snippet to use `import.meta` if `require` is `undefined`:
```ts
import path from 'path';

const _require = typeof require === 'undefined' ? import.meta : require; 
const getAbsolutePath = (packageName: string): any =>
  path
    .dirname(_require.resolve(path.join(value, 'package.json')))
    .replace(/^file:\/\//, '');
```

note that i originally tried to just switch over from `require` to `import.meta`, but that broke my build in CI (netlify) with the error ` "import.meta" is not available with the "cjs" output format and will be empty` (node v18.20.8), so i went for an approach that works in both esm and cjs environments.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

this PR only covers a documentation code snippet so it isn’t covered by automated tests, though i have manually verified the new code snippet in my environment (using node v23.11.0 on macOS 15.3.2).

#### Manual testing

as mentioned above, i manually verified the code snippet change and it makes it possible to run storybook using yarn PnP (v4.8.0) in my environment (node v23.11.0 on macOS 15.3.2), while the current code snippet in the documentation causes an error and prevents storybook for running. steps to verify:

1. in a repo with `"type": "module"` on the latest version of node, use PnP with your package manager (via yarn or pnpm)
2. try to run storybook with the existing code snippet from the docs (fails due to usage of `require.resolve`)
3. run storybook with the updated code snippet from this PR

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] [N.A.] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updated the documentation snippet for module resolution to provide an ESM-friendly workaround that supports Yarn PnP environments. The new snippet replaces `require.resolve` with `import.meta.resolve` and strips the `file://` prefix.

- Modified file: `docs/_snippets/storybook-main-pnpm-with-module-resolution.md`
- Replaced Node.js CommonJS API with ESM-compatible code.
- Ensures compatibility in fully ESM projects using Yarn PnP.
- Manually verified with Node v23.11.0 on macOS.



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->