### PR TITLE
Automigration: Fix consolidated-imports with sub-paths

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
@@ -42,8 +42,8 @@ function transformPackageJson(content: string): string | null {
       for (const [dep] of Object.entries(packageJson[depType])) {
         if (dep in consolidatedPackages) {
           const newPackage = consolidatedPackages[dep as keyof typeof consolidatedPackages];
-          // Only add to packagesToAdd if it's not being consolidated into storybook/*
-          if (!newPackage.startsWith('storybook/')) {
+          // Only add to packagesToAdd if it's not being consolidated into storybook/* or if it's a sub-path of a consolidated package
+          if (!newPackage.startsWith('storybook/') && !newPackage.match(/(?:.*\/){3,}/)) {
             packagesToAdd.add(newPackage);
           }
           delete packageJson[depType][dep];

--- a/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
@@ -43,7 +43,7 @@ function transformPackageJson(content: string): string | null {
         if (dep in consolidatedPackages) {
           const newPackage = consolidatedPackages[dep as keyof typeof consolidatedPackages];
           // Only add to packagesToAdd if it's not being consolidated into storybook/* or if it's a sub-path of a consolidated package
-          if (!newPackage.startsWith('storybook/') && !newPackage.match(/(?:.*\/){3,}/)) {
+          if (!newPackage.startsWith('storybook/') && !newPackage.match(/(?:.*\/){2,}/)) {
             packagesToAdd.add(newPackage);
           }
           delete packageJson[depType][dep];


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31120

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR fixes an issue in the automigration process where sub-path imports like '@storybook/addon-docs/blocks' were incorrectly being added to package.json dependencies.

- Modified `code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts` to prevent adding sub-path imports (with 3+ forward slashes) to package.json
- Fixed the specific issue reported in #31120 where '@storybook/addon-docs/blocks' was incorrectly added as a dependency
- The fix uses a regex pattern to identify and exclude deeper sub-paths from being added as standalone packages

Greptile AI



<!-- /greptile_comment -->