### PR TITLE
Next.js: Return mocked router instead of actual router in useRouter

### DIFF
--- a/code/frameworks/nextjs/src/export-mocks/navigation/index.ts
+++ b/code/frameworks/nextjs/src/export-mocks/navigation/index.ts
@@ -83,7 +83,14 @@ export const useSelectedLayoutSegment = fn(actual.useSelectedLayoutSegment).mock
 export const useSelectedLayoutSegments = fn(actual.useSelectedLayoutSegments).mockName(
   'next/navigation::useSelectedLayoutSegments'
 );
-export const useRouter = fn(actual.useRouter).mockName('next/navigation::useRouter');
+export const useRouter = fn(() => {
+  if (!navigationAPI) {
+    throw new NextjsRouterMocksNotAvailable({
+      importType: 'next/navigation',
+    });
+  }
+  return navigationAPI;
+}).mockName('next/navigation::useRouter');
 export const useServerInsertedHTML = fn(actual.useServerInsertedHTML).mockName(
   'next/navigation::useServerInsertedHTML'
 );


### PR DESCRIPTION
Closes #30390

## What I did

Modified the useRouter export in the Next.js navigation mock to return the mocked navigationAPI instead of the actual Next.js router. This prevents Link components in Next.js 15 from breaking out of the Storybook context when clicked.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

Manual testing performed:

- Set up local Storybook development environment with Next.js framework
- Created a test story with Next.js 15 Link component pointing to non-existent route
- Configured story with appDirectory: true to use App Router
- Verified that clicking the Link component now stays within Storybook context instead of navigating to "Not Found" page
- Confirmed that the mocked router is returned when useRouter() is called

To test this fix:

- Run a sandbox for Next.js template: yarn task --task sandbox --template nextjs/default-ts
- Create a story with a Next.js Link component that navigates to a non-existent route
- Set appDirectory: true in story parameters
- Click the Link component - it should now stay within Storybook instead of showing "Not Found"

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation updates required - this is an internal bug fix that restores expected behavior.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32131-sha-cac9c086`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32131-sha-cac9c086 sandbox` or in an existing project with `npx storybook@0.0.0-pr-32131-sha-cac9c086 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32131-sha-cac9c086`](https://npmjs.com/package/storybook/v/0.0.0-pr-32131-sha-cac9c086) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [JulioJ11/storybook](https://github.com/JulioJ11/storybook) |
| **Branch** | [`fix/nextjs-15-link-component`](https://github.com/JulioJ11/storybook/tree/fix/nextjs-15-link-component) |
| **Commit** | [`cac9c086`](https://github.com/JulioJ11/storybook/commit/cac9c08693305b3fa755bee944a6769c53c56db6) |
| **Datetime** | Mon Aug 11 11:34:50 UTC 2025 (`1754912091`) |
| **Workflow run** | [16878848009](https://github.com/storybookjs/storybook/actions/runs/16878848009) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32131`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a critical issue in Next.js 15 where Link components would navigate outside of Storybook stories to actual routes, causing "Not Found" errors. The fix modifies the `useRouter` export in the Next.js navigation mock (`code/frameworks/nextjs/src/export-mocks/navigation/index.ts`) to return the mocked `navigationAPI` instead of the actual Next.js router.

Previously, `useRouter` was implemented as a passthrough mock that called the real Next.js router implementation. This worked in earlier versions but broke with Next.js 15's changes to the Link component behavior. The new implementation returns the mock `navigationAPI` object when available, ensuring all navigation actions (push, replace, forward, back, prefetch, refresh) stay within the Storybook context.

This change integrates seamlessly with the existing navigation mock system, which already provides the `navigationAPI` object through the `createNavigation` function and manages mock lifecycle through `getRouter`. The fix maintains the same error handling pattern used elsewhere in the mock system by throwing `NextjsRouterMocksNotAvailable` when mocks aren't initialized.

## Confidence score: 4/5

• This fix addresses a clear regression and follows established patterns in the codebase
• The solution is targeted and minimal, changing only the problematic `useRouter` implementation
• Needs manual testing verification since automated test coverage is incomplete

<!-- /greptile_comment -->