### PR TITLE
fix: add missing link for Autodocs in final reference list

### DIFF
--- a/docs/writing-docs/autodocs.mdx
+++ b/docs/writing-docs/autodocs.mdx
@@ -270,7 +270,7 @@ If you turned off inline rendering for your stories via the [`inline`](../api/do
 
 **Learn more about Storybook documentation**
 
-* Autodocs for creating documentation for your stories
+* [Autodocs](./autodocs.mdx) for creating documentation for your stories
 * [MDX](./mdx.mdx) for customizing your documentation
 * [Doc Blocks](./doc-blocks.mdx) for authoring your documentation
 * [Publishing docs](./build-documentation.mdx) to automate the process of publishing your documentation


### PR DESCRIPTION
### 📌 Closes #

N/A

---

### ✨ What I did

- Added missing link for **Autodocs** in the final reference list of the `docs/writing-docs/autodocs.mdx` file.
- Ensured consistency across the reference links.
- This fixes a broken reference line by pointing to an existing file.

---

### ✅ Checklist for Contributors

**Testing**

- [ ] stories  
- [ ] unit tests  
- [ ] integration tests  
- [ ] end-to-end tests  

✅ **Manual testing**

This is a documentation-only change. No manual testing required.

---

**Documentation**

- [x] Add or update documentation reflecting your changes  
- [ ] If you are deprecating/removing a feature, make sure to update `MIGRATION.MD`

---

### 🛠️ Checklist for Maintainers

No changes required. This is a minor docs improvement.

---

### 🐛 Canary release

N/A – Docs-only PR.

---

📌 **Note:**  
This PR follows the [contributing guidelines](https://github.com/storybookjs/storybook/blob/next/CONTRIBUTING.md), [security policy](https://github.com/storybookjs/storybook/security/policy), and [code of conduct](https://github.com/storybookjs/storybook/blob/next/CODE_OF_CONDUCT.md).

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a minor documentation inconsistency in the `docs/writing-docs/autodocs.mdx` file. The change converts a plain text "Autodocs" entry in the final reference list (line 273) into a proper markdown link `[Autodocs](./autodocs.mdx)`. This ensures consistency with other reference links in the list (MDX, Doc Blocks, Publishing docs) which were already properly formatted as clickable markdown links.

The fix is purely cosmetic and improves user experience by making the Autodocs reference clickable and navigable, just like the other items in the reference list. This creates a self-referential link that allows users to easily return to or share the Autodocs documentation page. The change aligns with Storybook's documentation standards where reference lists should contain clickable links rather than plain text entries.

## Confidence score: 5/5

• This is an extremely safe documentation-only change that fixes a minor formatting inconsistency
• The change is minimal, well-scoped, and follows standard markdown link formatting
• No files need additional attention - this is a straightforward documentation improvement

<!-- /greptile_comment -->