### PR TITLE
Init: Exclude mdx stories when docs feature isn't selected during init

### DIFF
--- a/code/lib/create-storybook/src/generators/NUXT/index.ts
+++ b/code/lib/create-storybook/src/generators/NUXT/index.ts
@@ -2,6 +2,12 @@ import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
+  const extraStories = ['../components/**/*.stories.@(js|jsx|ts|tsx)'];
+
+  if (options.features.includes('docs')) {
+    extraStories.push('../components/**/*.mdx');
+  }
+
   await baseGenerator(
     packageManager,
     {
@@ -16,7 +22,7 @@ const generator: Generator = async (packageManager, npmOptions, options) => {
       installFrameworkPackages: false,
       componentsDestinationPath: './components',
       extraMain: {
-        stories: ['../components/**/*.mdx', '../components/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+        stories: extraStories,
       },
     },
     'nuxt'

--- a/code/lib/create-storybook/src/generators/NUXT/index.ts
+++ b/code/lib/create-storybook/src/generators/NUXT/index.ts
@@ -2,11 +2,9 @@ import { baseGenerator } from '../baseGenerator';
 import type { Generator } from '../types';
 
 const generator: Generator = async (packageManager, npmOptions, options) => {
-  const extraStories = ['../components/**/*.stories.@(js|jsx|ts|tsx)'];
+  const extraStories = options.features.includes('docs') ? ['../components/**/*.mdx'] : [];
 
-  if (options.features.includes('docs')) {
-    extraStories.push('../components/**/*.mdx');
-  }
+  extraStories.push('../components/**/*.stories.@(js|jsx|ts|tsx|mdx)');
 
   await baseGenerator(
     packageManager,

--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -419,6 +419,7 @@ export async function baseGenerator(
         name: frameworkPackagePath,
         options: options.framework || {},
       },
+      features,
       frameworkPackage,
       prefixes,
       storybookConfigFolder,

--- a/code/lib/create-storybook/src/generators/configure.test.ts
+++ b/code/lib/create-storybook/src/generators/configure.test.ts
@@ -26,6 +26,7 @@ describe('configureMain', () => {
         name: '@storybook/react-vite',
       },
       frameworkPackage: '@storybook/react-vite',
+      features: [],
     });
 
     const { calls } = vi.mocked(fsp.writeFile).mock;
@@ -37,6 +38,39 @@ describe('configureMain', () => {
 
       /** @type { import('@storybook/react-vite').StorybookConfig } */
       const config = {
+        "stories": [
+          "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+        ],
+        "addons": [],
+        "framework": {
+          "name": "@storybook/react-vite"
+        }
+      };
+      export default config;"
+    `);
+  });
+
+  it('should generate main.ts with docs feature', async () => {
+    await configureMain({
+      language: SupportedLanguage.TYPESCRIPT,
+      addons: [],
+      prefixes: [],
+      storybookConfigFolder: '.storybook',
+      framework: {
+        name: '@storybook/react-vite',
+      },
+      frameworkPackage: '@storybook/react-vite',
+      features: ['docs'],
+    });
+
+    const { calls } = vi.mocked(fsp.writeFile).mock;
+    const [mainConfigPath, mainConfigContent] = calls[0];
+
+    expect(mainConfigPath).toEqual('./.storybook/main.ts');
+    expect(mainConfigContent).toMatchInlineSnapshot(`
+      "import type { StorybookConfig } from '@storybook/react-vite';
+
+      const config: StorybookConfig = {
         "stories": [
           "../stories/**/*.mdx",
           "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)"
@@ -50,7 +84,7 @@ describe('configureMain', () => {
     `);
   });
 
-  it('should generate main.ts', async () => {
+  it('should generate main.ts without docs feature', async () => {
     await configureMain({
       language: SupportedLanguage.TYPESCRIPT,
       addons: [],
@@ -60,6 +94,7 @@ describe('configureMain', () => {
         name: '@storybook/react-vite',
       },
       frameworkPackage: '@storybook/react-vite',
+      features: [],
     });
 
     const { calls } = vi.mocked(fsp.writeFile).mock;
@@ -71,7 +106,6 @@ describe('configureMain', () => {
 
       const config: StorybookConfig = {
         "stories": [
-          "../stories/**/*.mdx",
           "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)"
         ],
         "addons": [],
@@ -96,6 +130,7 @@ describe('configureMain', () => {
         name: "%%path.dirname(require.resolve(path.join('@storybook/react-webpack5', 'package.json')))%%",
       },
       frameworkPackage: '@storybook/react-webpack5',
+      features: ['docs'],
     });
 
     const { calls } = vi.mocked(fsp.writeFile).mock;

--- a/code/lib/create-storybook/src/generators/configure.ts
+++ b/code/lib/create-storybook/src/generators/configure.ts
@@ -56,11 +56,9 @@ export async function configureMain({
 }: ConfigureMainOptions) {
   const srcPath = resolve(storybookConfigFolder, '../src');
   const prefix = (await pathExists(srcPath)) ? '../src' : '../stories';
-  const stories = [`**/*.stories.@(${extensions.join('|')})`];
+  const stories = features.includes('docs') ? [`${prefix}/**/*.mdx`] : [];
 
-  if (features.includes('docs')) {
-    stories.push(`${prefix}/**/*.mdx`);
-  }
+  stories.push(`${prefix}/**/*.stories.@(${extensions.join('|')})`);
 
   const config = {
     stories,

--- a/code/lib/create-storybook/src/generators/types.ts
+++ b/code/lib/create-storybook/src/generators/types.ts
@@ -19,7 +19,7 @@ export type GeneratorOptions = {
   frameworkPreviewParts?: FrameworkPreviewParts;
   // skip prompting the user
   yes: boolean;
-  features: string[];
+  features: Array<GeneratorFeature>;
 };
 
 export interface FrameworkOptions {


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32138

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32142-sha-424d5226`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32142-sha-424d5226 sandbox` or in an existing project with `npx storybook@0.0.0-pr-32142-sha-424d5226 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32142-sha-424d5226`](https://npmjs.com/package/storybook/v/0.0.0-pr-32142-sha-424d5226) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/init-storybook-without-mdx-stories`](https://github.com/storybookjs/storybook/tree/valentin/init-storybook-without-mdx-stories) |
| **Commit** | [`424d5226`](https://github.com/storybookjs/storybook/commit/424d5226abbf014325ee582e8a77a94bfe19e376) |
| **Datetime** | Mon Jul 28 12:58:55 UTC 2025 (`1753707535`) |
| **Workflow run** | [16569685274](https://github.com/storybookjs/storybook/actions/runs/16569685274) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32142`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a bug where Storybook's initialization process was incorrectly including MDX story patterns in the main configuration even when users selected minimal installations without the docs feature. The change addresses issue #32138 by making the story configuration dynamic based on selected features during init.

The core fix involves three coordinated changes:

1. **Type Safety Improvement**: The `GeneratorOptions.features` field is changed from `string[]` to `Array<GeneratorFeature>` in `types.ts`, restricting valid feature values to 'docs', 'test', and 'onboarding'. This provides compile-time checking and prevents invalid feature strings.

2. **Conditional MDX Pattern Logic**: The `configureMain` function in `configure.ts` is modified to conditionally add MDX story patterns (`**/*.mdx`) to the stories array only when `features.includes('docs')` is true. Previously, MDX patterns were always included regardless of feature selection.

3. **Feature Parameter Passing**: The `baseGenerator.ts` file is updated to pass the `features` array to the `configureMain` function call, ensuring that feature selection made during initialization is properly communicated to the configuration generation.

This change integrates with Storybook's existing feature system, which allows users to selectively enable functionality like docs, testing, and onboarding during the initialization process. The fix prevents "No story files found" warnings when running minimal Storybook installations that don't need MDX support, while maintaining backward compatibility for full installations that include the docs addon.

## Confidence score: 4/5

• This is a targeted bug fix that should resolve the specific issue without introducing new problems
• The implementation follows good practices with type safety improvements and conditional logic
• Need to verify that the feature detection logic works correctly across all initialization scenarios and that no edge cases are missed

<!-- /greptile_comment -->