### PR TITLE
Hooks: Stabilize experimental afterEach hook

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -24,6 +24,7 @@
     - [Story Store API Changes](#story-store-api-changes)
     - [Global State Management](#global-state-management)
     - [Experimental Status API has turned into a Status Store](#experimental-status-api-has-turned-into-a-status-store)
+    - [`experimental_afterEach` has been stabilized](#experimental_aftereach-has-been-stabilized)
     - [Testing Module Changes](#testing-module-changes)
     - [Consolidate `@storybook/blocks` into addon docs](#consolidate-storybookblocks-into-addon-docs)
   - [Configuration and Type Changes](#configuration-and-type-changes)
@@ -860,6 +861,21 @@ addons.register(MY_ADDON_ID, (api) => {
 +    title: 'Component tests',
 +    description: 'Works!',
 +  }]);
+```
+
+#### `experimental_afterEach` has been stabilized
+
+The experimental_afterEach hook has been promoted to a stable API and renamed to afterEach.
+
+To migrate, simply replace all instances of experimental_afterEach with afterEach in your stories, preview files, and configuration.
+
+```diff
+ export const MyStory = {
+-   experimental_afterEach: async ({ canvasElement }) => {
++   afterEach: async ({ canvasElement }) => {
+     // cleanup logic
+   },
+ };
 ```
 
 #### Testing Module Changes

--- a/code/addons/a11y/src/preview.test.tsx
+++ b/code/addons/a11y/src/preview.test.tsx
@@ -4,8 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StoryContext } from 'storybook/internal/csf';
 
 import { run } from './a11yRunner';
-import { withLinkPaths } from './a11yRunnerUtils';
-import { experimental_afterEach } from './preview';
+import { afterEach } from './preview';
 import { getIsVitestRunning, getIsVitestStandaloneRun } from './utils';
 
 const mocks = vi.hoisted(() => {
@@ -107,7 +106,7 @@ describe('afterEach', () => {
 
     mockedRun.mockResolvedValue(result as any);
 
-    await expect(() => experimental_afterEach(context)).rejects.toThrow();
+    await expect(() => afterEach(context)).rejects.toThrow();
 
     expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y, context.id);
 
@@ -128,7 +127,7 @@ describe('afterEach', () => {
     mockedRun.mockResolvedValue(result as any);
     mocks.getIsVitestStandaloneRun.mockReturnValue(false);
 
-    await experimental_afterEach(context);
+    await afterEach(context);
 
     expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y, context.id);
 
@@ -155,7 +154,7 @@ describe('afterEach', () => {
     mockedRun.mockResolvedValue(result as any);
     mocks.getIsVitestStandaloneRun.mockReturnValue(false);
 
-    await experimental_afterEach(context);
+    await afterEach(context);
 
     expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y, context.id);
 
@@ -174,7 +173,7 @@ describe('afterEach', () => {
     };
     mockedRun.mockResolvedValue(result as any);
 
-    await experimental_afterEach(context);
+    await afterEach(context);
 
     expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y, context.id);
     expect(context.reporting.addReport).toHaveBeenCalledWith({
@@ -194,7 +193,7 @@ describe('afterEach', () => {
       },
     });
 
-    await experimental_afterEach(context);
+    await afterEach(context);
 
     expect(mockedRun).not.toHaveBeenCalled();
     expect(context.reporting.addReport).not.toHaveBeenCalled();
@@ -209,7 +208,7 @@ describe('afterEach', () => {
       },
     });
 
-    await experimental_afterEach(context);
+    await afterEach(context);
 
     expect(mockedRun).not.toHaveBeenCalled();
     expect(context.reporting.addReport).not.toHaveBeenCalled();
@@ -224,7 +223,7 @@ describe('afterEach', () => {
       },
     });
 
-    await experimental_afterEach(context);
+    await afterEach(context);
 
     expect(mockedRun).not.toHaveBeenCalled();
     expect(context.reporting.addReport).not.toHaveBeenCalled();
@@ -235,7 +234,7 @@ describe('afterEach', () => {
     const error = new Error('Test error');
     mockedRun.mockRejectedValue(error);
 
-    await expect(() => experimental_afterEach(context)).rejects.toThrow();
+    await expect(() => afterEach(context)).rejects.toThrow();
 
     expect(mockedRun).toHaveBeenCalledWith(context.parameters.a11y, context.id);
     expect(context.reporting.addReport).toHaveBeenCalledWith({
@@ -253,7 +252,7 @@ describe('afterEach', () => {
       viewMode: 'docs',
     });
 
-    await experimental_afterEach(context);
+    await afterEach(context);
 
     expect(mockedRun).not.toHaveBeenCalled();
     expect(context.reporting.addReport).not.toHaveBeenCalled();

--- a/code/addons/a11y/src/preview.tsx
+++ b/code/addons/a11y/src/preview.tsx
@@ -8,7 +8,7 @@ import { getIsVitestStandaloneRun } from './utils';
 
 let vitestMatchersExtended = false;
 
-export const experimental_afterEach: AfterEach<any> = async ({
+export const afterEach: AfterEach<any> = async ({
   id: storyId,
   reporting,
   parameters,

--- a/code/core/src/components/components/Checkbox/Checkbox.stories.tsx
+++ b/code/core/src/components/components/Checkbox/Checkbox.stories.tsx
@@ -31,7 +31,7 @@ export const All: Story = {
       <small>(native)</small>
     </div>
   ),
-  experimental_afterEach: async ({ canvasElement }) => {
+  afterEach: async ({ canvasElement }) => {
     canvasElement.querySelectorAll<HTMLInputElement>('[data-indeterminate]').forEach((checkbox) => {
       checkbox.indeterminate = true;
     });
@@ -52,7 +52,7 @@ export const Checked: Story = {
 };
 
 export const Indeterminate: Story = {
-  experimental_afterEach: async ({ canvasElement }) => {
+  afterEach: async ({ canvasElement }) => {
     canvasElement.getElementsByTagName('input')[0].indeterminate = true;
   },
 };
@@ -74,7 +74,7 @@ export const DisabledIndeterminate: Story = {
   args: {
     disabled: true,
   },
-  experimental_afterEach: async ({ canvasElement }) => {
+  afterEach: async ({ canvasElement }) => {
     canvasElement.getElementsByTagName('input')[0].indeterminate = true;
   },
 };

--- a/code/core/src/csf/story.test.ts
+++ b/code/core/src/csf/story.test.ts
@@ -58,7 +58,7 @@ const simple: XMeta = {
     await doSomething();
     return cleanup;
   },
-  async experimental_afterEach() {
+  async afterEach() {
     await validateSomething();
   },
   args: { x: '1' },
@@ -77,7 +77,7 @@ const strict: XMeta<ButtonArgs> = {
     await doSomething();
     return cleanup;
   },
-  async experimental_afterEach() {
+  async afterEach() {
     await validateSomething();
   },
   argTypes: { x: { type: { name: 'string' } } },

--- a/code/core/src/csf/story.ts
+++ b/code/core/src/csf/story.ts
@@ -370,7 +370,7 @@ export interface BaseAnnotations<TRenderer extends Renderer = Renderer, TArgs = 
    * `afterEach` can be added to preview, the default export and to a specific story. They are run
    * (and awaited) reverse order: preview, default export, story
    */
-  experimental_afterEach?: AfterEach<TRenderer, TArgs>[] | AfterEach<TRenderer, TArgs>;
+  afterEach?: AfterEach<TRenderer, TArgs>[] | AfterEach<TRenderer, TArgs>;
 
   /**
    * Define a custom render function for the story(ies). If not passed, a default render function by

--- a/code/core/src/preview-api/modules/store/csf/composeConfigs.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/composeConfigs.test.ts
@@ -24,7 +24,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
-      experimental_afterEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -52,7 +52,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
-      experimental_afterEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -84,7 +84,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
-      experimental_afterEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -122,7 +122,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
-      experimental_afterEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -163,7 +163,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
-      experimental_afterEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -195,7 +195,7 @@ describe('composeConfigs', () => {
       loaders: ['1', '2', '3', '4'],
       beforeAll: expect.any(Function),
       beforeEach: [],
-      experimental_afterEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -227,7 +227,7 @@ describe('composeConfigs', () => {
       loaders: ['1', '2', '3'],
       beforeAll: expect.any(Function),
       beforeEach: [],
-      experimental_afterEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -255,7 +255,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
-      experimental_afterEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -284,7 +284,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
-      experimental_afterEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -316,7 +316,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
-      experimental_afterEach: [],
+      afterEach: [],
       render: 'render-2',
       renderToCanvas: 'renderToCanvas-2',
       applyDecorators: 'applyDecorators-2',

--- a/code/core/src/preview-api/modules/store/csf/composeConfigs.ts
+++ b/code/core/src/preview-api/modules/store/csf/composeConfigs.ts
@@ -64,7 +64,7 @@ export function composeConfigs<TRenderer extends Renderer>(
     loaders: getArrayField(moduleExportList, 'loaders'),
     beforeAll: composeBeforeAllHooks(beforeAllHooks),
     beforeEach: getArrayField(moduleExportList, 'beforeEach'),
-    experimental_afterEach: getArrayField(moduleExportList, 'experimental_afterEach'),
+    afterEach: getArrayField(moduleExportList, 'afterEach'),
     render: getSingletonField(moduleExportList, 'render'),
     renderToCanvas: getSingletonField(moduleExportList, 'renderToCanvas'),
     applyDecorators: getSingletonField(moduleExportList, 'applyDecorators'),

--- a/code/core/src/preview-api/modules/store/csf/normalizeProjectAnnotations.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeProjectAnnotations.ts
@@ -21,7 +21,7 @@ export function normalizeProjectAnnotations<TRenderer extends Renderer>({
   decorators,
   loaders,
   beforeEach,
-  experimental_afterEach,
+  afterEach,
   initialGlobals,
   ...annotations
 }: ProjectAnnotations<TRenderer>): NormalizedProjectAnnotations<TRenderer> {
@@ -31,7 +31,7 @@ export function normalizeProjectAnnotations<TRenderer extends Renderer>({
     decorators: normalizeArrays(decorators),
     loaders: normalizeArrays(loaders),
     beforeEach: normalizeArrays(beforeEach),
-    experimental_afterEach: normalizeArrays(experimental_afterEach),
+    afterEach: normalizeArrays(afterEach),
     argTypesEnhancers: [
       ...(argTypesEnhancers || []),
       inferArgTypes,

--- a/code/core/src/preview-api/modules/store/csf/normalizeStory.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeStory.test.ts
@@ -56,7 +56,7 @@ describe('normalizeStory', () => {
           "args": {},
           "beforeEach": [],
           "decorators": [],
-          "experimental_afterEach": [],
+          "afterEach": [],
           "globals": {},
           "id": "title--story-export",
           "loaders": [],
@@ -128,7 +128,7 @@ describe('normalizeStory', () => {
             "args": {},
             "beforeEach": [],
             "decorators": [],
-            "experimental_afterEach": [],
+            "afterEach": [],
             "globals": {},
             "id": "title--story-export",
             "loaders": [],
@@ -169,7 +169,7 @@ describe('normalizeStory', () => {
             "decorators": [
               [Function],
             ],
-            "experimental_afterEach": [],
+            "afterEach": [],
             "globals": {},
             "id": "title--story-export",
             "loaders": [
@@ -228,7 +228,7 @@ describe('normalizeStory', () => {
               [Function],
               [Function],
             ],
-            "experimental_afterEach": [],
+            "afterEach": [],
             "globals": {},
             "id": "title--story-export",
             "loaders": [

--- a/code/core/src/preview-api/modules/store/csf/normalizeStory.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeStory.test.ts
@@ -52,11 +52,11 @@ describe('normalizeStory', () => {
       const meta = { id: 'title', title: 'title' };
       expect(normalizeStory('storyExport', storyFn, meta)).toMatchInlineSnapshot(`
         {
+          "afterEach": [],
           "argTypes": {},
           "args": {},
           "beforeEach": [],
           "decorators": [],
-          "afterEach": [],
           "globals": {},
           "id": "title--story-export",
           "loaders": [],
@@ -124,11 +124,11 @@ describe('normalizeStory', () => {
         const normalized = normalizeStory('storyExport', storyObj, meta);
         expect(normalized).toMatchInlineSnapshot(`
           {
+            "afterEach": [],
             "argTypes": {},
             "args": {},
             "beforeEach": [],
             "decorators": [],
-            "afterEach": [],
             "globals": {},
             "id": "title--story-export",
             "loaders": [],
@@ -154,6 +154,7 @@ describe('normalizeStory', () => {
         const { moduleExport, ...normalized } = normalizeStory('storyExport', storyObj, meta);
         expect(normalized).toMatchInlineSnapshot(`
           {
+            "afterEach": [],
             "argTypes": {
               "storyArgType": {
                 "name": "storyArgType",
@@ -169,7 +170,6 @@ describe('normalizeStory', () => {
             "decorators": [
               [Function],
             ],
-            "afterEach": [],
             "globals": {},
             "id": "title--story-export",
             "loaders": [
@@ -205,6 +205,7 @@ describe('normalizeStory', () => {
         const { moduleExport, ...normalized } = normalizeStory('storyExport', storyObj, meta);
         expect(normalized).toMatchInlineSnapshot(`
           {
+            "afterEach": [],
             "argTypes": {
               "storyArgType": {
                 "name": "storyArgType",
@@ -228,7 +229,6 @@ describe('normalizeStory', () => {
               [Function],
               [Function],
             ],
-            "afterEach": [],
             "globals": {},
             "id": "title--story-export",
             "loaders": [

--- a/code/core/src/preview-api/modules/store/csf/normalizeStory.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeStory.ts
@@ -58,9 +58,9 @@ export function normalizeStory<TRenderer extends Renderer>(
     ...normalizeArrays(story?.beforeEach),
   ];
 
-  const experimental_afterEach = [
-    ...normalizeArrays(storyObject.experimental_afterEach),
-    ...normalizeArrays(story?.experimental_afterEach),
+  const afterEach = [
+    ...normalizeArrays(storyObject.afterEach),
+    ...normalizeArrays(story?.afterEach),
   ];
   const { render, play, tags = [], globals = {} } = storyObject;
 
@@ -76,7 +76,7 @@ export function normalizeStory<TRenderer extends Renderer>(
     argTypes: normalizeInputTypes(argTypes),
     loaders,
     beforeEach,
-    experimental_afterEach,
+    afterEach,
     globals,
     ...(render && { render }),
     ...(userStoryFn && { userStoryFn }),

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.ts
@@ -88,9 +88,9 @@ export function prepareStory<TRenderer extends Renderer>(
 
   const applyAfterEach = async (context: StoryContext<TRenderer>): Promise<void> => {
     const reversedFinalizers = [
-      ...normalizeArrays(projectAnnotations.experimental_afterEach),
-      ...normalizeArrays(componentAnnotations.experimental_afterEach),
-      ...normalizeArrays(storyAnnotations.experimental_afterEach),
+      ...normalizeArrays(projectAnnotations.afterEach),
+      ...normalizeArrays(componentAnnotations.afterEach),
+      ...normalizeArrays(storyAnnotations.afterEach),
     ].reverse();
     for (const finalizer of reversedFinalizers) {
       if (context.abortSignal.aborted) {

--- a/code/core/template/stories/order-of-hooks.stories.ts
+++ b/code/core/template/stories/order-of-hooks.stories.ts
@@ -9,7 +9,7 @@ const meta = {
   beforeEach() {
     console.log('2 - [from meta beforeEach]');
   },
-  async experimental_afterEach() {
+  async afterEach() {
     console.log('9 - [from meta afterEach]');
 
     await expect(mocked(console.log).mock.calls).toEqual([
@@ -48,7 +48,7 @@ export const OrderOfHooks = {
     console.log('6 - [after mount]');
     await userEvent.click(getByRole(canvasElement, 'button'));
   },
-  async experimental_afterEach() {
+  async afterEach() {
     console.log('8 - [from story afterEach]');
   },
 };


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Stabilizes the experimental afterEach hook by removing the 'experimental_' prefix, making it a standard feature while maintaining its existing functionality across the codebase.

- Renamed `experimental_afterEach` to `afterEach` in core files including `code/core/src/csf/story.ts` and `code/core/src/preview-api/modules/store/csf/*.ts`
- Updated a11y addon in `code/addons/a11y/src/preview.tsx` to use the stabilized hook for accessibility testing
- Modified test files to reflect the hook renaming while maintaining test coverage
- Added migration instructions in `MIGRATION.md` for users to update their code
- Preserved hook execution order (project -> component -> story) in `code/core/src/preview-api/modules/store/csf/prepareStory.ts`



<!-- /greptile_comment -->