### PR TITLE
CLI: Tweak init prompt

### DIFF
--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -342,7 +342,7 @@ export const promptInstallType = async ({
           value: 'recommended',
         },
         {
-          title: `${picocolors.bold('Minimal:')} Dev only`,
+          title: `${picocolors.bold('Minimal:')} Component dev only`,
           value: 'light',
         },
       ],


### PR DESCRIPTION


## What I did

Minor wording adjustment

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR updates the installation type prompt in the Storybook CLI, changing the 'Minimal' option description from 'Dev only' to 'Component dev only' for better clarity.

- Modified `code/lib/create-storybook/src/initiate.ts` to update prompt text for minimal installation option
- Improves user understanding by being more explicit about minimal installation contents
- Maintains existing functionality while enhancing UX through clearer wording



<!-- /greptile_comment -->