### PR TITLE
React: Don't use Act wrapper in Storybook when rendering in docs

### DIFF
--- a/code/renderers/react/src/act-compat.ts
+++ b/code/renderers/react/src/act-compat.ts
@@ -62,7 +62,11 @@ function withGlobalActEnvironment(actImplementation: (callback: () => void) => P
   };
 }
 
-export const getAct = async () => {
+export const getAct = async ({ disableAct = false }: { disableAct?: boolean } = {}) => {
+  if (process.env.NODE_ENV === 'production' || disableAct) {
+    return (cb: (...args: any[]) => any) => cb();
+  }
+
   let reactAct: typeof React.act;
   if (typeof clonedReact.act === 'function') {
     reactAct = clonedReact.act;
@@ -73,7 +77,5 @@ export const getAct = async () => {
     reactAct = deprecatedTestUtils?.default?.act ?? deprecatedTestUtils.act;
   }
 
-  return process.env.NODE_ENV === 'production'
-    ? (cb: (...args: any[]) => any) => cb()
-    : withGlobalActEnvironment(reactAct);
+  return withGlobalActEnvironment(reactAct);
 };

--- a/code/renderers/react/src/entry-preview.tsx
+++ b/code/renderers/react/src/entry-preview.tsx
@@ -28,6 +28,9 @@ export const decorators: Decorator[] = [
 ];
 
 export const beforeAll = async () => {
+  // Needed to make sure docs updates are also rendered in a react act environment:
+  // https://github.com/storybookjs/storybook/issues/30356
+  setReactActEnvironment(true);
   try {
     // copied from
     // https://github.com/testing-library/react-testing-library/blob/3dcd8a9649e25054c0e650d95fca2317b7008576/src/pure.js
@@ -78,6 +81,10 @@ export const beforeAll = async () => {
     // no-op
     // storybook/test might not be available
   }
+
+  return () => {
+    setReactActEnvironment(false);
+  };
 };
 
 /** The function is used to configure jest's fake timers in environments where React's act is enabled */

--- a/code/renderers/react/src/entry-preview.tsx
+++ b/code/renderers/react/src/entry-preview.tsx
@@ -28,9 +28,6 @@ export const decorators: Decorator[] = [
 ];
 
 export const beforeAll = async () => {
-  // Needed to make sure docs updates are also rendered in a react act environment:
-  // https://github.com/storybookjs/storybook/issues/30356
-  setReactActEnvironment(true);
   try {
     // copied from
     // https://github.com/testing-library/react-testing-library/blob/3dcd8a9649e25054c0e650d95fca2317b7008576/src/pure.js
@@ -81,10 +78,6 @@ export const beforeAll = async () => {
     // no-op
     // storybook/test might not be available
   }
-
-  return () => {
-    setReactActEnvironment(false);
-  };
 };
 
 /** The function is used to configure jest's fake timers in environments where React's act is enabled */

--- a/code/renderers/react/src/renderToCanvas.tsx
+++ b/code/renderers/react/src/renderToCanvas.tsx
@@ -97,7 +97,9 @@ export async function renderToCanvas(
     unmountElement(canvasElement);
   }
 
-  const act = await getAct();
+  // Disable act in docs, see:
+  // https://github.com/storybookjs/storybook/issues/30356
+  const act = await getAct({ disableAct: storyContext.viewMode === 'docs' });
   await new Promise<void>(async (resolve, reject) => {
     actQueue.push(async () => {
       try {


### PR DESCRIPTION
Closes #30356

## What I did

Disabling the act wrapping of react render for docs. This partly reverts:
https://github.com/storybookjs/storybook/pull/30037

As it seems that you can not use act in one react tree (the story), but not in other (the docs page). See:
#30356

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Introduces a new `disableAct` parameter to conditionally disable React's act functionality, particularly useful in documentation contexts to improve rendering behavior.  - Added `disableAct` parameter in `code/renderers/react/src/act-compat.ts` to optionally bypass React's act wrapper - Modified `code/renderers/react/src/renderToCanvas.tsx` to disable act specifically in Docs view mode - Implemented early return pattern in act-compat for cleaner conditional handling



<!-- /greptile_comment -->