### PR TITLE
Core: Enhance package manager install methods to support optional force flag

### DIFF
--- a/code/core/src/common/js-package-manager/BUNProxy.ts
+++ b/code/core/src/common/js-package-manager/BUNProxy.ts
@@ -190,10 +190,10 @@ export class BUNProxy extends JsPackageManager {
     };
   }
 
-  protected runInstall() {
+  protected runInstall(options?: { force?: boolean }) {
     return this.executeCommand({
       command: 'bun',
-      args: ['install', ...this.getInstallArgs()],
+      args: ['install', ...this.getInstallArgs(), options?.force ? '--force' : ''],
       stdio: 'inherit',
       cwd: this.cwd,
     });

--- a/code/core/src/common/js-package-manager/BUNProxy.ts
+++ b/code/core/src/common/js-package-manager/BUNProxy.ts
@@ -193,7 +193,7 @@ export class BUNProxy extends JsPackageManager {
   protected runInstall(options?: { force?: boolean }) {
     return this.executeCommand({
       command: 'bun',
-      args: ['install', ...this.getInstallArgs(), options?.force ? '--force' : ''],
+      args: ['install', ...this.getInstallArgs(), ...(options?.force ? ['--force'] : [])],
       stdio: 'inherit',
       cwd: this.cwd,
     });

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -134,8 +134,8 @@ export abstract class JsPackageManager {
     return false;
   }
 
-  async installDependencies() {
-    await prompt.executeTask(() => this.runInstall(), {
+  async installDependencies(options?: { force?: boolean }) {
+    await prompt.executeTask(() => this.runInstall(options), {
       id: 'install-dependencies',
       intro: 'Installing dependencies...',
       error: 'An error occurred while installing dependencies.',
@@ -535,7 +535,7 @@ export abstract class JsPackageManager {
     const resolutions = this.getResolutions(packageJson, versions);
     this.writePackageJson({ ...packageJson, ...resolutions }, operationDir);
   }
-  protected abstract runInstall(): ExecaChildProcess;
+  protected abstract runInstall(options?: { force?: boolean }): ExecaChildProcess;
 
   protected abstract runAddDeps(
     dependencies: string[],

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -146,13 +146,16 @@ export abstract class JsPackageManager {
     this.clearInstalledVersionCache();
   }
 
-  async dedupeDependencies() {
-    await prompt.executeTask(() => this.runInternalCommand('dedupe', [], this.cwd), {
-      id: 'dedupe-dependencies',
-      intro: 'Deduplicating dependencies...',
-      error: 'An error occurred while deduplicating dependencies.',
-      success: 'Dependencies deduplicated',
-    });
+  async dedupeDependencies(options?: { force?: boolean }) {
+    await prompt.executeTask(
+      () => this.runInternalCommand('dedupe', [...(options?.force ? ['--force'] : [])], this.cwd),
+      {
+        id: 'dedupe-dependencies',
+        intro: 'Deduplicating dependencies...',
+        error: 'An error occurred while deduplicating dependencies.',
+        success: 'Dependencies deduplicated',
+      }
+    );
 
     // Clear installed version cache after installation
     this.clearInstalledVersionCache();

--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -186,10 +186,10 @@ export class NPMProxy extends JsPackageManager {
     };
   }
 
-  protected runInstall() {
+  protected runInstall(options?: { force?: boolean }) {
     return this.executeCommand({
       command: 'npm',
-      args: ['install', ...this.getInstallArgs()],
+      args: ['install', ...this.getInstallArgs(), options?.force ? '--force' : ''],
       cwd: this.cwd,
       stdio: prompt.getPreferredStdio(),
     });

--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -189,7 +189,7 @@ export class NPMProxy extends JsPackageManager {
   protected runInstall(options?: { force?: boolean }) {
     return this.executeCommand({
       command: 'npm',
-      args: ['install', ...this.getInstallArgs(), options?.force ? '--force' : ''],
+      args: ['install', ...this.getInstallArgs(), ...(options?.force ? ['--force'] : [])],
       cwd: this.cwd,
       stdio: prompt.getPreferredStdio(),
     });

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -198,7 +198,7 @@ export class PNPMProxy extends JsPackageManager {
   protected runInstall(options?: { force?: boolean }) {
     return this.executeCommand({
       command: 'pnpm',
-      args: ['install', ...this.getInstallArgs(), options?.force ? '--force' : ''],
+      args: ['install', ...this.getInstallArgs(), ...(options?.force ? ['--force'] : [])],
       stdio: prompt.getPreferredStdio(),
       cwd: this.cwd,
     });

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -195,10 +195,10 @@ export class PNPMProxy extends JsPackageManager {
     };
   }
 
-  protected runInstall() {
+  protected runInstall(options?: { force?: boolean }) {
     return this.executeCommand({
       command: 'pnpm',
-      args: ['install', ...this.getInstallArgs()],
+      args: ['install', ...this.getInstallArgs(), options?.force ? '--force' : ''],
       stdio: prompt.getPreferredStdio(),
       cwd: this.cwd,
     });

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.ts
@@ -141,10 +141,10 @@ export class Yarn1Proxy extends JsPackageManager {
     };
   }
 
-  protected runInstall() {
+  protected runInstall(options?: { force?: boolean }) {
     return this.executeCommand({
       command: 'yarn',
-      args: ['install', ...this.getInstallArgs()],
+      args: ['install', ...this.getInstallArgs(), options?.force ? '--force' : ''],
       stdio: prompt.getPreferredStdio(),
       cwd: this.cwd,
     });

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.ts
@@ -144,7 +144,7 @@ export class Yarn1Proxy extends JsPackageManager {
   protected runInstall(options?: { force?: boolean }) {
     return this.executeCommand({
       command: 'yarn',
-      args: ['install', ...this.getInstallArgs(), options?.force ? '--force' : ''],
+      args: ['install', ...this.getInstallArgs(), ...(options?.force ? ['--force'] : [])],
       stdio: prompt.getPreferredStdio(),
       cwd: this.cwd,
     });

--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -427,7 +427,12 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
             ? JsPackageManagerFactory.getPackageManager({ force: options.packageManager })
             : storybookProjects[0].packageManager;
 
-        await rootPackageManager.installDependencies();
+        if (rootPackageManager.type === 'npm') {
+          // see https://github.com/npm/cli/issues/8059 for more details
+          await rootPackageManager.installDependencies({ force: true });
+        } else {
+          await rootPackageManager.installDependencies();
+        }
 
         if (rootPackageManager.type !== 'yarn1' && rootPackageManager.isStorybookInMonorepo()) {
           logger.warn(

--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -447,7 +447,12 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
             }));
 
           if (dedupe) {
-            await rootPackageManager.dedupeDependencies();
+            if (rootPackageManager.type === 'npm') {
+              // see https://github.com/npm/cli/issues/8059 for more details
+              await rootPackageManager.dedupeDependencies({ force: true });
+            } else {
+              await rootPackageManager.dedupeDependencies();
+            }
           } else {
             logger.log(
               `If you find any issues running Storybook, you can run ${rootPackageManager.getRunCommand('dedupe')} manually to deduplicate your dependencies and try again.`


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When upgrading dependencies, for npm users we always install dependencies with the `--force` flag set to circumvent the issue described here https://github.com/npm/cli/issues/8059
## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31796-sha-819607ae`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31796-sha-819607ae sandbox` or in an existing project with `npx storybook@0.0.0-pr-31796-sha-819607ae upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31796-sha-819607ae`](https://npmjs.com/package/storybook/v/0.0.0-pr-31796-sha-819607ae) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/circumvent-npm-peer-dep-error-during-upgrade`](https://github.com/storybookjs/storybook/tree/valentin/circumvent-npm-peer-dep-error-during-upgrade) |
| **Commit** | [`819607ae`](https://github.com/storybookjs/storybook/commit/819607aefb940ebf66c0c21e45241f9514bc2382) |
| **Datetime** | Tue Jun 17 10:02:35 UTC 2025 (`1750154555`) |
| **Workflow run** | [15704238128](https://github.com/storybookjs/storybook/actions/runs/15704238128) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31796`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enhances package manager install methods with a force flag option to address npm peer dependency issues during upgrades, particularly npm/cli#8059.

- Modified `JsPackageManager` base class to support optional force flag in `installDependencies` and `runInstall` methods
- Implemented force flag support across package manager proxies (NPM, PNPM, Yarn1, BUN)
- Updated `upgrade.ts` to automatically use --force flag for npm installations
- Changes affect installation behavior only for npm users while maintaining existing behavior for other package managers



<!-- /greptile_comment -->