### PR TITLE
CSF: Only add preview annotations to definePreview in csf-factories automigration

### DIFF
--- a/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/config-to-csf-factory.test.ts
@@ -221,4 +221,27 @@ describe('preview specific functionality', () => {
       });
     `);
   });
+
+  it('should not change non story exports', async () => {
+    await expect(
+      transform(dedent`
+        import type { Preview } from '@storybook/react-vite'
+        
+        export const withStore: Decorator = () => {}
+
+        const preview: Preview = {
+          tags: []
+        };
+        export default preview;
+      `)
+    ).resolves.toMatchInlineSnapshot(`
+      import { definePreview } from '@storybook/react-vite';
+
+      export const withStore: Decorator = () => {};
+
+      export default definePreview({
+        tags: [],
+      });
+    `);
+  });
 });

--- a/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.test.ts
@@ -191,7 +191,7 @@ describe('getConfigProperties', () => {
       bar: t.variableDeclarator(t.identifier('bar'), t.numericLiteral(42)),
     };
 
-    const properties = getConfigProperties(exportDecls);
+    const properties = getConfigProperties(exportDecls, { configType: 'main' });
 
     expect(properties).toHaveLength(2);
     expect(properties[0].key.name).toBe('foo');
@@ -205,7 +205,7 @@ describe('getConfigProperties', () => {
       foo: t.functionDeclaration(t.identifier('foo'), [], t.blockStatement([])),
     };
 
-    const properties = getConfigProperties(exportDecls);
+    const properties = getConfigProperties(exportDecls, { configType: 'main' });
 
     expect(properties).toHaveLength(1);
     expect(properties[0].key.name).toBe('foo');

--- a/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.ts
@@ -75,12 +75,38 @@ export function removeExportDeclarations(
 }
 
 export function getConfigProperties(
-  exportDecls: Record<string, t.VariableDeclarator | t.FunctionDeclaration>
+  exportDecls: Record<string, t.VariableDeclarator | t.FunctionDeclaration>,
+  options: { configType: 'main' | 'preview' }
 ) {
   const properties = [];
 
   // Collect properties from named exports
   for (const [name, decl] of Object.entries(exportDecls)) {
+    // only include real preview exports to definePreview factory
+    if (
+      options.configType === 'preview' &&
+      ![
+        'decorators',
+        'parameters',
+        'args',
+        'argTypes',
+        'loaders',
+        'beforeEach',
+        'afterEach',
+        'render',
+        'tags',
+        'mount',
+        'argsEnhancers',
+        'argTypesEnhancers',
+        'beforeAll',
+        'initialGlobals',
+        'globalTypes',
+        'applyDecorators',
+        'runStep',
+      ].includes(name)
+    ) {
+      continue;
+    }
     if (t.isVariableDeclarator(decl) && decl.init) {
       properties.push(t.objectProperty(t.identifier(name), decl.init));
     } else if (t.isFunctionDeclaration(decl)) {

--- a/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.ts
@@ -1,5 +1,25 @@
 import { types as t, traverse } from 'storybook/internal/babel';
 
+const projectAnnotationNames = [
+  'decorators',
+  'parameters',
+  'args',
+  'argTypes',
+  'loaders',
+  'beforeEach',
+  'afterEach',
+  'render',
+  'tags',
+  'mount',
+  'argsEnhancers',
+  'argTypesEnhancers',
+  'beforeAll',
+  'initialGlobals',
+  'globalTypes',
+  'applyDecorators',
+  'runStep',
+];
+
 export function cleanupTypeImports(programNode: t.Program, disallowList: string[]) {
   const usedIdentifiers = new Set<string>();
 
@@ -83,28 +103,7 @@ export function getConfigProperties(
   // Collect properties from named exports
   for (const [name, decl] of Object.entries(exportDecls)) {
     // only include real preview exports to definePreview factory
-    if (
-      options.configType === 'preview' &&
-      ![
-        'decorators',
-        'parameters',
-        'args',
-        'argTypes',
-        'loaders',
-        'beforeEach',
-        'afterEach',
-        'render',
-        'tags',
-        'mount',
-        'argsEnhancers',
-        'argTypesEnhancers',
-        'beforeAll',
-        'initialGlobals',
-        'globalTypes',
-        'applyDecorators',
-        'runStep',
-      ].includes(name)
-    ) {
+    if (options.configType === 'preview' && !projectAnnotationNames.includes(name)) {
       continue;
     }
     if (t.isVariableDeclarator(decl) && decl.init) {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Improves CSF factories automigration by ensuring only relevant preview annotations are included in `definePreview` calls.

- Modified `getConfigProperties` in `code/lib/cli-storybook/src/codemod/helpers/csf-factories-utils.ts` to filter preview config exports
- Added `configType` parameter to control property inclusion during transformation in `config-to-csf-factory.ts`
- Enhanced test coverage to verify preservation of non-story exports during CSF transformation
- Optimized code organization by reducing variable reassignments and improving property computation order



<!-- /greptile_comment -->