### PR TITLE
Telemetry: Add automigration errors

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/multi-project.ts
+++ b/code/lib/cli-storybook/src/automigrate/multi-project.ts
@@ -1,5 +1,6 @@
 import type { JsPackageManager } from 'storybook/internal/common';
 import { CLI_COLORS, type TaskLogInstance, logger, prompt } from 'storybook/internal/node-logger';
+import { sanitizeError } from 'storybook/internal/telemetry';
 import type { StorybookConfigRaw } from 'storybook/internal/types';
 
 import type { UpgradeOptions } from '../upgrade';
@@ -246,20 +247,24 @@ export async function promptForAutomigrations(
   return automigrations.filter((am) => selectedIds.includes(am.fix.id));
 }
 
+// Group automigrations by project
+type ConfigDir = string;
+type ErrorMessage = string;
+export type AutomigrationResult = {
+  automigrationStatuses: Record<FixId, FixStatus>;
+  automigrationErrors: Record<FixId, ErrorMessage>;
+};
 /** Runs selected automigrations for each project */
 export async function runAutomigrationsForProjects(
   selectedAutomigrations: AutomigrationCheckResult[],
   options: MultiProjectRunAutomigrationOptions
-): Promise<Record<string, Record<FixId, FixStatus>>> {
+): Promise<Record<ConfigDir, AutomigrationResult>> {
   const { dryRun, skipInstall, automigrations } = options;
-  const projectResults: Record<ConfigDir, Record<FixId, FixStatus>> = {};
+  const projectResults: Record<ConfigDir, AutomigrationResult> = {};
 
   const applicableAutomigrations = selectedAutomigrations.filter((am) =>
     am.reports.every((rep) => rep.status !== 'not_applicable')
   );
-
-  // Group automigrations by project
-  type ConfigDir = string;
   const projectAutomigrationResults = new Map<
     ConfigDir,
     {
@@ -327,6 +332,7 @@ export async function runAutomigrationsForProjects(
             },
           };
     const fixResults: Record<FixId, FixStatus> = {};
+    const fixFailures: Record<FixId, ErrorMessage> = {};
 
     for (const automigration of projectAutomigration) {
       const { fix, result, project, status } = automigration;
@@ -374,9 +380,12 @@ export async function runAutomigrationsForProjects(
           taskLog.message(CLI_COLORS.success(`${logger.SYMBOLS.success} ${fix.id}`));
         }
       } catch (error) {
+        const errorMessage =
+          (error instanceof Error ? error.stack : String(error)) ?? 'Unknown error';
         fixResults[fix.id] = FixStatus.FAILED;
+        fixFailures[fix.id] = sanitizeError(error as Error);
         taskLog.message(CLI_COLORS.error(`${logger.SYMBOLS.error} ${automigration.fix.id}`));
-        logger.debug(`${error instanceof Error ? error.stack : String(error)}`);
+        logger.debug(errorMessage);
       }
     }
 
@@ -391,7 +400,10 @@ export async function runAutomigrationsForProjects(
       taskLog.success(`${countPrefix}Completed automigrations for ${projectName}`);
     }
 
-    projectResults[configDir] = fixResults;
+    projectResults[configDir] = {
+      automigrationStatuses: fixResults,
+      automigrationErrors: fixFailures,
+    };
   }
 
   return projectResults;
@@ -402,7 +414,7 @@ export async function runAutomigrations(
   options: UpgradeOptions
 ): Promise<{
   detectedAutomigrations: AutomigrationCheckResult[];
-  automigrationResults: Record<string, Record<FixId, FixStatus>>;
+  automigrationResults: Record<string, AutomigrationResult>;
 }> {
   // Prepare project data for automigrations
   const projectAutomigrationData: ProjectAutomigrationData[] = projects.map((project) => ({
@@ -453,13 +465,13 @@ export async function runAutomigrations(
 
   // Special case handling for rnstorybook-config which renames the config dir
   // TODO: Remove this as soon as the rn-storybook-config automigration is removed
-  Object.entries(automigrationResults).forEach(([configDir, fixResults]) => {
-    if (fixResults[rnstorybookConfig.id] === FixStatus.SUCCEEDED) {
+  Object.entries(automigrationResults).forEach(([configDir, resultData]) => {
+    if (resultData.automigrationStatuses[rnstorybookConfig.id] === FixStatus.SUCCEEDED) {
       const project = projects.find((p) => p.configDir === configDir);
       if (project) {
         const oldConfigDir = project.configDir;
         project.configDir = project.configDir.replace('.storybook', '.rnstorybook');
-        automigrationResults[project.configDir] = fixResults;
+        automigrationResults[project.configDir] = resultData;
         delete automigrationResults[oldConfigDir];
       }
     }

--- a/code/lib/cli-storybook/src/upgrade.ts
+++ b/code/lib/cli-storybook/src/upgrade.ts
@@ -21,8 +21,11 @@ import semver, { clean, lt } from 'semver';
 import { dedent } from 'ts-dedent';
 
 import { processAutoblockerResults } from './autoblock/utils';
-import { type AutomigrationCheckResult, runAutomigrations } from './automigrate/multi-project';
-import type { FixId } from './automigrate/types';
+import {
+  type AutomigrationCheckResult,
+  type AutomigrationResult,
+  runAutomigrations,
+} from './automigrate/multi-project';
 import { FixStatus } from './automigrate/types';
 import { displayDoctorResults, runMultiProjectDoctor } from './doctor';
 import type { ProjectDoctorData, ProjectDoctorResults } from './doctor/types';
@@ -127,22 +130,24 @@ export type UpgradeOptions = {
 };
 
 function getUpgradeResults(
-  projectResults: Record<string, Record<FixId, FixStatus>>,
+  projectResults: Record<string, AutomigrationResult>,
   doctorResults: Record<string, ProjectDoctorResults>
 ) {
   const successfulProjects: string[] = [];
   const failedProjects: string[] = [];
   const projectsWithNoFixes: string[] = [];
 
-  const allProjects = Object.entries(projectResults).map(([configDir, fixResults]) => {
-    const automigrationResults = Object.entries(fixResults).map(([fixId, status]) => {
-      const succeeded = status === FixStatus.SUCCEEDED || status === FixStatus.MANUAL_SUCCEEDED;
-      return {
-        fixId,
-        status,
-        succeeded,
-      };
-    });
+  const allProjects = Object.entries(projectResults).map(([configDir, resultData]) => {
+    const automigrationResults = Object.entries(resultData.automigrationStatuses).map(
+      ([fixId, status]) => {
+        const succeeded = status === FixStatus.SUCCEEDED || status === FixStatus.MANUAL_SUCCEEDED;
+        return {
+          fixId,
+          status,
+          succeeded,
+        };
+      }
+    );
 
     const hasFailures = automigrationResults.some(
       (fix) => fix.status === FixStatus.FAILED || fix.status === FixStatus.CHECK_FAILED
@@ -150,7 +155,7 @@ function getUpgradeResults(
     const hasSuccessfulFixes = automigrationResults.some(
       (fix) => fix.status === FixStatus.SUCCEEDED || fix.status === FixStatus.MANUAL_SUCCEEDED
     );
-    const noFixesNeeded = Object.keys(fixResults).length === 0;
+    const noFixesNeeded = Object.keys(resultData.automigrationStatuses).length === 0;
 
     // Determine if migration was successful (has successful fixes and no failures)
     const migratedSuccessfully = hasSuccessfulFixes && !hasFailures;
@@ -196,7 +201,7 @@ function getUpgradeResults(
 
 /** Logs the results of the upgrade process, including project categorization and diagnostic messages */
 function logUpgradeResults(
-  projectResults: Record<string, Record<FixId, FixStatus>>,
+  projectResults: Record<string, AutomigrationResult>,
   detectedAutomigrations: AutomigrationCheckResult[],
   doctorResults: Record<string, ProjectDoctorResults>
 ) {
@@ -242,10 +247,10 @@ function logUpgradeResults(
   const automigrationLinks = detectedAutomigrations
     .filter((am) =>
       Object.entries(projectResults).some(
-        ([_, fixResults]) =>
-          fixResults[am.fix.id] === FixStatus.FAILED ||
-          fixResults[am.fix.id] === FixStatus.SUCCEEDED ||
-          fixResults[am.fix.id] === FixStatus.CHECK_FAILED
+        ([_, resultData]) =>
+          resultData.automigrationStatuses[am.fix.id] === FixStatus.FAILED ||
+          resultData.automigrationStatuses[am.fix.id] === FixStatus.SUCCEEDED ||
+          resultData.automigrationStatuses[am.fix.id] === FixStatus.CHECK_FAILED
       )
     )
     .map((am) => `• ${createHyperlink(am.fix.id, am.fix.link!)}`);
@@ -267,7 +272,7 @@ function logUpgradeResults(
 interface MultiUpgradeTelemetryOptions {
   allProjects: CollectProjectsSuccessResult[];
   selectedProjects: CollectProjectsSuccessResult[];
-  projectResults: Record<string, Record<FixId, FixStatus>>;
+  projectResults: Record<string, AutomigrationResult>;
   doctorResults: Record<string, ProjectDoctorResults>;
   hasUserInterrupted?: boolean;
 }
@@ -339,7 +344,7 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
         );
       }
 
-      const automigrationResults: Record<string, Record<FixId, FixStatus>> = {};
+      const automigrationResults: Record<string, AutomigrationResult> = {};
       let doctorResults: Record<string, ProjectDoctorResults> = {};
 
       // Set up signal handling for interruptions
@@ -481,7 +486,10 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
         // TELEMETRY
         if (!options.disableTelemetry) {
           for (const project of storybookProjects) {
-            const fixResults = automigrationResults[project.configDir] || {};
+            const resultData = automigrationResults[project.configDir] || {
+              automigrationStatuses: {},
+              automigrationErrors: {},
+            };
             let doctorFailureCount = 0;
             let doctorErrorCount = 0;
             Object.values(doctorResults[project.configDir]?.diagnostics || {}).forEach((status) => {
@@ -493,9 +501,7 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
                 doctorErrorCount++;
               }
             });
-            const automigrationFailureCount = Object.values(fixResults).filter(
-              (status) => status === 'failed'
-            ).length;
+            const automigrationFailureCount = Object.keys(resultData.automigrationErrors).length;
             const automigrationPreCheckFailure =
               project.autoblockerCheckResults && project.autoblockerCheckResults.length > 0
                 ? project.autoblockerCheckResults
@@ -510,7 +516,8 @@ export async function upgrade(options: UpgradeOptions): Promise<void> {
             await telemetry('upgrade', {
               beforeVersion: project.beforeVersion,
               afterVersion: project.currentCLIVersion,
-              automigrationResults: fixResults,
+              automigrationResults: resultData.automigrationStatuses,
+              automigrationErrors: resultData.automigrationErrors,
               automigrationFailureCount,
               automigrationPreCheckFailure,
               doctorResults: doctorResults[project.configDir]?.diagnostics || {},


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR attaches (sanitized, anonymized errors) to automigrations in the telemetry data, so we can detect patterns and use them to improve the Storybook upgrade experience.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR enhances Storybook's telemetry system by adding detailed error tracking for automigrations. The changes modify how error data is collected, stored, and transmitted during the upgrade process, specifically:

1. Introduces a new `AutomigrationResult` type that tracks both success statuses and error messages
2. Implements error sanitization using `sanitizeError` to ensure privacy when collecting error data
3. Updates the telemetry payload structure to include detailed error information
4. Modifies how failed automigrations are counted (now based on errors object length)

## Confidence score: 5/5

1. This PR is extremely safe to merge as it only adds telemetry data collection and doesn't affect core functionality
2. The changes are well-structured, properly typed, and include appropriate error sanitization
3. The modified files (upgrade.ts and multi-project.ts) need careful review to ensure proper error handling

<!-- /greptile_comment -->