### PR TITLE
Addon A11y: Fix usage of axe-core in pnpm projects

### DIFF
--- a/code/addons/a11y/src/a11yRunner.ts
+++ b/code/addons/a11y/src/a11yRunner.ts
@@ -41,7 +41,11 @@ const runNext = async () => {
 };
 
 export const run = async (input: A11yParameters = DEFAULT_PARAMETERS, storyId: string) => {
-  const { default: axe } = await import('axe-core');
+  const axeCore = await import('axe-core');
+  // We do this workaround when Vite projects can't optimize deps in pnpm projects
+  // as axe-core is UMD and therefore won't resolve.
+  // In that case, we just use the global axe (which will be there as a side effect of UMD import).
+  const axe = axeCore?.default || (globalThis as any).axe;
 
   const { config = {}, options = {} } = input;
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31371

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31422-sha-de723d73`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31422-sha-de723d73 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31422-sha-de723d73 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31422-sha-de723d73`](https://npmjs.com/package/storybook/v/0.0.0-pr-31422-sha-de723d73) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/debug-a11y-issue`](https://github.com/storybookjs/storybook/tree/yann/debug-a11y-issue) |
| **Commit** | [`de723d73`](https://github.com/storybookjs/storybook/commit/de723d735963e977b8283720421c1112cf9bcba2) |
| **Datetime** | Thu May  8 12:32:44 UTC 2025 (`1746707564`) |
| **Workflow run** | [14906538433](https://github.com/storybookjs/storybook/actions/runs/14906538433) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31422`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Modified the a11y addon to fix axe-core initialization issues specifically in pnpm+Vite environments by implementing a more robust module resolution approach.

- Updated `code/addons/a11y/src/a11yRunner.ts` to handle UMD module resolution edge cases in pnpm projects
- Added fallback to global axe instance when direct import fails
- Improved compatibility with Vite bundler environments



<!-- /greptile_comment -->