### PR TITLE
CLI: Fix `sb` CLI by explicitly exporting `bin/index.cjs` from `storybook` package

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -253,6 +253,9 @@
       "import": "./dist/bin/index.js",
       "require": "./dist/bin/index.cjs"
     },
+    "./bin/index.cjs": {
+      "require": "./bin/index.cjs"
+    },
     "./internal/instrumenter": {
       "types": "./dist/instrumenter/index.d.ts",
       "import": "./dist/instrumenter/index.js",

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -253,9 +253,6 @@
       "import": "./dist/bin/index.js",
       "require": "./dist/bin/index.cjs"
     },
-    "./bin/index.cjs": {
-      "require": "./bin/index.cjs"
-    },
     "./internal/instrumenter": {
       "types": "./dist/instrumenter/index.d.ts",
       "import": "./dist/instrumenter/index.js",
@@ -277,6 +274,7 @@
     "./internal/manager/globals-runtime": {
       "import": "./dist/manager/globals-runtime.js"
     },
+    "./bin/index.cjs": "./bin/index.cjs",
     "./package.json": "./package.json",
     "./internal/package.json": "./package.json"
   },

--- a/code/core/scripts/helpers/generatePackageJsonFile.ts
+++ b/code/core/scripts/helpers/generatePackageJsonFile.ts
@@ -68,6 +68,9 @@ export async function generatePackageJsonFile(entries: ReturnType<typeof getEntr
     return acc;
   }, {});
 
+  // Add CLI entry so `sb` can require it.
+  pkgJson.exports['./bin/index.cjs'] = './bin/index.cjs';
+
   // Add the package.json file to the exports, so we can use it to `require.resolve` the package's root easily
   pkgJson.exports['./package.json'] = './package.json';
   pkgJson.exports['./internal/package.json'] = './package.json';


### PR DESCRIPTION
Closes #31807

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added an entry for `./bin/index.cjs` to the `exports` map for the `storybook` package so that `require('storybook/bin/index.cjs')` does not throw `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31922-sha-01fa8b2d`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31922-sha-01fa8b2d sandbox` or in an existing project with `npx storybook@0.0.0-pr-31922-sha-01fa8b2d upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31922-sha-01fa8b2d`](https://npmjs.com/package/storybook/v/0.0.0-pr-31922-sha-01fa8b2d) |
| **Triggered by** | @ghengeveld |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`export-storybook-bin-index.cjs`](https://github.com/storybookjs/storybook/tree/export-storybook-bin-index.cjs) |
| **Commit** | [`01fa8b2d`](https://github.com/storybookjs/storybook/commit/01fa8b2d9c8ade99e1b981cc8c3933fb186543c5) |
| **Datetime** | Tue Jul  1 15:58:11 UTC 2025 (`1751385491`) |
| **Workflow run** | [16004313012](https://github.com/storybookjs/storybook/actions/runs/16004313012) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31922`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Fixed the Storybook CLI (`sb`) by adding `./bin/index.cjs` to the package exports map, resolving the `ERR_PACKAGE_PATH_NOT_EXPORTED` error when running CLI commands like `npx sb@latest upgrade`.

- Added explicit export mapping for `./bin/index.cjs` in `code/core/package.json`
- Ensures proper binary entrypoint accessibility following Node.js package exports rules
- Maintains compatibility with both CommonJS (`require()`) and ESM import patterns
- Fixes critical CLI functionality that was previously broken for end users



<!-- /greptile_comment -->