### PR TITLE
ESLint: Fix flat config setup

### DIFF
--- a/code/core/src/cli/eslintPlugin.test.ts
+++ b/code/core/src/cli/eslintPlugin.test.ts
@@ -229,7 +229,7 @@ describe('configureEslintPlugin', () => {
         import storybook from "eslint-plugin-storybook";
 
         import somePlugin from 'some-plugin';
-        export default [somePlugin, storybook.configs["flat/recommended"]];"
+        export default [somePlugin, ...storybook.configs["flat/recommended"]];"
       `);
     });
 
@@ -290,7 +290,7 @@ describe('configureEslintPlugin', () => {
         import storybook from "eslint-plugin-storybook";
 
         import eslint from "@eslint/js";
-        const options = [eslint.configs.recommended, storybook.configs["flat/recommended"]]
+        const options = [eslint.configs.recommended, ...storybook.configs["flat/recommended"]]
 
         export default options;"
       `);
@@ -322,7 +322,7 @@ describe('configureEslintPlugin', () => {
         import storybook from "eslint-plugin-storybook";
 
         import eslint from "@eslint/js";
-        const options = [eslint.configs.recommended, storybook.configs["flat/recommended"]] as Config
+        const options = [eslint.configs.recommended, ...storybook.configs["flat/recommended"]] as Config
 
         export default options;"
       `);
@@ -352,7 +352,7 @@ describe('configureEslintPlugin', () => {
         import storybook from "eslint-plugin-storybook";
 
         import eslint from "@eslint/js";
-        export default [eslint.configs.recommended, storybook.configs["flat/recommended"]] satisfies Config;"
+        export default [eslint.configs.recommended, ...storybook.configs["flat/recommended"]] satisfies Config;"
       `);
     });
 

--- a/code/core/src/cli/eslintPlugin.ts
+++ b/code/core/src/cli/eslintPlugin.ts
@@ -94,7 +94,7 @@ export const configureFlatConfig = async (code: string) => {
 
       // Case 1: Direct array
       if (t.isArrayExpression(eslintConfigExpression)) {
-        eslintConfigExpression.elements.push(storybookConfig);
+        eslintConfigExpression.elements.push(t.spreadElement(storybookConfig));
       }
 
       // Case 2: tseslint.config(...)
@@ -115,7 +115,7 @@ export const configureFlatConfig = async (code: string) => {
           const init = unwrapTSExpression(binding.path.node.init);
 
           if (t.isArrayExpression(init)) {
-            init.elements.push(storybookConfig);
+            init.elements.push(t.spreadElement(storybookConfig));
           }
         }
       }

--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -351,18 +351,13 @@ export async function baseGenerator(
     text: `Getting the correct version of ${packagesToInstall.length} packages`,
   }).start();
 
-  const versionedPackages = await packageManager.getVersionedPackages(
-    packagesToInstall as string[]
-  );
-  versionedPackagesSpinner.succeed();
-
   try {
     if (process.env.CI !== 'true') {
       const { hasEslint, isStorybookPluginInstalled, isFlatConfig, eslintConfigFile } =
         await extractEslintInfo(packageManager);
 
       if (hasEslint && !isStorybookPluginInstalled) {
-        versionedPackages.push('eslint-plugin-storybook');
+        packagesToInstall.push('eslint-plugin-storybook');
         await configureEslintPlugin({
           eslintConfigFile,
           packageManager,
@@ -373,6 +368,11 @@ export async function baseGenerator(
   } catch (err) {
     // any failure regarding configuring the eslint plugin should not fail the whole generator
   }
+
+  const versionedPackages = await packageManager.getVersionedPackages(
+    packagesToInstall as string[]
+  );
+  versionedPackagesSpinner.succeed();
 
   if (versionedPackages.length > 0) {
     const addDependenciesSpinner = ora({


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

For ESLint flat configs that use array, the storybook plugin should be spread and it wasn't. This PR fixes that

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR modifies the ESLint flat config setup in Storybook to properly spread plugin configurations in array-based setups.

- Fixed `configureFlatConfig` function in `code/core/src/cli/eslintPlugin.ts` to use `t.spreadElement()` when adding Storybook configs to arrays
- Updated test cases in `eslintPlugin.test.ts` to verify proper spreading behavior with various config types (JS, TS, const declarations)
- Ensures compatibility with TypeScript-specific configurations like `satisfies` and `as` type assertions
- Maintains backward compatibility with existing ESLint configurations while fixing array spreading



<!-- /greptile_comment -->