### PR TITLE
CLI: Update nx docs in Storybook detection error

### DIFF
--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -56,10 +56,10 @@ export class NxProjectDetectedError extends StorybookError {
     super({
       category: Category.CLI_INIT,
       code: 1,
-      documentation: 'https://nx.dev/packages/storybook',
+      documentation: 'https://nx.dev/nx-api/storybook#generating-storybook-configuration',
       message: dedent`
         We have detected Nx in your project. Nx has its own Storybook initializer, so please use it instead.
-        Run "nx g @nx/storybook:configuration" to add Storybook to your project.`,
+        Run "nx g @nx/storybook:configuration <your-project-name>" to add Storybook to a given Nx app or lib.`,
     });
   }
 }


### PR DESCRIPTION
A quick update in Nx's error message, as the link has changed.

<!-- greptile_comment -->

## Greptile Summary

Updates the Nx project detection error message and documentation link in Storybook CLI to provide clearer guidance for users encountering Nx integration issues.

- Modified `code/core/src/server-errors.ts` to update Nx documentation link to 'https://nx.dev/nx-api/storybook#generating-storybook-configuration'
- Enhanced error message to include project name placeholder in nx generate command for better user guidance



<!-- /greptile_comment -->