### PR TITLE
Test: Patch HTMLElement.prototype.focus method for settable focus in tests

### DIFF
--- a/code/core/src/test/preview.ts
+++ b/code/core/src/test/preview.ts
@@ -81,6 +81,8 @@ const nameSpiesAndWrapActionsInSpies: LoaderFunction = ({ initialArgs }) => {
   traverseArgs(initialArgs);
 };
 
+let patchedFocus = false;
+
 const enhanceContext: LoaderFunction = async (context) => {
   if (globalThis.HTMLElement && context.canvasElement instanceof globalThis.HTMLElement) {
     context.canvas = within(context.canvasElement);
@@ -93,6 +95,28 @@ const enhanceContext: LoaderFunction = async (context) => {
       { userEvent: uninstrumentedUserEvent.setup() },
       { intercept: true }
     ).userEvent;
+
+    let currentFocus = HTMLElement.prototype.focus;
+
+    if (!patchedFocus) {
+      // We need to patch the focus method of HTMLElement.prototype to make it settable.
+      // Testing library "setup" defines a custom focus method on HTMLElement.prototype that is not settable.
+      // Libraries like chakra-ui also wants to define a custom focus method on HTMLElement.prototype
+      // which is not settable if we don't do this.
+      // Related issue: https://github.com/storybookjs/storybook/issues/31243
+      Object.defineProperties(HTMLElement.prototype, {
+        focus: {
+          configurable: true,
+          set: (newFocus: () => void) => {
+            currentFocus = newFocus;
+            patchedFocus = true;
+          },
+          get: () => {
+            return currentFocus;
+          },
+        },
+      });
+    }
   }
 };
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31243

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31487-sha-978a5d3e`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31487-sha-978a5d3e sandbox` or in an existing project with `npx storybook@0.0.0-pr-31487-sha-978a5d3e upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31487-sha-978a5d3e`](https://npmjs.com/package/storybook/v/0.0.0-pr-31487-sha-978a5d3e) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-non-overridable-focus`](https://github.com/storybookjs/storybook/tree/valentin/fix-non-overridable-focus) |
| **Commit** | [`978a5d3e`](https://github.com/storybookjs/storybook/commit/978a5d3e5226a2564996de685a7f2660ac8e23f0) |
| **Datetime** | Thu May 15 11:21:00 UTC 2025 (`1747308060`) |
| **Workflow run** | [15043647894](https://github.com/storybookjs/storybook/actions/runs/15043647894) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31487`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR patches HTMLElement.prototype.focus to make it settable in tests, addressing an issue where Testing Library's setup prevented libraries like Chakra UI from defining custom focus methods.

- Added configurable property descriptor for HTMLElement.prototype.focus in `code/core/src/test/preview.ts`
- Implemented getter/setter pattern to maintain current focus behavior while allowing overrides
- Added `patchedFocus` flag to ensure patch is only applied once
- Fixed issue #31243 where Chakra UI and other libraries couldn't define custom focus methods



<!-- /greptile_comment -->