### PR TITLE
Angular: Fix Storybook experimentalZoneless is not compatible with Angular 20

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
@@ -9,6 +9,7 @@ import { getApplication } from './StorybookModule';
 import { storyPropsProvider } from './StorybookProvider';
 import { queueBootstrapping } from './utils/BootstrapQueue';
 import { PropertyExtractor } from './utils/PropertyExtractor';
+import { getProvideZonelessChangeDetectionFn } from './utils/Zoneless';
 
 type StoryRenderInfo = {
   storyFnAngular: StoryFnAngularReturnType;
@@ -127,13 +128,7 @@ export abstract class AbstractRenderer {
     ];
 
     if (STORYBOOK_ANGULAR_OPTIONS?.experimentalZoneless) {
-      const angularCore: any = await import('@angular/core');
-      const provideZonelessChangeDetectionFn =
-        'provideExperimentalZonelessChangeDetection' in angularCore
-          ? angularCore.provideExperimentalZonelessChangeDetection
-          : 'provideZonelessChangeDetection' in angularCore
-            ? angularCore.provideZonelessChangeDetection
-            : null;
+      const provideZonelessChangeDetectionFn = await getProvideZonelessChangeDetectionFn();
 
       if (!provideZonelessChangeDetectionFn) {
         throw new Error('Zoneless change detection requires Angular 18 or higher');

--- a/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
@@ -127,11 +127,18 @@ export abstract class AbstractRenderer {
     ];
 
     if (STORYBOOK_ANGULAR_OPTIONS?.experimentalZoneless) {
-      const { provideExperimentalZonelessChangeDetection } = await import('@angular/core');
-      if (!provideExperimentalZonelessChangeDetection) {
-        throw new Error('Experimental zoneless change detection requires Angular 18 or higher');
+      const angularCore: any = await import('@angular/core');
+      const provideZonelessChangeDetectionFn =
+        'provideExperimentalZonelessChangeDetection' in angularCore
+          ? angularCore.provideExperimentalZonelessChangeDetection
+          : 'provideZonelessChangeDetection' in angularCore
+            ? angularCore.provideZonelessChangeDetection
+            : null;
+
+      if (!provideZonelessChangeDetectionFn) {
+        throw new Error('Zoneless change detection requires Angular 18 or higher');
       } else {
-        providers.unshift(provideExperimentalZonelessChangeDetection());
+        providers.unshift(provideZonelessChangeDetectionFn());
       }
     }
 

--- a/code/frameworks/angular/src/client/angular-beta/utils/Zoneless.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/Zoneless.ts
@@ -1,0 +1,9 @@
+export const getProvideZonelessChangeDetectionFn = async () => {
+  const angularCore: any = await import('@angular/core');
+
+  return 'provideExperimentalZonelessChangeDetection' in angularCore
+    ? angularCore.provideExperimentalZonelessChangeDetection
+    : 'provideZonelessChangeDetection' in angularCore
+      ? angularCore.provideZonelessChangeDetection
+      : null;
+};


### PR DESCRIPTION

Closes #31652 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->
Angular 20 has rename the `provideExperimentalZonelessChangeDetection` to `provideZonelessChangeDetection`. So we reflects this change to fully support Angular 20.

**NOTE**: In Angular 20, zoneless is no longer experimental. We should also rename the `experimentalZoneless` option in `STORYBOOK_ANGULAR_OPTIONS` to `zoneless`, but it will introduce a BREAKING CHANGE. To keep compatibility with previous versions we skip this change.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates Angular support to handle the renamed zoneless change detection API in Angular 20, maintaining backwards compatibility with Angular 18-19.

- Modified `code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts` to support both `provideZonelessChangeDetection` (Angular 20+) and `provideExperimentalZonelessChangeDetection` (Angular 18-19)
- Maintains `experimentalZoneless` option name in `STORYBOOK_ANGULAR_OPTIONS` for backward compatibility
- Preserves functionality while adapting to Angular 20's non-experimental zoneless implementation
- Ensures smooth transition for projects using different Angular versions



<!-- /greptile_comment -->