### PR TITLE
Onboarding: Tweak referral wording in survey

### DIFF
--- a/code/addons/onboarding/src/features/IntentSurvey/IntentSurvey.tsx
+++ b/code/addons/onboarding/src/features/IntentSurvey/IntentSurvey.tsx
@@ -111,7 +111,7 @@ export const IntentSurvey = ({
       },
     },
     referrer: {
-      label: 'How did you learn about Storybook?',
+      label: 'How did you discover Storybook?',
       type: 'select',
       required: true,
       options: shuffleObject({


### PR DESCRIPTION
Closes N/A

## What I did

Update the wording of the referral question to clarify it

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR makes a minor but meaningful improvement to the onboarding survey in Storybook by updating the wording of a referral question. The change modifies a single line in the IntentSurvey component, replacing "How did you learn about Storybook?" with "How did you discover Storybook?" This text change is part of the onboarding addon, which helps new users get started with Storybook by collecting information about their background and how they found the tool.

The modification improves the clarity and accuracy of the survey question. The word "discover" better aligns with the intent of the question and the available answer options (such as "We use it at work", "Via friend or colleague", "Via social media"), which are about how users first encountered Storybook rather than how they learned to use it. This change enhances the user experience during the onboarding process by making the survey question more precise and intuitive.

## Confidence score: 5/5

- This PR is extremely safe to merge with no risk of issues
- Score reflects a simple, isolated text change with no functional impact on the codebase
- No files require special attention as this is a straightforward UI text improvement

<!-- /greptile_comment -->