### PR TITLE
Controls: Remove empty state video link

### DIFF
--- a/code/addons/docs/src/blocks/components/ArgsTable/Empty.tsx
+++ b/code/addons/docs/src/blocks/components/ArgsTable/Empty.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 
 import { EmptyTabContent, Link } from 'storybook/internal/components';
 
-import { DocumentIcon, VideoIcon } from '@storybook/icons';
+import { DocumentIcon } from '@storybook/icons';
 
 import { styled } from 'storybook/theming';
 
@@ -28,12 +28,6 @@ const Links = styled.div(({ theme }) => ({
   display: 'flex',
   fontSize: theme.typography.size.s2 - 1,
   gap: 25,
-}));
-
-const Divider = styled.div(({ theme }) => ({
-  width: 1,
-  height: 16,
-  backgroundColor: theme.appBorderColor,
 }));
 
 export const Empty: FC<EmptyProps> = ({ inAddonPanel }) => {
@@ -72,10 +66,6 @@ export const Empty: FC<EmptyProps> = ({ inAddonPanel }) => {
           <Links>
             {inAddonPanel && (
               <>
-                <Link href="https://youtu.be/0gOfS6K0x0E" target="_blank" withArrow>
-                  <VideoIcon /> Watch 5m video
-                </Link>
-                <Divider />
                 <Link
                   href="https://storybook.js.org/docs/essentials/controls"
                   target="_blank"


### PR DESCRIPTION
## What I did

See title

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Removes the video link from the empty state of the ArgsTable component, simplifying the UI by keeping only the documentation link as the call-to-action.

- Removed `VideoIcon` import and video link element from `code/addons/docs/src/blocks/components/ArgsTable/Empty.tsx`
- Simplified `Links` styled component by removing gap styling for multiple links
- Maintained core loading behavior and conditional rendering based on `inAddonPanel` prop



<!-- /greptile_comment -->