### PR TITLE
Next.js: Remove deprecated compatibility files

### DIFF
--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -47,16 +47,6 @@
       "import": "./dist/next-image-loader-stub.mjs",
       "require": "./dist/next-image-loader-stub.js"
     },
-    "./dist/compatibility/segment.compat": {
-      "types": "./dist/compatibility/segment.compat.d.ts",
-      "import": "./dist/compatibility/segment.compat.mjs",
-      "require": "./dist/compatibility/segment.compat.js"
-    },
-    "./dist/compatibility/redirect-status-code.compat": {
-      "types": "./dist/compatibility/redirect-status-code.compat.d.ts",
-      "import": "./dist/compatibility/redirect-status-code.compat.mjs",
-      "require": "./dist/compatibility/redirect-status-code.compat.js"
-    },
     "./dist/compatibility/draft-mode.compat": {
       "types": "./dist/compatibility/draft-mode.compat.d.ts",
       "import": "./dist/compatibility/draft-mode.compat.mjs",
@@ -218,8 +208,6 @@
       "./src/export-mocks/headers/index.ts",
       "./src/export-mocks/router/index.ts",
       "./src/export-mocks/navigation/index.ts",
-      "./src/compatibility/segment.compat.ts",
-      "./src/compatibility/redirect-status-code.compat.ts",
       "./src/compatibility/draft-mode.compat.ts",
       "./src/next-image-loader-stub.ts",
       "./src/images/decorator.tsx",

--- a/code/frameworks/nextjs/src/compatibility/compatibility-map.ts
+++ b/code/frameworks/nextjs/src/compatibility/compatibility-map.ts
@@ -4,15 +4,6 @@ import type { Configuration as WebpackConfig } from 'webpack';
 import { addScopedAlias, getNextjsVersion, setAlias } from '../utils';
 
 const mapping: Record<string, Record<string, string | boolean>> = {
-  '<14.1.0': {
-    // https://github.com/vercel/next.js/blob/v14.1.0/packages/next/src/shared/lib/segment.ts
-    'next/dist/shared/lib/segment': '@storybook/nextjs/dist/compatibility/segment.compat',
-  },
-  '<14.0.4': {
-    // https://github.com/vercel/next.js/blob/v14.0.4/packages/next/src/client/components/redirect-status-code.ts
-    'next/dist/client/components/redirect-status-code':
-      '@storybook/nextjs/dist/compatibility/redirect-status-code.compat',
-  },
   '<15.0.0': {
     'next/dist/server/request/headers': 'next/dist/client/components/headers',
     // this path only exists from Next 15 onwards

--- a/code/frameworks/nextjs/src/compatibility/redirect-status-code.compat.ts
+++ b/code/frameworks/nextjs/src/compatibility/redirect-status-code.compat.ts
@@ -1,6 +1,0 @@
-// Compatibility for Next 13
-export enum RedirectStatusCode {
-  SeeOther = 303,
-  TemporaryRedirect = 307,
-  PermanentRedirect = 308,
-}

--- a/code/frameworks/nextjs/src/compatibility/segment.compat.ts
+++ b/code/frameworks/nextjs/src/compatibility/segment.compat.ts
@@ -1,8 +1,0 @@
-// Compatibility for Next.js 14
-// from https://github.com/vercel/next.js/blob/606f9ff7903b58da51aa043bfe71cd7b6ea306fd/packages/next/src/shared/lib/segment.ts#L4
-export function isGroupSegment(segment: string) {
-  return segment[0] === '(' && segment.endsWith(')');
-}
-
-export const PAGE_SEGMENT_KEY = '__PAGE__';
-export const DEFAULT_SEGMENT_KEY = '__DEFAULT__';


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Removes deprecated Next.js compatibility files for versions below 14.1.0, streamlining the framework's compatibility layer by removing outdated segment handling and redirect status code implementations.

- Removed `code/frameworks/nextjs/src/compatibility/redirect-status-code.compat.ts` containing HTTP status code enums (303, 307, 308)
- Removed `code/frameworks/nextjs/src/compatibility/segment.compat.ts` with segment handling utilities and constants
- Updated `code/frameworks/nextjs/src/compatibility/compatibility-map.ts` to remove mappings for versions below 14.1.0
- Removed related exports from `code/frameworks/nextjs/package.json` while retaining draft-mode compatibility



<!-- /greptile_comment -->