### PR TITLE
CLI: Fix framework for preview imports

### DIFF
--- a/code/frameworks/nextjs-vite/template/stories/Link.stories.tsx
+++ b/code/frameworks/nextjs-vite/template/stories/Link.stories.tsx
@@ -40,16 +40,6 @@ const Component = () => (
       </Link>
     </li>
     <li>
-      <Link href="/legacy-behaviour" legacyBehavior>
-        <a>Legacy behavior</a>
-      </Link>
-    </li>
-    <li>
-      <Link href="/child-is-functional-component" passHref legacyBehavior>
-        <MyButton>child is a functional component</MyButton>
-      </Link>
-    </li>
-    <li>
       <Link href="/#hashid" scroll={false}>
         Disables scrolling to the top
       </Link>

--- a/code/frameworks/nextjs/template/stories/Link.stories.tsx
+++ b/code/frameworks/nextjs/template/stories/Link.stories.tsx
@@ -40,16 +40,6 @@ const Component = () => (
       </Link>
     </li>
     <li>
-      <Link href="/legacy-behaviour" legacyBehavior>
-        <a>Legacy behavior</a>
-      </Link>
-    </li>
-    <li>
-      <Link href="/child-is-functional-component" passHref legacyBehavior>
-        <MyButton>child is a functional component</MyButton>
-      </Link>
-    </li>
-    <li>
       <Link href="/#hashid" scroll={false}>
         Disables scrolling to the top
       </Link>

--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -424,7 +424,7 @@ export async function baseGenerator(
       frameworkPreviewParts,
       storybookConfigFolder: storybookConfigFolder as string,
       language,
-      rendererId,
+      frameworkPackage,
     });
   }
 

--- a/code/lib/create-storybook/src/generators/configure.test.ts
+++ b/code/lib/create-storybook/src/generators/configure.test.ts
@@ -129,7 +129,7 @@ describe('configurePreview', () => {
     await configurePreview({
       language: SupportedLanguage.JAVASCRIPT,
       storybookConfigFolder: '.storybook',
-      rendererId: 'react',
+      frameworkPackage: '@storybook/react-vite',
     });
 
     const { calls } = vi.mocked(fsp.writeFile).mock;
@@ -137,7 +137,7 @@ describe('configurePreview', () => {
 
     expect(previewConfigPath).toEqual('./.storybook/preview.js');
     expect(previewConfigContent).toMatchInlineSnapshot(`
-      "/** @type { import('@storybook/react').Preview } */
+      "/** @type { import('@storybook/react-vite').Preview } */
       const preview = {
         parameters: {
           controls: {
@@ -157,7 +157,7 @@ describe('configurePreview', () => {
     await configurePreview({
       language: SupportedLanguage.TYPESCRIPT_4_9,
       storybookConfigFolder: '.storybook',
-      rendererId: 'react',
+      frameworkPackage: '@storybook/react-vite',
     });
 
     const { calls } = vi.mocked(fsp.writeFile).mock;
@@ -165,7 +165,7 @@ describe('configurePreview', () => {
 
     expect(previewConfigPath).toEqual('./.storybook/preview.ts');
     expect(previewConfigContent).toMatchInlineSnapshot(`
-      "import type { Preview } from '@storybook/react'
+      "import type { Preview } from '@storybook/react-vite'
 
       const preview: Preview = {
         parameters: {
@@ -187,7 +187,7 @@ describe('configurePreview', () => {
     await configurePreview({
       language: SupportedLanguage.TYPESCRIPT_4_9,
       storybookConfigFolder: '.storybook',
-      rendererId: 'react',
+      frameworkPackage: '@storybook/react-vite',
     });
     expect(fsp.writeFile).not.toHaveBeenCalled();
   });
@@ -196,7 +196,7 @@ describe('configurePreview', () => {
     await configurePreview({
       language: SupportedLanguage.TYPESCRIPT_4_9,
       storybookConfigFolder: '.storybook',
-      rendererId: 'angular',
+      frameworkPackage: '@storybook/angular',
       frameworkPreviewParts: {
         prefix: dedent`
         import { setCompodocJson } from "@storybook/addon-docs/angular";

--- a/test-storybooks/portable-stories-kitchen-sink/nextjs/stories/Link.stories.tsx
+++ b/test-storybooks/portable-stories-kitchen-sink/nextjs/stories/Link.stories.tsx
@@ -38,16 +38,6 @@ const Component = () => (
       </Link>
     </li>
     <li>
-      <Link href="/legacy-behaviour" legacyBehavior>
-        <a>Legacy behavior</a>
-      </Link>
-    </li>
-    <li>
-      <Link href="/child-is-functional-component" passHref legacyBehavior>
-        <MyButton>child is a functional component</MyButton>
-      </Link>
-    </li>
-    <li>
       <Link href="/#hashid" scroll={false}>
         Disables scrolling to the top
       </Link>

--- a/test-storybooks/portable-stories-kitchen-sink/nextjs/stories/__snapshots__/portable-stories.test.tsx.snap
+++ b/test-storybooks/portable-stories-kitchen-sink/nextjs/stories/__snapshots__/portable-stories.test.tsx.snap
@@ -520,20 +520,6 @@ exports[`renders linkStories stories renders Default 1`] = `
         </li>
         <li>
           <a
-            href="/legacy-behaviour"
-          >
-            Legacy behavior
-          </a>
-        </li>
-        <li>
-          <a
-            href="/child-is-functional-component"
-          >
-            child is a functional component
-          </a>
-        </li>
-        <li>
-          <a
             href="/#hashid"
           >
             Disables scrolling to the top
@@ -596,20 +582,6 @@ exports[`renders linkStories stories renders InAppDir 1`] = `
             href="/replace-url"
           >
             Replace the URL instead of push
-          </a>
-        </li>
-        <li>
-          <a
-            href="/legacy-behaviour"
-          >
-            Legacy behavior
-          </a>
-        </li>
-        <li>
-          <a
-            href="/child-is-functional-component"
-          >
-            child is a functional component
           </a>
         </li>
         <li>


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have fixed the generation of `preview.<ts|js>` files, which were still referencing the `renderer`, instead of the `framework` package.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR refactors how Storybook handles framework-specific preview configurations in the project setup process.

- Changed `baseGenerator.ts` to pass `frameworkPackage` instead of `rendererId` to the `configurePreview` function
- Updated `ConfigurePreviewOptions` interface in `configure.ts` to use `frameworkPackage` parameter instead of `rendererId`
- Simplified the preview file generation logic to import Preview types directly from framework packages
- Aligns with Storybook's framework-centric architecture by ensuring preview configurations are properly associated with their respective frameworks
- Maintains consistency in how Storybook handles framework-specific configurations across the codebase

Greptile AI: This change improves type safety and architectural consistency by using the correct import source for framework-specific preview configurations.



<!-- /greptile_comment -->