### PR TITLE
Chore: Clean up stories for favicon

### DIFF
--- a/code/core/src/manager/components/sidebar/useDynamicFavicon.stories.tsx
+++ b/code/core/src/manager/components/sidebar/useDynamicFavicon.stories.tsx
@@ -28,23 +28,47 @@ export default {
   },
 };
 
-export const All = {
-  render: ({ size }: { size: number }) => {
-    return (
-      <div style={{ display: 'flex', gap: size / 2 }}>
-        <img width={size} height={size} src={'./favicon.svg'} />
-        <img width={size} height={size} src={'./favicon.svg?status=active'} />
-        <img width={size} height={size} src={'./favicon.svg?status=positive'} />
-        <img width={size} height={size} src={'./favicon.svg?status=warning'} />
-        <img width={size} height={size} src={'./favicon.svg?status=negative'} />
-        <img width={size} height={size} src={'./favicon.svg?status=critical'} />
-      </div>
-    );
+export const Statuses = {
+  argTypes: {
+    status: {
+      table: {
+        disable: true,
+      },
+    },
   },
+  parameters: {
+    chromatic: {
+      // Dynamic favicon status doesn't work in static builds
+      disableSnapshot: true,
+    },
+  },
+  render: ({ size }: { size: number }) => (
+    <div style={{ display: 'flex', gap: size / 2 }}>
+      <img width={size} height={size} src={'./favicon.svg'} />
+      <img width={size} height={size} src={'./favicon.svg?status=active'} />
+      <img width={size} height={size} src={'./favicon.svg?status=positive'} />
+      <img width={size} height={size} src={'./favicon.svg?status=warning'} />
+      <img width={size} height={size} src={'./favicon.svg?status=negative'} />
+      <img width={size} height={size} src={'./favicon.svg?status=critical'} />
+    </div>
+  ),
 };
-export const Default = {};
-export const Active = { args: { status: 'active' } };
-export const Positive = { args: { status: 'positive' } };
-export const Warning = { args: { status: 'warning' } };
-export const Negative = { args: { status: 'negative' } };
-export const Critical = { args: { status: 'critical' } };
+
+export const Sizes = {
+  argTypes: {
+    size: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  render: ({ status }: { status: Parameters<typeof getFaviconUrl>[1] }) => (
+    <div style={{ display: 'flex', gap: 10 }}>
+      <img width={16} height={16} src={`./favicon.svg?status=${status}`} />
+      <img width={32} height={32} src={`./favicon.svg?status=${status}`} />
+      <img width={64} height={64} src={`./favicon.svg?status=${status}`} />
+      <img width={128} height={128} src={`./favicon.svg?status=${status}`} />
+      <img width={256} height={256} src={`./favicon.svg?status=${status}`} />
+    </div>
+  ),
+};

--- a/code/core/src/manager/components/sidebar/useDynamicFavicon.stories.tsx
+++ b/code/core/src/manager/components/sidebar/useDynamicFavicon.stories.tsx
@@ -62,7 +62,7 @@ export const Sizes = {
       },
     },
   },
-  render: ({ status }: { status: Parameters<typeof getFaviconUrl>[1] }) => (
+  render: ({ status }: { status?: Parameters<typeof getFaviconUrl>[1] }) => (
     <div style={{ display: 'flex', gap: 10 }}>
       <img width={16} height={16} src={`./favicon.svg?status=${status}`} />
       <img width={32} height={32} src={`./favicon.svg?status=${status}`} />

--- a/code/frameworks/angular/template/stories/basics/component-with-provider/di.component.html
+++ b/code/frameworks/angular/template/stories/basics/component-with-provider/di.component.html
@@ -1,7 +1,7 @@
 <div>
   <div>All dependencies are defined: {{ isAllDeps() }}</div>
   <div>Title: {{ title }}</div>
-  <div>Injector: {{ injector.constructor.toString() }}</div>
+  <div data-chromatic="ignore">Injector: {{ injector.constructor.toString() }}</div>
   <div>ElementRef: {{ elRefStr() }}</div>
   <div>TestToken: {{ testToken }}</div>
 </div>


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Disabled Chromatic for the dynamic favicon stories because they would never work on static builds.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
