### PR TITLE
CLI: Fix `EXDEV`-errors when moving files across devices

### DIFF
--- a/code/core/src/common/utils/cli.test.ts
+++ b/code/core/src/common/utils/cli.test.ts
@@ -1,9 +1,4 @@
-import { rm } from 'node:fs/promises';
-import { join } from 'node:path';
-
 import { describe, expect, it, vi } from 'vitest';
-
-import { readFile } from 'fs/promises';
 
 import { createLogStream, isCorePackage } from './cli';
 

--- a/code/core/src/common/utils/cli.test.ts
+++ b/code/core/src/common/utils/cli.test.ts
@@ -55,6 +55,7 @@ describe('UTILS', () => {
       const content = await readLogFile();
       expect(content).toBe('exdev test content');
       await removeLogFile();
+      vi.clearAllMocks();
     });
   });
 });

--- a/code/core/src/common/utils/cli.ts
+++ b/code/core/src/common/utils/cli.ts
@@ -148,14 +148,16 @@ export const createLogStream = async (
   return new Promise((resolve, reject) => {
     logStream.once('open', () => {
       const moveLogFile = async () => {
-        rename(temporaryLogPath, finalLogPath).catch(async (error) => {
+        try {
+          await rename(temporaryLogPath, finalLogPath);
+        } catch (error: any) {
           if (error.code === 'EXDEV') {
             await copyFile(temporaryLogPath, finalLogPath);
             await rm(temporaryLogPath, { recursive: true, force: true });
           } else {
             throw error;
           }
-        });
+        }
       };
       const clearLogFile = async () => writeFile(temporaryLogPath, '');
       const removeLogFile = async () => rm(temporaryLogPath, { recursive: true, force: true });

--- a/code/core/src/common/utils/cli.ts
+++ b/code/core/src/common/utils/cli.ts
@@ -148,11 +148,12 @@ export const createLogStream = async (
   return new Promise((resolve, reject) => {
     logStream.once('open', () => {
       const moveLogFile = async () => {
-        rename(temporaryLogPath, finalLogPath).catch((error) => {
+        rename(temporaryLogPath, finalLogPath).catch(async (error) => {
           if (error.code === 'EXDEV') {
-            copyFile(temporaryLogPath, finalLogPath).then(() =>
-              rm(temporaryLogPath, { recursive: true, force: true })
-            );
+            await copyFile(temporaryLogPath, finalLogPath);
+            await rm(temporaryLogPath, { recursive: true, force: true });
+          } else {
+            throw error;
           }
         });
       };

--- a/code/lib/cli-storybook/src/automigrate/index.ts
+++ b/code/lib/cli-storybook/src/automigrate/index.ts
@@ -219,6 +219,8 @@ export const automigrate = async ({
       if (error['code'] === 'EXDEV') {
         await copyFile(TEMP_LOG_FILE_PATH, LOG_FILE_PATH);
         await rm(TEMP_LOG_FILE_PATH, { recursive: true, force: true });
+      } else {
+        throw error;
       }
     }
   } else {

--- a/code/lib/cli-storybook/src/automigrate/index.ts
+++ b/code/lib/cli-storybook/src/automigrate/index.ts
@@ -1,5 +1,5 @@
 import { createWriteStream } from 'node:fs';
-import { rename, rm } from 'node:fs/promises';
+import { copyFile, rename, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { PackageJson } from 'storybook/internal/common';
@@ -213,7 +213,14 @@ export const automigrate = async ({
 
   // if migration failed, display a log file in the users cwd
   if (hasFailures) {
-    await rename(TEMP_LOG_FILE_PATH, join(process.cwd(), LOG_FILE_NAME));
+    try {
+      await rename(TEMP_LOG_FILE_PATH, join(process.cwd(), LOG_FILE_NAME));
+    } catch (error: any) {
+      if (error['code'] === 'EXDEV') {
+        await copyFile(TEMP_LOG_FILE_PATH, LOG_FILE_PATH);
+        await rm(TEMP_LOG_FILE_PATH, { recursive: true, force: true });
+      }
+    }
   } else {
     await rm(TEMP_LOG_FILE_PATH, { recursive: true, force: true });
   }

--- a/code/lib/cli-storybook/src/doctor/index.ts
+++ b/code/lib/cli-storybook/src/doctor/index.ts
@@ -168,6 +168,8 @@ export const doctor = async ({
       if (error.code === 'EXDEV') {
         await copyFile(TEMP_LOG_FILE_PATH, join(process.cwd(), LOG_FILE_NAME));
         await rm(TEMP_LOG_FILE_PATH, { recursive: true, force: true });
+      } else {
+        throw error;
       }
     }
   } else {


### PR DESCRIPTION
## What I did
I wrote fallback for `fs.rename()` when operating temporary logs. Other occurrences of `fs.rename()` happens in migration (https://github.com/storybookjs/storybook/blob/25f8c83991faed4e2ae2f44383ba44c7a3ac4f38/code/lib/codemod/src/index.ts and https://github.com/storybookjs/storybook/blob/25f8c83991faed4e2ae2f44383ba44c7a3ac4f38/code/lib/cli-storybook/src/automigrate/fixes/rnstorybook-config.ts ) which is usually in the same device, so the fallback is not needed.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [x] integration tests
- [x] end-to-end tests

#### Manual testing

On *nix operating system where tmpdir points to /tmp and /tmp is mounted as tmpfs which is usually different from the file system where the repo resides, `fs.rename()` will fallback to `fs.copyFile()` and `fs.rm()`. Example reproduction: `storybook add @storybook/addon-vitest` which will try to add dependencies and write to log, and trigger the error and its fallback. 

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Implemented cross-device file movement fallback in Storybook's log handling system to fix `EXDEV` errors that occur when moving files between different filesystems.

- Added fallback mechanism in `code/core/src/common/utils/cli.ts` to use `copyFile` + `rm` when `rename` fails with EXDEV error
- Updated error handling in `code/lib/cli-storybook/src/automigrate/index.ts` to support cross-filesystem operations
- Modified `code/lib/cli-storybook/src/doctor/index.ts` to handle temporary log file moves across filesystems
- Added test coverage in `code/core/src/common/utils/cli.test.ts` for both normal and fallback operations
- Common scenario fixed: when `/tmp` is mounted as tmpfs on Unix systems, causing cross-device move errors



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->