### PR TITLE
Automigration: Improve renderer to framework automigration

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/renderer-to-framework.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/renderer-to-framework.ts
@@ -9,6 +9,7 @@ import {
 } from 'storybook/internal/common';
 import type { PackageJson } from 'storybook/internal/types';
 
+import picocolors from 'picocolors';
 import prompts from 'prompts';
 import { dedent } from 'ts-dedent';
 
@@ -174,6 +175,8 @@ export const rendererToFramework: Fix<MigrationResult> = {
       2. Remove the renderer packages from your package.json
       3. Install the necessary framework dependencies
       Would you like to proceed with these changes?
+
+      More info: ${picocolors.yellow('https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#moving-from-renderer-based-to-framework-based-configuration')}
     `;
   },
 
@@ -214,7 +217,6 @@ export const rendererToFramework: Fix<MigrationResult> = {
       }
 
       console.log(`\nMigrating ${rendererPackage} to ${selectedFramework}`);
-      console.log('Scanning for affected files...');
 
       const sourceFiles = await globby([glob], {
         ...commonGlobOptions(''),

--- a/code/lib/cli-storybook/src/automigrate/fixes/renderer-to-framework.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/renderer-to-framework.ts
@@ -209,6 +209,10 @@ export const rendererToFramework: Fix<MigrationResult> = {
         continue;
       }
 
+      if (rendererPackage === selectedFramework) {
+        continue;
+      }
+
       console.log(`\nMigrating ${rendererPackage} to ${selectedFramework}`);
       console.log('Scanning for affected files...');
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have changed how the `renderer-to-framework` automigration works.

Before it was:
- ignoring the fact that some renderers are also frameworks (e.g. @storybook/angular)
- prompted the user to choose to migrate all renderers to a particular framework, which is problematic in monorepos with multiple frameworks and renderers in place

After:
- renderers, which are also frameworks will not be transformed or removed from the package.json anymore
- I have removed the prompting, instead, I am looping over all frameworks and replace their mapped renderers by the framework. This solution should work greatly in monorepos as well.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31397-sha-04742ac8`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31397-sha-04742ac8 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31397-sha-04742ac8 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31397-sha-04742ac8`](https://npmjs.com/package/storybook/v/0.0.0-pr-31397-sha-04742ac8) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/improve-renderer-to-framework-automigration`](https://github.com/storybookjs/storybook/tree/valentin/improve-renderer-to-framework-automigration) |
| **Commit** | [`04742ac8`](https://github.com/storybookjs/storybook/commit/04742ac89ef8bcdcc60014f3eb55d3c20618af17) |
| **Datetime** | Wed May  7 09:58:30 UTC 2025 (`1746611910`) |
| **Workflow run** | [14880543753](https://github.com/storybookjs/storybook/actions/runs/14880543753) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31397`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the renderer-to-framework automigration improvements:

Improved Storybook's renderer-to-framework automigration process with smarter framework detection and automated migration handling.

- Filters out renderers that are also frameworks (e.g. @storybook/angular) to prevent unnecessary transformations
- Removes manual framework selection prompts in favor of automatic mapping between renderers and their corresponding frameworks
- Enhances monorepo support by processing each renderer-framework pair independently
- Updates `removeRendererInPackageJson` to handle single renderer removal more effectively
- Adds comprehensive test coverage for package.json modifications in both dependencies and devDependencies

The changes make the migration process more robust and automated, particularly benefiting projects using multiple frameworks in monorepos.



<!-- /greptile_comment -->