### PR TITLE
fix: ensure "You modified this story" banner is visible by increasing z-index

### DIFF
--- a/code/core/src/controls/components/SaveStory.tsx
+++ b/code/core/src/controls/components/SaveStory.tsx
@@ -59,6 +59,8 @@ const Info = styled.div({
   alignItems: 'center',
   marginLeft: 10,
   gap: 6,
+  position: 'relative',
+  zIndex: 10,
 });
 
 const Actions = styled.div(({ theme }) => ({


### PR DESCRIPTION
fix: ensure "You modified this story" banner is visible by increasing z-index

Closes #32091 

## What I did

Fixed a z-index issue where the "You modified this story" banner was getting overlapped by canvas objects.

- File changed: `SaveStory.tsx`
- Change made:
  ```ts
  styles={{
    zIndex: 10,
    position: 'relative',
  }}


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

To verify the fix manually:

1. Run a sandbox with:

   ```sh
   yarn task --task sandbox --start-from auto --template react-vite/default-ts
2. Open Storybook in the browser.

3. Modify a control on any story.

4. Ensure the "Modified" banner now appears above overlapping elements.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a z-index layering issue in the `SaveStory` component where the "You modified this story" banner was being visually covered by canvas objects. The fix adds `position: 'relative'` and `zIndex: 10` specifically to the `Info` styled component that renders the banner text.

The `SaveStory` component is part of Storybook's controls system and displays a sticky banner at the bottom of the screen when users modify story arguments. The component has a hierarchical structure where the outer `Container` already had `zIndex: 1` to position it above general page content, but when canvas elements or story content had higher z-index values, they would overlap the informational banner text inside.

By adding the z-index properties to the `Info` component (which contains the "You modified this story" message), the banner text now renders above overlapping elements while maintaining the existing component architecture. This is a surgical fix that addresses the specific visual bug without restructuring the component or affecting other functionality like the save, create, and reset story operations.

## Confidence score: 4/5

- This is a safe, targeted fix that addresses a specific visual layering problem without breaking existing functionality
- The change is minimal and follows established patterns (the parent Container already uses z-index)
- The z-index value of 10 is reasonable and unlikely to conflict with other UI elements
- No files need more attention - this is a straightforward CSS styling fix

<!-- /greptile_comment -->