### PR TITLE
Mock: Catch errors when transforming preview files

### DIFF
--- a/code/core/src/core-server/presets/vitePlugins/vite-mock/plugin.ts
+++ b/code/core/src/core-server/presets/vitePlugins/vite-mock/plugin.ts
@@ -167,7 +167,12 @@ export function viteMockPlugin(options: MockPluginOptions): Plugin[] {
       name: 'storybook:mock-loader-preview',
       transform(code, id) {
         if (id === normalizedPreviewConfigPath) {
-          return rewriteSbMockImportCalls(code);
+          try {
+            return rewriteSbMockImportCalls(code);
+          } catch (e) {
+            logger.debug(`Could not transform sb.mock(import(...)) calls: ${e}`);
+            return null;
+          }
         }
         return null;
       },

--- a/code/core/src/core-server/presets/vitePlugins/vite-mock/plugin.ts
+++ b/code/core/src/core-server/presets/vitePlugins/vite-mock/plugin.ts
@@ -170,7 +170,7 @@ export function viteMockPlugin(options: MockPluginOptions): Plugin[] {
           try {
             return rewriteSbMockImportCalls(code);
           } catch (e) {
-            logger.debug(`Could not transform sb.mock(import(...)) calls: ${e}`);
+            logger.debug(`Could not transform sb.mock(import(...)) calls in ${id}: ${e}`);
             return null;
           }
         }

--- a/code/core/src/core-server/presets/webpack/loaders/storybook-mock-transform-loader.ts
+++ b/code/core/src/core-server/presets/webpack/loaders/storybook-mock-transform-loader.ts
@@ -1,15 +1,29 @@
-import type { LoaderContext } from 'webpack';
+import { logger } from 'storybook/internal/node-logger';
+
+import type { LoaderDefinition } from 'webpack';
 
 import { rewriteSbMockImportCalls } from '../../../mocking-utils/extract';
 
 /**
  * A Webpack loader that normalize sb.mock(import(...)) calls to sb.mock(...)
  *
- * @param {string} source The original source code of the preview config file.
- * @this {LoaderContext<{}>} The Webpack loader context.
+ * @param source The original source code of the preview config file.
+ * @this The Webpack loader context.
  */
-export default function storybookMockTransformLoader(this: LoaderContext<{}>, source: string) {
-  const result = rewriteSbMockImportCalls(source);
+const storybookMockTransformLoader: LoaderDefinition = function mockTransformLoaderFn(
+  source,
+  sourceMap,
+  meta
+) {
   const callback = this.async();
-  callback(null, result.code, result.map || undefined);
-}
+
+  try {
+    const result = rewriteSbMockImportCalls(source);
+    callback(null, result.code, result.map || undefined, meta);
+  } catch (error) {
+    logger.debug(`Could not transform sb.mock(import(...)) calls: ${error}`);
+    callback(null, source, sourceMap, meta);
+  }
+};
+
+export default storybookMockTransformLoader;

--- a/code/core/src/core-server/presets/webpack/loaders/storybook-mock-transform-loader.ts
+++ b/code/core/src/core-server/presets/webpack/loaders/storybook-mock-transform-loader.ts
@@ -21,7 +21,8 @@ const storybookMockTransformLoader: LoaderDefinition = function mockTransformLoa
     const result = rewriteSbMockImportCalls(source);
     callback(null, result.code, result.map || undefined, meta);
   } catch (error) {
-    logger.debug(`Could not transform sb.mock(import(...)) calls: ${error}`);
+    const filePath = this.resourcePath;
+    logger.debug(`Could not transform sb.mock(import(...)) calls in ${filePath}: ${error}`);
     callback(null, source, sourceMap, meta);
   }
 };


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32192

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have added error handling when parsing and transforming preview files in the context of module mocking. When a preview file cannot be parsed, Storybook shouldn't crash, but rather log the error (debug loglevel)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds defensive error handling to Storybook's module mocking system when transforming preview files containing `sb.mock()` calls. The changes affect two key components: the Vite plugin and Webpack loader responsible for parsing and transforming these files.

The implementation wraps the `rewriteSbMockImportCalls` function in try-catch blocks in both transformation pipelines. When parsing or transformation fails, instead of crashing the build process, the system now logs a debug message and gracefully degrades - the Vite plugin returns `null` while the Webpack loader returns the original untransformed source code.

This change addresses issue #32192 where overly permissive regex patterns were causing build failures for files with 'preview' in their names (like 'my-orders-preview.ts') that aren't actually Storybook preview configuration files. The error handling follows an existing pattern in the codebase where `extractMockCalls` already has similar defensive error handling, making the mocking system more resilient to edge cases.

The changes integrate well with Storybook's existing error handling philosophy of graceful degradation rather than hard failures, ensuring that build processes continue even when individual files cannot be processed by the mocking transformation pipeline.

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it adds defensive error handling without changing core functionality
- Score reflects well-implemented error handling that follows existing patterns, but lacks automated test coverage
- Pay close attention to the transformation logic to ensure the fallback behavior works correctly in production scenarios

<!-- /greptile_comment -->