### PR TITLE
Addon-vitest: Fix wrong test count in telemetry

### DIFF
--- a/code/addons/vitest/src/node/test-manager.ts
+++ b/code/addons/vitest/src/node/test-manager.ts
@@ -255,6 +255,7 @@ export class TestManager {
   }, 500);
 
   onTestRunEnd(endResult: { totalTestCount: number; unhandledErrors: VitestError[] }) {
+    this.throttledFlushTestCaseResults.flush();
     this.store.setState((s) => ({
       ...s,
       currentRun: {

--- a/code/addons/vitest/src/preset.ts
+++ b/code/addons/vitest/src/preset.ts
@@ -192,11 +192,10 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
       });
     });
     store.subscribe('TEST_RUN_COMPLETED', async (event) => {
-      const { unhandledErrors, startedAt, finishedAt, storyIds, ...currentRun } = event.payload;
+      const { unhandledErrors, startedAt, finishedAt, ...currentRun } = event.payload;
       await telemetry('addon-test', {
         ...currentRun,
         duration: (finishedAt ?? 0) - (startedAt ?? 0),
-        selectedStoryCount: storyIds?.length ?? 0,
         unhandledErrorCount: unhandledErrors.length,
         ...(enableCrashReports &&
           unhandledErrors.length > 0 && {


### PR DESCRIPTION
Closes #31493

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

1. stopped collecting `selectedStoryCount`, as it was both confusing and not that useful
2. Flushed all pending test case results when test runs finishes. Let me explain:

Test case results continuously come in from Vitest in a steady stream. We throttle the handling of them, because otherwise it consistently chokes our  websocket connection for some reason. (this is very unfortunate, because seeing the test ran count go brrr is really great UX, but for some reason it's too many events for our channel). The problem here, was that when all tests completed we would emit `TEST_RUN_COMPLETED` immediately, even though there were still unhandled test case results left because of the throttled handling. This would result in the unhandled results not being part of the telemetry being emitted.

Now, when Vitest calls the `onTestRunEnd` lifecycle hook - which happens _just_ before `runTestSpecifications` finishes and thus our test run - we flush the throttle function, meaning that we force handle any test case results that are left. Then the test run actually finishes, and we send the telemetry event will all test case results.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. In `scripts` run `yarn jiti ./event-log-collector.ts`
2. Start the UI Storybook or a sandbox with the environment variable `STORYBOOK_TELEMETRY_URL="http://localhost:6007/event-log" yarn storybook`
3. Run local tests with a11y from within the testing widget
4. Visit `http://localhost:6007/event-log` and check that the last event has the same number of tests as those reported in the testing widget

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixed incorrect test count reporting in telemetry data for the Vitest addon by ensuring all test results are properly processed before sending completion events.

- Added `flush()` call in `code/addons/vitest/src/node/test-manager.ts` to process pending throttled test results before emitting completion event
- Removed confusing `selectedStoryCount` metric from telemetry data in `code/addons/vitest/src/preset.ts`
- Maintained 500ms throttling of test case results to prevent websocket overload



<!-- /greptile_comment -->