### PR TITLE
Telemetry: Add Svelte CSF usage

### DIFF
--- a/code/core/src/core-server/utils/summarizeIndex.test.ts
+++ b/code/core/src/core-server/utils/summarizeIndex.test.ts
@@ -146,6 +146,8 @@ describe('summarizeIndex', () => {
         "pageStoryCount": 0,
         "playStoryCount": 0,
         "storyCount": 0,
+        "svelteCsfV4Count": 0,
+        "svelteCsfV5Count": 0,
         "version": 5,
       }
     `);
@@ -186,7 +188,7 @@ describe('summarizeIndex', () => {
             title: 'Example/Button',
             name: 'Warning',
             importPath: './src/stories/Button.stories.ts',
-            tags: ['autodocs', 'story'],
+            tags: ['autodocs', 'story', 'svelte-csf-v4'],
             type: 'story',
           },
         },
@@ -203,6 +205,8 @@ describe('summarizeIndex', () => {
         "pageStoryCount": 0,
         "playStoryCount": 0,
         "storyCount": 0,
+        "svelteCsfV4Count": 0,
+        "svelteCsfV5Count": 0,
         "version": 5,
       }
     `);
@@ -233,7 +237,7 @@ describe('summarizeIndex', () => {
             title: 'stories/renderers/react/js-argtypes',
             name: 'Js Class Component',
             importPath: './src/stories/renderers/react/js-argtypes.stories.jsx',
-            tags: ['story'],
+            tags: ['story', 'svelte-csf-v5'],
             type: 'story',
           },
           'stories-renderers-react-js-argtypes--js-function-component': {
@@ -241,7 +245,7 @@ describe('summarizeIndex', () => {
             title: 'stories/renderers/react/js-argtypes',
             name: 'Js Function Component',
             importPath: './src/stories/renderers/react/js-argtypes.stories.jsx',
-            tags: ['story'],
+            tags: ['story', 'svelte-csf-v4'],
             type: 'story',
           },
         },
@@ -258,6 +262,8 @@ describe('summarizeIndex', () => {
         "pageStoryCount": 0,
         "playStoryCount": 0,
         "storyCount": 4,
+        "svelteCsfV4Count": 1,
+        "svelteCsfV5Count": 1,
         "version": 5,
       }
     `);
@@ -314,6 +320,8 @@ describe('summarizeIndex', () => {
         "pageStoryCount": 1,
         "playStoryCount": 1,
         "storyCount": 1,
+        "svelteCsfV4Count": 0,
+        "svelteCsfV5Count": 0,
         "version": 5,
       }
     `);
@@ -371,6 +379,8 @@ describe('summarizeIndex', () => {
         "pageStoryCount": 0,
         "playStoryCount": 0,
         "storyCount": 0,
+        "svelteCsfV4Count": 0,
+        "svelteCsfV5Count": 0,
         "version": 5,
       }
     `);
@@ -421,6 +431,8 @@ describe('summarizeIndex', () => {
         "pageStoryCount": 0,
         "playStoryCount": 0,
         "storyCount": 0,
+        "svelteCsfV4Count": 0,
+        "svelteCsfV5Count": 0,
         "version": 5,
       }
     `);

--- a/code/core/src/core-server/utils/summarizeIndex.ts
+++ b/code/core/src/core-server/utils/summarizeIndex.ts
@@ -4,6 +4,7 @@ import type { IndexEntry, StoryIndex } from 'storybook/internal/types';
 import { AUTODOCS_TAG, PLAY_FN_TAG, isMdxEntry } from './StoryIndexGenerator';
 
 const PAGE_REGEX = /(page|screen)/i;
+const SVELTE_CSF_TAG = 'svelte-csf';
 
 export const isPageStory = (storyId: string) => PAGE_REGEX.test(storyId);
 
@@ -35,6 +36,8 @@ export function summarizeIndex(storyIndex: StoryIndex) {
   let playStoryCount = 0;
   let autodocsCount = 0;
   let mdxCount = 0;
+  let svelteCsfV4Count = 0;
+  let svelteCsfV5Count = 0;
   Object.values(storyIndex.entries).forEach((entry) => {
     if (isCLIExampleEntry(entry)) {
       if (entry.type === 'story') {
@@ -61,6 +64,11 @@ export function summarizeIndex(storyIndex: StoryIndex) {
       if (entry.tags?.includes(PLAY_FN_TAG)) {
         playStoryCount += 1;
       }
+      if (entry.tags?.includes('svelte-csf-v4')) {
+        svelteCsfV4Count += 1;
+      } else if (entry.tags?.includes('svelte-csf-v5')) {
+        svelteCsfV5Count += 1;
+      }
     } else if (entry.type === 'docs') {
       if (isMdxEntry(entry)) {
         mdxCount += 1;
@@ -81,6 +89,8 @@ export function summarizeIndex(storyIndex: StoryIndex) {
     exampleDocsCount,
     onboardingStoryCount,
     onboardingDocsCount,
+    svelteCsfV4Count,
+    svelteCsfV5Count,
     version: storyIndex.v,
   };
 }


### PR DESCRIPTION
Closes N/A

## What I did

Record the number of stories that use the `svelte-csf` tag. 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

How I tested:
- Create a svelte sandbox
- Set `@storybook/addon-svelte-csf` to `4.2.1--canary.bfbad01.0` (https://github.com/storybookjs/addon-svelte-csf/pull/297)
- Rename Button `title` to `'Foo/Button'` (Example stories don't count)
- Run with `STORYBOOK_TELEMETRY_DEBUG=1`

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
