### PR TITLE
Manager: Add reactivity to useParameter

### DIFF
--- a/code/core/src/manager-api/root.tsx
+++ b/code/core/src/manager-api/root.tsx
@@ -13,6 +13,7 @@ import React, {
 import type { Listener } from 'storybook/internal/channels';
 import { deprecate } from 'storybook/internal/client-logger';
 import {
+  DOCS_PREPARED,
   SET_STORIES,
   SHARED_STATE_CHANGED,
   SHARED_STATE_SET,
@@ -341,16 +342,19 @@ export function useParameter<S>(parameterKey: string, defaultValue?: S) {
   const api = useStorybookApi();
   const [parameter, setParameter] = useState(api.getCurrentParameter<S>(parameterKey));
 
+  const handleParameterChange = useCallback(() => {
+    const newParameter = api.getCurrentParameter<S>(parameterKey);
+    if (newParameter !== parameter) {
+      setParameter(newParameter);
+    }
+  }, [api, parameter, parameterKey]);
+
   useChannel(
     {
-      [STORY_PREPARED]: () => {
-        const newParameter = api.getCurrentParameter<S>(parameterKey);
-        if (newParameter !== parameter) {
-          setParameter(newParameter);
-        }
-      },
+      [STORY_PREPARED]: handleParameterChange,
+      [DOCS_PREPARED]: handleParameterChange,
     },
-    []
+    [handleParameterChange]
   );
 
   return orDefault<S>(parameter, defaultValue!);

--- a/code/core/src/manager-api/root.tsx
+++ b/code/core/src/manager-api/root.tsx
@@ -346,7 +346,7 @@ export function useParameter<S>(parameterKey: string, defaultValue?: S) {
       [STORY_PREPARED]: () => {
         const newParameter = api.getCurrentParameter<S>(parameterKey);
         if (newParameter !== parameter) {
-          setParameter(api.getCurrentParameter<S>(parameterKey));
+          setParameter(newParameter);
         }
       },
     },

--- a/code/core/src/manager-api/root.tsx
+++ b/code/core/src/manager-api/root.tsx
@@ -344,10 +344,8 @@ export function useParameter<S>(parameterKey: string, defaultValue?: S) {
 
   const handleParameterChange = useCallback(() => {
     const newParameter = api.getCurrentParameter<S>(parameterKey);
-    if (newParameter !== parameter) {
-      setParameter(newParameter);
-    }
-  }, [api, parameter, parameterKey]);
+    setParameter(newParameter);
+  }, [api, parameterKey]);
 
   useChannel(
     {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28592

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have added reactivity to `useParameters`, which wasn't consistently returning a prepared story's parameters.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31579-sha-cf05dec5`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31579-sha-cf05dec5 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31579-sha-cf05dec5 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31579-sha-cf05dec5`](https://npmjs.com/package/storybook/v/0.0.0-pr-31579-sha-cf05dec5) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/add-reactivity-to-use-parameter`](https://github.com/storybookjs/storybook/tree/valentin/add-reactivity-to-use-parameter) |
| **Commit** | [`cf05dec5`](https://github.com/storybookjs/storybook/commit/cf05dec5aa05eea5d4b194f2ff6844cfa8a97b9d) |
| **Datetime** | Tue May 27 10:56:13 UTC 2025 (`1748343373`) |
| **Workflow run** | [15273427125](https://github.com/storybookjs/storybook/actions/runs/15273427125) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31579`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added reactivity to the `useParameter` hook in Storybook's manager API, enabling automatic parameter updates when story changes occur.

- Modified `code/core/src/manager-api/root.tsx` to add state management for parameter values
- Added `useChannel` hook to listen for `STORY_PREPARED` events and update parameters
- Implemented change detection to prevent unnecessary re-renders
- Maintained backwards compatibility while adding reactive functionality



<!-- /greptile_comment -->