### PR TITLE
Core: Remove `uuid` package from core

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -646,7 +646,6 @@
     "polished": "^4.2.2",
     "recast": "^0.23.5",
     "semver": "^7.6.2",
-    "uuid": "^9.0.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/code/core/src/actions/runtime/action.ts
+++ b/code/core/src/actions/runtime/action.ts
@@ -5,7 +5,6 @@ import { global } from '@storybook/global';
 
 import type { PreviewWeb } from 'storybook/preview-api';
 import { addons } from 'storybook/preview-api';
-import { v4 as uuidv4 } from 'uuid';
 
 import { EVENT_ID } from '../constants';
 import type { ActionDisplay, ActionOptions, HandlerFunction } from '../models';
@@ -48,14 +47,6 @@ const serializeArg = <T extends object>(a: T) => {
   return a;
 };
 
-// TODO react native doesn't have the crypto module, we should figure out a better way to generate these ids.
-const generateId = () => {
-  return typeof crypto === 'object' && typeof crypto.getRandomValues === 'function'
-    ? uuidv4()
-    : // pseudo random id, example response lo1e7zm4832bkr7yfl7
-      Date.now().toString(36) + Math.random().toString(36).substring(2);
-};
-
 export function action(name: string, options: ActionOptions = {}): HandlerFunction {
   const actionOptions = {
     ...config,
@@ -88,8 +79,9 @@ export function action(name: string, options: ActionOptions = {}): HandlerFuncti
     }
 
     const channel = addons.getChannel();
-    // this makes sure that in js environments like react native you can still get an id
-    const id = generateId();
+    // TODO react native doesn't have the crypto module, we should figure out a better way to generate these ids.
+    // pseudo random id, example response lo1e7zm4832bkr7yfl7
+    const id = Date.now().toString(36) + Math.random().toString(36).substring(2);
     const minDepth = 5; // anything less is really just storybook internals
     const serializedArgs = args.map(serializeArg);
     const normalizedArgs = args.length > 1 ? serializedArgs : serializedArgs[0];

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -25328,7 +25328,6 @@ __metadata:
     typescript: "npm:^5.7.3"
     unique-string: "npm:^3.0.0"
     use-resize-observer: "npm:^9.1.0"
-    uuid: "npm:^9.0.0"
     watchpack: "npm:^2.2.0"
     ws: "npm:^8.18.0"
   peerDependencies:
@@ -27053,15 +27052,6 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Removed the `uuid` package from Storybook core, as it was only used one place that could easily be done without it. It was probably brought in when actions where moved to core.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Removes the `uuid` package dependency from Storybook core by replacing UUID generation with a simpler timestamp + random number based ID generation in the actions runtime.

- Removed `uuid` dependency from `code/core/package.json`
- Modified `code/core/src/actions/runtime/action.ts` to use `Date.now()` and `Math.random()` for ID generation
- Consider removing `@types/uuid` dependency since it's no longer needed
- Note: New ID generation method has slightly higher theoretical collision chance than UUID v4



<!-- /greptile_comment -->