### PR TITLE
Addon-vitest: Remove internal log for `staticDir`

### DIFF
--- a/code/core/src/core-server/utils/server-statics.ts
+++ b/code/core/src/core-server/utils/server-statics.ts
@@ -1,7 +1,7 @@
 import { existsSync, statSync } from 'node:fs';
 import { basename, isAbsolute, posix, resolve, sep, win32 } from 'node:path';
 
-import { getDirectoryFromWorkingDir } from 'storybook/internal/common';
+import { getDirectoryFromWorkingDir, resolvePathInStorybookCache } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 import type { Options, StorybookConfigRaw } from 'storybook/internal/types';
 
@@ -9,6 +9,8 @@ import picocolors from 'picocolors';
 import type { Polka } from 'polka';
 import sirv from 'sirv';
 import { dedent } from 'ts-dedent';
+
+const cacheDir = resolvePathInStorybookCache('', 'ignored-sub').split('ignored-sub')[0];
 
 export async function useStatics(app: Polka, options: Options): Promise<void> {
   const staticDirs = (await options.presets.apply('staticDirs')) ?? [];
@@ -18,8 +20,8 @@ export async function useStatics(app: Polka, options: Options): Promise<void> {
     try {
       const { staticDir, staticPath, targetEndpoint } = mapStaticDir(dir, options.configDir);
 
-      // Don't log for the internal static dir
-      if (!targetEndpoint.startsWith('/sb-')) {
+      // Don't log for internal static dirs
+      if (!targetEndpoint.startsWith('/sb-') && !staticDir.startsWith(cacheDir)) {
         logger.info(
           `=> Serving static files from ${picocolors.cyan(staticDir)} at ${picocolors.cyan(targetEndpoint)}`
         );


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When you had `addon-vitest` enabled, you would always get this log when starting Storybook:

```
info => Serving static files from /Users/jeppe/dev/work/storybook/storybook/code/node_modules/.cache/storybook/default/coverage at /coverage
```

This change makes core not log this if the path starts with `/Users/jeppe/dev/work/storybook/storybook/code/node_modules/.cache/storybook`, as we should assume that those are internal static dirs that we don't need to inform the user about.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Modified server-statics.ts to suppress internal static directory logging when addon-vitest is enabled, improving log clarity by only showing relevant static directory information to users.

- Added check in `useStatics` to prevent logging when static directory path starts with Storybook cache directory
- Imported `resolvePathInStorybookCache` utility to determine cache directory path
- Maintains existing static file serving functionality while reducing unnecessary logging output
- Focused change improves developer experience by reducing noise in logs when using addon-vitest



<!-- /greptile_comment -->