### PR TITLE
Automigration: Await updateMainConfig in removeEssentials

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.ts
@@ -183,7 +183,7 @@ export const removeEssentials: Fix<AddonDocsOptions> = {
       }
 
       if (essentialsOptions) {
-        updateMainConfig(
+        await updateMainConfig(
           { mainConfigPath, dryRun: !!dryRun },
           moveEssentialOptions(dryRun, essentialsOptions)
         );


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32137

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32140-sha-c009bc02`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32140-sha-c009bc02 sandbox` or in an existing project with `npx storybook@0.0.0-pr-32140-sha-c009bc02 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32140-sha-c009bc02`](https://npmjs.com/package/storybook/v/0.0.0-pr-32140-sha-c009bc02) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-remove-essentials-automigration-execution-order`](https://github.com/storybookjs/storybook/tree/valentin/fix-remove-essentials-automigration-execution-order) |
| **Commit** | [`c009bc02`](https://github.com/storybookjs/storybook/commit/c009bc020daab49581cbc284469e2fe35e2f8bd1) |
| **Datetime** | Mon Jul 28 12:21:40 UTC 2025 (`1753705300`) |
| **Workflow run** | [16568886343](https://github.com/storybookjs/storybook/actions/runs/16568886343) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32140`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a critical race condition bug in the `removeEssentials` automigration by adding the missing `await` keyword before the `updateMainConfig` function call. The `removeEssentials` migration is part of Storybook's automated migration system that removes essential add-ons from the main configuration and moves their options to the features section.

The issue was that `updateMainConfig` is an asynchronous function that calls `moveEssentialOptions` (also async) to transform the configuration. Without awaiting this operation, there was no guarantee that the config update would complete before subsequent migration steps executed, potentially leading to incomplete migrations where essential options weren't properly moved to the main config's features section.

This fix ensures proper execution order in the migration sequence: remove add-ons → transform imports → update main config → add new add-ons. The change is minimal but critical for the reliability of Storybook's automigration system, which is used when users upgrade their Storybook installations.

**PR Description Notes:**
- The PR description is incomplete - the "What I did" section is empty and no testing checkboxes are filled out
- Missing issue reference after "Closes #"

## Confidence score: 4/5

- This is a straightforward async/await fix that addresses a clear race condition in critical migration code
- The change is minimal and surgical, adding only the missing `await` keyword where it's clearly needed
- The `code/lib/cli-storybook/src/automigrate/fixes/remove-essentials.ts` file should be reviewed to ensure no other async operations in the migration are missing await keywords

<!-- /greptile_comment -->