### PR TITLE
Test: Consider exports map

### DIFF
--- a/code/.storybook/preview.tsx
+++ b/code/.storybook/preview.tsx
@@ -41,6 +41,7 @@ sb.mock(import('../core/template/stories/test/ModuleAutoMocking.utils'));
 sb.mock(import('lodash-es'));
 sb.mock(import('lodash-es/add'));
 sb.mock(import('lodash-es/sum'));
+sb.mock(import('uuid'));
 
 const { document } = global;
 globalThis.CONFIG_TYPE = 'DEVELOPMENT';

--- a/code/__mocks__/uuid.js
+++ b/code/__mocks__/uuid.js
@@ -1,0 +1,3 @@
+export function v4() {
+  return 'MOCK-V4';
+}

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -567,6 +567,7 @@
     "react-transition-group": "^4.4.5",
     "require-from-string": "^2.0.2",
     "resolve-from": "^5.0.0",
+    "resolve.exports": "^2.0.3",
     "sirv": "^2.0.4",
     "slash": "^5.0.0",
     "source-map": "^0.7.4",

--- a/code/core/src/core-server/mocking-utils/resolve.ts
+++ b/code/core/src/core-server/mocking-utils/resolve.ts
@@ -22,6 +22,46 @@ function findPackageJson(specifier: string, basedir: string): { path: string; da
 }
 
 /**
+ * Resolves an external module path to its absolute path. It considers the "exports" map in the
+ * package.json file.
+ *
+ * @param path The raw module path from the `sb.mock()` call.
+ * @param root The project's root directory.
+ * @returns The absolute path to the module.
+ */
+export function resolveExternalModule(path: string, root: string) {
+  // --- External Package Resolution ---
+  const parts = path.split('/');
+  // For scoped packages like `@foo/bar`, the package name is the first two parts.
+  const packageName = path.startsWith('@') ? `${parts[0]}/${parts[1]}` : parts[0];
+  const entry = `.${path.slice(packageName.length)}`; // e.g., './add' from 'lodash-es/add'
+
+  const { path: packageJsonPath, data: pkg } = findPackageJson(packageName, root);
+  const packageDir = dirname(packageJsonPath);
+
+  // 1. Try to resolve using the "exports" map.
+  if (pkg.exports) {
+    const result = resolveExports(pkg, entry, {
+      browser: true,
+    });
+
+    if (result) {
+      return join(packageDir, result[0]);
+    }
+  }
+
+  return require.resolve(path, { paths: [root] });
+}
+
+export function getIsExternal(path: string, importer: string) {
+  try {
+    return !isAbsolute(path) && isModuleDirectory(require.resolve(path, { paths: [importer] }));
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
  * Resolves a mock path to its absolute path and checks for a `__mocks__` redirect. This function
  * uses `resolve.exports` to correctly handle modern ESM packages.
  *
@@ -30,49 +70,16 @@ function findPackageJson(specifier: string, basedir: string): { path: string; da
  * @param importer The absolute path of the file containing the mock call (the preview file).
  */
 export function resolveMock(path: string, root: string, importer: string) {
-  const isExternal = (function () {
-    try {
-      return !isAbsolute(path) && isModuleDirectory(require.resolve(path, { paths: [root] }));
-    } catch (e) {
-      return false;
-    }
-  })();
+  const isExternal = getIsExternal(path, root);
+  const externalPath = isExternal ? path : null;
 
-  const external = isExternal ? path : null;
-
-  let absolutePath: string | undefined;
-
-  if (isExternal) {
-    // --- External Package Resolution ---
-    const parts = path.split('/');
-    // For scoped packages like `@foo/bar`, the package name is the first two parts.
-    const packageName = path.startsWith('@') ? `${parts[0]}/${parts[1]}` : parts[0];
-    const entry = `.${path.slice(packageName.length)}`; // e.g., './add' from 'lodash-es/add'
-
-    const { path: packageJsonPath, data: pkg } = findPackageJson(packageName, root);
-    const packageDir = dirname(packageJsonPath);
-
-    // 1. Try to resolve using the "exports" map.
-    if (pkg.exports) {
-      const result = resolveExports(pkg, entry, {
-        browser: true,
-      });
-      absolutePath = result ? join(packageDir, result[0]) : undefined;
-    }
-
-    // 2. If "exports" map fails or doesn't exist, fall back to standard resolution
-    if (!absolutePath) {
-      absolutePath = require.resolve(path, { paths: [root] });
-    }
-  } else {
-    // --- Local File Resolution ---
-    // For relative paths, Node's standard resolver is sufficient and correct.
-    absolutePath = require.resolve(path, { paths: [dirname(importer)] });
-  }
+  const absolutePath = isExternal
+    ? resolveExternalModule(path, root)
+    : require.resolve(path, { paths: [dirname(importer)] });
 
   const normalizedAbsolutePath = resolve(absolutePath);
 
-  const redirectPath = findMockRedirect(root, normalizedAbsolutePath, external);
+  const redirectPath = findMockRedirect(root, normalizedAbsolutePath, externalPath);
 
   return {
     absolutePath: normalizedAbsolutePath,

--- a/code/core/src/core-server/mocking-utils/resolve.ts
+++ b/code/core/src/core-server/mocking-utils/resolve.ts
@@ -1,26 +1,74 @@
+import { readFileSync } from 'node:fs';
+
 import { findMockRedirect } from '@vitest/mocker/redirect';
-import { isAbsolute, join, resolve } from 'pathe';
+import { dirname, isAbsolute, join, resolve } from 'pathe';
+import { exports as resolveExports } from 'resolve.exports';
 
 import { isModuleDirectory } from './extract';
 
-export function resolveMock(mockPath: string, root: string, previewConfigPath: string) {
+/**
+ * Finds the package.json for a given module specifier.
+ *
+ * @param specifier The module specifier (e.g., 'uuid', 'lodash-es/add').
+ * @param basedir The directory to start the search from.
+ * @returns The path to the package.json and the package's contents.
+ */
+function findPackageJson(specifier: string, basedir: string): { path: string; data: any } {
+  const packageJsonPath = require.resolve(`${specifier}/package.json`, { paths: [basedir] });
+  return {
+    path: packageJsonPath,
+    data: JSON.parse(readFileSync(packageJsonPath, 'utf-8')),
+  };
+}
+
+/**
+ * Resolves a mock path to its absolute path and checks for a `__mocks__` redirect. This function
+ * uses `resolve.exports` to correctly handle modern ESM packages.
+ *
+ * @param path The raw module path from the `sb.mock()` call.
+ * @param root The project's root directory.
+ * @param importer The absolute path of the file containing the mock call (the preview file).
+ */
+export function resolveMock(path: string, root: string, importer: string) {
   const isExternal = (function () {
     try {
-      return (
-        !isAbsolute(mockPath) && isModuleDirectory(require.resolve(mockPath, { paths: [root] }))
-      );
+      return !isAbsolute(path) && isModuleDirectory(require.resolve(path, { paths: [root] }));
     } catch (e) {
       return false;
     }
   })();
 
-  const external = isExternal ? mockPath : null;
+  const external = isExternal ? path : null;
 
-  const absolutePath = external
-    ? require.resolve(mockPath, { paths: [root] })
-    : require.resolve(join(previewConfigPath, '..', mockPath), {
-        paths: [root],
+  let absolutePath: string | undefined;
+
+  if (isExternal) {
+    // --- External Package Resolution ---
+    const parts = path.split('/');
+    // For scoped packages like `@foo/bar`, the package name is the first two parts.
+    const packageName = path.startsWith('@') ? `${parts[0]}/${parts[1]}` : parts[0];
+    const entry = `.${path.slice(packageName.length)}`; // e.g., './add' from 'lodash-es/add'
+
+    const { path: packageJsonPath, data: pkg } = findPackageJson(packageName, root);
+    const packageDir = dirname(packageJsonPath);
+
+    // 1. Try to resolve using the "exports" map.
+    if (pkg.exports) {
+      const result = resolveExports(pkg, entry, {
+        browser: true,
       });
+      absolutePath = result ? join(packageDir, result[0]) : undefined;
+    }
+
+    // 2. If "exports" map fails or doesn't exist, fall back to standard resolution
+    if (!absolutePath) {
+      absolutePath = require.resolve(path, { paths: [root] });
+    }
+  } else {
+    // --- Local File Resolution ---
+    // For relative paths, Node's standard resolver is sufficient and correct.
+    absolutePath = require.resolve(path, { paths: [dirname(importer)] });
+  }
 
   const normalizedAbsolutePath = resolve(absolutePath);
 

--- a/code/core/src/core-server/presets/vitePlugins/vite-mock/plugin.ts
+++ b/code/core/src/core-server/presets/vitePlugins/vite-mock/plugin.ts
@@ -133,14 +133,16 @@ export function viteMockPlugin(options: MockPluginOptions): Plugin[] {
             const idNorm = normalizePathForComparison(id, preserveSymlinks);
             const callNorm = normalizePathForComparison(call.absolutePath, preserveSymlinks);
 
-            if (callNorm !== idNorm && viteConfig.command !== 'serve') {
-              continue;
-            }
+            if (viteConfig.command !== 'serve') {
+              if (callNorm !== idNorm) {
+                continue;
+              }
+            } else {
+              const cleanId = getCleanId(idNorm);
 
-            const cleanId = getCleanId(idNorm);
-
-            if (viteConfig.command === 'serve' && call.path !== cleanId && callNorm !== idNorm) {
-              continue;
+              if (call.path !== cleanId && callNorm !== idNorm) {
+                continue;
+              }
             }
 
             try {

--- a/code/core/template/__mocks__/uuid.js
+++ b/code/core/template/__mocks__/uuid.js
@@ -1,0 +1,3 @@
+export function v4() {
+  return 'MOCK-V4';
+}

--- a/code/core/template/stories/test/CjsNodeModuleMocking.stories.js
+++ b/code/core/template/stories/test/CjsNodeModuleMocking.stories.js
@@ -1,0 +1,26 @@
+import { global as globalThis } from '@storybook/global';
+
+import { expect } from 'storybook/test';
+import { v4 } from 'uuid';
+
+// This story is used to test the node module mocking for modules which have an exports field in their package.json.
+
+export default {
+  component: globalThis.__TEMPLATE_COMPONENTS__.Pre,
+  decorators: [
+    (storyFn) =>
+      storyFn({
+        args: {
+          text: `UUID Version: ${v4()}`,
+        },
+      }),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.innerHTML).toContain('UUID Version: MOCK-V4');
+  },
+};
+
+export const Original = {};

--- a/code/core/template/stories/test/ModuleAutoMocking.stories.ts
+++ b/code/core/template/stories/test/ModuleAutoMocking.stories.ts
@@ -1,6 +1,7 @@
 import { global as globalThis } from '@storybook/global';
 
 import { expect } from 'storybook/test';
+import { v4 } from 'uuid';
 
 import { fn } from './ModuleAutoMocking.utils';
 

--- a/code/package.json
+++ b/code/package.json
@@ -209,6 +209,7 @@
     "svelte": "^5.0.0-next.268",
     "ts-dedent": "^2.0.0",
     "typescript": "^5.8.3",
+    "uuid": "^11.1.0",
     "vite": "^6.2.5",
     "vite-plugin-inspect": "^11.0.0",
     "vitest": "^3.2.4",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7194,6 +7194,7 @@ __metadata:
     svelte: "npm:^5.0.0-next.268"
     ts-dedent: "npm:^2.0.0"
     typescript: "npm:^5.8.3"
+    uuid: "npm:^11.1.0"
     vite: "npm:^6.2.5"
     vite-plugin-inspect: "npm:^11.0.0"
     vitest: "npm:^3.2.4"
@@ -23507,7 +23508,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve.exports@npm:2.0.3":
+"resolve.exports@npm:2.0.3, resolve.exports@npm:^2.0.3":
   version: 2.0.3
   resolution: "resolve.exports@npm:2.0.3"
   checksum: 10c0/1ade1493f4642a6267d0a5e68faeac20b3d220f18c28b140343feb83694d8fed7a286852aef43689d16042c61e2ddb270be6578ad4a13990769e12065191200d
@@ -25081,6 +25082,7 @@ __metadata:
     recast: "npm:^0.23.5"
     require-from-string: "npm:^2.0.2"
     resolve-from: "npm:^5.0.0"
+    resolve.exports: "npm:^2.0.3"
     semver: "npm:^7.6.2"
     sirv: "npm:^2.0.4"
     slash: "npm:^5.0.0"
@@ -26868,6 +26870,15 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 10c0/02ba649de1b7ca8854bfe20a82f1dfbdda3fb57a22ab4a8972a63a34553cf7aa51bc9081cf7e001b035b88186d23689d69e71b510e610a09a4c66f68aa95b672
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
   languageName: node
   linkType: hard
 

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -801,6 +801,7 @@ export const extendPreview: Task['run'] = async ({ template, sandboxDir }) => {
     "sb.mock(import('lodash-es'));",
     "sb.mock(import('lodash-es/add'));",
     "sb.mock(import('lodash-es/sum'));",
+    "sb.mock(import('uuid'));",
     '',
   ].join('\n');
 

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -77,6 +77,7 @@ export const sandbox: Task = {
       // Adding the dep makes sure that even npx will use the linked workspace version.
       '@storybook/cli',
       'lodash-es',
+      'uuid',
     ];
 
     const shouldAddVitestIntegration = !details.template.skipTasks?.includes('vitest-integration');


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32151

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

### Why
This change addresses a critical bug in our module mocking logic that occurred during production builds (`vite build` or `webpack build`). The previous implementation used `require.resolve` to determine the absolute path of mocked node_modules packages. However, `require.resolve` follows legacy CJS resolution rules and often fails to respect the "exports" map in a modern package's package.json.

This created a mismatch:

- Bundler (Vite/Webpack): Correctly resolved a package like `uuid` to its modern ESM entry point (e.g., .../esm-browser/index.js).
- Our Mocking Plugin: Incorrectly resolved the same package to its CJS entry point (e.g., .../cjs/index.js).

Because the absolute paths did not match, our mocking logic failed to identify and replace the module during the build process, causing mocks for packages like uuid to be ignored in the final bundle.

### What
This PR updates the resolveMock utility to correctly and reliably resolve modern ESM packages by mimicking the bundler's own resolution strategy.

Prioritizes "exports" Map: The logic now first checks if a package's package.json contains an "exports" map.

Uses resolve.exports: If an "exports" map is present, it uses the `resolve.exports` package to parse it and find the correct ESM entry point, respecting conditions like "import" and "browser". This guarantees we resolve to the exact same file as Vite and Webpack.

Graceful Fallback: If no "exports" map is found, the resolver gracefully falls back to using the classic require.resolve. This ensures continued compatibility with older CJS-style packages.

This change makes our module resolution logic robust and consistent with modern bundler behavior, ensuring that mocks for third-party packages are applied correctly in all environments.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a critical bug in Storybook's module mocking system that caused third-party package mocks to fail during production builds (`vite build` or `webpack build`). The core issue was a resolution mismatch between modern bundlers and Storybook's mocking plugin:

- **Bundlers** (Vite/Webpack): Correctly resolved packages like `uuid` to their modern ESM entry points using the "exports" map in package.json
- **Storybook's Mocking Plugin**: Used `require.resolve` which follows legacy CJS resolution rules, resolving to different (CJS) entry points

This path mismatch prevented the mocking system from identifying and replacing modules during builds, causing mocks to be ignored in production.

The fix updates the `resolveMock` utility in `code/core/src/core-server/mocking-utils/resolve.ts` to:
1. **Prioritize exports maps**: First checks if a package has an "exports" field in its package.json
2. **Use `resolve.exports`**: Parses exports maps with proper ESM conditions ("import", "browser") to match bundler behavior
3. **Graceful fallback**: Falls back to standard `require.resolve` for older CJS packages
4. **Handle scoped packages**: Properly resolves `@scope/package` style imports

The changes also include comprehensive test coverage using the `uuid` package as a test case (which has modern exports maps), mock files, test stories, and sandbox configurations to validate the fix across different environments. The Vite plugin logic was also refined to ensure consistent path matching between development and production builds.

## Confidence score: 4/5

• This PR addresses a well-defined bug with a targeted solution that maintains backward compatibility
• The core logic changes are sound but involve complex module resolution that could have edge cases
• The `resolve.ts` file needs careful attention as it handles the critical path resolution logic that could break mocking entirely if incorrect

<!-- /greptile_comment -->