### PR TITLE
React Native Web: Simplify config by using vite-plugin-rnw

### DIFF
--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -62,7 +62,7 @@
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",
-    "vite-plugin-rnw": "^0.0.5",
+    "vite-plugin-rnw": "^0.0.6",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {

--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -59,13 +59,10 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@bunchtogether/vite-plugin-flow": "^1.0.2",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",
-    "@vitejs/plugin-react": "^4.3.2",
-    "vite-plugin-babel": "^1.3.2",
-    "vite-plugin-commonjs": "^0.10.4",
+    "vite-plugin-rnw": "^0.0.5",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {

--- a/code/frameworks/react-native-web-vite/src/preset.ts
+++ b/code/frameworks/react-native-web-vite/src/preset.ts
@@ -1,75 +1,16 @@
 import { viteFinal as reactViteFinal } from '@storybook/react-vite/preset';
 
-import { esbuildFlowPlugin, flowPlugin } from '@bunchtogether/vite-plugin-flow';
-import react from '@vitejs/plugin-react';
-import type { InlineConfig, PluginOption } from 'vite';
-import babel from 'vite-plugin-babel';
-import commonjs from 'vite-plugin-commonjs';
+import type { InlineConfig } from 'vite';
+import { rnw } from 'vite-plugin-rnw';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 import type { FrameworkOptions, StorybookConfig } from './types';
 
-export function reactNativeWeb(): PluginOption {
-  return {
-    name: 'vite:react-native-web',
-    config(_userConfig, env) {
-      return {
-        define: {
-          // reanimated support
-          'global.__x': {},
-          _frameTimestamp: undefined,
-          _WORKLET: false,
-          __DEV__: `${env.mode === 'development'}`,
-          'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || env.mode),
-        },
-        optimizeDeps: {
-          include: [],
-          esbuildOptions: {
-            jsx: 'automatic',
-            resolveExtensions: [
-              '.web.js',
-              '.web.ts',
-              '.web.tsx',
-              '.js',
-              '.jsx',
-              '.json',
-              '.ts',
-              '.tsx',
-              '.mjs',
-            ],
-            loader: {
-              '.js': 'jsx',
-            },
-          },
-        },
-        resolve: {
-          extensions: [
-            '.web.js',
-            '.web.ts',
-            '.web.tsx',
-            '.js',
-            '.jsx',
-            '.json',
-            '.ts',
-            '.tsx',
-            '.mjs',
-          ],
-          alias: {
-            'react-native': 'react-native-web',
-          },
-        },
-      };
-    },
-  };
-}
-
 export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) => {
   const { mergeConfig } = await import('vite');
 
-  const { pluginReactOptions = {}, pluginBabelOptions = {} } =
+  const { pluginReactOptions = {} } =
     await options.presets.apply<FrameworkOptions>('frameworkOptions');
-
-  const isDevelopment = options.configType !== 'PRODUCTION';
 
   const { plugins = [], ...reactConfigWithoutPlugins } = await reactViteFinal(config, options);
 
@@ -77,11 +18,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
     plugins: [
       tsconfigPaths(),
 
-      // fix for react native packages shipping with flow types untranspiled
-      flowPlugin({
-        exclude: [/node_modules\/(?!react-native|@react-native)/],
-      }),
-      react({
+      rnw({
         ...pluginReactOptions,
         jsxRuntime: pluginReactOptions.jsxRuntime || 'automatic',
         babel: {
@@ -91,55 +28,8 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
         },
       }),
 
-      // we need to add this extra babel config because the react plugin doesn't allow
-      // for transpiling node_modules. We need this because many react native packages are un-transpiled.
-      // see this pr for more context: https://github.com/vitejs/vite-plugin-react/pull/306
-      // However we keep the react plugin to get the fast refresh and the other stuff its doing
-      babel({
-        ...pluginBabelOptions,
-        include: pluginBabelOptions.include || [
-          /node_modules\/(react-native|@react-native|expo|@expo)/,
-        ],
-        exclude: pluginBabelOptions.exclude,
-        babelConfig: {
-          babelrc: false,
-          configFile: false,
-          ...pluginBabelOptions.babelConfig,
-          presets: [
-            [
-              '@babel/preset-react',
-              {
-                development: isDevelopment,
-                runtime: 'automatic',
-                ...(pluginBabelOptions.presetReact || {}),
-              },
-            ],
-            ...(pluginBabelOptions.babelConfig?.presets || []),
-          ],
-          plugins: [
-            [
-              // this is a fix for reanimated not working in production
-              '@babel/plugin-transform-modules-commonjs',
-              {
-                strict: false,
-                strictMode: false, // prevent "use strict" injections
-                allowTopLevelThis: true, // dont rewrite global `this` -> `undefined`
-              },
-            ],
-            ...(pluginBabelOptions.babelConfig?.plugins || []),
-          ],
-        },
-      }),
       ...plugins,
-      reactNativeWeb(),
-      commonjs(),
     ],
-    optimizeDeps: {
-      esbuildOptions: {
-        // fix for react native packages shipping with flow types untranspiled
-        plugins: [esbuildFlowPlugin(new RegExp(/\.(flow|jsx?)$/), (_path: string) => 'jsx')],
-      },
-    },
   } satisfies InlineConfig);
 };
 

--- a/code/frameworks/react-native-web-vite/src/preset.ts
+++ b/code/frameworks/react-native-web-vite/src/preset.ts
@@ -6,10 +6,24 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 import type { FrameworkOptions, StorybookConfig } from './types';
 
+const getExcludeOptions = (modulesToTranspile: string[]) => {
+  const defaultModulesToTranspile = ['react-native', '@react-native', 'expo', '@expo'];
+  const uniqueModulesToTranspile = Array.from(
+    new Set([...modulesToTranspile, ...defaultModulesToTranspile])
+  );
+
+  if (modulesToTranspile.length) {
+    // produce a regex of `/\/node_modules\/(?!react-native|@react-native|expo|@expo|[others])/`
+    return { exclude: new RegExp(`/node_modules/(?!${uniqueModulesToTranspile.join('|')})`) };
+  }
+
+  return {};
+};
+
 export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) => {
   const { mergeConfig } = await import('vite');
 
-  const { pluginReactOptions = {} } =
+  const { pluginReactOptions = {}, modulesToTranspile = [] } =
     await options.presets.apply<FrameworkOptions>('frameworkOptions');
 
   const { plugins = [], ...reactConfigWithoutPlugins } = await reactViteFinal(config, options);
@@ -19,6 +33,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, options) =
       tsconfigPaths(),
 
       rnw({
+        ...getExcludeOptions(modulesToTranspile),
         ...pluginReactOptions,
         jsxRuntime: pluginReactOptions.jsxRuntime || 'automatic',
         babel: {

--- a/code/frameworks/react-native-web-vite/src/types.ts
+++ b/code/frameworks/react-native-web-vite/src/types.ts
@@ -5,18 +5,10 @@ import type {
   StorybookConfig as StorybookConfigBase,
 } from '@storybook/react-vite';
 
-import type { BabelOptions, Options as ReactOptions } from '@vitejs/plugin-react';
-import type { BabelPluginOptions } from 'vite-plugin-babel';
+import type { BabelOptions, Options as ReactOptions } from 'vite-plugin-rnw';
 
 export type FrameworkOptions = FrameworkOptionsBase & {
   pluginReactOptions?: Omit<ReactOptions, 'babel'> & { babel?: BabelOptions };
-  pluginBabelOptions?: BabelPluginOptions & {
-    presetReact?: {
-      [key: string]: any;
-      runtime?: 'automatic' | 'classic';
-      importSource?: string;
-    };
-  };
 };
 
 type FrameworkName = CompatibleString<'@storybook/react-native-web-vite'>;

--- a/code/frameworks/react-native-web-vite/src/types.ts
+++ b/code/frameworks/react-native-web-vite/src/types.ts
@@ -9,6 +9,12 @@ import type { BabelOptions, Options as ReactOptions } from 'vite-plugin-rnw';
 
 export type FrameworkOptions = FrameworkOptionsBase & {
   pluginReactOptions?: Omit<ReactOptions, 'babel'> & { babel?: BabelOptions };
+  /**
+   * @deprecated These options will be ignored. Use `pluginReactOptions` now for everything and
+   *   override includes in order to transpile node_modules pluginBabelOptions will be removed in
+   *   the next major version. To configure babel, use `pluginReactOptions.babel`.
+   */
+  pluginBabelOptions?: Record<string, unknown>;
 };
 
 type FrameworkName = CompatibleString<'@storybook/react-native-web-vite'>;

--- a/code/frameworks/react-native-web-vite/src/types.ts
+++ b/code/frameworks/react-native-web-vite/src/types.ts
@@ -8,6 +8,14 @@ import type {
 import type { BabelOptions, Options as ReactOptions } from 'vite-plugin-rnw';
 
 export type FrameworkOptions = FrameworkOptionsBase & {
+  /**
+   * Many react native libraries arent transpiled for the web, add them to this list to make sure
+   * they get transpiled before attempting to load them on the web. We will automatically add
+   * `react-native`, `@react-native`, `expo`, and `@expo` to this list.
+   *
+   * @example {modulesToTranspile: ['my-library']}
+   */
+  modulesToTranspile?: string[];
   pluginReactOptions?: Omit<ReactOptions, 'babel'> & { babel?: BabelOptions };
   /**
    * @deprecated These options will be ignored. Use `pluginReactOptions` now for everything and

--- a/code/frameworks/react-native-web-vite/src/types.ts
+++ b/code/frameworks/react-native-web-vite/src/types.ts
@@ -9,7 +9,7 @@ import type { BabelOptions, Options as ReactOptions } from 'vite-plugin-rnw';
 
 export type FrameworkOptions = FrameworkOptionsBase & {
   /**
-   * Many react native libraries arent transpiled for the web, add them to this list to make sure
+   * Many react native libraries aren't transpiled for the web, add them to this list to make sure
    * they get transpiled before attempting to load them on the web. We will automatically add
    * `react-native`, `@react-native`, `expo`, and `@expo` to this list.
    *

--- a/code/frameworks/react-native-web-vite/src/typings.d.ts
+++ b/code/frameworks/react-native-web-vite/src/typings.d.ts
@@ -1,1 +1,0 @@
-declare module '@bunchtogether/vite-plugin-flow';

--- a/code/frameworks/react-native-web-vite/src/vite-plugin.ts
+++ b/code/frameworks/react-native-web-vite/src/vite-plugin.ts
@@ -1,18 +1,11 @@
-import react from '@vitejs/plugin-react';
+import { rnw } from 'vite-plugin-rnw';
 import tsconfigPaths from 'vite-tsconfig-paths';
-
-import { reactNativeWeb } from './preset';
 
 export const storybookReactNativeWeb = () => {
   return [
     tsconfigPaths(),
-    react({
-      babel: {
-        babelrc: false,
-        configFile: false,
-      },
+    rnw({
       jsxRuntime: 'automatic',
     }),
-    reactNativeWeb(),
   ];
 };

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6992,7 +6992,7 @@ __metadata:
     "@storybook/react-vite": "workspace:*"
     "@types/node": "npm:^22.0.0"
     typescript: "npm:^5.8.3"
-    vite-plugin-rnw: "npm:^0.0.5"
+    vite-plugin-rnw: "npm:^0.0.6"
     vite-tsconfig-paths: "npm:^5.1.4"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -27020,9 +27020,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-rnw@npm:^0.0.5":
-  version: 0.0.5
-  resolution: "vite-plugin-rnw@npm:0.0.5"
+"vite-plugin-rnw@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "vite-plugin-rnw@npm:0.0.6"
   dependencies:
     "@babel/core": "npm:^7.28.0"
     "@babel/plugin-transform-flow-strip-types": "npm:^7.27.1"
@@ -27038,7 +27038,7 @@ __metadata:
     react-native-web: "*"
     typescript: ^5
     vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10c0/ca3f8a219da75f9e09a81be0e23faebe802832665c509bafe58b23b9c931f62440dfb5b7df9ca6a2434412a655b8431701595e9693ee97a9c754e4e470b00cfd
+  checksum: 10c0/a2b90d45ad9484fe02273a35b3b7125b8d6aaf6e7f0c239f2d9dafe12b2b38bdfe14257d3fe05c913d02312b4b75d006d9cc92c874a1deb2840c6168f07ffff9
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -422,10 +422,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/code-frame@npm:7.27.1"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.27.1"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10c0/5dd9a18baa5fce4741ba729acc3a3272c49c25cb8736c4b18e113099520e7ef7b545a4096a26d600e4416157e63e87d66db46aa3fbf0a5f2286da2705c12da00
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.26.8":
   version: 7.26.8
   resolution: "@babel/compat-data@npm:7.26.8"
   checksum: 10c0/66408a0388c3457fff1c2f6c3a061278dd7b3d2f0455ea29bb7b187fa52c60ae8b4054b3c0a184e21e45f0eaac63cf390737bc7504d1f4a088a6e7f652c068ca
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.27.2":
+  version: 7.28.0
+  resolution: "@babel/compat-data@npm:7.28.0"
+  checksum: 10c0/c4e527302bcd61052423f757355a71c3bc62362bac13f7f130de16e439716f66091ff5bdecda418e8fa0271d4c725f860f0ee23ab7bf6e769f7a8bb16dfcb531
   languageName: node
   linkType: hard
 
@@ -475,6 +493,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/core@npm:7.28.0"
+  dependencies:
+    "@ampproject/remapping": "npm:^2.2.0"
+    "@babel/code-frame": "npm:^7.27.1"
+    "@babel/generator": "npm:^7.28.0"
+    "@babel/helper-compilation-targets": "npm:^7.27.2"
+    "@babel/helper-module-transforms": "npm:^7.27.3"
+    "@babel/helpers": "npm:^7.27.6"
+    "@babel/parser": "npm:^7.28.0"
+    "@babel/template": "npm:^7.27.2"
+    "@babel/traverse": "npm:^7.28.0"
+    "@babel/types": "npm:^7.28.0"
+    convert-source-map: "npm:^2.0.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.2.3"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/423302e7c721e73b1c096217880272e02020dfb697a55ccca60ad01bba90037015f84d0c20c6ce297cf33a19bb704bc5c2b3d3095f5284dfa592bd1de0b9e8c3
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:7.17.7":
   version: 7.17.7
   resolution: "@babel/generator@npm:7.17.7"
@@ -512,6 +553,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/generator@npm:7.28.0"
+  dependencies:
+    "@babel/parser": "npm:^7.28.0"
+    "@babel/types": "npm:^7.28.0"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10c0/1b3d122268ea3df50fde707ad864d9a55c72621357d5cebb972db3dd76859c45810c56e16ad23123f18f80cc2692f5a015d2858361300f0f224a05dc43d36a92
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:7.25.9, @babel/helper-annotate-as-pure@npm:^7.18.6, @babel/helper-annotate-as-pure@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-annotate-as-pure@npm:7.25.9"
@@ -531,6 +585,19 @@ __metadata:
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
   checksum: 10c0/375c9f80e6540118f41bd53dd54d670b8bf91235d631bdead44c8b313b26e9cd89aed5c6df770ad13a87a464497b5346bb72b9462ba690473da422f5402618b6
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.27.2":
+  version: 7.27.2
+  resolution: "@babel/helper-compilation-targets@npm:7.27.2"
+  dependencies:
+    "@babel/compat-data": "npm:^7.27.2"
+    "@babel/helper-validator-option": "npm:^7.27.1"
+    browserslist: "npm:^4.24.0"
+    lru-cache: "npm:^5.1.1"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/f338fa00dcfea931804a7c55d1a1c81b6f0a09787e528ec580d5c21b3ecb3913f6cb0f361368973ce953b824d910d3ac3e8a8ee15192710d3563826447193ad1
   languageName: node
   linkType: hard
 
@@ -598,6 +665,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/helper-globals@npm:7.28.0"
+  checksum: 10c0/5a0cd0c0e8c764b5f27f2095e4243e8af6fa145daea2b41b53c0c1414fe6ff139e3640f4e2207ae2b3d2153a1abd346f901c26c290ee7cb3881dd922d4ee9232
+  languageName: node
+  linkType: hard
+
 "@babel/helper-hoist-variables@npm:^7.22.5":
   version: 7.24.7
   resolution: "@babel/helper-hoist-variables@npm:7.24.7"
@@ -627,6 +701,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-module-imports@npm:7.27.1"
+  dependencies:
+    "@babel/traverse": "npm:^7.27.1"
+    "@babel/types": "npm:^7.27.1"
+  checksum: 10c0/e00aace096e4e29290ff8648455c2bc4ed982f0d61dbf2db1b5e750b9b98f318bf5788d75a4f974c151bd318fd549e81dbcab595f46b14b81c12eda3023f51e8
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.25.9, @babel/helper-module-transforms@npm:^7.26.0":
   version: 7.26.0
   resolution: "@babel/helper-module-transforms@npm:7.26.0"
@@ -637,6 +721,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 10c0/ee111b68a5933481d76633dad9cdab30c41df4479f0e5e1cc4756dc9447c1afd2c9473b5ba006362e35b17f4ebddd5fca090233bef8dfc84dca9d9127e56ec3a
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.27.3":
+  version: 7.27.3
+  resolution: "@babel/helper-module-transforms@npm:7.27.3"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.27.1"
+    "@babel/helper-validator-identifier": "npm:^7.27.1"
+    "@babel/traverse": "npm:^7.27.3"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10c0/fccb4f512a13b4c069af51e1b56b20f54024bcf1591e31e978a30f3502567f34f90a80da6a19a6148c249216292a8074a0121f9e52602510ef0f32dbce95ca01
   languageName: node
   linkType: hard
 
@@ -653,6 +750,13 @@ __metadata:
   version: 7.26.5
   resolution: "@babel/helper-plugin-utils@npm:7.26.5"
   checksum: 10c0/cdaba71d4b891aa6a8dfbe5bac2f94effb13e5fa4c2c487667fdbaa04eae059b78b28d85a885071f45f7205aeb56d16759e1bed9c118b94b16e4720ef1ab0f65
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-plugin-utils@npm:7.27.1"
+  checksum: 10c0/94cf22c81a0c11a09b197b41ab488d416ff62254ce13c57e62912c85700dc2e99e555225787a4099ff6bae7a1812d622c80fbaeda824b79baa10a6c5ac4cf69b
   languageName: node
   linkType: hard
 
@@ -708,6 +812,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-string-parser@npm:7.27.1"
+  checksum: 10c0/8bda3448e07b5583727c103560bcf9c4c24b3c1051a4c516d4050ef69df37bb9a4734a585fe12725b8c2763de0a265aa1e909b485a4e3270b7cfd3e4dbe4b602
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.16.7, @babel/helper-validator-identifier@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-identifier@npm:7.25.9"
@@ -715,10 +826,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-validator-identifier@npm:7.27.1"
+  checksum: 10c0/c558f11c4871d526498e49d07a84752d1800bf72ac0d3dad100309a2eaba24efbf56ea59af5137ff15e3a00280ebe588560534b0e894a4750f8b1411d8f78b84
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-option@npm:7.25.9"
   checksum: 10c0/27fb195d14c7dcb07f14e58fe77c44eea19a6a40a74472ec05c441478fa0bb49fa1c32b2d64be7a38870ee48ef6601bdebe98d512f0253aea0b39756c4014f3e
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-validator-option@npm:7.27.1"
+  checksum: 10c0/6fec5f006eba40001a20f26b1ef5dbbda377b7b68c8ad518c05baa9af3f396e780bdfded24c4eef95d14bb7b8fd56192a6ed38d5d439b97d10efc5f1a191d148
   languageName: node
   linkType: hard
 
@@ -743,6 +868,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.27.6":
+  version: 7.27.6
+  resolution: "@babel/helpers@npm:7.27.6"
+  dependencies:
+    "@babel/template": "npm:^7.27.2"
+    "@babel/types": "npm:^7.27.6"
+  checksum: 10c0/448bac96ef8b0f21f2294a826df9de6bf4026fd023f8a6bb6c782fe3e61946801ca24381490b8e58d861fee75cd695a1882921afbf1f53b0275ee68c938bd6d3
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.5, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.22.5, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.25.4, @babel/parser@npm:^7.26.10, @babel/parser@npm:^7.26.9, @babel/parser@npm:^7.27.0, @babel/parser@npm:^7.4.5, @babel/parser@npm:^7.6.0, @babel/parser@npm:^7.9.6":
   version: 7.27.0
   resolution: "@babel/parser@npm:7.27.0"
@@ -751,6 +886,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/ba2ed3f41735826546a3ef2a7634a8d10351df221891906e59b29b0a0cd748f9b0e7a6f07576858a9de8e77785aad925c8389ddef146de04ea2842047c9d2859
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/parser@npm:7.28.0"
+  dependencies:
+    "@babel/types": "npm:^7.28.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/c2ef81d598990fa949d1d388429df327420357cb5200271d0d0a2784f1e6d54afc8301eb8bdf96d8f6c77781e402da93c7dc07980fcc136ac5b9d5f1fce701b5
   languageName: node
   linkType: hard
 
@@ -914,6 +1060,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/3d5cc1627a67af8be9df8cfe246869f18e7e9e2592f4b6f1c4bcd9bbe4ad27102784a25b31ebdbed23499ecb6fc23aaf7891ccf5ac3f432fd26a27123d1e242b
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-flow@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/plugin-syntax-flow@npm:7.27.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.27.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/4d34ca47044398665cbe0293baea7be230ca4090bc7981ffba5273402a215c95976c6f811c7b32f10b326cc6aab6886f26c29630c429aa45c3f350c5ccdfdbbf
   languageName: node
   linkType: hard
 
@@ -1186,6 +1343,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-flow-strip-types@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/plugin-transform-flow-strip-types@npm:7.27.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/plugin-syntax-flow": "npm:^7.27.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/c61c43244aacdcd479ad9ba618e1c095a5db7e4eadc3d19249602febc4e97153230273c014933f5fe4e92062fa56dab9bed4bc430197d5b2ffeb2158a4bf6786
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-for-of@npm:^7.26.9":
   version: 7.26.9
   resolution: "@babel/plugin-transform-for-of@npm:7.26.9"
@@ -1276,6 +1445,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/82e59708f19f36da29531a64a7a94eabbf6ff46a615e0f5d9b49f3f59e8ef10e2bac607d749091508d3fa655146c9e5647c3ffeca781060cdabedb4c7a33c6f2
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-commonjs@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.27.1"
+  dependencies:
+    "@babel/helper-module-transforms": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.27.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/4def972dcd23375a266ea1189115a4ff61744b2c9366fc1de648b3fab2c650faf1a94092de93a33ff18858d2e6c4dddeeee5384cb42ba0129baeab01a5cdf1e2
   languageName: node
   linkType: hard
 
@@ -1489,6 +1670,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-react-jsx-self@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.27.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.27.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/00a4f917b70a608f9aca2fb39aabe04a60aa33165a7e0105fd44b3a8531630eb85bf5572e9f242f51e6ad2fa38c2e7e780902176c863556c58b5ba6f6e164031
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-jsx-source@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-react-jsx-source@npm:7.25.9"
@@ -1497,6 +1689,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/fc9ee08efc9be7cbd2cc6788bbf92579adf3cab37912481f1b915221be3d22b0613b5b36a721df5f4c0ab65efe8582fcf8673caab83e6e1ce4cc04ceebf57dfa
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx-source@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/plugin-transform-react-jsx-source@npm:7.27.1"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.27.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/5e67b56c39c4d03e59e03ba80692b24c5a921472079b63af711b1d250fc37c1733a17069b63537f750f3e937ec44a42b1ee6a46cd23b1a0df5163b17f741f7f2
   languageName: node
   linkType: hard
 
@@ -1913,6 +2116,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.27.2":
+  version: 7.27.2
+  resolution: "@babel/template@npm:7.27.2"
+  dependencies:
+    "@babel/code-frame": "npm:^7.27.1"
+    "@babel/parser": "npm:^7.27.2"
+    "@babel/types": "npm:^7.27.1"
+  checksum: 10c0/ed9e9022651e463cc5f2cc21942f0e74544f1754d231add6348ff1b472985a3b3502041c0be62dc99ed2d12cfae0c51394bf827452b98a2f8769c03b87aadc81
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:7.23.2":
   version: 7.23.2
   resolution: "@babel/traverse@npm:7.23.2"
@@ -1946,6 +2160,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.27.3, @babel/traverse@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/traverse@npm:7.28.0"
+  dependencies:
+    "@babel/code-frame": "npm:^7.27.1"
+    "@babel/generator": "npm:^7.28.0"
+    "@babel/helper-globals": "npm:^7.28.0"
+    "@babel/parser": "npm:^7.28.0"
+    "@babel/template": "npm:^7.27.2"
+    "@babel/types": "npm:^7.28.0"
+    debug: "npm:^4.3.1"
+  checksum: 10c0/32794402457827ac558173bcebdcc0e3a18fa339b7c41ca35621f9f645f044534d91bb923ff385f5f960f2e495f56ce18d6c7b0d064d2f0ccb55b285fa6bc7b9
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:7.17.0":
   version: 7.17.0
   resolution: "@babel/types@npm:7.17.0"
@@ -1963,6 +2192,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.25.9"
     "@babel/helper-validator-identifier": "npm:^7.25.9"
   checksum: 10c0/6f1592eabe243c89a608717b07b72969be9d9d2fce1dee21426238757ea1fa60fdfc09b29de9e48d8104311afc6e6fb1702565a9cc1e09bc1e76f2b2ddb0f6e1
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.27.1, @babel/types@npm:^7.27.6, @babel/types@npm:^7.28.0":
+  version: 7.28.1
+  resolution: "@babel/types@npm:7.28.1"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.27.1"
+    "@babel/helper-validator-identifier": "npm:^7.27.1"
+  checksum: 10c0/5e99b346c11ee42ffb0cadc28159fe0b184d865a2cc1593df79b199772a534f6453969b4942aa5e4a55a3081863096e1cc3fc1c724d826926dc787cf229b845d
   languageName: node
   linkType: hard
 
@@ -3368,6 +3607,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/gen-mapping@npm:^0.3.12":
+  version: 0.3.12
+  resolution: "@jridgewell/gen-mapping@npm:0.3.12"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10c0/32f771ae2467e4d440be609581f7338d786d3d621bac3469e943b9d6d116c23c4becb36f84898a92bbf2f3c0511365c54a945a3b86a83141547a2a360a5ec0c7
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.3.2, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.8
   resolution: "@jridgewell/gen-mapping@npm:0.3.8"
@@ -3427,6 +3676,16 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10c0/3d1ce6ebc69df9682a5a8896b414c6537e428a1d68b02fcc8363b04284a8ca0df04d0ee3013132252ab14f2527bc13bea6526a912ecb5658f0e39fd2860b4df4
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.28":
+  version: 0.3.29
+  resolution: "@jridgewell/trace-mapping@npm:0.3.29"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: 10c0/fb547ba31658c4d74eb17e7389f4908bf7c44cef47acb4c5baa57289daf68e6fe53c639f41f751b3923aca67010501264f70e7b49978ad1f040294b22c37b333
   languageName: node
   linkType: hard
 
@@ -5561,6 +5820,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/pluginutils@npm:1.0.0-beta.24":
+  version: 1.0.0-beta.24
+  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.24"
+  checksum: 10c0/148af131a0a91f1d0786742068417768de97de0492483cc3e0a928212f33a8afd9a4e48cb5551436193b6099903217849ff5f414dd9a9ccaa37f3c62ff1f4bce
+  languageName: node
+  linkType: hard
+
 "@rollup/pluginutils@npm:^5.0.2":
   version: 5.1.4
   resolution: "@rollup/pluginutils@npm:5.1.4"
@@ -6721,15 +6987,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/react-native-web-vite@workspace:frameworks/react-native-web-vite"
   dependencies:
-    "@bunchtogether/vite-plugin-flow": "npm:^1.0.2"
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": "workspace:*"
     "@storybook/react-vite": "workspace:*"
     "@types/node": "npm:^22.0.0"
-    "@vitejs/plugin-react": "npm:^4.3.2"
     typescript: "npm:^5.8.3"
-    vite-plugin-babel: "npm:^1.3.2"
-    vite-plugin-commonjs: "npm:^0.10.4"
+    vite-plugin-rnw: "npm:^0.0.5"
     vite-tsconfig-paths: "npm:^5.1.4"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -26712,16 +26975,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-babel@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "vite-plugin-babel@npm:1.3.2"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-    vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10c0/177f51dab2956b282ee6c630cd31df625714a0b33dea7418a5648bc153f3f6aa98c54d8960d68fdbe106e5dfde9d8c2f0e65b929964f41de33815caa8e691ab7
-  languageName: node
-  linkType: hard
-
 "vite-plugin-commonjs@npm:^0.10.4":
   version: 0.10.4
   resolution: "vite-plugin-commonjs@npm:0.10.4"
@@ -26764,6 +27017,28 @@ __metadata:
     "@nuxt/kit":
       optional: true
   checksum: 10c0/b7a5d3f882864113520f17e3dfa857b751f53e54371a67cd99a860e24a98cd40beea4389a667de33c6d71cb8411a9da1d5c183689c95e5b42b2c0aea28ffd138
+  languageName: node
+  linkType: hard
+
+"vite-plugin-rnw@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "vite-plugin-rnw@npm:0.0.5"
+  dependencies:
+    "@babel/core": "npm:^7.28.0"
+    "@babel/plugin-transform-flow-strip-types": "npm:^7.27.1"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.27.1"
+    "@babel/plugin-transform-react-jsx-self": "npm:^7.27.1"
+    "@babel/plugin-transform-react-jsx-source": "npm:^7.27.1"
+    "@bunchtogether/vite-plugin-flow": "npm:^1.0.2"
+    "@rolldown/pluginutils": "npm:1.0.0-beta.24"
+    "@types/babel__core": "npm:^7.20.5"
+    react-refresh: "npm:^0.17.0"
+    vite-plugin-commonjs: "npm:^0.10.4"
+  peerDependencies:
+    react-native-web: "*"
+    typescript: ^5
+    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+  checksum: 10c0/ca3f8a219da75f9e09a81be0e23faebe802832665c509bafe58b23b9c931f62440dfb5b7df9ca6a2434412a655b8431701595e9693ee97a9c754e4e470b00cfd
   languageName: node
   linkType: hard
 

--- a/docs/get-started/frameworks/react-native-web-vite.mdx
+++ b/docs/get-started/frameworks/react-native-web-vite.mdx
@@ -144,23 +144,11 @@ const config: StorybookConfig = {
           presets: Array<string | [string, any]>,
           // ... other compatible babel options
         }
-        include: Array<string|RegExp>,
-        exclude: Array<string|RegExp>,
+        include: Array<string|RegExp>, 
+        
+        // default excludes: /\/node_modules\/(?!react-native|@react-native|expo|@expo)/;
+        exclude: Array<string|RegExp>, 
         // ... other compatible @vitejs/plugin-react options
-      }
-
-      // these options are used to configure transpilation of node_modules via babel
-      // in most cases, you don't need to configure these options, but they are available if you need them
-      pluginBabelOptions: {
-        include: Array<string|RegExp>, // default: [/node_modules\/(react-native|@react-native)/]
-        exclude: Array<string|RegExp>, // default: undefined
-        presets: Array<string|[string, any]>,
-        plugins: Array<string|[string, any]>,
-        presetReact?: {
-          runtime?: 'automatic' | 'classic'; // default: 'automatic'
-          importSource?: string; // default: 'react'
-        };
-        // ... other compatible vite-plugin-babel options
       }
     },
   },
@@ -204,6 +192,26 @@ const main: StorybookConfig = {
     options: {
       pluginReactOptions: {
         jsxImportSource: "nativewind",
+      },
+    },
+  },
+}
+```
+
+#### Example configuration to transpile additional node_modules
+
+Lets say you need to transpile a library called `my-library` that is not included in the default excludes.
+You can do so by overriding the `exclude` option.
+
+```ts title=".storybook/main.ts"
+const main: StorybookConfig = {
+  // ... rest of config
+
+  framework: {
+    name: "@storybook/react-native-web-vite",
+    options: {
+      pluginReactOptions: {
+        exclude: /\/node_modules\/(?!react-native|@react-native|expo|@expo|my-library)/;
       },
     },
   },

--- a/docs/get-started/frameworks/react-native-web-vite.mdx
+++ b/docs/get-started/frameworks/react-native-web-vite.mdx
@@ -133,6 +133,8 @@ const config: StorybookConfig = {
   framework: {
     name: '@storybook/react-native-web-vite',
     options: {
+      modulesToTranspile: ['my-library'], // add libraries that are not transpiled for web by default
+
       // You should apply babel plugins and presets here for your project that you want to apply to your code
       // for example put the reanimated preset here if you are using reanimated
       // or the nativewind jsxImportSource for example
@@ -146,7 +148,6 @@ const config: StorybookConfig = {
         }
         include: Array<string|RegExp>, 
         
-        // default excludes: /\/node_modules\/(?!react-native|@react-native|expo|@expo)/;
         exclude: Array<string|RegExp>, 
         // ... other compatible @vitejs/plugin-react options
       }
@@ -200,8 +201,8 @@ const main: StorybookConfig = {
 
 #### Example configuration to transpile additional node_modules
 
-Lets say you need to transpile a library called `my-library` that is not included in the default excludes.
-You can do so by overriding the `exclude` option.
+Lets say you need to transpile a library called `my-library` that is not transpiled for web by default.
+You can add it to the `modulesToTranspile` option.
 
 ```ts title=".storybook/main.ts"
 const main: StorybookConfig = {
@@ -210,9 +211,7 @@ const main: StorybookConfig = {
   framework: {
     name: "@storybook/react-native-web-vite",
     options: {
-      pluginReactOptions: {
-        exclude: /\/node_modules\/(?!react-native|@react-native|expo|@expo|my-library)/;
-      },
+      modulesToTranspile: ['my-library'],
     },
   },
 }

--- a/docs/get-started/frameworks/react-native-web-vite.mdx
+++ b/docs/get-started/frameworks/react-native-web-vite.mdx
@@ -200,7 +200,7 @@ const main: StorybookConfig = {
 
 #### Example configuration to transpile additional node_modules
 
-Lets say you need to transpile a library called `my-library` that is not transpiled for web by default.
+Let's say you need to transpile a library called `my-library` that is not transpiled for web by default.
 You can add it to the `modulesToTranspile` option.
 
 ```ts title=".storybook/main.ts"

--- a/docs/get-started/frameworks/react-native-web-vite.mdx
+++ b/docs/get-started/frameworks/react-native-web-vite.mdx
@@ -147,8 +147,7 @@ const config: StorybookConfig = {
           // ... other compatible babel options
         }
         include: Array<string|RegExp>, 
-        
-        exclude: Array<string|RegExp>, 
+        exclude: Array<string|RegExp>,
         // ... other compatible @vitejs/plugin-react options
       }
     },


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

A problem with vite plugin react is that we can't do some of the module transforms we need to do because they completely block any node_modules from being transformed. This lead to the need for a babel plugin and the need for a separate set of config for what should be transformed essentially duplicating all the configuration and making it harder to use.

The rnw plugin I created takes the react plugin and adjusts it to better support react native web by allowing node_modules to be transformed, it also adds all the boilerplate crap that we need to make react native libraries believe we're ok to run on the web.

The main benefit in my mind is that the configuration becomes simplified

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32051-sha-e639acf8`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32051-sha-e639acf8 sandbox` or in an existing project with `npx storybook@0.0.0-pr-32051-sha-e639acf8 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32051-sha-e639acf8`](https://npmjs.com/package/storybook/v/0.0.0-pr-32051-sha-e639acf8) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`dannyhw/feat/use-vite-plugin-rnw`](https://github.com/storybookjs/storybook/tree/dannyhw/feat/use-vite-plugin-rnw) |
| **Commit** | [`e639acf8`](https://github.com/storybookjs/storybook/commit/e639acf8e20ac8b98c69f7b76545b5072d0620d3) |
| **Datetime** | Sun Jul 20 15:39:18 UTC 2025 (`1753025958`) |
| **Workflow run** | [16401524121](https://github.com/storybookjs/storybook/actions/runs/16401524121) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32051`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR significantly simplifies the React Native Web configuration in Storybook by replacing multiple Vite plugins with a single unified `vite-plugin-rnw`. The key changes include:

1. Removing the dual configuration for module transformation that was previously required
2. Replacing multiple plugins (@bunchtogether/vite-plugin-flow, @vitejs/plugin-react, vite-plugin-babel, vite-plugin-commonjs) with vite-plugin-rnw
3. Introducing a new `modulesToTranspile` option for better control over which node_modules packages get transformed
4. Deprecating `pluginBabelOptions` in favor of `pluginReactOptions`

This change addresses a fundamental limitation where Vite's plugin-react completely blocked node_modules from being transformed, which forced the use of duplicate configurations and separate babel plugins. The new plugin extends React's plugin functionality while adding proper support for React Native Web-specific requirements.

## Confidence score: 4/5

1. This PR is safe to merge as it simplifies configuration while maintaining existing functionality
2. The score reflects high confidence because the changes are well-structured and improve the developer experience, though the lack of automated tests is a minor concern
3. Key files needing attention:
   - docs/get-started/frameworks/react-native-web-vite.mdx (ensure documentation accuracy)
   - code/frameworks/react-native-web-vite/src/preset.ts (verify module transformation logic)

<sub>6 files reviewed, 4 comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=storybook_32051)</sub>

<!-- /greptile_comment -->