### PR TITLE
Addon A11y: Prevent setting highlights for old results

### DIFF
--- a/code/addons/a11y/src/components/A11yContext.tsx
+++ b/code/addons/a11y/src/components/A11yContext.tsx
@@ -295,11 +295,13 @@ export const A11yContextProvider: FC<PropsWithChildren> = (props) => {
     setStatus(getInitialStatus(manual));
   }, [getInitialStatus, manual]);
 
+  const isInitial = status === 'initial';
+
   useEffect(() => {
     emit(REMOVE_HIGHLIGHT, `${ADDON_ID}/selected`);
     emit(REMOVE_HIGHLIGHT, `${ADDON_ID}/others`);
 
-    if (!highlighted) {
+    if (!highlighted || isInitial) {
       return;
     }
 
@@ -312,84 +314,88 @@ export const A11yContextProvider: FC<PropsWithChildren> = (props) => {
       const target = result?.nodes[Number(number) - 1]?.target;
       return target ? [String(target)] : [];
     });
-    emit(HIGHLIGHT, {
-      id: `${ADDON_ID}/selected`,
-      priority: 1,
-      selectors: selected,
-      styles: {
-        outline: `1px solid color-mix(in srgb, ${colorsByType[tab]}, transparent 30%)`,
-        backgroundColor: 'transparent',
-      },
-      hoverStyles: {
-        outlineWidth: '2px',
-      },
-      focusStyles: {
-        backgroundColor: 'transparent',
-      },
-      menu: results?.[tab as RuleType].map<HighlightMenuItem[]>((result) => {
-        const selectors = result.nodes
-          .flatMap((n) => n.target)
-          .map(String)
-          .filter((e) => selected.includes(e));
-        return [
-          {
-            id: `${tab}.${result.id}:info`,
-            title: getTitleForAxeResult(result),
-            description: getFriendlySummaryForAxeResult(result),
-            selectors,
-          },
-          {
-            id: `${tab}.${result.id}`,
-            iconLeft: 'info',
-            iconRight: 'shareAlt',
-            title: 'Learn how to resolve this violation',
-            clickEvent: EVENTS.SELECT,
-            selectors,
-          },
-        ];
-      }),
-    });
+    if (selected.length) {
+      emit(HIGHLIGHT, {
+        id: `${ADDON_ID}/selected`,
+        priority: 1,
+        selectors: selected,
+        styles: {
+          outline: `1px solid color-mix(in srgb, ${colorsByType[tab]}, transparent 30%)`,
+          backgroundColor: 'transparent',
+        },
+        hoverStyles: {
+          outlineWidth: '2px',
+        },
+        focusStyles: {
+          backgroundColor: 'transparent',
+        },
+        menu: results?.[tab as RuleType].map<HighlightMenuItem[]>((result) => {
+          const selectors = result.nodes
+            .flatMap((n) => n.target)
+            .map(String)
+            .filter((e) => selected.includes(e));
+          return [
+            {
+              id: `${tab}.${result.id}:info`,
+              title: getTitleForAxeResult(result),
+              description: getFriendlySummaryForAxeResult(result),
+              selectors,
+            },
+            {
+              id: `${tab}.${result.id}`,
+              iconLeft: 'info',
+              iconRight: 'shareAlt',
+              title: 'Learn how to resolve this violation',
+              clickEvent: EVENTS.SELECT,
+              selectors,
+            },
+          ];
+        }),
+      });
+    }
 
     const others = results?.[tab as RuleType]
       .flatMap((r) => r.nodes.flatMap((n) => n.target).map(String))
       .filter((e) => ![...unhighlightedSelectors, ...selected].includes(e));
-    emit(HIGHLIGHT, {
-      id: `${ADDON_ID}/others`,
-      selectors: others,
-      styles: {
-        outline: `1px solid color-mix(in srgb, ${colorsByType[tab]}, transparent 30%)`,
-        backgroundColor: `color-mix(in srgb, ${colorsByType[tab]}, transparent 60%)`,
-      },
-      hoverStyles: {
-        outlineWidth: '2px',
-      },
-      focusStyles: {
-        backgroundColor: 'transparent',
-      },
-      menu: results?.[tab as RuleType].map<HighlightMenuItem[]>((result) => {
-        const selectors = result.nodes
-          .flatMap((n) => n.target)
-          .map(String)
-          .filter((e) => !selected.includes(e));
-        return [
-          {
-            id: `${tab}.${result.id}:info`,
-            title: getTitleForAxeResult(result),
-            description: getFriendlySummaryForAxeResult(result),
-            selectors,
-          },
-          {
-            id: `${tab}.${result.id}`,
-            iconLeft: 'info',
-            iconRight: 'shareAlt',
-            title: 'Learn how to resolve this violation',
-            clickEvent: EVENTS.SELECT,
-            selectors,
-          },
-        ];
-      }),
-    });
-  }, [emit, highlighted, results, tab, selectedItems]);
+    if (others?.length) {
+      emit(HIGHLIGHT, {
+        id: `${ADDON_ID}/others`,
+        selectors: others,
+        styles: {
+          outline: `1px solid color-mix(in srgb, ${colorsByType[tab]}, transparent 30%)`,
+          backgroundColor: `color-mix(in srgb, ${colorsByType[tab]}, transparent 60%)`,
+        },
+        hoverStyles: {
+          outlineWidth: '2px',
+        },
+        focusStyles: {
+          backgroundColor: 'transparent',
+        },
+        menu: results?.[tab as RuleType].map<HighlightMenuItem[]>((result) => {
+          const selectors = result.nodes
+            .flatMap((n) => n.target)
+            .map(String)
+            .filter((e) => !selected.includes(e));
+          return [
+            {
+              id: `${tab}.${result.id}:info`,
+              title: getTitleForAxeResult(result),
+              description: getFriendlySummaryForAxeResult(result),
+              selectors,
+            },
+            {
+              id: `${tab}.${result.id}`,
+              iconLeft: 'info',
+              iconRight: 'shareAlt',
+              title: 'Learn how to resolve this violation',
+              clickEvent: EVENTS.SELECT,
+              selectors,
+            },
+          ];
+        }),
+      });
+    }
+  }, [isInitial, emit, highlighted, results, tab, selectedItems]);
 
   const discrepancy: TestDiscrepancy = useMemo(() => {
     if (!currentStoryA11yStatusValue) {


### PR DESCRIPTION
Closes #32135

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Prevent setting highlights for old a11y results. When switching stories, the a11y results from the previous story would apply highlights to the new story before the a11y results of the new story were ready, causing incorrect highlights to briefly appear. This is resolved by preventing a11y highlights from being set until the report is either running or ready (i.e. not `initial`).

**Before:**

Note how the outline buttons are already highlighted before the others.

https://github.com/user-attachments/assets/54c8b3aa-3a2f-4aac-8e8f-1b2e3002273a

**After:**

https://github.com/user-attachments/assets/b70fff54-90a4-43dd-86d3-c2bdfa3fe845

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Have two stories, one of which renders a component in multiple variants, and the other renders one identical variant and one whole new variant. When switching between the stories, the identical variant should yield identical classnames. Now enable a11y highlights (e.g. passing) and switch between the stories. All highlights should clear before new highlights are added. Previously the identical component would "inherit" the highlight from the other story due to the identical classname.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32178-sha-9b4c95c0`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32178-sha-9b4c95c0 sandbox` or in an existing project with `npx storybook@0.0.0-pr-32178-sha-9b4c95c0 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32178-sha-9b4c95c0`](https://npmjs.com/package/storybook/v/0.0.0-pr-32178-sha-9b4c95c0) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`clear-a11y-highlights-on-changed-story`](https://github.com/storybookjs/storybook/tree/clear-a11y-highlights-on-changed-story) |
| **Commit** | [`9b4c95c0`](https://github.com/storybookjs/storybook/commit/9b4c95c08b3f79bda67a2d26b15d083122419e94) |
| **Datetime** | Thu Aug 14 11:01:51 UTC 2025 (`1755169311`) |
| **Workflow run** | [16963328850](https://github.com/storybookjs/storybook/actions/runs/16963328850) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32178`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a UX issue in the Accessibility addon where highlights from the previous story would briefly flash on a new story before the new story's accessibility analysis completed. The change modifies the `A11yContextProvider` component in `A11yContext.tsx` to add a guard that prevents setting highlights when the addon status is `'initial'`.

The implementation adds an `isInitial` boolean flag that checks if the current status is `'initial'`, and updates the highlighting `useEffect` to return early when `!highlighted || isInitial`. This ensures highlights are only applied when the addon has progressed to either `'running'` or `'ready'` status, preventing stale highlights from appearing during story transitions.

Additionally, the PR adds defensive checks around `HIGHLIGHT` event emissions to only emit events when there are actual selectors to highlight, avoiding unnecessary empty highlight events. The `useEffect` dependency array is updated to include the `isInitial` flag to ensure proper re-evaluation when the status changes.

This change integrates well with the existing accessibility addon architecture, which already manages different status states (`'initial'`, `'running'`, `'ready'`) throughout the accessibility testing lifecycle. The fix addresses the timing issue without disrupting the core functionality of the accessibility analysis and reporting system.

## Confidence score: 4/5

• This is a focused bug fix that addresses a specific UX issue with minimal risk of breaking existing functionality
• The implementation follows existing patterns in the codebase and adds appropriate safeguards
• The change requires manual testing to verify the fix works as intended, as the issue involves timing and visual behavior during story transitions

<!-- /greptile_comment -->