### PR TITLE
Chore: Fix story decorators

### DIFF
--- a/code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx
+++ b/code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx
@@ -23,13 +23,11 @@ const meta = {
   // This decorator is used to show the modal in the side by side view
   decorators: [
     (Story, context) => {
-      const [container, setContainer] = useState<HTMLElement | null>(null);
+      const [container, setContainer] = useState<HTMLElement | undefined>(undefined);
 
       return (
         <div
-          ref={(element) => {
-            setContainer(element);
-          }}
+          ref={(element) => setContainer(element ?? undefined)}
           style={{
             width: '100%',
             height: '100%',
@@ -37,7 +35,7 @@ const meta = {
             transform: 'translateZ(0)',
           }}
         >
-          <Story {...context.args} container={container} />
+          <Story args={{ ...context.args, container }} />
         </div>
       );
     },

--- a/code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx
+++ b/code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx
@@ -102,7 +102,7 @@ export const WithSearchResults: Story = {
     const moduleSingleExport = await findByText(parent, 'module-single-export.js');
     await fireEvent.click(moduleSingleExport);
 
-    expect(args.onCreateNewStory).toHaveBeenCalledWith({
+    await expect(args.onCreateNewStory).toHaveBeenCalledWith({
       componentExportCount: 1,
       componentExportName: 'default',
       componentFilePath: 'src/module-single-export.js',

--- a/code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx
+++ b/code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx
@@ -37,8 +37,7 @@ const meta = {
             transform: 'translateZ(0)',
           }}
         >
-          {/* @ts-expect-error (non strict) */}
-          {Story({ args: { ...context.args, container } })}
+          <Story {...context.args} container={container} />
         </div>
       );
     },

--- a/code/frameworks/nextjs-vite/template/stories/Image.stories.tsx
+++ b/code/frameworks/nextjs-vite/template/stories/Image.stories.tsx
@@ -55,7 +55,11 @@ export const FilledParent: Story = {
     fill: true,
   },
   decorators: [
-    (Story) => <div style={{ width: 500, height: 500, position: 'relative' }}>{Story()}</div>,
+    (Story) => (
+      <div style={{ width: 500, height: 500, position: 'relative' }}>
+        <Story />
+      </div>
+    ),
   ],
 };
 
@@ -65,7 +69,11 @@ export const Sized: Story = {
     sizes: '(max-width: 600px) 100vw, 600px',
   },
   decorators: [
-    (Story) => <div style={{ width: 800, height: 800, position: 'relative' }}>{Story()}</div>,
+    (Story) => (
+      <div style={{ width: 800, height: 800, position: 'relative' }}>
+        <Story />
+      </div>
+    ),
   ],
 };
 
@@ -79,7 +87,7 @@ export const Lazy: Story = {
     (Story) => (
       <>
         <div style={{ height: '200vh' }} />
-        {Story()}
+        <Story />
       </>
     ),
   ],

--- a/code/frameworks/nextjs/template/stories/Image.stories.tsx
+++ b/code/frameworks/nextjs/template/stories/Image.stories.tsx
@@ -53,7 +53,11 @@ export const FilledParent: Story = {
     fill: true,
   },
   decorators: [
-    (Story) => <div style={{ width: 500, height: 500, position: 'relative' }}>{Story()}</div>,
+    (Story) => (
+      <div style={{ width: 500, height: 500, position: 'relative' }}>
+        <Story />
+      </div>
+    ),
   ],
 };
 
@@ -63,7 +67,11 @@ export const Sized: Story = {
     sizes: '(max-width: 600px) 100vw, 600px',
   },
   decorators: [
-    (Story) => <div style={{ width: 800, height: 800, position: 'relative' }}>{Story()}</div>,
+    (Story) => (
+      <div style={{ width: 800, height: 800, position: 'relative' }}>
+        <Story />
+      </div>
+    ),
   ],
 };
 
@@ -77,7 +85,7 @@ export const Lazy: Story = {
     (Story) => (
       <>
         <div style={{ height: '200vh' }} />
-        {Story()}
+        <Story />
       </>
     ),
   ],

--- a/test-storybooks/portable-stories-kitchen-sink/nextjs/.storybook/preview.tsx
+++ b/test-storybooks/portable-stories-kitchen-sink/nextjs/.storybook/preview.tsx
@@ -9,7 +9,7 @@ const preview: Preview = {
       <div data-testid="global-decorator">
         Global Decorator
         <br />
-        {StoryFn()}
+        <StoryFn />
       </div>
     ),
   ],

--- a/test-storybooks/portable-stories-kitchen-sink/nextjs/stories/Image.stories.tsx
+++ b/test-storybooks/portable-stories-kitchen-sink/nextjs/stories/Image.stories.tsx
@@ -51,7 +51,11 @@ export const FilledParent: Story = {
     fill: true,
   },
   decorators: [
-    (Story) => <div style={{ width: 500, height: 500, position: 'relative' }}>{Story()}</div>,
+    (Story) => (
+      <div style={{ width: 500, height: 500, position: 'relative' }}>
+        <Story />
+      </div>
+    ),
   ],
 };
 
@@ -61,7 +65,11 @@ export const Sized: Story = {
     sizes: '(max-width: 600px) 100vw, 600px',
   },
   decorators: [
-    (Story) => <div style={{ width: 800, height: 800, position: 'relative' }}>{Story()}</div>,
+    (Story) => (
+      <div style={{ width: 800, height: 800, position: 'relative' }}>
+        <Story />
+      </div>
+    ),
   ],
 };
 
@@ -75,7 +83,7 @@ export const Lazy: Story = {
     (Story) => (
       <>
         <div style={{ height: '200vh' }} />
-        {Story()}
+        <Story />
       </>
     ),
   ],


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Updated a bunch of decorators to use the `<Story />` JSX syntax rather than invoking `Story` as a function.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates story decorator syntax across multiple files to use modern JSX component syntax (`<Story />`) instead of function calls (`Story()`), improving type safety and aligning with Storybook best practices.

- Changed decorator syntax in `code/frameworks/nextjs-vite/template/stories/Image.stories.tsx` for FilledParent, Sized, and Lazy stories
- Updated decorator in `test-storybooks/portable-stories-kitchen-sink/nextjs/.storybook/preview.tsx` to use JSX component syntax
- Fixed TypeScript error suppression and improved type safety in `code/core/src/manager/components/sidebar/FileSearchModal.stories.tsx`
- Added 'await' keyword to expect assertion in play function for better test reliability



<!-- /greptile_comment -->