### PR TITLE
Docs: Remove experimental labelling from `nextjs-vite` framework

### DIFF
--- a/docs/get-started/frameworks/nextjs.mdx
+++ b/docs/get-started/frameworks/nextjs.mdx
@@ -17,8 +17,8 @@ Storybook for Next.js is a [framework](../../contribute/framework.mdx) that make
 
 ## Requirements
 
-* Next.js ≥ 13.5
-* Storybook ≥ 7.0
+* Next.js ≥ 14.1
+* Storybook ≥ 9.0
 
 ## Getting started
 
@@ -77,10 +77,6 @@ Finally, if you were using Storybook plugins to integrate with Next.js, those ar
 #### With Vite
 
 Storybook recommends using the `@storybook/nextjs-vite` framework, which is based on Vite and removes the need for Webpack and Babel. It supports all of the features documented here.
-
-<Callout variant="info">
-  Using the Next.js framework with Vite requires Next.js 14.1.0 or later.
-</Callout>
 
 {/* prettier-ignore-start */}
 

--- a/docs/get-started/frameworks/nextjs.mdx
+++ b/docs/get-started/frameworks/nextjs.mdx
@@ -76,9 +76,7 @@ Finally, if you were using Storybook plugins to integrate with Next.js, those ar
 
 #### With Vite
 
-(⚠️ **Experimental**)
-
-You can use our freshly baked, experimental `@storybook/nextjs-vite` framework, which is based on Vite and removes the need for Webpack and Babel. It supports all of the features documented here.
+Storybook recommends using the `@storybook/nextjs-vite` framework, which is based on Vite and removes the need for Webpack and Babel. It supports all of the features documented here.
 
 <Callout variant="info">
   Using the Next.js framework with Vite requires Next.js 14.1.0 or later.
@@ -901,7 +899,7 @@ You might get this if you're using Yarn v2 or v3. See [Notes for Yarn v2 and v3 
 
 ### What if I'm using the Vite builder?
 
-We have introduced experimental Vite builder support. Just install the experimental framework package `@storybook/nextjs-vite` and replace all instances of `@storybook/nextjs` with `@storybook/nextjs-vite`.
+Storybook provides a Vite-based framework for Next.js. Follow the [installation instructions](#with-vite) and replace all instances of `@storybook/nextjs` with `@storybook/nextjs-vite`.
 
 ### Error: You are importing avif images, but you don't have sharp installed. You have to install sharp in order to use image optimization features in Next.js.
 


### PR DESCRIPTION
Closes #30972

## What I did

See title

## Checklist for Contributors

### Testing

#### Manual testing

1. Sync this branch with locally running docs

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>


<!-- greptile_comment -->

## Greptile Summary

Updates documentation to remove experimental labeling from the Next.js Vite framework, establishing it as the stable and recommended approach for integrating Storybook with Next.js.

- Removes experimental warning labels and references from `docs/get-started/frameworks/nextjs.mdx`
- Updates wording to present `@storybook/nextjs-vite` as the recommended framework
- Aligns with stabilization of Next.js Vite plugin in upcoming release
- Consolidates documentation to reflect maturity of the integration



<!-- /greptile_comment -->