### PR TITLE
React Native: Fix support for 9.0

### DIFF
--- a/code/core/scripts/entries.ts
+++ b/code/core/scripts/entries.ts
@@ -62,7 +62,7 @@ export const getEntries = (cwd: string) => {
       'src/manager-api/index.ts',
       ['browser', 'node'],
       true,
-      ['react', '@storybook/icons', 'react-dom'],
+      ['react', 'react-dom'],
       [],
       [],
       true

--- a/code/core/src/manager-api/modules/whatsnew.tsx
+++ b/code/core/src/manager-api/modules/whatsnew.tsx
@@ -9,7 +9,6 @@ import {
 import type { WhatsNewCache, WhatsNewData } from 'storybook/internal/core-events';
 
 import { global } from '@storybook/global';
-import { StorybookIcon } from '@storybook/icons';
 
 import type { ModuleFn } from '../lib/types';
 
@@ -24,6 +23,33 @@ export type SubAPI = {
 };
 
 const WHATS_NEW_NOTIFICATION_ID = 'whats-new';
+
+/*
+Copied from https://github.com/storybookjs/icons/blob/main/src/icons/StorybookIcon.tsx
+because:
+A. if we import the icon from @storybook/icons, the CJS output can't tree-shake the package, so it increases the bundle size with +200KB
+B. we can't rely on the globalization by the manager, because react native also uses this manager-api and doesn't do the globalization
+
+TODO: turn this into an import again when we go ESM-only in Storybook 10, as the ESM output tree-shakes fine
+*/
+const StorybookIcon = ({ color = 'currentColor', size = 14 }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M2.042.616a.704.704 0 00-.66.729L1.816 12.9c.014.367.306.66.672.677l9.395.422h.032a.704.704 0 00.704-.703V.704c0-.015 0-.03-.002-.044a.704.704 0 00-.746-.659l-.773.049.057 1.615a.105.105 0 01-.17.086l-.52-.41-.617.468a.105.105 0 01-.168-.088L9.746.134 2.042.616zm8.003 4.747c-.247.192-2.092.324-2.092.05.04-1.045-.429-1.091-.689-1.091-.247 0-.662.075-.662.634 0 .57.607.893 1.32 1.27 1.014.538 2.24 1.188 2.24 2.823 0 1.568-1.273 2.433-2.898 2.433-1.676 0-3.141-.678-2.976-3.03.065-.275 2.197-.21 2.197 0-.026.971.195 1.256.753 1.256.43 0 .624-.236.624-.634 0-.602-.633-.958-1.361-1.367-.987-.554-2.148-1.205-2.148-2.7 0-1.494 1.027-2.489 2.86-2.489 1.832 0 2.832.98 2.832 2.845z"
+        fill={color}
+      />
+    </svg>
+  );
+};
 
 export const init: ModuleFn = ({ fullAPI, store, provider }) => {
   const state: SubState = {

--- a/code/core/src/preview-api/modules/preview-web/render/animation-utils.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/animation-utils.ts
@@ -8,11 +8,7 @@ export function isTestEnvironment() {
       // @ts-expect-error this property exists in certain environments
       !!globalThis.__vitest_browser__ ||
       // @ts-expect-error this property exists in certain environments
-      !!globalThis.__playwright__binding__ ||
-      // @ts-expect-error this property exists in certain environments
-      !!import.meta.vitest ||
-      // @ts-expect-error this property exists in certain environments
-      import.meta.env.MODE === 'test'
+      !!globalThis.__playwright__binding__
     );
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (e) {


### PR DESCRIPTION
Closes #31481

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

1. Removed redundant checks via `import.meta` which React Native doesn't support out of the box. I tested that `globalThis.__vitest_browser__` was sufficient, it _did_ pause animations at end, but SB UI waited correctly.
2. stopped externalising `@storybook/icons` in `manager-api`, so they are inlined. This is because `@storybook/icons` is usually globalized in the manager, and thus not an actual dependency in storybook. But in React Native Storybook this globalization doesn't happen, so it was crashing on not finding the package.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31518-sha-a4ae4499`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31518-sha-a4ae4499 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31518-sha-a4ae4499 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31518-sha-a4ae4499`](https://npmjs.com/package/storybook/v/0.0.0-pr-31518-sha-a4ae4499) |
| **Triggered by** | @JReinhold |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`jeppe/fix-react-native-9.0`](https://github.com/storybookjs/storybook/tree/jeppe/fix-react-native-9.0) |
| **Commit** | [`a4ae4499`](https://github.com/storybookjs/storybook/commit/a4ae449960fff7a3d06a34f57d6218e91298b574) |
| **Datetime** | Tue May 20 14:18:19 UTC 2025 (`1747750699`) |
| **Workflow run** | [15140016513](https://github.com/storybookjs/storybook/actions/runs/15140016513) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31518`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR fixes React Native compatibility issues in Storybook 9.0 by removing unsupported `import.meta` checks and handling icon dependencies differently in the manager API.

- Removed `import.meta` checks in `code/core/src/preview-api/modules/preview-web/render/animation-utils.ts`, replacing with `globalThis.__vitest_browser__` for test environment detection
- Inlined `@storybook/icons` in manager-api instead of externalizing it to fix React Native package resolution
- Modified `code/core/scripts/entries.ts` to reflect the new icons dependency handling



<!-- /greptile_comment -->