### PR TITLE
Core: Check that frameworks do exist when generating the frameworks.t…

### DIFF
--- a/code/core/scripts/helpers/sourcefiles.ts
+++ b/code/core/scripts/helpers/sourcefiles.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { readdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -61,7 +62,9 @@ async function generateFrameworksFile(prettierConfig: prettier.Options | null): 
   const location = join(__dirname, '..', '..', 'src', 'types', 'modules', 'frameworks.ts');
   const frameworksDirectory = join(__dirname, '..', '..', '..', 'frameworks');
 
-  const readFrameworks = await readdir(frameworksDirectory);
+  const readFrameworks = (await readdir(frameworksDirectory)).filter((framework) =>
+    existsSync(join(frameworksDirectory, framework, 'project.json'))
+  );
   const frameworks = [...readFrameworks.sort(), ...thirdPartyFrameworks]
     .map((framework) => `'${framework}'`)
     .join(' | ');


### PR DESCRIPTION
…s type file

## What I did

Added a basic check for `project.json` in the `frameworks.ts` generation script.

This ensures that deprecated/removed folders that still have gitignored files locally (e.g. `svelte-webpack5` don't get picked up by the generation script. If they did get picked up, it would cause build errors as these unwanted types aren't reflected elsewhere.

That issue is a bit annoying to debug, since one has to find why `frameworks.ts` changes, who updates it, and why some frameworks are being generated that shouldn't. The usual tricks of resetting NX cache, build files or node modules don't apply here.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

> [!CAUTION]
> Changes are untested. This is internal to build prep scripts.

#### Manual testing

1. On the `next` branch, add an empty folder to `code/frameworks`, and watch chaos unfold
2. Switch to this branch, watch the build process now correctly moving forward without adding stub entries to `frameworks.ts`

-->

### Documentation

> [!CAUTION]
> Changes are undocumented. This is internal to build prep scripts.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added a validation check in the framework type generation script to ensure only valid framework directories with project.json files are included, preventing build errors from deprecated framework folders.

- Added `existsSync` check in `generateFrameworksFile()` to filter frameworks by `project.json` presence
- Prevents invalid frameworks from being added to `SupportedFrameworks` type
- Helps avoid build errors from deprecated/removed framework folders with lingering files
- Improves debugging experience by preventing silent inclusion of invalid frameworks



<!-- /greptile_comment -->