### PR TITLE
Addon Docs: Fix `layout: centered` in conjunction with `inline: false`

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Canvas.stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/Canvas.stories.tsx
@@ -158,8 +158,8 @@ export const PropSource: Story = {
   },
 };
 
-export const PropInlineStory: Story = {
-  name: 'Prop story = { ..., inline: true }',
+export const PropIframeStory: Story = {
+  name: 'Prop story = { ..., inline: false }',
   args: {
     of: ButtonStories.Primary,
     story: { inline: false, height: '200px' },

--- a/code/addons/docs/src/blocks/blocks/Canvas.tsx
+++ b/code/addons/docs/src/blocks/blocks/Canvas.tsx
@@ -78,6 +78,7 @@ export const Canvas: FC<CanvasProps> = (props) => {
     props.additionalActions ?? story.parameters.docs?.canvas?.additionalActions;
   const sourceState = props.sourceState ?? story.parameters.docs?.canvas?.sourceState ?? 'hidden';
   const className = props.className ?? story.parameters.docs?.canvas?.className;
+  // By default, stories will be iframed, but most frameworks support inline rendering and override that in a docs entry file
   const inline = props.story?.inline ?? story.parameters?.docs?.story?.inline ?? false;
 
   return (

--- a/code/addons/docs/src/blocks/blocks/Canvas.tsx
+++ b/code/addons/docs/src/blocks/blocks/Canvas.tsx
@@ -78,6 +78,7 @@ export const Canvas: FC<CanvasProps> = (props) => {
     props.additionalActions ?? story.parameters.docs?.canvas?.additionalActions;
   const sourceState = props.sourceState ?? story.parameters.docs?.canvas?.sourceState ?? 'hidden';
   const className = props.className ?? story.parameters.docs?.canvas?.className;
+  const inline = props.story?.inline ?? story.parameters?.docs?.story?.inline ?? false;
 
   return (
     <PurePreview
@@ -87,6 +88,7 @@ export const Canvas: FC<CanvasProps> = (props) => {
       additionalActions={additionalActions}
       className={className}
       layout={layout}
+      inline={inline}
     >
       <Story of={of || story.moduleExport} meta={props.meta} {...props.story} />
     </PurePreview>

--- a/code/addons/docs/src/blocks/components/Preview.stories.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.stories.tsx
@@ -204,10 +204,24 @@ export const WithCenteredSingle = (
   <Preview inline withToolbar layout="centered">
     <Story
       inline
-      story={getPreparedStory(docsContext, ButtonStories.Primary)}
+      story={getPreparedStory(docsContext, ButtonStories.Centered)}
       renderStoryToElement={renderStoryToElement}
       autoplay={false}
       forceInitialArgs={false}
+      primary={false}
+      height="100px"
+    />
+  </Preview>
+);
+
+export const WithCenteredIframe = (
+  args: any,
+  { loaded: { docsContext } }: { loaded: { docsContext: DocsContextProps } }
+) => (
+  <Preview inline={false} withToolbar layout="centered">
+    <Story
+      inline={false}
+      story={getPreparedStory(docsContext, ButtonStories.Centered)}
       primary={false}
       height="100px"
     />
@@ -221,7 +235,7 @@ export const WithCenteredMulti = (
   <Preview inline withToolbar layout="centered">
     <Story
       inline
-      story={getPreparedStory(docsContext, ButtonStories.Primary)}
+      story={getPreparedStory(docsContext, ButtonStories.Centered)}
       renderStoryToElement={renderStoryToElement}
       autoplay={false}
       forceInitialArgs={false}
@@ -230,7 +244,7 @@ export const WithCenteredMulti = (
     />
     <Story
       inline
-      story={getPreparedStory(docsContext, ButtonStories.Primary)}
+      story={getPreparedStory(docsContext, ButtonStories.Centered)}
       renderStoryToElement={renderStoryToElement}
       autoplay={false}
       forceInitialArgs={false}

--- a/code/addons/docs/src/blocks/components/Preview.stories.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.stories.tsx
@@ -28,31 +28,31 @@ const getPreparedStory = (docsContext: DocsContextProps, moduleExport: ModuleExp
 export const Loading = () => <PreviewSkeleton />;
 
 export const CodeCollapsed = () => (
-  <Preview isExpanded={false} withSource={sourceStories.JSX.args}>
+  <Preview inline isExpanded={false} withSource={sourceStories.JSX.args}>
     <Button variant="outline">Button 1</Button>
   </Preview>
 );
 
 export const CodeExpanded = () => (
-  <Preview isExpanded withSource={sourceStories.JSX.args}>
+  <Preview inline isExpanded withSource={sourceStories.JSX.args}>
     <Button variant="outline">Button 1</Button>
   </Preview>
 );
 
 export const CodeError = () => (
-  <Preview isExpanded withSource={sourceStories.SourceUnavailable.args}>
+  <Preview inline isExpanded withSource={sourceStories.SourceUnavailable.args}>
     <Button variant="outline">Button 1</Button>
   </Preview>
 );
 
 export const Single = () => (
-  <Preview>
+  <Preview inline>
     <Button variant="outline">Button 1</Button>
   </Preview>
 );
 
 export const Row = () => (
-  <Preview>
+  <Preview inline>
     <Button variant="outline">Button 1</Button>
     <Button variant="outline">Button 2</Button>
     <Button variant="outline">Button 3</Button>
@@ -64,7 +64,7 @@ export const Row = () => (
 );
 
 export const Column = () => (
-  <Preview isColumn>
+  <Preview inline isColumn>
     <Button variant="outline">Button 1</Button>
     <Button variant="outline">Button 2</Button>
     <Button variant="outline">Button 3</Button>
@@ -72,7 +72,7 @@ export const Column = () => (
 );
 
 export const GridWith3Columns = () => (
-  <Preview columns={3}>
+  <Preview inline columns={3}>
     <Button variant="outline">Button 1</Button>
     <Button variant="outline">Button 2</Button>
     <Button variant="outline">Button 3</Button>
@@ -100,7 +100,7 @@ export const WithToolbar = (
   args: any,
   { loaded: { docsContext } }: { loaded: { docsContext: DocsContextProps } }
 ) => (
-  <Preview withToolbar>
+  <Preview inline withToolbar>
     <Story
       inline
       story={getPreparedStory(docsContext, ButtonStories.Primary)}
@@ -119,7 +119,7 @@ const Horizontal = styled((props: ComponentProps<typeof Spaced>) => <Spaced col=
 });
 
 export const Wide = () => (
-  <Preview withToolbar>
+  <Preview inline withToolbar>
     <Horizontal>
       <div>START</div>
       <div>middle</div>
@@ -132,7 +132,7 @@ export const WithToolbarMulti = (
   args: any,
   { loaded: { docsContext } }: { loaded: { docsContext: DocsContextProps } }
 ) => (
-  <Preview withToolbar>
+  <Preview inline withToolbar>
     <Story
       inline
       story={getPreparedStory(docsContext, ButtonStories.Primary)}
@@ -158,7 +158,7 @@ export const WithFullscreenSingle = (
   args: any,
   { loaded: { docsContext } }: { loaded: { docsContext: DocsContextProps } }
 ) => (
-  <Preview withToolbar layout="fullscreen">
+  <Preview inline withToolbar layout="fullscreen">
     <Story
       inline
       story={getPreparedStory(docsContext, ButtonStories.Primary)}
@@ -175,7 +175,7 @@ export const WithFullscreenMulti = (
   args: any,
   { loaded: { docsContext } }: { loaded: { docsContext: DocsContextProps } }
 ) => (
-  <Preview withToolbar layout="fullscreen">
+  <Preview inline withToolbar layout="fullscreen">
     <Story
       inline
       story={getPreparedStory(docsContext, ButtonStories.Primary)}
@@ -201,7 +201,7 @@ export const WithCenteredSingle = (
   args: any,
   { loaded: { docsContext } }: { loaded: { docsContext: DocsContextProps } }
 ) => (
-  <Preview withToolbar layout="centered">
+  <Preview inline withToolbar layout="centered">
     <Story
       inline
       story={getPreparedStory(docsContext, ButtonStories.Primary)}
@@ -218,7 +218,7 @@ export const WithCenteredMulti = (
   args: any,
   { loaded: { docsContext } }: { loaded: { docsContext: DocsContextProps } }
 ) => (
-  <Preview withToolbar layout="centered">
+  <Preview inline withToolbar layout="centered">
     <Story
       inline
       story={getPreparedStory(docsContext, ButtonStories.Primary)}
@@ -242,6 +242,7 @@ export const WithCenteredMulti = (
 
 export const WithAdditionalActions = () => (
   <Preview
+    inline
     additionalActions={[
       {
         title: 'Open on GitHub',

--- a/code/addons/docs/src/blocks/components/Preview.stories.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.stories.tsx
@@ -108,7 +108,7 @@ export const WithToolbar = (
       autoplay={false}
       forceInitialArgs={false}
       primary={false}
-      height="100px"
+      height="36px"
     />
   </Preview>
 );
@@ -140,7 +140,7 @@ export const WithToolbarMulti = (
       autoplay={false}
       forceInitialArgs={false}
       primary={false}
-      height="100px"
+      height="36px"
     />
     <Story
       inline
@@ -149,7 +149,7 @@ export const WithToolbarMulti = (
       autoplay={false}
       forceInitialArgs={false}
       primary={false}
-      height="100px"
+      height="36px"
     />
   </Preview>
 );
@@ -166,7 +166,7 @@ export const WithFullscreenSingle = (
       autoplay={false}
       forceInitialArgs={false}
       primary={false}
-      height="100px"
+      height="36px"
     />
   </Preview>
 );
@@ -183,7 +183,7 @@ export const WithFullscreenMulti = (
       autoplay={false}
       forceInitialArgs={false}
       primary={false}
-      height="100px"
+      height="36px"
     />
     <Story
       inline
@@ -192,7 +192,7 @@ export const WithFullscreenMulti = (
       autoplay={false}
       forceInitialArgs={false}
       primary={false}
-      height="100px"
+      height="36px"
     />
   </Preview>
 );
@@ -209,7 +209,7 @@ export const WithCenteredSingle = (
       autoplay={false}
       forceInitialArgs={false}
       primary={false}
-      height="100px"
+      height="36px"
     />
   </Preview>
 );
@@ -240,7 +240,7 @@ export const WithCenteredMulti = (
       autoplay={false}
       forceInitialArgs={false}
       primary={false}
-      height="100px"
+      height="36px"
     />
     <Story
       inline
@@ -249,7 +249,7 @@ export const WithCenteredMulti = (
       autoplay={false}
       forceInitialArgs={false}
       primary={false}
-      height="100px"
+      height="36px"
     />
   </Preview>
 );

--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -264,7 +264,7 @@ export const Preview: FC<PreviewProps> = ({
             layout={layout}
             inline={inline}
           >
-            <Zoom.Element scale={scale}>
+            <Zoom.Element scale={inline ? scale : 1}>
               {Array.isArray(children) ? (
                 children.map((child, i) => <div key={i}>{child}</div>)
               ) : (

--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -17,6 +17,7 @@ import { ZoomContext } from './ZoomContext';
 export type PreviewProps = PropsWithChildren<{
   isLoading?: true;
   layout?: Layout;
+  inline?: boolean;
   isColumn?: boolean;
   columns?: number;
   withSource?: SourceProps;
@@ -56,8 +57,8 @@ const ChildrenContainer = styled.div<PreviewProps & { layout: Layout }>(
           },
         }
       : {},
-  ({ layout = 'padded' }) =>
-    layout === 'centered'
+  ({ layout = 'padded', inline }) =>
+    layout === 'centered' && inline
       ? {
           display: 'flex',
           justifyContent: 'center',
@@ -188,6 +189,7 @@ export const Preview: FC<PreviewProps> = ({
   additionalActions,
   className,
   layout = 'padded',
+  inline = false,
   ...props
 }) => {
   const [expanded, setExpanded] = useState(isExpanded);
@@ -260,6 +262,7 @@ export const Preview: FC<PreviewProps> = ({
             isColumn={isColumn || !Array.isArray(children)}
             columns={columns}
             layout={layout}
+            inline={inline}
           >
             <Zoom.Element scale={scale}>
               {Array.isArray(children) ? (

--- a/code/addons/docs/src/blocks/components/Preview.tsx
+++ b/code/addons/docs/src/blocks/components/Preview.tsx
@@ -47,13 +47,13 @@ const ChildrenContainer = styled.div<PreviewProps & { layout: Layout }>(
           display: 'inline-block',
         },
   }),
-  ({ layout = 'padded' }) =>
+  ({ layout = 'padded', inline }) =>
     layout === 'centered' || layout === 'padded'
       ? {
-          padding: '30px 20px',
+          padding: inline ? '32px 22px' : '0px',
           '& .innerZoomElementWrapper > *': {
             width: 'auto',
-            border: '10px solid transparent!important',
+            border: '8px solid transparent!important',
           },
         }
       : {},
@@ -264,7 +264,7 @@ export const Preview: FC<PreviewProps> = ({
             layout={layout}
             inline={inline}
           >
-            <Zoom.Element scale={inline ? scale : 1}>
+            <Zoom.Element centered={layout === 'centered'} scale={inline ? scale : 1}>
               {Array.isArray(children) ? (
                 children.map((child, i) => <div key={i}>{child}</div>)
               ) : (

--- a/code/addons/docs/src/blocks/examples/Button.stories.tsx
+++ b/code/addons/docs/src/blocks/examples/Button.stories.tsx
@@ -140,3 +140,13 @@ export const ErrorStory: Story = {
   },
   tags: ['!test', '!vitest'],
 };
+
+export const Centered: Story = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+  parameters: {
+    layout: 'centered',
+  },
+};

--- a/code/core/src/components/components/Zoom/ZoomElement.tsx
+++ b/code/core/src/components/components/Zoom/ZoomElement.tsx
@@ -7,7 +7,6 @@ import useResizeObserver from 'use-resize-observer';
 
 const ZoomElementWrapper = styled.div<{ scale: number; elementHeight: number }>(
   ({ scale = 1, elementHeight }) => ({
-    width: '100%',
     height: elementHeight || 'auto',
     transformOrigin: 'top left',
     transform: `scale(${1 / scale})`,

--- a/code/core/src/components/components/Zoom/ZoomElement.tsx
+++ b/code/core/src/components/components/Zoom/ZoomElement.tsx
@@ -5,20 +5,21 @@ import { styled } from 'storybook/theming';
 import type { ResizeHandler } from 'use-resize-observer';
 import useResizeObserver from 'use-resize-observer';
 
-const ZoomElementWrapper = styled.div<{ scale: number; elementHeight: number }>(
-  ({ scale = 1, elementHeight }) => ({
+const ZoomElementWrapper = styled.div<{ centered?: boolean; scale: number; elementHeight: number }>(
+  ({ centered = false, scale = 1, elementHeight }) => ({
     height: elementHeight || 'auto',
-    transformOrigin: 'top left',
+    transformOrigin: centered ? 'center top' : 'left top',
     transform: `scale(${1 / scale})`,
   })
 );
 
 type ZoomProps = {
+  centered?: boolean;
   scale: number;
   children: ReactElement | ReactElement[];
 };
 
-export function ZoomElement({ scale, children }: ZoomProps) {
+export function ZoomElement({ centered, scale, children }: ZoomProps) {
   const componentWrapperRef = useRef<HTMLDivElement>(null);
   const [elementHeight, setElementHeight] = useState(0);
 
@@ -43,7 +44,7 @@ export function ZoomElement({ scale, children }: ZoomProps) {
   });
 
   return (
-    <ZoomElementWrapper scale={scale} elementHeight={elementHeight}>
+    <ZoomElementWrapper centered={centered} scale={scale} elementHeight={elementHeight}>
       <div ref={componentWrapperRef} className="innerZoomElementWrapper">
         {children}
       </div>


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Rather than forcing 100% width on the zoom wrapper, don't apply centering logic to non-inline stories.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31430-sha-71f19c2a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31430-sha-71f19c2a sandbox` or in an existing project with `npx storybook@0.0.0-pr-31430-sha-71f19c2a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31430-sha-71f19c2a`](https://npmjs.com/package/storybook/v/0.0.0-pr-31430-sha-71f19c2a) |
| **Triggered by** | @ghengeveld |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`fix-docs-preview-iframe-centered-layout`](https://github.com/storybookjs/storybook/tree/fix-docs-preview-iframe-centered-layout) |
| **Commit** | [`71f19c2a`](https://github.com/storybookjs/storybook/commit/71f19c2ad5d25940efd5e979339b8ab094878bc6) |
| **Datetime** | Fri May  9 09:14:09 UTC 2025 (`1746782049`) |
| **Workflow run** | [14925613499](https://github.com/storybookjs/storybook/actions/runs/14925613499) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31430`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR modifies the Preview component to improve layout handling for centered stories, specifically addressing how centering is applied based on the inline property.

- Modified `ChildrenContainer` in `Preview.tsx` to only apply centering styles when both `layout === 'centered'` and `inline` is true
- Removed fixed `width: '100%'` style from `ZoomElementWrapper` in `ZoomElement.tsx` to improve width calculations
- Added `inline` prop support in `Canvas.tsx` with default value of false, controlling story rendering behavior
- Updated type definitions to properly handle the new inline property configuration



<!-- /greptile_comment -->