### PR TITLE
Docs: Fix incorrect @next version specifiers

### DIFF
--- a/docs/_snippets/init-command.md
+++ b/docs/_snippets/init-command.md
@@ -1,11 +1,11 @@
 ```shell renderer="common" language="js" packageManager="npm"
-npx storybook@next init
+npx storybook@latest init
 ```
 
 ```shell renderer="common" language="js" packageManager="pnpm"
-pnpm dlx storybook@next init
+pnpm dlx storybook@latest init
 ```
 
 ```shell renderer="common" language="js" packageManager="yarn"
-yarn dlx storybook@next init
+yarn dlx storybook@latest init
 ```

--- a/docs/_snippets/storybook-upgrade.md
+++ b/docs/_snippets/storybook-upgrade.md
@@ -1,11 +1,11 @@
 ```shell renderer="common" language="js" packageManager="npm"
-npx storybook@next upgrade
+npx storybook@latest upgrade
 ```
 
 ```shell renderer="common" language="js" packageManager="pnpm"
-pnpm dlx storybook@next upgrade
+pnpm dlx storybook@latest upgrade
 ```
 
 ```shell renderer="common" language="js" packageManager="yarn"
-yarn dlx storybook@next upgrade
+yarn dlx storybook@latest upgrade
 ```

--- a/docs/get-started/frameworks/angular.mdx
+++ b/docs/get-started/frameworks/angular.mdx
@@ -276,7 +276,7 @@ export const WithCustomProvider: Story = {
 
 The Storybook [Angular builder](https://angular.io/guide/glossary#builder) is a way to run Storybook in an Angular workspace. It is a drop-in replacement for running `storybook dev` and `storybook build` directly.
 
-You can run `npx storybook@next automigrate` to try letting Storybook detect and automatically fix your configuration. Otherwise, you can follow the next steps to adjust your configuration manually.
+You can run `npx storybook@latest automigrate` to try letting Storybook detect and automatically fix your configuration. Otherwise, you can follow the next steps to adjust your configuration manually.
 
 #### Do you have only one Angular project in your workspace?
 


### PR DESCRIPTION
## What I did

Replace `@next` version specifiers with `@latest` in docs snippets and code examples.

(Note that this PR targets `main`, to only affect the latest docs.)

## Checklist for Contributors

### Testing

#### Manual testing

N/A

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- greptile_comment -->

## Greptile Summary

This pull request updates Storybook documentation to replace `@next` version specifiers with `@latest` across multiple documentation files and code snippets. The changes affect three key files:

1. **docs/get-started/frameworks/angular.mdx** - Updates the automigrate command example to use `@latest` instead of `@next`
2. **docs/_snippets/init-command.md** - Changes initialization commands for all package managers (npm, pnpm, yarn) to use `@latest`
3. **docs/_snippets/storybook-upgrade.md** - Updates upgrade commands across all package managers to use `@latest`

The change ensures that documentation examples direct users to the stable latest version of Storybook rather than pre-release versions. This is important because `@next` typically refers to pre-release or beta versions that may be unstable, while `@latest` refers to the most recent stable release. Since this PR targets the `main` branch (which affects the production documentation), it makes sense to standardize on `@latest` to provide users with stable, production-ready versions by default.

These snippet files are likely included in multiple documentation pages throughout the Storybook docs, so this change will have a broad impact on user-facing installation and upgrade instructions. The change aligns with standard package management practices and ensures consistency across all package manager examples.

## Confidence score: 5/5

- This PR is extremely safe to merge with minimal risk
- Score reflects simple documentation changes with no code logic modifications
- No files require special attention as these are straightforward text replacements

<!-- /greptile_comment -->