### PR TITLE
CLI: Supress npm notice update log messages

### DIFF
--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -20,6 +20,12 @@ export type PackageManagerName = 'npm' | 'yarn1' | 'yarn2' | 'pnpm' | 'bun';
 
 type StorybookPackage = keyof typeof storybookPackagesVersions;
 
+export const COMMON_ENV_VARS = {
+  COREPACK_ENABLE_STRICT: '0',
+  COREPACK_ENABLE_AUTO_PIN: '0',
+  NO_UPDATE_NOTIFIER: 'true',
+};
+
 /**
  * Extract package name and version from input
  *
@@ -533,7 +539,10 @@ export abstract class JsPackageManager {
         stdio: stdio ?? 'pipe',
         shell: true,
         cleanup: true,
-        env,
+        env: {
+          ...COMMON_ENV_VARS,
+          ...env,
+        },
         ...execaOptions,
       });
 
@@ -577,7 +586,10 @@ export abstract class JsPackageManager {
         encoding: 'utf8',
         shell: true,
         cleanup: true,
-        env,
+        env: {
+          ...COMMON_ENV_VARS,
+          ...env,
+        },
         ...execaOptions,
       });
 

--- a/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
@@ -5,6 +5,7 @@ import { findUpSync } from 'find-up';
 
 import { BUNProxy } from './BUNProxy';
 import type { JsPackageManager, PackageManagerName } from './JsPackageManager';
+import { COMMON_ENV_VARS } from './JsPackageManager';
 import { NPMProxy } from './NPMProxy';
 import { PNPMProxy } from './PNPMProxy';
 import { Yarn1Proxy } from './Yarn1Proxy';
@@ -145,8 +146,7 @@ function hasNPM(cwd?: string) {
     shell: true,
     env: {
       ...process.env,
-      COREPACK_ENABLE_STRICT: '0',
-      COREPACK_ENABLE_AUTO_PIN: '0',
+      ...COMMON_ENV_VARS,
     },
   });
   return npmVersionCommand.status === 0;
@@ -158,8 +158,7 @@ function hasBun(cwd?: string) {
     shell: true,
     env: {
       ...process.env,
-      COREPACK_ENABLE_STRICT: '0',
-      COREPACK_ENABLE_AUTO_PIN: '0',
+      ...COMMON_ENV_VARS,
     },
   });
   return pnpmVersionCommand.status === 0;
@@ -171,8 +170,7 @@ function hasPNPM(cwd?: string) {
     shell: true,
     env: {
       ...process.env,
-      COREPACK_ENABLE_STRICT: '0',
-      COREPACK_ENABLE_AUTO_PIN: '0',
+      ...COMMON_ENV_VARS,
     },
   });
   return pnpmVersionCommand.status === 0;
@@ -184,8 +182,7 @@ function getYarnVersion(cwd?: string): 1 | 2 | undefined {
     shell: true,
     env: {
       ...process.env,
-      COREPACK_ENABLE_STRICT: '0',
-      COREPACK_ENABLE_AUTO_PIN: '0',
+      ...COMMON_ENV_VARS,
     },
   });
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Implements environment variable configuration to suppress npm update notifications and standardize package manager behavior across the Storybook CLI.

- Added `COMMON_ENV_VARS` in `code/core/src/common/js-package-manager/JsPackageManager.ts` to centralize environment settings
- Updated package manager detection functions in `code/core/src/common/js-package-manager/JsPackageManagerFactory.ts` to use shared environment variables
- Added `NO_UPDATE_NOTIFIER` to disable npm update notifications
- Configured `COREPACK_ENABLE_STRICT` and `COREPACK_ENABLE_AUTO_PIN` for consistent package manager behavior



<!-- /greptile_comment -->