### PR TITLE
CLI: Detect correct storybook version on upgrade

### DIFF
--- a/code/lib/cli-storybook/src/upgrade.test.ts
+++ b/code/lib/cli-storybook/src/upgrade.test.ts
@@ -9,6 +9,7 @@ import { doUpgrade, getStorybookVersion, toUpgradedDependencies } from './upgrad
 
 const findInstallationsMock =
   vi.fn<(arg: string[]) => Promise<sbcc.InstallationMetadata | undefined>>();
+const getInstalledVersionMock = vi.fn<(arg: string) => Promise<string | undefined>>();
 
 vi.mock('storybook/internal/telemetry');
 vi.mock('storybook/internal/common', async (importOriginal) => {
@@ -18,6 +19,7 @@ vi.mock('storybook/internal/common', async (importOriginal) => {
     JsPackageManagerFactory: {
       getPackageManager: () => ({
         findInstallations: findInstallationsMock,
+        getInstalledVersion: getInstalledVersionMock,
         latestVersion: async () => '8.0.0',
         retrievePackageJson: async () => {},
         getAllDependencies: async () => ({ storybook: '8.0.0' }),
@@ -69,6 +71,18 @@ describe('Upgrade errors', () => {
     expect(findInstallationsMock).toHaveBeenCalledWith(Object.keys(sbcc.versions));
   });
   it('should show a warning when upgrading to the same version number', async () => {
+    findInstallationsMock.mockResolvedValue({
+      dependencies: {
+        storybook: [
+          {
+            version: '9.0.0',
+          },
+        ],
+      },
+      duplicatedDependencies: {},
+      infoCommand: '',
+      dedupeCommand: '',
+    });
     findInstallationsMock.mockResolvedValue({
       dependencies: {
         storybook: [

--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -49,6 +49,11 @@ export const getStorybookVersion = (line: string) => {
 };
 
 const getInstalledStorybookVersion = async (packageManager: JsPackageManager) => {
+  const storybookCliVersion = await packageManager.getInstalledVersion('storybook');
+  if (storybookCliVersion) {
+    return storybookCliVersion;
+  }
+
   const installations = await packageManager.findInstallations(Object.keys(versions));
   if (!installations) {
     return;


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31297

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Before, the Storybook CLI would detect any package as "the storybook package" and get its version. This change makes it so that checking for `storybook` takes precedence, and if for whatever reason the user doesn't have `storybook`, it will fallback to the previous mechanism.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Improved version detection in Storybook CLI upgrade process by prioritizing the 'storybook' package version check before falling back to other Storybook-related packages.

- Modified `code/lib/cli-storybook/src/upgrade.ts` to first check for 'storybook' package version using `getInstalledVersion('storybook')`
- Added fallback to existing version detection mechanism if 'storybook' package version isn't found
- Ensures more accurate version detection during upgrade process



<!-- /greptile_comment -->