### PR TITLE
CI: Skip check for `Starting` text to prevent E2E flake

### DIFF
--- a/test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/component-testing.spec.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/component-testing.spec.ts
@@ -213,16 +213,8 @@ test.describe("component testing", () => {
     await runTestsButton.click();
     await Promise.all([
       expect(watchModeButton).toBeDisabled(),
-      expect(page.locator("#testing-module-description")).toHaveText(
-        /Starting/
-      ),
+      expect(page.locator("#testing-module-description")).toHaveText(/Testing/),
     ]);
-
-    // Wait for Vitest to start
-    await expect(page.locator("#testing-module-description")).toHaveText(
-      /Testing/,
-      { timeout: 10000 }
-    );
 
     // Wait for test results to appear
     await expect(page.locator("#testing-module-description")).toHaveText(


### PR DESCRIPTION
## What I did

Another attempt at getting E2E tests to stabilize. Checking for the "Starting" text is functionally appropriate but very easy for Playwright to miss because it may appear only very briefly. It's not really worth checking for so it's better to skip it. The default timeout of 5 seconds should be enough for Vitest to start (if it hasn't already, most likely) so the 10 second override isn't necessary.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Improves E2E test stability by removing flaky UI state check in component testing suite.

- Removed check for transient 'Starting' text state in `test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/component-testing.spec.ts`
- Eliminated unnecessary 10-second timeout override, relying on default 5-second timeout
- Maintains effective test coverage while reducing false failures from timing-sensitive assertions
- Focuses on core functionality verification rather than intermediate UI states



<!-- /greptile_comment -->