### PR TITLE
Maintenance: Additional fixes

### DIFF
--- a/code/addons/vitest/template/stories/basics.stories.ts
+++ b/code/addons/vitest/template/stories/basics.stories.ts
@@ -45,8 +45,9 @@ export const Step = {
 };
 
 export const TypeAndClear = {
-  play: async ({ canvasElement, userEvent }) => {
-    const canvas = within(canvasElement);
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.clear(canvas.getByTestId('value'));
+
     await userEvent.type(canvas.getByTestId('value'), 'initial value');
     await userEvent.clear(canvas.getByTestId('value'));
     await userEvent.type(canvas.getByTestId('value'), 'final value');

--- a/code/core/src/node-logger/index.ts
+++ b/code/core/src/node-logger/index.ts
@@ -7,7 +7,7 @@ import * as newLogger from './logger/logger';
 export { prompt } from './prompts';
 export { logTracker } from './logger/log-tracker';
 export type { SpinnerInstance, TaskLogInstance } from './prompts/prompt-provider-base';
-export { protectUrls } from './wrap-utils';
+export { protectUrls, createHyperlink } from './wrap-utils';
 export { CLI_COLORS } from './logger/colors';
 
 // The default is stderr, which can cause some tools (like rush.js) to think

--- a/code/core/src/node-logger/wrap-utils.ts
+++ b/code/core/src/node-logger/wrap-utils.ts
@@ -116,6 +116,20 @@ export function protectUrls(
   });
 }
 
+/**
+ * Creates a hyperlink with custom title text if supported, otherwise falls back to "title: url"
+ * format
+ */
+export function createHyperlink(title: string, url: string): string {
+  if (supportsHyperlinks()) {
+    // Create hyperlink using OSC 8 escape sequence: title as display text, url as target
+    return `\u001b]8;;${url}\u0007${title}\u001b]8;;\u0007`;
+  }
+
+  // Fallback for terminals that don't support hyperlinks
+  return `${title}: ${url}`;
+}
+
 /** Enhanced word splitting that treats URLs as single units */
 function splitTextPreservingUrls(text: string): string[] {
   const parts: string[] = [];

--- a/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.ts
@@ -200,7 +200,8 @@ export const removeEssentials: Fix<AddonDocsOptions> = {
             yes: true,
           });
         } else {
-          const isDocsInstalled = await packageManager.isPackageInstalled('@storybook/addon-docs');
+          const isDocsInstalled =
+            packageManager.getAllDependencies()['@storybook/addon-docs'] !== undefined;
 
           if (!isDocsInstalled) {
             await packageManager.addDependencies({ type: 'devDependencies', skipInstall: true }, [

--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -1,7 +1,13 @@
 import type { PackageManagerName } from 'storybook/internal/common';
 import { HandledError, JsPackageManagerFactory, isCorePackage } from 'storybook/internal/common';
 import { withTelemetry } from 'storybook/internal/core-server';
-import { CLI_COLORS, logTracker, logger, prompt } from 'storybook/internal/node-logger';
+import {
+  CLI_COLORS,
+  createHyperlink,
+  logTracker,
+  logger,
+  prompt,
+} from 'storybook/internal/node-logger';
 import {
   UpgradeStorybookToLowerVersionError,
   UpgradeStorybookUnknownCurrentVersionError,
@@ -201,8 +207,14 @@ function logUpgradeResults(
   const automigrationLinksMessage = [
     'If you want to learn more about the automigrations that executed in your project(s), please check the following links:',
     ...detectedAutomigrations
-      .filter((am) => am.fix.link)
-      .map((am) => `• ${am.fix.id}: ${am.fix.link}`),
+      .filter(
+        (am) =>
+          (am.fix.link && am.reports.some((report) => report.status === 'check_failed')) ||
+          // TODO: Valentin change true to automigration id that failed
+          true
+      )
+      .map((am) => `• ${createHyperlink(am.fix.id, am.fix.link!)}`),
+    // .map((am) => `• ${am.fix.id}: ${CLI_COLORS.link(am.fix.link)}`),
   ].join('\n');
 
   logger.log(automigrationLinksMessage);

--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -340,8 +340,7 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
         });
 
         if (hasBlockers) {
-          logger.outro(CLI_COLORS.error('Upgrade aborted'));
-          process.exit(1);
+          throw new HandledError('Blockers detected');
         }
 
         // Checks whether we can upgrade


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Major improvements to Storybook CLI's upgrade process focusing on error handling, type safety, and dependency management in automigration functionality.

- Replaced direct `process.exit()` calls with `HandledError` throws in `code/lib/cli-storybook/src/upgrade.ts` for better error propagation
- Added explicit return type declarations for `runAutomigrations` in `code/lib/cli-storybook/src/automigrate/multi-project.ts` improving type safety
- Enhanced dependency verification in `code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.ts` by switching to direct `package.json` inspection
- Added documentation links section to automigration results for better user guidance



<!-- /greptile_comment -->