### PR TITLE
CLI: Add `storybook-static` to `.gitignore` on init

### DIFF
--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -522,8 +522,17 @@ export async function doInitiate(options: CommandOptions): Promise<
   const rootDirectory = getProjectRoot();
   if (foundGitIgnoreFile && foundGitIgnoreFile.includes(rootDirectory)) {
     const contents = await fs.readFile(foundGitIgnoreFile, 'utf-8');
-    if (!contents.includes('*storybook.log')) {
-      await fs.appendFile(foundGitIgnoreFile, '\n*storybook.log\n');
+    const hasStorybookLog = contents.includes('*storybook.log');
+    const hasStorybookStatic = contents.includes('storybook-static');
+    const linesToAdd = [
+      !hasStorybookLog ? '*storybook.log' : '',
+      !hasStorybookStatic ? 'storybook-static' : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    if (linesToAdd) {
+      await fs.appendFile(foundGitIgnoreFile, `\n${linesToAdd}\n`);
     }
   }
 


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added `storybook-static` to the `.gitignore` file on init.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. In the monorepo, create a sandbox
2. See that the sandbox's `.gitignore` contains `storybook-static`.
3. Remove `storybook-static` from the monorepo's root `.gitignore`
4. Build Storybook in the sandbox
5. See the `storybook-static` dir is still ignored by git.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR adds functionality to include 'storybook-static' in the .gitignore file during Storybook initialization, ensuring build output is not version controlled.

- Modifies `code/lib/create-storybook/src/initiate.ts` to add 'storybook-static' pattern to .gitignore during project setup
- Enhances existing logic that was already handling '*storybook.log' pattern
- Checks for both patterns and adds any missing ones
- Maintains clean version control by excluding build artifacts



<!-- /greptile_comment -->