### PR TITLE
Addon Vitest: Ensure vitest exclusions are relative to the project root, not cwd

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -210,9 +210,6 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
       finalOptions.vitestRoot =
         testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
 
-      const root =
-        testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
-
       const includeStories = stories
         .map((story) => {
           let storyPath;
@@ -226,7 +223,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
           return join(finalOptions.configDir, storyPath);
         })
         .map((story) => {
-          return relative(root, story);
+          return relative(finalOptions.vitestRoot, story);
         });
 
       finalOptions.includeStories = includeStories;
@@ -262,7 +259,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
           include: includeStories,
           exclude: [
             ...(nonMutableInputConfig.test?.exclude ?? []),
-            join(relative(root, process.cwd()), '**/*.mdx').replaceAll(sep, '/'),
+            join(relative(finalOptions.vitestRoot, process.cwd()), '**/*.mdx').replaceAll(sep, '/'),
           ],
 
           // if the existing deps.inline is true, we keep it as-is, because it will inline everything

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -22,7 +22,7 @@ import { oneWayHash } from 'storybook/internal/telemetry';
 import type { Presets } from 'storybook/internal/types';
 
 import { match } from 'micromatch';
-import { dirname, join, relative, resolve } from 'pathe';
+import { dirname, join, relative, resolve, sep } from 'pathe';
 import picocolors from 'picocolors';
 import sirv from 'sirv';
 import { dedent } from 'ts-dedent';
@@ -210,6 +210,9 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
       finalOptions.vitestRoot =
         testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
 
+      const root =
+        testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
+
       const includeStories = stories
         .map((story) => {
           let storyPath;
@@ -223,8 +226,6 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
           return join(finalOptions.configDir, storyPath);
         })
         .map((story) => {
-          const root =
-            testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
           return relative(root, story);
         });
 
@@ -259,7 +260,10 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
           },
 
           include: includeStories,
-          exclude: [...(nonMutableInputConfig.test?.exclude ?? []), '**/*.mdx'],
+          exclude: [
+            ...(nonMutableInputConfig.test?.exclude ?? []),
+            join(relative(root, process.cwd()), '**/*.mdx').replaceAll(sep, '/'),
+          ],
 
           // if the existing deps.inline is true, we keep it as-is, because it will inline everything
           ...(nonMutableInputConfig.test?.server?.deps?.inline !== true


### PR DESCRIPTION
Closes #31500

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

If you keep all your config in your `./.storybook` directory, then your test patterns will likely be something like:

`["../stories/**/*.stories.ts", "../stories/**/*.mdx"]`

By default, addon-vitest only adds an ignore pattern of `**/*.mdx`, which does not match the patterns above.

This change ensures that the mdx exclusion glob is relative to the project root directory rather than cwd, to match the inclusion globs.

More refinement and testing required, I just thought of this on the way to bed.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Modified Vitest plugin to fix MDX file exclusion patterns by making them relative to the project root instead of the current working directory, addressing test file discovery issues.

- Updated path handling in `code/addons/vitest/src/vitest-plugin/index.ts` to use `join(relative(root, process.cwd()), '**/*.mdx')` for correct MDX exclusion
- Added `sep` import from `pathe` for cross-platform path separator handling
- Normalized path separators using `replaceAll(sep, '/')`



<!-- /greptile_comment -->