### PR TITLE
Telemetry: Fix prompting without checking isTTY

### DIFF
--- a/code/core/src/core-server/withTelemetry.ts
+++ b/code/core/src/core-server/withTelemetry.ts
@@ -14,7 +14,7 @@ type TelemetryOptions = {
 };
 
 const promptCrashReports = async () => {
-  if (process.env.CI) {
+  if (process.env.CI || !process.stdout.isTTY) {
     return undefined;
   }
 
@@ -179,6 +179,6 @@ export async function withTelemetry<T>(
 
     throw error;
   } finally {
-    process.off('SIGINIT', cancelTelemetry);
+    process.off('SIGINT', cancelTelemetry);
   }
 }


### PR DESCRIPTION
## What I did

Most modules check both process.env.CI as well as process.env.stdout.isTTY before prompting the user. Telemetry was only checking process.env.CI.

This caused builds in non interactive environments to fail with a success code.

This commit aligns the check with the rest of storybook.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- Put yourself in a configuration that will make building storybook fail. In our case, this was due to a storybook sub package version not being aligned with the main storybook version in our package.json
- Build storybook using npm in a docker container without the option CI=true
- Without this PR, the build should succeed, despite the build actually failing
- With this PR, the build will properly fail

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixes telemetry prompting behavior by adding a process.stdout.isTTY check, preventing silent build failures in non-interactive environments like Docker containers without CI=true set.

- Added TTY check in `code/core/src/core-server/withTelemetry.ts` to align with other Storybook modules
- Fixed typo in SIGINT event listener removal (currently 'SIGINIT')
- Important for builds where package versions are misaligned, as it properly surfaces build failures
- Critical fix for Docker and other non-interactive environments where builds could silently fail
- Needs additional telemetry-specific unit tests to verify the new behavior



<!-- /greptile_comment -->