### PR TITLE
Next.js: Add webpack alias to resolve Next.js package conflicts

### DIFF
--- a/code/frameworks/nextjs/src/aliases/webpack.ts
+++ b/code/frameworks/nextjs/src/aliases/webpack.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import type { Configuration as WebpackConfig } from 'webpack';
 
 import { configureCompatibilityAliases } from '../compatibility/compatibility-map';
@@ -12,6 +13,7 @@ export const configureAliases = (baseConfig: WebpackConfig): void => {
     alias: {
       ...(baseConfig.resolve?.alias ?? {}),
       '@opentelemetry/api': 'next/dist/compiled/@opentelemetry/api',
+      next: path.dirname(require.resolve('next/package.json')),
     },
   };
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

### Problem
When using pnpm with different Next.js versions across apps, pnpm cannot hoist the Next.js package to the root due to version conflicts. This results in packages like @storybook/nextjs and package-a carrying their own Next.js packages in nested node_modules folders.

This creates a critical issue where multiple Next.js instances exist in the bundle, leading to React Context problems. For example:
- Storybook sets up a Next.js Router Context Provider using Next.js instance "A"
- Application code or libraries try to access the context using Next.js instance "B"
- React.useContext() fails to resolve the context because it's looking for a provider from a different Next.js instance

### Solution
Add a webpack alias that resolves all next and next/**/* imports to a single Next.js package location:

```js
next: path.dirname(require.resolve('next/package.json'))
```

Why this approach:
- `require.resolve('next/package.json')` resolves to the package.json of the Next.js version in the current app's node_modules
- path.dirname() returns the package directory, enabling access to sub-paths like next/dist/shared/lib/app-router-context.shared-runtime
- We can't use require.resolve('next') directly as it resolves to the entry file (e.g., next/dist/server/next.js), which doesn't support sub-path resolution

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added webpack alias configuration to resolve Next.js package conflicts in pnpm monorepo setups, preventing React Context failures caused by multiple Next.js instances.

- Added webpack alias to map all `next/**/*` imports to a single Next.js package location using `path.dirname(require.resolve('next/package.json'))`
- Ensures consistent module resolution when multiple Next.js versions exist across apps
- Prevents React Context provider/consumer mismatches between different Next.js instances
- Resolves critical issues with Router Context Provider in Storybook when using pnpm



<!-- /greptile_comment -->