### PR TITLE
Addon Vitest: Trigger tests on preview file changes in watch mode

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -251,6 +251,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
             ...storybookEnv,
             // To be accessed by the setup file
             __STORYBOOK_URL__: finalOptions.storybookUrl,
+            __STORYBOOK_CONFIG_DIR__: finalOptions.configDir,
 
             VITEST_STORYBOOK: vitestStorybook,
             __VITEST_INCLUDE_TAGS__: finalOptions.tags.include.join(','),
@@ -258,6 +259,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
             __VITEST_SKIP_TAGS__: finalOptions.tags.skip.join(','),
           },
 
+          forceRerunTriggers: [finalOptions.configDir],
           include: includeStories,
           exclude: [...(nonMutableInputConfig.test?.exclude ?? []), '**/*.mdx'],
 
@@ -360,6 +362,12 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
     },
     configureVitest(context) {
       context.vitest.config.coverage.exclude.push('storybook-static');
+
+      // TODO:
+      // From Vitest 3.2 (unreleased so far) there will be a better API we can use: watchTriggerPatterns
+      context.vitest.onFilterWatchedSpecification((spec) => {
+        return spec.project.config.env?.__STORYBOOK_CONFIG_DIR__ === finalOptions.configDir;
+      });
     },
     async configureServer(server) {
       if (staticDirs) {

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 
 import type { Plugin } from 'vitest/config';
-import { mergeConfig } from 'vitest/config';
+import { configDefaults, mergeConfig } from 'vitest/config';
 import type { ViteUserConfig } from 'vitest/config';
 
 import {
@@ -258,8 +258,6 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
             __VITEST_EXCLUDE_TAGS__: finalOptions.tags.exclude.join(','),
             __VITEST_SKIP_TAGS__: finalOptions.tags.skip.join(','),
           },
-
-          forceRerunTriggers: [finalOptions.configDir],
           include: includeStories,
           exclude: [...(nonMutableInputConfig.test?.exclude ?? []), '**/*.mdx'],
 
@@ -364,7 +362,12 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
       context.vitest.config.coverage.exclude.push('storybook-static');
 
       // TODO:
+      // Instead of using forceRerunTriggers + onFilterWatchedSpecification,
       // From Vitest 3.2 (unreleased so far) there will be a better API we can use: watchTriggerPatterns
+      context.vitest.config.forceRerunTriggers = [
+        ...configDefaults.forceRerunTriggers,
+        join(finalOptions.configDir, '*'),
+      ];
       context.vitest.onFilterWatchedSpecification((spec) => {
         return spec.project.config.env?.__STORYBOOK_CONFIG_DIR__ === finalOptions.configDir;
       });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Vitest addon will now trigger all tests in watch mode when the preview.js file is changed, when running in the CLI!

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31489-sha-9a1e0548`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31489-sha-9a1e0548 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31489-sha-9a1e0548 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31489-sha-9a1e0548`](https://npmjs.com/package/storybook/v/0.0.0-pr-31489-sha-9a1e0548) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/support-preview-watch-mode`](https://github.com/storybookjs/storybook/tree/yann/support-preview-watch-mode) |
| **Commit** | [`9a1e0548`](https://github.com/storybookjs/storybook/commit/9a1e0548724496806f1850a4efec07a361ee8cc0) |
| **Datetime** | Thu May 15 13:13:38 UTC 2025 (`1747314818`) |
| **Workflow run** | [15045905442](https://github.com/storybookjs/storybook/actions/runs/15045905442) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31489`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhanced Vitest addon to support dynamic test re-running when preview files change in watch mode, improving the development workflow for Storybook configurations.

- Added watch mode support to trigger test reruns when preview.js changes during CLI execution
- Implemented `forceRerunTriggers` configuration to track Storybook config directory changes
- Added `__STORYBOOK_CONFIG_DIR__` environment variable for config directory tracking
- Integrated with Vitest's watch mode filtering system for targeted test reruns
- Created temporary solution using combined triggers until Vitest 3.2's `watchTriggerPatterns` API is available



<!-- /greptile_comment -->