### PR TITLE
Addon Vitest: Fix path comparison on Windows

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -23,7 +23,7 @@ import { oneWayHash } from 'storybook/internal/telemetry';
 import type { Presets } from 'storybook/internal/types';
 
 import { match } from 'micromatch';
-import { dirname, join, relative, resolve, sep } from 'pathe';
+import { dirname, join, normalize, relative, resolve, sep } from 'pathe';
 import picocolors from 'picocolors';
 import sirv from 'sirv';
 import { dedent } from 'ts-dedent';
@@ -427,7 +427,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
   // to find the right project to run, thus we override
   // with a unique identifier using the path to the config dir
   if (process.env.VITEST_STORYBOOK) {
-    const projectName = join('storybook:', finalOptions.configDir);
+    const projectName = `storybook:${normalize(finalOptions.configDir)}`;
     plugins.push({
       name: 'storybook:workspace-name-override',
       config: {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31619

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31634-sha-cc94c32c`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31634-sha-cc94c32c sandbox` or in an existing project with `npx storybook@0.0.0-pr-31634-sha-cc94c32c upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31634-sha-cc94c32c`](https://npmjs.com/package/storybook/v/0.0.0-pr-31634-sha-cc94c32c) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/addon-vitest-windows-bug`](https://github.com/storybookjs/storybook/tree/valentin/addon-vitest-windows-bug) |
| **Commit** | [`cc94c32c`](https://github.com/storybookjs/storybook/commit/cc94c32cdcaeeb4ef179cc414bfe5b182e5ddda4) |
| **Datetime** | Sun Jun  1 20:05:52 UTC 2025 (`1748808352`) |
| **Workflow run** | [15378912273](https://github.com/storybookjs/storybook/actions/runs/15378912273) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31634`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixed path comparison issues in the Vitest addon for Windows environments by implementing the `normalize` function from the `pathe` library to ensure consistent path handling across operating systems.

- Modified `code/addons/vitest/src/vitest-plugin/index.ts` to normalize config directory paths when generating project names
- Ensures consistent test execution behavior between Windows and Unix-like systems
- Improves cross-platform compatibility without affecting existing functionality



<!-- /greptile_comment -->