### PR TITLE
UI: Visual focus indicators (VFIs) aren't visible in high contrast mode (rebase)

### DIFF
--- a/code/addons/docs/src/blocks/controls/Boolean.tsx
+++ b/code/addons/docs/src/blocks/controls/Boolean.tsx
@@ -92,9 +92,8 @@ const Label = styled.label(({ theme }) => ({
         : `${theme.appBorderColor} 0 0 0 1px`,
     color: theme.color.defaultText,
     padding: '7px 15px',
-  },
-  '@media (forced-colors: active)': {
-    'input:checked ~ span:last-of-type, input:not(:checked) ~ span:first-of-type': {
+
+    '@media (forced-colors: active)': {
       textDecoration: 'underline',
     },
   },

--- a/code/addons/docs/src/blocks/controls/Boolean.tsx
+++ b/code/addons/docs/src/blocks/controls/Boolean.tsx
@@ -47,9 +47,7 @@ const Label = styled.label(({ theme }) => ({
     },
     '@media (forced-colors: active)': {
       '&:focus': {
-        outlineColor: 'transparent',
-        outlineWidth: '1px',
-        outlineStyle: 'solid',
+        outline: '1px solid highlight',
       },
     },
   },

--- a/code/addons/docs/src/blocks/controls/Boolean.tsx
+++ b/code/addons/docs/src/blocks/controls/Boolean.tsx
@@ -45,6 +45,13 @@ const Label = styled.label(({ theme }) => ({
       outline: 'none',
       boxShadow: `${theme.color.secondary} 0 0 0 1px inset !important`,
     },
+    '@media (forced-colors: active)': {
+      '&:focus': {
+        outlineColor: 'transparent',
+        outlineWidth: '1px',
+        outlineStyle: 'solid',
+      },
+    },
   },
 
   span: {
@@ -87,6 +94,11 @@ const Label = styled.label(({ theme }) => ({
         : `${theme.appBorderColor} 0 0 0 1px`,
     color: theme.color.defaultText,
     padding: '7px 15px',
+  },
+  '@media (forced-colors: active)': {
+    'input:checked ~ span:last-of-type, input:not(:checked) ~ span:first-of-type': {
+      textDecoration: 'underline',
+    },
   },
 }));
 

--- a/code/core/src/components/components/ActionBar/ActionBar.tsx
+++ b/code/core/src/components/components/ActionBar/ActionBar.tsx
@@ -45,10 +45,8 @@ export const ActionButton = styled.button<{ disabled: boolean }>(
     '&:focus': {
       boxShadow: `${theme.color.secondary} 0 -3px 0 0 inset`,
       outline: '0 none',
-    },
 
-    '@media (forced-colors: active)': {
-      '&:focus': {
+      '@media (forced-colors: active)': {
         outline: '1px solid highlight',
       },
     },

--- a/code/core/src/components/components/ActionBar/ActionBar.tsx
+++ b/code/core/src/components/components/ActionBar/ActionBar.tsx
@@ -49,9 +49,7 @@ export const ActionButton = styled.button<{ disabled: boolean }>(
 
     '@media (forced-colors: active)': {
       '&:focus': {
-        outlineColor: 'transparent',
-        outlineWidth: '1px',
-        outlineStyle: 'solid',
+        outline: '1px solid highlight',
       },
     },
   }),

--- a/code/core/src/components/components/ActionBar/ActionBar.tsx
+++ b/code/core/src/components/components/ActionBar/ActionBar.tsx
@@ -46,6 +46,14 @@ export const ActionButton = styled.button<{ disabled: boolean }>(
       boxShadow: `${theme.color.secondary} 0 -3px 0 0 inset`,
       outline: '0 none',
     },
+
+    '@media (forced-colors: active)': {
+      '&:focus': {
+        outlineColor: 'transparent',
+        outlineWidth: '1px',
+        outlineStyle: 'solid',
+      },
+    },
   }),
   ({ disabled }) =>
     disabled && {

--- a/code/core/src/components/components/form/input/input.tsx
+++ b/code/core/src/components/components/form/input/input.tsx
@@ -60,6 +60,11 @@ const styles = (({ theme }: { theme: StorybookTheme }) => ({
     boxShadow: `${theme.color.secondary} 0 0 0 1px inset`,
     outline: 'none',
   },
+  '@media (forced-colors: active)': {
+    '&:focus': {
+      border: '1px solid transparent',
+    },
+  },
   '&[disabled]': {
     cursor: 'not-allowed',
     opacity: 0.5,

--- a/code/core/src/components/components/form/input/input.tsx
+++ b/code/core/src/components/components/form/input/input.tsx
@@ -59,12 +59,11 @@ const styles = (({ theme }: { theme: StorybookTheme }) => ({
   '&:focus': {
     boxShadow: `${theme.color.secondary} 0 0 0 1px inset`,
     outline: 'none',
-  },
-  '@media (forced-colors: active)': {
-    '&:focus': {
+    '@media (forced-colors: active)': {
       outline: '1px solid highlight',
     },
   },
+
   '&[disabled]': {
     cursor: 'not-allowed',
     opacity: 0.5,

--- a/code/core/src/components/components/form/input/input.tsx
+++ b/code/core/src/components/components/form/input/input.tsx
@@ -62,7 +62,7 @@ const styles = (({ theme }: { theme: StorybookTheme }) => ({
   },
   '@media (forced-colors: active)': {
     '&:focus': {
-      border: '1px solid transparent',
+      outline: '1px solid highlight',
     },
   },
   '&[disabled]': {


### PR DESCRIPTION
Closes #25935

## What I did

Rebase of https://github.com/storybookjs/storybook/pull/29239. The original PR was approved by @MichaelArestad. The PR was left without review for ~9 months but seemed finished overall, so I'm helping it reach a mergeable state.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

> [!CAUTION]
> This does not appear to be testable automatically ([see StackOverflow](https://stackoverflow.com/questions/75771539/emulating-windows-high-contrast-mode-forced-colors-dark-on-a-site)).

#### Manual testing

1. Open this PR's Storybook instance (and a control one) from Windows with high-contrast mode enabled
2. Check that focus indicators are more visible on this PR's instance

@MichaelArestad could you please confirm if you had completed manual testing as part of your review?

### Documentation

N/A

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Improves accessibility by adding Windows high contrast mode support across core UI components, ensuring focus indicators remain visible when system high contrast is enabled.

- Added forced-colors media query support in `code/addons/docs/src/blocks/controls/Boolean.tsx` for visible state indicators
- Enhanced focus indicators in `code/core/src/components/components/ActionBar/ActionBar.tsx` using system highlight colors
- Implemented high-contrast compatible outlines in `code/core/src/components/components/form/input/input.tsx` while preserving existing focus styles



<!-- /greptile_comment -->