### PR TITLE
Core: Prevent `BAIL` state from showing in interactions panel when switching stories

### DIFF
--- a/code/core/src/component-testing/components/Panel.tsx
+++ b/code/core/src/component-testing/components/Panel.tsx
@@ -239,6 +239,7 @@ export const Panel = memo<{ refId?: string; storyId: string; storyUrl: string }>
       return () => observer?.disconnect();
     }, []);
 
+    const lastStoryId = useRef<string>(undefined);
     const lastRenderId = useRef<number>(0);
     const emit = useChannel(
       {
@@ -253,12 +254,16 @@ export const Panel = memo<{ refId?: string; storyId: string; storyUrl: string }>
           );
         },
         [STORY_RENDER_PHASE_CHANGED]: (event) => {
-          if (event.newPhase === 'preparing' || event.newPhase === 'loading') {
-            // A render cycle may not actually make it to the rendering phase.
+          if (
+            lastStoryId.current === event.storyId &&
+            ['preparing', 'loading'].includes(event.newPhase)
+          ) {
+            // A rerender cycle may not actually make it to the rendering phase.
             // We don't want to update any state until it does.
             return;
           }
 
+          lastStoryId.current = event.storyId;
           lastRenderId.current = Math.max(lastRenderId.current, event.renderId || 0);
           if (lastRenderId.current !== event.renderId) {
             return;

--- a/code/core/src/controls/components/SaveStory.stories.tsx
+++ b/code/core/src/controls/components/SaveStory.stories.tsx
@@ -42,14 +42,12 @@ export const Creating = {
 } satisfies Story;
 
 export const Created: Story = {
-  play: async ({ canvas, context, userEvent }) => {
+  play: async ({ canvas, context }) => {
     await Creating.play(context);
-    const event = userEvent.setup({ delay: null });
 
     const dialog = await canvas.findByRole('dialog');
     const input = await within(dialog).findByRole('textbox');
-    await event.type(input, 'MyNewStory');
-
+    await fireEvent.change(input, { target: { value: 'MyNewStory' } });
     await fireEvent.submit(dialog.getElementsByTagName('form')[0]);
     await expect(context.args.createStory).toHaveBeenCalledWith('MyNewStory');
   },

--- a/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
@@ -116,16 +116,15 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
   }
 
   private checkIfAborted(signal: AbortSignal): boolean {
-    if (signal.aborted) {
+    if (signal.aborted && !['finished', 'aborted', 'errored'].includes(this.phase as RenderPhase)) {
       this.phase = 'aborted';
       this.channel.emit(STORY_RENDER_PHASE_CHANGED, {
         newPhase: this.phase,
         renderId: this.renderId,
         storyId: this.id,
       });
-      return true;
     }
-    return false;
+    return signal.aborted;
   }
 
   async prepare() {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Originally fixed for #32163 but regressed when another (more severe) issue was fixed. So this is the 2nd attempt at fixing the problem, in a way that avoids reintroducing the more severe problem.

The source of these bugs is overlapping `STORY_RENDER_PHASE_CHANGED` events originating from different render cycles and/or stories. The two issues are:
- Interaction logs being cleared on `preparing` phase for render cycles that never actually render, causing the logs to stay empty. This is the most severe issue and was resolved by ignoring the `preparing` and `loading` phases and only clear the log on the `rendering` phase.
- Status badge showing `BAIL` when switching stories. This happens when the previous story's render cycle is aborted. The render cycle for the new story would only kick in at the `rendering` phase, and so if `aborted` arrives before rendering starts, you'd see the `BAIL` label on the new story even though that update was intended for the previous story. 

That's why in this PR, I have extended the condition to ignore `preparing` / `loading` only when we're not switching stories. If we are switching stories, the `preparing` phase will update `lastRenderId`, thereby causing the `aborted` update to be ignored (as it uses an older `renderId`). 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Switch between two stories which have (long-running) play functions. In the interactions panel, there should not be a purple `BAIL` label showing when switching stories. When you HMR while the play function is running, the `BAIL` label should show.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32172-sha-72b63e9f`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32172-sha-72b63e9f sandbox` or in an existing project with `npx storybook@0.0.0-pr-32172-sha-72b63e9f upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32172-sha-72b63e9f`](https://npmjs.com/package/storybook/v/0.0.0-pr-32172-sha-72b63e9f) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`reset-on-change-story`](https://github.com/storybookjs/storybook/tree/reset-on-change-story) |
| **Commit** | [`72b63e9f`](https://github.com/storybookjs/storybook/commit/72b63e9fbd2efddd771616b4ea3219f78277c1ff) |
| **Datetime** | Fri Aug  1 11:06:48 UTC 2025 (`1754046408`) |
| **Workflow run** | [16673478050](https://github.com/storybookjs/storybook/actions/runs/16673478050) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32172`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a race condition issue that causes the interactions panel to incorrectly display a "BAIL" status when switching between stories in Storybook. The root cause stems from overlapping `STORY_RENDER_PHASE_CHANGED` events from different render cycles, where an aborted render cycle from the previous story can interfere with the new story's render phases.

The solution involves two key changes to the event handling logic:

1. **Smart phase filtering in Panel.tsx**: Instead of blindly ignoring `preparing` and `loading` phases (which caused the BAIL issue), the code now tracks the current story ID using a `lastStoryId` ref. It only ignores early phases when re-rendering the same story, allowing story switches to proceed normally while still protecting against premature log clearing during rerenders.

2. **Terminal state protection in StoryRender.ts**: The `checkIfAborted` method now prevents emitting `STORY_RENDER_PHASE_CHANGED` events with 'aborted' phase when the render is already in a terminal state (['finished', 'aborted', 'errored']). This prevents stale abort events from previous render cycles from affecting new stories.

The changes integrate well with Storybook's existing render phase management system, building on the existing `STORY_RENDER_PHASE_CHANGED` event infrastructure while adding safeguards against race conditions. Additionally, the PR includes a minor test refactoring in `SaveStory.stories.tsx` that switches from `userEvent` to `fireEvent` for simpler input testing.

## Confidence score: 4/5

• This PR addresses a well-documented race condition with a targeted solution that maintains existing functionality while fixing the specific BAIL state issue
• The logic appears sound but deals with complex async event timing that could have edge cases not immediately apparent
• The StoryRender.ts and Panel.tsx files need careful review as they handle critical render phase state management

<!-- /greptile_comment -->