### PR TITLE
Vitest: Remove beforeAll in vitest.setup.ts in automigration

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.test.ts
@@ -49,7 +49,14 @@ const mockFiles: Record<string, string> = {
   `,
   'vitest.setup.ts': `
     import { setup } from '@storybook/experimental-addon-test';
-    // Vitest setup
+    import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
+    import { beforeAll } from 'vitest'
+    import { setProjectAnnotations } from '@storybook/nextjs-vite'
+    import * as projectAnnotations from './preview'
+    
+    const project = setProjectAnnotations([a11yAddonAnnotations, projectAnnotations])
+    
+    beforeAll(project.beforeAll)
   `,
   'vite.config.ts': `
     import { defineConfig } from 'vite';
@@ -222,6 +229,21 @@ describe('addon-experimental-test fix', () => {
           'utf-8'
         );
       });
+
+      expect(writeFileSync).toHaveBeenCalledWith(
+        'vitest.setup.ts',
+        `
+    import { setup } from '@storybook/addon-vitest';
+    import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
+    import { beforeAll } from 'vitest'
+    import { setProjectAnnotations } from '@storybook/nextjs-vite'
+    import * as projectAnnotations from './preview'
+    
+    const project = setProjectAnnotations([a11yAddonAnnotations, projectAnnotations])
+    
+  `,
+        'utf-8'
+      );
 
       // Verify package dependencies were updated
       expect(packageManager.removeDependencies).toHaveBeenCalledWith({}, [

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.test.ts
@@ -240,7 +240,6 @@ describe('addon-experimental-test fix', () => {
     import * as projectAnnotations from './preview'
     
     const project = setProjectAnnotations([a11yAddonAnnotations, projectAnnotations])
-    
   `,
         'utf-8'
       );

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.ts
@@ -87,10 +87,17 @@ export const addonExperimentalTest: Fix<AddonExperimentalTestOptions> = {
     // Update all files that contain @storybook/experimental-addon-test
     for (const file of matchingFiles) {
       const content = readFileSync(file, 'utf-8');
-      const updatedContent = content.replace(
+      let updatedContent = content.replace(
         /@storybook\/experimental-addon-test/g,
         '@storybook/addon-vitest'
       );
+
+      if (file.includes('vitest.setup')) {
+        updatedContent = updatedContent
+          .split('\n')
+          .filter((line) => !line.trim().startsWith('beforeAll'))
+          .join('\n');
+      }
 
       if (!dryRun) {
         writeFileSync(file, updatedContent, 'utf-8');

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.ts
@@ -93,10 +93,7 @@ export const addonExperimentalTest: Fix<AddonExperimentalTestOptions> = {
       );
 
       if (file.includes('vitest.setup')) {
-        updatedContent = updatedContent
-          .split('\n')
-          .filter((line) => !line.trim().startsWith('beforeAll'))
-          .join('\n');
+        updatedContent = updatedContent.replace(/^\s*beforeAll.*\n?/gm, '');
       }
 
       if (!dryRun) {

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -428,8 +428,7 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
       import projectAnnotations from './preview'
 
       // setProjectAnnotations still kept to support non-CSF4 story tests
-      const annotations = setProjectAnnotations(projectAnnotations.composed)
-      beforeAll(annotations.beforeAll)
+      setProjectAnnotations(projectAnnotations.composed)
       `
     );
   } else {
@@ -444,15 +443,13 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
       import * as projectAnnotations from './preview'
       ${isVue ? 'import * as vueAnnotations from "../src/stories/renderers/vue3/preview.js"' : ''}
   
-      const annotations = setProjectAnnotations([
+      setProjectAnnotations([
         ${isVue ? 'vueAnnotations,' : ''}
         rendererDocsAnnotations,
         templateAnnotations,
         addonA11yAnnotations,
         projectAnnotations,
       ])
-  
-      beforeAll(annotations.beforeAll)`
     );
   }
 

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -449,7 +449,7 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
         templateAnnotations,
         addonA11yAnnotations,
         projectAnnotations,
-      ])
+      ])`
     );
   }
 

--- a/test-storybooks/portable-stories-kitchen-sink/react/.storybook/vitest.setup.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/.storybook/vitest.setup.ts
@@ -1,4 +1,3 @@
-import { beforeAll } from 'vitest'
 import { setProjectAnnotations } from '@storybook/react'
 import * as addonA11yAnnotations from '@storybook/addon-a11y/preview'
 import * as projectAnnotations from './preview'

--- a/test-storybooks/portable-stories-kitchen-sink/react/.storybook/vitest.setup.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/.storybook/vitest.setup.ts
@@ -4,11 +4,9 @@ import * as addonA11yAnnotations from '@storybook/addon-a11y/preview'
 import * as projectAnnotations from './preview'
 import { getString } from './setup-file-dependency';
 
-const annotations = setProjectAnnotations([
+setProjectAnnotations([
   addonA11yAnnotations,
   projectAnnotations,
 ]);
-
-beforeAll(annotations.beforeAll);
 
 console.log(getString())


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the PR changes:

Implements migration logic to remove the beforeAll hook from vitest.setup.ts files when migrating from @storybook/experimental-addon-test to @storybook/addon-vitest.

- Added filtering logic in `code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.ts` to remove beforeAll hooks
- Updated mock files in `addon-experimental-test.test.ts` with realistic vitest.setup.ts content
- Added test case to verify beforeAll hook removal while preserving other imports/setup code
- Maintains existing functionality for experimental addon replacement and package.json updates



<!-- /greptile_comment -->