### PR TITLE
feat: re-export Assertion and util from `chai`

### DIFF
--- a/code/core/src/test/index.ts
+++ b/code/core/src/test/index.ts
@@ -3,11 +3,12 @@ import type { userEvent } from '@testing-library/user-event';
 
 import { instrument } from 'storybook/internal/instrumenter';
 
-import { Assertion } from 'chai';
+import { Assertion, util } from 'chai';
 
 import { expect as rawExpect } from './expect';
 import { type queries } from './testing-library';
 
+export { Assertion, util }
 export * from './spy';
 
 type Queries = BoundFunctions<typeof queries>;


### PR DESCRIPTION
Closes #32222

## What I did

Re-export `Assertion` and `util` from `chai` to enable more customization to `expect`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR re-exports the `Assertion` class and `util` object from the chai testing library through Storybook's test module (`code/core/src/test/index.ts`). The change addresses issue #32222 by exposing chai's internal APIs to enable more customization of the `expect` function.

The `Assertion` class was already being imported and used internally within the `getKeys` function to identify chai assertion objects and handle their property enumeration differently. By re-exporting it along with chai's `util` object, users now have access to the low-level building blocks needed to create custom assertions and extend the testing framework's capabilities.

This change integrates seamlessly with Storybook's existing test infrastructure. The codebase already uses chai extensively through its custom `expect` implementation (as seen in `code/core/src/test/expect.ts`), which combines chai assertions with Jest-style matchers. This PR simply makes more of chai's API surface available to end users without changing any existing functionality.

## Confidence score: 5/5

- This PR is extremely safe to merge with virtually no risk of breaking existing functionality
- Score reflects the minimal nature of the change - only adding new exports without modifying existing behavior
- No files require special attention as this is a straightforward API expansion

<!-- /greptile_comment -->