### PR TITLE
Automigration: Correctly apply the wrap-require automigration in ESM modules

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/wrap-require-utils.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/wrap-require-utils.ts
@@ -13,7 +13,7 @@ const defaultRequireWrapperName = 'getAbsolutePath';
  * function <name>() {}
  * ```
  */
-function doesVariableOrFunctionDeclarationExist(node: t.Node, name: string) {
+export function doesVariableOrFunctionDeclarationExist(node: t.Node, name: string) {
   return (
     (t.isVariableDeclaration(node) &&
       node.declarations.length === 1 &&

--- a/code/lib/cli-storybook/src/automigrate/fixes/wrap-require.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/wrap-require.test.ts
@@ -119,7 +119,7 @@ describe('wrapRequire', () => {
     },
   };
   export default config;
-  const require = createRequire(import.meta, url);
+  const require = createRequire(import.meta.url);
 
   function getAbsolutePath(value) {
     return dirname(require.resolve(join(value, "package.json")));

--- a/code/lib/cli-storybook/src/automigrate/fixes/wrap-require.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/wrap-require.test.ts
@@ -100,7 +100,7 @@ describe('wrapRequire', () => {
 
       expect(call[1]).toMatchInlineSnapshot(`
   "import { createRequire } from "node:module";
-  import { dirname, join } from "path";
+  import { dirname, join } from "node:path";
   const config = {
     stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
     addons: [

--- a/code/lib/cli-storybook/src/automigrate/fixes/wrap-require.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/wrap-require.test.ts
@@ -99,7 +99,8 @@ describe('wrapRequire', () => {
       const call = writeFile.mock.calls[0];
 
       expect(call[1]).toMatchInlineSnapshot(`
-  "import { dirname, join } from "path";
+  "import { createRequire } from "node:module";
+  import { dirname, join } from "path";
   const config = {
     stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
     addons: [
@@ -118,6 +119,7 @@ describe('wrapRequire', () => {
     },
   };
   export default config;
+  const require = createRequire(import.meta, url);
 
   function getAbsolutePath(value) {
     return dirname(require.resolve(join(value, "package.json")));

--- a/code/lib/cli-storybook/src/automigrate/fixes/wrap-require.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/wrap-require.ts
@@ -90,10 +90,7 @@ export const wrapRequire: Fix<WrapRequireRunOptions> = {
               t.variableDeclaration('const', [
                 t.variableDeclarator(
                   t.identifier('require'),
-                  t.callExpression(t.identifier('createRequire'), [
-                    t.memberExpression(t.identifier('import'), t.identifier('meta')),
-                    t.identifier('url'),
-                  ])
+                  t.callExpression(t.identifier('createRequire'), [t.identifier('import.meta.url')])
                 ),
               ])
             );

--- a/code/lib/cli-storybook/src/automigrate/fixes/wrap-require.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/wrap-require.ts
@@ -75,9 +75,9 @@ export const wrapRequire: Fix<WrapRequireRunOptions> = {
           mainConfig?.fileName?.endsWith('.cjsx') ||
           mainConfig?.fileName?.endsWith('.ctsx')
         ) {
-          mainConfig.setRequireImport(['dirname', 'join'], 'path');
+          mainConfig.setRequireImport(['dirname', 'join'], 'node:path');
         } else {
-          mainConfig.setImport(['dirname', 'join'], 'path');
+          mainConfig.setImport(['dirname', 'join'], 'node:path');
           mainConfig.setImport(['createRequire'], 'node:module');
 
           // Continue here


### PR DESCRIPTION
Relates https://github.com/storybookjs/storybook/issues/31415

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The `wrap-require` automigration was applying a helper function to wrap addon and framework definitions so that they can be properly resolved in package managers with a strict dependency requirement.

The automigration was transforming a file like this:

```ts
const config = {
  stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
  addons: [
    {
      name: '@chromatic-com/storybook',
      options: {},
    },
    '@storybook/addon-vitest',
  ],
  framework: {
    name: '@storybook/angular',
    options: {},
  },
  docs: {
    autodocs: 'tag',
  },
};
export default config;
```

To this:

```ts
import { dirname, join } from "path";

const config = {
    stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
    addons: [
      {
        name: getAbsolutePath("@chromatic-com/storybook"),
        options: {},
      },
      getAbsolutePath("@storybook/addon-vitest"),
    ],
    framework: {
      name: getAbsolutePath("@storybook/angular"),
      options: {},
    },
    docs: {
      autodocs: 'tag',
    },
  };
export default config;

function getAbsolutePath(value) {
  return dirname(require.resolve(join(value, "package.json")));
}
```

In Node.js v24, though, `.storybook/main.ts` ESM module is tre ESM module and therefore CJS globals like `require` are not available. I have enhanced the automigration to add the following:

```diff
import { createRequire } from "node:module";
+ import { dirname, join } from "path";
const config = {
    stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
    addons: [
      {
        name: getAbsolutePath("@chromatic-com/storybook"),
        options: {},
      },
      getAbsolutePath("@storybook/addon-vitest"),
    ],
    framework: {
      name: getAbsolutePath("@storybook/angular"),
      options: {},
    },
    docs: {
      autodocs: 'tag',
    },
  };
export default config;
+ const require = createRequire(import.meta, url);

function getAbsolutePath(value) {
    return dirname(require.resolve(join(value, "package.json")));
}
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31420-sha-a3613a15`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31420-sha-a3613a15 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31420-sha-a3613a15 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31420-sha-a3613a15`](https://npmjs.com/package/storybook/v/0.0.0-pr-31420-sha-a3613a15) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/make-wrap-pnp-automigration-node-24-compatible`](https://github.com/storybookjs/storybook/tree/valentin/make-wrap-pnp-automigration-node-24-compatible) |
| **Commit** | [`a3613a15`](https://github.com/storybookjs/storybook/commit/a3613a15c6e36cb3ff32b812340cd0e00731a318) |
| **Datetime** | Thu May  8 09:53:53 UTC 2025 (`1746698033`) |
| **Workflow run** | [14903718880](https://github.com/storybookjs/storybook/actions/runs/14903718880) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31420`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided files and pull request information, I'll create a concise summary of the changes:

Updates the wrap-require automigration to properly handle ESM modules in Node.js v24 environments, particularly focusing on module resolution in strict dependency contexts.

- Fixed critical bug in `wrap-require.ts` where `import.meta.url` was incorrectly referenced as `import.meta, url`
- Added `createRequire` import from `node:module` for ESM compatibility in `.storybook/main.ts`
- Updated test snapshots in `wrap-require.test.ts` to verify ESM module handling
- Made `doesVariableOrFunctionDeclarationExist` exportable in `wrap-require-utils.ts` for better module checking



<!-- /greptile_comment -->