### PR TITLE
Core: Fix addon scrollbars and align scrollbar colors with toolbars

### DIFF
--- a/code/addons/a11y/src/components/Tabs.tsx
+++ b/code/addons/a11y/src/components/Tabs.tsx
@@ -58,6 +58,8 @@ const Subnav = styled.div(({ theme }) => ({
   overflow: 'auto',
   paddingRight: 10,
   gap: 6,
+  scrollbarColor: `${theme.barTextColor} ${theme.background.app}`,
+  scrollbarWidth: 'thin',
 }));
 
 const TabsWrapper = styled.div({});

--- a/code/core/src/component-testing/components/Subnav.tsx
+++ b/code/core/src/component-testing/components/Subnav.tsx
@@ -19,7 +19,7 @@ import {
   SyncIcon,
 } from '@storybook/icons';
 
-import { styled } from 'storybook/theming';
+import { styled, useTheme } from 'storybook/theming';
 
 import { type Call, CallStates, type ControlStates } from '../../instrumenter/types';
 import type { Controls } from './InteractionsPanel';
@@ -33,13 +33,13 @@ const SubnavWrapper = styled.div(({ theme }) => ({
   zIndex: 1,
 }));
 
-const StyledSubnav = styled.nav(({ theme }) => ({
+const StyledSubnav = styled.nav({
   height: 40,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
   paddingLeft: 15,
-}));
+});
 
 interface SubnavProps {
   controls: Controls;
@@ -121,10 +121,11 @@ export const Subnav: React.FC<SubnavProps> = ({
   onScrollToEnd,
 }) => {
   const buttonText = status === CallStates.ERROR ? 'Scroll to error' : 'Scroll to end';
+  const theme = useTheme();
 
   return (
     <SubnavWrapper>
-      <Bar>
+      <Bar backgroundColor={theme.background.app}>
         <StyledSubnav aria-label="Component tests toolbar">
           <Group>
             <StatusBadge status={status} />

--- a/code/core/src/components/components/bar/bar.tsx
+++ b/code/core/src/components/components/bar/bar.tsx
@@ -52,14 +52,17 @@ const UnstyledBar = ({ children, className, scrollable }: UnstyledBarProps) =>
   );
 
 export interface BarProps extends UnstyledBarProps {
+  backgroundColor?: string;
   border?: boolean;
 }
 export const Bar = styled(UnstyledBar)<BarProps>(
-  ({ theme, scrollable = true }) => ({
+  ({ backgroundColor, theme, scrollable = true }) => ({
     color: theme.barTextColor,
     width: '100%',
-    height: 40,
+    minHeight: 40,
     flexShrink: 0,
+    scrollbarColor: `${theme.barTextColor} ${backgroundColor || theme.barBg}`,
+    scrollbarWidth: 'thin',
     overflow: scrollable ? 'auto' : 'hidden',
     overflowY: 'hidden',
   }),
@@ -94,7 +97,7 @@ export interface FlexBarProps extends ComponentProps<typeof Bar> {
 export const FlexBar = ({ children, backgroundColor, className, ...rest }: FlexBarProps) => {
   const [left, right] = Children.toArray(children);
   return (
-    <Bar className={`sb-bar ${className}`} {...rest}>
+    <Bar backgroundColor={backgroundColor} className={`sb-bar ${className}`} {...rest}>
       <BarInner bgColor={backgroundColor}>
         <Side scrollable={rest.scrollable} left>
           {left}

--- a/code/core/src/manager/components/preview/Toolbar.tsx
+++ b/code/core/src/manager/components/preview/Toolbar.tsx
@@ -232,6 +232,8 @@ const Toolbar = styled.div<{ shown: boolean }>(({ theme, shown }) => ({
   marginTop: shown ? 0 : -40,
   boxShadow: `${theme.appBorderColor}  0 -1px 0 0 inset`,
   background: theme.barBg,
+  scrollbarColor: `${theme.barTextColor} ${theme.barBg}`,
+  scrollbarWidth: 'thin',
   zIndex: 4,
 }));
 


### PR DESCRIPTION
Continuation of https://github.com/storybookjs/storybook/pull/31704.

I found other toolbars that had the same bug so I fixed them. Also changed the colours of toolbars to make it easier for end users to associate them with the toolbar and not the content below.

@MichaelArestad assigning you for a design review and for your general awareness of this theming use case. Currently using theme backgrounds and text foregrounds to colour the scrollbars until Theme 2.0.

## What I did
### Before
![preview and interactions addon with white scrollbar over the toolbar content](https://github.com/user-attachments/assets/4279cd5b-f6ed-4e76-95c1-3702d7ff7cf5)
![preview and a11y addon with white scrollbar over the toolbar content](https://github.com/user-attachments/assets/a1ec3b18-5651-4c40-b7de-8f5acd1c1756)


### After
![preview and interactions addon with scrollbars using the theme colours, under the toolbars](https://github.com/user-attachments/assets/80a9c585-b82f-4d6e-b8fa-24f59b0d7e5f)
![preview and a11y addon with scrollbars using the theme colours, under the toolbars](https://github.com/user-attachments/assets/80c3d3e4-da90-4c3f-8c7f-09ed96ac9361)



## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

I don't think these are covered. There may be movement on some Chromatic tests though due to the changes affecting UI layout for two addons.

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run `yarn storybook:ui` and navigate to a story
2. Move the addon panel to the side (Alt+D) and set it up to have scrollbars
3. Check out the interactions and a11y panels

### Documentation

N/A

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates scrollbar styling and toolbar theming across multiple Storybook components to improve visual consistency and usability of the UI.

- Modified `code/core/src/components/components/bar/bar.tsx` to add backgroundColor prop and flexible height with scrollbar theming support
- Updated `code/addons/a11y/src/components/Tabs.tsx` to theme scrollbars using toolbar colors instead of default white
- Enhanced `code/core/src/manager/components/preview/Toolbar.tsx` with theme-aware scrollbar colors to match toolbar design
- Refactored `code/core/src/component-testing/components/Subnav.tsx` to improve theme handling and toolbar color consistency



<!-- /greptile_comment -->