### PR TITLE
Save from Controls: Replace rendererPackage with frameworkPackage

### DIFF
--- a/code/core/src/core-server/utils/get-new-story-file.test.ts
+++ b/code/core/src/core-server/utils/get-new-story-file.test.ts
@@ -34,7 +34,45 @@ describe('get-new-story-file', () => {
 
     expect(exportedStoryName).toBe('Default');
     expect(storyFileContent).toMatchInlineSnapshot(`
-      "import type { Meta, StoryObj } from '@storybook/react';
+      "import type { Meta, StoryObj } from '@storybook/nextjs';
+
+      import { Page } from './Page';
+
+      const meta = {
+        component: Page,
+      } satisfies Meta<typeof Page>;
+
+      export default meta;
+
+      type Story = StoryObj<typeof meta>;
+
+      export const Default: Story = {};"
+    `);
+    expect(storyFilePath).toBe(join(__dirname, 'src', 'components', 'Page.stories.tsx'));
+  });
+
+  it('should create a new story file (TypeScript) with a framework package using the pnp workaround', async () => {
+    const { exportedStoryName, storyFileContent, storyFilePath } = await getNewStoryFile(
+      {
+        componentFilePath: 'src/components/Page.tsx',
+        componentExportName: 'Page',
+        componentIsDefaultExport: false,
+        componentExportCount: 1,
+      },
+      {
+        presets: {
+          apply: (val: string) => {
+            if (val === 'framework') {
+              return Promise.resolve('path/to/@storybook/react-vite');
+            }
+          },
+        },
+      } as any
+    );
+
+    expect(exportedStoryName).toBe('Default');
+    expect(storyFileContent).toMatchInlineSnapshot(`
+      "import type { Meta, StoryObj } from '@storybook/react-vite';
 
       import { Page } from './Page';
 

--- a/code/core/src/core-server/utils/get-new-story-file.ts
+++ b/code/core/src/core-server/utils/get-new-story-file.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { basename, dirname, extname, join } from 'node:path';
 
 import {
+  extractProperFrameworkName,
   extractProperRendererNameFromFramework,
   findConfigFile,
   getFrameworkName,
@@ -30,10 +31,7 @@ export async function getNewStoryFile(
   const cwd = getProjectRoot();
 
   const frameworkPackageName = await getFrameworkName(options);
-  const rendererName = await extractProperRendererNameFromFramework(frameworkPackageName);
-  const rendererPackage = Object.entries(rendererPackages).find(
-    ([, value]) => value === rendererName
-  )?.[0];
+  const sanitizedFrameworkPackageName = extractProperFrameworkName(frameworkPackageName);
 
   const base = basename(componentFilePath);
   const extension = extname(componentFilePath);
@@ -67,12 +65,12 @@ export async function getNewStoryFile(
     });
   } else {
     storyFileContent =
-      isTypescript && rendererPackage
+      isTypescript && frameworkPackageName
         ? await getTypeScriptTemplateForNewStoryFile({
             basenameWithoutExtension,
             componentExportName,
             componentIsDefaultExport,
-            rendererPackage,
+            frameworkPackage: sanitizedFrameworkPackageName,
             exportedStoryName,
           })
         : await getJavaScriptTemplateForNewStoryFile({

--- a/code/core/src/core-server/utils/new-story-templates/typescript.test.ts
+++ b/code/core/src/core-server/utils/new-story-templates/typescript.test.ts
@@ -8,12 +8,12 @@ describe('typescript', () => {
       basenameWithoutExtension: 'foo',
       componentExportName: 'default',
       componentIsDefaultExport: true,
-      rendererPackage: '@storybook/react',
+      frameworkPackage: '@storybook/react-vite',
       exportedStoryName: 'Default',
     });
 
     expect(result).toMatchInlineSnapshot(`
-      "import type { Meta, StoryObj } from '@storybook/react';
+      "import type { Meta, StoryObj } from '@storybook/react-vite';
 
       import Foo from './foo';
 
@@ -34,12 +34,12 @@ describe('typescript', () => {
       basenameWithoutExtension: 'foo',
       componentExportName: 'Example',
       componentIsDefaultExport: false,
-      rendererPackage: '@storybook/react',
+      frameworkPackage: '@storybook/react-vite',
       exportedStoryName: 'Default',
     });
 
     expect(result).toMatchInlineSnapshot(`
-      "import type { Meta, StoryObj } from '@storybook/react';
+      "import type { Meta, StoryObj } from '@storybook/react-vite';
 
       import { Example } from './foo';
 

--- a/code/core/src/core-server/utils/new-story-templates/typescript.ts
+++ b/code/core/src/core-server/utils/new-story-templates/typescript.ts
@@ -7,8 +7,8 @@ interface TypeScriptTemplateData {
   basenameWithoutExtension: string;
   componentExportName: string;
   componentIsDefaultExport: boolean;
-  /** The renderer package name, e.g. @storybook/nextjs */
-  rendererPackage: string;
+  /** The framework package name, e.g. @storybook/nextjs */
+  frameworkPackage: string;
   /** The exported name of the default story */
   exportedStoryName: string;
 }
@@ -22,7 +22,7 @@ export async function getTypeScriptTemplateForNewStoryFile(data: TypeScriptTempl
     : `import { ${importName} } from './${data.basenameWithoutExtension}'`;
 
   return dedent`
-  import type { Meta, StoryObj } from '${data.rendererPackage}';
+  import type { Meta, StoryObj } from '${data.frameworkPackage}';
 
   ${importStatement};
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31112

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Adjusted the creation of a new story by changing the import of TypeScript types to not use the renderer package, but rather the framework package instead.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR replaces `rendererPackage` with `frameworkPackage` in the story file generation utilities to standardize terminology across the codebase.

- Changed parameter name from `rendererPackage` to `frameworkPackage` in `code/core/src/core-server/utils/new-story-templates/typescript.ts` interface and function
- Updated import logic in `code/core/src/core-server/utils/get-new-story-file.ts` to use `extractProperFrameworkName` instead of renderer extraction
- Updated tests in `code/core/src/core-server/utils/get-new-story-file.test.ts` to reflect framework package imports
- Modified test snapshots in `code/core/src/core-server/utils/new-story-templates/typescript.test.ts` to use framework references



<!-- /greptile_comment -->