### PR TITLE
Docs: Remove oudated links from the tutorials

### DIFF
--- a/docs/sharing/design-integrations.mdx
+++ b/docs/sharing/design-integrations.mdx
@@ -143,4 +143,4 @@ Integrate Adobe XD with Storybook using the [design addon](https://storybook.js.
 Extend and customize Storybook by building an integration. Integrate with lower-level Storybook APIs or bootstrap an addon to customize Storybook's UI and behavior.
 
 * [Addon documentation](../addons/index.mdx)
-* [Create an addon tutorial](https://storybook.js.org/tutorials/create-an-addon/)
+* [Create an addon tutorial](../addons/writing-addons.mdx)

--- a/docs/sharing/publish-storybook.mdx
+++ b/docs/sharing/publish-storybook.mdx
@@ -109,7 +109,7 @@ Commit and push the file. Congratulations, you've successfully automated publish
 
 ### Review with your team
 
-Publishing Storybook as part of the development process makes it quick and easy to [gather team feedback](https://storybook.js.org/tutorials/design-systems-for-developers/react/en/review/).
+Publishing Storybook as part of the development process makes it quick and easy to gather team feedback.
 
 A common method to ask for review is to paste a link to the published Storybook in a pull request or Slack.
 


### PR DESCRIPTION
Closes #

With this pull request, the documentation was updated to remove links to the tutorials site for tutorials that no longer exist or are soon to be removed.

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did
- Removed the links to the tutorials (including non-existing ones)

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates documentation by removing outdated tutorial links, specifically from the design integrations and publish storybook pages, replacing them with current internal documentation references.

- Updated link in `docs/sharing/design-integrations.mdx` to point to internal addon writing documentation instead of deprecated tutorial
- Removed outdated team feedback tutorial link from `docs/sharing/publish-storybook.mdx`



<!-- /greptile_comment -->