### PR TITLE
Update mock-sveltekit-stores.ts

### DIFF
--- a/code/frameworks/sveltekit/src/plugins/mock-sveltekit-stores.ts
+++ b/code/frameworks/sveltekit/src/plugins/mock-sveltekit-stores.ts
@@ -15,6 +15,7 @@ export function mockSveltekitStores() {
           '$app/forms': resolve(dir, '../src/mocks/app/forms.ts'),
           '$app/navigation': resolve(dir, '../src/mocks/app/navigation.ts'),
           '$app/stores': resolve(dir, '../src/mocks/app/stores.ts'),
+          '$app/state': resolve(dir, '../src/mocks/app/stores.ts'),
         },
       },
     }),


### PR DESCRIPTION
Request the change on line 18 be incorporated to allow for use of $app/state since $app/stores is depreciated in Svelte 5.  Related issue 31257.  Sorry if some of my info below is wrong.  I've never contributed to a project before.  Thank you.

Comment with more detail:
https://github.com/storybookjs/storybook/discussions/31257

Closes #31257


## What I did

I found that the page store was not updating for Sveltekit stories.  The page context was updating, but the page store would not.  I looked through the files and realized the alias was for $app/stores, which is depreciated in Svelte 5.  I think just aliasing both will fix the issue without breaking any Svelte 4 users.

## Checklist for Contributors

It was just me.  One line of code.

### Testing

I didn't do any automated testing.  I just updated my story to use the $app/stores import and validated the import worked.  

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I don't believe a manual test is required, because it is just taking the same stores export and allowing it to use a second alias to align with the current page store import in Svelte 5.

### Documentation

I don't believe any update to documentation is required.  If both aliases are allowed, the page store should be successfully mocked by users. 

## Checklist for Maintainers

  - `other`: Changes that don't fit in the above categories.

<!-- greptile_comment -->

## Greptile Summary

Added support for Svelte 5's `$app/state` module while maintaining backward compatibility with Svelte 4's `$app/stores` in the SvelteKit framework plugin.

- Added alias for `$app/state` in `code/frameworks/sveltekit/src/plugins/mock-sveltekit-stores.ts` pointing to the same mock implementation as `$app/stores`
- Maintains compatibility by keeping both `$app/stores` and `$app/state` aliases active
- Addresses deprecation of `$app/stores` in Svelte 5 while supporting existing Svelte 4 implementations



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->