### PR TITLE
Core: Update `Layout` stories to avoid dynamic content when running Chromatic

### DIFF
--- a/code/core/src/manager/components/layout/Layout.stories.tsx
+++ b/code/core/src/manager/components/layout/Layout.stories.tsx
@@ -10,6 +10,7 @@ import { action } from 'storybook/actions';
 import { fn } from 'storybook/test';
 import { styled } from 'storybook/theming';
 
+import { isChromatic } from '../../../../../.storybook/isChromatic';
 import MobileNavigationStoriesMeta from '../mobile/navigation/MobileNavigation.stories';
 import { Layout } from './Layout';
 import { LayoutProvider } from './LayoutProvider';
@@ -26,6 +27,9 @@ const PlaceholderBlock = styled.div({
 const PlaceholderClock: FC<PropsWithChildren> = ({ children }) => {
   const [count, setCount] = React.useState(0);
   React.useEffect(() => {
+    if (isChromatic()) {
+      return;
+    }
     const interval = setInterval(() => {
       setCount(count + 1);
     }, 1000);


### PR DESCRIPTION
## What I did

Updated `Layout` stories to avoid `setState` in a `setInterval` when running Chromatic snapshots, as this was causing inconsistent snapshots such as [this one](https://www.chromatic.com/test?appId=635781f3500dd2c49e189caf&id=680c899b5a9042abe3acce32).

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates Layout stories to prevent dynamic content updates during Chromatic visual regression testing by conditionally disabling the PlaceholderClock's interval-based counter when running in Chromatic environment.

- Added `isChromatic()` check in `PlaceholderClock` component's `useEffect` hook in `/code/core/src/manager/components/layout/Layout.stories.tsx`
- Prevents state updates from `setInterval` during Chromatic snapshots to avoid flaky visual regression tests



<!-- /greptile_comment -->