### PR TITLE
Build: Restore storybook-benchmarking-bot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -841,10 +841,9 @@ workflows:
       - knip:
           requires:
             - build
-      # TODO: don't forget to reenable this
-      #      - bench-packages:
-      #          requires:
-      #            - build
+      - bench-packages:
+          requires:
+            - build
       - check
       - unit-tests:
           requires:
@@ -918,10 +917,9 @@ workflows:
       - knip:
           requires:
             - build
-      # TODO: don't forget to reenable this
-      #      - bench-packages:
-      #          requires:
-      #            - build
+      - bench-packages:
+          requires:
+            - build
       - check
       - unit-tests:
           requires:
@@ -996,10 +994,9 @@ workflows:
       - knip:
           requires:
             - build
-      # TODO: don't forget to reenable this
-      #      - bench-packages:
-      #          requires:
-      #            - build
+      - bench-packages:
+          requires:
+            - build
       - check
       - unit-tests:
           requires:

--- a/scripts/bench/bench-packages.ts
+++ b/scripts/bench/bench-packages.ts
@@ -344,8 +344,7 @@ const uploadToGithub = async ({
   pullRequest: number;
 }) => {
   console.log('Uploading results to GitHub...');
-  // const response = await fetch('http://localhost:3000/package-bench', {
-  const response = await fetch('https://storybook-benchmark-bot.vercel.app/package-bench', {
+  const response = await fetch('https://storybook-benchmark-bot.netlify.app//package-bench', {
     method: 'POST',
     body: JSON.stringify({
       owner: 'storybookjs',

--- a/scripts/bench/bench-packages.ts
+++ b/scripts/bench/bench-packages.ts
@@ -344,7 +344,7 @@ const uploadToGithub = async ({
   pullRequest: number;
 }) => {
   console.log('Uploading results to GitHub...');
-  const response = await fetch('https://storybook-benchmark-bot.netlify.app//package-bench', {
+  const response = await fetch('https://storybook-benchmark-bot.netlify.app/package-bench', {
     method: 'POST',
     body: JSON.stringify({
       owner: 'storybookjs',

--- a/scripts/upload-bench.ts
+++ b/scripts/upload-bench.ts
@@ -96,7 +96,7 @@ const uploadBench = async () => {
     });
 
     return prNumber && prNumber !== '0'
-      ? fetch('https://storybook-benchmark-bot.vercel.app/description', {
+      ? fetch('https://storybook-benchmark-bot.netlify.app//description', {
           method: 'POST',
           body: JSON.stringify({
             owner: 'storybookjs',

--- a/scripts/upload-bench.ts
+++ b/scripts/upload-bench.ts
@@ -96,7 +96,7 @@ const uploadBench = async () => {
     });
 
     return prNumber && prNumber !== '0'
-      ? fetch('https://storybook-benchmark-bot.netlify.app//description', {
+      ? fetch('https://storybook-benchmark-bot.netlify.app/description', {
           method: 'POST',
           body: JSON.stringify({
             owner: 'storybookjs',


### PR DESCRIPTION
## What I did

This pull request updates the URLs used for API requests in the benchmarking scripts to reflect a new deployment location. The changes ensure that the scripts now point to the correct Netlify-hosted endpoints instead of the previous Vercel-hosted ones.

### URL Updates in Benchmarking Scripts:

* [`scripts/bench/bench-packages.ts`](diffhunk://#diff-fc4051513f7f043c21a2115ed590b150539f60d7efd6b0857f9408b859cdeac6L347-R347): Updated the URL in the `uploadToGithub` function to use `https://storybook-benchmark-bot.netlify.app//package-bench` instead of the Vercel-hosted endpoint.

* [`scripts/upload-bench.ts`](diffhunk://#diff-486eb4117ac7dafd2916f1d57310938854c8c9d1f1c1e572b3ccbbf7bb7a8f4bL99-R99): Updated the URL in the `uploadBench` function to use `https://storybook-benchmark-bot.netlify.app//description` instead of the Vercel-hosted endpoint.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates benchmarking infrastructure by migrating endpoints from Vercel to Netlify and re-enables benchmarking functionality in CircleCI workflows.

- Updated endpoint URL in `scripts/bench/bench-packages.ts` to `storybook-benchmark-bot.netlify.app/package-bench`
- Updated endpoint URL in `scripts/upload-bench.ts` to `storybook-benchmark-bot.netlify.app/description`
- Re-enabled `bench-packages` job in `.circleci/config.yml` for all workflows (normal, merged, daily)
- Fixed double slash issue in Netlify URLs that was present in previous paths



<!-- /greptile_comment -->