### PR TITLE
CLI: Do not fail incompatible package check in doctor if only core packages used

### DIFF
--- a/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.test.ts
+++ b/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.test.ts
@@ -135,6 +135,19 @@ describe('getIncompatibleStorybookPackages', () => {
     vi.mocked(packageManagerMock.getModulePackageJSON).mockReturnValue({ version: '9.0.0' });
   });
 
+  it('succeeds if only core storybook packages used', async () => {
+    vi.mocked(packageManagerMock.getAllDependencies).mockReturnValueOnce({
+      storybook: '9.0.0',
+    });
+
+    const result = await getIncompatibleStorybookPackages({
+      currentStorybookVersion: '9.0.0',
+      packageManager: packageManagerMock as JsPackageManager,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
   it('returns an array of incompatible packages', async () => {
     // Mock a non-core storybook package that would be found
     vi.mocked(packageManagerMock.getAllDependencies).mockReturnValueOnce({

--- a/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.ts
+++ b/code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.ts
@@ -1,6 +1,6 @@
 /* eslint-disable local-rules/no-uncategorized-errors */
 import type { JsPackageManager } from 'storybook/internal/common';
-import { versions as storybookCorePackages, versions } from 'storybook/internal/common';
+import { versions as storybookCorePackages } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 
 import picocolors from 'picocolors';
@@ -102,13 +102,15 @@ export const getIncompatibleStorybookPackages = async (
   context: Context
 ): Promise<AnalysedPackage[]> => {
   const allDeps = context.packageManager.getAllDependencies();
-  const storybookLikeDeps = Object.keys(allDeps).filter(
-    (dep) => dep.includes('storybook') && !versions[dep as keyof typeof versions]
-  );
+  const storybookLikeDeps = Object.keys(allDeps).filter((dep) => dep.includes('storybook'));
   if (storybookLikeDeps.length === 0 && !context.skipErrors) {
     throw new Error('No Storybook dependencies found in the package.json');
   }
-  return Promise.all(storybookLikeDeps.map((dep) => checkPackageCompatibility(dep, context)));
+  return Promise.all(
+    storybookLikeDeps
+      .filter((dep) => !storybookCorePackages[dep as keyof typeof storybookCorePackages])
+      .map((dep) => checkPackageCompatibility(dep, context))
+  );
 };
 
 export const getIncompatiblePackagesSummary = (


### PR DESCRIPTION
Closes #31891

## What I did

`storybook doctor` was throwing a spurious error `'No Storybook dependencies found in the package.json'` if run on a package that only had core storybook packages.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixed a bug in `storybook doctor` command where it incorrectly reported 'No Storybook dependencies found' error when only core packages were present in package.json.

- Modified package compatibility checking logic in `code/lib/cli-storybook/src/doctor/getIncompatibleStorybookPackages.ts` to handle core packages correctly
- Added unit tests in `getIncompatibleStorybookPackages.test.ts` to verify core package handling
- Removed unnecessary dependency on 'versions' import, simplifying to use only 'storybookCorePackages'
- Streamlined dependency filtering to properly include all Storybook packages in the check



<!-- /greptile_comment -->