### PR TITLE
Docs: Replace outdated MDX VSCode setting with a new one

### DIFF
--- a/docs/writing-docs/mdx.mdx
+++ b/docs/writing-docs/mdx.mdx
@@ -294,7 +294,7 @@ Additionally, if you're working with VSCode, you can add the [MDX extension](htt
 
 ```json
 {
-  "mdx.experimentalLanguageServer": true
+  "mdx.server.enable": true
 }
 ```
 


### PR DESCRIPTION


## What I did

In version [1.5.0](https://github.com/mdx-js/mdx-analyzer/blob/fa0a6cfcdf109925068731e7d2fbd30adde75d44/packages/vscode-mdx/CHANGELOG.md?plain=1#L171) vscode-mdx replaced the old experimental setting with a stable new one

## Checklist for Contributors

### Testing

#### Manual testing

No manual test is necessary

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR updates the VSCode MDX extension configuration in the documentation, replacing the outdated experimental setting with the stable one introduced in version 1.5.0.

- Changed `mdx.experimentalLanguageServer` to `mdx.server.enable` in `docs/writing-docs/mdx.mdx`
- Aligns documentation with the current stable configuration for the VSCode MDX extension
- Ensures users follow the correct setup instructions for MDX language support
- Improves developer experience by recommending the officially supported setting



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->