### PR TITLE
Provide ability to leverage CSS variables for status values provided by Vitest

### DIFF
--- a/code/core/src/manager/utils/status.tsx
+++ b/code/core/src/manager/utils/status.tsx
@@ -45,13 +45,13 @@ export const statusMapping: Record<StatusValue, [ReactElement | null, string | n
     <svg key="icon" viewBox="0 0 14 14" width="14" height="14">
       <UseSymbol type="warning" />
     </svg>,
-    '#A15C20',
+    'var(--status-value-warning, #A15C20)',
   ],
   ['status-value:error']: [
     <svg key="icon" viewBox="0 0 14 14" width="14" height="14">
       <UseSymbol type="error" />
     </svg>,
-    'brown',
+    'var(--status-value-error, brown)',
   ],
 };
 

--- a/code/core/src/manager/utils/status.tsx
+++ b/code/core/src/manager/utils/status.tsx
@@ -45,13 +45,13 @@ export const statusMapping: Record<StatusValue, [ReactElement | null, string | n
     <svg key="icon" viewBox="0 0 14 14" width="14" height="14">
       <UseSymbol type="warning" />
     </svg>,
-    'var(--status-value-warning, #A15C20)',
+    'var(--status-value-color-warning, #A15C20)',
   ],
   ['status-value:error']: [
     <svg key="icon" viewBox="0 0 14 14" width="14" height="14">
       <UseSymbol type="error" />
     </svg>,
-    'var(--status-value-error, brown)',
+    'var(--status-value-color-error, brown)',
   ],
 };
 


### PR DESCRIPTION
Closes #31462

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Attaches CSS variables to status values, with fallbacks to their existing values. This allows things to work as-is with the ability to change them based on needs.

<img width="339" alt="Screenshot 2025-05-12 at 12 54 06 PM" src="https://github.com/user-attachments/assets/89688e67-1fc5-4912-b932-a7a0bb055d7d" />

<img width="279" alt="Screenshot 2025-05-12 at 12 54 16 PM" src="https://github.com/user-attachments/assets/43942c7b-c690-46f7-9aff-b1da482d04dc" />


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Set the CSS variable on the class provided to the button.
2. When the tests error you'll now see the updated color. 

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the PR changes:

Introduces CSS variables for status value colors in the Storybook UI's sidebar, focusing on warning and error states to improve accessibility and theme customization.

- Added `--status-value-color-warning` CSS variable with fallback to `#A15C20` in `code/core/src/manager/utils/status.tsx`
- Added `--status-value-color-error` CSS variable with fallback to `brown` in `code/core/src/manager/utils/status.tsx`
- Maintains backward compatibility through fallback values for existing implementations
- Addresses color contrast accessibility issues in the sidebar for Vitest addon status indicators



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->