### PR TITLE
Telemetry: Improve dev cancellation handling

### DIFF
--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -151,6 +151,7 @@ export async function storybookDevServer(options: Options) {
 
   if (!core?.disableTelemetry) {
     process.on('SIGINT', cancelTelemetry);
+    process.on('SIGTERM', cancelTelemetry);
   }
 
   return { previewResult, managerResult, address, networkAddress };


### PR DESCRIPTION
Closes N/A

## What I did

Fix for https://github.com/storybookjs/storybook/pull/32168. The previous PR works when you run the process directly in node and cancel out with the keyboard. However, when you run through an outer process like `nr storybook` it does not get the `SIGINT` signal. This attempts to fix that case.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Install the canary in a project
2. Run it with `STORYBOOK_TELEMETRY_DEBUG=1 nr storybook`
3. Kill it with ctrl-C and verify that the `canceled` event is sent.

**⚠️ NOTE: this does not fix the problem. But it hopefully fixes other related issues.**

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32218-sha-525e5323`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32218-sha-525e5323 sandbox` or in an existing project with `npx storybook@0.0.0-pr-32218-sha-525e5323 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32218-sha-525e5323`](https://npmjs.com/package/storybook/v/0.0.0-pr-32218-sha-525e5323) |
| **Triggered by** | @shilman |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`shilman/fix-cancel-telemetry`](https://github.com/storybookjs/storybook/tree/shilman/fix-cancel-telemetry) |
| **Commit** | [`525e5323`](https://github.com/storybookjs/storybook/commit/525e53236513b96eb152b4919612122a0e3b71c4) |
| **Datetime** | Fri Aug  8 02:07:25 UTC 2025 (`1754618845`) |
| **Workflow run** | [16820177616](https://github.com/storybookjs/storybook/actions/runs/16820177616) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32218`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds SIGTERM signal handling to improve telemetry cancellation when Storybook is terminated through wrapper processes. The change is minimal but important - it adds a single line in `code/core/src/core-server/dev-server.ts` that registers the existing `cancelTelemetry` function to handle SIGTERM signals alongside the existing SIGINT handler.

The core issue being addressed is that when Storybook runs through process managers or wrapper commands like `nr storybook`, the SIGINT signal (typically sent by Ctrl-C) doesn't always propagate properly to the Node.js process. SIGTERM is the standard termination signal used by most process managers and container orchestrators for graceful shutdowns. By adding SIGTERM handling, the PR ensures telemetry data is properly sent even when Storybook is terminated through these wrapper processes.

This change integrates seamlessly with the existing signal handling architecture in Storybook's development server. The implementation follows the same pattern as the SIGINT handler, maintaining consistency in the codebase and ensuring that the same telemetry cleanup process runs regardless of which termination signal is received.

## Confidence score: 5/5

- This PR is extremely safe to merge with virtually no risk of causing issues
- Score reflects the minimal, well-understood change that follows existing patterns and addresses a legitimate operational concern
- No files require special attention - the single line addition is straightforward and follows established conventions

<!-- /greptile_comment -->