### PR TITLE
Nextjs-Vite: Use tsconfig paths plugin

### DIFF
--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -108,7 +108,7 @@
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",
     "styled-jsx": "5.1.6",
-    "vite-plugin-storybook-nextjs": "2.0.0"
+    "vite-plugin-storybook-nextjs": "2.0.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6378,7 +6378,7 @@ __metadata:
     postcss-load-config: "npm:^6.0.1"
     styled-jsx: "npm:5.1.6"
     typescript: "npm:^5.8.3"
-    vite-plugin-storybook-nextjs: "npm:2.0.0"
+    vite-plugin-storybook-nextjs: "npm:2.0.2"
   peerDependencies:
     next: ^14.1.0 || ^15.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -26503,20 +26503,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-storybook-nextjs@npm:2.0.0":
-  version: 2.0.0
-  resolution: "vite-plugin-storybook-nextjs@npm:2.0.0"
+"vite-plugin-storybook-nextjs@npm:2.0.2":
+  version: 2.0.2
+  resolution: "vite-plugin-storybook-nextjs@npm:2.0.2"
   dependencies:
     "@next/env": "npm:^15.0.3"
     image-size: "npm:^2.0.0"
     magic-string: "npm:^0.30.11"
     module-alias: "npm:^2.2.3"
     ts-dedent: "npm:^2.2.0"
+    vite-tsconfig-paths: "npm:^5.1.4"
   peerDependencies:
     next: ^14.1.0 || ^15.0.0
-    storybook: ^9.0.0-0
+    storybook: ^0.0.0-0 || ^9.0.0 || ^9.1.0-0
     vite: ^5.0.0 || ^6.0.0
-  checksum: 10c0/fdb4d6977674c26d6105c9b5c4d90f3c0dba186b03482fd3ee6d9d797b2c0da99df9835ec184dcbca4c545ced45b7da238870708c3b4d622017edd6e9073a968
+  checksum: 10c0/52db273d836bc5f8d9e7bcd61ee7560acf6499bf041306e9574e009b0d3388fa690379d6c56299ad4870867318716832d2c4cd93a34bb87d565f36abee18d4bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #31599

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31764-sha-f043b02d`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31764-sha-f043b02d sandbox` or in an existing project with `npx storybook@0.0.0-pr-31764-sha-f043b02d upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31764-sha-f043b02d`](https://npmjs.com/package/storybook/v/0.0.0-pr-31764-sha-f043b02d) |
| **Triggered by** | @kasperpeulen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`kasper/tsconfig-paths-vite-nextjs`](https://github.com/storybookjs/storybook/tree/kasper/tsconfig-paths-vite-nextjs) |
| **Commit** | [`f043b02d`](https://github.com/storybookjs/storybook/commit/f043b02d9c896b7b2479bca68e31580b5a042753) |
| **Datetime** | Thu Jun 12 14:28:37 UTC 2025 (`1749738517`) |
| **Workflow run** | [15613330814](https://github.com/storybookjs/storybook/actions/runs/15613330814) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31764`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates the `vite-plugin-storybook-nextjs` dependency in `@storybook/nextjs-vite` to add TypeScript path alias support through tsconfig paths plugin.

- Updates `vite-plugin-storybook-nextjs` from v2.0.0 to v2.0.2--canary.41.5d54947.0 in `code/frameworks/nextjs-vite/package.json`
- Enables automatic resolution of TypeScript path aliases in Next.js + Vite setup
- Package contains critical path resolution functionality for Next.js Vite builder
- PR needs completed issue number reference and testing documentation



<!-- /greptile_comment -->