### PR TITLE
Test: Fix missing source map for Webpack/Vite mock loaders and plugins

### DIFF
--- a/code/core/src/core-server/presets/webpack/loaders/storybook-mock-transform-loader.ts
+++ b/code/core/src/core-server/presets/webpack/loaders/storybook-mock-transform-loader.ts
@@ -10,5 +10,6 @@ import { rewriteSbMockImportCalls } from '../../../mocking-utils/extract';
  */
 export default function storybookMockTransformLoader(this: LoaderContext<{}>, source: string) {
   const result = rewriteSbMockImportCalls(source);
-  return result.code;
+  const callback = this.async();
+  callback(null, result.code, result.map || undefined);
 }

--- a/code/core/src/core-server/presets/webpack/loaders/webpack-automock-loader.ts
+++ b/code/core/src/core-server/presets/webpack/loaders/webpack-automock-loader.ts
@@ -1,5 +1,3 @@
-import { parse } from '@babel/parser';
-import type { ParserOptions } from '@babel/parser';
 import type { LoaderContext } from 'webpack';
 
 import { getAutomockCode } from '../../../mocking-utils/automock';
@@ -28,14 +26,15 @@ interface AutomockLoaderOptions {
 export default function webpackAutomockLoader(
   this: LoaderContext<AutomockLoaderOptions>,
   source: string
-): string {
+) {
   // Retrieve the options passed in the resource query string (e.g., `?spy=true`).
   const options = this.getOptions();
+  const callback = this.async();
   const isSpy = options.spy === 'true';
 
   // Generate the mocked source code using the utility from @vitest/mocker.
   const mocked = getAutomockCode(source, isSpy, babelParser as any);
 
   // Return the transformed code to Webpack for further processing.
-  return mocked.toString();
+  callback(null, mocked.toString(), mocked.generateMap());
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes missing source map generation for two Webpack loaders used in Storybook's mocking system. The changes modify both `webpack-automock-loader.ts` and `storybook-mock-transform-loader.ts` to return an object containing both transformed code and source maps, rather than just the code string.

In the `webpack-automock-loader.ts`, the change leverages the `MagicString` instance returned by `getAutomockCode()` to generate proper source maps using its built-in `generateMap()` method. The loader now returns `{ code: mocked.toString(), map: mocked.generateMap() }` instead of just the string.

The `storybook-mock-transform-loader.ts` is similarly updated to return `{ code: result.code, map: result.map }` from the `rewriteSbMockImportCalls()` function result. This aligns both loaders with the standard Webpack loader pattern of providing source maps for better debugging support.

These loaders are part of Storybook's core infrastructure for handling module mocking during development and testing. The source maps enable developers to debug their original code instead of seeing transformed/generated mock code in their debugger, significantly improving the developer experience when working with mocked modules.

PR Description Notes:
- The PR description is incomplete - the "What I did" section is empty and no testing approach is described
- No issue number is provided despite the template asking for one
- All checkboxes remain unchecked

## Confidence score: 2/5

- This PR has a critical issue that could cause runtime errors in production
- The `storybook-mock-transform-loader.ts` assumes `result.map` exists, but the `rewriteSbMockImportCalls()` function may not generate source maps by default
- The `storybook-mock-transform-loader.ts` file needs careful review to ensure source maps are properly generated before being returned

<!-- /greptile_comment -->