### PR TITLE
Onboarding: Replace `require.resolve` with json import

### DIFF
--- a/code/addons/onboarding/src/preset.ts
+++ b/code/addons/onboarding/src/preset.ts
@@ -28,4 +28,6 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
       telemetry('onboarding-survey', { ...event, addonVersion: packageJson.version });
     }
   });
+
+  return channel;
 };

--- a/code/addons/onboarding/src/preset.ts
+++ b/code/addons/onboarding/src/preset.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'node:fs';
-
 import type { Channel } from 'storybook/internal/channels';
 import { telemetry } from 'storybook/internal/telemetry';
 import type { CoreConfig, Options } from 'storybook/internal/types';
@@ -15,21 +13,19 @@ type Event = {
 export const experimental_serverChannel = async (channel: Channel, options: Options) => {
   const { disableTelemetry } = await options.presets.apply<CoreConfig>('core', {});
 
-  if (!disableTelemetry) {
-    const packageJsonPath = require.resolve('@storybook/addon-onboarding/package.json');
-
-    const { version: addonVersion } = JSON.parse(
-      readFileSync(packageJsonPath, { encoding: 'utf-8' })
-    );
-
-    channel.on(STORYBOOK_ADDON_ONBOARDING_CHANNEL, ({ type, ...event }: Event) => {
-      if (type === 'telemetry') {
-        telemetry('addon-onboarding', { ...event, addonVersion });
-      } else if (type === 'survey') {
-        telemetry('onboarding-survey', { ...event, addonVersion });
-      }
-    });
+  if (disableTelemetry) {
+    return channel;
   }
 
-  return channel;
+  const { default: packageJson } = await import('@storybook/addon-onboarding/package.json', {
+    with: { type: 'json' },
+  });
+
+  channel.on(STORYBOOK_ADDON_ONBOARDING_CHANNEL, ({ type, ...event }: Event) => {
+    if (type === 'telemetry') {
+      telemetry('addon-onboarding', { ...event, addonVersion: packageJson.version });
+    } else if (type === 'survey') {
+      telemetry('onboarding-survey', { ...event, addonVersion: packageJson.version });
+    }
+  });
 };

--- a/code/addons/onboarding/src/preset.ts
+++ b/code/addons/onboarding/src/preset.ts
@@ -2,6 +2,7 @@ import type { Channel } from 'storybook/internal/channels';
 import { telemetry } from 'storybook/internal/telemetry';
 import type { CoreConfig, Options } from 'storybook/internal/types';
 
+import { version as addonVersion } from '../package.json';
 import { STORYBOOK_ADDON_ONBOARDING_CHANNEL } from './constants';
 
 type Event = {
@@ -17,15 +18,11 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
     return channel;
   }
 
-  const { default: packageJson } = await import('@storybook/addon-onboarding/package.json', {
-    with: { type: 'json' },
-  });
-
   channel.on(STORYBOOK_ADDON_ONBOARDING_CHANNEL, ({ type, ...event }: Event) => {
     if (type === 'telemetry') {
-      telemetry('addon-onboarding', { ...event, addonVersion: packageJson.version });
+      telemetry('addon-onboarding', { ...event, addonVersion });
     } else if (type === 'survey') {
-      telemetry('onboarding-survey', { ...event, addonVersion: packageJson.version });
+      telemetry('onboarding-survey', { ...event, addonVersion });
     }
   });
 


### PR DESCRIPTION
Works on https://github.com/storybookjs/storybook/issues/31787

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Removed a `require.resolve` that had snuck its way in from `next`.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Replaces synchronous `require.resolve` with ESM-style JSON import in the onboarding addon to get package version for telemetry, aligning with Storybook's ESM-only initiative.

- Modernizes telemetry code in `code/addons/onboarding/src/preset.ts` by replacing Node.js `require.resolve` with ESM imports
- Simplifies logic flow by inverting telemetry check condition for early return
- Maintains existing telemetry and survey data functionality while improving code modularity



<!-- /greptile_comment -->