### PR TITLE
Automigrations: Fix installation of addon-docs

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.test.ts
@@ -418,34 +418,40 @@ describe('remove-essentials migration', () => {
       );
     });
 
-    it('does install docs addon as dependency if essentials is present and docs is configured in main config', async () => {
-      await typedAddonDocsEssentials.run({
-        result: {
-          hasEssentials: true,
-          hasDocsDisabled: false,
-          hasDocsAddon: true,
-          additionalAddonsToRemove: [],
-          allDeps: {
-            storybook: '^9.0.0',
+    it.each([
+      { type: 'devDependencies', asDevDependency: true },
+      { type: 'dependencies', asDevDependency: false },
+    ])(
+      'does install docs addon as $type if essentials is present and docs is configured in main config',
+      async ({ type, asDevDependency }) => {
+        await typedAddonDocsEssentials.run({
+          result: {
+            hasEssentials: true,
+            hasDocsDisabled: false,
+            hasDocsAddon: true,
+            additionalAddonsToRemove: [],
+            allDeps: {
+              storybook: '^9.0.0',
+            },
           },
-        },
-        packageManager: mockPackageManager,
-        packageJson: {
-          dependencies: {
-            storybook: '^9.1.0',
+          packageManager: mockPackageManager,
+          packageJson: {
+            [type]: {
+              storybook: '^9.1.0',
+            },
           },
-        },
-        mainConfigPath: '.storybook/main.ts',
-        configDir: '.storybook',
-        storybookVersion: '8.0.0',
-        mainConfig: {} as StorybookConfigRaw,
-      });
+          mainConfigPath: '.storybook/main.ts',
+          configDir: '.storybook',
+          storybookVersion: '8.0.0',
+          mainConfig: {} as StorybookConfigRaw,
+        });
 
-      expect(mockPackageManager.addDependencies).toHaveBeenCalledWith(
-        { installAsDevDependencies: false },
-        ['@storybook/addon-docs@^9.0.0']
-      );
-    });
+        expect(mockPackageManager.addDependencies).toHaveBeenCalledWith(
+          { installAsDevDependencies: asDevDependency },
+          ['@storybook/addon-docs@^9.0.0']
+        );
+      }
+    );
 
     it('handles import transformations', async () => {
       const { scanAndTransformFiles } = await import('storybook/internal/common');


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

As part of the remove-essentials automigration addon docs should sometimes be added via storybook add command, but sometimes an installation is enough due to the fact, that people might configure `@storybook/addon-docs` in their main configuration, but the package is actually not installed, because it was a dependency of @storybook/addon-essentials.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31399-sha-1bb3fc57`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31399-sha-1bb3fc57 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31399-sha-1bb3fc57 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31399-sha-1bb3fc57`](https://npmjs.com/package/storybook/v/0.0.0-pr-31399-sha-1bb3fc57) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-remove-essentials-addon-docs`](https://github.com/storybookjs/storybook/tree/valentin/fix-remove-essentials-addon-docs) |
| **Commit** | [`1bb3fc57`](https://github.com/storybookjs/storybook/commit/1bb3fc572ae332c7d29a352c2e636d70e1b5207b) |
| **Datetime** | Tue May  6 20:48:02 UTC 2025 (`1746564482`) |
| **Workflow run** | [14869429666](https://github.com/storybookjs/storybook/actions/runs/14869429666) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31399`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhanced the remove-essentials automigration to properly handle @storybook/addon-docs installation when it's configured but not present in dependencies.

- Modified `code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.ts` to check if addon-docs is actually installed before attempting installation
- Updated `code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.ts` to match Storybook's version when installing addon-docs
- Added test cases in `remove-essentials.test.ts` to verify correct dependency type (dev/prod) handling
- Enhanced test coverage for package manager mock functionality



<!-- /greptile_comment -->