### PR TITLE
Add TypeScript note about args type safety to component testing docs

### DIFF
--- a/docs/writing-tests/component-testing.mdx
+++ b/docs/writing-tests/component-testing.mdx
@@ -63,9 +63,9 @@ You can also use `mount` to create mock data that you want to pass to the compon
 <CodeSnippets path="mount-advanced.md" />
 
 <Callout variant="info">
-  When you call `mount()` with no arguments, the component is rendered using the story’s render function, whether the [implicit default](../api/csf.mdx#default-render-functions) or the [explicit custom definition](../api/csf.mdx#custom-render-functions).
+  When you call `mount()` with no arguments, the component is rendered using the story's render function, whether the [implicit default](../api/csf.mdx#default-render-functions) or the [explicit custom definition](../api/csf.mdx#custom-render-functions).
 
-  When you mount a specific component inside the `mount` function like in the example above, the story’s render function will be ignored. This is why you must forward the `args` to the component.
+  When you mount a specific component inside the `mount` function like in the example above, the story's render function will be ignored. This is why you must forward the `args` to the component.
 </Callout>
 
 </If>
@@ -161,7 +161,7 @@ You can return a cleanup function from the `beforeEach` function, which will run
 
 ### API for user-events
 
-Under the hood, Storybook’s `storybook/test` package provides Testing Library’s [`user-events`](https://testing-library.com/docs/user-event/intro/) APIs. If you’re familiar with [Testing Library](https://testing-library.com/), you should be at home in Storybook.
+Under the hood, Storybook's `storybook/test` package provides Testing Library's [`user-events`](https://testing-library.com/docs/user-event/intro/) APIs. If you're familiar with [Testing Library](https://testing-library.com/), you should be at home in Storybook.
 
 Below is an abridged API for user-event. For more, check out the [official user-event docs](https://testing-library.com/docs/user-event/utility/).
 
@@ -172,20 +172,33 @@ Below is an abridged API for user-event. For more, check out the [official user-
 | `dblClick`        | Clicks the element twice <br />`userEvent.dblClick(await within(canvasElement).getByText('mycheckbox'));`                                                 |
 | `deselectOptions` | Removes the selection from a specific option of a select element <br />`userEvent.deselectOptions(await within(canvasElement).getByRole('listbox'),'1');` |
 | `hover`           | Hovers an element <br />`userEvent.hover(await within(canvasElement).getByTestId('example-test'));`                                                       |
-| `keyboard`        | Simulates the keyboard events <br />`userEvent.keyboard(‘foo’);`                                                                                          |
+| `keyboard`        | Simulates the keyboard events <br />`userEvent.keyboard('foo');`                                                                                          |
 | `selectOptions`   | Selects the specified option, or options of a select element <br />`userEvent.selectOptions(await within(canvasElement).getByRole('listbox'),['1','2']);` |
 | `type`            | Writes text inside inputs, or textareas <br />`userEvent.type(await within(canvasElement).getByRole('my-input'),'Some text');`                            |
 | `unhover`         | Unhovers out of element <br />`userEvent.unhover(await within(canvasElement).getByLabelText(/Example/i));`                                                |
 
 ### Assert tests with Vitest's APIs
 
-Storybook’s `storybook/test` also provides APIs from [Vitest](https://vitest.dev/), such as [`expect`](https://vitest.dev/api/expect.html#expect) and [`vi.fn`](https://vitest.dev/api/vi.html#vi-fn). These APIs improve your testing experience, helping you assert whether a function has been called, if an element exists in the DOM, and much more. If you are used to `expect` from testing packages such as [Jest](https://jestjs.io/) or [Vitest](https://vitest.dev/), you can write component tests in much the same way.
+Storybook's `storybook/test` also provides APIs from [Vitest](https://vitest.dev/), such as [`expect`](https://vitest.dev/api/expect.html#expect) and [`vi.fn`](https://vitest.dev/api/vi.html#vi-fn). These APIs improve your testing experience, helping you assert whether a function has been called, if an element exists in the DOM, and much more. If you are used to `expect` from testing packages such as [Jest](https://jestjs.io/) or [Vitest](https://vitest.dev/), you can write component tests in much the same way.
 
 {/* prettier-ignore-start */}
 
 <CodeSnippets path="storybook-interactions-play-function.md" />
 
 {/* prettier-ignore-end */}
+
+<Callout variant="info" title="TypeScript Note">
+  If you're using TypeScript, you might encounter an error like `Property 'onSubmit' does not exist on type '{}'` when accessing properties on the `args` object (e.g., `args.onSubmit`). This is because `args` is typed as a generic object (`{}`) by default in this test context.
+
+  To resolve this, you can provide an explicit type for `args` when accessing properties. For example, if your story args type is `LoginFormArgs`, you can use a type assertion:
+
+  ```ts
+  // Assuming LoginFormArgs is defined elsewhere
+  await waitFor(() => expect((args as LoginFormArgs).onSubmit).toHaveBeenCalled());
+  ```
+
+  Alternatively, ensure your test setup correctly infers or defines the type for `args` based on your story or component.
+</Callout>
 
 ### Group interactions with the `step` function
 
@@ -221,7 +234,7 @@ If you check your interactions panel, you'll see the step-by-step flow. It also 
 
 ### Permalinks for reproductions
 
-The `play` function is executed after the story is rendered. If there’s an error, it’ll be shown in the interaction addon panel to help with debugging.
+The `play` function is executed after the story is rendered. If there's an error, it'll be shown in the interaction addon panel to help with debugging.
 
 Since Storybook is a webapp, anyone with the URL can reproduce the error with the same detailed information without any additional environment configuration or tooling required.
 
@@ -251,7 +264,7 @@ Once you're ready to push your code into a pull request, you'll want to automati
 
 ## Troubleshooting
 
-#### What’s the difference between component tests and visual tests?
+#### What's the difference between component tests and visual tests?
 
 Component tests can be expensive to maintain when applied wholesale to every component. We recommend combining them with other methods like visual testing for comprehensive coverage with less maintenance work.
 

--- a/docs/writing-tests/component-testing.mdx
+++ b/docs/writing-tests/component-testing.mdx
@@ -63,9 +63,9 @@ You can also use `mount` to create mock data that you want to pass to the compon
 <CodeSnippets path="mount-advanced.md" />
 
 <Callout variant="info">
-  When you call `mount()` with no arguments, the component is rendered using the story's render function, whether the [implicit default](../api/csf.mdx#default-render-functions) or the [explicit custom definition](../api/csf.mdx#custom-render-functions).
+  When you call `mount()` with no arguments, the component is rendered using the story’s render function, whether the [implicit default](../api/csf.mdx#default-render-functions) or the [explicit custom definition](../api/csf.mdx#custom-render-functions).
 
-  When you mount a specific component inside the `mount` function like in the example above, the story's render function will be ignored. This is why you must forward the `args` to the component.
+  When you mount a specific component inside the `mount` function like in the example above, the story’s render function will be ignored. This is why you must forward the `args` to the component.
 </Callout>
 
 </If>
@@ -161,7 +161,7 @@ You can return a cleanup function from the `beforeEach` function, which will run
 
 ### API for user-events
 
-Under the hood, Storybook's `storybook/test` package provides Testing Library's [`user-events`](https://testing-library.com/docs/user-event/intro/) APIs. If you're familiar with [Testing Library](https://testing-library.com/), you should be at home in Storybook.
+Under the hood, Storybook’s `storybook/test` package provides Testing Library’s [`user-events`](https://testing-library.com/docs/user-event/intro/) APIs. If you’re familiar with [Testing Library](https://testing-library.com/), you should be at home in Storybook.
 
 Below is an abridged API for user-event. For more, check out the [official user-event docs](https://testing-library.com/docs/user-event/utility/).
 
@@ -172,14 +172,14 @@ Below is an abridged API for user-event. For more, check out the [official user-
 | `dblClick`        | Clicks the element twice <br />`userEvent.dblClick(await within(canvasElement).getByText('mycheckbox'));`                                                 |
 | `deselectOptions` | Removes the selection from a specific option of a select element <br />`userEvent.deselectOptions(await within(canvasElement).getByRole('listbox'),'1');` |
 | `hover`           | Hovers an element <br />`userEvent.hover(await within(canvasElement).getByTestId('example-test'));`                                                       |
-| `keyboard`        | Simulates the keyboard events <br />`userEvent.keyboard('foo');`                                                                                          |
+| `keyboard`        | Simulates the keyboard events <br />`userEvent.keyboard(‘foo’);`                                                                                          |
 | `selectOptions`   | Selects the specified option, or options of a select element <br />`userEvent.selectOptions(await within(canvasElement).getByRole('listbox'),['1','2']);` |
 | `type`            | Writes text inside inputs, or textareas <br />`userEvent.type(await within(canvasElement).getByRole('my-input'),'Some text');`                            |
 | `unhover`         | Unhovers out of element <br />`userEvent.unhover(await within(canvasElement).getByLabelText(/Example/i));`                                                |
 
 ### Assert tests with Vitest's APIs
 
-Storybook's `storybook/test` also provides APIs from [Vitest](https://vitest.dev/), such as [`expect`](https://vitest.dev/api/expect.html#expect) and [`vi.fn`](https://vitest.dev/api/vi.html#vi-fn). These APIs improve your testing experience, helping you assert whether a function has been called, if an element exists in the DOM, and much more. If you are used to `expect` from testing packages such as [Jest](https://jestjs.io/) or [Vitest](https://vitest.dev/), you can write component tests in much the same way.
+Storybook’s `storybook/test` also provides APIs from [Vitest](https://vitest.dev/), such as [`expect`](https://vitest.dev/api/expect.html#expect) and [`vi.fn`](https://vitest.dev/api/vi.html#vi-fn). These APIs improve your testing experience, helping you assert whether a function has been called, if an element exists in the DOM, and much more. If you are used to `expect` from testing packages such as [Jest](https://jestjs.io/) or [Vitest](https://vitest.dev/), you can write component tests in much the same way.
 
 {/* prettier-ignore-start */}
 
@@ -234,7 +234,7 @@ If you check your interactions panel, you'll see the step-by-step flow. It also 
 
 ### Permalinks for reproductions
 
-The `play` function is executed after the story is rendered. If there's an error, it'll be shown in the interaction addon panel to help with debugging.
+The `play` function is executed after the story is rendered. If there’s an error, it’ll be shown in the interaction addon panel to help with debugging.
 
 Since Storybook is a webapp, anyone with the URL can reproduce the error with the same detailed information without any additional environment configuration or tooling required.
 
@@ -264,7 +264,7 @@ Once you're ready to push your code into a pull request, you'll want to automati
 
 ## Troubleshooting
 
-#### What's the difference between component tests and visual tests?
+#### What’s the difference between component tests and visual tests?
 
 Component tests can be expensive to maintain when applied wholesale to every component. We recommend combining them with other methods like visual testing for comprehensive coverage with less maintenance work.
 


### PR DESCRIPTION
Closes #31106


<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added documentation note in `docs/writing-tests/component-testing.mdx` addressing TypeScript type safety concerns when working with the `args` object in component testing.

- Added TypeScript-specific guidance explaining that `args` is typed as `{}` by default
- Provided two solutions: using type assertions or ensuring proper type inference in test setup
- Placed note strategically after the Vitest API testing section where `args` is first introduced



<sub>💡 (5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->