### PR TITLE
Addon-vitest: Fix adding with `--skip-install` failing missing packageJson invariant

### DIFF
--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -89,7 +89,11 @@ export default async function postInstall(options: PostinstallOptions) {
 
     if (out.migrateToNextjsVite) {
       await packageManager.addDependencies(
-        { installAsDevDependencies: true, skipInstall: options.skipInstall },
+        {
+          installAsDevDependencies: true,
+          skipInstall: options.skipInstall,
+          packageJson: await packageManager.readPackageJson(),
+        },
         [`@storybook/nextjs-vite@${versions['@storybook/nextjs-vite']}`]
       );
 

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -268,7 +268,11 @@ export default async function postInstall(options: PostinstallOptions) {
     logger.plain(colors.gray('  ' + versionedDependencies.join(', ')));
 
     await packageManager.addDependencies(
-      { installAsDevDependencies: true, skipInstall: options.skipInstall },
+      {
+        installAsDevDependencies: true,
+        skipInstall: options.skipInstall,
+        packageJson: await packageManager.readPackageJson(),
+      },
       versionedDependencies
     );
   }

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -236,18 +236,24 @@ export abstract class JsPackageManager {
    */
   public async addDependencies(
     options: {
-      skipInstall?: boolean;
       installAsDevDependencies?: boolean;
-      packageJson?: PackageJson;
       writeOutputToFile?: boolean;
-    },
+    } & (
+      | {
+          skipInstall?: false;
+          packageJson?: PackageJson;
+        }
+      | {
+          skipInstall: true;
+          packageJson: PackageJson;
+        }
+    ),
     dependencies: string[]
   ) {
     const { skipInstall, writeOutputToFile = true } = options;
 
     if (skipInstall) {
       const { packageJson } = options;
-      invariant(packageJson, 'Missing packageJson.');
 
       const dependenciesMap = dependencies.reduce((acc, dep) => {
         const [packageName, packageVersion] = getPackageDetails(dep);

--- a/code/lib/cli-storybook/src/automigrate/fixes/eslint-plugin.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/eslint-plugin.ts
@@ -74,7 +74,14 @@ export const eslintPlugin: Fix<EslintPluginRunOptions> = {
 
     logger.info(`✅ Adding dependencies: ${deps}`);
     if (!dryRun) {
-      await packageManager.addDependencies({ installAsDevDependencies: true, skipInstall }, deps);
+      await packageManager.addDependencies(
+        {
+          installAsDevDependencies: true,
+          skipInstall,
+          packageJson: await packageManager.readPackageJson(),
+        },
+        deps
+      );
     }
 
     if (!dryRun && unsupportedExtension) {


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Follow-up to https://github.com/storybookjs/storybook/pull/31605

This fixes a bug, that running `packageManager.addDependencies()` with `skipInstall: true` _required_ that you also pass `packageJson`, which the postinstall script from addon-vitest did not.

An alternative solution would be that `JsPackageManager` itself read the package.json (`this.readPackageJson()`) if it was not passed, but it was unclear to me whether that would work in all instances or not.

This bug is currently blocking the installation of addon-vitest with the `sv` (Svelte) CLI because that always runs with `--skip-install`.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. In a fresh project without `node_modules`, `package-lock.json`, without `vitest` installed and without the addon installed, run `npx storybook@latest add @storybook/addon-vitest --skip-install`
2. See that it fails with

```
Error running postinstall script for @storybook/addon-vitest
Error: Invariant failed: Missing packageJson.
```
3. Revert back to the pristine repo, and add the canary instead (if using npm, remember to enable legacy peer deps): `npx storybook@0.0.0-pr-31720-sha-0f081578 add @storybook/addon-vitest --skip-install`
4. See that it works


<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
5. Open Storybook in your browser
6. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31720-sha-0f081578`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31720-sha-0f081578 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31720-sha-0f081578 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31720-sha-0f081578`](https://npmjs.com/package/storybook/v/0.0.0-pr-31720-sha-0f081578) |
| **Triggered by** | @JReinhold |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`jeppe/fix-addon-vitest-skipinstall`](https://github.com/storybookjs/storybook/tree/jeppe/fix-addon-vitest-skipinstall) |
| **Commit** | [`0f081578`](https://github.com/storybookjs/storybook/commit/0f0815785922d9e06a549ccf26ce2f38b8f4d804) |
| **Datetime** | Tue Jun 10 08:47:48 UTC 2025 (`1749545268`) |
| **Workflow run** | [15554925367](https://github.com/storybookjs/storybook/actions/runs/15554925367) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31720`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixes a critical bug in `@storybook/addon-vitest` where installation fails with `--skip-install` flag due to missing `packageJson` requirement.

- Fixed `code/addons/vitest/src/postinstall.ts` to explicitly include required `packageJson` parameter in `addDependencies` calls
- Enhanced type safety in `JsPackageManager.ts` to enforce `packageJson` parameter when `skipInstall: true`
- Particularly important fix for Svelte CLI users who always run with `--skip-install`
- Added proper error handling for package.json requirement in eslint-plugin fixes



<!-- /greptile_comment -->