### PR TITLE
Core: Restore original clipboard after invoking `userEvent.setup()`

### DIFF
--- a/code/core/src/test/preview.ts
+++ b/code/core/src/test/preview.ts
@@ -92,11 +92,18 @@ const enhanceContext: LoaderFunction = async (context) => {
 
   // userEvent.setup() cannot be called in non browser environment and will attempt to access window.navigator.clipboard
   // which will throw an error in react native for example.
-  if (globalThis.window?.navigator?.clipboard) {
+  const { clipboard } = globalThis.window?.navigator;
+  if (clipboard) {
     context.userEvent = instrument(
       { userEvent: uninstrumentedUserEvent.setup() },
       { intercept: true }
     ).userEvent;
+
+    // Restore original clipboard, which was replaced with a stub by userEvent.setup()
+    Object.defineProperty(globalThis.window.navigator, 'clipboard', {
+      get: () => clipboard,
+      configurable: true,
+    });
 
     let currentFocus = HTMLElement.prototype.focus;
 

--- a/code/core/src/test/preview.ts
+++ b/code/core/src/test/preview.ts
@@ -92,7 +92,7 @@ const enhanceContext: LoaderFunction = async (context) => {
 
   // userEvent.setup() cannot be called in non browser environment and will attempt to access window.navigator.clipboard
   // which will throw an error in react native for example.
-  const { clipboard } = globalThis.window?.navigator;
+  const clipboard = globalThis.window?.navigator?.clipboard;
   if (clipboard) {
     context.userEvent = instrument(
       { userEvent: uninstrumentedUserEvent.setup() },


### PR DESCRIPTION
Closes #31626

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This restores the original `window.navigator.clipboard` instance to restore clipboard functionality after calling `userEvent.setup()`, which replaced it with a stub.

Users who want to test clipboard functionality should call `userEvent.setup()` themselves.

I've opened [an issue on user-event](https://github.com/testing-library/user-event/issues/1289) to address this problem at the source.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixes clipboard functionality by restoring the original `window.navigator.clipboard` after `userEvent.setup()` is invoked in test environment.

- Captures and preserves original clipboard object before userEvent.setup() modifies it
- Uses Object.defineProperty to restore original clipboard functionality after tests
- Prevents clipboard functionality from being broken by userEvent's stub implementation
- Maintains existing focus method patching behavior
- Delegates clipboard testing responsibility to users who specifically need it by having them call userEvent.setup() themselves



<!-- /greptile_comment -->