### PR TITLE
CLI: Fix Docs migration link in migrations

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/helpers/logMigrationSummary.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/logMigrationSummary.test.ts
@@ -111,7 +111,7 @@ describe('logMigrationSummary', () => {
 
       The automigrations try to migrate common patterns in your project, but might not contain everything needed to migrate to the latest version of Storybook.
 
-      Please check the changelog and migration guide for manual migrations and more information: https://storybook.js.org/docs/migration-guide
+      Please check the changelog and migration guide for manual migrations and more information: https://storybook.js.org/docs/releases/migration-guide
       And reach out on Discord if you need help: https://discord.gg/storybook"
     `);
   });
@@ -132,7 +132,7 @@ describe('logMigrationSummary', () => {
 
       The automigrations try to migrate common patterns in your project, but might not contain everything needed to migrate to the latest version of Storybook.
 
-      Please check the changelog and migration guide for manual migrations and more information: https://storybook.js.org/docs/migration-guide
+      Please check the changelog and migration guide for manual migrations and more information: https://storybook.js.org/docs/releases/migration-guide
       And reach out on Discord if you need help: https://discord.gg/storybook"
     `);
   });
@@ -153,7 +153,7 @@ describe('logMigrationSummary', () => {
 
       The automigrations try to migrate common patterns in your project, but might not contain everything needed to migrate to the latest version of Storybook.
 
-      Please check the changelog and migration guide for manual migrations and more information: https://storybook.js.org/docs/migration-guide
+      Please check the changelog and migration guide for manual migrations and more information: https://storybook.js.org/docs/releases/migration-guide
       And reach out on Discord if you need help: https://discord.gg/storybook"
     `);
   });

--- a/code/lib/cli-storybook/src/automigrate/helpers/logMigrationSummary.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/logMigrationSummary.ts
@@ -63,7 +63,7 @@ export function logMigrationSummary({
     The automigrations try to migrate common patterns in your project, but might not contain everything needed to migrate to the latest version of Storybook.
     
     Please check the changelog and migration guide for manual migrations and more information: ${picocolors.yellow(
-      'https://storybook.js.org/docs/migration-guide'
+      'https://storybook.js.org/docs/releases/migration-guide'
     )}
     And reach out on Discord if you need help: ${picocolors.yellow('https://discord.gg/storybook')}
   `);


### PR DESCRIPTION
Follows up on:
- #32148
- #31662

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did
With this pull request the CLI, specifically the migration links, were updated to prevent them from 404ing as a result of #31662 getting merged and published

What was done:
- Updated the link in the migration summary and also the tests


@yannbf, I tagged you in this because you've been working a bit on the CLI and migrations and have some context on it. Let me know your feedback, and we'll go from there.

Thanks in advance

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a broken documentation link in the Storybook CLI that was causing 404 errors for users after running automigrations. The change updates the migration guide URL from `https://storybook.js.org/docs/migration-guide` to `https://storybook.js.org/docs/releases/migration-guide` in both the CLI output message and corresponding test snapshots.

The fix addresses a user experience issue where the CLI's migration summary was directing users to a non-existent page. This follows from a documentation restructuring (referenced in issues #32148 and #31662) where migration guides were moved under the `/docs/releases/` path. The change is limited to two files: the main migration summary helper that generates the CLI output message, and its test file that validates the expected output format.

This is a straightforward URL update that ensures users can access the migration documentation they need after upgrading Storybook versions. The change maintains the existing functionality while correcting the link destination to point to the valid location of the migration guide.

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only updates a URL string
- Score reflects the straightforward nature of fixing a broken link with no logic changes
- No files require special attention as the changes are simple URL updates

### Context used:
**Context -** In the documentation, ensure that the links to the builder's documentation and the Next.js framework documentation are correct and not broken. ([link](https://app.greptile.com/review/custom-context?memory=86992950-baea-4ad2-ba5f-71be57d01261))

<!-- /greptile_comment -->