### PR TITLE
Test: Invalidate vite cache for manual mocks

### DIFF
--- a/code/core/src/core-server/presets/vitePlugins/vite-mock/plugin.ts
+++ b/code/core/src/core-server/presets/vitePlugins/vite-mock/plugin.ts
@@ -117,6 +117,7 @@ export function viteMockPlugin(options: MockPluginOptions): Plugin[] {
             }
 
             if (call.redirectPath) {
+              this.addWatchFile(call.redirectPath);
               return readFileSync(call.redirectPath, 'utf-8');
             }
           }


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32149

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

### What:

Explicitly tell Vite about the relationship between the module being loaded and the file its content comes from. I am doing it using the `this.addWatchFile()` method, which is available on the plugin context within the load and transform hooks.

### Why:

When the load hook executes for a mocked module (e.g., uuid), it does this:

```ts
if (call.redirectPath) {
  // You read the file from disk...
  return readFileSync(call.redirectPath, 'utf-8'); 
}
```

We are returning the content of the `__mocks__/uuid.ts` file as a raw string. From Vite's perspective, the module uuid simply is that string content. It has no idea that this content originated from another file on the disk (__mocks__/uuid.ts).

As a result, when you change `__mocks__/uuid.ts`, Vite's watcher sees a file change, and the `invalidateAffectedFiles` function correctly invalidates the uuid module in the module graph. However, when Vite's dev server goes to re-serve the invalidated uuid module, it hits your load hook again. Since nothing in the hook's logic has changed, it serves the new content, but because the module's own identity (uuid) hasn't changed, Vite doesn't generate a new timestamp (?v=...). The browser, seeing a request for the exact same URL, correctly serves the old version from its cache.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a browser caching issue with Vite's development server when using manual mocks in Storybook. The change adds a single line `this.addWatchFile(call.redirectPath)` to Storybook's Vite mock plugin.

The problem occurs when Storybook's mock plugin reads content from `__mocks__` files (e.g., `__mocks__/uuid.ts`) and returns it as the content for the mocked module. From Vite's perspective, the module content is just a string with no knowledge that it originated from a different file on disk. When developers modify mock files, Vite correctly invalidates the module in its module graph, but the browser continues serving cached content because Vite doesn't generate new URL timestamps (`?v=...`) since it's unaware of the source file dependency.

The fix uses Vite's `addWatchFile()` API to explicitly inform Vite about the relationship between the requested module and its source mock file. This ensures proper cache invalidation and Hot Module Replacement (HMR) behavior when mock files are modified during development.

This change integrates seamlessly with Storybook's existing mock system and follows standard Vite plugin patterns for handling dependencies between virtual modules and their source files.

**PR Description Notes:**
- The PR title doesn't follow the 'Area: Summary' format specified in the style guide
- No issue number is provided in the "Closes #" section
- Manual testing steps are not provided despite being marked as mandatory

## Confidence score: 5/5

- This is a safe, targeted fix that addresses a specific browser caching issue with minimal risk
- The solution follows established Vite plugin patterns and uses the appropriate API (`addWatchFile`)
- No files need additional attention as the change is minimal and well-understood

### Context used:
**Context -** PR titles must be in the format of 'Area: Summary', with both Area and Summary starting with a capital letter. ([link](https://app.greptile.com/review/custom-context?memory=b5aedbe7-fa39-4616-a54b-c8147b7dce13))

<!-- /greptile_comment -->