### PR TITLE
Docs: Adds missing Svelte CSF Snippets

### DIFF
--- a/docs/_snippets/addon-actions-action-function.md
+++ b/docs/_snippets/addon-actions-action-function.md
@@ -20,7 +20,7 @@ export default meta;
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
-  import { action } from 'storybook/actions/decorator';
+  import { action } from 'storybook/actions';
 
   import Button from './Button.svelte';
 
@@ -66,7 +66,7 @@ export default {
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
-  import { action } from 'storybook/actions/decorator';
+  import { action } from 'storybook/actions';
 
   import Button from './Button.svelte';
 

--- a/docs/_snippets/addon-actions-action-function.md
+++ b/docs/_snippets/addon-actions-action-function.md
@@ -16,6 +16,38 @@ const meta: Meta<Button> = {
 export default meta;
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { action } from 'storybook/actions/decorator';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+    args: {
+      // 👇 Create an action that appears when the onClick event is fired
+      onClick: action('on-click'),
+    },
+  });
+</script>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { action } from 'storybook/actions';
+
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+  args: {
+    // 👇 Create an action that appears when the onClick event is fired
+    onClick: action('on-click'),
+  },
+};
+```
+
 ```js filename="Button.stories.js" renderer="common" language="js"
 import { action } from 'storybook/actions';
 
@@ -28,6 +60,43 @@ export default {
     onClick: action('on-click'),
   },
 };
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { action } from 'storybook/actions/decorator';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+    args: {
+      // 👇 Create an action that appears when the onClick event is fired
+      onClick: action('on-click'),
+    },
+  });
+</script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import { action } from 'storybook/actions';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+  args: {
+    // 👇 Create an action that appears when the onClick event is fired
+    onClick: action('on-click'),
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```
 
 ```ts filename="Button.stories.ts" renderer="common" language="ts"

--- a/docs/_snippets/addon-backgrounds-define-globals.md
+++ b/docs/_snippets/addon-backgrounds-define-globals.md
@@ -22,7 +22,7 @@ export const OnDark: Story = {
 };
 ```
 
-```svelte filename="Button.stories.svelte" renderer="svelte" language="js"
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -46,7 +46,26 @@ export const OnDark: Story = {
 />
 ```
 
-```svelte filename="Button.stories.svelte" renderer="svelte" language="ts"
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+  globals: {
+    // 👇 Set background value for all component stories
+    backgrounds: { value: 'gray', grid: false },
+  },
+};
+
+export const OnDark = {
+  globals: {
+    // 👇 Override background value for this story
+    backgrounds: { value: 'dark' },
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -68,6 +87,31 @@ export const OnDark: Story = {
     backgrounds: { value: "dark" },
   }}
 />
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+  globals: {
+    // 👇 Set background value for all component stories
+    backgrounds: { value: 'gray', grid: false },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OnDark: Story = {
+  globals: {
+    // 👇 Override background value for this story
+    backgrounds: { value: 'dark' },
+  },
+};
 ```
 
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"

--- a/docs/_snippets/addon-backgrounds-disabled.md
+++ b/docs/_snippets/addon-backgrounds-disabled.md
@@ -1,4 +1,4 @@
-```svelte filename="Button.stories.svelte" renderer="svelte" language="js"
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -17,7 +17,21 @@
 />
 ```
 
-```svelte filename="Button.stories.svelte" renderer="svelte" language="ts"
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+};
+
+export const Large = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -34,6 +48,26 @@
     backgrounds: { disable: true },
   }}
 />
+```
+
+```ts filename="Button.stories.ts|tsx" renderer="common" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import { Meta, StoryObj } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Large: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+};
 ```
 
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"

--- a/docs/_snippets/addon-backgrounds-grid.md
+++ b/docs/_snippets/addon-backgrounds-grid.md
@@ -22,7 +22,7 @@ const meta: Meta<Button> = {
 export default meta;
 ```
 
-```svelte filename="Button.stories.svelte" renderer="svelte" language="js"
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -46,7 +46,27 @@ export default meta;
 </script>
 ```
 
-```svelte filename="Button.stories.svelte" renderer="svelte" language="ts"
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+// To apply a grid to all stories of Button:
+export default {
+  component: Button,
+  parameters: {
+    backgrounds: {
+      grid: {
+        cellSize: 20,
+        opacity: 0.5,
+        cellAmount: 5,
+        offsetX: 16, // Default is 0 if story has 'fullscreen' layout, 16 if layout is 'padded'
+        offsetY: 16, // Default is 0 if story has 'fullscreen' layout, 16 if layout is 'padded'
+      },
+    },
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -68,6 +88,31 @@ export default meta;
     },
   });
 </script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+// To apply a set of backgrounds to all stories of Button:
+const meta = {
+  component: Button,
+  parameters: {
+    backgrounds: {
+      grid: {
+        cellSize: 20,
+        opacity: 0.5,
+        cellAmount: 5,
+        offsetX: 16, // Default is 0 if story has 'fullscreen' layout, 16 if layout is 'padded'
+        offsetY: 16, // Default is 0 if story has 'fullscreen' layout, 16 if layout is 'padded'
+      },
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```
 
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"

--- a/docs/_snippets/addon-backgrounds-options-in-meta.md
+++ b/docs/_snippets/addon-backgrounds-options-in-meta.md
@@ -136,7 +136,7 @@ const meta = {
 export default meta;
 ```
 
-```svelte filename="Button.stories.svelte" renderer="svelte" language="js"
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -158,7 +158,25 @@ export default meta;
 </script>
 ```
 
-```svelte filename="Button.stories.svelte" renderer="svelte" language="ts"
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+  parameters: {
+    backgrounds: {
+      options: {
+        // 👇 Override the default `dark` option
+        dark: { name: 'Dark', value: '#000' },
+        // 👇 Add a new option
+        gray: { name: 'Gray', value: '#CCC' },
+      },
+    },
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -178,4 +196,27 @@ export default meta;
     },
   });
 </script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+  parameters: {
+    backgrounds: {
+      options: {
+        // 👇 Override the default `dark` option
+        dark: { name: 'Dark', value: '#000' },
+        // 👇 Add a new option
+        gray: { name: 'Gray', value: '#CCC' },
+      },
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```

--- a/docs/_snippets/addon-viewport-configuration-in-meta.md
+++ b/docs/_snippets/addon-viewport-configuration-in-meta.md
@@ -89,7 +89,7 @@ const meta = {
 export default meta;
 ```
 
-```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js"
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -109,7 +109,23 @@ export default meta;
 </script>
 ```
 
-```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts"
+```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { INITIAL_VIEWPORTS } from 'storybook/viewport';
+
+import MyComponent from './MyComponent.svelte';
+
+export default {
+  component: MyComponent,
+  parameters: {
+    viewport: {
+      //👇 Set available viewports for every story in the file
+      options: INITIAL_VIEWPORTS,
+    },
+  },
+};
+```
+
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -127,6 +143,27 @@ export default meta;
     },
   });
 </script>
+```
+
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { INITIAL_VIEWPORTS } from 'storybook/viewport';
+
+import MyComponent from './MyComponent.svelte';
+
+const meta = {
+  component: MyComponent,
+  parameters: {
+    viewport: {
+      //👇 Set available viewports for every story in the file
+      options: INITIAL_VIEWPORTS,
+    },
+  },
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
 ```
 
 ```js filename="MyComponent.stories.js" renderer="vue" language="js"

--- a/docs/_snippets/addon-viewport-define-globals.md
+++ b/docs/_snippets/addon-viewport-define-globals.md
@@ -22,7 +22,7 @@ export const OnPhone: Story = {
 };
 ```
 
-```svelte filename="Button.stories.svelte" renderer="svelte" language="js"
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -45,7 +45,26 @@ export const OnPhone: Story = {
 />
 ```
 
-```svelte filename="Button.stories.svelte" renderer="svelte" language="ts"
+```js filename="Button.stories.js"renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+  globals: {
+    // 👇 Set viewport for all component stories
+    viewport: { value: 'tablet', isRotated: false },
+  },
+};
+
+export const OnPhone = {
+  globals: {
+    // 👇 Override viewport for this story
+    viewport: { value: 'mobile1', isRotated: false },
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -66,6 +85,31 @@ export const OnPhone: Story = {
     viewport: { value: "mobile1", isRotated: false },
   }}
 />
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with nextjs or nextjs-vite
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { Button } from './Button';
+
+const meta = {
+  component: Button,
+  globals: {
+    // 👇 Set viewport for all component stories
+    viewport: { value: 'tablet', isRotated: false },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OnPhone: Story = {
+  globals: {
+    // 👇 Override viewport for this story
+    viewport: { value: 'mobile1', isRotated: false },
+  },
+};
 ```
 
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"

--- a/docs/_snippets/addon-viewport-define-globals.md
+++ b/docs/_snippets/addon-viewport-define-globals.md
@@ -45,7 +45,7 @@ export const OnPhone: Story = {
 />
 ```
 
-```js filename="Button.stories.js"renderer="svelte" language="js" tabTitle="CSF"
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
 import Button from './Button.svelte';
 
 export default {
@@ -88,7 +88,7 @@ export const OnPhone = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-// Replace your-framework with nextjs or nextjs-vite
+// Replace your-framework with svelte-vite or sveltekit
 import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { Button } from './Button';

--- a/docs/_snippets/api-doc-block-argtypes-parameter.md
+++ b/docs/_snippets/api-doc-block-argtypes-parameter.md
@@ -15,6 +15,36 @@ const meta: Meta<Button> = {
 export default meta;
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const meta = defineMeta({
+    component: Button,
+    parameters: {
+      docs: {
+        controls: { exclude: ['style'] },
+      },
+    },
+  });
+</script>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+  parameters: {
+    docs: {
+      controls: { exclude: ['style'] },
+    },
+  },
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
@@ -26,6 +56,41 @@ export default {
     },
   },
 };
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const meta = defineMeta({
+    component: Button,
+    parameters: {
+      docs: {
+        controls: { exclude: ['style'] },
+      },
+    },
+  });
+</script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+  parameters: {
+    docs: {
+      controls: { exclude: ['style'] },
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```
 
 ```ts filename="Button.stories.ts|tsx" renderer="common" language="ts"
@@ -42,6 +107,32 @@ const meta = {
     },
   },
 } satisfies Meta<typeof Button>;
+
+export default meta;
+```
+
+```js filename="Button.stories.js" renderer="web-components" language="js"
+export default {
+  component: 'demo-button',
+  parameters: {
+    docs: {
+      controls: { exclude: ['style'] },
+    },
+  },
+};
+```
+
+```ts filename="Button.ts" renderer="web-components" language="ts"
+import type { Meta } from '@storybook/web-components-vite';
+
+const meta: Meta = {
+  component: 'demo-button',
+  parameters: {
+    docs: {
+      controls: { exclude: ['style'] },
+    },
+  },
+};
 
 export default meta;
 ```

--- a/docs/_snippets/api-doc-block-canvas-parameter.md
+++ b/docs/_snippets/api-doc-block-canvas-parameter.md
@@ -25,7 +25,7 @@ export const Basic: Story = {
 
   import Button from './Button.svelte';
 
-  const meta = defineMeta({
+  const { Story } = defineMeta({
     component: Button,
   });
 </script>
@@ -77,7 +77,7 @@ export const Basic = {
 
   import Button from './Button.svelte';
 
-  const meta = defineMeta({
+  const { Story } = defineMeta({
     component: Button,
   });
 </script>

--- a/docs/_snippets/api-doc-block-canvas-parameter.md
+++ b/docs/_snippets/api-doc-block-canvas-parameter.md
@@ -19,8 +19,92 @@ export const Basic: Story = {
 };
 ```
 
-```js filename="Button.stories.js|jsx" renderer="common" language="js"
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const meta = defineMeta({
+    component: Button,
+  });
+</script>
+
+<Story
+  name="Basic"
+  parameters={{
+    docs: {
+      canvas: { sourceState: 'shown' },
+    },
+  }} />
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+};
+
 export const Basic = {
+  parameters: {
+    docs: {
+      canvas: { sourceState: 'shown' },
+    },
+  },
+};
+```
+
+```js filename="Button.stories.js|jsx" renderer="common" language="js"
+import { Button } from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Basic = {
+  parameters: {
+    docs: {
+      canvas: { sourceState: 'shown' },
+    },
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const meta = defineMeta({
+    component: Button,
+  });
+</script>
+
+<Story
+  name="Basic"
+  parameters={{
+    docs: {
+      canvas: { sourceState: 'shown' },
+    },
+  }} />
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
   parameters: {
     docs: {
       canvas: { sourceState: 'shown' },

--- a/docs/_snippets/api-doc-block-controls-parameter.md
+++ b/docs/_snippets/api-doc-block-controls-parameter.md
@@ -15,6 +15,36 @@ const meta: Meta<Button> = {
 export default meta;
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const meta = defineMeta({
+    component: Button,
+    parameters: {
+      docs: {
+        controls: { exclude: ['style'] },
+      },
+    },
+  });
+</script>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+  parameters: {
+    docs: {
+      controls: { exclude: ['style'] },
+    },
+  },
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
@@ -26,6 +56,41 @@ export default {
     },
   },
 };
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const meta = defineMeta({
+    component: Button,
+    parameters: {
+      docs: {
+        controls: { exclude: ['style'] },
+      },
+    },
+  });
+</script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+  parameters: {
+    docs: {
+      controls: { exclude: ['style'] },
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```
 
 ```ts filename="Button.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/api-doc-block-description-example.md
+++ b/docs/_snippets/api-doc-block-description-example.md
@@ -36,6 +36,77 @@ export const Primary: Story = {
 };
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  /**
+   * Button stories
+   * These stories showcase the button
+   */
+  const meta = defineMeta({
+    component: Button,
+    parameters: {
+      docs: {
+        description: {
+          component: 'Another description, overriding the comments',
+        },
+      },
+    },
+  });
+</script>
+
+<!--
+ Button stories
+ These stories showcase the button
+ -->
+
+<Story
+  name="Primary"
+  parameters={{
+    docs: {
+      description: {
+        story: 'Another description on the story, overriding the comments'
+      },
+    },
+  }} />
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+/**
+ * Button stories
+ * These stories showcase the button
+ */
+export default {
+  component: Button,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Another description, overriding the comments',
+      },
+    },
+  },
+};
+
+/**
+ * Primary Button
+ * This is the primary button
+ */
+export const Primary = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Another description on the story, overriding the comments',
+      },
+    },
+  },
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
@@ -59,6 +130,83 @@ export default {
  * This is the primary button
  */
 export const Primary = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Another description on the story, overriding the comments',
+      },
+    },
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  /**
+   * Button stories
+   * These stories showcase the button
+   */
+  const meta = defineMeta({
+    component: Button,
+    parameters: {
+      docs: {
+        description: {
+          component: 'Another description, overriding the comments',
+        },
+      },
+    },
+  });
+</script>
+
+<!--
+ Button stories
+ These stories showcase the button
+ -->
+
+<Story
+  name="Primary"
+  parameters={{
+    docs: {
+      description: {
+        story: 'Another description on the story, overriding the comments'
+      },
+    },
+  }} />
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+/**
+ * Button stories
+ * These stories showcase the button
+ */
+const meta = {
+  component: Button,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Another description, overriding the comments',
+      },
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Primary Button
+ * This is the primary button
+ */
+export const Primary: Story = {
   parameters: {
     docs: {
       description: {

--- a/docs/_snippets/api-doc-block-source-parameter.md
+++ b/docs/_snippets/api-doc-block-source-parameter.md
@@ -19,17 +19,95 @@ export const Basic: Story = {
 };
 ```
 
-```js filename="Button.stories.js|jsx" renderer="common" language="js"
-const meta = {
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const meta = defineMeta({
+    component: Button,
+  });
+</script>
+
+<Story
+  name="Basic"
+  parameters={{
+    docs: {
+      source: { language: 'tsx' },
+    },
+  }} />
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
   component: Button,
 };
-
-export default meta;
 
 export const Basic = {
   parameters: {
     docs: {
       source: { language: 'jsx' },
+    },
+  },
+};
+```
+
+```js filename="Button.stories.js|jsx" renderer="common" language="js"
+import { Button } from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Basic = {
+  parameters: {
+    docs: {
+      source: { language: 'jsx' },
+    },
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const meta = defineMeta({
+    component: Button,
+  });
+</script>
+
+<Story
+  name="Basic"
+  parameters={{
+    docs: {
+      source: { language: 'tsx' },
+    },
+  }} />
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  parameters: {
+    docs: {
+      source: { language: 'tsx' },
     },
   },
 };

--- a/docs/_snippets/api-doc-block-story-parameter.md
+++ b/docs/_snippets/api-doc-block-story-parameter.md
@@ -19,13 +19,92 @@ export const Basic: Story = {
 };
 ```
 
-```js filename="Button.stories.js|jsx" renderer="common" language="js"
-const meta = {
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const meta = defineMeta({
+    component: Button,
+  });
+</script>
+
+<Story
+  name="Basic"
+  parameters={{
+    docs: {
+      story: { autoplay: true },
+    },
+  }} />
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
   component: Button,
 };
-export default meta;
 
 export const Basic = {
+  parameters: {
+    docs: {
+      story: { autoplay: true },
+    },
+  },
+};
+```
+
+```js filename="Button.stories.js|jsx" renderer="common" language="js"
+import { Button } from './Button';
+
+export default {
+  component: Button,
+};
+
+export const Basic = {
+  parameters: {
+    docs: {
+      story: { autoplay: true },
+    },
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const meta = defineMeta({
+    component: Button,
+  });
+</script>
+
+<Story
+  name="Basic"
+  parameters={{
+    docs: {
+      story: { autoplay: true },
+    },
+  }} />
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
   parameters: {
     docs: {
       story: { autoplay: true },

--- a/docs/_snippets/arg-types-control.md
+++ b/docs/_snippets/arg-types-control.md
@@ -20,6 +20,46 @@ const meta: Meta<Example> = {
 export default meta;
 ```
 
+```svelte filename="Example.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example  from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      value: {
+        control: {
+          type: 'number',
+          min: 0,
+          max: 100,
+          step: 10,
+        },
+      },
+    },
+  });
+</script>
+```
+
+```js filename="Example.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Example from './Example.svelte';
+
+export default {
+  component: Example,
+  argTypes: {
+    value: {
+      control: {
+        type: 'number',
+        min: 0,
+        max: 100,
+        step: 10,
+      },
+    },
+  },
+};
+```
+
 ```js filename="Example.stories.js|jsx" renderer="common" language="js"
 import { Example } from './Example';
 
@@ -36,6 +76,51 @@ export default {
     },
   },
 };
+```
+
+```svelte filename="Example.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example  from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      value: {
+        control: {
+          type: 'number',
+          min: 0,
+          max: 100,
+          step: 10,
+        },
+      },
+    },
+  });
+</script>
+```
+
+```ts filename="Example.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Example from './Example.svelte';
+
+const meta = {
+  component: Example,
+  argTypes: {
+    value: {
+      control: {
+        type: 'number',
+        min: 0,
+        max: 100,
+        step: 10,
+      },
+    },
+  },
+} satisfies Meta<typeof Example>;
+
+export default meta;
 ```
 
 ```ts filename="Example.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/arg-types-control.md
+++ b/docs/_snippets/arg-types-control.md
@@ -24,7 +24,7 @@ export default meta;
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
-  import Example  from './Example.svelte';
+  import Example from './Example.svelte';
 
   const { Story } = defineMeta({
     component: Example,
@@ -82,7 +82,7 @@ export default {
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
-  import Example  from './Example.svelte';
+  import Example from './Example.svelte';
 
   const { Story } = defineMeta({
     component: Example,

--- a/docs/_snippets/arg-types-default-value.md
+++ b/docs/_snippets/arg-types-default-value.md
@@ -20,6 +20,46 @@ const meta: Meta<Example> = {
 export default meta;
 ```
 
+```svelte filename="Example.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      value: {
+        // ⛔️ Deprecated, do not use
+        defaultValue: 0,
+      },
+    },
+    // ✅ Do this instead
+    args: {
+      value: 0,
+    },
+  });
+</script>
+```
+
+```js filename="Example.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Example from './Example.svelte';
+
+export default {
+  component: Example,
+  argTypes: {
+    value: {
+      // ⛔️ Deprecated, do not use
+      defaultValue: 0,
+    },
+  },
+  // ✅ Do this instead
+  args: {
+    value: 0,
+  },
+};
+```
+
 ```js filename="Example.stories.js|jsx" renderer="common" language="js"
 import { Example } from './Example';
 
@@ -36,6 +76,51 @@ export default {
     value: 0,
   },
 };
+```
+
+```svelte filename="Example.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      value: {
+        // ⛔️ Deprecated, do not use
+        defaultValue: 0,
+      },
+    },
+    // ✅ Do this instead
+    args: {
+      value: 0,
+    },
+  });
+</script>
+```
+
+```ts filename="Example.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Example from './Example.svelte';
+
+const meta = {
+  component: Example,
+  argTypes: {
+    value: {
+      // ❌ Deprecated
+      defaultValue: 0,
+    },
+  },
+  // ✅ Do this instead
+  args: {
+    value: 0,
+  },
+} satisfies Meta<typeof Example>;
+
+export default meta;
 ```
 
 ```ts filename="Example.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/arg-types-description.md
+++ b/docs/_snippets/arg-types-description.md
@@ -15,6 +15,36 @@ const meta: Meta<Example> = {
 export default meta;
 ```
 
+```svelte filename="Example.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      value: {
+        description: 'The value of the slider',
+      },
+    },
+  });
+</script>
+```
+
+```js filename="Example.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Example from './Example.svelte';
+
+export default {
+  component: Example,
+  argTypes: {
+    value: {
+      description: 'The value of the slider',
+    },
+  },
+};
+```
+
 ```js filename="Example.stories.js|jsx" renderer="common" language="js"
 import { Example } from './Example';
 
@@ -26,6 +56,41 @@ export default {
     },
   },
 };
+```
+
+```svelte filename="Example.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      value: {
+        description: 'The value of the slider',
+      },
+    },
+  });
+</script>
+```
+
+```ts filename="Example.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Example from './Example.svelte';
+
+const meta = {
+  component: Example,
+  argTypes: {
+    value: {
+      description: 'The value of the slider',
+    },
+  },
+} satisfies Meta<typeof Example>;
+
+export default meta;
 ```
 
 ```ts filename="Example.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/arg-types-if.md
+++ b/docs/_snippets/arg-types-if.md
@@ -37,6 +37,80 @@ const meta: Meta<Example> = {
 export default meta;
 ```
 
+```svelte filename="Example.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      parent: { control: 'select', options: ['one', 'two', 'three'] },
+
+      // 👇 Only shown when `parent` arg exists
+      parentExists: { if: { arg: 'parent', exists: true } },
+
+      // 👇 Only shown when `parent` arg does not exist
+      parentDoesNotExist: { if: { arg: 'parent', exists: false } },
+
+      // 👇 Only shown when `parent` arg value is truthy
+      parentIsTruthy: { if: { arg: 'parent' } },
+      parentIsTruthyVerbose: { if: { arg: 'parent', truthy: true } },
+
+      // 👇 Only shown when `parent` arg value is not truthy
+      parentIsNotTruthy: { if: { arg: 'parent', truthy: false } },
+
+      // 👇 Only shown when `parent` arg value is 'three'
+      parentIsEqToValue: { if: { arg: 'parent', eq: 'three' } },
+
+      // 👇 Only shown when `parent` arg value is not 'three'
+      parentIsNotEqToValue: { if: { arg: 'parent', neq: 'three' } },
+
+      // Each of the above can also be conditional on the value of a globalType, e.g.:
+
+      // 👇 Only shown when `theme` global exists
+      parentExists: { if: { global: 'theme', exists: true } },
+    },
+  });
+</script>
+```
+
+```js filename="Example.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Example from './Example.svelte';
+
+export default {
+  component: Example,
+  argTypes: {
+    parent: { control: 'select', options: ['one', 'two', 'three'] },
+
+    // 👇 Only shown when `parent` arg exists
+    parentExists: { if: { arg: 'parent', exists: true } },
+
+    // 👇 Only shown when `parent` arg does not exist
+    parentDoesNotExist: { if: { arg: 'parent', exists: false } },
+
+    // 👇 Only shown when `parent` arg value is truthy
+    parentIsTruthy: { if: { arg: 'parent' } },
+    parentIsTruthyVerbose: { if: { arg: 'parent', truthy: true } },
+
+    // 👇 Only shown when `parent` arg value is not truthy
+    parentIsNotTruthy: { if: { arg: 'parent', truthy: false } },
+
+    // 👇 Only shown when `parent` arg value is 'three'
+    parentIsEqToValue: { if: { arg: 'parent', eq: 'three' } },
+
+    // 👇 Only shown when `parent` arg value is not 'three'
+    parentIsNotEqToValue: { if: { arg: 'parent', neq: 'three' } },
+
+    // Each of the above can also be conditional on the value of a globalType, e.g.:
+
+    // 👇 Only shown when `theme` global exists
+    parentExists: { if: { global: 'theme', exists: true } },
+  },
+};
+```
+
 ```js filename="Example.stories.js|jsx" renderer="common" language="js"
 import { Example } from './Example';
 
@@ -70,6 +144,85 @@ export default {
     parentExists: { if: { global: 'theme', exists: true } },
   },
 };
+```
+
+```svelte filename="Example.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      parent: { control: 'select', options: ['one', 'two', 'three'] },
+
+      // 👇 Only shown when `parent` arg exists
+      parentExists: { if: { arg: 'parent', exists: true } },
+
+      // 👇 Only shown when `parent` arg does not exist
+      parentDoesNotExist: { if: { arg: 'parent', exists: false } },
+
+      // 👇 Only shown when `parent` arg value is truthy
+      parentIsTruthy: { if: { arg: 'parent' } },
+      parentIsTruthyVerbose: { if: { arg: 'parent', truthy: true } },
+
+      // 👇 Only shown when `parent` arg value is not truthy
+      parentIsNotTruthy: { if: { arg: 'parent', truthy: false } },
+
+      // 👇 Only shown when `parent` arg value is 'three'
+      parentIsEqToValue: { if: { arg: 'parent', eq: 'three' } },
+
+      // 👇 Only shown when `parent` arg value is not 'three'
+      parentIsNotEqToValue: { if: { arg: 'parent', neq: 'three' } },
+
+      // Each of the above can also be conditional on the value of a globalType, e.g.:
+
+      // 👇 Only shown when `theme` global exists
+      parentExists: { if: { global: 'theme', exists: true } },
+    },
+  });
+</script>
+```
+
+```ts filename="Example.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Example from './Example.svelte';
+
+const meta = {
+  component: Example,
+  argTypes: {
+    parent: { control: 'select', options: ['one', 'two', 'three'] },
+
+    // 👇 Only shown when `parent` arg exists
+    parentExists: { if: { arg: 'parent', exists: true } },
+
+    // 👇 Only shown when `parent` arg does not exist
+    parentDoesNotExist: { if: { arg: 'parent', exists: false } },
+
+    // 👇 Only shown when `parent` arg value is truthy
+    parentIsTruthy: { if: { arg: 'parent' } },
+    parentIsTruthyVerbose: { if: { arg: 'parent', truthy: true } },
+
+    // 👇 Only shown when `parent` arg value is not truthy
+    parentIsNotTruthy: { if: { arg: 'parent', truthy: false } },
+
+    // 👇 Only shown when `parent` arg value is 'three'
+    parentIsEqToValue: { if: { arg: 'parent', eq: 'three' } },
+
+    // 👇 Only shown when `parent` arg value is not 'three'
+    parentIsNotEqToValue: { if: { arg: 'parent', neq: 'three' } },
+
+    // Each of the above can also be conditional on the value of a globalType, e.g.:
+
+    // 👇 Only shown when `theme` global exists
+    parentExists: { if: { global: 'theme', exists: true } },
+  },
+} satisfies Meta<typeof Example>;
+
+export default meta;
 ```
 
 ```ts filename="Example.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/arg-types-in-meta.md
+++ b/docs/_snippets/arg-types-in-meta.md
@@ -17,6 +17,40 @@ const meta: Meta<Button> = {
 export default meta;
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+    argTypes: {
+      // 👇 All Button stories expect a label arg
+      label: {
+        control: 'text',
+        description: 'Overwritten description',
+      },
+    },
+  });
+</script>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { Button } from './Button';
+
+export default {
+  component: Button,
+  argTypes: {
+    // 👇 All Button stories expect a label arg
+    label: {
+      control: 'text',
+      description: 'Overwritten description',
+    },
+  },
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
@@ -30,6 +64,45 @@ export default {
     },
   },
 };
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+    argTypes: {
+      // 👇 All Button stories expect a label arg
+      label: {
+        control: 'text',
+        description: 'Overwritten description',
+      },
+    },
+  });
+</script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import { Button } from './Button';
+
+const meta = {
+  component: Button,
+  argTypes: {
+    // 👇 All Button stories expect a label arg
+    label: {
+      control: 'text',
+      description: 'Overwritten description',
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```
 
 ```ts filename="Button.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/arg-types-in-story.md
+++ b/docs/_snippets/arg-types-in-story.md
@@ -98,7 +98,7 @@ export const Basic = {
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
 // Replace your-framework with svelte-vite or sveltekit
-import type { Meta } from '@storybook/your-framework';
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 
@@ -107,7 +107,6 @@ const meta = {
 } satisfies Meta<typeof Button>;
 
 export default meta;
-
 type Story = StoryObj<typeof meta>;
 
 export const Basic = {
@@ -123,7 +122,7 @@ export const Basic = {
 
 ```ts filename="Button.stories.ts|tsx" renderer="common" language="ts"
 // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite, angular, etc.)
-import type { Meta } from '@storybook/your-framework';
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { Button } from './Button';
 
@@ -132,10 +131,9 @@ const meta = {
 } satisfies Meta<typeof Button>;
 
 export default meta;
-
 type Story = StoryObj<typeof meta>;
 
-export const Basic = {
+export const Basic: Story = {
   argTypes: {
     // 👇 This story expects a label arg
     label: {

--- a/docs/_snippets/arg-types-in-story.md
+++ b/docs/_snippets/arg-types-in-story.md
@@ -22,6 +22,43 @@ export const Basic: Story = {
 };
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+  });
+</script>
+
+<Story
+  name="Basic"
+  argTypes={{
+    label: { control: 'text', description: 'Overwritten description' }
+  }}
+/>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+};
+
+export const Basic = {
+  argTypes: {
+    // 👇 This story expects a label arg
+    label: {
+      control: 'text',
+      description: 'Overwritten description',
+    },
+  },
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
@@ -38,6 +75,50 @@ export const Basic = {
     },
   },
 };
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+  });
+</script>
+
+<Story
+  name="Basic"
+  argTypes={{
+    label: { control: 'text', description: 'Overwritten description' }
+  }}
+/>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic = {
+  argTypes: {
+    // 👇 This story expects a label arg
+    label: {
+      control: 'text',
+      description: 'Overwritten description',
+    },
+  },
+} satisfies Story;
 ```
 
 ```ts filename="Button.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/arg-types-mapping.md
+++ b/docs/_snippets/arg-types-mapping.md
@@ -7,6 +7,7 @@ const meta: Meta<Example> = {
   component: Example,
   argTypes: {
     label: {
+      control: { type: 'select' },
       options: ['Normal', 'Bold', 'Italic'],
       mapping: {
         Bold: <b>Bold</b>,
@@ -19,6 +20,74 @@ const meta: Meta<Example> = {
 export default meta;
 ```
 
+```svelte filename="Example.stories.svelte" renderer="svelte" language="js"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      label: {
+        control: { type: 'select' },
+        options: ['Normal', 'Bold', 'Italic'],
+        mapping: {
+          Normal: normal,
+          Bold: bold,
+          Italic: italic,
+        },
+      },
+    },
+  });
+</script>
+
+{#snippet normal()}
+  <span>Normal</span>
+{/snippet}
+
+{#snippet bold()}
+  <b>Bold</b>
+{/snippet}
+{#snippet italic()}
+  <i>Italic</i>
+{/snippet}
+```
+
+```svelte filename="Example.stories.svelte" renderer="svelte" language="ts"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      label: {
+        control: { type: 'select' },
+        options: ['Normal', 'Bold', 'Italic'],
+        mapping: {
+          Normal: normal,
+          Bold: bold,
+          Italic: italic,
+        },
+      },
+    },
+  });
+</script>
+
+{#snippet normal()}
+  <span>Normal</span>
+{/snippet}
+
+{#snippet bold()}
+  <b>Bold</b>
+{/snippet}
+{#snippet italic()}
+  <i>Italic</i>
+{/snippet}
+```
+
 ```js filename="Example.stories.js|jsx" renderer="common" language="js"
 import { Example } from './Example';
 
@@ -26,6 +95,7 @@ export default {
   component: Example,
   argTypes: {
     label: {
+      control: { type: 'select' },
       options: ['Normal', 'Bold', 'Italic'],
       mapping: {
         Bold: <b>Bold</b>,
@@ -46,6 +116,7 @@ const meta = {
   component: Example,
   argTypes: {
     label: {
+      control: { type: 'select' },
       options: ['Normal', 'Bold', 'Italic'],
       mapping: {
         Bold: <b>Bold</b>,
@@ -65,6 +136,7 @@ export default {
   component: 'demo-example',
   argTypes: {
     label: {
+      control: { type: 'select' },
       options: ['Normal', 'Bold', 'Italic'],
       mapping: {
         Bold: html`<b>Bold</b>`,
@@ -84,6 +156,7 @@ const meta: Meta = {
   component: 'demo-example',
   argTypes: {
     label: {
+      control: { type: 'select' },
       options: ['Normal', 'Bold', 'Italic'],
       mapping: {
         Bold: html`<b>Bold</b>`,

--- a/docs/_snippets/arg-types-name.md
+++ b/docs/_snippets/arg-types-name.md
@@ -15,6 +15,36 @@ const meta: Meta<Example> = {
 export default meta;
 ```
 
+```svelte filename="Example.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      actualArgName: {
+        name: 'Friendly name',
+      },
+    },
+  });
+</script>
+```
+
+```js filename="Example.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Example from './Example.svelte';
+
+export default {
+  component: Example,
+  argTypes: {
+    actualArgName: {
+      name: 'Friendly name',
+    },
+  },
+};
+```
+
 ```js filename="Example.stories.js|jsx" renderer="common" language="js"
 import { Example } from './Example';
 
@@ -26,6 +56,41 @@ export default {
     },
   },
 };
+```
+
+```svelte filename="Example.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      actualArgName: {
+        name: 'Friendly name',
+      },
+    },
+  });
+</script>
+```
+
+```ts filename="Example.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Example from './Example.svelte';
+
+const meta = {
+  component: Example,
+  argTypes: {
+    actualArgName: {
+      name: 'Friendly name',
+    },
+  },
+} satisfies Meta<typeof Example>;
+
+export default meta;
 ```
 
 ```ts filename="Example.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/arg-types-options.md
+++ b/docs/_snippets/arg-types-options.md
@@ -75,7 +75,7 @@ export default {
 </script>
 ```
 
-```ts filename="Example.stories.ts" renderer="svelte" language="ts" tabTitle="CSF
+```ts filename="Example.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
 // Replace your-framework with svelte-vite or sveltekit
 import type { Meta } from '@storybook/your-framework';
 

--- a/docs/_snippets/arg-types-options.md
+++ b/docs/_snippets/arg-types-options.md
@@ -15,11 +15,87 @@ const meta: Meta<Example> = {
 export default meta;
 ```
 
+```svelte filename="Example.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      icon: {
+        options: ['arrow-up', 'arrow-down', 'loading'],
+      },
+    },
+  });
+</script>
+```
+
+```js filename="Example.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Example from './Example.svelte';
+
+export default {
+  component: Example,
+  argTypes: {
+    icon: {
+      options: ['arrow-up', 'arrow-down', 'loading'],
+    },
+  },
+};
+```
+
 ```js filename="Example.stories.js|jsx" renderer="common" language="js"
 import { Example } from './Example';
 
 export default {
   component: Example,
+  argTypes: {
+    icon: {
+      options: ['arrow-up', 'arrow-down', 'loading'],
+    },
+  },
+};
+```
+
+```svelte filename="Example.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      icon: {
+        options: ['arrow-up', 'arrow-down', 'loading'],
+      },
+    },
+  });
+</script>
+```
+
+```ts filename="Example.stories.ts" renderer="svelte" language="ts" tabTitle="CSF
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Example from './Example.svelte';
+
+const meta = {
+  component: Example,
+  argTypes: {
+    icon: {
+      options: ['arrow-up', 'arrow-down', 'loading'],
+    },
+  },
+} satisfies Meta<typeof Example>;
+
+export default meta;
+```
+
+```js filename="Example.stories.js" renderer="web-components" language="js"
+export default {
+  component: 'demo-example',
   argTypes: {
     icon: {
       options: ['arrow-up', 'arrow-down', 'loading'],

--- a/docs/_snippets/arg-types-table.md
+++ b/docs/_snippets/arg-types-table.md
@@ -18,6 +18,42 @@ const meta: Meta<Example> = {
 export default meta;
 ```
 
+```svelte filename="Example.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      value: {
+        table: {
+          defaultValue: { summary: 0 },
+          type: { summary: 'number' },
+        },
+      },
+    },
+  });
+</script>
+```
+
+```js filename="Example.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Example from './Example.svelte';
+
+export default {
+  component: Example,
+  argTypes: {
+    value: {
+      table: {
+        defaultValue: { summary: 0 },
+        type: { summary: 'number' },
+      },
+    },
+  },
+};
+```
+
 ```js filename="Example.stories.js|jsx" renderer="common" language="js"
 import { Example } from './Example';
 
@@ -32,6 +68,47 @@ export default {
     },
   },
 };
+```
+
+```svelte filename="Example.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      value: {
+        table: {
+          defaultValue: { summary: 0 },
+          type: { summary: 'number' },
+        },
+      },
+    },
+  });
+</script>
+```
+
+```ts filename="Example.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import { Example } from './Example';
+
+const meta = {
+  component: Example,
+  argTypes: {
+    value: {
+      table: {
+        defaultValue: { summary: 0 },
+        type: { summary: 'number' },
+      },
+    },
+  },
+} satisfies Meta<typeof Example>;
+
+export default meta;
 ```
 
 ```ts filename="Example.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/arg-types-type.md
+++ b/docs/_snippets/arg-types-type.md
@@ -13,11 +13,77 @@ const meta: Meta<Example> = {
 export default meta;
 ```
 
+```svelte filename="Example.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      value: { type: 'number' },
+    },
+  });
+</script>
+```
+
+```js filename="Example.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Example from './Example.svelte';
+
+export default {
+  component: Example,
+  argTypes: {
+    value: { type: 'number' },
+  },
+};
+```
+
 ```js filename="Example.stories.js|jsx" renderer="common" language="js"
 import { Example } from './Example';
 
 export default {
   component: Example,
+  argTypes: {
+    value: { type: 'number' },
+  },
+};
+```
+
+```svelte filename="Example.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Example from './Example.svelte';
+
+  const { Story } = defineMeta({
+    component: Example,
+    argTypes: {
+      value: { type: 'number' },
+    },
+  });
+</script>
+```
+
+```ts filename="Example.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Example from './Example.svelte';
+
+const meta = {
+  component: Example,
+  argTypes: {
+    value: { type: 'number' },
+  },
+} satisfies Meta<typeof Example>;
+
+export default meta;
+```
+
+```js filename="Example.stories.js" renderer="web-components" language="js"
+export default {
+  component: 'demo-example',
   argTypes: {
     value: { type: 'number' },
   },

--- a/docs/_snippets/arg-types-type.md
+++ b/docs/_snippets/arg-types-type.md
@@ -81,15 +81,6 @@ const meta = {
 export default meta;
 ```
 
-```js filename="Example.stories.js" renderer="web-components" language="js"
-export default {
-  component: 'demo-example',
-  argTypes: {
-    value: { type: 'number' },
-  },
-};
-```
-
 ```ts filename="Example.stories.ts|tsx" renderer="common" language="ts"
 // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite, angular, etc.)
 import type { Meta } from '@storybook/your-framework';

--- a/docs/_snippets/before-each-in-meta-mock-date.md
+++ b/docs/_snippets/before-each-in-meta-mock-date.md
@@ -30,6 +30,64 @@ export const Default: Story = {
 };
 ```
 
+```svelte filename="Page.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MockDate from 'mockdate';
+
+  // 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+  import { getUserFromSession } from '#api/session.mock';
+
+  import { Page } from './Page.svelte';
+
+  const meta = defineMeta({
+    component: Page,
+    // 👇 Set the value of Date for every story in the file
+    async beforeEach() {
+      MockDate.set('2024-02-14');
+
+      // 👇 Reset the Date after each story
+      return () => {
+        MockDate.reset();
+      };
+    },
+  });
+</script>
+
+<Story name="Default" play={async ({ canvasElement }) => {
+  // ... This will run with the mocked Date
+  }}
+/>
+```
+
+```js filename="Page.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import MockDate from 'mockdate';
+
+import { getUserFromSession } from '#api/session.mock';
+
+import Page from './Page.svelte';
+
+export default {
+  component: Page,
+  // 👇 Set the value of Date for every story in the file
+  async beforeEach() {
+    MockDate.set('2024-02-14');
+
+    // 👇 Reset the Date after each story
+    return () => {
+      MockDate.reset();
+    };
+  },
+};
+
+export const Default = {
+  async play({ canvasElement }) {
+    // ... This will run with the mocked Date
+  },
+};
+```
+
 ```js filename="Page.stories.js" renderer="common" language="js"
 import MockDate from 'mockdate';
 
@@ -50,6 +108,70 @@ export default {
 };
 
 export const Default = {
+  async play({ canvasElement }) {
+    // ... This will run with the mocked Date
+  },
+};
+```
+
+```svelte filename="Page.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MockDate from 'mockdate';
+
+  // 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+  import { getUserFromSession } from '#api/session.mock';
+
+  import { Page } from './Page.svelte';
+
+  const meta = defineMeta({
+    component: Page,
+    // 👇 Set the value of Date for every story in the file
+    async beforeEach() {
+      MockDate.set('2024-02-14');
+
+      // 👇 Reset the Date after each story
+      return () => {
+        MockDate.reset();
+      };
+    },
+  });
+</script>
+
+<Story name="Default" play={async ({ canvasElement }) => {
+  // ... This will run with the mocked Date
+  }}
+/>
+```
+
+```ts filename="Page.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import MockDate from 'mockdate';
+
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { getUserFromSession } from '#api/session.mock';
+import { Page } from './Page';
+
+const meta = {
+  component: Page,
+  // 👇 Set the value of Date for every story in the file
+  async beforeEach() {
+    MockDate.set('2024-02-14');
+
+    // 👇 Reset the Date after each story
+    return () => {
+      MockDate.reset();
+    };
+  },
+} satisfies Meta<typeof Page>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
   async play({ canvasElement }) {
     // ... This will run with the mocked Date
   },

--- a/docs/_snippets/before-each-in-meta-mock-date.md
+++ b/docs/_snippets/before-each-in-meta-mock-date.md
@@ -39,7 +39,7 @@ export const Default: Story = {
   // 👇 Must include the `.mock` portion of filename to have mocks typed correctly
   import { getUserFromSession } from '#api/session.mock';
 
-  import { Page } from './Page.svelte';
+  import Page from './Page.svelte';
 
   const meta = defineMeta({
     component: Page,
@@ -123,7 +123,7 @@ export const Default = {
   // 👇 Must include the `.mock` portion of filename to have mocks typed correctly
   import { getUserFromSession } from '#api/session.mock';
 
-  import { Page } from './Page.svelte';
+  import Page from './Page.svelte';
 
   const meta = defineMeta({
     component: Page,
@@ -153,7 +153,7 @@ import MockDate from 'mockdate';
 
 // 👇 Must include the `.mock` portion of filename to have mocks typed correctly
 import { getUserFromSession } from '#api/session.mock';
-import { Page } from './Page';
+import Page from './Page.svelte';
 
 const meta = {
   component: Page,

--- a/docs/_snippets/button-group-story.md
+++ b/docs/_snippets/button-group-story.md
@@ -179,7 +179,8 @@ export const Pair = {
 ```
 
 ```ts filename="ButtonGroup.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import ButtonGroup from './ButtonGroup.svelte';
 

--- a/docs/_snippets/button-story-action-event-handle.md
+++ b/docs/_snippets/button-story-action-event-handle.md
@@ -18,6 +18,42 @@ const meta: Meta<Button> = {
 export default meta;
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  import { withActions } from 'storybook/actions/decorator';
+
+  const { Story } = defineMeta({
+    component: Button,
+    parameters: {
+      actions: {
+        handles: ['mouseover', 'click .btn'],
+      },
+    },
+    decorators: [withActions],
+  });
+</script>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+import { withActions } from 'storybook/actions/decorator';
+
+export default {
+  component: Button,
+  parameters: {
+    actions: {
+      handles: ['mouseover', 'click .btn'],
+    },
+  },
+  decorators: [withActions],
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
@@ -32,6 +68,47 @@ export default {
   },
   decorators: [withActions],
 };
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  import { withActions } from 'storybook/actions/decorator';
+
+  const { Story } = defineMeta({
+    component: Button,
+    parameters: {
+      actions: {
+        handles: ['mouseover', 'click .btn'],
+      },
+    },
+    decorators: [withActions],
+  });
+</script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+import { withActions } from 'storybook/actions/decorator';
+
+const meta = {
+  component: Button,
+  parameters: {
+    actions: {
+      handles: ['mouseover', 'click .btn'],
+    },
+  },
+  decorators: [withActions],
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```
 
 ```ts filename="Button.stories.ts" renderer="common" language="ts"

--- a/docs/_snippets/button-story-component-args-primary.md
+++ b/docs/_snippets/button-story-component-args-primary.md
@@ -147,7 +147,8 @@ export default {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/button-story-component-decorator.md
+++ b/docs/_snippets/button-story-component-decorator.md
@@ -190,7 +190,8 @@ export default {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 import MarginDecorator from './MarginDecorator.svelte';

--- a/docs/_snippets/button-story-controls-primary-variant.md
+++ b/docs/_snippets/button-story-controls-primary-variant.md
@@ -74,7 +74,8 @@ export const Primary = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/button-story-controls-radio-group.md
+++ b/docs/_snippets/button-story-controls-radio-group.md
@@ -81,7 +81,8 @@ export default {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/button-story-decorator.md
+++ b/docs/_snippets/button-story-decorator.md
@@ -166,7 +166,8 @@ export const Primary = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 import MarginDecorator from './MarginDecorator.svelte';

--- a/docs/_snippets/button-story-default-export-with-component.md
+++ b/docs/_snippets/button-story-default-export-with-component.md
@@ -97,7 +97,8 @@ export default {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/button-story-default-export.md
+++ b/docs/_snippets/button-story-default-export.md
@@ -15,6 +15,36 @@ const meta: Meta<Button> = {
 export default meta;
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    /* 👇 The title prop is optional.
+    * See https://storybook.js.org/docs/configure/#configure-story-loading
+    * to learn how to generate automatic titles
+   */
+    title: 'Button',
+    component: Button,
+  });
+</script>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Button',
+  component: Button,
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
@@ -26,6 +56,41 @@ export default {
   title: 'Button',
   component: Button,
 };
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    /* 👇 The title prop is optional.
+    * See https://storybook.js.org/docs/configure/#configure-story-loading
+    * to learn how to generate automatic titles
+   */
+    title: 'Button',
+    component: Button,
+  });
+</script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Button',
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```
 
 ```ts filename="Button.stories.ts" renderer="common" language="ts"

--- a/docs/_snippets/button-story-default-export.md
+++ b/docs/_snippets/button-story-default-export.md
@@ -25,7 +25,7 @@ export default meta;
     /* 👇 The title prop is optional.
     * See https://storybook.js.org/docs/configure/#configure-story-loading
     * to learn how to generate automatic titles
-   */
+    */
     title: 'Button',
     component: Button,
   });
@@ -68,7 +68,7 @@ export default {
     /* 👇 The title prop is optional.
     * See https://storybook.js.org/docs/configure/#configure-story-loading
     * to learn how to generate automatic titles
-   */
+    */
     title: 'Button',
     component: Button,
   });

--- a/docs/_snippets/button-story-grouped.md
+++ b/docs/_snippets/button-story-grouped.md
@@ -15,6 +15,36 @@ const meta: Meta<Button> = {
 export default meta;
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    /* 👇 The title prop is optional.
+     * See https://storybook.js.org/docs/configure/#configure-story-loading
+     * to learn how to generate automatic titles
+     */
+    title: 'Design System/Atoms/Button',
+    component: Button,
+  });
+</script>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Design System/Atoms/Button',
+  component: Button,
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
@@ -26,6 +56,41 @@ export default {
   title: 'Design System/Atoms/Button',
   component: Button,
 };
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    /* 👇 The title prop is optional.
+     * See https://storybook.js.org/docs/configure/#configure-story-loading
+     * to learn how to generate automatic titles
+     */
+    title: 'Design System/Atoms/Button',
+    component: Button,
+  });
+</script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Design System/Atoms/Button',
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```
 
 ```ts filename="Button.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/button-story-matching-argtypes.md
+++ b/docs/_snippets/button-story-matching-argtypes.md
@@ -11,6 +11,28 @@ const meta: Meta<Button> = {
 export default meta;
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+    parameters: { actions: { argTypesRegex: '^on.*' } },
+  });
+</script>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+  parameters: { actions: { argTypesRegex: '^on.*' } },
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
@@ -18,6 +40,33 @@ export default {
   component: Button,
   parameters: { actions: { argTypesRegex: '^on.*' } },
 };
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+    parameters: { actions: { argTypesRegex: '^on.*' } },
+  });
+</script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+  parameters: { actions: { argTypesRegex: '^on.*' } },
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```
 
 ```ts filename="Button.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/button-story-onclick-action-spy.md
+++ b/docs/_snippets/button-story-onclick-action-spy.md
@@ -64,7 +64,7 @@ export default {
 
   const { Story } = defineMeta({
     component: Button,
-     // 👇 Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked
+    // 👇 Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked
     args: { onClick: fn() },
   });
 </script>

--- a/docs/_snippets/button-story-onclick-action-spy.md
+++ b/docs/_snippets/button-story-onclick-action-spy.md
@@ -14,6 +14,34 @@ const meta: Meta<Button> = {
 export default meta;
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { fn } from 'storybook/test';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+    // 👇 Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked
+    args: { onClick: fn() },
+  });
+</script>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { fn } from 'storybook/test';
+
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+  // 👇 Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked
+  args: { onClick: fn() },
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { fn } from 'storybook/test';
 
@@ -24,6 +52,39 @@ export default {
   // 👇 Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked
   args: { onClick: fn() },
 };
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { fn } from 'storybook/test';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+     // 👇 Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked
+    args: { onClick: fn() },
+  });
+</script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import { fn } from 'storybook/test';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+  // 👇 Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked
+  args: { onClick: fn() },
+} satisfies Meta<typeof Button>;
+
+export default meta;
 ```
 
 ```ts filename="Button.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/button-story-primary-composition.md
+++ b/docs/_snippets/button-story-primary-composition.md
@@ -46,7 +46,7 @@ export const Secondary: Story = {
 <Story name="Secondary" args={{...primaryArgs, primary: false}} />
 ```
 
-```js filename="Button.stories.js|jsx" renderer="svelte" language="js" tabTitle="CSF"
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
 import Button from './Button.svelte';
 
 export default {
@@ -112,7 +112,8 @@ export const Secondary = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/button-story-primary-long-name.md
+++ b/docs/_snippets/button-story-primary-long-name.md
@@ -120,7 +120,8 @@ export const PrimaryLongName = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/button-story-using-args.md
+++ b/docs/_snippets/button-story-using-args.md
@@ -346,7 +346,8 @@ export const Tertiary = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/button-story-with-addon-example.md
+++ b/docs/_snippets/button-story-with-addon-example.md
@@ -217,7 +217,8 @@ export const Basic = {};
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/button-story-with-args.md
+++ b/docs/_snippets/button-story-with-args.md
@@ -240,7 +240,8 @@ export const Primary = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/button-story-with-emojis.md
+++ b/docs/_snippets/button-story-with-emojis.md
@@ -282,7 +282,8 @@ export const Tertiary = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/button-story.md
+++ b/docs/_snippets/button-story.md
@@ -358,7 +358,8 @@ export const Primary = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/checkbox-story-csf.md
+++ b/docs/_snippets/checkbox-story-csf.md
@@ -84,7 +84,8 @@ export const Unchecked = {
 ```
 
 ```ts filename="Checkbox.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Checkbox from './Checkbox.svelte';
 

--- a/docs/_snippets/checkbox-story-grouped.md
+++ b/docs/_snippets/checkbox-story-grouped.md
@@ -15,6 +15,36 @@ const meta: Meta<Checkbox> = {
 export default meta;
 ```
 
+```svelte filename="Checkbox.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import CheckBox from './Checkbox.svelte';
+
+  const { Story } = defineMeta({
+    /* 👇 The title prop is optional.
+     * See https://storybook.js.org/docs/configure/#configure-story-loading
+     * to learn how to generate automatic titles
+     */
+    title: 'Design System/Atoms/Checkbox',
+    component: CheckBox,
+  });
+</script>
+```
+
+```js filename="Checkbox.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import CheckBox from './Checkbox.svelte';
+
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Design System/Atoms/Checkbox',
+  component: CheckBox,
+};
+```
+
 ```js filename="Checkbox.stories.js|jsx" renderer="common" language="js"
 import { CheckBox } from './Checkbox';
 
@@ -26,6 +56,41 @@ export default {
   title: 'Design System/Atoms/Checkbox',
   component: CheckBox,
 };
+```
+
+```svelte filename="Checkbox.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import CheckBox from './Checkbox.svelte';
+
+  const { Story } = defineMeta({
+    /* 👇 The title prop is optional.
+     * See https://storybook.js.org/docs/configure/#configure-story-loading
+     * to learn how to generate automatic titles
+     */
+    title: 'Design System/Atoms/Checkbox',
+    component: CheckBox,
+  });
+</script>
+```
+
+```ts filename="CheckBox.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import CheckBox from './Checkbox.svelte';
+
+const meta = {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Design System/Atoms/Checkbox',
+  component: CheckBox,
+} satisfies Meta<typeof CheckBox>;
+
+export default meta;
 ```
 
 ```ts filename="CheckBox.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/component-story-conditional-controls-mutual-exclusion.md
+++ b/docs/_snippets/component-story-conditional-controls-mutual-exclusion.md
@@ -106,7 +106,8 @@ export default {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/component-story-conditional-controls-toggle.md
+++ b/docs/_snippets/component-story-conditional-controls-toggle.md
@@ -91,7 +91,8 @@ export default {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/component-story-custom-args-complex.md
+++ b/docs/_snippets/component-story-custom-args-complex.md
@@ -323,7 +323,8 @@ export const ExampleStory = {
 ```
 
 ```ts filename="YourComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import YourComponent from './YourComponent.svelte';
 

--- a/docs/_snippets/component-story-custom-args-mapping.md
+++ b/docs/_snippets/component-story-custom-args-mapping.md
@@ -151,7 +151,8 @@ export default {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/component-story-disable-controls-alt.md
+++ b/docs/_snippets/component-story-disable-controls-alt.md
@@ -81,7 +81,8 @@ export default {
 ```
 
 ```ts filename="YourComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import YourComponent from './YourComponent.svelte';
 

--- a/docs/_snippets/component-story-disable-controls-regex.md
+++ b/docs/_snippets/component-story-disable-controls-regex.md
@@ -180,7 +180,8 @@ export const RegexExclude = {
 ```
 
 ```ts filename="YourComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import YourComponent from './YourComponent.svelte';
 

--- a/docs/_snippets/component-story-disable-controls.md
+++ b/docs/_snippets/component-story-disable-controls.md
@@ -91,7 +91,8 @@ export default {
 ```
 
 ```ts filename="YourComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import YourComponent from './YourComponent.svelte';
 

--- a/docs/_snippets/component-story-figma-integration.md
+++ b/docs/_snippets/component-story-figma-integration.md
@@ -101,7 +101,29 @@ export const Example: Story = {
 };
 ```
 
-```js filename="MyComponent.stories.js" renderer="svelte" language="js"
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="Example"
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/Sample-File',
+    },
+  }}
+/>
+```
+
+```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
 import MyComponent from './MyComponent.svelte';
 
 // More on default export: https://storybook.js.org/docs/writing-stories/#default-export
@@ -119,8 +141,31 @@ export const Example = {
 };
 ```
 
-```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="Example"
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/Sample-File',
+    },
+  }}
+/>
+```
+
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import MyComponent from './MyComponent.svelte';
 

--- a/docs/_snippets/component-story-highlight.md
+++ b/docs/_snippets/component-story-highlight.md
@@ -78,6 +78,114 @@ export const Highlighted: Story = {
 };
 ```
 
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { HIGHLIGHT } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="Highlighted"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+      });
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { useChannel } from 'storybook/preview-api';
+import { HIGHLIGHT } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+export default {
+  component: MyComponent,
+};
+
+export const Highlighted = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+      });
+      return storyFn();
+    },
+  ],
+};
+```
+
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { HIGHLIGHT } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="Highlighted"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+      });
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { useChannel } from 'storybook/preview-api';
+import { HIGHLIGHT } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+const meta = {
+  component: MyComponent,
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Highlighted: Story = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+      });
+      return storyFn();
+    },
+  ],
+};
+```
+
 ```js filename="MyComponent.stories.js" renderer="vue" language="js"
 import { useChannel } from 'storybook/preview-api';
 import { HIGHLIGHT } from 'storybook/highlight';

--- a/docs/_snippets/component-story-sort-controls.md
+++ b/docs/_snippets/component-story-sort-controls.md
@@ -56,7 +56,8 @@ export default {
 ```
 
 ```ts filename="YourComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import YourComponent from './YourComponent.svelte';
 

--- a/docs/_snippets/component-story-static-asset-cdn.md
+++ b/docs/_snippets/component-story-static-asset-cdn.md
@@ -143,7 +143,8 @@ export const WithAnImage = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import MyComponent from './MyComponent.svelte';
 

--- a/docs/_snippets/component-story-static-asset-with-import.md
+++ b/docs/_snippets/component-story-static-asset-with-import.md
@@ -183,7 +183,8 @@ export const WithAnImage = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import MyComponent from './MyComponent.svelte';
 

--- a/docs/_snippets/component-story-static-asset-without-import.md
+++ b/docs/_snippets/component-story-static-asset-without-import.md
@@ -135,7 +135,8 @@ export const WithAnImage = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import MyComponent from './MyComponent.svelte';
 

--- a/docs/_snippets/document-screen-with-graphql.md
+++ b/docs/_snippets/document-screen-with-graphql.md
@@ -465,90 +465,94 @@ export function DocumentScreen() {
 
 ```svelte filename="YourPage.svelte" renderer="svelte" language="js"
 <script>
-  import gql from 'graphql-tag';
-  import { query } from 'svelte-apollo';
+  import { queryStore, gql, getContextClient } from '@urql/svelte';
+
   import PageLayout from './PageLayout.svelte';
   import DocumentHeader from './DocumentHeader.svelte';
   import DocumentList from './DocumentList.svelte';
 
-  const AllInfoQuery = gql`
-    query AllInfoQuery {
-      user {
-        userID
-        name
+  const AllInfoQuery = queryStore({
+    client: getContextClient(),
+    query: gql`
+      query AllInfoQuery {
+        user {
+          userID
+          name
+        }
+        document {
+          id
+          userID
+          title
+          brief
+          status
+        }
+        subdocuments {
+          id
+          userID
+          title
+          content
+          status
+        }
       }
-      document {
-        id
-        userID
-        title
-        brief
-        status
-      }
-      subdocuments {
-        id
-        userID
-        title
-        content
-        status
-      }
-    }
-  `;
-  const infoResult = query(AllInfoQuery);
+    `,
+  });
 </script>
 
-{#if $infoResult.loading}
+{#if $AllInfoQuery.fetching}
 <p>Loading...</p>
-{:else if $infoResult.error}
+{:else if $AllInfoQuery.error}
 <p>There was an error fetching the data!</p>
 {:else}
-<PageLayout {$infoResult.data.user}>
-  <DocumentHeader {$infoResult.data.document} />
-  <DocumentList {$infoResult.data.subdocuments} />
+<PageLayout user={$AllInfoQuery.data.AllInfoQuery.user}>
+  <DocumentHeader document={$AllInfoQuery.data.AllInfoQuery.document} />
+  <DocumentList documents={$AllInfoQuery.data.AllInfoQuery.subdocuments} />
 </PageLayout>
 {/if}
 ```
 
 ```svelte filename="YourPage.svelte" renderer="svelte" language="ts"
 <script lang="ts">
-  import gql from 'graphql-tag';
-  import { query } from 'svelte-apollo';
+  import { queryStore, gql, getContextClient } from '@urql/svelte';
+
   import PageLayout from './PageLayout.svelte';
   import DocumentHeader from './DocumentHeader.svelte';
   import DocumentList from './DocumentList.svelte';
 
-  const AllInfoQuery = gql`
-    query AllInfoQuery {
-      user {
-        userID
-        name
+  const AllInfoQuery = queryStore({
+    client: getContextClient(),
+    query: gql`
+      query AllInfoQuery {
+        user {
+          userID
+          name
+        }
+        document {
+          id
+          userID
+          title
+          brief
+          status
+        }
+        subdocuments {
+          id
+          userID
+          title
+          content
+          status
+        }
       }
-      document {
-        id
-        userID
-        title
-        brief
-        status
-      }
-      subdocuments {
-        id
-        userID
-        title
-        content
-        status
-      }
-    }
-  `;
-  const infoResult = query(AllInfoQuery);
+    `,
+  });
 </script>
 
-{#if $infoResult.loading}
+{#if $AllInfoQuery.fetching}
 <p>Loading...</p>
-{:else if $infoResult.error}
+{:else if $AllInfoQuery.error}
 <p>There was an error fetching the data!</p>
 {:else}
-<PageLayout {$infoResult.data.user}>
-  <DocumentHeader {$infoResult.data.document} />
-  <DocumentList {$infoResult.data.subdocuments} />
+<PageLayout user={$AllInfoQuery.data.AllInfoQuery.user}>
+  <DocumentHeader document={$AllInfoQuery.data.AllInfoQuery.document} />
+  <DocumentList documents={$AllInfoQuery.data.AllInfoQuery.subdocuments} />
 </PageLayout>
 {/if}
 ```

--- a/docs/_snippets/foo-bar-baz-story.md
+++ b/docs/_snippets/foo-bar-baz-story.md
@@ -22,7 +22,7 @@ export const Baz: Story = {};
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
-  import Foo  from './Foo.svelte';
+  import Foo from './Foo.svelte';
 
   const { Story } = defineMeta({
     /* 👇 The title prop is optional.
@@ -71,7 +71,7 @@ export const Baz = {};
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
-  import Foo  from './Foo.svelte';
+  import Foo from './Foo.svelte';
 
   const { Story } = defineMeta({
     /* 👇 The title prop is optional.

--- a/docs/_snippets/foo-bar-baz-story.md
+++ b/docs/_snippets/foo-bar-baz-story.md
@@ -18,6 +18,40 @@ type Story = StoryObj<Foo>;
 export const Baz: Story = {};
 ```
 
+```svelte filename="FooBar.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Foo  from './Foo.svelte';
+
+  const { Story } = defineMeta({
+    /* 👇 The title prop is optional.
+     * See https://storybook.js.org/docs/configure/#configure-story-loading
+     * to learn how to generate automatic titles
+     */
+    title: 'Foo/Bar',
+    component: Foo,
+  });
+</script>
+
+<Story name="Baz" />
+```
+
+```js filename="FooBar.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Foo from './Foo.svelte';
+
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Foo/Bar',
+  component: Foo,
+};
+
+export const Baz = {};
+```
+
 ```js filename="FooBar.stories.js|jsx" renderer="common" language="js"
 import { Foo } from './Foo';
 
@@ -31,6 +65,46 @@ export default {
 };
 
 export const Baz = {};
+```
+
+```svelte filename="FooBar.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Foo  from './Foo.svelte';
+
+  const { Story } = defineMeta({
+    /* 👇 The title prop is optional.
+     * See https://storybook.js.org/docs/configure/#configure-story-loading
+     * to learn how to generate automatic titles
+     */
+    title: 'Foo/Bar',
+    component: Foo,
+  });
+</script>
+
+<Story name="Baz" />
+```
+
+```ts filename="FooBar.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import Foo from './Foo.svelte';
+
+const meta = {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Foo/Bar',
+  component: Foo,
+} satisfies Meta<typeof Foo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Baz: Story = {};
 ```
 
 ```ts filename="FooBar.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/gizmo-story-controls-customization.md
+++ b/docs/_snippets/gizmo-story-controls-customization.md
@@ -286,7 +286,8 @@ export default {
 ```
 
 ```ts filename="Gizmo.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Gizmo from './Gizmo.svelte';
 

--- a/docs/_snippets/highlight-custom-style.md
+++ b/docs/_snippets/highlight-custom-style.md
@@ -129,6 +129,182 @@ export const StyledHighlight: Story = {
 };
 ```
 
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { HIGHLIGHT } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="StyledHighlight"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+        styles: {
+          backgroundColor: `color-mix(in srgb, hotpink, transparent 90%)`,
+          outline: '3px solid hotpink',
+          animation: 'pulse 3s linear infinite',
+          transition: 'outline-offset 0.2s ease-in-out',
+        },
+        hoverStyles: {
+          outlineOffset: '3px',
+        },
+        focusStyles: {
+          backgroundColor: 'transparent',
+        },
+         keyframes: `@keyframes pulse {
+          0% { outline-color: rgba(255, 105, 180, 1); }
+          50% { outline-color: rgba(255, 105, 180, 0.2); }
+          100% { outline-color: rgba(255, 105, 180, 1); }
+        }`,
+      });
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { useChannel } from 'storybook/preview-api';
+import { HIGHLIGHT } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+export default {
+  component: MyComponent,
+};
+
+export const StyledHighlight = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+        styles: {
+          backgroundColor: `color-mix(in srgb, hotpink, transparent 90%)`,
+          outline: '3px solid hotpink',
+          animation: 'pulse 3s linear infinite',
+          transition: 'outline-offset 0.2s ease-in-out',
+        },
+        hoverStyles: {
+          outlineOffset: '3px',
+        },
+        focusStyles: {
+          backgroundColor: 'transparent',
+        },
+        keyframes: `@keyframes pulse {
+          0% { outline-color: rgba(255, 105, 180, 1); }
+          50% { outline-color: rgba(255, 105, 180, 0.2); }
+          100% { outline-color: rgba(255, 105, 180, 1); }
+        }`,
+      });
+      return storyFn();
+    },
+  ],
+};
+```
+
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { HIGHLIGHT } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="StyledHighlight"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+        styles: {
+          backgroundColor: `color-mix(in srgb, hotpink, transparent 90%)`,
+          outline: '3px solid hotpink',
+          animation: 'pulse 3s linear infinite',
+          transition: 'outline-offset 0.2s ease-in-out',
+        },
+        hoverStyles: {
+          outlineOffset: '3px',
+        },
+        focusStyles: {
+          backgroundColor: 'transparent',
+        },
+         keyframes: `@keyframes pulse {
+          0% { outline-color: rgba(255, 105, 180, 1); }
+          50% { outline-color: rgba(255, 105, 180, 0.2); }
+          100% { outline-color: rgba(255, 105, 180, 1); }
+        }`,
+      });
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { useChannel } from 'storybook/preview-api';
+import { HIGHLIGHT } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+const meta = {
+  component: MyComponent,
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StyledHighlight: Story = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+        styles: {
+          backgroundColor: `color-mix(in srgb, hotpink, transparent 90%)`,
+          outline: '3px solid hotpink',
+          animation: 'pulse 3s linear infinite',
+          transition: 'outline-offset 0.2s ease-in-out',
+        },
+        hoverStyles: {
+          outlineOffset: '3px',
+        },
+        focusStyles: {
+          backgroundColor: 'transparent',
+        },
+        keyframes: `@keyframes pulse {
+          0% { outline-color: rgba(255, 105, 180, 1); }
+          50% { outline-color: rgba(255, 105, 180, 0.2); }
+          100% { outline-color: rgba(255, 105, 180, 1); }
+        }`,
+      });
+      return storyFn();
+    },
+  ],
+};
+```
+
 ```js filename="MyComponent.stories.js" renderer="vue" language="js"
 import { useChannel } from 'storybook/preview-api';
 import { HIGHLIGHT } from 'storybook/highlight';

--- a/docs/_snippets/highlight-custom-style.md
+++ b/docs/_snippets/highlight-custom-style.md
@@ -162,7 +162,7 @@ export const StyledHighlight: Story = {
         focusStyles: {
           backgroundColor: 'transparent',
         },
-         keyframes: `@keyframes pulse {
+        keyframes: `@keyframes pulse {
           0% { outline-color: rgba(255, 105, 180, 1); }
           50% { outline-color: rgba(255, 105, 180, 0.2); }
           100% { outline-color: rgba(255, 105, 180, 1); }
@@ -247,7 +247,7 @@ export const StyledHighlight = {
         focusStyles: {
           backgroundColor: 'transparent',
         },
-         keyframes: `@keyframes pulse {
+        keyframes: `@keyframes pulse {
           0% { outline-color: rgba(255, 105, 180, 1); }
           50% { outline-color: rgba(255, 105, 180, 0.2); }
           100% { outline-color: rgba(255, 105, 180, 1); }

--- a/docs/_snippets/highlight-menu.md
+++ b/docs/_snippets/highlight-menu.md
@@ -117,6 +117,166 @@ export const StyledHighlight: Story = {
 };
 ```
 
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { HIGHLIGHT } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="StyledHighlight"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+        menu: [
+          {
+            id: 'button-name',
+            title: 'Login',
+            description: 'Navigate to the login page',
+            clickEvent: 'my-menu-click-event',
+          },
+          {
+            id: 'h2-home',
+            title: 'Acme',
+            description: 'Navigate to the home page',
+          },
+        ],
+      });
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { useChannel } from 'storybook/preview-api';
+import { HIGHLIGHT } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+export default {
+  component: MyComponent,
+};
+
+export const StyledHighlight = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+        menu: [
+          {
+            id: 'button-name',
+            title: 'Login',
+            description: 'Navigate to the login page',
+            clickEvent: 'my-menu-click-event',
+          },
+          {
+            id: 'h2-home',
+            title: 'Acme',
+            description: 'Navigate to the home page',
+          },
+        ],
+      });
+      return storyFn();
+    },
+  ],
+};
+```
+
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { HIGHLIGHT } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="StyledHighlight"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+        menu: [
+          {
+            id: 'button-name',
+            title: 'Login',
+            description: 'Navigate to the login page',
+            clickEvent: 'my-menu-click-event',
+          },
+          {
+            id: 'h2-home',
+            title: 'Acme',
+            description: 'Navigate to the home page',
+          },
+        ],
+      });
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { useChannel } from 'storybook/preview-api';
+import { HIGHLIGHT } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+const meta = {
+  component: MyComponent,
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StyledHighlight: Story = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        selectors: ['h2', 'a', '.storybook-button'],
+        menu: [
+          {
+            id: 'button-name',
+            title: 'Login',
+            description: 'Navigate to the login page',
+            clickEvent: 'my-menu-click-event',
+          },
+          {
+            id: 'h2-home',
+            title: 'Acme',
+            description: 'Navigate to the home page',
+          },
+        ],
+      });
+      return storyFn();
+    },
+  ],
+};
+```
+
 ```js filename="MyComponent.stories.js" renderer="vue" language="js"
 import { useChannel } from 'storybook/preview-api';
 import { HIGHLIGHT } from 'storybook/highlight';

--- a/docs/_snippets/highlight-remove.md
+++ b/docs/_snippets/highlight-remove.md
@@ -84,6 +84,122 @@ export const RemoveHighlight: Story = {
 };
 ```
 
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { HIGHLIGHT, REMOVE_HIGHLIGHT } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="RemoveHighlight"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        id: 'my-unique-id',
+        selectors: ['header', 'section', 'footer'],
+      });
+      emit(REMOVE_HIGHLIGHT, 'my-unique-id');
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { useChannel } from 'storybook/preview-api';
+import { HIGHLIGHT, REMOVE_HIGHLIGHT } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+export default {
+  component: MyComponent,
+};
+
+export const RemoveHighlight = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        id: 'my-unique-id',
+        selectors: ['header', 'section', 'footer'],
+      });
+      emit(REMOVE_HIGHLIGHT, 'my-unique-id');
+      return storyFn();
+    },
+  ],
+};
+```
+
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { HIGHLIGHT, REMOVE_HIGHLIGHT } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="RemoveHighlight"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        id: 'my-unique-id',
+        selectors: ['header', 'section', 'footer'],
+      });
+      emit(REMOVE_HIGHLIGHT, 'my-unique-id');
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { useChannel } from 'storybook/preview-api';
+import { HIGHLIGHT, REMOVE_HIGHLIGHT } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+const meta = {
+  component: MyComponent,
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RemoveHighlight: Story = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(HIGHLIGHT, {
+        id: 'my-unique-id',
+        selectors: ['header', 'section', 'footer'],
+      });
+      emit(REMOVE_HIGHLIGHT, 'my-unique-id');
+      return storyFn();
+    },
+  ],
+};
+```
+
 ```js filename="MyComponent.stories.js" renderer="vue" language="js"
 import { useChannel } from 'storybook/preview-api';
 import { HIGHLIGHT, REMOVE_HIGHLIGHT } from 'storybook/highlight';

--- a/docs/_snippets/highlight-reset.md
+++ b/docs/_snippets/highlight-reset.md
@@ -81,6 +81,118 @@ export const ResetHighlight: Story = {
 };
 ```
 
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { HIGHLIGHT, RESET_HIGHLIGHT } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="ResetHighlight"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(RESET_HIGHLIGHT); //👈 Remove previously highlighted elements
+      emit(HIGHLIGHT, {
+        selectors: ['header', 'section', 'footer'],
+      });
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { useChannel } from 'storybook/preview-api';
+import { HIGHLIGHT, RESET_HIGHLIGHT } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+export default {
+  component: MyComponent,
+};
+
+export const ResetHighlight = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(RESET_HIGHLIGHT); //👈 Remove previously highlighted elements
+      emit(HIGHLIGHT, {
+        selectors: ['header', 'section', 'footer'],
+      });
+      return storyFn();
+    },
+  ],
+};
+```
+
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { HIGHLIGHT, RESET_HIGHLIGHT } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="ResetHighlight"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(RESET_HIGHLIGHT); //👈 Remove previously highlighted elements
+      emit(HIGHLIGHT, {
+        selectors: ['header', 'section', 'footer'],
+      });
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { useChannel } from 'storybook/preview-api';
+import { HIGHLIGHT, RESET_HIGHLIGHT } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+const meta = {
+  component: MyComponent,
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ResetHighlight: Story = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(RESET_HIGHLIGHT); //👈 Remove previously highlighted elements
+      emit(HIGHLIGHT, {
+        selectors: ['header', 'section', 'footer'],
+      });
+      return storyFn();
+    },
+  ],
+};
+```
+
 ```js filename="MyComponent.stories.js" renderer="vue" language="js"
 import { useChannel } from 'storybook/preview-api';
 import { HIGHLIGHT, RESET_HIGHLIGHT } from 'storybook/highlight';

--- a/docs/_snippets/highlight-scroll-into-view.md
+++ b/docs/_snippets/highlight-scroll-into-view.md
@@ -72,6 +72,106 @@ export const ScrollIntoView: Story = {
 };
 ```
 
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { SCROLL_INTO_VIEW } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="ScrollIntoView"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(SCROLL_INTO_VIEW, '#footer');
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { useChannel } from 'storybook/preview-api';
+import { SCROLL_INTO_VIEW } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+export default {
+  component: MyComponent,
+};
+
+export const ScrollIntoView = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(SCROLL_INTO_VIEW, '#footer');
+      return storyFn();
+    },
+  ],
+};
+```
+
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { useChannel } from 'storybook/preview-api';
+  import { SCROLL_INTO_VIEW } from 'storybook/highlight';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<Story
+  name="ScrollIntoView"
+  decorators={[
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(SCROLL_INTO_VIEW, '#footer');
+      return storyFn();
+    },
+  ]}
+/>
+```
+
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { useChannel } from 'storybook/preview-api';
+import { SCROLL_INTO_VIEW } from 'storybook/highlight';
+
+import MyComponent from './MyComponent.svelte';
+
+const meta = {
+  component: MyComponent,
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ScrollIntoView: Story = {
+  decorators: [
+    (storyFn) => {
+      const emit = useChannel({});
+      emit(SCROLL_INTO_VIEW, '#footer');
+      return storyFn();
+    },
+  ],
+};
+```
+
 ```js filename="MyComponent.stories.js" renderer="vue" language="js"
 import { useChannel } from 'storybook/preview-api';
 import { SCROLL_INTO_VIEW } from 'storybook/highlight';

--- a/docs/_snippets/histogram-story.md
+++ b/docs/_snippets/histogram-story.md
@@ -245,7 +245,8 @@ export const Default = {
 ```
 
 ```ts filename="Histogram.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Histogram from './Histogram.svelte';
 

--- a/docs/_snippets/list-story-reuse-data.md
+++ b/docs/_snippets/list-story-reuse-data.md
@@ -191,6 +191,58 @@ export const ManyItems: Story = {
 };
 ```
 
+```svelte filename="List.stories.svelte" renderer="svelte" language="js"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import List from './List.svelte';
+  import ListItem from './ListItem.svelte';
+
+  //👇 We're importing the necessary stories from ListItem
+  import { Selected, Unselected } from './ListItem.stories.svelte';
+
+  const { Story } = defineMeta({
+    component: List,
+  });
+</script>
+
+<Story name="Many Items">
+  {#snippet children(args)}
+    <List {...args}>
+      <ListItem {...Selected.args} />
+      <ListItem {...Unselected.args} />
+      <ListItem {...Unselected.args} />
+    </List>
+  {/snippet}
+</Story>
+```
+
+```svelte filename="List.stories.svelte" renderer="svelte" language="ts"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import List from './List.svelte';
+  import ListItem from './ListItem.svelte';
+
+  //👇 We're importing the necessary stories from ListItem
+  import { Selected, Unselected } from './ListItem.stories.svelte';
+
+  const { Story } = defineMeta({
+    component: List,
+  });
+</script>
+
+<Story name="Many Items">
+  {#snippet children(args)}
+    <List {...args}>
+      <ListItem {...Selected.args} />
+      <ListItem {...Unselected.args} />
+      <ListItem {...Unselected.args} />
+    </List>
+  {/snippet}
+</Story>
+```
+
 ```js filename="List.stories.js" renderer="vue" language="js"
 import List from './ListComponent.vue';
 import ListItem from './ListItem.vue';

--- a/docs/_snippets/list-story-starter.md
+++ b/docs/_snippets/list-story-starter.md
@@ -164,7 +164,8 @@ export const Empty = {};
 ```
 
 ```ts filename="List.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import List from './List.svelte';
 

--- a/docs/_snippets/list-story-template.md
+++ b/docs/_snippets/list-story-template.md
@@ -291,7 +291,7 @@ export const OneItem = {
 <Story
   name="One Item"
   args={{
-    items: [{ ...Unselected.args }],
+    items: [{ ...Unchecked.args }],
   }}
   {template}
 />
@@ -334,7 +334,7 @@ export const OneItem = {
 <Story
   name="One Item"
   args={{
-    items: [{ ...Unselected.args }],
+    items: [{ ...Unchecked.args }],
   }}
   {template}
 />

--- a/docs/_snippets/list-story-template.md
+++ b/docs/_snippets/list-story-template.md
@@ -254,6 +254,92 @@ export const OneItem = {
 };
 ```
 
+```svelte filename="List.stories.svelte" renderer="svelte" language="js"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import List from './List.svelte';
+  import ListItem from './ListItem.svelte';
+
+  //👇 Imports a specific story from ListItem stories
+  import { Unchecked } from './ListItem.stories.svelte';
+
+  const { Story } = defineMeta({
+    /* 👇 The title prop is optional.
+     * See https://storybook.js.org/docs/configure/#configure-story-loading
+     * to learn how to generate automatic titles
+    */
+    title: 'List',
+    component: List,
+  });
+</script>
+
+<!--
+  The template construct will be spread to the existing stories.
+  It's based on Svelte's snippet syntax allowing you share the same UI with small variations.
+-->
+{#snippet template(args)}
+  <List {...args}>
+    {#each args.items as item}
+      <ListItem {...item} />
+    {/each}
+  </List>
+{/snippet}
+
+<Story name="Empty" args={{ items: [] }} {template} />
+
+<Story
+  name="One Item"
+  args={{
+    items: [{ ...Unselected.args }],
+  }}
+  {template}
+/>
+```
+
+```svelte filename="List.stories.svelte" renderer="svelte" language="ts"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import List from './List.svelte';
+  import ListItem from './ListItem.svelte';
+
+  //👇 Imports a specific story from ListItem stories
+  import { Unchecked } from './ListItem.stories.svelte';
+
+  const { Story } = defineMeta({
+    /* 👇 The title prop is optional.
+     * See https://storybook.js.org/docs/configure/#configure-story-loading
+     * to learn how to generate automatic titles
+    */
+    title: 'List',
+    component: List,
+  });
+</script>
+
+<!--
+  The template construct will be spread to the existing stories.
+  It's based on Svelte's snippet syntax allowing you share the same UI with small variations.
+-->
+{#snippet template(args)}
+  <List {...args}>
+    {#each args.items as item}
+      <ListItem {...item} />
+    {/each}
+  </List>
+{/snippet}
+
+<Story name="Empty" args={{ items: [] }} {template} />
+
+<Story
+  name="One Item"
+  args={{
+    items: [{ ...Unselected.args }],
+  }}
+  {template}
+/>
+```
+
 ```js filename="List.stories.js" renderer="vue" language="js"
 import List from './List.vue';
 import ListItem from './ListItem.vue';

--- a/docs/_snippets/list-story-with-subcomponents.md
+++ b/docs/_snippets/list-story-with-subcomponents.md
@@ -142,6 +142,54 @@ export const OneItem: Story = {
 };
 ```
 
+```svelte filename="List.stories.svelte" renderer="svelte" language="js"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import List from './List.svelte';
+  import ListItem from './ListItem.svelte';
+
+  const { Story } = defineMeta({
+    component: List,
+    subcomponents: { ListItem },
+  });
+</script>
+
+<Story name="Empty" />
+
+<Story name="One Item">
+  {#snippet children(args)}
+    <List {...args}>
+      <ListItem />
+    </List>
+  {/snippet}
+</Story>
+```
+
+```svelte filename="List.stories.svelte" renderer="svelte" language="ts"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import List from './List.svelte';
+  import ListItem from './ListItem.svelte';
+
+  const { Story } = defineMeta({
+    component: List,
+    subcomponents: { ListItem },
+  });
+</script>
+
+<Story name="Empty" />
+
+<Story name="One Item">
+  {#snippet children(args)}
+    <List {...args}>
+      <ListItem />
+    </List>
+  {/snippet}
+</Story>
+```
+
 ```js filename="List.stories.js" renderer="web-components" language="js"
 import { html } from 'lit';
 

--- a/docs/_snippets/loader-story.md
+++ b/docs/_snippets/loader-story.md
@@ -138,7 +138,35 @@ export const Primary: Story = {
 };
 ```
 
-```js filename="TodoItem.stories.js" renderer="svelte" language="js"
+```svelte filename="TodoItem.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import TodoItem from './TodoItem.svelte';
+
+  const { Story } = defineMeta({
+    component: TodoItem,
+    render: template,
+  });
+</script>
+
+{#snippet template(args, { loaded: { todo } })}
+  <TodoItem {...args} {...todo} />
+{/snippet}
+
+<Story
+  name="Primary"
+  loaders={[
+    async () => ({
+      todo: await (
+        await fetch('https://jsonplaceholder.typicode.com/todos/1')
+      ).json(),
+    }),
+  ]}
+/>
+```
+
+```js filename="TodoItem.stories.js" renderer="svelte" language="js" tabTitle="CSF"
 import TodoItem from './TodoItem.svelte';
 
 export default {
@@ -166,8 +194,37 @@ export const Primary = {
 };
 ```
 
-```ts filename="TodoItem.stories.ts" renderer="svelte" language="ts"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+```svelte filename="TodoItem.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import TodoItem from './TodoItem.svelte';
+
+  const { Story } = defineMeta({
+    component: TodoItem,
+    render: template,
+  });
+</script>
+
+{#snippet template(args, { loaded: { todo } })}
+  <TodoItem {...args} {...todo} />
+{/snippet}
+
+<Story
+  name="Primary"
+  loaders={[
+    async () => ({
+      todo: await (
+        await fetch('https://jsonplaceholder.typicode.com/todos/1')
+      ).json(),
+    }),
+  ]}
+/>
+```
+
+```ts filename="TodoItem.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import TodoItem from './TodoItem.svelte';
 

--- a/docs/_snippets/login-form-with-play-function.md
+++ b/docs/_snippets/login-form-with-play-function.md
@@ -320,7 +320,8 @@ export const FilledForm = {
 ```
 
 ```ts filename="LoginForm.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { expect, userEvent, within } from 'storybook/test';
 

--- a/docs/_snippets/main-config-svelte-csf-register.md
+++ b/docs/_snippets/main-config-svelte-csf-register.md
@@ -1,5 +1,3 @@
-<!-- Vet and test this -->
-
 ```js filename=".storybook/main.js" renderer="svelte" language="js"
 export default {
   stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|svelte)'],

--- a/docs/_snippets/main-config-svelte-csf-register.md
+++ b/docs/_snippets/main-config-svelte-csf-register.md
@@ -1,3 +1,5 @@
+<!-- Vet and test this -->
+
 ```js filename=".storybook/main.js" renderer="svelte" language="js"
 export default {
   stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|svelte)'],
@@ -9,7 +11,7 @@ export default {
 ```
 
 ```ts filename=".storybook/main.ts" renderer="svelte" language="ts"
-// Replace your-framework with the name of your Svelte framework
+// Replace your-framework with svelte-vite or sveltekit
 import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {

--- a/docs/_snippets/margindecorator.md
+++ b/docs/_snippets/margindecorator.md
@@ -1,16 +1,4 @@
-```svelte filename="MarginDecorator.svelte" renderer="svelte" language="js" tabTitle="Svelte 4"
-<div>
-  <slot />
-</div>
-
-<style>
-  div {
-    margin: 3em;
-  }
-</style>
-```
-
-```svelte filename="MarginDecorator.svelte" renderer="svelte" language="js" tabTitle="Svelte 5"
+```svelte filename="MarginDecorator.svelte" renderer="svelte" language="js"
 <script>
   let { children } = $props();
 </script>
@@ -26,19 +14,7 @@
 </style>
 ```
 
-```svelte filename="MarginDecorator.svelte" renderer="svelte" language="ts" tabTitle="Svelte 4"
-<div>
-  <slot />
-</div>
-
-<style>
-  div {
-    margin: 3em;
-  }
-</style>
-```
-
-```svelte filename="MarginDecorator.svelte" renderer="svelte" language="ts" tabTitle="Svelte 5"
+```svelte filename="MarginDecorator.svelte" renderer="svelte" language="ts"
 <script>
   import type { Snippet } from 'svelte';
 

--- a/docs/_snippets/msw-addon-configure-handlers-graphql.md
+++ b/docs/_snippets/msw-addon-configure-handlers-graphql.md
@@ -322,7 +322,87 @@ export const MockedError: Story = {
 };
 ```
 
-```js filename="YourPage.stories.js" renderer="svelte" language="js" tabTitle="story"
+```svelte filename="YourPage.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { graphql, HttpResponse, delay } from 'msw';
+
+  import MockApolloWrapperClient from './MockApolloWrapperClient.svelte';
+  import DocumentScreen from './YourPage.svelte';
+
+  const { Story } = defineMeta({
+    component: SamplePage,
+    decorators: [() => MockApolloWrapperClient],
+  });
+
+  //👇The mocked data that will be used in the story
+  const TestData = {
+    user: {
+      userID: 1,
+      name: 'Someone',
+    },
+    document: {
+      id: 1,
+      userID: 1,
+      title: 'Something',
+      brief: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      status: 'approved',
+    },
+    subdocuments: [
+      {
+        id: 1,
+        userID: 1,
+        title: 'Something',
+        content:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+        status: 'approved',
+      },
+    ],
+  };
+</script>
+
+<Story
+  name="MockedSuccess"
+  parameters={{
+    msw: {
+      handlers: [
+        graphql.query('AllInfoQuery', () => {
+          return HttpResponse.json({
+            data: {
+              AllInfoQuery: {
+                ...TestData,
+              },
+            },
+          });
+        }),
+      ],
+    },
+  }}
+/>
+
+<Story
+  name="MockedError"
+  parameters={{
+    msw: {
+      handlers: [
+        graphql.query('AllInfoQuery', async () => {
+          await delay(800);
+          return HttpResponse.json({
+            errors: [
+              {
+                message: 'Access denied',
+              },
+            ],
+          });
+        }),
+      ],
+    },
+  }}
+/>
+```
+
+```js filename="YourPage.stories.js" renderer="svelte" language="js" tabTitle="CSF"
 import { graphql, HttpResponse, delay } from 'msw';
 
 import MockApolloWrapperClient from './MockApolloWrapperClient.svelte';
@@ -398,32 +478,111 @@ export const MockedError = {
 
 ```svelte filename="MockApolloWrapperClient.svelte" renderer="svelte" language="js" tabTitle="apollo-wrapper-component"
 <script>
-  import { ApolloClient, InMemoryCache } from '@apollo/client';
+  import {
+    Client,
+    setContextClient,
+    cacheExchange,
+    fetchExchange,
+  } from '@urql/svelte';
 
-  import { setClient } from 'svelte-apollo';
-
-  const mockedClient = new ApolloClient({
-    uri: 'https://your-graphql-endpoint',
-    cache: new InMemoryCache(),
-    defaultOptions: {
-      watchQuery: {
-        fetchPolicy: 'no-cache',
-        errorPolicy: 'all',
-      },
-      query: {
-        fetchPolicy: 'no-cache',
-        errorPolicy: 'all',
-      },
-    },
+  const client = new Client({
+    url: 'https://your-graphql-endpoint',
+    exchanges: [cacheExchange, fetchExchange],
   });
-  setClient(mockedClient);
+
+  setContextClient(client);
+
+  const { children } = $props();
 </script>
 
-<slot />
+<div>
+  {@render children()}
+</div>
 ```
 
-```ts filename="YourPage.stories.ts" renderer="svelte" language="ts" tabTitle="story"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+```svelte filename="YourPage.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { graphql, HttpResponse, delay } from 'msw';
+
+  import MockApolloWrapperClient from './MockApolloWrapperClient.svelte';
+  import DocumentScreen from './YourPage.svelte';
+
+  const { Story } = defineMeta({
+    component: SamplePage,
+    decorators: [() => MockApolloWrapperClient],
+  });
+
+  //👇The mocked data that will be used in the story
+  const TestData = {
+    user: {
+      userID: 1,
+      name: 'Someone',
+    },
+    document: {
+      id: 1,
+      userID: 1,
+      title: 'Something',
+      brief: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      status: 'approved',
+    },
+    subdocuments: [
+      {
+        id: 1,
+        userID: 1,
+        title: 'Something',
+        content:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+        status: 'approved',
+      },
+    ],
+  };
+</script>
+
+<Story
+  name="MockedSuccess"
+  parameters={{
+    msw: {
+      handlers: [
+        graphql.query('AllInfoQuery', () => {
+          return HttpResponse.json({
+            data: {
+              AllInfoQuery: {
+                ...TestData,
+              },
+            },
+          });
+        }),
+      ],
+    },
+  }}
+/>
+
+<Story
+  name="MockedError"
+  parameters={{
+    msw: {
+      handlers: [
+        graphql.query('AllInfoQuery', async () => {
+          await delay(800);
+          return HttpResponse.json({
+            errors: [
+              {
+                message: 'Access denied',
+              },
+            ],
+          });
+        }),
+      ],
+    },
+  }}
+/>
+```
+
+```ts filename="YourPage.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { graphql, HttpResponse, delay } from 'msw';
 
@@ -503,28 +662,30 @@ export const MockedError: Story = {
 
 ```svelte filename="MockApolloWrapperClient.svelte" renderer="svelte" language="ts" tabTitle="apollo-wrapper-component"
 <script lang="ts">
-  import { ApolloClient, InMemoryCache } from '@apollo/client';
+  import {
+    Client,
+    setContextClient,
+    cacheExchange,
+    fetchExchange,
+  } from '@urql/svelte';
 
-  import { setClient } from 'svelte-apollo';
-
-  const mockedClient = new ApolloClient({
-    uri: 'https://your-graphql-endpoint',
-    cache: new InMemoryCache(),
-    defaultOptions: {
-      watchQuery: {
-        fetchPolicy: 'no-cache',
-        errorPolicy: 'all',
-      },
-      query: {
-        fetchPolicy: 'no-cache',
-        errorPolicy: 'all',
-      },
-    },
+  const client = new Client({
+    url: 'https://your-graphql-endpoint',
+    exchanges: [cacheExchange, fetchExchange],
   });
-  setClient(mockedClient);
+
+  setContextClient(client);
+
+  interface Props {
+    children: any;
+  }
+  const { children }: Props = $props();
 </script>
 
-<slot />
+<div>
+  {@render children?.()}
+</div>
+
 ```
 
 ```js filename="YourPage.stories.js" renderer="vue" language="js" tabTitle="story"

--- a/docs/_snippets/msw-addon-configure-handlers-graphql.md
+++ b/docs/_snippets/msw-addon-configure-handlers-graphql.md
@@ -332,7 +332,7 @@ export const MockedError: Story = {
   import DocumentScreen from './YourPage.svelte';
 
   const { Story } = defineMeta({
-    component: SamplePage,
+    component: DocumentScreen,
     decorators: [() => MockApolloWrapperClient],
   });
 
@@ -510,7 +510,7 @@ export const MockedError = {
   import DocumentScreen from './YourPage.svelte';
 
   const { Story } = defineMeta({
-    component: SamplePage,
+    component: DocumentScreen,
     decorators: [() => MockApolloWrapperClient],
   });
 

--- a/docs/_snippets/msw-addon-configure-handlers-http.md
+++ b/docs/_snippets/msw-addon-configure-handlers-http.md
@@ -65,6 +65,136 @@ export const MockedError: Story = {
 };
 ```
 
+```svelte filename="YourPage.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { http, HttpResponse, delay } from 'msw';
+
+  import DocumentScreen  from './YourPage.svelte';
+
+  const { Story } = defineMeta({
+    component: DocumentScreen,
+  });
+
+  // 👇 The mocked data that will be used in the story
+  const TestData = {
+    user: {
+      userID: 1,
+      name: 'Someone',
+    },
+    document: {
+      id: 1,
+      userID: 1,
+      title: 'Something',
+      brief: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      status: 'approved',
+    },
+    subdocuments: [
+      {
+        id: 1,
+        userID: 1,
+        title: 'Something',
+        content:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.,
+        status: "approved",
+      },
+    ],
+  };
+</script>
+
+<Story
+  name="MockedSuccess"
+  parameters={{
+    msw: {
+      handlers: [
+        http.get('https://your-restful-endpoint', () => {
+          return HttpResponse.json(TestData);
+        }),
+      ],
+    },
+  }}
+/>
+
+<Story
+  name="MockedError"
+  parameters={{
+    msw: {
+      handlers: [
+        http.get('https://your-restful-endpoint', async () => {
+          await delay(800);
+          return new HttpResponse(null, {
+            status: 403,
+          });
+        }),
+      ],
+    },
+  }}
+/>
+```
+
+```js filename="YourPage.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { http, HttpResponse, delay } from 'msw';
+
+import DocumentScreen from './YourPage.svelte';
+
+export default {
+  component: DocumentScreen,
+};
+
+// 👇 The mocked data that will be used in the story
+const TestData = {
+  user: {
+    userID: 1,
+    name: 'Someone',
+  },
+  document: {
+    id: 1,
+    userID: 1,
+    title: 'Something',
+    brief: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    status: 'approved',
+  },
+  subdocuments: [
+    {
+      id: 1,
+      userID: 1,
+      title: 'Something',
+      content:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+      status: 'approved',
+    },
+  ],
+};
+
+export const MockedSuccess = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('https://your-restful-endpoint/', () => {
+          return HttpResponse.json(TestData);
+        }),
+      ],
+    },
+  },
+};
+
+export const MockedError = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('https://your-restful-endpoint', async () => {
+          await delay(800);
+          return new HttpResponse(null, {
+            status: 403,
+          });
+        }),
+      ],
+    },
+  },
+};
+```
+
 ```js filename="YourPage.stories.js|jsx" renderer="common" language="js"
 import { http, HttpResponse, delay } from 'msw';
 
@@ -127,13 +257,149 @@ export const MockedError = {
 };
 ```
 
+```svelte filename="YourPage.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { http, HttpResponse, delay } from 'msw';
+
+  import DocumentScreen  from './YourPage.svelte';
+
+  const { Story } = defineMeta({
+    component: DocumentScreen,
+  });
+
+  // 👇 The mocked data that will be used in the story
+  const TestData = {
+    user: {
+      userID: 1,
+      name: 'Someone',
+    },
+    document: {
+      id: 1,
+      userID: 1,
+      title: 'Something',
+      brief: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      status: 'approved',
+    },
+    subdocuments: [
+      {
+        id: 1,
+        userID: 1,
+        title: 'Something',
+        content:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.,
+        status: "approved",
+      },
+    ],
+  };
+</script>
+
+<Story
+  name="MockedSuccess"
+  parameters={{
+    msw: {
+      handlers: [
+        http.get('https://your-restful-endpoint', () => {
+          return HttpResponse.json(TestData);
+        }),
+      ],
+    },
+  }}
+/>
+
+<Story
+  name="MockedError"
+  parameters={{
+    msw: {
+      handlers: [
+        http.get('https://your-restful-endpoint', async () => {
+          await delay(800);
+          return new HttpResponse(null, {
+            status: 403,
+          });
+        }),
+      ],
+    },
+  }}
+/>
+```
+
+```ts filename="YourPage.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { http, HttpResponse, delay } from 'msw';
+
+import DocumentScreen from './YourPage.svelte';
+
+const meta = {
+  component: DocumentScreen,
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 👇 The mocked data that will be used in the story
+const TestData = {
+  user: {
+    userID: 1,
+    name: 'Someone',
+  },
+  document: {
+    id: 1,
+    userID: 1,
+    title: 'Something',
+    brief: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    status: 'approved',
+  },
+  subdocuments: [
+    {
+      id: 1,
+      userID: 1,
+      title: 'Something',
+      content:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+      status: 'approved',
+    },
+  ],
+};
+
+export const MockedSuccess: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('https://your-restful-endpoint/', () => {
+          return HttpResponse.json(TestData);
+        }),
+      ],
+    },
+  },
+};
+
+export const MockedError: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('https://your-restful-endpoint', async () => {
+          await delay(800);
+          return new HttpResponse(null, {
+            status: 403,
+          });
+        }),
+      ],
+    },
+  },
+};
+```
+
 ```ts filename="YourPage.stories.ts|tsx" renderer="common" language="ts"
 // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite, angular, etc.)
 import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { http, HttpResponse, delay } from 'msw';
 
-import { MyComponent } from './MyComponent';
+import { DocumentScreen } from './YourPage';
 
 const meta = {
   component: DocumentScreen,

--- a/docs/_snippets/msw-addon-configure-handlers-http.md
+++ b/docs/_snippets/msw-addon-configure-handlers-http.md
@@ -96,7 +96,7 @@ export const MockedError: Story = {
         userID: 1,
         title: 'Something',
         content:
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.,
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
         status: "approved",
       },
     ],
@@ -288,7 +288,7 @@ export const MockedError = {
         userID: 1,
         title: 'Something',
         content:
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.,
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
         status: "approved",
       },
     ],
@@ -335,7 +335,7 @@ import DocumentScreen from './YourPage.svelte';
 
 const meta = {
   component: DocumentScreen,
-} satisfies Meta<typeof MyComponent>;
+} satisfies Meta<typeof DocumentScreen>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -403,7 +403,7 @@ import { DocumentScreen } from './YourPage';
 
 const meta = {
   component: DocumentScreen,
-} satisfies Meta<typeof MyComponent>;
+} satisfies Meta<typeof DocumentScreen>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/docs/_snippets/my-component-disable-toc.md
+++ b/docs/_snippets/my-component-disable-toc.md
@@ -91,7 +91,8 @@ export default {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import MyComponent from './MyComponent.svelte';
 

--- a/docs/_snippets/my-component-play-function-alt-queries.md
+++ b/docs/_snippets/my-component-play-function-alt-queries.md
@@ -125,7 +125,8 @@ export const ExampleWithRole = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { userEvent, within } from 'storybook/test';
 

--- a/docs/_snippets/my-component-play-function-query-findby.md
+++ b/docs/_snippets/my-component-play-function-query-findby.md
@@ -135,7 +135,8 @@ export const AsyncExample = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { userEvent, within } from 'storybook/test';
 

--- a/docs/_snippets/my-component-play-function-waitfor.md
+++ b/docs/_snippets/my-component-play-function-waitfor.md
@@ -190,7 +190,8 @@ export const ExampleAsyncStory = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { userEvent, waitFor, within } from 'storybook/test';
 

--- a/docs/_snippets/my-component-play-function-with-canvas.md
+++ b/docs/_snippets/my-component-play-function-with-canvas.md
@@ -121,7 +121,8 @@ export const ExampleStory = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { userEvent, within } from 'storybook/test';
 

--- a/docs/_snippets/my-component-play-function-with-clickevent.md
+++ b/docs/_snippets/my-component-play-function-with-clickevent.md
@@ -174,7 +174,8 @@ export const FireEventExample = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { fireEvent, userEvent, within } from 'storybook/test';
 

--- a/docs/_snippets/my-component-play-function-with-delay.md
+++ b/docs/_snippets/my-component-play-function-with-delay.md
@@ -172,7 +172,8 @@ export const DelayedStory = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { userEvent, within } from 'storybook/test';
 

--- a/docs/_snippets/my-component-play-function-with-selectevent.md
+++ b/docs/_snippets/my-component-play-function-with-selectevent.md
@@ -185,7 +185,8 @@ export const ExampleChangeEvent = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { userEvent, within } from 'storybook/test';
 

--- a/docs/_snippets/my-component-story-basic-and-props.md
+++ b/docs/_snippets/my-component-story-basic-and-props.md
@@ -152,7 +152,8 @@ export const WithProp = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import MyComponent from './MyComponent.svelte';
 

--- a/docs/_snippets/my-component-story-mandatory-export.md
+++ b/docs/_snippets/my-component-story-mandatory-export.md
@@ -21,6 +21,48 @@ const meta: Meta<MyComponent> = {
 export default meta;
 ```
 
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const meta = defineMeta({
+    /* 👇 The title prop is optional.
+     * See https://storybook.js.org/docs/configure/#configure-story-loading
+     * to learn how to generate automatic titles
+     */
+    title: 'Path/To/MyComponent',
+    component: MyComponent,
+    decorators: [
+      /* ... */
+    ],
+    parameters: {
+      /* ... */
+    },
+  });
+</script>
+```
+
+```js filename="MyComponent.story.js" renderer="svelte" language="js" tabTitle="CSF"
+import { MyComponent } from './MyComponent';
+
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Path/To/MyComponent',
+  component: MyComponent,
+  decorators: [
+    /* ... */
+  ],
+  parameters: {
+    /* ... */
+  },
+};
+```
+
 ```js filename="MyComponent.story.js|jsx" renderer="common" language="js"
 import { MyComponent } from './MyComponent';
 
@@ -38,6 +80,53 @@ export default {
     /* ... */
   },
 };
+```
+
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const meta = defineMeta({
+    /* 👇 The title prop is optional.
+     * See https://storybook.js.org/docs/configure/#configure-story-loading
+     * to learn how to generate automatic titles
+     */
+    title: 'Path/To/MyComponent',
+    component: MyComponent,
+    decorators: [
+      /* ... */
+    ],
+    parameters: {
+      /* ... */
+    },
+  });
+</script>
+```
+
+```ts filename="MyComponent.stories.ts|tsx" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import MyComponent from './MyComponent.svelte';
+
+const meta = {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: 'Path/To/MyComponent',
+  component: MyComponent,
+  decorators: [
+    /* ... */
+  ],
+  parameters: {
+    /* ... */
+  },
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
 ```
 
 ```ts filename="MyComponent.stories.ts|tsx" renderer="common" language="ts"

--- a/docs/_snippets/my-component-story-use-globaltype.md
+++ b/docs/_snippets/my-component-story-use-globaltype.md
@@ -165,7 +165,45 @@ export const StoryWithLocale = {
 };
 ```
 
-```js filename="MyComponent.stories.js" renderer="svelte" language="js"
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+
+  import MyComponent from "./MyComponent.svelte";
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<script>
+  const getCaptionForLocale = (locale) => {
+    switch (locale) {
+      case 'es':
+        return 'Hola!';
+      case 'fr':
+        return 'Bonjour!';
+      case "kr":
+        return '안녕하세요!';
+      case "zh":
+        return '你好!';
+      default:
+        return 'Hello!';
+    }
+  };
+</script>
+
+<Story name="StoryWithLocale">
+  {#snippet template(args, { globals: { locale } })}
+    <MyComponent
+      {...args}
+      locale={getCaptionForLocale(locale)}
+    />
+  {/snippet}
+</Story>
+```
+
+```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
 import MyComponent from './MyComponent.svelte';
 
 export default {
@@ -200,8 +238,47 @@ export const StoryWithLocale = {
 };
 ```
 
-```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+
+  import MyComponent from "./MyComponent.svelte";
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+  });
+</script>
+
+<script lang="ts">
+  const getCaptionForLocale = (locale:string) => {
+    switch (locale) {
+      case 'es':
+        return 'Hola!';
+      case 'fr':
+        return 'Bonjour!';
+      case "kr":
+        return '안녕하세요!';
+      case "zh":
+        return '你好!';
+      default:
+        return 'Hello!';
+    }
+  };
+</script>
+
+<Story name="StoryWithLocale">
+  {#snippet template(args, { globals: { locale } })}
+    <MyComponent
+      {...args}
+      locale={getCaptionForLocale(locale)}
+    />
+  {/snippet}
+</Story>
+```
+
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import MyComponent from './MyComponent.svelte';
 

--- a/docs/_snippets/my-component-story-with-nonstory.md
+++ b/docs/_snippets/my-component-story-with-nonstory.md
@@ -159,7 +159,7 @@ export const ComplexStory: Story = {
 
   const { Story } = defineMeta({
     component: MyComponent,
-    includeStories: ['SimpleStory", "ComplexStory'], // 👈 Storybook loads these stories
+    includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
     excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
   });
 
@@ -168,9 +168,9 @@ export const ComplexStory: Story = {
   export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
 </script>
 
-<Story name="Simple Story" args={{ data: simpleData }} />
+<Story name="SimpleStory" args={{ data: simpleData }} />
 
-<Story name="Complex Story" args={{ data: complexData }} />
+<Story name="ComplexStory" args={{ data: complexData }} />
 ```
 
 ```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
@@ -210,7 +210,7 @@ export const ComplexStory = {
 
   const { Story } = defineMeta({
     component: MyComponent,
-    includeStories: ['SimpleStory", "ComplexStory'], // 👈 Storybook loads these stories
+    includeStories: ['SimpleStory', 'ComplexStory'], // 👈 Storybook loads these stories
     excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
   });
 
@@ -219,9 +219,9 @@ export const ComplexStory = {
   export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
 </script>
 
-<Story name="Simple Story" args={{ data: simpleData }} />
+<Story name="SimpleStory" args={{ data: simpleData }} />
 
-<Story name="Complex Story" args={{ data: complexData }} />
+<Story name="ComplexStory" args={{ data: complexData }} />
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"

--- a/docs/_snippets/my-component-story-with-nonstory.md
+++ b/docs/_snippets/my-component-story-with-nonstory.md
@@ -149,7 +149,31 @@ export const ComplexStory: Story = {
 };
 ```
 
-```js filename="MyComponent.stories.js" renderer="svelte" language="js"
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MyComponent from './MyComponent.svelte';
+
+  import someData from './data.json';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+    includeStories: ['SimpleStory", "ComplexStory'], // 👈 Storybook loads these stories
+    excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
+  });
+
+  export const simpleData = { foo: 1, bar: 'baz' };
+
+  export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
+</script>
+
+<Story name="Simple Story" args={{ data: simpleData }} />
+
+<Story name="Complex Story" args={{ data: complexData }} />
+```
+
+```js filename="MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
 import MyComponent from './MyComponent.svelte';
 
 import someData from './data.json';
@@ -176,8 +200,33 @@ export const ComplexStory = {
 };
 ```
 
-```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+```svelte filename="MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MyComponent from './MyComponent.svelte';
+
+  import someData from './data.json';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+    includeStories: ['SimpleStory", "ComplexStory'], // 👈 Storybook loads these stories
+    excludeStories: /.*Data$/, // 👈 Storybook ignores anything that contains Data
+  });
+
+  export const simpleData = { foo: 1, bar: 'baz' };
+
+  export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
+</script>
+
+<Story name="Simple Story" args={{ data: simpleData }} />
+
+<Story name="Complex Story" args={{ data: complexData }} />
+```
+
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import MyComponent from './MyComponent.svelte';
 

--- a/docs/_snippets/my-component-vite-env-variables.md
+++ b/docs/_snippets/my-component-vite-env-variables.md
@@ -69,7 +69,8 @@ export const ExampleStory = {
 ```
 
 ```tsx filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import MyComponent from './MyComponent.svelte';
 

--- a/docs/_snippets/my-component-with-env-variables.md
+++ b/docs/_snippets/my-component-with-env-variables.md
@@ -84,7 +84,8 @@ export const ExampleStory = {
 ```
 
 ```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import MyComponent from './MyComponent.svelte';
 

--- a/docs/_snippets/page-story-with-args-composition.md
+++ b/docs/_snippets/page-story-with-args-composition.md
@@ -24,6 +24,53 @@ export const Simple: Story = {
 };
 ```
 
+```svelte filename="YourPage.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import DocumentScreen from './YourPage.svelte';
+
+  // 👇 Imports the required stories
+  import * as PageLayout from './PageLayout.stories.svelte';
+  import * as DocumentHeader from './DocumentHeader.stories.svelte';
+  import * as DocumentList from './DocumentList.stories.svelte';
+
+  const { Story } = defineMeta({
+    component: DocumentScreen,
+  });
+</script>
+
+<Story
+  name="Simple"
+  args={{
+    user: PageLayout.Simple.args.user,
+    document: DocumentHeader.Simple.args.document,
+    subdocuments: DocumentList.Simple.args.documents,
+  }}
+/>
+```
+
+```js filename="YourPage.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import DocumentScreen from './YourPage.svelte';
+
+// 👇 Imports the required stories
+import * as PageLayout from './PageLayout.stories';
+import * as DocumentHeader from './DocumentHeader.stories';
+import * as DocumentList from './DocumentList.stories';
+
+export default {
+  component: DocumentScreen,
+};
+
+export const Simple = {
+  args: {
+    user: PageLayout.Simple.args.user,
+    document: DocumentHeader.Simple.args.document,
+    subdocuments: DocumentList.Simple.args.documents,
+  },
+};
+```
+
 ```js filename="YourPage.stories.js|jsx" renderer="common" language="js"
 import { DocumentScreen } from './YourPage';
 
@@ -37,6 +84,59 @@ export default {
 };
 
 export const Simple = {
+  args: {
+    user: PageLayout.Simple.args.user,
+    document: DocumentHeader.Simple.args.document,
+    subdocuments: DocumentList.Simple.args.documents,
+  },
+};
+```
+
+```svelte filename="YourPage.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import DocumentScreen from './YourPage.svelte';
+
+  // 👇 Imports the required stories
+  import * as PageLayout from './PageLayout.stories.svelte';
+  import * as DocumentHeader from './DocumentHeader.stories.svelte';
+  import * as DocumentList from './DocumentList.stories.svelte';
+
+  const { Story } = defineMeta({
+    component: DocumentScreen,
+  });
+</script>
+
+<Story
+  name="Simple"
+  args={{
+    user: PageLayout.Simple.args.user,
+    document: DocumentHeader.Simple.args.document,
+    subdocuments: DocumentList.Simple.args.documents,
+  }}
+/>
+```
+
+```ts filename="YourPage.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import DocumentScreen from './YourPage.svelte';
+
+// 👇 Imports the required stories
+import * as PageLayout from './PageLayout.stories';
+import * as DocumentHeader from './DocumentHeader.stories';
+import * as DocumentList from './DocumentList.stories';
+
+const meta = {
+  component: DocumentScreen,
+} satisfies Meta<typeof DocumentScreen>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Simple: Story = {
   args: {
     user: PageLayout.Simple.args.user,
     document: DocumentHeader.Simple.args.document,

--- a/docs/_snippets/page-story.md
+++ b/docs/_snippets/page-story.md
@@ -160,7 +160,8 @@ export const LoggedIn = {
 ```
 
 ```ts filename="Page.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Page from './Page.svelte';
 

--- a/docs/_snippets/parameters-in-meta.md
+++ b/docs/_snippets/parameters-in-meta.md
@@ -81,7 +81,8 @@ export default {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/parameters-in-story.md
+++ b/docs/_snippets/parameters-in-story.md
@@ -119,7 +119,8 @@ export const Primary = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/register-component-with-play-function.md
+++ b/docs/_snippets/register-component-with-play-function.md
@@ -216,7 +216,8 @@ export const FilledForm = {
 ```
 
 ```ts filename="RegistrationForm.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { userEvent, within } from 'storybook/test';
 

--- a/docs/_snippets/storybook-addon-a11y-component-config.md
+++ b/docs/_snippets/storybook-addon-a11y-component-config.md
@@ -335,7 +335,7 @@ export default meta;
 </script>
 ```
 
-```ts filename="MyComponent.stories.ts|tsx" renderer="svelte" language="ts" tabTitle="CSF"
+```ts filename="MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
 import type { Meta } from '@storybook/svelte';
 
 import MyComponent from './MyComponent.svelte';

--- a/docs/_snippets/storybook-component-layout-param.md
+++ b/docs/_snippets/storybook-component-layout-param.md
@@ -12,11 +12,82 @@ const meta: Meta<Button> = {
 };
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+    // Sets the layout parameter component wide.
+    parameters: {
+      layout: 'centered',
+    },
+  });
+</script>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+  // Sets the layout parameter component wide.
+  parameters: {
+    layout: 'centered',
+  },
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
 export default {
   component: Button,
+  // Sets the layout parameter component wide.
+  parameters: {
+    layout: 'centered',
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+    // Sets the layout parameter component wide.
+    parameters: {
+      layout: 'centered',
+    },
+  });
+</script>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+  // Sets the layout parameter component wide.
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+```
+
+```js filename="Button.stories.js" renderer="web-components" language="js"
+export default {
+  component: 'demo-button',
   // Sets the layout parameter component wide.
   parameters: {
     layout: 'centered',

--- a/docs/_snippets/storybook-component-layout-param.md
+++ b/docs/_snippets/storybook-component-layout-param.md
@@ -112,16 +112,6 @@ const meta = {
 export default meta;
 ```
 
-```js filename="Button.stories.js" renderer="web-components" language="js"
-export default {
-  component: 'demo-button',
-  // Sets the layout parameter component wide.
-  parameters: {
-    layout: 'centered',
-  },
-};
-```
-
 ```ts filename="Button.stories.ts" renderer="web-components" language="ts"
 import type { Meta } from '@storybook/web-components-vite';
 

--- a/docs/_snippets/storybook-csf-3-auto-title-redundant.md
+++ b/docs/_snippets/storybook-csf-3-auto-title-redundant.md
@@ -22,6 +22,36 @@ export const Default: Story = {
 };
 ```
 
+```svelte filename="components/MyComponent/MyComponent.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+    title: 'components/MyComponent/MyComponent',
+  });
+</script>
+
+<Story name="Default" args={{ something: 'Something else' }} />
+```
+
+```js filename="components/MyComponent/MyComponent.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import MyComponent from './MyComponent.svelte';
+
+export default {
+  component: MyComponent,
+  title: 'components/MyComponent/MyComponent',
+};
+
+export const Default = {
+  args: {
+    something: 'Something else',
+  },
+};
+```
+
 ```js filename="components/MyComponent/MyComponent.stories.js|jsx" renderer="common" language="js"
 import { MyComponent } from './MyComponent';
 
@@ -37,7 +67,47 @@ export const Default = {
 };
 ```
 
-```ts filename="components/MyComponent/MyComponent.stories.js|jsx" renderer="common" language="ts"
+```svelte filename="components/MyComponent/MyComponent.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MyComponent from './MyComponent.svelte';
+
+  const { Story } = defineMeta({
+    component: MyComponent,
+    title: 'components/MyComponent/MyComponent',
+  });
+</script>
+
+<Story name="Default" args={{ something: 'Something else'}} />
+```
+
+```ts filename="components/MyComponent/MyComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import MyComponent from './MyComponent.svelte';
+
+const meta = {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/configure/#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  component: MyComponent,
+  title: 'components/MyComponent/MyComponent',
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    something: 'Something else',
+  },
+};
+```
+
+```ts filename="components/MyComponent/MyComponent.stories.ts|tsx" renderer="common" language="ts"
 // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite, angular, etc.)
 import type { Meta, StoryObj } from '@storybook/your-framework';
 

--- a/docs/_snippets/storybook-interactions-play-function.md
+++ b/docs/_snippets/storybook-interactions-play-function.md
@@ -39,6 +39,84 @@ export const Submitted: Story = {
 };
 ```
 
+```svelte filename="Form.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { userEvent, waitFor, within, expect, fn } from 'storybook/test';
+
+  import Form from './Form.svelte';
+
+  const { Story } = defineMeta({
+    component: Form,
+    args: {
+      // 👇 Use `fn` to spy on the submit output
+      onSubmit: fn(),
+    },
+  });
+</script>
+
+<!--
+  See https://storybook.js.org/docs/writing-stories/play-function#working-with-the-canvas
+  to learn more about using the canvasElement to query the DOM
+ -->
+<Story
+  name="Submitted"
+  play={async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Enter credentials', async () => {
+      await userEvent.type(canvas.getByTestId('email'), 'hi@example.com');
+      await userEvent.type(canvas.getByTestId('password'), 'supersecret');
+    });
+
+    await step('Submit form', async () => {
+      await userEvent.click(canvas.getByRole('button'));
+    });
+
+    // 👇 Now we can assert that the onSubmit arg was called
+    await waitFor(() => expect(args.onSubmit).toHaveBeenCalled());
+  }}
+/>
+```
+
+```js filename="Form.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { userEvent, waitFor, within, expect, fn } from 'storybook/test';
+
+import Form from './Form.svelte';
+
+export default {
+  component: Form,
+  args: {
+    // 👇 Use `fn` to spy on the onSubmit arg
+    onSubmit: fn(),
+  },
+};
+
+/*
+ * See https://storybook.js.org/docs/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
+export const Submitted = {
+  play: async ({ args, canvasElement, step }) => {
+    // Starts querying the component from its root element
+    const canvas = within(canvasElement);
+
+    await step('Enter credentials', async () => {
+      await userEvent.type(canvas.getByTestId('email'), 'hi@example.com');
+      await userEvent.type(canvas.getByTestId('password'), 'supersecret');
+    });
+
+    await step('Submit form', async () => {
+      await userEvent.click(canvas.getByRole('button'));
+    });
+
+    // 👇 Now we can assert that the onSubmit arg was called
+    await waitFor(() => expect(args.onSubmit).toHaveBeenCalled());
+  },
+};
+```
+
 ```js filename="Form.stories.js|jsx" renderer="common" language="js"
 import { userEvent, waitFor, within, expect, fn } from 'storybook/test';
 
@@ -59,6 +137,89 @@ export default {
 export const Submitted = {
   play: async ({ args, canvasElement, step }) => {
     // Starts querying the component from its root element
+    const canvas = within(canvasElement);
+
+    await step('Enter credentials', async () => {
+      await userEvent.type(canvas.getByTestId('email'), 'hi@example.com');
+      await userEvent.type(canvas.getByTestId('password'), 'supersecret');
+    });
+
+    await step('Submit form', async () => {
+      await userEvent.click(canvas.getByRole('button'));
+    });
+
+    // 👇 Now we can assert that the onSubmit arg was called
+    await waitFor(() => expect(args.onSubmit).toHaveBeenCalled());
+  },
+};
+```
+
+```svelte filename="Form.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { userEvent, waitFor, within, expect, fn } from 'storybook/test';
+
+  import Form from './Form.svelte';
+
+  const { Story } = defineMeta({
+    component: Form,
+    args: {
+      // 👇 Use `fn` to spy on the submit output
+      onSubmit: fn(),
+    },
+  });
+</script>
+
+<!--
+  See https://storybook.js.org/docs/writing-stories/play-function#working-with-the-canvas
+  to learn more about using the canvasElement to query the DOM
+ -->
+<Story
+  name="Submitted"
+  play={async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Enter credentials', async () => {
+      await userEvent.type(canvas.getByTestId('email'), 'hi@example.com');
+      await userEvent.type(canvas.getByTestId('password'), 'supersecret');
+    });
+
+    await step('Submit form', async () => {
+      await userEvent.click(canvas.getByRole('button'));
+    });
+
+    // 👇 Now we can assert that the onSubmit arg was called
+    await waitFor(() => expect(args.onSubmit).toHaveBeenCalled());
+  }}
+/>
+```
+
+```ts filename="Form.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { userEvent, waitFor, within, expect, fn } from 'storybook/test';
+
+import Form from './Form.svelte';
+
+const meta = {
+  component: Form,
+  args: {
+    // 👇 Use `fn` to spy on the onSubmit arg
+    onSubmit: fn(),
+  },
+} satisfies Meta<typeof Form>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/*
+ * See https://storybook.js.org/docs/writing-stories/play-function#working-with-the-canvas
+ * to learn more about using the canvasElement to query the DOM
+ */
+export const Submitted: Story = {
+  play: async ({ args, canvasElement, step }) => {
     const canvas = within(canvasElement);
 
     await step('Enter credentials', async () => {

--- a/docs/_snippets/storybook-story-layout-param.md
+++ b/docs/_snippets/storybook-story-layout-param.md
@@ -17,6 +17,39 @@ export const WithLayout: Story = {
 };
 ```
 
+```svelte filename="Button.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+  });
+</script>
+
+<Story
+  name="WithLayout"
+  parameters={{
+    layout: "centered",
+  }}
+/>
+```
+
+```js filename="Button.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import Button from './Button.svelte';
+
+export default {
+  component: Button,
+};
+
+export const WithLayout = {
+  parameters: {
+    layout: 'centered',
+  },
+};
+```
+
 ```js filename="Button.stories.js|jsx" renderer="common" language="js"
 import { Button } from './Button';
 
@@ -25,6 +58,45 @@ export default {
 };
 
 export const WithLayout = {
+  parameters: {
+    layout: 'centered',
+  },
+};
+```
+
+```svelte filename="Button.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+  });
+</script>
+
+<Story
+  name="WithLayout"
+  parameters={{
+    layout: "centered",
+  }}
+/>
+```
+
+```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import Button from './Button.svelte';
+
+const meta = {
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithLayout: Story = {
   parameters: {
     layout: 'centered',
   },

--- a/docs/_snippets/storybook-story-layout-param.md
+++ b/docs/_snippets/storybook-story-layout-param.md
@@ -31,7 +31,7 @@ export const WithLayout: Story = {
 <Story
   name="WithLayout"
   parameters={{
-    layout: "centered",
+    layout: 'centered',
   }}
 />
 ```
@@ -78,7 +78,7 @@ export const WithLayout = {
 <Story
   name="WithLayout"
   parameters={{
-    layout: "centered",
+    layout: 'centered',
   }}
 />
 ```

--- a/docs/_snippets/storybook-test-fn-mock-spy.md
+++ b/docs/_snippets/storybook-test-fn-mock-spy.md
@@ -36,6 +36,72 @@ export const SaveFlow: Story = {
 };
 ```
 
+```svelte filename="NoteUI.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { expect, userEvent, within } from 'storybook/test';
+
+  // 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+  import { saveNote } from '#app/actions.mock';
+  import { createNotes } from '#mocks/notes';
+
+  import NoteUI from './note-ui.svelte';
+
+  const meta = defineMeta({
+    title: 'Mocked/NoteUI',
+    component: NoteUI,
+  });
+</script>
+
+<script>
+  const notes = createNotes();
+</script>
+
+<Story name="Save Flow ▶"
+  args={{ isEditing: true, note: notes[0] }}
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const saveButton = canvas.getByRole('menuitem', { name: /done/i });
+    await userEvent.click(saveButton);
+    // 👇 This is the mock function, so you can assert its behavior
+    await expect(saveNote).toHaveBeenCalled();
+  }} />
+```
+
+```js filename="NoteUI.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { expect, userEvent, within } from 'storybook/test';
+
+import { saveNote } from '#app/actions.mock';
+import { createNotes } from '#mocks/notes';
+
+import NoteUI from './note-ui.svelte';
+
+export default {
+  title: 'Mocked/NoteUI',
+  component: NoteUI,
+};
+
+const notes = createNotes();
+
+export const SaveFlow = {
+  name: 'Save Flow ▶',
+  args: {
+    isEditing: true,
+    note: notes[0],
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    const saveButton = canvas.getByRole('menuitem', { name: /done/i });
+    await userEvent.click(saveButton);
+    // 👇 This is the mock function, so you can assert its behavior
+    await expect(saveNote).toHaveBeenCalled();
+  },
+};
+```
+
 ```js filename="NoteUI.stories.js" renderer="common" language="js"
 import { expect, userEvent, within } from 'storybook/test';
 
@@ -52,6 +118,79 @@ export default {
 const notes = createNotes();
 
 export const SaveFlow = {
+  name: 'Save Flow ▶',
+  args: {
+    isEditing: true,
+    note: notes[0],
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    const saveButton = canvas.getByRole('menuitem', { name: /done/i });
+    await userEvent.click(saveButton);
+    // 👇 This is the mock function, so you can assert its behavior
+    await expect(saveNote).toHaveBeenCalled();
+  },
+};
+```
+
+```svelte filename="NoteUI.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { expect, userEvent, within } from 'storybook/test';
+
+  // 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+  import { saveNote } from '#app/actions.mock';
+  import { createNotes } from '#mocks/notes';
+
+  import NoteUI from './note-ui.svelte';
+
+  const meta = defineMeta({
+    title: 'Mocked/NoteUI',
+    component: NoteUI,
+  });
+</script>
+
+<script>
+  const notes = createNotes();
+</script>
+
+<Story name="Save Flow ▶"
+  args={{ isEditing: true, note: notes[0] }}
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const saveButton = canvas.getByRole('menuitem', { name: /done/i });
+    await userEvent.click(saveButton);
+    // 👇 This is the mock function, so you can assert its behavior
+    await expect(saveNote).toHaveBeenCalled();
+  }} />
+```
+
+```ts filename="NoteUI.stories.ts" renderer="common" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { expect, userEvent, within } from 'storybook/test';
+
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { saveNote } from '#app/actions.mock';
+import { createNotes } from '#mocks/notes';
+
+import NoteUI from './note-ui.svelte';
+
+const meta = {
+  title: 'Mocked/NoteUI',
+  component: NoteUI,
+} satisfies Meta<typeof NoteUI>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const notes = createNotes();
+
+export const SaveFlow: Story = {
   name: 'Save Flow ▶',
   args: {
     isEditing: true,

--- a/docs/_snippets/storybook-test-mock-return-value.md
+++ b/docs/_snippets/storybook-test-mock-return-value.md
@@ -21,6 +21,43 @@ export const Default: Story = {
 };
 ```
 
+```svelte filename="Page.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  // 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+  import { getUserFromSession } from '#api/session.mock';
+
+  import Page from './Page.svelte';
+
+  const meta = defineMeta({
+    component: Page,
+  });
+</script>
+
+<Story name="Default" beforeEach={() => {
+  // 👇 Set the return value for the getUserFromSession function
+  getUserFromSession.mockReturnValue({ id: '1', name: 'Alice' });
+}} />
+```
+
+```js filename="Page.stories.js" renderer="svelte" language="js" tabTitle="CSF"
+import { getUserFromSession } from '#api/session.mock';
+
+import Page from './Page.svelte';
+
+export default {
+  component: Page,
+};
+
+export const Default = {
+  async beforeEach() {
+    // 👇 Set the return value for the getUserFromSession function
+    getUserFromSession.mockReturnValue({ id: '1', name: 'Alice' });
+  },
+};
+```
+
 ```js filename="Page.stories.js" renderer="common" language="js"
 import { getUserFromSession } from '#api/session.mock';
 
@@ -31,6 +68,51 @@ export default {
 };
 
 export const Default = {
+  async beforeEach() {
+    // 👇 Set the return value for the getUserFromSession function
+    getUserFromSession.mockReturnValue({ id: '1', name: 'Alice' });
+  },
+};
+```
+
+```svelte filename="Page.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  // 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+  import { getUserFromSession } from '#api/session.mock';
+
+  import Page from './Page.svelte';
+
+  const meta = defineMeta({
+    component: Page,
+  });
+</script>
+
+<Story name="Default" beforeEach={() => {
+  // 👇 Set the return value for the getUserFromSession function
+  getUserFromSession.mockReturnValue({ id: '1', name: 'Alice' });
+}} />
+```
+
+```ts filename="Page.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+// 👇 Must include the `.mock` portion of filename to have mocks typed correctly
+import { getUserFromSession } from '#api/session.mock';
+
+import Page from './Page.svelte';
+
+const meta = {
+  component: Page,
+} satisfies Meta<typeof Page>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
   async beforeEach() {
     // 👇 Set the return value for the getUserFromSession function
     getUserFromSession.mockReturnValue({ id: '1', name: 'Alice' });

--- a/docs/_snippets/tags-autodocs-in-meta.md
+++ b/docs/_snippets/tags-autodocs-in-meta.md
@@ -60,7 +60,8 @@ export default {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/tags-autodocs-remove-component.md
+++ b/docs/_snippets/tags-autodocs-remove-component.md
@@ -60,7 +60,8 @@ export default {
 ```
 
 ```ts filename="Page.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Page from './Page.svelte';
 

--- a/docs/_snippets/tags-autodocs-remove-story.md
+++ b/docs/_snippets/tags-autodocs-remove-story.md
@@ -83,7 +83,8 @@ export const UndocumentedStory = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/tags-docs-only-in-meta.md
+++ b/docs/_snippets/tags-docs-only-in-meta.md
@@ -80,7 +80,8 @@ export default {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/tags-in-meta-and-story.md
+++ b/docs/_snippets/tags-in-meta-and-story.md
@@ -138,7 +138,8 @@ export const ExperimentalFeatureStory = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/tags-remove-in-story.md
+++ b/docs/_snippets/tags-remove-in-story.md
@@ -83,7 +83,8 @@ export const ExperimentalFeatureStory = {
 ```
 
 ```ts filename="Button.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import Button from './Button.svelte';
 

--- a/docs/_snippets/your-component-with-decorator.md
+++ b/docs/_snippets/your-component-with-decorator.md
@@ -124,7 +124,8 @@ export default {
 ```
 
 ```ts filename="YourComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta } from '@storybook/your-framework';
 
 import YourComponent from './YourComponent.svelte';
 import MarginDecorator from './MarginDecorator.svelte';

--- a/docs/_snippets/your-component.md
+++ b/docs/_snippets/your-component.md
@@ -223,7 +223,8 @@ export const FirstStory = {
 ```
 
 ```ts filename="YourComponent.stories.ts" renderer="svelte" language="ts" tabTitle="CSF"
-import type { Meta, StoryObj } from '@storybook/svelte-vite';
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import YourComponent from './YourComponent.svelte';
 

--- a/docs/api/arg-types.mdx
+++ b/docs/api/arg-types.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ArgTypes specify the behavior of [args](../writing-stories/args.mdx). By specifying the type of an arg, you constrain the values that it can accept and provide information about args that are not explicitly set (i.e., [description](#description)).
 
-You can also use argTypes to “annotate” args with information used by addons that make use of those args. For instance, to instruct the [controls addon](../essentials/controls.mdx) to render a color picker, you could specify the `'color'` [control type](#control).
+You can also use argTypes to “annotate” args with information used by addons that make use of those args. For instance, to instruct the [controls panel](../essentials/controls.mdx) to render a color picker, you could specify the `'color'` [control type](#control).
 
 The most concrete realization of argTypes is the [`ArgTypes` doc block](./doc-blocks/doc-block-argtypes.mdx) ([`Controls`](./doc-blocks/doc-block-controls.mdx) is similar). Each row in the table corresponds to a single argType and the current value of that arg.
 
@@ -108,7 +108,7 @@ Default:
 2. Else, inferred from [`type`](#type)
 3. Else, `'object'`
 
-Specify the behavior of the [controls addon](../essentials/controls.mdx) for the arg. If you specify a string, it's used as the [`type`](#controltype) of the control. If you specify an object, you can provide additional configuration. Specifying `false` will prevent the control from rendering.
+Specify the behavior of the [controls panel](../essentials/controls.mdx) for the arg. If you specify a string, it's used as the [`type`](#controltype) of the control. If you specify an object, you can provide additional configuration. Specifying `false` will prevent the control from rendering.
 
 {/* prettier-ignore-start */}
 
@@ -122,7 +122,7 @@ Type: `ControlType | null`
 
 Default: [Inferred](#automatic-argtype-inference); `'select'`, if [`options`](#options) are specified; falling back to `'object'`
 
-Specifies the type of control used to change the arg value with the [controls addon](../essentials/controls.mdx). Here are the available types, `ControlType`, grouped by the type of data they handle:
+Specifies the type of control used to change the arg value with the [controls panel](../essentials/controls.mdx). Here are the available types, `ControlType`, grouped by the type of data they handle:
 
 | Data type      | ControlType      | Description                                                                                                                                                                             |
 | -------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -224,7 +224,7 @@ Type: `{ [key: string]: { [option: string]: any } }`
 
 Map [`options`](#options) to values.
 
-When dealing with non-primitive values, you'll notice that you'll run into some limitations. The most obvious issue is that not every value can be represented as part of the `args` param in the URL, losing the ability to share and deeplink to such a state. Beyond that, complex values such as JSX cannot be synchronized between the manager (e.g., Controls addon) and the preview (your story).
+When dealing with non-primitive values, you'll notice that you'll run into some limitations. The most obvious issue is that not every value can be represented as part of the `args` param in the URL, losing the ability to share and deeplink to such a state. Beyond that, complex values such as JSX cannot be synchronized between the manager (e.g., Controls panel) and the preview (your story).
 
 `mapping` doesn't have to be exhaustive. If the currently selected option is not listed, it's used verbatim. Can be used with [`control.labels`](#labels).
 
@@ -288,7 +288,7 @@ Type:
 
 Default: [Inferred](#automatic-argtype-inference)
 
-Specify how the arg is documented in the [`ArgTypes` doc block](./doc-blocks/doc-block-argtypes.mdx), [`Controls` doc block](./doc-blocks/doc-block-controls.mdx), and [Controls addon panel](../essentials/controls.mdx).
+Specify how the arg is documented in the [`ArgTypes` doc block](./doc-blocks/doc-block-argtypes.mdx), [`Controls` doc block](./doc-blocks/doc-block-controls.mdx), and [Controls panel](../essentials/controls.mdx).
 
 {/* prettier-ignore-start */}
 

--- a/docs/api/portable-stories/portable-stories-vitest.mdx
+++ b/docs/api/portable-stories/portable-stories-vitest.mdx
@@ -15,6 +15,13 @@ sidebar:
 
 <If renderer="svelte">
   (⚠️ **Experimental**)
+
+    <Callout variant="info">
+
+    This feature is not supported with the Svelte CSF. To opt-in to this feature with Svelte, you must use Storybook's [Component Story Format](../csf/index.mdx).
+  
+  </Callout>
+
 </If>
 
 <If renderer="react">

--- a/docs/get-started/frameworks/svelte-vite.mdx
+++ b/docs/get-started/frameworks/svelte-vite.mdx
@@ -39,8 +39,6 @@ This framework is designed to work with Storybook 7+. If you’re not already us
 
 #### Automatic migration
 
-{/* TK: Vet this for accuracy, the migration never prompted me to opt-in to the @storybook/sveltekit package, instead it updated the package version. Additionally the example refers to svelte-vite, not sveltekit */}
-
 When running the `upgrade` command above, you should get a prompt asking you to migrate to `@storybook/svelte-vite`, which should handle everything for you. In case that auto-migration does not work for your project, refer to the manual migration below.
 
 #### Manual migration

--- a/docs/get-started/whats-a-story.mdx
+++ b/docs/get-started/whats-a-story.mdx
@@ -68,7 +68,7 @@ Storybook makes it easy to work on one component in one state (aka a story) at a
 
 <Video src="../_assets/get-started/new-component-story-in-code-optimized.mp4" />
 
-If you're working on a component that already has other stories, you can use the [Controls addon](../essentials/controls.mdx) to adjust the value of a control and then save those changes as a new story.
+If you're working on a component that already has other stories, you can use the [Controls panel](../essentials/controls.mdx) to adjust the value of a control and then save those changes as a new story.
 
 <Video src="../_assets/get-started/new-story-from-controls-optimized.mp4" />
 
@@ -78,7 +78,7 @@ Or, if you prefer, edit the story file's code to add a new named export for your
 
 ### Edit a story
 
-Using the [Controls addon](../essentials/controls.mdx), update a control's value for a story. You can then save the changes to the story and the story file's code will be updated for you.
+Using the [Controls panel](../essentials/controls.mdx), update a control's value for a story. You can then save the changes to the story and the story file's code will be updated for you.
 
 <Video src="../_assets/get-started/edit-story-from-controls-optimized.mp4" />
 

--- a/docs/writing-stories/args.mdx
+++ b/docs/writing-stories/args.mdx
@@ -149,7 +149,7 @@ Args specified through the URL will extend and override any default values of ar
 
 ## Mapping to complex arg values
 
-Complex values such as JSX elements cannot be serialized to the manager (e.g., the Controls addon) or synced with the URL. Arg values can be "mapped" from a simple string to a complex type using the `mapping` property in `argTypes` to work around this limitation. It works in any arg but makes the most sense when used with the `select` control type.
+Complex values such as JSX elements cannot be serialized to the manager (e.g., the Controls panel) or synced with the URL. Arg values can be "mapped" from a simple string to a complex type using the `mapping` property in `argTypes` to work around this limitation. It works in any arg but makes the most sense when used with the `select` control type.
 
 {/* prettier-ignore-start */}
 

--- a/docs/writing-stories/index.mdx
+++ b/docs/writing-stories/index.mdx
@@ -60,12 +60,6 @@ components/
 
   {/* prettier-ignore-end */}
 
-  <Callout variant="info">
-
-    Starting with Storybook version 7.0, story titles are analyzed statically as part of the build process. With Svelte, the `defineMeta` function or *default* export must contain a `title` property that can be read statically. Using the `id` property to customize your story URL must also be statically readable.
-
-  </Callout>
-
 </If>
 
 <If notRenderer="svelte">
@@ -140,6 +134,7 @@ You can rename any particular story you need. For instance, to give it a more ac
 
 {/* prettier-ignore-end */}
 
+
 Your story will now be shown in the sidebar with the given text.
 
 {/* Maintaining a prior heading */}
@@ -160,7 +155,6 @@ Your story will now be shown in the sidebar with the given text.
   A story is an object that describes how to render a component. You can have multiple stories per component, and those stories can build upon one another. For example, we can add Secondary and Tertiary stories based on our Primary story from above.
 
 </If>
-
 
 {/* prettier-ignore-start */}
 

--- a/docs/writing-stories/mocking-data-and-modules/mocking-network-requests.mdx
+++ b/docs/writing-stories/mocking-data-and-modules/mocking-network-requests.mdx
@@ -81,9 +81,21 @@ GraphQL is another common way to fetch data in components. You can use MSW to mo
 
 {/* prettier-ignore-end */}
 
+<If renderer="svelte">
+
+<Callout variant="info">
+  This example uses [URQL](https://formidable.com/open-source/urql/) to make network requests. If you're using a different library (e.g., [Houdini](https://houdinigraphql.com/) or [Graffle](https://graffle.js.org/)), you can apply the same principles to mock network requests in Storybook.
+</Callout>
+
+</If>
+
+<If notRenderer="svelte">
+
 <Callout variant="info">
   This example uses GraphQL with [Apollo Client](https://www.apollographql.com/docs/) to make network requests. If you're using a different library (e.g. [URQL](https://formidable.com/open-source/urql/) or [React Query](https://react-query.tanstack.com/)), you can apply the same principles to mock network requests in Storybook.
 </Callout>
+
+</If>
 
 The MSW addon allows you to write stories that use MSW to mock the GraphQL requests. Here's an example demonstrating two stories for the document screen component. The first story fetches data successfully, while the second story fails.
 

--- a/docs/writing-stories/naming-components-and-hierarchy.mdx
+++ b/docs/writing-stories/naming-components-and-hierarchy.mdx
@@ -61,19 +61,23 @@ Yields this:
 
 By default, the top-level grouping will be displayed as “root” in the Storybook UI (i.e., the uppercased, non-expandable items). If you need, you can [configure Storybook](../configure/user-interface/sidebar-and-urls.mdx#roots) and disable this behavior. Useful if you need to provide a streamlined experience for your users; nevertheless, if you have a large Storybook composed of multiple component stories, we recommend naming your components according to the file hierarchy.
 
-## Single-story hoisting
+<If notRenderer="svelte">
 
-Single-story components (i.e., component stories without **siblings**) whose **display name** exactly matches the component's name (last part of `title`) are automatically hoisted up to replace their parent component in the UI. For example:
+  ## Single-story hoisting
 
-{/* prettier-ignore-start */}
+  Single-story components (i.e., component stories without **siblings**) whose **display name** exactly matches the component's name (last part of `title`) are automatically hoisted up to replace their parent component in the UI. For example:
 
-<CodeSnippets path="button-story-hoisted.md" />
+  {/* prettier-ignore-start */}
 
-{/* prettier-ignore-end */}
+  <CodeSnippets path="button-story-hoisted.md" />
 
-![Stories hierarchy with single story hoisting](../_assets/writing-stories/naming-hierarchy-single-story-hoisting.png)
+  {/* prettier-ignore-end */}
 
-Because story exports are automatically "start cased" (`myStory` becomes `"My Story"`), your component name should match that. Alternatively, you can override the story name using `myStory.storyName = '...'` to match the component name.
+  ![Stories hierarchy with single story hoisting](../_assets/writing-stories/naming-hierarchy-single-story-hoisting.png)
+
+  Because story exports are automatically "start cased" (`myStory` becomes `"My Story"`), your component name should match that. Alternatively, you can override the story name using `myStory.storyName = '...'` to match the component name.
+
+</If>
 
 ## Sorting stories
 

--- a/docs/writing-stories/typescript.mdx
+++ b/docs/writing-stories/typescript.mdx
@@ -92,20 +92,24 @@ Sometimes stories need to define args that aren’t included in the component's 
 
   Svelte offers excellent TypeScript support for .svelte files. For example, consider the following component. You can run type checks using svelte-check and add VSCode editor support with the [Svelte for VSCode extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
 
-  ```html
+  ```svelte
   <script lang="ts">
-    import { createEventDispatcher } from 'svelte';
+    let count: number = $state(0);
+    let disabled: boolean = $state(false);
 
-    export let count: number;
-    export let disabled: boolean;
-
-    const dispatch = createEventDispatcher();
+    const increaseBy = () => {
+      count += 1
+    };
+    
+    const decreaseBy = () => {
+      count -= 1
+    };
   </script>
 
   <div class="card">
     {count}
-    <button on:click={() => dispatch('increaseBy', 1)} {disabled}> Increase by 1 </button>
-    <button on:click={() => dispatch('decreaseBy', 1)} {disabled}> Decrease by 1 </button>
+    <button onclick={increaseBy} {disabled}> Increase by 1 </button>
+    <button onclick={decreaseBy} {disabled}> Decrease by 1 </button>
   </div>
   ```
 


### PR DESCRIPTION
Addresses [#267](https://github.com/storybookjs/addon-svelte-csf/discussions/267) and [31202](https://github.com/storybookjs/storybook/issues/31202)

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

With this pull request, the documentation was updated to contain the remaining Svelte Snippets.
What was done:
- Added missing Svelte CSF Snippets
- Fixed some documentation to address the mentioned discussion
- Minor docs changes related to Storybook's Essentials (i.e., Controls addon=> Controls panel)
- Fixed assorted snippets


Content updates, including the CSF page and other assorted changes, will be added as a follow-up pull request.

@JReinhold, can you look at this pull request and let me know of any feedback you may have? Thanks in advance

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request changes:

Added missing Svelte CSF (Component Story Format) snippets across Storybook's documentation, improving coverage and clarity for Svelte users.

- Added Svelte CSF code examples in both JavaScript and TypeScript formats using `@storybook/addon-svelte-csf` package
- Updated import statements to use placeholder framework name with instructions to use either 'svelte-vite' or 'sveltekit'
- Replaced Apollo client with URQL in GraphQL-related Svelte examples
- Updated terminology from 'Controls addon' to 'Controls panel' throughout documentation
- Added conditional rendering blocks to provide framework-specific guidance for Svelte vs other frameworks

The changes are part of the Svelte CSF addon stabilization effort and improve documentation accuracy for Svelte developers.



<!-- /greptile_comment -->