### PR TITLE
Addon-vitest: Support paths with spaces

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -24,7 +24,6 @@ import picocolors from 'picocolors';
 import sirv from 'sirv';
 import { convertPathToPattern } from 'tinyglobby';
 import { dedent } from 'ts-dedent';
-import type { PluginOption } from 'vite';
 
 // ! Relative import to prebundle it without needing to depend on the Vite builder
 import { withoutVitePlugins } from '../../../../builders/builder-vite/src/utils/without-vite-plugins';

--- a/code/addons/vitest/src/vitest-plugin/test-utils.ts
+++ b/code/addons/vitest/src/vitest-plugin/test-utils.ts
@@ -20,6 +20,21 @@ declare module '@vitest/browser/context' {
 
 const { getInitialGlobals } = server.commands;
 
+/**
+ * Converts a file URL to a file path, handling URL encoding
+ *
+ * @param url The file URL to convert (e.g. file:///path/to/file.js)
+ * @returns The decoded file path
+ */
+export const convertToFilePath = (url: string): string => {
+  // Remove the file:// protocol
+  const path = url.replace(/^file:\/\//, '');
+  // Handle Windows paths
+  const normalizedPath = path.replace(/^\/+([a-zA-Z]:)/, '$1');
+  // Convert %20 to spaces
+  return normalizedPath.replace(/%20/g, ' ');
+};
+
 export const testStory = (
   exportName: string,
   story: ComposedStoryFn,

--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -74,14 +74,14 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const _meta = {
             component: Button,
             title: "automatic/calculated/title"
           };
           export default _meta;
           export const Story = {};
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Story", _testStory("Story", Story, _meta, []));
           }
@@ -103,14 +103,14 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const _meta = {
             title: "automatic/calculated/title",
             component: Button
           };
           export default _meta;
           export const Story = {};
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Story", _testStory("Story", Story, _meta, []));
           }
@@ -133,14 +133,14 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const meta = {
             component: Button,
             title: "automatic/calculated/title"
           };
           export default meta;
           export const Story = {};
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Story", _testStory("Story", Story, meta, []));
           }
@@ -164,14 +164,14 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const meta = {
             title: "automatic/calculated/title",
             component: Button
           };
           export default meta;
           export const Story = {};
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Story", _testStory("Story", Story, meta, []));
           }
@@ -196,7 +196,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const _meta = {
             component: Button,
             title: "automatic/calculated/title"
@@ -207,7 +207,7 @@ describe('transformer', () => {
               label: 'Primary Button'
             }
           };
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Primary", _testStory("Primary", Primary, _meta, []));
           }
@@ -223,7 +223,7 @@ describe('transformer', () => {
 
           expect(result.code).toMatchInlineSnapshot(`
             import { test as _test, expect as _expect } from "vitest";
-            import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+            import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
             const _meta = {
               component: Button,
               title: "automatic/calculated/title"
@@ -232,7 +232,7 @@ describe('transformer', () => {
             export const Primary = {
               name: "custom name"
             };
-            const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+            const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
             if (_isRunningFromThisFile) {
               _test("custom name", _testStory("Primary", Primary, _meta, []));
             }
@@ -247,7 +247,7 @@ describe('transformer', () => {
           const result = await transform({ code: code });
           expect(result.code).toMatchInlineSnapshot(`
             import { test as _test, expect as _expect } from "vitest";
-            import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+            import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
             const _meta = {
               component: Button,
               title: "automatic/calculated/title"
@@ -255,7 +255,7 @@ describe('transformer', () => {
             export default _meta;
             export const Story = () => {};
             Story.storyName = 'custom name';
-            const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+            const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
             if (_isRunningFromThisFile) {
               _test("custom name", _testStory("Story", Story, _meta, []));
             }
@@ -279,7 +279,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const _meta = {
             title: "automatic/calculated/title"
           };
@@ -290,7 +290,7 @@ describe('transformer', () => {
             }
           };
           export { Primary };
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Primary", _testStory("Primary", Primary, _meta, []));
           }
@@ -313,7 +313,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const _meta = {
             title: "automatic/calculated/title"
           };
@@ -324,7 +324,7 @@ describe('transformer', () => {
             }
           };
           export { Primary as PrimaryStory };
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("PrimaryStory", _testStory("PrimaryStory", Primary, _meta, []));
           }
@@ -348,7 +348,7 @@ describe('transformer', () => {
         const result = await transform({ code });
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const _meta = {
             title: "automatic/calculated/title"
           };
@@ -360,7 +360,7 @@ describe('transformer', () => {
           };
           export const Secondary = {};
           export { Primary };
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Secondary", _testStory("Secondary", Secondary, _meta, []));
             _test("Primary", _testStory("Primary", Primary, _meta, []));
@@ -383,7 +383,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const _meta = {
             title: "automatic/calculated/title",
             component: Button,
@@ -392,7 +392,7 @@ describe('transformer', () => {
           export default _meta;
           export const Story = {};
           export const nonStory = 123;
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Story", _testStory("Story", Story, _meta, []));
           }
@@ -440,7 +440,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const _meta = {
             title: "automatic/calculated/title"
           };
@@ -449,7 +449,7 @@ describe('transformer', () => {
             tags: ['include-me']
           };
           export const NotIncluded = {};
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Included", _testStory("Included", Included, _meta, []));
           }
@@ -471,7 +471,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const _meta = {
             title: "automatic/calculated/title"
           };
@@ -480,7 +480,7 @@ describe('transformer', () => {
           export const NotIncluded = {
             tags: ['exclude-me']
           };
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Included", _testStory("Included", Included, _meta, []));
           }
@@ -500,7 +500,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const _meta = {
             title: "automatic/calculated/title"
           };
@@ -508,7 +508,7 @@ describe('transformer', () => {
           export const Skipped = {
             tags: ['skip-me']
           };
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Skipped", _testStory("Skipped", Skipped, _meta, ["skip-me"]));
           }
@@ -533,14 +533,14 @@ describe('transformer', () => {
 
         expect(transformedCode).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           const meta = {
             title: "automatic/calculated/title",
             component: Button
           };
           export default meta;
           export const Primary = {};
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Primary", _testStory("Primary", Primary, meta, []));
           }
@@ -590,14 +590,14 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           import { config } from '#.storybook/preview';
           const meta = config.meta({
             component: Button,
             title: "automatic/calculated/title"
           });
           export const Story = meta.story({});
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Story", _testStory("Story", Story, meta, []));
           }
@@ -615,7 +615,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           import { config } from '#.storybook/preview';
           const meta = config.meta({
             component: Button,
@@ -624,7 +624,7 @@ describe('transformer', () => {
           export const Primary = meta.story({
             name: "custom name"
           });
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("custom name", _testStory("Primary", Primary, meta, []));
           }
@@ -648,7 +648,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           import { config } from '#.storybook/preview';
           const meta = config.meta({
             component: Button,
@@ -660,7 +660,7 @@ describe('transformer', () => {
             }
           });
           export { Primary };
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Primary", _testStory("Primary", Primary, meta, []));
           }
@@ -684,7 +684,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           import { config } from '#.storybook/preview';
           const meta = config.meta({
             component: Button,
@@ -696,7 +696,7 @@ describe('transformer', () => {
             }
           });
           export { Primary as PrimaryStory };
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("PrimaryStory", _testStory("PrimaryStory", Primary, meta, []));
           }
@@ -719,25 +719,25 @@ describe('transformer', () => {
 
         const result = await transform({ code });
         expect(result.code).toMatchInlineSnapshot(`
-        import { test as _test, expect as _expect } from "vitest";
-        import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
-        const _meta = {
-          title: "automatic/calculated/title"
-        };
-        export default _meta;
-        const Primary = {
-          args: {
-            label: 'Primary Button'
+          import { test as _test, expect as _expect } from "vitest";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          const _meta = {
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          const Primary = {
+            args: {
+              label: 'Primary Button'
+            }
+          };
+          export const Secondary = {};
+          export { Primary };
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            _test("Secondary", _testStory("Secondary", Secondary, _meta, []));
+            _test("Primary", _testStory("Primary", Primary, _meta, []));
           }
-        };
-        export const Secondary = {};
-        export { Primary };
-        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
-        if (_isRunningFromThisFile) {
-          _test("Secondary", _testStory("Secondary", Secondary, _meta, []));
-          _test("Primary", _testStory("Primary", Primary, _meta, []));
-        }
-      `);
+        `);
       });
 
       it('should exclude exports via excludeStories', async () => {
@@ -754,21 +754,21 @@ describe('transformer', () => {
         const result = await transform({ code });
 
         expect(result.code).toMatchInlineSnapshot(`
-        import { test as _test, expect as _expect } from "vitest";
-        import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
-        const _meta = {
-          title: "automatic/calculated/title",
-          component: Button,
-          excludeStories: ['nonStory']
-        };
-        export default _meta;
-        export const Story = {};
-        export const nonStory = 123;
-        const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
-        if (_isRunningFromThisFile) {
-          _test("Story", _testStory("Story", Story, _meta, []));
-        }
-      `);
+          import { test as _test, expect as _expect } from "vitest";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          const _meta = {
+            title: "automatic/calculated/title",
+            component: Button,
+            excludeStories: ['nonStory']
+          };
+          export default _meta;
+          export const Story = {};
+          export const nonStory = 123;
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            _test("Story", _testStory("Story", Story, _meta, []));
+          }
+        `);
       });
 
       it('should return a describe with skip if there are no valid stories', async () => {
@@ -813,7 +813,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           import { config } from '#.storybook/preview';
           const meta = config.meta({
             title: "automatic/calculated/title"
@@ -822,7 +822,7 @@ describe('transformer', () => {
             tags: ['include-me']
           });
           export const NotIncluded = meta.story({});
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Included", _testStory("Included", Included, meta, []));
           }
@@ -845,7 +845,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           import { config } from '#.storybook/preview';
           const meta = config.meta({
             title: "automatic/calculated/title"
@@ -854,7 +854,7 @@ describe('transformer', () => {
           export const NotIncluded = meta.story({
             tags: ['exclude-me']
           });
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Included", _testStory("Included", Included, meta, []));
           }
@@ -875,7 +875,7 @@ describe('transformer', () => {
 
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           import { config } from '#.storybook/preview';
           const meta = config.meta({
             title: "automatic/calculated/title"
@@ -883,7 +883,7 @@ describe('transformer', () => {
           export const Skipped = meta.story({
             tags: ['skip-me']
           });
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Skipped", _testStory("Skipped", Skipped, meta, ["skip-me"]));
           }
@@ -905,13 +905,13 @@ describe('transformer', () => {
 
         expect(transformedCode).toMatchInlineSnapshot(`
           import { test as _test, expect as _expect } from "vitest";
-          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
           import { config } from '#.storybook/preview';
           const meta = config.meta({
             title: "automatic/calculated/title"
           });
           export const Primary = meta.story({});
-          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Primary", _testStory("Primary", Primary, meta, []));
           }

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -179,13 +179,15 @@ export async function vitestTransform({
         testPathProperty
       );
 
-      // Create the final expression: import.meta.url.includes(...)
+      // Create the final expression: convertToFilePath(import.meta.url).includes(...)
       const includesCall = t.callExpression(
         t.memberExpression(
-          t.memberExpression(
-            t.memberExpression(t.identifier('import'), t.identifier('meta')),
-            t.identifier('url')
-          ),
+          t.callExpression(t.identifier('convertToFilePath'), [
+            t.memberExpression(
+              t.memberExpression(t.identifier('import'), t.identifier('meta')),
+              t.identifier('url')
+            ),
+          ]),
           t.identifier('includes')
         ),
         [nullishCoalescingExpression]
@@ -264,7 +266,10 @@ export async function vitestTransform({
         t.stringLiteral('vitest')
       ),
       t.importDeclaration(
-        [t.importSpecifier(testStoryId, t.identifier('testStory'))],
+        [
+          t.importSpecifier(testStoryId, t.identifier('testStory')),
+          t.importSpecifier(t.identifier('convertToFilePath'), t.identifier('convertToFilePath')),
+        ],
         t.stringLiteral('@storybook/addon-vitest/internal/test-utils')
       ),
     ];


### PR DESCRIPTION
Closes #29572

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This pull request introduces a utility function to handle file URL conversions and integrates it across multiple test cases to improve code clarity and maintainability. Below are the most important changes grouped by theme:

### New Utility Function:
* Added `convertToFilePath` to `code/addons/vitest/src/vitest-plugin/test-utils.ts`. This function converts file URLs to file paths, handling URL encoding and Windows-specific path normalization.

### Refactoring Test Cases:
* Updated various test cases in `code/core/src/csf-tools/vitest-plugin/transformer.test.ts` to use `convertToFilePath` for determining if a test is running from the current file. This replaces direct usage of `import.meta.url.includes` with the new utility function for improved readability and consistency. [[1]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL77-R84) [[2]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL106-R113) [[3]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL136-R143) [[4]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL167-R174) [[5]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL199-R199) [[6]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL210-R210) [[7]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL226-R226) [[8]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL235-R235) [[9]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL250-R258) [[10]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL282-R282) [[11]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL293-R293) [[12]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL316-R316) [[13]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL327-R327) [[14]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL351-R351) [[15]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL363-R363) [[16]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL386-R386) [[17]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL395-R395) [[18]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL443-R443) [[19]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL452-R452) [[20]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL474-R474) [[21]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL483-R483) [[22]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL503-R511) [[23]](diffhunk://#diff-d8310f728402b4c56054fbaae851ac76e1bc8be63e0b61459ca8af176314523bL536-R543)

### Code Cleanup:
* Removed an unused `PluginOption` type import from `code/addons/vitest/src/vitest-plugin/index.ts` to streamline the code.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added a new `convertToFilePath` utility function to handle paths with spaces in the Vitest addon, fixing test failures when project paths contain spaces.

- Added `convertToFilePath` in `code/addons/vitest/src/vitest-plugin/test-utils.ts` to properly decode URL-encoded paths
- Updated path handling in `code/core/src/csf-tools/vitest-plugin/transformer.ts` to use `convertToFilePath` for file path checks
- Modified test snapshots in `transformer.test.ts` to validate new path conversion functionality
- Fixed Windows path handling by properly normalizing file:// protocol paths



<!-- /greptile_comment -->