### PR TITLE
CLI: Remove `@latest` from `yarn create` commands

### DIFF
--- a/code/lib/create-storybook/src/scaffold-new-project.ts
+++ b/code/lib/create-storybook/src/scaffold-new-project.ts
@@ -35,7 +35,7 @@ const SUPPORTED_PROJECTS: Record<string, SupportedProject> = {
     },
     createScript: {
       npm: 'npm create vite@latest . -- --template react-ts',
-      yarn: 'yarn create vite@latest . --template react-ts',
+      yarn: 'yarn create vite . --template react-ts',
       pnpm: 'pnpm create vite@latest . --template react-ts',
     },
   },
@@ -59,7 +59,7 @@ const SUPPORTED_PROJECTS: Record<string, SupportedProject> = {
     },
     createScript: {
       npm: 'npm create vite@latest . -- --template vue-ts',
-      yarn: 'yarn create vite@latest . --template vue-ts',
+      yarn: 'yarn create vite . --template vue-ts',
       pnpm: 'pnpm create vite@latest . --template vue-ts',
     },
   },
@@ -82,7 +82,7 @@ const SUPPORTED_PROJECTS: Record<string, SupportedProject> = {
     },
     createScript: {
       npm: 'npm create vite@latest . -- --template lit-ts',
-      yarn: 'yarn create vite@latest . --template lit-ts && touch yarn.lock && yarn set version berry && yarn config set nodeLinker pnp',
+      yarn: 'yarn create vite . --template lit-ts && touch yarn.lock && yarn set version berry && yarn config set nodeLinker pnp',
       pnpm: 'pnpm create vite@latest . --template lit-ts',
     },
   },

--- a/docs/_snippets/create-command-custom-package-manager.md
+++ b/docs/_snippets/create-command-custom-package-manager.md
@@ -7,5 +7,5 @@ pnpm create storybook@latest --package-manager=npm
 ```
 
 ```shell renderer="common" language="js" packageManager="yarn"
-yarn create storybook@latest --package-manager=npm
+yarn create storybook --package-manager=npm
 ```

--- a/docs/_snippets/create-command-custom-version.md
+++ b/docs/_snippets/create-command-custom-version.md
@@ -5,7 +5,3 @@ npm create storybook@8.3
 ```shell renderer="common" language="js" packageManager="pnpm"
 pnpm create storybook@8.3
 ```
-
-```shell renderer="common" language="js" packageManager="yarn"
-yarn create storybook@8.3
-```

--- a/docs/_snippets/create-command-manual-framework.md
+++ b/docs/_snippets/create-command-manual-framework.md
@@ -7,5 +7,5 @@ pnpm create storybook@latest --type solid
 ```
 
 ```shell renderer="common" language="js" packageManager="yarn"
-yarn create storybook@latest --type solid
+yarn create storybook --type solid
 ```

--- a/docs/_snippets/create-command.md
+++ b/docs/_snippets/create-command.md
@@ -7,5 +7,5 @@ pnpm create storybook@latest
 ```
 
 ```shell renderer="common" language="js" packageManager="yarn"
-yarn create storybook@latest
+yarn create storybook
 ```


### PR DESCRIPTION
## What I did

- Removed `@latest` tag from all `yarn create` commands in the codebase
- Updated yarn commands in scaffold-new-project.ts for React, Vue, and Lit templates
- Updated yarn commands in documentation snippets
- Removed redundant yarn version command example from create-command-custom-version.md

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates documentation and code to remove `@latest` tag from yarn create commands while maintaining it for npm and pnpm, aligning with yarn's version handling behavior.

- Removed `@latest` tag from yarn commands in all documentation snippets under `/docs/_snippets/`
- Updated project scaffolding in `code/lib/create-storybook/src/scaffold-new-project.ts` for React, Vue, and Lit templates
- Removed redundant yarn example from `create-command-custom-version.md`
- Maintains version specifier consistency with npm/pnpm commands still using `@latest`



<!-- /greptile_comment -->