### PR TITLE
Builder-Vite: Fix logic related to setting allowedHosts when IP address used

### DIFF
--- a/code/builders/builder-vite/src/vite-server.ts
+++ b/code/builders/builder-vite/src/vite-server.ts
@@ -1,6 +1,8 @@
+import { logger } from 'storybook/internal/node-logger';
 import type { Options } from 'storybook/internal/types';
 
 import type { Server } from 'http';
+import { dedent } from 'ts-dedent';
 import type { InlineConfig, ServerOptions } from 'vite';
 
 import { sanitizeEnvVars } from './envs';
@@ -29,14 +31,18 @@ export async function createViteServer(options: Options, devServer: Server) {
     optimizeDeps: await getOptimizeDeps(commonCfg, options),
   };
 
-  const ipRegex = /^(?:\d{1,3}\.){3}\d{1,3}$|^(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}$/;
-
-  if (
-    !(config.server.allowedHosts as string[])?.length &&
-    options.host &&
-    !ipRegex.test(options.host)
-  ) {
-    config.server.allowedHosts = [options.host.toLowerCase()];
+  // '0.0.0.0' binds to all interfaces, which is useful for Docker and other containerized environments.
+  // but without server.allowedHosts set, requests from outside the container will be rejected.
+  if (options.host === '0.0.0.0' && !config.server.allowedHosts) {
+    config.server.allowedHosts = true;
+    logger.warn(dedent`'host' is set to '0.0.0.0' but 'allowedHosts' is not defined.
+      Defaulting 'allowedHosts' to true, which permits all hostnames.
+      To restrict allowed hostnames, add the following to your 'viteFinal' config:
+      Example: { server: { allowedHosts: ['mydomain.com'] } }
+      See:
+      - https://vite.dev/config/server-options.html#server-allowedhosts
+      - https://storybook.js.org/docs/api/main-config/main-config-vite-final
+    `);
   }
 
   const finalConfig = await presets.apply('viteFinal', config, options);


### PR DESCRIPTION
Related to #30523, #30432, and #30338

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Previous PR set `allowedHosts` to `true` by default, this was reverted but no longer set the `allowedHosts` value when an IP address was used for `options.host`.

This change sets `allowedHosts` to `true` only if `allowedHosts` is undefined and an IP address is passed as the host. Otherwise [no hostname other than 'localhost'](https://vite.dev/config/server-options#server-allowedhosts) would be allowed to access the devserver.

Note, this is my personal opinion on what the logic should be, to more closely align with existing functionality prior to the breaking change from Vite. If, for security reasons, this is not desired then updating the PR to add a warning to the console would be another good option, along with additional documentation on setting `allowedHosts` when using the Vite dev-server with Storybook.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR enhances Vite server security in Storybook by implementing stricter host access controls while maintaining flexibility for custom configurations.

- Modified `code/builders/builder-vite/src/vite-server.ts` to restrict access to localhost by default, following Vite's secure practices
- Added support for IP-based host access through conditional allowedHosts configuration
- Implemented clear error messaging in both console and iframe for unauthorized host access
- Added ability to override host restrictions via `--host` CLI flag or `viteFinal` config
- Fixed host validation logic when using IP addresses as server hosts

The changes improve security while maintaining backward compatibility and providing clear paths for customization when needed.



<sub>💡 (3/5) Reply to the bot's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->