### PR TITLE
Addon Vitest: Fix path comparison on Windows

### DIFF
--- a/code/addons/vitest/src/node/boot-test-runner.ts
+++ b/code/addons/vitest/src/node/boot-test-runner.ts
@@ -9,7 +9,7 @@ import type { EventInfo, Options } from 'storybook/internal/types';
 
 // eslint-disable-next-line depend/ban-dependencies
 import { execaNode } from 'execa';
-import { join } from 'pathe';
+import { join, normalize } from 'pathe';
 
 import {
   STATUS_STORE_CHANNEL_EVENT_NAME,
@@ -81,7 +81,7 @@ const bootTestRunner = async ({
           TEST: 'true',
           VITEST_CHILD_PROCESS: 'true',
           NODE_ENV: process.env.NODE_ENV ?? 'test',
-          STORYBOOK_CONFIG_DIR: options.configDir,
+          STORYBOOK_CONFIG_DIR: normalize(options.configDir),
         },
         extendEnv: true,
       });


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31619

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Paths were normalized before comparing them.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31630-sha-13817eb5`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31630-sha-13817eb5 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31630-sha-13817eb5 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31630-sha-13817eb5`](https://npmjs.com/package/storybook/v/0.0.0-pr-31630-sha-13817eb5) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-configDir-comparison-on-windows`](https://github.com/storybookjs/storybook/tree/valentin/fix-configDir-comparison-on-windows) |
| **Commit** | [`13817eb5`](https://github.com/storybookjs/storybook/commit/13817eb5563354c001da91c06f4b9b87fc733d67) |
| **Datetime** | Sat May 31 21:23:40 UTC 2025 (`1748726620`) |
| **Workflow run** | [15367667403](https://github.com/storybookjs/storybook/actions/runs/15367667403) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31630`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixes path comparison issues in the Vitest addon for Windows by implementing path normalization in `code/addons/vitest/src/node/boot-test-runner.ts`.

- Added `normalize` function from `pathe` to standardize path handling across operating systems
- Applied path normalization to `configDir` when setting environment variables for child process
- Resolves issue #31619 where Vitest failed to start from Storybook's browser UI on Windows



<!-- /greptile_comment -->