### PR TITLE
Backgrounds/Viewport: Fix resetting

### DIFF
--- a/code/core/src/backgrounds/components/Tool.tsx
+++ b/code/core/src/backgrounds/components/Tool.tsx
@@ -73,7 +73,7 @@ const Pure = memo(function PureTool(props: PureProps) {
   } = props;
 
   const update = useCallback(
-    (input: GlobalStateUpdate) => {
+    (input: GlobalStateUpdate | undefined) => {
       updateGlobals({
         [KEY]: input,
       });
@@ -109,7 +109,7 @@ const Pure = memo(function PureTool(props: PureProps) {
                           title: 'Reset background',
                           icon: <RefreshIcon />,
                           onClick: () => {
-                            update({ value: undefined, grid: isGrid });
+                            update(undefined);
                             onHide();
                           },
                         },

--- a/code/core/src/preview-api/modules/store/GlobalsStore.ts
+++ b/code/core/src/preview-api/modules/store/GlobalsStore.ts
@@ -62,5 +62,11 @@ export class GlobalsStore {
 
   update(newGlobals: Globals) {
     this.globals = { ...this.globals, ...this.filterAllowedGlobals(newGlobals) };
+
+    for (const key in newGlobals) {
+      if (newGlobals[key] === undefined) {
+        this.globals[key] = this.initialGlobals[key];
+      }
+    }
   }
 }

--- a/code/core/src/viewport/components/Tool.tsx
+++ b/code/core/src/viewport/components/Tool.tsx
@@ -106,7 +106,7 @@ const Pure = React.memo(function PureTool(props: PureProps) {
   } = props;
 
   const update = useCallback(
-    (input: GlobalStateUpdate) => updateGlobals({ [PARAM_KEY]: input }),
+    (input: GlobalStateUpdate | undefined) => updateGlobals({ [PARAM_KEY]: input }),
     [updateGlobals]
   );
 
@@ -124,7 +124,7 @@ const Pure = React.memo(function PureTool(props: PureProps) {
                       title: 'Reset viewport',
                       icon: <RefreshIcon />,
                       onClick: () => {
-                        update({ value: undefined, isRotated: false });
+                        update(undefined);
                         onHide();
                       },
                     },


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31381

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixing an issue to properly reset values for backgrounds and viewports in the toolbar.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR implements fixes for resetting functionality in Storybook's backgrounds and viewport toolbar controls. Here's a concise summary of the key changes:

- Modified `GlobalsStore.update()` to properly reset values to their initial state when undefined is passed
- Simplified reset handling in `backgrounds/Tool.tsx` and `viewport/Tool.tsx` by allowing direct undefined values
- Updated type signatures in both tools to explicitly accept undefined as valid input for the update functions
- Streamlined reset logic by removing unnecessary object wrappers when clearing values

The changes improve the reliability of the reset functionality while maintaining type safety. The implementation looks solid but could benefit from additional test coverage to verify the reset behavior works as expected across different scenarios.



<!-- /greptile_comment -->