### PR TITLE
Core: Fix issue where collapsed test controls can be tabbed into

### DIFF
--- a/code/core/src/manager/components/sidebar/TestingModule.tsx
+++ b/code/core/src/manager/components/sidebar/TestingModule.tsx
@@ -288,34 +288,6 @@ export const TestingModule = ({
       data-updated={isUpdated}
     >
       <Card>
-        {hasTestProviders && (
-          <Collapsible
-            data-testid="collapse"
-            style={{
-              transition: isChangingCollapse ? 'max-height 250ms' : 'max-height 0ms',
-              display: hasTestProviders ? 'block' : 'none',
-              maxHeight: isCollapsed ? 0 : maxHeight,
-            }}
-          >
-            <Content ref={contentRef}>
-              {Object.values(registeredTestProviders).map((registeredTestProvider) => {
-                const { render: Render, id } = registeredTestProvider;
-                if (!Render) {
-                  once.warn(
-                    `No render function found for test provider with id '${id}', skipping...`
-                  );
-                  return null;
-                }
-                return (
-                  <TestProvider key={id} data-module-id={id}>
-                    <Render />
-                  </TestProvider>
-                );
-              })}
-            </Content>
-          </Collapsible>
-        )}
-
         <Bar {...(hasTestProviders ? { onClick: (e) => toggleCollapsed(e) } : {})}>
           <Action>
             {hasTestProviders && (
@@ -450,6 +422,35 @@ export const TestingModule = ({
             )}
           </Filters>
         </Bar>
+
+        {hasTestProviders && (
+          <Collapsible
+            data-testid="collapse"
+            {...(isCollapsed && { inert: '' as any })}
+            style={{
+              transition: isChangingCollapse ? 'max-height 250ms' : 'max-height 0ms',
+              display: hasTestProviders ? 'block' : 'none',
+              maxHeight: isCollapsed ? 0 : maxHeight,
+            }}
+          >
+            <Content ref={contentRef}>
+              {Object.values(registeredTestProviders).map((registeredTestProvider) => {
+                const { render: Render, id } = registeredTestProvider;
+                if (!Render) {
+                  once.warn(
+                    `No render function found for test provider with id '${id}', skipping...`
+                  );
+                  return null;
+                }
+                return (
+                  <TestProvider key={id} data-module-id={id}>
+                    <Render />
+                  </TestProvider>
+                );
+              })}
+            </Content>
+          </Collapsible>
+        )}
       </Card>
     </Outline>
   );

--- a/code/core/src/manager/components/sidebar/TestingModule.tsx
+++ b/code/core/src/manager/components/sidebar/TestingModule.tsx
@@ -70,6 +70,8 @@ const Card = styled.div(({ theme }) => ({
   zIndex: 1,
   borderRadius: theme.appBorderRadius,
   backgroundColor: theme.background.content,
+  display: 'flex',
+  flexDirection: 'column-reverse',
 
   '&:hover #testing-module-collapse-toggle': {
     opacity: 1,
@@ -78,7 +80,6 @@ const Card = styled.div(({ theme }) => ({
 
 const Collapsible = styled.div(({ theme }) => ({
   overflow: 'hidden',
-
   willChange: 'auto',
   boxShadow: `inset 0 -1px 0 ${theme.appBorderColor}`,
 }));
@@ -426,7 +427,7 @@ export const TestingModule = ({
         {hasTestProviders && (
           <Collapsible
             data-testid="collapse"
-            {...(isCollapsed && { inert: '' as any })}
+            {...(isCollapsed && { inert: '' })}
             style={{
               transition: isChangingCollapse ? 'max-height 250ms' : 'max-height 0ms',
               display: hasTestProviders ? 'block' : 'none',


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31647

## What I did

This PR addresses an accessibility/UX issue where screen readers and keyboard users can tab inside the expanded views of the testing module which could make it seem initially that pressing Tab isn't working for a number of presses but it's actually tabbing into the test module elements before reaching the Run tests button.

I have opted to utilize the inert HTML property over individually applying the aria-disabled property the the test module elements as inert is designed to handle this behavior more appropriately wherein if the menu is expanded, the elements can be tabbed into and if not it skips them. 
https://web.dev/articles/inert

I've also modified the order of the DOM elements to ensure that after expanding the menu, the next tab goes directly into the expanded menu to make the order make more sense. This would introduce a minor change where instead of popping the menu upwards, it would bring the test bar itself upwards and show the test module elements below. I believe this to be a necessary modification to make accessibility for the test module elements more straightforward and is also more inline with WACG guidelines for focus ordering. 
https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run yarn start
2. Open Storybook in your browser
3. Navigate to the sidebar (Stories for me)
4. Tab through to Run Tests button
5. Tab once more to the collapse button and expand the test module
6. The tab sequencing should now make more sense
7. Also, if the test module is collapsed, it would not be navigatable

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Improves keyboard navigation accessibility in Storybook's test module by preventing tab-focus on collapsed content and reorganizing DOM elements for logical focus order.

- Added HTML `inert` property to collapsible test module section when collapsed to prevent keyboard focus on hidden elements
- Reordered DOM elements to place collapsible content after control bar for more intuitive tab sequence
- Modified UI behavior to show test module elements below the test bar instead of popping upwards
- Changes align with WCAG focus order guidelines for better screen reader experience
- Fixes issue where users could tab into hidden collapsed test controls



<!-- /greptile_comment -->