### PR TITLE
Next.js: Enhance Vite configuration with styled-jsx aliasing

### DIFF
--- a/code/frameworks/nextjs-vite/src/preset.ts
+++ b/code/frameworks/nextjs-vite/src/preset.ts
@@ -39,6 +39,8 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entry =
 export const optimizeViteDeps = [
   '@storybook/nextjs-vite/navigation.mock',
   '@storybook/nextjs-vite/router.mock',
+  '@storybook/nextjs-vite > styled-jsx',
+  '@storybook/nextjs-vite > styled-jsx/style',
 ];
 
 export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, options) => {
@@ -71,14 +73,6 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, option
         'styled-jsx/style': require.resolve('styled-jsx/style'),
         'styled-jsx/style.js': require.resolve('styled-jsx/style'),
       },
-    },
-    optimizeDeps: {
-      ...config.optimizeDeps,
-      include: [
-        ...(config.optimizeDeps?.include || []),
-        '@storybook/nextjs-vite > styled-jsx',
-        '@storybook/nextjs-vite > styled-jsx/style',
-      ],
     },
     plugins: [...(reactConfig?.plugins ?? []), vitePluginStorybookNextjs({ dir: nextDir })],
   };

--- a/code/frameworks/nextjs-vite/src/preset.ts
+++ b/code/frameworks/nextjs-vite/src/preset.ts
@@ -1,5 +1,5 @@
 // https://storybook.js.org/docs/react/addons/writing-presets
-import path from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 import { getProjectRoot } from 'storybook/internal/common';
 import { IncompatiblePostCssConfigError } from 'storybook/internal/server-errors';
@@ -8,7 +8,6 @@ import type { PresetProperty } from 'storybook/internal/types';
 import type { StorybookConfigVite } from '@storybook/builder-vite';
 import { viteFinal as reactViteFinal } from '@storybook/react-vite/preset';
 
-import { dirname, join } from 'path';
 import postCssLoadConfig from 'postcss-load-config';
 import vitePluginStorybookNextjs from 'vite-plugin-storybook-nextjs';
 
@@ -60,10 +59,27 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, option
 
   const { nextConfigPath } = await options.presets.apply<FrameworkOptions>('frameworkOptions');
 
-  const nextDir = nextConfigPath ? path.dirname(nextConfigPath) : undefined;
+  const nextDir = nextConfigPath ? dirname(nextConfigPath) : undefined;
 
   return {
     ...reactConfig,
+    resolve: {
+      ...(reactConfig?.resolve ?? {}),
+      alias: {
+        ...(reactConfig?.resolve?.alias ?? {}),
+        'styled-jsx': dirname(resolve('styled-jsx/package.json')),
+        'styled-jsx/style': resolve('styled-jsx/style'),
+        'styled-jsx/style.js': resolve('styled-jsx/style'),
+      },
+    },
+    optimizeDeps: {
+      ...config.optimizeDeps,
+      include: [
+        ...(config.optimizeDeps?.include || []),
+        '@storybook/nextjs-vite > styled-jsx',
+        '@storybook/nextjs-vite > styled-jsx/style',
+      ],
+    },
     plugins: [...(reactConfig?.plugins ?? []), vitePluginStorybookNextjs({ dir: nextDir })],
   };
 };

--- a/code/frameworks/nextjs-vite/src/preset.ts
+++ b/code/frameworks/nextjs-vite/src/preset.ts
@@ -1,5 +1,5 @@
 // https://storybook.js.org/docs/react/addons/writing-presets
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { getProjectRoot } from 'storybook/internal/common';
 import { IncompatiblePostCssConfigError } from 'storybook/internal/server-errors';
@@ -67,9 +67,9 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, option
       ...(reactConfig?.resolve ?? {}),
       alias: {
         ...(reactConfig?.resolve?.alias ?? {}),
-        'styled-jsx': dirname(resolve('styled-jsx/package.json')),
-        'styled-jsx/style': resolve('styled-jsx/style'),
-        'styled-jsx/style.js': resolve('styled-jsx/style'),
+        'styled-jsx': dirname(require.resolve('styled-jsx/package.json')),
+        'styled-jsx/style': require.resolve('styled-jsx/style'),
+        'styled-jsx/style.js': require.resolve('styled-jsx/style'),
       },
     },
     optimizeDeps: {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31549

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

### Problem
When initializing Storybook in a Next.js v15 project using pnpm, the Storybook UI gets stuck on the loading screen with the following error in the browser console:

```
Uncaught SyntaxError: The requested module '/node_modules/.pnpm/styled-jsx@5.1.6_@babel+core@7.27.1_react@19.1.0/node_modules/styled-jsx/index.js?v=1422bc3a' does not provide an export named 'StyleRegistry'
```

### Root Cause: pnpm's Non-Hoisted Dependencies
This is specifically a pnpm issue due to how pnpm handles dependency resolution differently from npm/yarn:
- **pnpm doesn't hoist dependencies** - Unlike npm/yarn which hoist dependencies to the root node_modules, pnpm maintains strict dependency isolation
- **styled-jsx is a direct dependency of @storybook/nextjs-vite** - In pnpm, it gets installed in a nested path like `/node_modules/.pnpm/styled-jsx@5.1.6_@babel+core@7.27.1_react@19.1.0/node_modules/styled-jsx/`.
Vite can't resolve the nested dependency - Vite's module resolution expects to find styled-jsx in a more accessible location, but pnpm's strict isolation prevents this. Additionally, Vite has issues to optimize dependencies for transitive dependencies of packages. If `styled-jsx` is listed in `optimizeDeps.include`, Vite will not optimize it in pnpm projects if it is a transitive dependency. We have to tell Vite explicitly about the transitive dependency structure.
- **Works fine with npm/yarn** - With hoisted dependencies, styled-jsx would be available at the root level where Vite can easily find it

### Solution
This fix addresses the pnpm-specific module resolution issue by:
1. **Adding explicit styled-jsx aliases to help Vite resolve the pnpm-nested dependency:**
- Maps styled-jsx to its actual package location using require.resolve()
- Explicitly resolves styled-jsx/style and styled-jsx/style.js to their correct entry points
2. Including styled-jsx in Vite's optimization dependencies:
- Ensures styled-jsx modules are pre-bundled and optimized by Vite
- Uses the @storybook/nextjs-vite > styled-jsx syntax to reference the nested dependency correctly

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31757-sha-dd96f9f4`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31757-sha-dd96f9f4 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31757-sha-dd96f9f4 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31757-sha-dd96f9f4`](https://npmjs.com/package/storybook/v/0.0.0-pr-31757-sha-dd96f9f4) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/nextjs-alias-styled-jsx`](https://github.com/storybookjs/storybook/tree/valentin/nextjs-alias-styled-jsx) |
| **Commit** | [`dd96f9f4`](https://github.com/storybookjs/storybook/commit/dd96f9f45fba8082d818fa2f497eeb2e190b9886) |
| **Datetime** | Wed Jun 11 21:18:52 UTC 2025 (`1749676732`) |
| **Workflow run** | [15595921406](https://github.com/storybookjs/storybook/actions/runs/15595921406) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31757`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhanced Next.js Vite configuration in Storybook to properly handle styled-jsx module aliasing and optimization, fixing loading issues with Next.js v15.3.2.

- Added resolution aliases for styled-jsx and its style submodules in preset configuration
- Included styled-jsx in optimizeDeps configuration for better dependency handling
- Fixed module export errors that were causing Storybook to hang during loading
- Consolidated path imports using node:path for better maintainability
- Implemented more reliable path resolution using the resolve utility



<!-- /greptile_comment -->