### PR TITLE
Documentation: Add missing comma in withAddonDecorator configuration

### DIFF
--- a/docs/_snippets/storybook-addons-api-makedecorator.md
+++ b/docs/_snippets/storybook-addons-api-makedecorator.md
@@ -4,7 +4,7 @@ import { makeDecorator } from 'storybook/preview-api';
 export const withAddonDecorator = makeDecorator({
   name: 'withSomething',
   parameterName: 'CustomParameter',
-  skipIfNoParametersOrOptions: true
+  skipIfNoParametersOrOptions: true,
   wrapper: (getStory, context, { parameters }) => {
     /*
     * Write your custom logic here based on the parameters passed in Storybook's stories.


### PR DESCRIPTION
## What I did

Added a missing trailing comma to the skipIfNoParametersOrOptions property in the withAddonDecorator example within `storybook-addons-api-makedecorator.md`. This is a minor syntax cleanup for consistency and to prevent potential copy-paste issues.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added missing trailing comma in the `withAddonDecorator` configuration example within Storybook documentation for improved code consistency.

- Fixed syntax in `docs/_snippets/storybook-addons-api-makedecorator.md` by adding trailing comma after `skipIfNoParametersOrOptions` property

Note: This is a minimal documentation change that maintains the previous review's essence while following the standard format. The change is straightforward and doesn't require additional bullet points since it's a single, focused modification.



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->