### PR TITLE
Addon A11y: Provide full report in a11y manual runs

### DIFF
--- a/code/addons/a11y/src/a11yRunnerUtils.test.ts
+++ b/code/addons/a11y/src/a11yRunnerUtils.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+
+import type { AxeResults } from 'axe-core';
+
+import { withLinkPaths } from './a11yRunnerUtils';
+
+describe('a11yRunnerUtils', () => {
+  describe('withLinkPaths', () => {
+    it('should add link paths to the axe results', () => {
+      const axeResults = {
+        violations: [
+          {
+            id: 'color-contrast',
+            nodes: [
+              {
+                html: '<button>Click me</button>',
+                target: ['.button'],
+              },
+              {
+                html: '<a href="#">Link</a>',
+                target: ['.link'],
+              },
+            ],
+          },
+        ],
+        passes: [
+          {
+            id: 'button-name',
+            nodes: [
+              {
+                html: '<button>Valid Button</button>',
+                target: ['.valid-button'],
+              },
+            ],
+          },
+        ],
+        incomplete: [
+          {
+            id: 'aria-valid',
+            nodes: [
+              {
+                html: '<div aria-label="test">Test</div>',
+                target: ['.aria-test'],
+              },
+            ],
+          },
+        ],
+        inapplicable: [],
+      } as unknown as AxeResults;
+
+      const result = withLinkPaths(axeResults, 'test-story-id');
+
+      expect(result.violations[0].nodes[0].linkPath).toBe(
+        '/?path=/story/test-story-id&addonPanel=storybook/a11y/panel&a11ySelection=violations.color-contrast.1'
+      );
+      expect(result.violations[0].nodes[1].linkPath).toBe(
+        '/?path=/story/test-story-id&addonPanel=storybook/a11y/panel&a11ySelection=violations.color-contrast.2'
+      );
+
+      expect(result.passes[0].nodes[0].linkPath).toBe(
+        '/?path=/story/test-story-id&addonPanel=storybook/a11y/panel&a11ySelection=passes.button-name.1'
+      );
+
+      expect(result.incomplete[0].nodes[0].linkPath).toBe(
+        '/?path=/story/test-story-id&addonPanel=storybook/a11y/panel&a11ySelection=incomplete.aria-valid.1'
+      );
+    });
+  });
+});

--- a/code/addons/a11y/src/a11yRunnerUtils.ts
+++ b/code/addons/a11y/src/a11yRunnerUtils.ts
@@ -1,0 +1,34 @@
+import { global } from '@storybook/global';
+
+import type { AxeResults, Result } from 'axe-core';
+
+import { PANEL_ID } from './constants';
+import type { EnhancedResults } from './types';
+
+const { document } = global;
+
+// Augment axe results with debuggable links
+export const withLinkPaths = (results: AxeResults, storyId: string) => {
+  const pathname = document.location.pathname.replace(/iframe\.html$/, '');
+
+  // Make a copy of the original results
+  const enhancedResults = { ...results };
+
+  // Enhance specific keys
+  const propertiesToAugment = ['incomplete', 'passes', 'violations'] as const;
+
+  propertiesToAugment.forEach((key) => {
+    if (Array.isArray(results[key])) {
+      enhancedResults[key] = results[key].map((result: Result) => ({
+        ...result,
+        nodes: result.nodes.map((node, index) => {
+          const id = `${key}.${result.id}.${index + 1}`;
+          const linkPath = `${pathname}?path=/story/${storyId}&addonPanel=${PANEL_ID}&a11ySelection=${id}`;
+          return { id, ...node, linkPath };
+        }),
+      }));
+    }
+  });
+
+  return enhancedResults as EnhancedResults;
+};

--- a/code/addons/a11y/src/preview.test.tsx
+++ b/code/addons/a11y/src/preview.test.tsx
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StoryContext } from 'storybook/internal/csf';
 
 import { run } from './a11yRunner';
-import { experimental_afterEach, withLinkPaths } from './preview';
+import { withLinkPaths } from './a11yRunnerUtils';
+import { experimental_afterEach } from './preview';
 import { getIsVitestRunning, getIsVitestStandaloneRun } from './utils';
 
 const mocks = vi.hoisted(() => {
@@ -108,12 +109,12 @@ describe('afterEach', () => {
 
     await expect(() => experimental_afterEach(context)).rejects.toThrow();
 
-    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y);
+    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y, context.id);
 
     expect(context.reporting.addReport).toHaveBeenCalledWith({
       type: 'a11y',
       version: 1,
-      result: withLinkPaths(result as any, context.id),
+      result,
       status: 'failed',
     });
   });
@@ -129,12 +130,12 @@ describe('afterEach', () => {
 
     await experimental_afterEach(context);
 
-    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y);
+    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y, context.id);
 
     expect(context.reporting.addReport).toHaveBeenCalledWith({
       type: 'a11y',
       version: 1,
-      result: withLinkPaths(result as any, context.id),
+      result,
       status: 'failed',
     });
   });
@@ -156,12 +157,12 @@ describe('afterEach', () => {
 
     await experimental_afterEach(context);
 
-    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y);
+    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y, context.id);
 
     expect(context.reporting.addReport).toHaveBeenCalledWith({
       type: 'a11y',
       version: 1,
-      result: withLinkPaths(result as any, context.id),
+      result,
       status: 'warning',
     });
   });
@@ -175,11 +176,11 @@ describe('afterEach', () => {
 
     await experimental_afterEach(context);
 
-    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y);
+    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y, context.id);
     expect(context.reporting.addReport).toHaveBeenCalledWith({
       type: 'a11y',
       version: 1,
-      result: withLinkPaths(result as any, context.id),
+      result,
       status: 'passed',
     });
   });
@@ -236,25 +237,7 @@ describe('afterEach', () => {
 
     await expect(() => experimental_afterEach(context)).rejects.toThrow();
 
-    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y);
-    expect(context.reporting.addReport).toHaveBeenCalledWith({
-      type: 'a11y',
-      version: 1,
-      result: {
-        error,
-      },
-      status: 'failed',
-    });
-  });
-
-  it('should report error when run throws an error', async () => {
-    const context = createContext();
-    const error = new Error('Test error');
-    mockedRun.mockRejectedValue(error);
-
-    await expect(() => experimental_afterEach(context)).rejects.toThrow();
-
-    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y);
+    expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y, context.id);
     expect(context.reporting.addReport).toHaveBeenCalledWith({
       type: 'a11y',
       version: 1,
@@ -274,19 +257,5 @@ describe('afterEach', () => {
 
     expect(mockedRun).not.toHaveBeenCalled();
     expect(context.reporting.addReport).not.toHaveBeenCalled();
-  });
-});
-
-describe('withLinkPaths', () => {
-  it('should add link paths to the result', () => {
-    const result = { violations };
-    // @ts-expect-error - linkPath doesn't exist here
-    expect(result.violations[0].nodes[0].linkPath).toBeUndefined();
-
-    const linkPaths = withLinkPaths(result as any, 'test-story');
-
-    expect(linkPaths.violations[0].nodes[0].linkPath).toEqual(
-      '/?path=/story/test-story&addonPanel=storybook/a11y/panel&a11ySelection=violations.color-contrast.1'
-    );
   });
 });

--- a/code/addons/a11y/src/preview.tsx
+++ b/code/addons/a11y/src/preview.tsx
@@ -1,33 +1,10 @@
 import type { AfterEach } from 'storybook/internal/types';
 
-import type { AxeResults, Result } from 'axe-core';
 import { expect } from 'storybook/test';
 
 import { run } from './a11yRunner';
-import { PANEL_ID } from './constants';
 import type { A11yParameters } from './params';
 import { getIsVitestStandaloneRun } from './utils';
-
-export const withLinkPaths = (results: AxeResults, storyId: string) => {
-  const pathname = document.location.pathname.replace(/iframe\.html$/, '');
-  return Object.fromEntries(
-    Object.entries(results).map(([key, value]) =>
-      ['incomplete', 'passes', 'violations'].includes(key)
-        ? [
-            key,
-            value.map((result: Result) => ({
-              ...result,
-              nodes: result.nodes.map((node, index) => {
-                const id = `${key}.${result.id}.${index + 1}`;
-                const linkPath = `${pathname}?path=/story/${storyId}&addonPanel=${PANEL_ID}&a11ySelection=${id}`;
-                return { id, ...node, linkPath };
-              }),
-            })),
-          ]
-        : [key, value]
-    )
-  );
-};
 
 let vitestMatchersExtended = false;
 
@@ -58,7 +35,7 @@ export const experimental_afterEach: AfterEach<any> = async ({
 
   if (shouldRunEnvironmentIndependent && viewMode === 'story') {
     try {
-      const result = await run(a11yParameter);
+      const result = await run(a11yParameter, storyId);
 
       if (result) {
         const hasViolations = (result?.violations.length ?? 0) > 0;
@@ -66,7 +43,7 @@ export const experimental_afterEach: AfterEach<any> = async ({
         reporting.addReport({
           type: 'a11y',
           version: 1,
-          result: withLinkPaths(result, storyId),
+          result,
           status: hasViolations ? getMode() : 'passed',
         });
 


### PR DESCRIPTION
Closes #

This PR modifies the a11y runner so that it augments the reports in all cases:
- the reporting object coming from the afterEach hook
- the channel event emitted by the addon

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request changes:

Refactored the accessibility (a11y) addon to consistently augment test results with navigable link paths, improving the debugging experience for accessibility issues in Storybook.

- Added new `withLinkPaths` utility in `code/addons/a11y/src/a11yRunnerUtils.ts` to generate debuggable links for accessibility issues
- Modified `code/addons/a11y/src/a11yRunner.ts` to integrate link path generation directly in the runner
- Added comprehensive tests in `a11yRunnerUtils.test.ts` to verify link path generation for violations, passes, and incomplete results
- Removed duplicate link path handling from `preview.tsx` to centralize the functionality in the runner
- Updated channel event handling to include story context for proper link generation



<!-- /greptile_comment -->