### PR TITLE
Automigration: Enhance removeEssentials to convert options

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/__test__/main-config-with-essential-options.js
+++ b/code/lib/cli-storybook/src/automigrate/fixes/__test__/main-config-with-essential-options.js
@@ -1,0 +1,20 @@
+const config = {
+  stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: [
+    {
+      name: '@storybook/addon-essentials',
+      options: {
+        docs: false,
+        backgrounds: false,
+        measure: false,
+        outline: false,
+        grid: false,
+      },
+    },
+  ],
+  framework: {
+    name: '@storybook/angular',
+    options: {},
+  },
+};
+export default config;

--- a/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { JsPackageManager, PackageJson } from 'storybook/internal/common';
+import { formatConfig, readConfig } from 'storybook/internal/csf-tools';
 import type { StorybookConfigRaw } from 'storybook/internal/types';
+
+import { dedent } from 'ts-dedent';
 
 import type { CheckOptions, RunOptions } from '../types';
 import { removeEssentials } from './remove-essentials';
+import { moveEssentialOptions } from './remove-essentials.utils';
 
 // Mock modules before any other imports or declarations
 vi.mock('node:fs/promises', async () => {
@@ -526,5 +530,33 @@ describe('remove-essentials migration', () => {
 
       expect(mockPackageManager.runPackageCommand).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('moveEssentialOptions', () => {
+  it('should move essential options to features', async () => {
+    const main = await readConfig('main.ts');
+    await moveEssentialOptions(false, {
+      docs: false,
+      backgrounds: false,
+      measure: false,
+      outline: false,
+      grid: false,
+    })(main);
+
+    expect(dedent(formatConfig(main))).toMatchInlineSnapshot(`
+      "export default {
+        stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+        addons: ['@storybook/addon-links'],
+
+        features: {
+          docs: false,
+          backgrounds: false,
+          measure: false,
+          outline: false,
+          grid: false
+        }
+      };"
+    `);
   });
 });

--- a/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.ts
@@ -10,6 +10,7 @@ import { dedent } from 'ts-dedent';
 
 import { updateMainConfig } from '../helpers/mainConfigFile';
 import type { Fix } from '../types';
+import { moveEssentialOptions } from './remove-essentials.utils';
 
 interface AddonDocsOptions {
   hasEssentials: boolean;
@@ -228,16 +229,10 @@ export const removeEssentials: Fix<AddonDocsOptions> = {
       }
 
       if (essentialsOptions) {
-        updateMainConfig({ mainConfigPath, dryRun: !!dryRun }, async (main) => {
-          const features = main.getFieldValue(['features']) || {};
-
-          if (!dryRun) {
-            main.setFieldValue(['features'], {
-              ...features,
-              ...essentialsOptions,
-            });
-          }
-        });
+        updateMainConfig(
+          { mainConfigPath, dryRun: !!dryRun },
+          moveEssentialOptions(dryRun, essentialsOptions)
+        );
       }
 
       // If docs was enabled (not disabled) and not already installed, add it

--- a/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.utils.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.utils.ts
@@ -1,0 +1,17 @@
+import type { ConfigFile } from 'storybook/internal/csf-tools';
+
+export function moveEssentialOptions(
+  dryRun: boolean | undefined,
+  essentialsOptions: Record<string, any>
+): (main: ConfigFile) => Promise<void> | void {
+  return async (main) => {
+    const features = main.getFieldValue(['features']) || {};
+
+    if (!dryRun) {
+      main.setFieldValue(['features'], {
+        ...features,
+        ...essentialsOptions,
+      });
+    }
+  };
+}


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31610

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhanced the Storybook 8->9 migration script to properly handle disabled features when transitioning from `@storybook/addon-essentials`, ensuring configuration preservation during upgrades.

- Added new `moveEssentialOptions` utility to migrate disabled features from essentials options to `features` section in main config
- Implemented comprehensive test coverage in `remove-essentials.test.ts` for options migration scenarios
- Added test fixtures with real-world configurations in `main-config-with-essential-options.js`
- Enhanced the `removeEssentials` migration to handle addon options preservation during removal



<!-- /greptile_comment -->