### PR TITLE
Addon A11y: Improve selector automigration detection

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-parameters.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-parameters.ts
@@ -49,12 +49,15 @@ export const addonA11yParameters: Fix<A11yOptions> = {
       absolute: true,
     });
 
+    const maybeHasA11yParameter = (content: string) =>
+      content.includes('a11y:') && content.includes('element:');
+
     // Filter files that contain both 'a11y' and 'element' in their content
     const storyFilesWithA11y = (
       await Promise.all(
         storyFiles.map(async (file) => {
           const content = await readFile(file, 'utf-8');
-          return content.includes('a11y') && content.includes('element') ? file : null;
+          return maybeHasA11yParameter(content) ? file : null;
         })
       )
     ).filter((file): file is string => file !== null);
@@ -63,7 +66,7 @@ export const addonA11yParameters: Fix<A11yOptions> = {
 
     if (previewConfigPath) {
       const content = await readFile(previewConfigPath, 'utf-8');
-      hasA11yConfigInPreview = content.includes('a11y') && content.includes('element');
+      hasA11yConfigInPreview = maybeHasA11yParameter(content);
     }
 
     if (storyFilesWithA11y.length === 0 && !hasA11yConfigInPreview) {

--- a/code/lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.ts
@@ -38,7 +38,7 @@ function migrateA11yParameters(obj: t.ObjectExpression): boolean {
 }
 
 export function transformStoryA11yParameters(code: string): CsfFile | null {
-  const parsed = loadCsf(code, { makeTitle: (title) => title }).parse();
+  const parsed = loadCsf(code, { makeTitle: (title?: string) => title || 'default' }).parse();
 
   let hasChanges = false;
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The a11y addon automigration was getting triggered incorrectly, plus it had a bug that would crash on stories that had no title in the meta (see image). This PR fixes both cases.

![image](https://github.com/user-attachments/assets/3c442e85-db2d-4556-90de-f6fe1cc5e8fd)


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Improved the automigration logic for Storybook's a11y addon parameters, fixing crashes on stories without titles and enhancing detection accuracy for files requiring updates.

- Fixed crash in `code/lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.ts` by adding default title handling in `loadCsf`
- Added `maybeHasA11yParameter` function in `code/lib/cli-storybook/src/automigrate/fixes/addon-a11y-parameters.ts` for more precise detection
- Updated detection logic to check for both 'a11y:' and 'element:' patterns in file content
- Improved error handling and rate limiting for file processing during migration



<!-- /greptile_comment -->