### PR TITLE
CLI: Improve CLI upgrade for `@latest` and `@next`

### DIFF
--- a/code/core/src/common/satellite-addons.ts
+++ b/code/core/src/common/satellite-addons.ts
@@ -1,0 +1,10 @@
+// Storybook packages that are not part of the monorepo but we maintain.
+export default [
+  '@storybook/test-runner',
+  '@chromatic-com/storybook',
+  '@storybook/addon-designs',
+  '@storybook/addon-svelte-csf',
+  '@storybook/addon-coverage',
+  '@storybook/addon-webpack5-compiler-babel',
+  '@storybook/addon-webpack5-compiler-swc',
+];

--- a/code/core/src/common/utils/cli.ts
+++ b/code/core/src/common/utils/cli.ts
@@ -157,5 +157,6 @@ export const createLogStream = async (
   });
 };
 
-export const isCorePackage = (pkg: string) => Object.keys(storybookPackagesVersions).includes(pkg);
+export const isCorePackage = (pkg: string) =>
+  !!storybookPackagesVersions[pkg as keyof typeof storybookPackagesVersions];
 export const isSatelliteAddon = (pkg: string) => satelliteAddons.includes(pkg);

--- a/code/core/src/common/utils/cli.ts
+++ b/code/core/src/common/utils/cli.ts
@@ -8,7 +8,8 @@ import { type MergeExclusive } from 'type-fest';
 import uniqueString from 'unique-string';
 
 import type { JsPackageManager } from '../js-package-manager';
-import versions from '../versions';
+import satelliteAddons from '../satellite-addons';
+import storybookPackagesVersions from '../versions';
 import { rendererPackages } from './get-storybook-info';
 
 const tempDir = () => realpath(os.tmpdir());
@@ -82,7 +83,7 @@ export async function getCoercedStorybookVersion(packageManager: JsPackageManage
     )
   ).filter(({ version }) => !!version);
 
-  return packages[0]?.version || versions.storybook;
+  return packages[0]?.version || storybookPackagesVersions.storybook;
 }
 
 export function getEnvConfig(program: Record<string, any>, configEnv: Record<string, any>): void {
@@ -156,4 +157,5 @@ export const createLogStream = async (
   });
 };
 
-export const isCorePackage = (pkg: string) => Object.keys(versions).includes(pkg);
+export const isCorePackage = (pkg: string) => Object.keys(storybookPackagesVersions).includes(pkg);
+export const isSatelliteAddon = (pkg: string) => satelliteAddons.includes(pkg);

--- a/code/lib/cli-storybook/src/automigrate/fixes/upgrade-storybook-related-dependencies.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/upgrade-storybook-related-dependencies.test.ts
@@ -79,11 +79,6 @@ describe('upgrade-storybook-related-dependencies fix', () => {
       {
         "upgradable": [
           {
-            "afterVersion": "2.0.0",
-            "beforeVersion": "1.2.9",
-            "packageName": "@chromatic-com/storybook",
-          },
-          {
             "afterVersion": "1.0.0",
             "beforeVersion": "0.2.3",
             "packageName": "@storybook/jest",

--- a/code/lib/cli-storybook/src/automigrate/fixes/upgrade-storybook-related-dependencies.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/upgrade-storybook-related-dependencies.ts
@@ -1,5 +1,5 @@
 import type { JsPackageManager } from 'storybook/internal/common';
-import { isCorePackage } from 'storybook/internal/common';
+import { isCorePackage, isSatelliteAddon } from 'storybook/internal/common';
 
 import { cyan, yellow } from 'picocolors';
 import { gt } from 'semver';
@@ -56,7 +56,7 @@ export const upgradeStorybookRelatedDependencies = {
     const allDependencies = (await packageManager.getAllDependencies()) as Record<string, string>;
     const storybookDependencies = Object.keys(allDependencies)
       .filter((dep) => dep.includes('storybook'))
-      .filter((dep) => !isCorePackage(dep));
+      .filter((dep) => !isCorePackage(dep) && !isSatelliteAddon(dep));
     const incompatibleDependencies = analyzedPackages
       .filter((pkg) => pkg.hasIncompatibleDependencies)
       .map((pkg) => pkg.packageName);
@@ -80,7 +80,7 @@ export const upgradeStorybookRelatedDependencies = {
 
   prompt({ upgradable }) {
     return dedent`
-      You're upgrading to the latest version of Storybook. We recommend upgrading the following packages:
+      You're upgrading Storybook, but you are using community packages that might need to be upgraded as well. We recommend upgrading them:
       ${upgradable
         .map(({ packageName, afterVersion, beforeVersion }) => {
           return `- ${cyan(packageName)}: ${cyan(beforeVersion)} => ${cyan(afterVersion)}`;
@@ -89,6 +89,8 @@ export const upgradeStorybookRelatedDependencies = {
 
       After upgrading, we will run the dedupe command, which could possibly have effects on dependencies that are not Storybook related.
       see: https://docs.npmjs.com/cli/commands/npm-dedupe
+
+      Attention: As these packages are maintained by the community, we cannot guarantee that they are compatible with the new version of Storybook. If you encounter any issues, please report them to the package maintainers.
 
       Do you want to proceed (upgrade the detected packages)?
     `;

--- a/code/lib/cli-storybook/src/upgrade.test.ts
+++ b/code/lib/cli-storybook/src/upgrade.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as sbcc from 'storybook/internal/common';
+import type { JsPackageManager } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 import { UpgradeStorybookToLowerVersionError } from 'storybook/internal/server-errors';
 
-import { doUpgrade, getStorybookVersion } from './upgrade';
+import { doUpgrade, getStorybookVersion, toUpgradedDependencies } from './upgrade';
 
 const findInstallationsMock =
   vi.fn<(arg: string[]) => Promise<sbcc.InstallationMetadata | undefined>>();
@@ -24,7 +25,7 @@ vi.mock('storybook/internal/common', async (importOriginal) => {
     },
     versions: Object.keys(originalModule.versions).reduce(
       (acc, key) => {
-        acc[key] = '8.0.0';
+        acc[key] = '9.0.0';
         return acc;
       },
       {} as Record<string, string>
@@ -55,7 +56,7 @@ describe('Upgrade errors', () => {
       dependencies: {
         storybook: [
           {
-            version: '8.1.0',
+            version: '9.1.0',
           },
         ],
       },
@@ -72,7 +73,7 @@ describe('Upgrade errors', () => {
       dependencies: {
         storybook: [
           {
-            version: '8.0.0',
+            version: '9.0.0',
           },
         ],
       },
@@ -90,5 +91,156 @@ describe('Upgrade errors', () => {
       'You are upgrading Storybook to the same version that is currently installed in the project'
     );
     expect(findInstallationsMock).toHaveBeenCalledWith(Object.keys(sbcc.versions));
+  });
+});
+
+describe('toUpgradedDependencies', () => {
+  let mockPackageManager: JsPackageManager;
+
+  beforeEach(() => {
+    mockPackageManager = {
+      latestVersion: vi.fn(),
+    } as unknown as JsPackageManager;
+
+    vi.mocked(mockPackageManager.latestVersion).mockImplementation(async (packageName: string) => {
+      if (packageName === '@storybook/addon-designs@next') {
+        return '9.0.0-beta.1';
+      }
+      if (packageName === '@storybook/addon-designs') {
+        return '8.0.0';
+      }
+      if (packageName === '@chromatic-com/storybook@next') {
+        return '4.0.0-0';
+      }
+      if (packageName === '@chromatic-com/storybook') {
+        return '3.0.0';
+      }
+
+      return '9.0.0';
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('core storybook packages', () => {
+    it('should upgrade Storybook core dependencies respecting the version modifier of the dependency to upgrade', async () => {
+      const deps = {
+        '@storybook/react': '8.0.0',
+        '@storybook/vue3': '~8.0.0',
+        '@storybook/svelte': '^8.0.0',
+        '@storybook/angular': '>=8.0.0',
+        // in this case, it uses the first modifier of the first version defined
+        '@storybook/html': '>8.0.0 || ^0.0.0-pr.0',
+        // invalid cases become fixed version
+        '@storybook/web-components': '*',
+        '@storybook/react-vite': 'workspace:*',
+        react: '18.0.0',
+      };
+
+      const result = await toUpgradedDependencies(deps, mockPackageManager);
+
+      expect(result).toEqual([
+        '@storybook/react@9.0.0',
+        '@storybook/vue3@~9.0.0',
+        '@storybook/svelte@^9.0.0',
+        '@storybook/angular@>=9.0.0',
+        '@storybook/html@>9.0.0',
+        '@storybook/web-components@9.0.0',
+        '@storybook/react-vite@9.0.0',
+      ]);
+    });
+
+    it('should not add ^ for outdated CLI versions', async () => {
+      const deps = {
+        '@storybook/react': '^8.0.0',
+      };
+
+      const result = await toUpgradedDependencies(deps, mockPackageManager, {
+        isCLIOutdated: true,
+      });
+
+      expect(result).toEqual(['@storybook/react@9.0.0']);
+    });
+
+    it('should not add ^ for canary versions', async () => {
+      const deps = {
+        '@storybook/react': '^8.0.0',
+      };
+
+      const result = await toUpgradedDependencies(deps, mockPackageManager, {
+        isCanary: true,
+      });
+
+      expect(result).toEqual(['@storybook/react@9.0.0']);
+    });
+  });
+
+  describe('satellite packages', () => {
+    it('should include satellite dependencies for latest stable version', async () => {
+      const deps = {
+        '@storybook/react': '8.0.0',
+        '@storybook/addon-designs': '8.0.0',
+        '@storybook/test-runner': '^8.0.0',
+        '@chromatic-com/storybook': '~3.0.0',
+      };
+
+      const result = await toUpgradedDependencies(deps, mockPackageManager, {
+        isCLIExactLatest: true,
+      });
+
+      expect(result).toEqual([
+        '@storybook/react@9.0.0',
+        '@storybook/addon-designs@8.0.0',
+        '@storybook/test-runner@^9.0.0',
+        '@chromatic-com/storybook@~3.0.0',
+      ]);
+      expect(mockPackageManager.latestVersion).toHaveBeenCalledWith('@storybook/addon-designs');
+    });
+
+    it('should include satellite dependencies with @next for prerelease version', async () => {
+      const deps = {
+        '@storybook/react': '^8.0.0',
+        '@storybook/addon-designs': '8.0.0',
+      };
+
+      const result = await toUpgradedDependencies(deps, mockPackageManager, {
+        isCLIExactPrerelease: true,
+        isCLIPrerelease: true,
+      });
+
+      expect(result).toContainEqual('@storybook/react@^9.0.0');
+      expect(result).toContainEqual('@storybook/addon-designs@9.0.0-beta.1');
+      expect(mockPackageManager.latestVersion).toHaveBeenCalledWith(
+        '@storybook/addon-designs@next'
+      );
+    });
+
+    it('should handle errors when fetching satellite dependencies', async () => {
+      const deps = {
+        '@storybook/react': '^8.0.0',
+        '@storybook/addon-designs': '8.0.0',
+      };
+
+      vi.mocked(mockPackageManager.latestVersion).mockRejectedValueOnce(
+        new Error('MOCKED Network error')
+      );
+
+      const result = await toUpgradedDependencies(deps, mockPackageManager, {
+        isCLIExactLatest: true,
+      });
+
+      // Should still have the core dependencies
+      expect(result).toContainEqual('@storybook/react@^9.0.0');
+
+      // Satellite dependencies should be omitted due to the error
+      expect(result).not.toContainEqual(expect.stringContaining('@storybook/addon-designs'));
+    });
+  });
+
+  it('should handle empty dependencies', async () => {
+    const result = await toUpgradedDependencies({}, mockPackageManager);
+    expect(result).toEqual([]);
   });
 });

--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -251,9 +251,7 @@ export const doUpgrade = async (allOptions: UpgradeOptions) => {
 
       let storybookSatelliteUpgrades: string[] = [];
       if (isCLIExactPrerelease || isCLIExactLatest) {
-        const satelliteDependencies = Object.keys(packageJson.dependencies).filter(
-          isSatelliteAddon
-        );
+        const satelliteDependencies = Object.keys(deps).filter(isSatelliteAddon);
 
         if (satelliteDependencies.length > 0) {
           try {
@@ -262,7 +260,7 @@ export const doUpgrade = async (allOptions: UpgradeOptions) => {
                 const latestVersion = await packageManager.latestVersion(
                   isCLIPrerelease ? `${dependency}@next` : dependency
                 );
-                return `${dependency}@${latestVersion}`;
+                return `^${dependency}@${latestVersion}`;
               })
             );
           } catch (error) {

--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -311,7 +311,7 @@ export const doUpgrade = async (allOptions: UpgradeOptions) => {
   // INSTALL UPDATED DEPENDENCIES
   if (!dryRun && !results) {
     const upgradedDependencies = await toUpgradedDependencies(
-      packageJson.dependencies || {},
+      packageJson.dependencies as Record<string, string>,
       packageManager,
       {
         isCanary,
@@ -323,7 +323,7 @@ export const doUpgrade = async (allOptions: UpgradeOptions) => {
     );
 
     const upgradedDevDependencies = await toUpgradedDependencies(
-      packageJson.devDependencies || {},
+      packageJson.devDependencies as Record<string, string>,
       packageManager,
       {
         isCanary,

--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -425,8 +425,6 @@ export const doUpgrade = async (allOptions: UpgradeOptions) => {
     });
   }
 
-  await doctor(allOptions);
-
   // TELEMETRY
   if (!options.disableTelemetry) {
     const { preCheckFailure, fixResults } = results || {};
@@ -441,6 +439,8 @@ export const doUpgrade = async (allOptions: UpgradeOptions) => {
       ...automigrationTelemetry,
     });
   }
+
+  await doctor(allOptions);
 };
 
 export async function upgrade(options: UpgradeOptions): Promise<void> {


### PR DESCRIPTION
Closes #31314

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- Introduced a new module for managing Storybook satellite addons.
- Updated CLI utility functions to include checks for satellite addons.
- Enhanced the upgrade process to handle satellite dependencies, ensuring they are upgraded alongside core Storybook packages (but only when it's an exact match for @latest or @next, as users could be downgrading or installing specific versions which might be tricky).
- Improved messaging in the upgrade prompts to inform users about community-maintained packages.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31356-sha-36d464a6`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31356-sha-36d464a6 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31356-sha-36d464a6 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31356-sha-36d464a6`](https://npmjs.com/package/storybook/v/0.0.0-pr-31356-sha-36d464a6) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/improve-upgrade-command`](https://github.com/storybookjs/storybook/tree/yann/improve-upgrade-command) |
| **Commit** | [`36d464a6`](https://github.com/storybookjs/storybook/commit/36d464a66a9e8ebad331e5e1a0ed906eba297a9b) |
| **Datetime** | Fri May  2 13:42:33 UTC 2025 (`1746193353`) |
| **Workflow run** | [14796402208](https://github.com/storybookjs/storybook/actions/runs/14796402208) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31356`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhances Storybook's upgrade process by introducing automatic handling of satellite addons and improving user messaging during package upgrades for @latest and @next versions.

- Added new `code/core/src/common/satellite-addons.ts` to manage Storybook-maintained packages outside the monorepo
- Enhanced `code/lib/cli-storybook/src/upgrade.ts` to automatically upgrade satellite addons for @latest/@next versions
- Updated `code/lib/cli-storybook/src/automigrate/fixes/upgrade-storybook-related-dependencies.ts` with clearer messaging about community package compatibility
- Added `isSatelliteAddon` utility in `code/core/src/common/utils/cli.ts` to identify satellite addons during upgrades



<!-- /greptile_comment -->