### PR TITLE
Addon Vitest: Fix support for plain `stories.tsx` files

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -93,6 +93,11 @@ const config = defineMain({
       directory: '../addons/vitest/template/stories',
       titlePrefix: 'addons/vitest',
     },
+    {
+      directory: '../addons/vitest/src',
+      titlePrefix: 'addons/vitest',
+      files: 'stories.tsx',
+    },
   ],
   addons: [
     '@storybook/addon-themes',

--- a/code/addons/vitest/src/stories.tsx
+++ b/code/addons/vitest/src/stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { expect } from 'storybook/test';
+
+const meta = {
+  title: 'StoriesTsx',
+  render: () => <div>This is a story coming from a /stories.tsx file detected via custom glob</div>,
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async () => {
+    expect(true).toBe(true);
+  },
+};

--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -48,17 +48,6 @@ const transform = async ({
 };
 
 describe('transformer', () => {
-  describe('no-op', () => {
-    it('should return original code if the file is not a story file', async () => {
-      const code = `console.log('Not a story file');`;
-      const fileName = 'src/components/Button.js';
-
-      const result = await transform({ code, fileName });
-
-      expect(result.code).toMatchInlineSnapshot(`console.log('Not a story file');`);
-    });
-  });
-
   describe('CSF v1/v2/v3', () => {
     describe('default exports (meta)', () => {
       it('should add title to inline default export if not present', async () => {
@@ -124,7 +113,7 @@ describe('transformer', () => {
             component: Button,
           };
           export default meta;
-  
+
           export const Story = {};
         `;
 
@@ -153,9 +142,9 @@ describe('transformer', () => {
           const meta = {
             title: 'Button',
             component: Button,
-          };  
+          };
           export default meta;
-  
+
           export const Story = {};
         `;
 
@@ -272,7 +261,7 @@ describe('transformer', () => {
               label: 'Primary Button',
             },
           };
-  
+
           export { Primary };
         `;
 
@@ -306,7 +295,7 @@ describe('transformer', () => {
               label: 'Primary Button',
             },
           };
-  
+
           export { Primary as PrimaryStory };
         `;
 
@@ -340,9 +329,9 @@ describe('transformer', () => {
               label: 'Primary Button',
             },
           };
-  
+
           export const Secondary = {}
-  
+
           export { Primary };
         `;
 
@@ -430,7 +419,7 @@ describe('transformer', () => {
         const code = `
           export default {};
           export const Included = { tags: ['include-me'] };
-  
+
           export const NotIncluded = {}
         `;
 
@@ -461,7 +450,7 @@ describe('transformer', () => {
         const code = `
           export default {};
           export const Included = {};
-  
+
           export const NotIncluded = { tags: ['exclude-me'] }
         `;
 
@@ -636,7 +625,7 @@ describe('transformer', () => {
         const code = `
         import { config } from '#.storybook/preview';
         const meta = config.meta({ component: Button });
-        const Primary = meta.story({ 
+        const Primary = meta.story({
           args: {
             label: 'Primary Button',
           }
@@ -672,7 +661,7 @@ describe('transformer', () => {
         const code = `
         import { config } from '#.storybook/preview';
         const meta = config.meta({ component: Button });
-        const Primary = meta.story({ 
+        const Primary = meta.story({
           args: {
             label: 'Primary Button',
           }

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -46,11 +46,6 @@ export async function vitestTransform({
   stories: StoriesEntry[];
   previewLevelTags: Tag[];
 }): Promise<ReturnType<typeof formatCsf>> {
-  const isStoryFile = /\.stor(y|ies)\./.test(fileName);
-  if (!isStoryFile) {
-    return code;
-  }
-
   const parsed = loadCsf(code, {
     fileName,
     transformInlineMeta: true,


### PR DESCRIPTION
Closes #31966

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Removed a check against a file pattern in the vitest transformer which was preventing `stories.tsx` files from being transformed, thereby crashing Vitest. We already check against stories globs higher up the chain so we don't need the check in the transformer.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR removes an overly restrictive file pattern check in the Vitest transformer that was preventing files named `stories.tsx` (without a component prefix) from being properly processed. The change simplifies the code by removing redundant validation that was already being handled by Storybook's glob patterns higher up in the build chain.

This fix addresses issue #31966 where files named `stories.tsx` were being skipped by the transformer, causing Vitest to crash. The removed check was superfluous since Storybook already handles story file detection through its glob patterns at a higher level.

The changes involve:
1. Removing the `.stor(y|ies)\.` regex check from the transformer
2. Removing associated test cases that were validating this now-removed functionality

## Confidence score: 5/5

1. This PR is extremely safe to merge as it removes redundant validation
2. The score is 5/5 because the change is a straightforward removal of duplicate validation that was causing issues, with the proper validation already being handled elsewhere in the codebase
3. Files that need attention:
   - code/core/src/csf-tools/vitest-plugin/transformer.ts
   - code/core/src/csf-tools/vitest-plugin/transformer.test.ts

<sub>2 files reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=storybook_32041)</sub>

<!-- /greptile_comment -->