### PR TITLE
Core: Assert updated state in play function

### DIFF
--- a/code/core/src/manager/components/sidebar/TestingModule.stories.tsx
+++ b/code/core/src/manager/components/sidebar/TestingModule.stories.tsx
@@ -11,7 +11,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { ManagerContext, mockChannel } from 'storybook/manager-api';
-import { fireEvent, fn } from 'storybook/test';
+import { expect, fireEvent, fn, waitFor } from 'storybook/test';
 import { styled } from 'storybook/theming';
 
 import { internal_fullTestProviderStore } from '../../manager-stores.mock';
@@ -186,7 +186,11 @@ export const Crashed: Story = {
 export const SettingsUpdated: Story = {
   play: async (playContext) => {
     await Expanded.play!(playContext);
+    const testingModule = document.getElementById('storybook-testing-module');
+    await waitFor(() => expect(testingModule!.dataset.updated).toBe('false'));
     internal_fullTestProviderStore.settingsChanged();
+    await waitFor(() => expect(testingModule!.dataset.updated).toBe('true'));
+    await waitFor(() => expect(testingModule!.dataset.updated).toBe('false'));
   },
 };
 

--- a/code/core/src/manager/components/sidebar/TestingModule.tsx
+++ b/code/core/src/manager/components/sidebar/TestingModule.tsx
@@ -267,6 +267,7 @@ export const TestingModule = ({
       crashed={isCrashed}
       failed={errorCount > 0}
       updated={isUpdated}
+      data-updated={isUpdated}
     >
       <Card>
         {hasTestProviders && (


### PR DESCRIPTION
## What I did

Fixes inconsistent visual test for the "Settings updated" story, which changes box-shadow based on a prop controlled by the play function, and so is not affected by disabling animations.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR fixes visual testing for the TestingModule's 'Settings updated' story by adding a `data-updated` attribute and proper assertions to verify state transitions.

- Added `data-updated` attribute to `Outline` component in `code/core/src/manager/components/sidebar/TestingModule.tsx` to track settings update state
- Added `waitFor` assertions in `TestingModule.stories.tsx` to verify `data-updated` transitions from 'false' to 'true' and back
- Imported test utilities from `storybook/test` to support new assertions
- Fixed inconsistent visual test behavior that was not properly captured by animation disabling



<!-- /greptile_comment -->