### PR TITLE
Svelte: Remove dependency on `sveltedoc-parser`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -36,6 +36,7 @@
   - [Framework-specific changes](#framework-specific-changes)
     - [Svelte: Require v5 and up](#svelte-require-v5-and-up)
     - [Svelte: Dropped support for @storybook/svelte-webpack5](#svelte-dropped-support-for-storybooksvelte-webpack5)
+    - [Svelte: Dropped automatic docgen for events and slots](#svelte-dropped-automatic-docgen-for-events-and-slots)
     - [Angular = Require v18 and up](#angular--require-v18-and-up)
     - [Dropped webpack5 Builder Support in Favor of Vite](#dropped-webpack5-builder-support-in-favor-of-vite)
     - [Next.js = Require v14 and up](#nextjs--require-v14-and-up)
@@ -1023,6 +1024,12 @@ export default {
 ```
 
 For more details, please refer to the [Svelte & Vite documentation](https://storybook.js.org/docs/get-started/frameworks/svelte-vite).
+
+#### Svelte: Dropped automatic docgen for events and slots
+
+The internal docgen logic for legacy Svelte components have been changed to match what already happened for rune-based components, using the same `svelte2tsx` parsing that the official Svelte tools use.
+
+This means that argTypes are no longer automatically generated for slots and events defined with `on:my-event`.
 
 #### Angular = Require v18 and up
 

--- a/code/addons/docs/src/typings.d.ts
+++ b/code/addons/docs/src/typings.d.ts
@@ -2,10 +2,6 @@ declare module '@egoist/vue-to-react';
 declare module 'acorn-jsx';
 declare module 'vue/dist/vue';
 
-declare module 'sveltedoc-parser' {
-  export function parse(options: any): Promise<any>;
-}
-
 declare var FEATURES: import('storybook/internal/types').StorybookConfigRaw['features'];
 declare var __DOCS_CONTEXT__: any;
 declare var PREVIEW_URL: any;

--- a/code/frameworks/svelte-vite/package.json
+++ b/code/frameworks/svelte-vite/package.json
@@ -59,7 +59,6 @@
     "magic-string": "^0.30.0",
     "svelte-preprocess": "^5.1.1",
     "svelte2tsx": "^0.7.35",
-    "sveltedoc-parser": "^4.2.1",
     "ts-dedent": "^2.2.0",
     "typescript": "^4.9.4 || ^5.0.0"
   },
@@ -67,6 +66,7 @@
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@types/node": "^22.0.0",
     "svelte": "^5.0.5",
+    "sveltedoc-parser": "^4.2.1",
     "typescript": "^5.7.3",
     "vite": "^6.2.5"
   },

--- a/code/frameworks/svelte-vite/src/plugins/generateDocgen.ts
+++ b/code/frameworks/svelte-vite/src/plugins/generateDocgen.ts
@@ -6,7 +6,6 @@ import ts from 'typescript';
 
 export type Docgen = {
   name?: string;
-  propsRuneUsed?: boolean;
   props: PropInfo[];
 };
 
@@ -261,7 +260,6 @@ export function generateDocgen(targetFileName: string, cache: DocgenCache): Docg
   if (targetFileName.endsWith('.svelte')) {
     targetFileName = targetFileName + '.tsx';
   }
-  let propsRuneUsed = false;
 
   if (cache.options === undefined || !cache.rootNames?.has(targetFileName)) {
     [cache.options, cache.rootNames] = loadConfig(targetFileName);
@@ -489,7 +487,6 @@ export function generateDocgen(targetFileName: string, cache: DocgenCache): Docg
             declaration.type && propsType === checker.getTypeFromTypeNode(declaration.type);
 
           if (isPropsRune || isPropsType) {
-            propsRuneUsed = true;
             declaration.name.elements.forEach((element) => {
               const name = element.name.getText();
               const prop = propMap.get(name);
@@ -525,6 +522,5 @@ export function generateDocgen(targetFileName: string, cache: DocgenCache): Docg
 
   return {
     props: Array.from(propMap.values()),
-    propsRuneUsed,
   };
 }

--- a/code/frameworks/svelte-vite/src/preset.ts
+++ b/code/frameworks/svelte-vite/src/preset.ts
@@ -16,13 +16,8 @@ export const core: PresetProperty<'core'> = {
 
 export const viteFinal: NonNullable<StorybookConfig['viteFinal']> = async (config, options) => {
   const { plugins = [] } = config;
-  // TODO: set up eslint import to use typescript resolver
 
-  const { loadSvelteConfig } = await import('@sveltejs/vite-plugin-svelte');
-  const svelteConfig = await loadSvelteConfig();
-
-  // Add docgen plugin
-  plugins.push(await svelteDocgen(svelteConfig));
+  plugins.push(await svelteDocgen());
 
   await handleSvelteKit(plugins, options);
 

--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@storybook/global": "^5.0.0",
-    "sveltedoc-parser": "^4.2.1",
     "ts-dedent": "^2.0.0",
     "type-fest": "~2.19"
   },
@@ -66,6 +65,7 @@
     "expect-type": "^1.1.0",
     "svelte": "^5.20.5",
     "svelte-check": "^4.1.4",
+    "sveltedoc-parser": "^4.2.1",
     "typescript": "^5.7.3",
     "vite": "^6.2.5"
   },


### PR DESCRIPTION
Follow up to https://github.com/storybookjs/storybook/pull/30703 and Reaction to https://github.com/storybookjs/storybook/pull/30703#discussion_r2061333954
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR removes the runtime usage of `sveltedoc-parser` and moves it from a regular dependency to a `devDependency`. In Storybook ( it was only kept for backwards compatibility, and meant to be removed in v9, especially with the move to Svelte 5.

This PR removes the _runtime_ usage of the package, however _it is still being used internally for types_. None of this makes it into the dist. Ideally it should be completely removed, but I don't have the time right now to do it. The reason we're keeping it for types, is because the original docgen flow was:

- `sveltedoc-parser` -> Storybook argTypes

When we introduced the new and improved docgen in https://github.com/storybookjs/storybook/pull/29423, it had to be compatible with the existing docgen, so the easiest thing to do was to augment that and have the flow:

- `svelte2tsx` (aka. TypeScript) props info -> `sveltedoc-parser` format -> Storybook argTypes

That code flow is still there now, and so the internal types for the middle-step are still necessary.

We can easily fix this later without it being a breaking change. There's no need for the middle-step, we _can_ just go directly from `svelte2tsx` to argTypes.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing


<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

The actual consequences of this change, is that Svelte components that _don't use runes_ are now parsed with `svelte2tsx` instead of `sveltedoc-parser`. Luckily we have very strong regression testing for this in place, so just check that the following legacy stories still produces correct Controls/argTypes:

- https://jeppe-remove-sveltedoc-parser--630873996e4e3557791c069c.chromatic.com/?path=/story/stories-frameworks-svelte-vite-svelte-vite-default-ts-docgen-ts-legacy--default
- https://jeppe-remove-sveltedoc-parser--6308736456ad2046275c0ae7.chromatic.com/?path=/story/stories-frameworks-svelte-vite-svelte-vite-default-js-docgen-jsdoc--default

Chromatic snapshots will catch any changes here.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR removes the runtime dependency on `sveltedoc-parser` and moves it to devDependencies, while maintaining type compatibility for the existing docgen flow in Svelte components.

- Removed `sveltedoc-parser` type declaration from `code/addons/docs/src/typings.d.ts`
- Moved `sveltedoc-parser` to devDependencies in both `code/frameworks/svelte-vite/package.json` and `code/renderers/svelte/package.json`
- Simplified component parsing in `code/frameworks/svelte-vite/src/plugins/svelte-docgen.ts` to use `svelte2tsx` for non-rune components
- Updated `MIGRATION.md` to document dropped automatic docgen for Svelte events and slots
- Removed `propsRuneUsed` field and related logic from `code/frameworks/svelte-vite/src/plugins/generateDocgen.ts`



<!-- /greptile_comment -->