### PR TITLE
Addon Vitest: Improve handling multiple browser mode projects

### DIFF
--- a/code/addons/vitest/src/node/boot-test-runner.ts
+++ b/code/addons/vitest/src/node/boot-test-runner.ts
@@ -5,7 +5,7 @@ import {
   internal_universalStatusStore,
   internal_universalTestProviderStore,
 } from 'storybook/internal/core-server';
-import type { EventInfo } from 'storybook/internal/types';
+import type { EventInfo, Options } from 'storybook/internal/types';
 
 // eslint-disable-next-line depend/ban-dependencies
 import { execaNode } from 'execa';
@@ -43,9 +43,16 @@ const forwardUniversalStoreEvent =
     });
   };
 
-const bootTestRunner = async (channel: Channel, store: Store) => {
+const bootTestRunner = async ({
+  channel,
+  store,
+  options,
+}: {
+  channel: Channel;
+  store: Store;
+  options: Options;
+}) => {
   let stderr: string[] = [];
-
   const killChild = () => {
     unsubscribeStore?.();
     unsubscribeStatusStore?.();
@@ -74,6 +81,7 @@ const bootTestRunner = async (channel: Channel, store: Store) => {
           TEST: 'true',
           VITEST_CHILD_PROCESS: 'true',
           NODE_ENV: process.env.NODE_ENV ?? 'test',
+          STORYBOOK_CONFIG_DIR: options.configDir,
         },
         extendEnv: true,
       });
@@ -145,18 +153,25 @@ const bootTestRunner = async (channel: Channel, store: Store) => {
   });
 };
 
-export const runTestRunner = async (
-  channel: Channel,
-  store: Store,
-  initEvent?: string,
-  initArgs?: any[]
-) => {
+export const runTestRunner = async ({
+  channel,
+  store,
+  initEvent,
+  initArgs,
+  options,
+}: {
+  channel: Channel;
+  store: Store;
+  initEvent?: string;
+  initArgs?: any[];
+  options: Options;
+}) => {
   if (!ready && initEvent) {
     eventQueue.push({ type: initEvent, args: initArgs });
   }
   if (!child) {
     ready = false;
-    await bootTestRunner(channel, store);
+    await bootTestRunner({ channel, store, options });
     ready = true;
   }
 };

--- a/code/addons/vitest/src/node/test-manager.test.ts
+++ b/code/addons/vitest/src/node/test-manager.test.ts
@@ -4,6 +4,7 @@ import { createVitest as actualCreateVitest } from 'vitest/node';
 import { Channel, type ChannelTransport } from 'storybook/internal/channels';
 import { experimental_MockUniversalStore } from 'storybook/internal/core-server';
 import type {
+  Options,
   StatusStoreByTypeId,
   StoryIndex,
   TestProviderStoreById,
@@ -129,6 +130,9 @@ const options: TestManagerOptions = {
     throw error;
   },
   onReady: vi.fn(),
+  storybookOptions: {
+    configDir: '.storybook',
+  } as Options,
 };
 
 describe('TestManager', () => {

--- a/code/addons/vitest/src/node/test-manager.ts
+++ b/code/addons/vitest/src/node/test-manager.ts
@@ -2,6 +2,7 @@ import type { TestResult, TestState } from 'vitest/dist/node.js';
 
 import type { experimental_UniversalStore } from 'storybook/internal/core-server';
 import type {
+  Options,
   StatusStoreByTypeId,
   StatusValue,
   TestProviderStoreById,
@@ -16,6 +17,7 @@ import { errorToErrorLike } from '../utils';
 import { VitestManager } from './vitest-manager';
 
 export type TestManagerOptions = {
+  storybookOptions: Options;
   store: experimental_UniversalStore<StoreState, StoreEvent>;
   componentTestStatusStore: StatusStoreByTypeId;
   a11yStatusStore: StatusStoreByTypeId;
@@ -45,6 +47,8 @@ export class TestManager {
 
   private onReady?: TestManagerOptions['onReady'];
 
+  public storybookOptions: Options;
+
   private batchedTestCaseResults: {
     storyId: string;
     testResult: TestResult;
@@ -57,6 +61,7 @@ export class TestManager {
     this.a11yStatusStore = options.a11yStatusStore;
     this.testProviderStore = options.testProviderStore;
     this.onReady = options.onReady;
+    this.storybookOptions = options.storybookOptions;
 
     this.vitestManager = new VitestManager(this);
 

--- a/code/addons/vitest/src/node/vitest-manager.ts
+++ b/code/addons/vitest/src/node/vitest-manager.ts
@@ -10,12 +10,7 @@ import type {
 } from 'vitest/node';
 
 import { resolvePathInStorybookCache } from 'storybook/internal/common';
-import type {
-  DocsIndexEntry,
-  StoryId,
-  StoryIndex,
-  StoryIndexEntry,
-} from 'storybook/internal/types';
+import type { StoryId, StoryIndex, StoryIndexEntry } from 'storybook/internal/types';
 
 import { findUp } from 'find-up';
 import path, { dirname, join, normalize } from 'pathe';
@@ -30,12 +25,6 @@ import type { TestManager } from './test-manager';
 
 const VITEST_CONFIG_FILE_EXTENSIONS = ['mts', 'mjs', 'cts', 'cjs', 'ts', 'tsx', 'js', 'jsx'];
 const VITEST_WORKSPACE_FILE_EXTENSION = ['ts', 'js', 'json'];
-
-type TagsFilter = {
-  include: string[];
-  exclude: string[];
-  skip: string[];
-};
 
 const packageDir = dirname(require.resolve('@storybook/addon-vitest/package.json'));
 
@@ -81,11 +70,15 @@ export class VitestManager {
       ...VITEST_CONFIG_FILE_EXTENSIONS.map((ext) => `vitest.config.${ext}`),
     ]);
 
+    const projectName = 'storybook:' + process.env.STORYBOOK_CONFIG_DIR;
+    console.log('Filtering with projectName', projectName);
+
     try {
       this.vitest = await createVitest('test', {
         root: vitestWorkspaceConfig ? dirname(vitestWorkspaceConfig) : process.cwd(),
         watch: true,
         passWithNoTests: false,
+        project: [projectName],
         // TODO:
         // Do we want to enable Vite's default reporter?
         // The output in the terminal might be too spamy and it might be better to

--- a/code/addons/vitest/src/node/vitest-manager.ts
+++ b/code/addons/vitest/src/node/vitest-manager.ts
@@ -71,7 +71,6 @@ export class VitestManager {
     ]);
 
     const projectName = 'storybook:' + process.env.STORYBOOK_CONFIG_DIR;
-    console.log('Filtering with projectName', projectName);
 
     try {
       this.vitest = await createVitest('test', {
@@ -91,8 +90,8 @@ export class VitestManager {
       const originalMessage = String(err.message);
       if (originalMessage.includes('Found multiple projects')) {
         const custom = [
-          'Storybook was unable to start the test run because you have multiple Vitest projects in headed browser mode.',
-          'Please set `headless: true` in your Storybook vitest config, or if you want to run Storybook tests in headed browser mode, set `headless: true` to all other browser mode projects.\n\n',
+          'Storybook was unable to start the test run because you have multiple Vitest projects (or browsers) in headed mode.',
+          'Please set `headless: true` in your Storybook vitest config.\n\n',
         ].join('\n');
 
         if (!originalMessage.startsWith(custom)) {

--- a/code/addons/vitest/src/node/vitest.ts
+++ b/code/addons/vitest/src/node/vitest.ts
@@ -49,6 +49,9 @@ new TestManager({
   onReady: () => {
     process.send?.({ type: 'ready' });
   },
+  storybookOptions: {
+    configDir: process.env.STORYBOOK_CONFIG_DIR || '',
+  } as any,
 });
 
 const exit = (code = 0) => {

--- a/code/addons/vitest/src/preset.ts
+++ b/code/addons/vitest/src/preset.ts
@@ -105,7 +105,13 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
       ...s,
       fatalError: undefined,
     }));
-    runTestRunner(channel, store, STORE_CHANNEL_EVENT_NAME, [{ event, eventInfo }]);
+    runTestRunner({
+      channel,
+      store,
+      initEvent: STORE_CHANNEL_EVENT_NAME,
+      initArgs: [{ event, eventInfo }],
+      options,
+    });
   });
   store.subscribe('TOGGLE_WATCHING', (event, eventInfo) => {
     store.setState((s) => ({
@@ -120,7 +126,13 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
       },
     }));
     if (event.payload.to) {
-      runTestRunner(channel, store, STORE_CHANNEL_EVENT_NAME, [{ event, eventInfo }]);
+      runTestRunner({
+        channel,
+        store,
+        initEvent: STORE_CHANNEL_EVENT_NAME,
+        initArgs: [{ event, eventInfo }],
+        options,
+      });
     }
   });
   store.subscribe('FATAL_ERROR', (event) => {

--- a/code/addons/vitest/src/utils.ts
+++ b/code/addons/vitest/src/utils.ts
@@ -22,7 +22,8 @@ export function errorToErrorLike(error: Error): ErrorLike {
   return {
     message: error.message,
     name: error.name,
-    stack: error.stack,
+    // avoid duplicating the error message in the stack trace
+    stack: error.stack?.replace(error.message, ''),
     cause: error.cause && error.cause instanceof Error ? errorToErrorLike(error.cause) : undefined,
   };
 }

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -183,183 +183,180 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
         .replace('</head>', `${headHtmlSnippet ?? ''}</head>`)
         .replace('<body>', `<body>${bodyHtmlSnippet ?? ''}`);
     },
-    config: {
-      order: 'pre',
-      async handler(nonMutableInputConfig: ViteUserConfig) {
-        // ! We're not mutating the input config, instead we're returning a new partial config
-        // ! see https://vite.dev/guide/api-plugin.html#config
-        try {
-          await validateConfigurationFiles(finalOptions.configDir);
-        } catch (err) {
-          throw new MainFileMissingError({
-            location: finalOptions.configDir,
-            source: 'vitest',
-          });
-        }
+    async config(nonMutableInputConfig) {
+      // ! We're not mutating the input config, instead we're returning a new partial config
+      // ! see https://vite.dev/guide/api-plugin.html#config
+      try {
+        await validateConfigurationFiles(finalOptions.configDir);
+      } catch (err) {
+        throw new MainFileMissingError({
+          location: finalOptions.configDir,
+          source: 'vitest',
+        });
+      }
 
-        const frameworkName = typeof framework === 'string' ? framework : framework.name;
+      const frameworkName = typeof framework === 'string' ? framework : framework.name;
 
-        // If we end up needing to know if we are running in browser mode later
-        // const isRunningInBrowserMode = config.plugins.find((plugin: Plugin) =>
-        //   plugin.name?.startsWith('vitest:browser')
-        // )
+      // If we end up needing to know if we are running in browser mode later
+      // const isRunningInBrowserMode = config.plugins.find((plugin: Plugin) =>
+      //   plugin.name?.startsWith('vitest:browser')
+      // )
 
-        // We signal the test runner that we are not running it via Storybook
-        // We are overriding the environment variable to 'true' if vitest runs via @storybook/addon-vitest's backend
-        const vitestStorybook = process.env.VITEST_STORYBOOK ?? 'false';
+      // We signal the test runner that we are not running it via Storybook
+      // We are overriding the environment variable to 'true' if vitest runs via @storybook/addon-vitest's backend
+      const vitestStorybook = process.env.VITEST_STORYBOOK ?? 'false';
 
-        const testConfig = nonMutableInputConfig.test;
-        finalOptions.vitestRoot =
-          testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
+      const testConfig = nonMutableInputConfig.test;
+      finalOptions.vitestRoot =
+        testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
 
-        const includeStories = stories
-          .map((story) => {
-            let storyPath;
+      const includeStories = stories
+        .map((story) => {
+          let storyPath;
 
-            if (typeof story === 'string') {
-              storyPath = story;
-            } else {
-              storyPath = `${story.directory}/${story.files ?? DEFAULT_FILES_PATTERN}`;
-            }
+          if (typeof story === 'string') {
+            storyPath = story;
+          } else {
+            storyPath = `${story.directory}/${story.files ?? DEFAULT_FILES_PATTERN}`;
+          }
 
-            return join(finalOptions.configDir, storyPath);
-          })
-          .map((story) => {
-            const root =
-              testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
-            return relative(root, story);
-          });
+          return join(finalOptions.configDir, storyPath);
+        })
+        .map((story) => {
+          const root =
+            testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
+          return relative(root, story);
+        });
 
-        finalOptions.includeStories = includeStories;
-        const projectId = oneWayHash(finalOptions.configDir);
+      finalOptions.includeStories = includeStories;
+      const projectId = oneWayHash(finalOptions.configDir);
 
-        const baseConfig: Omit<ViteUserConfig, 'plugins'> = {
-          cacheDir: resolvePathInStorybookCache('sb-vitest', projectId),
-          test: {
-            setupFiles: [
-              join(PACKAGE_DIR, 'dist/vitest-plugin/setup-file.mjs'),
-              // if the existing setupFiles is a string, we have to include it otherwise we're overwriting it
-              typeof nonMutableInputConfig.test?.setupFiles === 'string' &&
-                nonMutableInputConfig.test?.setupFiles,
-            ].filter(Boolean) as string[],
+      const baseConfig: Omit<ViteUserConfig, 'plugins'> = {
+        cacheDir: resolvePathInStorybookCache('sb-vitest', projectId),
+        test: {
+          setupFiles: [
+            join(PACKAGE_DIR, 'dist/vitest-plugin/setup-file.mjs'),
+            // if the existing setupFiles is a string, we have to include it otherwise we're overwriting it
+            typeof nonMutableInputConfig.test?.setupFiles === 'string' &&
+              nonMutableInputConfig.test?.setupFiles,
+          ].filter(Boolean) as string[],
 
-            ...(finalOptions.storybookScript
-              ? {
-                  globalSetup: [join(PACKAGE_DIR, 'dist/vitest-plugin/global-setup.mjs')],
-                }
-              : {}),
+          ...(finalOptions.storybookScript
+            ? {
+                globalSetup: [join(PACKAGE_DIR, 'dist/vitest-plugin/global-setup.mjs')],
+              }
+            : {}),
 
-            env: {
-              ...storybookEnv,
-              // To be accessed by the setup file
-              __STORYBOOK_URL__: finalOptions.storybookUrl,
+          env: {
+            ...storybookEnv,
+            // To be accessed by the setup file
+            __STORYBOOK_URL__: finalOptions.storybookUrl,
 
-              VITEST_STORYBOOK: vitestStorybook,
-              __VITEST_INCLUDE_TAGS__: finalOptions.tags.include.join(','),
-              __VITEST_EXCLUDE_TAGS__: finalOptions.tags.exclude.join(','),
-              __VITEST_SKIP_TAGS__: finalOptions.tags.skip.join(','),
-            },
+            VITEST_STORYBOOK: vitestStorybook,
+            __VITEST_INCLUDE_TAGS__: finalOptions.tags.include.join(','),
+            __VITEST_EXCLUDE_TAGS__: finalOptions.tags.exclude.join(','),
+            __VITEST_SKIP_TAGS__: finalOptions.tags.skip.join(','),
+          },
 
-            include: includeStories,
-            exclude: [...(nonMutableInputConfig.test?.exclude ?? []), '**/*.mdx'],
+          include: includeStories,
+          exclude: [...(nonMutableInputConfig.test?.exclude ?? []), '**/*.mdx'],
 
-            // if the existing deps.inline is true, we keep it as-is, because it will inline everything
-            ...(nonMutableInputConfig.test?.server?.deps?.inline !== true
-              ? {
-                  server: {
-                    deps: {
-                      inline: ['@storybook/addon-vitest'],
-                    },
+          // if the existing deps.inline is true, we keep it as-is, because it will inline everything
+          ...(nonMutableInputConfig.test?.server?.deps?.inline !== true
+            ? {
+                server: {
+                  deps: {
+                    inline: ['@storybook/addon-vitest'],
                   },
+                },
+              }
+            : {}),
+
+          browser: {
+            commands: {
+              getInitialGlobals: () => {
+                const envConfig = JSON.parse(process.env.VITEST_STORYBOOK_CONFIG ?? '{}');
+
+                const shouldRunA11yTests = process.env.VITEST_STORYBOOK
+                  ? (envConfig.a11y ?? false)
+                  : true;
+
+                return {
+                  a11y: {
+                    manual: !shouldRunA11yTests,
+                  },
+                };
+              },
+            },
+            // if there is a test.browser config AND test.browser.screenshotFailures is not explicitly set, we set it to false
+            ...(nonMutableInputConfig.test?.browser &&
+            nonMutableInputConfig.test.browser.screenshotFailures === undefined
+              ? {
+                  screenshotFailures: false,
                 }
               : {}),
-
-            browser: {
-              commands: {
-                getInitialGlobals: () => {
-                  const envConfig = JSON.parse(process.env.VITEST_STORYBOOK_CONFIG ?? '{}');
-
-                  const shouldRunA11yTests = process.env.VITEST_STORYBOOK
-                    ? (envConfig.a11y ?? false)
-                    : true;
-
-                  return {
-                    a11y: {
-                      manual: !shouldRunA11yTests,
-                    },
-                  };
-                },
-              },
-              // if there is a test.browser config AND test.browser.screenshotFailures is not explicitly set, we set it to false
-              ...(nonMutableInputConfig.test?.browser &&
-              nonMutableInputConfig.test.browser.screenshotFailures === undefined
-                ? {
-                    screenshotFailures: false,
-                  }
-                : {}),
-            },
           },
+        },
 
-          envPrefix: Array.from(
-            new Set([...(nonMutableInputConfig.envPrefix || []), 'STORYBOOK_', 'VITE_'])
-          ),
+        envPrefix: Array.from(
+          new Set([...(nonMutableInputConfig.envPrefix || []), 'STORYBOOK_', 'VITE_'])
+        ),
 
-          resolve: {
-            conditions: [
-              'storybook',
-              'stories',
-              'test',
-              // copying straight from https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L60
-              // to avoid having to maintain Vite as a dependency just for this
-              'module',
-              'browser',
-              'development|production',
-            ],
-          },
+        resolve: {
+          conditions: [
+            'storybook',
+            'stories',
+            'test',
+            // copying straight from https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L60
+            // to avoid having to maintain Vite as a dependency just for this
+            'module',
+            'browser',
+            'development|production',
+          ],
+        },
 
-          optimizeDeps: {
-            include: [
-              '@storybook/addon-vitest/internal/setup-file',
-              '@storybook/addon-vitest/internal/global-setup',
-              '@storybook/addon-vitest/internal/test-utils',
-              ...(frameworkName?.includes('react') || frameworkName?.includes('nextjs')
-                ? ['react-dom/test-utils']
-                : []),
-            ],
-          },
+        optimizeDeps: {
+          include: [
+            '@storybook/addon-vitest/internal/setup-file',
+            '@storybook/addon-vitest/internal/global-setup',
+            '@storybook/addon-vitest/internal/test-utils',
+            ...(frameworkName?.includes('react') || frameworkName?.includes('nextjs')
+              ? ['react-dom/test-utils']
+              : []),
+          ],
+        },
 
-          define: {
-            ...(frameworkName?.includes('vue3')
-              ? { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false' }
-              : {}),
-          },
-        };
+        define: {
+          ...(frameworkName?.includes('vue3')
+            ? { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false' }
+            : {}),
+        },
+      };
 
-        // Merge config from storybook with the plugin config
-        const config: Omit<ViteUserConfig, 'plugins'> = mergeConfig(
-          baseConfig,
-          viteConfigFromStorybook
+      // Merge config from storybook with the plugin config
+      const config: Omit<ViteUserConfig, 'plugins'> = mergeConfig(
+        baseConfig,
+        viteConfigFromStorybook
+      );
+
+      // alert the user of problems
+      if ((nonMutableInputConfig.test?.include?.length ?? 0) > 0) {
+        // remove the user's existing include, because we're replacing it with our own heuristic based on main.ts#stories
+        // @ts-expect-error: Ignore
+        nonMutableInputConfig.test.include = [];
+        console.log(
+          picocolors.yellow(dedent`
+            Warning: Starting in Storybook 8.5.0-alpha.18, the "test.include" option in Vitest is discouraged in favor of just using the "stories" field in your Storybook configuration.
+
+            The values you passed to "test.include" will be ignored, please remove them from your Vitest configuration where the Storybook plugin is applied.
+            
+            More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#addon-test-indexing-behavior-of-storybookaddon-test-is-changed
+          `)
         );
+      }
 
-        // alert the user of problems
-        if ((nonMutableInputConfig.test?.include?.length ?? 0) > 0) {
-          // remove the user's existing include, because we're replacing it with our own heuristic based on main.ts#stories
-          // @ts-expect-error: Ignore
-          nonMutableInputConfig.test.include = [];
-          console.log(
-            picocolors.yellow(dedent`
-              Warning: Starting in Storybook 8.5.0-alpha.18, the "test.include" option in Vitest is discouraged in favor of just using the "stories" field in your Storybook configuration.
-
-              The values you passed to "test.include" will be ignored, please remove them from your Vitest configuration where the Storybook plugin is applied.
-              
-              More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#addon-test-indexing-behavior-of-storybookaddon-test-is-changed
-            `)
-          );
-        }
-
-        // return the new config, it will be deep-merged by vite
-        return config;
-      },
+      // return the new config, it will be deep-merged by vite
+      return config;
     },
     configureVitest(context) {
       context.vitest.config.coverage.exclude.push('storybook-static');

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -499,9 +499,11 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
               testNamePattern: /^(?!.*(UseState)).*$/,
               browser: {
                 enabled: true,
-                name: "chromium",
                 provider: "playwright",
                 headless: true,
+                instances: [{
+                  browser: 'chromium'
+                }]
               },
               setupFiles: ["./.storybook/vitest.setup.ts"],
               environment: "happy-dom",
@@ -570,10 +572,12 @@ export async function setupVitest(details: TemplateDetails, options: PassedOptio
             // @ts-expect-error this type does not exist but the property does!
             testNamePattern: /^(?!.*(UseState)).*$/,
             browser: {
-              enabled: true,
-              name: "chromium",
+              enabled: true,  
               provider: "playwright",
               headless: true,
+              instances: [{
+                browser: 'chromium'
+              }]
             },
             setupFiles: ["./.storybook/vitest.setup.ts"],
             environment: "happy-dom",


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/30673

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Vitest addon now injects a fixed name to a given Vitest project, a combination of `storybook:${absoluteConfigDirPath}` so that it can be uniquely identified. Then, that same name is passed when running tests via the Storybook UI, so now Vitest will filter out the project upon start, differently than before which was upon evaluating all projects

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31508-sha-d39cb90b`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31508-sha-d39cb90b sandbox` or in an existing project with `npx storybook@0.0.0-pr-31508-sha-d39cb90b upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31508-sha-d39cb90b`](https://npmjs.com/package/storybook/v/0.0.0-pr-31508-sha-d39cb90b) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/multi-browser-experiment`](https://github.com/storybookjs/storybook/tree/yann/multi-browser-experiment) |
| **Commit** | [`d39cb90b`](https://github.com/storybookjs/storybook/commit/d39cb90b01517274276b1632daf26ba7f46c2fee) |
| **Datetime** | Tue May 20 13:23:24 UTC 2025 (`1747747404`) |
| **Workflow run** | [15138728836](https://github.com/storybookjs/storybook/actions/runs/15138728836) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31508`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
