### PR TITLE
Test: Remove source map generation from webpack automock-loader

### DIFF
--- a/code/core/src/core-server/presets/webpack/loaders/webpack-automock-loader.ts
+++ b/code/core/src/core-server/presets/webpack/loaders/webpack-automock-loader.ts
@@ -29,12 +29,11 @@ export default function webpackAutomockLoader(
 ) {
   // Retrieve the options passed in the resource query string (e.g., `?spy=true`).
   const options = this.getOptions();
-  const callback = this.async();
   const isSpy = options.spy === 'true';
 
   // Generate the mocked source code using the utility from @vitest/mocker.
   const mocked = getAutomockCode(source, isSpy, babelParser as any);
 
   // Return the transformed code to Webpack for further processing.
-  callback(null, mocked.toString(), mocked.generateMap());
+  return mocked.toString();
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR simplifies the webpack automock loader by removing source map generation. The change converts the loader from using Webpack's asynchronous callback pattern (`this.async()` and `callback()`) to a synchronous return pattern. Previously, the loader would call `callback(null, mocked.toString(), mocked.generateMap())` to return both the transformed code and source maps. Now it directly returns `mocked.toString()`, eliminating source map generation entirely.

The automock functionality itself remains unchanged - the `getAutomockCode` function from `@vitest/mocker` still handles the core transformation logic for creating mocked modules. This loader is part of Storybook's webpack preprocessing pipeline and is used to automatically generate mocks for modules during testing scenarios. The change streamlines the loader implementation by removing unnecessary complexity around source map handling, which may not be critical for automocked test modules.

PR Description Notes:
- The "What I did" section is empty and should describe the change
- No testing approach is specified in the manual testing section
- The PR doesn't reference a specific issue number

## Confidence score: 4/5

- This change is relatively safe as it simplifies the loader without affecting core functionality
- The risk is primarily around potential debugging difficulties due to missing source maps, but this is acceptable for test automation contexts
- The file `code/core/src/core-server/presets/webpack/loaders/webpack-automock-loader.ts` should be reviewed to ensure the synchronous pattern works correctly with webpack's loader API

<!-- /greptile_comment -->