### PR TITLE
CSF-Tools: Add support for existing node imports and improve import handling

### DIFF
--- a/code/core/src/csf-tools/ConfigFile.test.ts
+++ b/code/core/src/csf-tools/ConfigFile.test.ts
@@ -1259,6 +1259,25 @@ describe('ConfigFile', () => {
       `);
     });
 
+    it(`uses the existing node import when using node:xyz paths but the package xyz is already imported`, () => {
+      const source = dedent`
+        import { join } from 'path';
+        const config: StorybookConfig = { };
+        export default config;
+      `;
+
+      const config = loadConfig(source).parse();
+      config.setImport(['dirname'], 'node:path');
+
+      const parsed = babelPrint(config._ast);
+
+      expect(parsed).toMatchInlineSnapshot(`
+        import { join, dirname } from 'path';
+        const config: StorybookConfig = { };
+        export default config;
+      `);
+    });
+
     it(`supports setting a default import for a field that does exist`, () => {
       const source = dedent`
         const config: StorybookConfig = { };
@@ -1404,6 +1423,30 @@ describe('ConfigFile', () => {
 
       const config = loadConfig(source).parse();
       config.setRequireImport(['dirname', 'basename'], 'path');
+
+      const parsed = babelPrint(config._ast);
+
+      expect(parsed).toMatchInlineSnapshot(`
+        const {
+          dirname,
+          basename,
+        } = require('path');
+
+        const config: StorybookConfig = { };
+        export default config;
+      `);
+    });
+
+    it(`supports setting a named import for a field where the source already exists without "node:" prefix`, () => {
+      const source = dedent`
+        const { dirname } = require('path');
+
+        const config: StorybookConfig = { };
+        export default config;
+      `;
+
+      const config = loadConfig(source).parse();
+      config.setRequireImport(['dirname', 'basename'], 'node:path');
 
       const parsed = babelPrint(config._ast);
 

--- a/code/core/src/csf-tools/ConfigFile.ts
+++ b/code/core/src/csf-tools/ConfigFile.ts
@@ -865,11 +865,17 @@ export class ConfigFile {
    * @param fromImport - The module to import from
    */
   setImport(importSpecifier: string[] | string | { namespace: string } | null, fromImport: string) {
-    this._ast.program.body.forEach((node) => {
-      if (t.isImportDeclaration(node) && node.source.value === fromImport.split('node:')[1]) {
+    const importDeclaration = this._ast.program.body.find((node) => {
+      const hasDeclaration =
+        t.isImportDeclaration(node) &&
+        (node.source.value === fromImport || node.source.value === fromImport.split('node:')[1]);
+
+      if (hasDeclaration) {
         fromImport = node.source.value;
       }
-    });
+
+      return hasDeclaration;
+    }) as t.ImportDeclaration | undefined;
 
     const getNewImportSpecifier = (specifier: string) =>
       t.importSpecifier(t.identifier(specifier), t.identifier(specifier));
@@ -917,10 +923,6 @@ export class ConfigFile {
           t.isIdentifier(specifier.local) &&
           specifier.local.name === name
       );
-
-    const importDeclaration = this._ast.program.body.find(
-      (node) => t.isImportDeclaration(node) && node.source.value === fromImport
-    ) as t.ImportDeclaration | undefined;
 
     // Handle side-effect imports (e.g., import 'foo')
     if (importSpecifier === null) {

--- a/code/core/src/csf-tools/ConfigFile.ts
+++ b/code/core/src/csf-tools/ConfigFile.ts
@@ -736,8 +736,8 @@ export class ConfigFile {
    * @param fromImport - The module to import from
    */
   setRequireImport(importSpecifier: string[] | string, fromImport: string) {
-    const requireDeclaration = this._ast.program.body.find(
-      (node) =>
+    const requireDeclaration = this._ast.program.body.find((node) => {
+      const hasDeclaration =
         t.isVariableDeclaration(node) &&
         node.declarations.length === 1 &&
         t.isVariableDeclarator(node.declarations[0]) &&
@@ -745,8 +745,15 @@ export class ConfigFile {
         t.isIdentifier(node.declarations[0].init.callee) &&
         node.declarations[0].init.callee.name === 'require' &&
         t.isStringLiteral(node.declarations[0].init.arguments[0]) &&
-        node.declarations[0].init.arguments[0].value === fromImport
-    ) as t.VariableDeclaration | undefined;
+        (node.declarations[0].init.arguments[0].value === fromImport ||
+          node.declarations[0].init.arguments[0].value === fromImport.split('node:')[1]);
+      if (hasDeclaration) {
+        // @ts-expect-error the node declaration was found above already
+        fromImport = node.declarations[0].init.arguments[0].value;
+      }
+
+      return hasDeclaration;
+    }) as t.VariableDeclaration | undefined;
 
     /**
      * Returns true, when the given import declaration has the given import specifier
@@ -858,6 +865,12 @@ export class ConfigFile {
    * @param fromImport - The module to import from
    */
   setImport(importSpecifier: string[] | string | { namespace: string } | null, fromImport: string) {
+    this._ast.program.body.forEach((node) => {
+      if (t.isImportDeclaration(node) && node.source.value === fromImport.split('node:')[1]) {
+        fromImport = node.source.value;
+      }
+    });
+
     const getNewImportSpecifier = (specifier: string) =>
       t.importSpecifier(t.identifier(specifier), t.identifier(specifier));
     /**
@@ -885,7 +898,7 @@ export class ConfigFile {
      *
      * ```ts
      * // import foo from 'bar';
-     * hasImportSpecifier(declaration, 'foo');
+     * hasNamespaceImportSpecifier(declaration, 'foo');
      * ```
      */
     const hasNamespaceImportSpecifier = (declaration: t.ImportDeclaration, name: string) =>


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31477

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When setting imports for node namespaced modules, like `node:path`, setting these imports will check whether node packages without the `node:` namespace are available and will then add the import specifier to the existing import instead.

**Before:**

```tsx
// file
import { dirname } from 'path';

const config: StorybookConfig = { };
export default config;

// automigration
config.setImport(['dirname, join'], 'node:path');

// file after transformation
import { dirname, join } from 'node:path';
import { dirname } from 'path'; // dirname already exists

const config: StorybookConfig = { };
export default config;
```

**After:**

```tsx
// file
import { dirname } from 'path';

const config: StorybookConfig = { };
export default config;

// automigration
config.setImport(['dirname, join'], 'node:path');

// file after transformation
import { dirname, join } from 'path';

const config: StorybookConfig = { };
export default config;
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
