### PR TITLE
Telemetry: Add nodeLinker to telemetry

### DIFF
--- a/code/core/src/telemetry/get-package-manager-info.test.ts
+++ b/code/core/src/telemetry/get-package-manager-info.test.ts
@@ -139,7 +139,7 @@ describe('getPackageManagerInfo', () => {
       detect.mockResolvedValue({
         name: 'npm',
         version: '9.8.0',
-        agent: 'npm@9.8.0',
+        agent: 'npm',
       });
     });
 
@@ -149,7 +149,7 @@ describe('getPackageManagerInfo', () => {
       expect(result).toEqual({
         type: 'npm',
         version: '9.8.0',
-        agent: 'npm@9.8.0',
+        agent: 'npm',
         nodeLinker: 'node_modules',
       });
       expect(execaCommand).not.toHaveBeenCalled();

--- a/code/core/src/telemetry/get-package-manager-info.test.ts
+++ b/code/core/src/telemetry/get-package-manager-info.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// eslint-disable-next-line depend/ban-dependencies
+import { execaCommand as rawExecaCommand } from 'execa';
+import { detect as rawDetect } from 'package-manager-detector';
+
+import { getPackageManagerInfo } from './get-package-manager-info';
+
+vi.mock('execa', async () => {
+  return {
+    execaCommand: vi.fn(),
+  };
+});
+
+vi.mock('package-manager-detector', async () => {
+  return {
+    detect: vi.fn(),
+  };
+});
+
+vi.mock('../common', async () => {
+  return {
+    getProjectRoot: () => '/mock/project/root',
+  };
+});
+
+const execaCommand = vi.mocked(rawExecaCommand);
+const detect = vi.mocked(rawDetect);
+
+beforeEach(() => {
+  execaCommand.mockReset();
+  detect.mockReset();
+});
+
+describe('getPackageManagerInfo', () => {
+  describe('when no package manager is detected', () => {
+    it('should return undefined', async () => {
+      detect.mockResolvedValue(null);
+
+      const result = await getPackageManagerInfo();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('when yarn is detected', () => {
+    beforeEach(() => {
+      detect.mockResolvedValue({
+        name: 'yarn',
+        version: '3.6.0',
+        agent: 'yarn@berry',
+      });
+    });
+
+    it('should return yarn info with default nodeLinker when command fails', async () => {
+      execaCommand.mockRejectedValue(new Error('Command failed'));
+
+      const result = await getPackageManagerInfo();
+
+      expect(result).toEqual({
+        type: 'yarn',
+        version: '3.6.0',
+        agent: 'yarn@berry',
+        nodeLinker: 'node_modules',
+      });
+    });
+
+    it('should return yarn info with node_modules nodeLinker', async () => {
+      execaCommand.mockResolvedValue({
+        stdout: 'node_modules\n',
+      } as any);
+
+      const result = await getPackageManagerInfo();
+
+      expect(result).toEqual({
+        type: 'yarn',
+        version: '3.6.0',
+        agent: 'yarn@berry',
+        nodeLinker: 'node_modules',
+      });
+    });
+
+    it('should return yarn info with pnp nodeLinker', async () => {
+      execaCommand.mockResolvedValue({
+        stdout: 'pnp\n',
+      } as any);
+
+      const result = await getPackageManagerInfo();
+
+      expect(result).toEqual({
+        type: 'yarn',
+        version: '3.6.0',
+        agent: 'yarn@berry',
+        nodeLinker: 'pnp',
+      });
+    });
+  });
+
+  describe('when pnpm is detected', () => {
+    beforeEach(() => {
+      detect.mockResolvedValue({
+        name: 'pnpm',
+        version: '8.15.0',
+        agent: 'pnpm',
+      });
+    });
+
+    it('should return pnpm info with default isolated nodeLinker when command fails', async () => {
+      execaCommand.mockRejectedValue(new Error('Command failed'));
+
+      const result = await getPackageManagerInfo();
+
+      expect(result).toEqual({
+        type: 'pnpm',
+        version: '8.15.0',
+        agent: 'pnpm',
+        nodeLinker: 'node_modules',
+      });
+    });
+
+    it('should return pnpm info with isolated nodeLinker', async () => {
+      execaCommand.mockResolvedValue({
+        stdout: 'isolated\n',
+      } as any);
+
+      const result = await getPackageManagerInfo();
+
+      expect(result).toEqual({
+        type: 'pnpm',
+        version: '8.15.0',
+        agent: 'pnpm',
+        nodeLinker: 'isolated',
+      });
+    });
+  });
+
+  describe('when npm is detected', () => {
+    beforeEach(() => {
+      detect.mockResolvedValue({
+        name: 'npm',
+        version: '9.8.0',
+        agent: 'npm@9.8.0',
+      });
+    });
+
+    it('should return npm info with default node_modules nodeLinker', async () => {
+      const result = await getPackageManagerInfo();
+
+      expect(result).toEqual({
+        type: 'npm',
+        version: '9.8.0',
+        agent: 'npm@9.8.0',
+        nodeLinker: 'node_modules',
+      });
+      expect(execaCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when bun is detected', () => {
+    beforeEach(() => {
+      detect.mockResolvedValue({
+        name: 'bun',
+        version: '1.0.0',
+        agent: 'bun',
+      });
+    });
+
+    it('should return bun info with default node_modules nodeLinker', async () => {
+      const result = await getPackageManagerInfo();
+
+      expect(result).toEqual({
+        type: 'bun',
+        version: '1.0.0',
+        agent: 'bun',
+        nodeLinker: 'node_modules',
+      });
+      expect(execaCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      detect.mockResolvedValue({
+        name: 'yarn',
+        version: '3.6.0',
+        agent: 'yarn',
+      });
+    });
+
+    it('should handle yarn command errors gracefully', async () => {
+      execaCommand.mockRejectedValue(new Error('yarn command not found'));
+
+      const result = await getPackageManagerInfo();
+
+      expect(result).toEqual({
+        type: 'yarn',
+        version: '3.6.0',
+        agent: 'yarn',
+        nodeLinker: 'node_modules',
+      });
+    });
+
+    it('should handle pnpm command errors gracefully', async () => {
+      detect.mockResolvedValue({
+        name: 'pnpm',
+        version: '8.15.0',
+        agent: 'pnpm',
+      });
+      execaCommand.mockRejectedValue(new Error('pnpm command not found'));
+
+      const result = await getPackageManagerInfo();
+
+      expect(result).toEqual({
+        type: 'pnpm',
+        version: '8.15.0',
+        agent: 'pnpm',
+        nodeLinker: 'node_modules',
+      });
+    });
+  });
+});

--- a/code/core/src/telemetry/get-package-manager-info.ts
+++ b/code/core/src/telemetry/get-package-manager-info.ts
@@ -1,0 +1,40 @@
+// eslint-disable-next-line depend/ban-dependencies
+import { execaCommand } from 'execa';
+import { detect } from 'package-manager-detector';
+
+import { getProjectRoot } from '../common';
+
+export const getPackageManagerInfo = async () => {
+  const packageManagerType = await detect({ cwd: getProjectRoot() });
+
+  if (!packageManagerType) {
+    return undefined;
+  }
+
+  let nodeLinker: 'node_modules' | 'pnp' | 'pnpm' | 'isolated' | 'hoisted' = 'node_modules';
+
+  if (packageManagerType.name === 'yarn') {
+    try {
+      const { stdout } = await execaCommand('yarn config get nodeLinker', {
+        cwd: getProjectRoot(),
+      });
+      nodeLinker = stdout.trim() as 'node_modules' | 'pnp' | 'pnpm';
+    } catch (e) {}
+  }
+
+  if (packageManagerType.name === 'pnpm') {
+    try {
+      const { stdout } = await execaCommand('pnpm config get nodeLinker', {
+        cwd: getProjectRoot(),
+      });
+      nodeLinker = (stdout.trim() as 'isolated' | 'hoisted' | 'pnpm') ?? 'isolated';
+    } catch (e) {}
+  }
+
+  return {
+    type: packageManagerType.name,
+    version: packageManagerType.version,
+    agent: packageManagerType.agent,
+    nodeLinker,
+  };
+};

--- a/code/core/src/telemetry/storybook-metadata.ts
+++ b/code/core/src/telemetry/storybook-metadata.ts
@@ -1,7 +1,6 @@
 import { dirname } from 'node:path';
 
 import {
-  getProjectRoot,
   getStorybookConfiguration,
   getStorybookInfo,
   loadMainConfig,
@@ -11,7 +10,6 @@ import { readConfig } from 'storybook/internal/csf-tools';
 import type { PackageJson, StorybookConfig } from 'storybook/internal/types';
 
 import { findPackage, findPackagePath } from 'fd-package-json';
-import { detect } from 'package-manager-detector';
 
 import { version } from '../../package.json';
 import { globalSettings } from '../cli/globalSettings';
@@ -20,6 +18,7 @@ import { getChromaticVersionSpecifier } from './get-chromatic-version';
 import { getFrameworkInfo } from './get-framework-info';
 import { getHasRouterPackage } from './get-has-router-package';
 import { getMonorepoType } from './get-monorepo-type';
+import { getPackageManagerInfo } from './get-package-manager-info';
 import { getPortableStoriesFileCount } from './get-portable-stories-usage';
 import { getActualPackageVersion, getActualPackageVersions } from './package-json';
 import { cleanPaths } from './sanitize';
@@ -120,19 +119,7 @@ export const computeStorybookMetadata = async ({
     metadata.monorepo = monorepoType;
   }
 
-  try {
-    const packageManagerType = await detect({ cwd: getProjectRoot() });
-    if (packageManagerType) {
-      metadata.packageManager = {
-        type: packageManagerType.name,
-        version: packageManagerType.version,
-        agent: packageManagerType.agent,
-      };
-    }
-
-    // Better be safe than sorry, some codebases/paths might end up breaking with something like "spawn pnpm ENOENT"
-    // so we just set the package manager if the detection is successful
-  } catch (err) {}
+  metadata.packageManager = await getPackageManagerInfo();
 
   const language = allDependencies.typescript ? 'typescript' : 'javascript';
 

--- a/code/core/src/telemetry/types.ts
+++ b/code/core/src/telemetry/types.ts
@@ -58,6 +58,7 @@ export type StorybookMetadata = {
     type: DetectResult['name'];
     version: DetectResult['version'];
     agent: DetectResult['agent'];
+    nodeLinker: 'node_modules' | 'pnp' | 'pnpm' | 'isolated' | 'hoisted';
   };
   typescriptOptions?: Partial<TypescriptOptions>;
   addons?: Record<string, StorybookAddon>;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added nodeLinker to telemetry

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR enhances Storybook's telemetry system by adding information about the package manager's node module linking strategy (`nodeLinker`). The changes include:

1. Adding a new `nodeLinker` field to the `packageManager` metadata type
2. Creating a new module `get-package-manager-info.ts` to handle package manager detection
3. Implementing detection of nodeLinker configuration for Yarn and pnpm

This data will help the Storybook team better understand how users configure their development environments, which can inform future compatibility decisions and features.

## Confidence score: 4/5

1. This PR is safe to merge as it only adds telemetry data collection
2. The score is 4 because while the implementation is solid, there's no test coverage added
3. Files that need attention:
   - `get-package-manager-info.ts`: Consider adding error handling and tests

<sub>3 files reviewed, 2 comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=storybook_32072)</sub>

<!-- /greptile_comment -->