### PR TITLE
Svelte: Fix source view always using `<wrapper ...>`

### DIFF
--- a/code/renderers/svelte/src/docs/sourceDecorator.ts
+++ b/code/renderers/svelte/src/docs/sourceDecorator.ts
@@ -22,6 +22,11 @@ const skipSourceRender = (context: StoryContext<SvelteRenderer>) => {
   const sourceParams = context?.parameters.docs?.source;
   const isArgsStory = context?.parameters.__isArgsStory;
 
+  if ((context?.tags ?? []).some((tag) => tag.startsWith('svelte-csf'))) {
+    // skip if Svelte CSF, as the addon does its own source code generation
+    return true;
+  }
+
   // always render if the user forces it
   if (sourceParams?.type === SourceType.DYNAMIC) {
     return false;


### PR DESCRIPTION
Closes https://bsky.app/profile/hmans.dev/post/3lqfb4z3pf224

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

In the core Svelte source generator, we now skip sorce generation if it's a Svelte CSF story, as the addon will do its own source generation in https://github.com/storybookjs/addon-svelte-csf/blob/a475611195a9fe94a0410af6c8bcae9d3c2437b1/src/runtime/emit-code.ts#L23-L44

Previously this was not an issue, as the addon would emit on the following tick, so always after the core had emitted its source code, but potentially https://github.com/storybookjs/storybook/pull/31488 flipped the timing of this.

Svelte CSF has a similar (opposite) skip condition at https://github.com/storybookjs/addon-svelte-csf/blob/a475611195a9fe94a0410af6c8bcae9d3c2437b1/src/runtime/emit-code.ts#L50-L54

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Open the Svelte-Vite Storybook from `next`, expand the source view, and see the wrong component name: https://630873996e4e3557791c069c-pagxgwozgc.chromatic.com/?path=/docs/example-button--docs
2. Open the same Storybook from this branch, expand the source view, and see the correct component name: https://630873996e4e3557791c069c-biyuvgoutj.chromatic.com/?path=/docs/example-button--docs

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
3. Open Storybook in your browser
4. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixes source code generation for Svelte CSF stories by preventing duplicate source rendering between core and addon implementations. The change ensures proper source view display without wrapper elements.

- Modified `skipSourceRender` in `code/renderers/svelte/src/docs/sourceDecorator.ts` to skip core source generation for Svelte CSF stories
- Added test coverage in `sourceDecorator.test.ts` to validate source generation behavior
- Prevents timing conflicts between core and addon source generation implementations
- Aligns with existing skip condition in addon-svelte-csf for consistent source handling
- Resolves incorrect component name display in source view documentation



<!-- /greptile_comment -->