### PR TITLE
Core: Cleanup of type following up v9 and small verbatimModuleSyntax type fix 

### DIFF
--- a/code/core/src/actions/preview.ts
+++ b/code/core/src/actions/preview.ts
@@ -4,7 +4,7 @@ import * as addArgs from './addArgs';
 import * as loaders from './loaders';
 import type { ActionsTypes } from './types';
 
-export { ActionsTypes };
+export type { ActionsTypes };
 
 export default () =>
   definePreviewAddon<ActionsTypes>({

--- a/code/core/src/types/modules/csf.ts
+++ b/code/core/src/types/modules/csf.ts
@@ -1,11 +1,6 @@
 import type { ViewMode as ViewModeBase } from 'storybook/internal/csf';
-import type { Renderer as CSFRenderer } from 'storybook/internal/csf';
 
 import type { Addon_OptionsParameterV7 } from './addons';
-
-// Fix https://github.com/storybookjs/storybook/issues/30540
-// Can be removed once @storybook/core and storybook are merged in 9.0
-export interface Renderer extends CSFRenderer {}
 
 export type {
   AfterEach,
@@ -40,6 +35,7 @@ export type {
   PlayFunction,
   PlayFunctionContext,
   ProjectAnnotations as BaseProjectAnnotations,
+  Renderer,
   SBArrayType,
   SBEnumType,
   SBIntersectionType,


### PR DESCRIPTION
## What I did

- Cleanup of the fix #30566 now that v9 is live
- Fix a typecheck issue related to [verbatimModuleSyntax](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) while working on the cleanup

```
   ✖  nx run svelte:check
      ====================================
      Loading svelte-check in workspace: /xxx/storybook/code/renderers/svelte
      Getting Svelte diagnostics...

      /xxx/storybook/code/renderers/svelte/../../core/src/actions/preview.ts:7:10
      Error: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

      export { ActionsTypes };
```

## Checklist for Contributors

### Testing
#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests
- [x] hopefully covered by type checking 🤞

#### Manual testing


> _This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

Those are TypeScript changes that should have no impact. 

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates TypeScript type exports to support verbatimModuleSyntax and cleans up v9-related type definitions in core modules.

- Modifies `export { ActionsTypes }` to use explicit `export type` in `code/core/src/actions/preview.ts` to fix verbatimModuleSyntax errors
- Removes temporary Renderer interface that extended CSFRenderer in `code/core/src/types/modules/csf.ts`
- Switches to direct export of Renderer type from storybook/internal/csf
- Removes unnecessary CSFRenderer import for cleaner type definitions



<!-- /greptile_comment -->