### PR TITLE
Docs: Fix broken link in migration guide

### DIFF
--- a/docs/releases/migration-guide.mdx
+++ b/docs/releases/migration-guide.mdx
@@ -56,7 +56,7 @@ You may wish to read the [full migration notes][full-migration-notes] before mig
 
 ## Automatic upgrade
 
-To upgrade your Storybook, run the [upgrade](../configure/upgrading.mdx) command in the root of your repository:
+To upgrade your Storybook, run the [upgrade](./upgrading.mdx) command in the root of your repository:
 
 {/* prettier-ignore-start */}
 


### PR DESCRIPTION
## What I did

Corresponds with #32196

## Checklist for Contributors

### Testing

#### Manual testing

1. Confirm the updated link is correct

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a broken internal link in the Storybook migration guide documentation. The change updates a relative path from `../configure/upgrading.mdx` to `./upgrading.mdx` on line 59 of the migration guide file. This addresses a 404 error that was occurring after documentation restructuring where migration guides were moved under the `/docs/releases/` path.

The fix is straightforward - it corrects the link reference to point to the upgrading documentation within the same releases directory instead of trying to navigate to a non-existent configure directory. This ensures users can successfully access upgrade instructions when following links from the migration guide. The change aligns with Storybook's documentation structure and maintains the user experience by providing working navigation between related documentation pages.

## Confidence score: 5/5

- This PR is extremely safe to merge with no risk of breaking functionality
- Score reflects a simple documentation link fix with clear intent and minimal complexity  
- No files require special attention as this is a single-line documentation correction

### Context used:
**Context -** In the documentation, ensure that the links to the builder's documentation and the Next.js framework documentation are correct and not broken. ([link](https://app.greptile.com/review/custom-context?memory=86992950-baea-4ad2-ba5f-71be57d01261))

<!-- /greptile_comment -->