### PR TITLE
Maintenance: Add flag to toggle default automigrations

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-experimental-test.ts
@@ -1,5 +1,4 @@
 import { readFileSync, writeFileSync } from 'fs';
-import picocolors from 'picocolors';
 
 import { findFilesUp } from '../../util';
 import type { Fix } from '../types';

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-mdx-gfm-remove.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-mdx-gfm-remove.ts
@@ -1,7 +1,5 @@
 import { getAddonNames, removeAddon } from 'storybook/internal/common';
 
-import picocolors from 'picocolors';
-
 import type { Fix } from '../types';
 
 type AddonMdxGfmOptions = true;

--- a/code/lib/cli-storybook/src/automigrate/fixes/upgrade-storybook-related-dependencies.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/upgrade-storybook-related-dependencies.ts
@@ -67,7 +67,7 @@ function isValidVersionType(packageName: string, specifier: string) {
 export const upgradeStorybookRelatedDependencies = {
   id: 'upgrade-storybook-related-dependencies',
   promptType: 'auto',
-  promptDefaultValue: false,
+  defaultSelected: false,
 
   async check({ packageManager, storybookVersion }) {
     logger.debug('Checking for incompatible storybook packages...');

--- a/code/lib/cli-storybook/src/automigrate/index.ts
+++ b/code/lib/cli-storybook/src/automigrate/index.ts
@@ -327,7 +327,7 @@ export async function runFixes({
           const shouldRun = await prompt.confirm(
             {
               message: `Do you want to run the '${picocolors.cyan(f.id)}' migration on your project?`,
-              initialValue: f.promptDefaultValue ?? true,
+              initialValue: f.defaultSelected ?? true,
             },
             {
               onCancel: () => {

--- a/code/lib/cli-storybook/src/automigrate/multi-project.ts
+++ b/code/lib/cli-storybook/src/automigrate/multi-project.ts
@@ -235,13 +235,14 @@ export async function promptForAutomigrations(
       value: am.fix.id,
       label,
       hint: hint.join('\n'),
+      defaultSelected: am.fix.defaultSelected ?? true,
     };
   });
 
   const selectedIds = await prompt.multiselect({
     message: 'Select automigrations to run',
     options: choices,
-    initialValues: choices.map((c) => c.value),
+    initialValues: choices.filter((c) => c.defaultSelected).map((c) => c.value),
   });
 
   return automigrations.filter((am) => selectedIds.includes(am.fix.id));

--- a/code/lib/cli-storybook/src/automigrate/types.ts
+++ b/code/lib/cli-storybook/src/automigrate/types.ts
@@ -40,7 +40,8 @@ type BaseFix<ResultType = any> = {
   check: (options: CheckOptions) => Promise<ResultType | null>;
   /** Keep the prompt message short and concise. */
   prompt: () => string;
-  promptDefaultValue?: boolean;
+  /** Whether the automigration is selected by default when the user is prompted. */
+  defaultSelected?: boolean;
   link?: string;
 };
 

--- a/code/lib/cli-storybook/src/bin/index.ts
+++ b/code/lib/cli-storybook/src/bin/index.ts
@@ -228,6 +228,7 @@ command('automigrate [fixId]')
   )
   .option('--skip-doctor', 'Skip doctor check')
   .action(async (fixId, options) => {
+    prompt.setPromptLibrary('clack');
     await doAutomigrate({ fixId, ...options }).catch(handleCommandFailure);
   });
 


### PR DESCRIPTION
- Updated the automigration prompt logic to utilize 'defaultSelected' instead of 'promptDefaultValue' for better clarity.
- Adjusted related files to ensure consistent usage of the new property across automigration fixes.
- Removed unnecessary imports of 'picocolors' in specific fix files to streamline the code.

Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When running via `storybook upgrade`, the automigration is deselected
<img width="1022" height="588" alt="image" src="https://github.com/user-attachments/assets/50ac8ba1-3067-4196-9704-1cdc018b0e84" />

When running via `storybook automigrate`, "No" is selected
<img width="1066" height="296" alt="image" src="https://github.com/user-attachments/assets/34e0f904-b608-4700-b245-5835c6010373" />

-----------------------

Additionally I set clack as prompt library for `storybook automigrate`:
<img width="1062" height="298" alt="image" src="https://github.com/user-attachments/assets/50b1f3fb-0788-4329-b10f-8084b404152c" />

otherwise it looks really bad
<img width="1038" height="656" alt="image" src="https://github.com/user-attachments/assets/4db82008-7c19-4b6a-84db-7b9ef05ee67d" />


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR introduces a new `defaultSelected` property to the automigration system to provide more granular control over which automigrations are pre-selected when users run Storybook upgrade commands.

The key changes include:

1. **Property Rename**: Replaces the confusing `promptDefaultValue` property with the more intuitive `defaultSelected` property across the automigration system
2. **Improved User Experience**: When running `storybook upgrade`, automigrations are now deselected by default, while `storybook automigrate` defaults to "No" - giving users more control over potentially disruptive changes
3. **Granular Control**: Individual automigration fixes can now specify whether they should be selected by default using `defaultSelected: false` (as demonstrated in the `upgrade-storybook-related-dependencies` fix)
4. **UI Enhancement**: Switches the prompt library to 'clack' for the automigrate command to improve visual presentation
5. **Code Cleanup**: Removes unused `picocolors` imports from several automigration fix files

The change integrates with Storybook's existing automigration infrastructure by updating the `BaseFix` type definition, modifying the prompt logic in both single-project and multi-project scenarios, and maintaining backward compatibility by defaulting to `true` when the property is not specified. This allows the system to distinguish between different upgrade contexts and provide appropriate default behaviors for each.

## Confidence score: 4/5

- This PR appears safe to merge with well-structured changes that improve the user experience
- The implementation maintains backward compatibility and follows established patterns in the codebase
- The multi-project.ts file needs careful testing to ensure the new filtering logic works correctly across different project configurations

<!-- /greptile_comment -->