### PR TITLE
Core: Remove duplicate notification dot on sidebar buttons on mobile

### DIFF
--- a/code/core/src/manager/components/sidebar/Menu.tsx
+++ b/code/core/src/manager/components/sidebar/Menu.tsx
@@ -83,8 +83,7 @@ export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick
         <SidebarIconButton
           title="About Storybook"
           aria-label="About Storybook"
-          // @ts-expect-error (non strict)
-          highlighted={isHighlighted}
+          highlighted={!!isHighlighted}
           active={false}
           // @ts-expect-error (non strict)
           onClick={onClick}
@@ -95,8 +94,7 @@ export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick
         <SidebarIconButton
           title="Close menu"
           aria-label="Close menu"
-          // @ts-expect-error (non strict)
-          highlighted={isHighlighted}
+          highlighted={false}
           active={false}
           onClick={() => setMobileMenuOpen(false)}
           isMobile={true}
@@ -117,10 +115,10 @@ export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick
       <SidebarIconButton
         title="Shortcuts"
         aria-label="Shortcuts"
-        // @ts-expect-error (non strict)
-        highlighted={isHighlighted}
+        highlighted={!!isHighlighted}
         active={isTooltipVisible}
         size="medium"
+        isMobile={false}
       >
         <CogIcon />
       </SidebarIconButton>


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Removed the notification dot on the close icon, seen here:

<img width="366" alt="Screenshot 2025-05-15 at 09 31 06" src="https://github.com/user-attachments/assets/b2e791df-da94-45d9-9195-43b30a95a850" />

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Removes duplicate notification dot on mobile sidebar menu by modifying the close button's `highlighted` prop in `code/core/src/manager/components/sidebar/Menu.tsx`.

- Modified `MenuButtonGroup` to set `highlighted={false}` on close menu button to prevent duplicate notification dot
- Added `!!` type conversion for `isHighlighted` prop to ensure boolean value
- Added required `isMobile` prop to desktop `SidebarIconButton` component



<!-- /greptile_comment -->