### PR TITLE
Docs: In Svelte CSF, use `template` instead of `children`

### DIFF
--- a/docs/_snippets/component-story-custom-args-complex.md
+++ b/docs/_snippets/component-story-custom-args-complex.md
@@ -318,7 +318,7 @@ export const ExampleStory: Story = {
     propertyB: 'Another Item One',
   }}
 >
-  {#snippet children(args)}
+  {#snippet template(args)}
     <YourComponent
       {...args}
       someProperty={someFunction(args.propertyA, args.propertyB)}
@@ -397,7 +397,7 @@ export const ExampleStory = {
     propertyB: 'Another Item One',
   }}
 >
-  {#snippet children(args)}
+  {#snippet template(args)}
     <YourComponent
       {...args}
       someProperty={someFunction(args.propertyA, args.propertyB)}
@@ -481,7 +481,7 @@ export const ExampleStory: Story = {
     propertyB: 'Another Item One',
   }}
 >
-  {#snippet children(args)}
+  {#snippet template(args)}
     <YourComponent
       {...args}
       someProperty={someFunction(args.propertyA, args.propertyB)}

--- a/docs/_snippets/list-story-expanded.md
+++ b/docs/_snippets/list-story-expanded.md
@@ -373,7 +373,7 @@ export const ManyItems: Story = {
 <Story name="Empty" />
 
 <Story name="One Item">
-  {#snippet children(args)}
+  {#snippet template(args)}
     <List {...args} >
       <ListItem />
     </List>
@@ -381,7 +381,7 @@ export const ManyItems: Story = {
 </Story>
 
 <Story name="Many Items">
-  {#snippet children(args)}
+  {#snippet template(args)}
     <List {...args} >
       <ListItem />
       <ListItem />
@@ -406,7 +406,7 @@ export const ManyItems: Story = {
 <Story name="Empty" />
 
 <Story name="One Item">
-  {#snippet children(args)}
+  {#snippet template(args)}
     <List {...args} >
       <ListItem />
     </List>
@@ -414,7 +414,7 @@ export const ManyItems: Story = {
 </Story>
 
 <Story name="Many Items">
-  {#snippet children(args)}
+  {#snippet template(args)}
     <List {...args} >
       <ListItem />
       <ListItem />
@@ -439,7 +439,7 @@ export const ManyItems: Story = {
 <Story name="Empty" />
 
 <Story name="One Item">
-  {#snippet children(args)}
+  {#snippet template(args)}
     <List {...args} >
       <ListItem />
     </List>
@@ -447,7 +447,7 @@ export const ManyItems: Story = {
 </Story>
 
 <Story name="Many Items">
-  {#snippet children(args)}
+  {#snippet template(args)}
     <List {...args} >
       <ListItem />
       <ListItem />

--- a/docs/_snippets/page-story-slots.md
+++ b/docs/_snippets/page-story-slots.md
@@ -183,7 +183,7 @@ export const CustomFooter: Story = {
 </script>
 
 <Story name="CustomFooter" args={{ footer: 'Built with Storybook' }}>
-  {#snippet children(args)}
+  {#snippet template(args)}
     <Page {...args} >
       <footer>{args.footer}</footer>
     </Page>
@@ -203,7 +203,7 @@ export const CustomFooter: Story = {
 </script>
 
 <Story name="CustomFooter" args={{ footer: 'Built with Storybook' }}>
-  {#snippet children(args)}
+  {#snippet template(args)}
     <Page {...args} >
       <footer>{args.footer}</footer>
     </Page>
@@ -223,7 +223,7 @@ export const CustomFooter: Story = {
 </script>
 
 <Story name="CustomFooter" args={{ footer: 'Built with Storybook' }}>
-  {#snippet children(args)}
+  {#snippet template(args)}
     <Page {...args} >
       <footer>{args.footer}</footer>
     </Page>

--- a/docs/get-started/frameworks/svelte-vite.mdx
+++ b/docs/get-started/frameworks/svelte-vite.mdx
@@ -147,7 +147,7 @@ If you used the `Template` component to control how the component renders in the
 
 #### Story slots to snippets
 
-With Svelte's slot deprecation and the introduction of reusable [`snippets`](https://svelte.dev/docs/svelte/v5-migration-guide#Snippets-instead-of-slots), the addon also introduced support for this feature allowing you to extend the `Story` component and provide a custom snippet to provide dynamic content to your stories. This feature extends the built-in `children` support in the `Story` component, allowing you to create dynamic stories without losing reactivity.
+With Svelte's slot deprecation and the introduction of reusable [`snippets`](https://svelte.dev/docs/svelte/v5-migration-guide#Snippets-instead-of-slots), the addon also introduced support for this feature allowing you to extend the `Story` component and provide a custom snippet to provide dynamic content to your stories. `Story` accepts a `template` snippet, allowing you to create dynamic stories without losing reactivity.
 
 ```svelte title="MyComponent.stories.svelte"
 <script>
@@ -161,7 +161,7 @@ With Svelte's slot deprecation and the introduction of reusable [`snippets`](htt
 </script>
 
 <Story name="Default" args={{ exampleProperty: true }}>
-  {#snippet children(args)}
+  {#snippet template(args)}
     <MyComponent {...args}>Reactive component</MyComponent>
   {/snippet}
 </Story>

--- a/docs/get-started/frameworks/sveltekit.mdx
+++ b/docs/get-started/frameworks/sveltekit.mdx
@@ -231,7 +231,7 @@ If you used the `Template` component to control how the component renders in the
 
 #### Story slots to snippets
 
-With Svelte's slot deprecation and the introduction of reusable [`snippets`](https://svelte.dev/docs/svelte/v5-migration-guide#Snippets-instead-of-slots), the addon also introduced support for this feature allowing you to extend the `Story` component and provide a custom snippet to provide dynamic content to your stories. This feature extends the built-in `children` support in the `Story` component, allowing you to create dynamic stories without losing reactivity.
+With Svelte's slot deprecation and the introduction of reusable [`snippets`](https://svelte.dev/docs/svelte/v5-migration-guide#Snippets-instead-of-slots), the addon also introduced support for this feature allowing you to extend the `Story` component and provide a custom snippet to provide dynamic content to your stories. `Story` accepts a `template` snippet, allowing you to create dynamic stories without losing reactivity.
 
 ```svelte title="MyComponent.stories.svelte"
 <script>
@@ -245,7 +245,7 @@ With Svelte's slot deprecation and the introduction of reusable [`snippets`](htt
 </script>
 
 <Story name="Default" args={{ exampleProperty: true }}>
-  {#snippet children(args)}
+  {#snippet template(args)}
     <MyComponent {...args}>Reactive component</MyComponent>
   {/snippet}
 </Story>


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Updated docs to use `template`-prop instead of `children`, as that has been removed in https://github.com/storybookjs/addon-svelte-csf/pull/228

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates Svelte CSF documentation to replace the `children` prop with `template` prop across framework guides and code snippets, aligning with Svelte 5's new snippet-based approach and deprecation of slots.

- Updated `svelte-vite.mdx` and `sveltekit.mdx` to reflect new snippet-based template syntax
- Modified code examples in `component-story-custom-args-complex.md` to use `template` instead of `children`
- Updated story examples in `list-story-expanded.md` and `page-story-slots.md` with new template syntax
- Ensures consistent documentation of the new approach across all Svelte CSF examples



<!-- /greptile_comment -->