### PR TITLE
Docs: Recommend Vitest addon instead of Portable stories in Vitest

### DIFF
--- a/docs/api/portable-stories/portable-stories-vitest.mdx
+++ b/docs/api/portable-stories/portable-stories-vitest.mdx
@@ -3,6 +3,7 @@ title: 'Portable stories in Vitest'
 sidebar:
   title: Vitest
   order: 1
+  hidden: true
 ---
 
 <If notRenderer={['react', 'vue', 'svelte']}>
@@ -24,20 +25,16 @@ sidebar:
 
 </If>
 
-<If renderer="react">
-  <Callout variant="info" icon="💡">
-    If you are using the [experimental CSF Factories format](../../api/csf/csf-factories.mdx), you don't need to use the portable stories API. Instead, you can [import and use your stories directly](../../api/csf/csf-factories.mdx#5-reusing-stories-in-test-files).
-  </Callout>
-</If>
-
 <If renderer={['react', 'vue', 'svelte']}>
+  <Callout variant="warning">
+    Storybook now recommends testing your stories in Vitest with the [Vitest addon](../../writing-tests/integrations/vitest-addon.mdx), which automatically transforms stories into real Vitest tests (using this API under the hood).
+    
+    This API is still available for those who prefer to use portable stories directly, but we recommend using the Vitest addon for a more streamlined testing experience.
+  </Callout>
+
   Portable stories are Storybook [stories](../../writing-stories/index.mdx) which can be used in external environments, such as [Vitest](https://vitest.dev).
 
   Normally, Storybook composes a story and its [annotations](#annotations) automatically, as part of the [story pipeline](#story-pipeline). When using stories in Vitest tests, you must handle the story pipeline yourself, which is what the [`composeStories`](#composestories) and [`composeStory`](#composestory) functions enable.
-
-  <Callout variant="info">
-    The API specified here is available in Storybook `8.2.7` and up. If you're using an older version of Storybook, you can upgrade to the latest version (`npx storybook@latest upgrade`) to use this API. If you're unable to upgrade, you can use previous API, which uses the `.play()` method instead of `.run()`, but is otherwise identical.
-  </Callout>
 
   <If renderer="react">
     <Callout variant="warning">


### PR DESCRIPTION
## What I did

- Hide `/docs/api/portable-stories/portable-stories-vitest` from sidebar nav
- Add callout to recommend the Vitest addon (and remove other callouts, to simplify)

## Checklist for Contributors

### Testing

#### Manual testing

1. Sync this branch with locally running docs
2. Confirm that the API > Portable stories group in the sidebar does _not_ have a Vitest item

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [1MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>


<!-- greptile_comment -->

## Greptile Summary

Updates documentation to deprecate Portable Stories for Vitest in favor of the official `@storybook/addon-vitest` package, improving testing guidance clarity.

- Hides `docs/api/portable-stories/portable-stories-vitest.mdx` from sidebar navigation to discourage direct portable stories usage
- Aligns with test runner deprecation rule by adding callout recommending `@storybook/addon-vitest` addon
- Simplifies documentation by removing React-specific CSF Factories information
- Removes redundant version-specific notices for cleaner documentation
- Improves framework-agnostic approach by standardizing on the Vitest addon



<!-- /greptile_comment -->