### PR TITLE
Addon Docs: Add `__STORYBOOK_UNSAFE_TOCBOT__` global

### DIFF
--- a/code/addons/docs/src/preview.ts
+++ b/code/addons/docs/src/preview.ts
@@ -1,5 +1,12 @@
 import type { PreparedStory } from 'storybook/internal/types';
 
+import * as tocbot from 'tocbot';
+
+if (!globalThis.__STORYBOOK_UNSAFE_TOCBOT__) {
+  // Users that load dynamic content need to have a way to refresh the TOC, so we expose the tocbot instance
+  globalThis.__STORYBOOK_UNSAFE_TOCBOT__ = tocbot.default ?? tocbot;
+}
+
 const excludeTags = Object.entries(globalThis.TAGS_OPTIONS ?? {}).reduce(
   (acc, entry) => {
     const [tag, option] = entry;

--- a/code/addons/docs/src/typings.d.ts
+++ b/code/addons/docs/src/typings.d.ts
@@ -7,6 +7,7 @@ declare var __DOCS_CONTEXT__: any;
 declare var PREVIEW_URL: any;
 declare var LOGLEVEL: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent' | undefined;
 declare var TAGS_OPTIONS: import('storybook/internal/types').TagsOptions;
+declare var __STORYBOOK_UNSAFE_TOCBOT__: typeof import('tocbot').default;
 
 declare module '*.md';
 declare module '*.md?raw';


### PR DESCRIPTION
Closes #https://github.com/storybookjs/storybook/issues/31449

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Previously, Storybook was using an older version of tocbot (4.23.0) and the package was being bundled as its CJS version, which by side effect, ended up exposing `tocbot` on the window object. Now, Storybook uses a newer version which is now bundled as its ESM version and therefore that `tocbot` is not exposed anymore.

This PR introduces a way to re-acess the object via `globalThis.__STORYBOOK_UNSAFE_TOCBOT__` (at your own risk) to allow usage the same way a before. This is an undocumented feature and shouldn't be used unless you know what you're doing, and it can change in between versions of Storybook.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR introduces the `__STORYBOOK_UNSAFE_TOCBOT__` global variable to restore access to the tocbot instance that was lost when Storybook upgraded from tocbot 4.23.0 to a newer version. The change addresses a breaking issue where users who relied on the accidentally exposed tocbot instance (previously available due to CJS bundling side effects) to refresh table of contents for dynamically loaded content lost this functionality when Storybook switched to ESM bundling.

The implementation adds a conditional assignment in `preview.ts` that exposes either `tocbot.default` or `tocbot` itself via `globalThis.__STORYBOOK_UNSAFE_TOCBOT__`, handling both CJS and ESM module formats. A corresponding TypeScript declaration is added to `typings.d.ts` to provide proper typing support. The "UNSAFE" naming convention clearly signals this is an undocumented escape hatch that may change between versions.

This change fits into Storybook's addon architecture by providing backward compatibility while explicitly marking the API as unstable through its naming convention, allowing users to migrate their code while maintaining functionality.

**PR Description Notes:**
- The issue link appears malformed (contains extra "https://" prefix)
- Manual testing section is incomplete with no specific testing steps provided
- No automated tests are marked as covering these changes

## Confidence score: 4/5

- This is a safe compatibility fix that restores previously available functionality without breaking existing code
- The implementation properly handles both CJS and ESM module formats and includes appropriate TypeScript declarations
- The conditional check prevents overwriting existing values and the "UNSAFE" naming clearly communicates the API's instability
- Minor concerns about the lack of automated tests and incomplete manual testing documentation, but the changes are straightforward and low-risk

<!-- /greptile_comment -->