### PR TITLE
cli: respawn in the active package manager

### DIFF
--- a/code/core/src/bin/dispatcher.ts
+++ b/code/core/src/bin/dispatcher.ts
@@ -53,7 +53,7 @@ async function run() {
           args,
         } as const);
 
-  const packageManager = JsPackageManagerFactory.getPackageManager();
+  const packageManager = await JsPackageManagerFactory.getPackageManager();
 
   let command;
   try {

--- a/code/core/src/common/js-package-manager/BUNProxy.ts
+++ b/code/core/src/common/js-package-manager/BUNProxy.ts
@@ -76,13 +76,8 @@ export class BUNProxy extends JsPackageManager {
     return 'bun run storybook';
   }
 
-  getRunCommand(command: string): string {
-    return `bun run ${command}`;
-  }
-
-  getRemoteRunCommand(pkg: string, args: string[], specifier?: string): string {
-    return `bunx ${pkg}${specifier ? `@${specifier}` : ''} ${args.join(' ')}`;
-  }
+  runCommand = ['bun', 'run'];
+  remoteRunCommand = ['bunx'];
 
   public async getModulePackageJSON(packageName: string): Promise<PackageJson | null> {
     const packageJsonPath = findUpSync(

--- a/code/core/src/common/js-package-manager/JsPackageManagerFactory.test.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManagerFactory.test.ts
@@ -1,374 +1,47 @@
-import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-import { sync as spawnSync } from 'cross-spawn';
-import { findUpMultipleSync, findUpSync } from 'find-up';
-
-import { BUNProxy } from './BUNProxy';
 import { JsPackageManagerFactory } from './JsPackageManagerFactory';
 import { NPMProxy } from './NPMProxy';
 import { PNPMProxy } from './PNPMProxy';
 import { Yarn1Proxy } from './Yarn1Proxy';
 import { Yarn2Proxy } from './Yarn2Proxy';
 
-vi.mock('cross-spawn');
-const spawnSyncMock = vi.mocked(spawnSync);
-
-vi.mock('find-up');
-const findUpSyncMock = vi.mocked(findUpSync);
-const findUpMultipleSyncMock = vi.mocked(findUpMultipleSync);
 describe('CLASS: JsPackageManagerFactory', () => {
   beforeEach(() => {
     JsPackageManagerFactory.clearCache();
-    findUpSyncMock.mockReturnValue(undefined);
-    findUpMultipleSyncMock.mockReturnValue([]);
-    spawnSyncMock.mockReturnValue({ status: 1 } as any);
-    delete process.env.npm_config_user_agent;
   });
 
   describe('METHOD: getPackageManager', () => {
     describe('NPM proxy', () => {
-      it('FORCE: it should return a NPM proxy when `force` option is `npm`', () => {
-        expect(JsPackageManagerFactory.getPackageManager({ force: 'npm' })).toBeInstanceOf(
+      it('FORCE: it should return a NPM proxy when `force` option is `npm`', async () => {
+        expect(await JsPackageManagerFactory.getPackageManager({ force: 'npm' })).toBeInstanceOf(
           NPMProxy
         );
-      });
-
-      it('USER AGENT: it should infer npm from the user agent', () => {
-        process.env.npm_config_user_agent = 'npm/7.24.0';
-        expect(JsPackageManagerFactory.getPackageManager()).toBeInstanceOf(NPMProxy);
-      });
-
-      it('ALL EXIST: when all package managers are ok, but only a `package-lock.json` file is found', () => {
-        spawnSyncMock.mockImplementation((command) => {
-          // Yarn is ok
-          if (command === 'yarn') {
-            return {
-              status: 0,
-              output: '1.22.4',
-            };
-          }
-          // NPM is ok
-          if (command === 'npm') {
-            return {
-              status: 0,
-              output: '6.5.12',
-            };
-          }
-          // PNPM is ok
-          if (command === 'pnpm') {
-            return {
-              status: 0,
-              output: '7.9.5',
-            };
-          }
-          // Unknown package manager is ko
-          return {
-            status: 1,
-          } as any;
-        });
-
-        // There is only a package-lock.json
-        findUpSyncMock.mockImplementation(() => '/Users/johndoe/Documents/package-lock.json');
-
-        expect(JsPackageManagerFactory.getPackageManager()).toBeInstanceOf(NPMProxy);
       });
     });
 
     describe('PNPM proxy', () => {
-      it('FORCE: it should return a PNPM proxy when `force` option is `pnpm`', () => {
-        expect(JsPackageManagerFactory.getPackageManager({ force: 'pnpm' })).toBeInstanceOf(
+      it('FORCE: it should return a PNPM proxy when `force` option is `pnpm`', async () => {
+        expect(await JsPackageManagerFactory.getPackageManager({ force: 'pnpm' })).toBeInstanceOf(
           PNPMProxy
         );
-      });
-
-      it('USER AGENT: it should infer pnpm from the user agent', () => {
-        process.env.npm_config_user_agent = 'pnpm/7.4.0';
-        expect(JsPackageManagerFactory.getPackageManager()).toBeInstanceOf(PNPMProxy);
-      });
-
-      it('ALL EXIST: when all package managers are ok, but only a `pnpm-lock.yaml` file is found', () => {
-        spawnSyncMock.mockImplementation((command) => {
-          // Yarn is ok
-          if (command === 'yarn') {
-            return {
-              status: 0,
-              output: '1.22.4',
-            };
-          }
-          // NPM is ok
-          if (command === 'npm') {
-            return {
-              status: 0,
-              output: '6.5.12',
-            };
-          }
-          // PNPM is ok
-          if (command === 'pnpm') {
-            return {
-              status: 0,
-              output: '7.9.5',
-            };
-          }
-          // Unknown package manager is ko
-          return {
-            status: 1,
-          } as any as any;
-        });
-
-        // There is only a pnpm-lock.yaml
-        findUpSyncMock.mockImplementation(() => '/Users/johndoe/Documents/pnpm-lock.yaml');
-
-        expect(JsPackageManagerFactory.getPackageManager()).toBeInstanceOf(PNPMProxy);
-      });
-
-      it('PNPM LOCK IF CLOSER: when a pnpm-lock.yaml file is closer than a yarn.lock', async () => {
-        // Allow find-up to work as normal, we'll set the cwd to our fixture package
-        findUpSyncMock.mockImplementation(
-          (await vi.importActual<typeof import('find-up')>('find-up')).findUpSync
-        );
-
-        spawnSyncMock.mockImplementation((command) => {
-          // Yarn is ok
-          if (command === 'yarn') {
-            return {
-              status: 0,
-              output: '1.22.4',
-            };
-          }
-          // NPM is ok
-          if (command === 'npm') {
-            return {
-              status: 0,
-              output: '6.5.12',
-            };
-          }
-          // PNPM is ok
-          if (command === 'pnpm') {
-            return {
-              status: 0,
-              output: '7.9.5',
-            };
-          }
-          // Unknown package manager is ko
-          return {
-            status: 1,
-          } as any;
-        });
-        const fixture = join(__dirname, 'fixtures', 'pnpm-workspace', 'package');
-        expect(JsPackageManagerFactory.getPackageManager({}, fixture)).toBeInstanceOf(PNPMProxy);
       });
     });
 
     describe('Yarn 1 proxy', () => {
-      it('FORCE: it should return a Yarn1 proxy when `force` option is `yarn1`', () => {
-        expect(JsPackageManagerFactory.getPackageManager({ force: 'yarn1' })).toBeInstanceOf(
+      it('FORCE: it should return a Yarn1 proxy when `force` option is `yarn1`', async () => {
+        expect(await JsPackageManagerFactory.getPackageManager({ force: 'yarn1' })).toBeInstanceOf(
           Yarn1Proxy
         );
-      });
-
-      it('USER AGENT: it should infer yarn1 from the user agent', () => {
-        process.env.npm_config_user_agent = 'yarn/1.22.11';
-        expect(JsPackageManagerFactory.getPackageManager()).toBeInstanceOf(Yarn1Proxy);
-      });
-
-      it('when Yarn command is ok and a yarn.lock file is found', () => {
-        spawnSyncMock.mockImplementation((command) => {
-          // Yarn is ok
-          if (command === 'yarn') {
-            return {
-              status: 0,
-              output: '1.22.4',
-            };
-          }
-          // NPM is ko
-          if (command === 'npm') {
-            return {
-              status: 1,
-            };
-          }
-          // PNPM is ko
-          if (command === 'pnpm') {
-            return {
-              status: 1,
-            };
-          }
-          // Unknown package manager is ko
-          return {
-            status: 1,
-          } as any;
-        });
-
-        // there is no lockfile
-        findUpSyncMock.mockReturnValue('yarn.lock');
-
-        expect(JsPackageManagerFactory.getPackageManager()).toBeInstanceOf(Yarn1Proxy);
-      });
-
-      it('when Yarn command is ok, Yarn version is <2, NPM and PNPM are ok, there is a `yarn.lock` file', () => {
-        spawnSyncMock.mockImplementation((command) => {
-          // Yarn is ok
-          if (command === 'yarn') {
-            return {
-              status: 0,
-              output: '1.22.4',
-            };
-          }
-          // NPM is ok
-          if (command === 'npm') {
-            return {
-              status: 0,
-              output: '6.5.12',
-            };
-          }
-          // PNPM is ok
-          if (command === 'pnpm') {
-            return {
-              status: 0,
-              output: '7.9.5',
-            };
-          }
-          // Unknown package manager is ko
-          return {
-            status: 1,
-          } as any;
-        });
-
-        // There is a yarn.lock
-        findUpSyncMock.mockImplementation(() => '/Users/johndoe/Documents/yarn.lock');
-
-        expect(JsPackageManagerFactory.getPackageManager()).toBeInstanceOf(Yarn1Proxy);
-      });
-
-      it('when multiple lockfiles are in a project, prefers yarn', async () => {
-        // Allow find-up to work as normal, we'll set the cwd to our fixture package
-        findUpSyncMock.mockImplementation(
-          (await vi.importActual<typeof import('find-up')>('find-up')).findUpSync
-        );
-
-        spawnSyncMock.mockImplementation((command) => {
-          // Yarn is ok
-          if (command === 'yarn') {
-            return {
-              status: 0,
-              output: '1.22.4',
-            };
-          }
-          // NPM is ok
-          if (command === 'npm') {
-            return {
-              status: 0,
-              output: '6.5.12',
-            };
-          }
-          // PNPM is ok
-          if (command === 'pnpm') {
-            return {
-              status: 0,
-              output: '7.9.5',
-            };
-          }
-          // Unknown package manager is ko
-          return {
-            status: 1,
-          } as any;
-        });
-        const fixture = join(__dirname, 'fixtures', 'multiple-lockfiles');
-        expect(JsPackageManagerFactory.getPackageManager({}, fixture)).toBeInstanceOf(Yarn1Proxy);
       });
     });
 
     describe('Yarn 2 proxy', () => {
-      it('FORCE: it should return a Yarn2 proxy when `force` option is `yarn2`', () => {
-        expect(JsPackageManagerFactory.getPackageManager({ force: 'yarn2' })).toBeInstanceOf(
+      it('FORCE: it should return a Yarn2 proxy when `force` option is `yarn2`', async () => {
+        expect(await JsPackageManagerFactory.getPackageManager({ force: 'yarn2' })).toBeInstanceOf(
           Yarn2Proxy
         );
       });
-
-      it('USER AGENT: it should infer yarn2 from the user agent', () => {
-        process.env.npm_config_user_agent = 'yarn/2.2.10';
-        expect(JsPackageManagerFactory.getPackageManager()).toBeInstanceOf(Yarn2Proxy);
-      });
-
-      it('ONLY YARN 2: when Yarn command is ok, Yarn version is >=2, NPM is ko, PNPM is ko, and a yarn.lock file is found', () => {
-        spawnSyncMock.mockImplementation((command) => {
-          // Yarn is ok
-          if (command === 'yarn') {
-            return {
-              status: 0,
-              output: '2.0.0-rc.33',
-            };
-          }
-          // NPM is ko
-          if (command === 'npm') {
-            return {
-              status: 1,
-            };
-          }
-          // PNPM is ko
-          if (command === 'pnpm') {
-            return {
-              status: 1,
-            };
-          }
-          // Unknown package manager is ko
-          return {
-            status: 1,
-          } as any;
-        });
-
-        findUpSyncMock.mockImplementation(() => 'yarn.lock');
-
-        expect(JsPackageManagerFactory.getPackageManager()).toBeInstanceOf(Yarn2Proxy);
-      });
-
-      it('when Yarn command is ok, Yarn version is >=2, NPM and PNPM are ok, there is a `yarn.lock` file', () => {
-        spawnSyncMock.mockImplementation((command) => {
-          // Yarn is ok
-          if (command === 'yarn') {
-            return {
-              status: 0,
-              output: '2.0.0-rc.33',
-            };
-          }
-          // NPM is ok
-          if (command === 'npm') {
-            return {
-              status: 0,
-              output: '6.5.12',
-            };
-          }
-          // PNPM is ok
-          if (command === 'pnpm') {
-            return {
-              status: 0,
-              output: '7.9.5',
-            };
-          }
-
-          if (command === 'bun') {
-            return {
-              status: 0,
-              output: '1.0.0',
-            };
-          }
-          // Unknown package manager is ko
-          return {
-            status: 1,
-          } as any;
-        });
-
-        // There is a yarn.lock
-        findUpSyncMock.mockImplementation(() => '/Users/johndoe/Documents/bun.lockb');
-
-        expect(JsPackageManagerFactory.getPackageManager()).toBeInstanceOf(BUNProxy);
-      });
-    });
-
-    it('throws an error if Yarn, NPM, and PNPM are not found', () => {
-      spawnSyncMock.mockReturnValue({ status: 1 } as any);
-      expect(() => JsPackageManagerFactory.getPackageManager()).toThrow();
     });
   });
 });

--- a/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManagerFactory.ts
@@ -1,23 +1,11 @@
-import { basename, parse, relative } from 'node:path';
+import { detect } from 'package-manager-detector/detect';
 
-import { sync as spawnSync } from 'cross-spawn';
-import { findUpSync } from 'find-up';
-
-import { getProjectRoot } from '../utils/paths';
 import { BUNProxy } from './BUNProxy';
 import type { JsPackageManager, PackageManagerName } from './JsPackageManager';
-import { COMMON_ENV_VARS } from './JsPackageManager';
 import { NPMProxy } from './NPMProxy';
 import { PNPMProxy } from './PNPMProxy';
 import { Yarn1Proxy } from './Yarn1Proxy';
 import { Yarn2Proxy } from './Yarn2Proxy';
-import {
-  BUN_LOCKFILE,
-  BUN_LOCKFILE_BINARY,
-  NPM_LOCKFILE,
-  PNPM_LOCKFILE,
-  YARN_LOCKFILE,
-} from './constants';
 
 type PackageManagerProxy =
   | typeof NPMProxy
@@ -52,77 +40,24 @@ export class JsPackageManagerFactory {
    * @returns Package manager type as string: 'npm', 'pnpm', 'bun', 'yarn1', or 'yarn2'
    * @throws Error if no usable package manager is found
    */
-  public static getPackageManagerType(cwd = process.cwd()): PackageManagerName {
-    const root = getProjectRoot();
+  public static async getPackageManagerType(cwd = process.cwd()): Promise<PackageManagerName> {
+    const pm = await detect({ cwd });
 
-    const lockFiles = [
-      findUpSync(YARN_LOCKFILE, { cwd, stopAt: root }),
-      findUpSync(PNPM_LOCKFILE, { cwd, stopAt: root }),
-      findUpSync(NPM_LOCKFILE, { cwd, stopAt: root }),
-      findUpSync(BUN_LOCKFILE, { cwd, stopAt: root }),
-      findUpSync(BUN_LOCKFILE_BINARY, { cwd, stopAt: root }),
-    ]
-      .filter(Boolean)
-      .sort((a, b) => {
-        const dirA = parse(a as string).dir;
-        const dirB = parse(b as string).dir;
-
-        const compare = relative(dirA, dirB);
-
-        if (dirA === dirB) {
-          return 0;
-        }
-
-        if (compare.startsWith('..')) {
-          return -1;
-        }
-
-        return 1;
-      });
-
-    // Option 1: We try to infer the package manager from the closest lockfile
-    const closestLockfilePath = lockFiles[0];
-    const closestLockfile = closestLockfilePath && basename(closestLockfilePath);
-
-    const yarnVersion = getYarnVersion(cwd);
-
-    if (yarnVersion && closestLockfile === YARN_LOCKFILE) {
-      return yarnVersion === 1 ? 'yarn1' : 'yarn2';
+    switch (pm?.name) {
+      case 'yarn':
+        return pm.agent.includes('berry') ? 'yarn2' : 'yarn1';
+      case 'deno':
+        return 'npm';
+      case undefined:
+        throw new Error(
+          'Unable to find a usable package manager within NPM, PNPM, Yarn and Yarn 2'
+        );
+      default:
+        return pm?.name || 'npm';
     }
-
-    if (hasPNPM(cwd) && closestLockfile === PNPM_LOCKFILE) {
-      return 'pnpm';
-    }
-
-    const isNPMCommandOk = hasNPM(cwd);
-
-    if (isNPMCommandOk && closestLockfile === NPM_LOCKFILE) {
-      return 'npm';
-    }
-
-    if (
-      hasBun(cwd) &&
-      (closestLockfile === BUN_LOCKFILE || closestLockfile === BUN_LOCKFILE_BINARY)
-    ) {
-      return 'bun';
-    }
-
-    // Option 2: If the user is running a command via npx/pnpx/yarn create/etc, we infer the package manager from the command
-    const inferredPackageManager = this.inferPackageManagerFromUserAgent();
-    if (inferredPackageManager && inferredPackageManager in this.PROXY_MAP) {
-      return inferredPackageManager;
-    }
-
-    // Default fallback, whenever users try to use something different than NPM, PNPM, Yarn,
-    // but still have NPM installed
-    if (isNPMCommandOk) {
-      return 'npm';
-    }
-
-    throw new Error('Unable to find a usable package manager within NPM, PNPM, Yarn and Yarn 2');
   }
 
-  public static getPackageManager(
+  public static async getPackageManager(
     {
       force,
       configDir = '.storybook',
@@ -135,7 +70,7 @@ export class JsPackageManagerFactory {
       ignoreCache?: boolean;
     } = {},
     cwd = process.cwd()
-  ): JsPackageManager {
+  ): Promise<JsPackageManager> {
     // Check cache first, unless ignored
     const cacheKey = this.getCacheKey(force, configDir, cwd, storiesPaths);
     const cached = this.cache.get(cacheKey);
@@ -151,7 +86,7 @@ export class JsPackageManagerFactory {
     }
 
     // Option 2: Detect package managers based on some heuristics
-    const packageManagerType = this.getPackageManagerType(cwd);
+    const packageManagerType = await this.getPackageManagerType(cwd);
     const packageManager = new this.PROXY_MAP[packageManagerType]({ cwd, configDir, storiesPaths });
     this.cache.set(cacheKey, packageManager);
     return packageManager;
@@ -165,86 +100,4 @@ export class JsPackageManagerFactory {
     yarn2: Yarn2Proxy,
     bun: BUNProxy,
   };
-
-  /**
-   * Infer the package manager based on the command the user is running. Each package manager sets
-   * the `npm_config_user_agent` environment variable with its name and version e.g. "npm/7.24.0"
-   * Which is really useful when invoking commands via npx/pnpx/yarn create/etc.
-   */
-  private static inferPackageManagerFromUserAgent(): PackageManagerName | undefined {
-    const userAgent = process.env.npm_config_user_agent;
-    if (userAgent) {
-      const packageSpec = userAgent.split(' ')[0];
-      const [pkgMgrName, pkgMgrVersion] = packageSpec.split('/');
-
-      if (pkgMgrName === 'pnpm') {
-        return 'pnpm';
-      }
-
-      if (pkgMgrName === 'npm') {
-        return 'npm';
-      }
-
-      if (pkgMgrName === 'yarn') {
-        return `yarn${pkgMgrVersion?.startsWith('1.') ? '1' : '2'}`;
-      }
-    }
-
-    return undefined;
-  }
-}
-
-function hasNPM(cwd?: string) {
-  const npmVersionCommand = spawnSync('npm', ['--version'], {
-    cwd,
-    shell: true,
-    env: {
-      ...process.env,
-      ...COMMON_ENV_VARS,
-    },
-  });
-  return npmVersionCommand.status === 0;
-}
-
-function hasBun(cwd?: string) {
-  const pnpmVersionCommand = spawnSync('bun', ['--version'], {
-    cwd,
-    shell: true,
-    env: {
-      ...process.env,
-      ...COMMON_ENV_VARS,
-    },
-  });
-  return pnpmVersionCommand.status === 0;
-}
-
-function hasPNPM(cwd?: string) {
-  const pnpmVersionCommand = spawnSync('pnpm', ['--version'], {
-    cwd,
-    shell: true,
-    env: {
-      ...process.env,
-      ...COMMON_ENV_VARS,
-    },
-  });
-  return pnpmVersionCommand.status === 0;
-}
-
-function getYarnVersion(cwd?: string): 1 | 2 | undefined {
-  const yarnVersionCommand = spawnSync('yarn', ['--version'], {
-    cwd,
-    shell: true,
-    env: {
-      ...process.env,
-      ...COMMON_ENV_VARS,
-    },
-  });
-
-  if (yarnVersionCommand.status !== 0) {
-    return undefined;
-  }
-
-  const yarnVersion = yarnVersionCommand.output.toString().replace(/,/g, '').replace(/"/g, '');
-
-  return /^1\.+/.test(yarnVersion) ? 1 : 2;
 }

--- a/code/core/src/common/js-package-manager/NPMProxy.ts
+++ b/code/core/src/common/js-package-manager/NPMProxy.ts
@@ -68,13 +68,8 @@ export class NPMProxy extends JsPackageManager {
 
   installArgs: string[] | undefined;
 
-  getRunCommand(command: string): string {
-    return `npm run ${command}`;
-  }
-
-  getRemoteRunCommand(pkg: string, args: string[], specifier?: string): string {
-    return `npx ${pkg}${specifier ? `@${specifier}` : ''} ${args.join(' ')}`;
-  }
+  runCommand = ['npm', 'run'];
+  remoteRunCommand = ['npx'];
 
   async getModulePackageJSON(packageName: string): Promise<PackageJson | null> {
     const packageJsonPath = findUpSync(

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -44,13 +44,8 @@ export class PNPMProxy extends JsPackageManager {
     return existsSync(pnpmWorkspaceYaml);
   }
 
-  getRunCommand(command: string): string {
-    return `pnpm run ${command}`;
-  }
-
-  getRemoteRunCommand(pkg: string, args: string[], specifier?: string): string {
-    return `pnpm dlx ${pkg}${specifier ? `@${specifier}` : ''} ${args.join(' ')}`;
-  }
+  runCommand = ['pnpm', 'run'];
+  remoteRunCommand = ['pnpm', 'dlx'];
 
   async getPnpmVersion(): Promise<string> {
     const result = await this.executeCommand({

--- a/code/core/src/common/js-package-manager/Yarn1Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn1Proxy.ts
@@ -41,13 +41,8 @@ export class Yarn1Proxy extends JsPackageManager {
     return this.installArgs;
   }
 
-  getRunCommand(command: string): string {
-    return `yarn ${command}`;
-  }
-
-  getRemoteRunCommand(pkg: string, args: string[], specifier?: string): string {
-    return `npx ${pkg}${specifier ? `@${specifier}` : ''} ${args.join(' ')}`;
-  }
+  runCommand = ['yarn'];
+  remoteRunCommand = ['npx'];
 
   public runPackageCommandSync(
     command: string,

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.ts
@@ -84,13 +84,9 @@ export class Yarn2Proxy extends JsPackageManager {
     return this.installArgs;
   }
 
-  getRunCommand(command: string): string {
-    return `yarn ${command}`;
-  }
-
-  getRemoteRunCommand(pkg: string, args: string[], specifier?: string): string {
-    return `yarn dlx ${pkg}${specifier ? `@${specifier}` : ''} ${args.join(' ')}`;
-  }
+  runCommand = ['yarn'];
+  runNodeCommand = ['yarn', 'node'];
+  remoteRunCommand = ['yarn', 'dlx'];
 
   public runPackageCommandSync(
     command: string,

--- a/code/lib/cli-storybook/src/codemod/csf-factories.ts
+++ b/code/lib/cli-storybook/src/codemod/csf-factories.ts
@@ -29,15 +29,17 @@ async function runStoriesCodemod(options: {
 
     logger.log('\n🛠️  Applying codemod on your stories, this might take some time...');
 
+    const command = packageManager.getRemoteRunCommand('storybook', [
+      'migrate',
+      'csf-2-to-3',
+      '--glob',
+      globString,
+    ]);
+
     // TODO: Move the csf-2-to-3 codemod into automigrations
     await packageManager.executeCommand({
-      command: packageManager.getRemoteRunCommand('storybook', [
-        'migrate',
-        'csf-2-to-3',
-        '--glob',
-        globString,
-      ]),
-      args: [],
+      command: command[0],
+      args: command.slice(1),
       stdio: 'ignore',
       ignoreError: true,
     });

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -387,7 +387,7 @@ export async function doInitiate(options: CommandOptions): Promise<
   const { packageManager: pkgMgr } = options;
 
   const isEmptyDirProject = options.force !== true && currentDirectoryIsEmpty();
-  let packageManagerType = JsPackageManagerFactory.getPackageManagerType();
+  let packageManagerType = await JsPackageManagerFactory.getPackageManagerType();
 
   // Check if the current directory is empty.
   if (isEmptyDirProject) {
@@ -404,7 +404,7 @@ export async function doInitiate(options: CommandOptions): Promise<
     invalidateProjectRootCache();
   }
 
-  const packageManager = JsPackageManagerFactory.getPackageManager({
+  const packageManager = await JsPackageManagerFactory.getPackageManager({
     force: pkgMgr,
   });
 

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -649,7 +649,7 @@ export async function doInitiate(options: CommandOptions): Promise<
 
       Then to start RN Storybook, run:
 
-      ${picocolors.inverse(' ' + packageManager.getRunCommand('start') + ' ')}
+      ${picocolors.inverse(' ' + packageManager.getRunCommand('start').join(' ') + ' ')}
     `);
 
     if (projectType === ProjectType.REACT_NATIVE_AND_RNW) {
@@ -659,7 +659,7 @@ export async function doInitiate(options: CommandOptions): Promise<
 
         To start RNW Storybook, run:
 
-        ${picocolors.inverse(' ' + packageManager.getRunCommand('storybook') + ' ')}
+        ${picocolors.inverse(' ' + packageManager.getRunCommand('storybook').join(' ') + ' ')}
       `);
     }
     return { shouldRunDev: false };
@@ -686,7 +686,7 @@ export async function doInitiate(options: CommandOptions): Promise<
   const storybookCommand =
     projectType === ProjectType.ANGULAR
       ? `ng run ${installResult.projectName}:storybook`
-      : packageManager.getRunCommand('storybook');
+      : packageManager.getRunCommand('storybook').join(' ');
 
   if (selectedFeatures.has('test')) {
     const flags = ['--yes', options.skipInstall && '--skip-install'].filter(Boolean).join(' ');


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Update invocations of storybook cli to respawn in the current package manager, to hopefully improve the cli's ability to use package manager runtimes.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
