### PR TITLE
AddonVitest: Use framework package, not renderer

### DIFF
--- a/code/addons/vitest/src/constants.ts
+++ b/code/addons/vitest/src/constants.ts
@@ -19,10 +19,13 @@ export const COVERAGE_DIRECTORY = 'coverage';
 export const SUPPORTED_FRAMEWORKS = [
   '@storybook/nextjs',
   '@storybook/nextjs-vite',
+  '@storybook/react-vite',
+  '@storybook/svelte-vite',
+  '@storybook/vue3-vite',
+  '@storybook/html-vite',
+  '@storybook/web-components-vite',
   '@storybook/sveltekit',
 ];
-
-export const SUPPORTED_RENDERERS = ['@storybook/react', '@storybook/svelte', '@storybook/vue3'];
 
 export const storeOptions = {
   id: ADDON_ID,

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -26,7 +26,7 @@ import { coerce, satisfies } from 'semver';
 import { dedent } from 'ts-dedent';
 
 import { type PostinstallOptions } from '../../../lib/cli-storybook/src/add';
-import { SUPPORTED_FRAMEWORKS, SUPPORTED_RENDERERS } from './constants';
+import { SUPPORTED_FRAMEWORKS } from './constants';
 import { printError, printInfo, printSuccess, printWarning, step } from './postinstall-logger';
 import { loadTemplate, updateConfigFile, updateWorkspaceFile } from './updateVitestFile';
 import { getAddonNames } from './utils';
@@ -112,9 +112,7 @@ export default async function postInstall(options: PostinstallOptions) {
     ? info.frameworkPackageName === '@storybook/nextjs'
       ? '@storybook/nextjs-vite'
       : info.frameworkPackageName
-    : info.rendererPackageName && SUPPORTED_RENDERERS.includes(info.rendererPackageName)
-      ? info.rendererPackageName
-      : null;
+    : null;
 
   const isRendererSupported = !!annotationsImport;
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
@@ -8,10 +8,7 @@ import picocolors from 'picocolors';
 import { dedent } from 'ts-dedent';
 
 // Relative path import to avoid dependency to storybook/test
-import {
-  SUPPORTED_FRAMEWORKS,
-  SUPPORTED_RENDERERS,
-} from '../../../../../addons/vitest/src/constants';
+import { SUPPORTED_FRAMEWORKS } from '../../../../../addons/vitest/src/constants';
 import { getFrameworkPackageName, getRendererName } from '../helpers/mainConfigFile';
 import type { Fix } from '../types';
 
@@ -63,12 +60,7 @@ export const addonA11yAddonTest: Fix<AddonA11yAddonTestOptions> = {
     const hasA11yAddon = !!addons.find((addon) => addon.includes('@storybook/addon-a11y'));
     const hasTestAddon = !!addons.find((addon) => addon.includes('@storybook/addon-vitest'));
 
-    if (
-      !SUPPORTED_FRAMEWORKS.find((framework) => frameworkPackageName?.includes(framework)) &&
-      !SUPPORTED_RENDERERS.find((renderer) =>
-        rendererPackageName?.includes(rendererPackages[renderer])
-      )
-    ) {
+    if (!SUPPORTED_FRAMEWORKS.find((framework) => frameworkPackageName?.includes(framework))) {
       return null;
     }
 

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-addon-test.ts
@@ -9,7 +9,7 @@ import { dedent } from 'ts-dedent';
 
 // Relative path import to avoid dependency to storybook/test
 import { SUPPORTED_FRAMEWORKS } from '../../../../../addons/vitest/src/constants';
-import { getFrameworkPackageName, getRendererName } from '../helpers/mainConfigFile';
+import { getFrameworkPackageName } from '../helpers/mainConfigFile';
 import type { Fix } from '../types';
 
 export const fileExtensions = [
@@ -55,7 +55,6 @@ export const addonA11yAddonTest: Fix<AddonA11yAddonTestOptions> = {
     const addons = getAddonNames(mainConfig);
 
     const frameworkPackageName = getFrameworkPackageName(mainConfig);
-    const rendererPackageName = getRendererName(mainConfig);
 
     const hasA11yAddon = !!addons.find((addon) => addon.includes('@storybook/addon-a11y'));
     const hasTestAddon = !!addons.find((addon) => addon.includes('@storybook/addon-vitest'));


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31122

## What I did

This pull request includes updates to the `code/addons/vitest` module, specifically adding support for new frameworks and simplifying the post-installation script by removing unnecessary imports and conditions.

Framework support:

* [`code/addons/vitest/src/constants.ts`](diffhunk://#diff-53faff6e9ab25863bfac3d5c158b575432cc304328bdd5cc07e51c89cb8033fdR22-L26): Added support for additional Vite frameworks including `@storybook/react-vite`, `@storybook/svelte-vite`, `@storybook/vue3-vite`, `@storybook/html-vite`, and `@storybook/web-components-vite`.

Code simplification:

* [`code/addons/vitest/src/postinstall.ts`](diffhunk://#diff-f6ce5c3a6e756925c91ff681c11809203bab260332d82acef7ec3bff8baeca2cL29-R29): Removed the `SUPPORTED_RENDERERS` import and its usage in the post-installation script, simplifying the logic for determining supported frameworks. [[1]](diffhunk://#diff-f6ce5c3a6e756925c91ff681c11809203bab260332d82acef7ec3bff8baeca2cL29-R29) [[2]](diffhunk://#diff-f6ce5c3a6e756925c91ff681c11809203bab260332d82acef7ec3bff8baeca2cL115-L116)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR updates the Vitest addon to use framework packages instead of renderer packages for Storybook 9 compatibility, where projects only have framework packages installed directly.

- Modified `code/addons/vitest/src/constants.ts` to add support for Vite frameworks (`@storybook/react-vite`, `@storybook/svelte-vite`, `@storybook/vue3-vite`, `@storybook/html-vite`, `@storybook/web-components-vite`)
- Removed `SUPPORTED_RENDERERS` constant and its imports from `code/addons/vitest/src/postinstall.ts`
- Simplified post-installation script to only check for supported framework packages rather than falling back to renderer checks
- Ensures proper imports in generated setup files, using framework packages like `@storybook/react-vite` instead of renderer packages



<!-- /greptile_comment -->