### PR TITLE
Core: Set a minimum height/width for the targetable area of highlights

### DIFF
--- a/code/core/src/highlight/constants.ts
+++ b/code/core/src/highlight/constants.ts
@@ -6,3 +6,4 @@ export const RESET_HIGHLIGHT = `${ADDON_ID}/reset`;
 export const SCROLL_INTO_VIEW = `${ADDON_ID}/scroll-into-view`;
 
 export const MAX_Z_INDEX = 2147483647;
+export const MIN_TOUCH_AREA_SIZE = 28;

--- a/code/core/src/highlight/useHighlights.ts
+++ b/code/core/src/highlight/useHighlights.ts
@@ -174,7 +174,9 @@ export const useHighlights = (channel: Channel) => {
           'data-highlight-dimensions': `w${box.width.toFixed(0)}h${box.height.toFixed(0)}`,
           'data-highlight-coordinates': `x${box.left.toFixed(0)}y${box.top.toFixed(0)}`,
         };
-        boxElement = root.appendChild(createElement('div', props) as HTMLDivElement);
+        boxElement = root.appendChild(
+          createElement('div', props, [createElement('div')]) as HTMLDivElement
+        );
         boxElementByTargetElement.set(box.element, boxElement);
       }
     });
@@ -274,8 +276,20 @@ export const useHighlights = (channel: Channel) => {
           height: `${box.height}px`,
           margin: 0,
           padding: 0,
-          cursor: box.menu ? 'pointer' : 'default',
+          cursor: box.menu && isHovered ? 'pointer' : 'default',
           pointerEvents: box.menu ? 'auto' : 'none',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          overflow: 'visible',
+        });
+        Object.assign((boxElement.children[0] as HTMLDivElement).style, {
+          width: '100%',
+          height: '100%',
+          minHeight: '28px',
+          minWidth: '28px',
+          boxSizing: 'content-box',
+          padding: boxElement.style.outlineWidth || '0px',
         });
 
         showPopover(boxElement);

--- a/code/core/src/highlight/useHighlights.ts
+++ b/code/core/src/highlight/useHighlights.ts
@@ -5,6 +5,7 @@ import { STORY_RENDER_PHASE_CHANGED } from 'storybook/internal/core-events';
 import {
   HIGHLIGHT,
   MAX_Z_INDEX,
+  MIN_TOUCH_AREA_SIZE,
   REMOVE_HIGHLIGHT,
   RESET_HIGHLIGHT,
   SCROLL_INTO_VIEW,
@@ -286,8 +287,8 @@ export const useHighlights = (channel: Channel) => {
         Object.assign((boxElement.children[0] as HTMLDivElement).style, {
           width: '100%',
           height: '100%',
-          minHeight: '28px',
-          minWidth: '28px',
+          minHeight: `${MIN_TOUCH_AREA_SIZE}px`,
+          minWidth: `${MIN_TOUCH_AREA_SIZE}px`,
           boxSizing: 'content-box',
           padding: boxElement.style.outlineWidth || '0px',
         });

--- a/code/core/src/highlight/utils.ts
+++ b/code/core/src/highlight/utils.ts
@@ -1,4 +1,5 @@
 /* eslint-env browser */
+import { MIN_TOUCH_AREA_SIZE } from './constants';
 import { type IconName, iconPaths } from './icons';
 import type {
   Box,
@@ -216,13 +217,13 @@ export const isTargeted = (
     return false;
   }
   let { left, top, width, height } = box;
-  if (height < 28) {
-    top = top - Math.round((28 - height) / 2);
-    height = 28;
+  if (height < MIN_TOUCH_AREA_SIZE) {
+    top = top - Math.round((MIN_TOUCH_AREA_SIZE - height) / 2);
+    height = MIN_TOUCH_AREA_SIZE;
   }
-  if (width < 28) {
-    left = left - Math.round((28 - width) / 2);
-    width = 28;
+  if (width < MIN_TOUCH_AREA_SIZE) {
+    left = left - Math.round((MIN_TOUCH_AREA_SIZE - width) / 2);
+    width = MIN_TOUCH_AREA_SIZE;
   }
   if (boxElement.style.position === 'fixed') {
     left += window.scrollX;

--- a/code/core/src/highlight/utils.ts
+++ b/code/core/src/highlight/utils.ts
@@ -10,7 +10,7 @@ import type {
 
 const svgElements = 'svg,path,rect,circle,line,polyline,polygon,ellipse,text'.split(',');
 
-export const createElement = (type: string, props: Record<string, any>, children?: any[]) => {
+export const createElement = (type: string, props: Record<string, any> = {}, children?: any[]) => {
   const element = svgElements.includes(type)
     ? document.createElementNS('http://www.w3.org/2000/svg', type)
     : document.createElement(type);
@@ -216,11 +216,13 @@ export const isTargeted = (
     return false;
   }
   let { left, top, width, height } = box;
-  if (height === 0 || width === 0) {
-    left -= 10;
-    top -= 10;
-    width += 20;
-    height += 20;
+  if (height < 28) {
+    top = top - Math.round((28 - height) / 2);
+    height = 28;
+  }
+  if (width < 28) {
+    left = left - Math.round((28 - width) / 2);
+    width = 28;
   }
   if (boxElement.style.position === 'fixed') {
     left += window.scrollX;


### PR DESCRIPTION
Closes #31418

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Each highlight box now has a child div with a min-width & min-height of 28px. They are positioned in the center of their parent box so they may expand out on all sides equally. A mouse pointer will appear when hovered. These targetable areas are shown here in red for clarity (normally they are fully transparent):

https://github.com/user-attachments/assets/e3e99cc4-5263-4fd5-94a9-e5c841daaba9

Note that the lack of a pointer hand is a bug in Mac OS' screen capturing. In practice there is one.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Introduces a minimum clickable area (28x28px) for highlight boxes to improve usability when interacting with small elements in Storybook's highlighting feature.

- Added centered child div with min-width/min-height of 28px in `code/core/src/highlight/useHighlights.ts`
- Updated `isTargeted` function in `code/core/src/highlight/utils.ts` to handle expanded clickable area
- Implemented content-box sizing to properly account for outline width
- Modified cursor style to only show pointer when box has menu and is being hovered



<!-- /greptile_comment -->