### PR TITLE
Docs: Fix incorrect snippets on the main branch

### DIFF
--- a/docs/_snippets/login-form-with-play-function.md
+++ b/docs/_snippets/login-form-with-play-function.md
@@ -33,8 +33,8 @@ export const FilledForm: Story = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -70,8 +70,8 @@ export const FilledForm = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -112,8 +112,8 @@ export const FilledForm: Story = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -154,8 +154,8 @@ export const FilledForm: Story = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -191,8 +191,8 @@ export const FilledForm = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -235,8 +235,8 @@ export const FilledForm: Story = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -279,8 +279,8 @@ export const FilledForm: Story = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -357,8 +357,8 @@ export const FilledForm = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -439,8 +439,8 @@ export const FilledForm: Story = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -522,8 +522,8 @@ export const FilledForm: Story = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -568,8 +568,8 @@ export const FilledForm = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -619,8 +619,8 @@ export const FilledForm: Story = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -670,8 +670,8 @@ export const FilledForm: Story = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -705,8 +705,8 @@ export const FilledForm = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };
@@ -744,8 +744,8 @@ export const FilledForm: Story = {
     // 👇 Assert DOM structure
     await expect(
       canvas.getByText(
-        'Everything is perfect. Your account is ready and we should probably get you started!',
-      ),
+        'Everything is perfect. Your account is ready and we should probably get you started!'
+      )
     ).toBeInTheDocument();
   },
 };

--- a/docs/_snippets/portable-stories-jest-override-globals.md
+++ b/docs/_snippets/portable-stories-jest-override-globals.md
@@ -9,7 +9,7 @@ test('renders in English', async () => {
   const Primary = composeStory(
     PrimaryStory,
     meta,
-    { globals: { locale: 'en' } }, // 👈 Project annotations to override the locale
+    { globals: { locale: 'en' } } // 👈 Project annotations to override the locale
   );
 
   await Primary.run();
@@ -33,7 +33,7 @@ test('renders in English', async () => {
   const Primary = composeStory(
     PrimaryStory,
     meta,
-    { globals: { locale: 'en' } }, // 👈 Project annotations to override the locale
+    { globals: { locale: 'en' } } // 👈 Project annotations to override the locale
   );
 
   await Primary.run();

--- a/docs/_snippets/portable-stories-playwright-ct-override-globals.md
+++ b/docs/_snippets/portable-stories-playwright-ct-override-globals.md
@@ -6,7 +6,7 @@ import meta, { Primary } from './Button.stories';
 export const PrimaryEnglish = composeStory(
   Primary,
   meta,
-  { globals: { locale: 'en' } }, // 👈 Project annotations to override the locale
+  { globals: { locale: 'en' } } // 👈 Project annotations to override the locale
 );
 
 export const PrimarySpanish = composeStory(Primary, meta, { globals: { locale: 'es' } });
@@ -20,7 +20,7 @@ import meta, { Primary } from './Button.stories';
 export const PrimaryEnglish = composeStory(
   Primary,
   meta,
-  { globals: { locale: 'en' } }, // 👈 Project annotations to override the locale
+  { globals: { locale: 'en' } } // 👈 Project annotations to override the locale
 );
 
 export const PrimarySpanish = composeStory(Primary, meta, { globals: { locale: 'es' } });

--- a/docs/_snippets/portable-stories-vitest-override-globals.md
+++ b/docs/_snippets/portable-stories-vitest-override-globals.md
@@ -9,7 +9,7 @@ test('renders in English', async () => {
   const Primary = composeStory(
     PrimaryStory,
     meta,
-    { globals: { locale: 'en' } }, // 👈 Project annotations to override the locale
+    { globals: { locale: 'en' } } // 👈 Project annotations to override the locale
   );
 
   await Primary.run();
@@ -33,7 +33,7 @@ test('renders in English', async () => {
   const Primary = composeStory(
     PrimaryStory,
     meta,
-    { globals: { locale: 'en' } }, // 👈 Project annotations to override the locale
+    { globals: { locale: 'en' } } // 👈 Project annotations to override the locale
   );
 
   await Primary.run();
@@ -57,7 +57,7 @@ test('renders in English', async () => {
   const Primary = composeStory(
     PrimaryStory,
     meta,
-    { globals: { locale: 'en' } }, // 👈 Project annotations to override the locale
+    { globals: { locale: 'en' } } // 👈 Project annotations to override the locale
   );
 
   await Primary.run();


### PR DESCRIPTION
Addresses https://github.com/storybookjs/storybook/pull/31191#discussion_r2069007144 and https://github.com/storybookjs/storybook/pull/31191#discussion_r2069016520 but for the `main` branch

@kylegach when you can. Can you take a look and let me know of any feedback you may have

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates code snippet formatting across documentation files by removing unnecessary trailing commas in function calls and configuration objects to improve code correctness and readability.

- Modified `docs/_snippets/portable-stories-playwright-ct-override-globals.md` to remove trailing commas in `composeStory` function calls
- Updated `docs/_snippets/login-form-with-play-function.md` to fix trailing commas in `getByText` calls across all framework examples
- Fixed formatting in `docs/_snippets/portable-stories-jest-override-globals.md` for Jest test examples
- Standardized `docs/_snippets/portable-stories-vitest-override-globals.md` by removing trailing commas in Vitest test snippets



<!-- /greptile_comment -->