### PR TITLE
Angular: Fix `entry.polyfills` undefined error

### DIFF
--- a/code/frameworks/angular/src/server/angular-cli-webpack.js
+++ b/code/frameworks/angular/src/server/angular-cli-webpack.js
@@ -158,6 +158,7 @@ exports.getWebpackConfig = async (baseConfig, { builderOptions, builderContext }
   );
 
   if (!builderOptions.experimentalZoneless && !cliConfig.entry.polyfills?.includes('zone.js')) {
+    cliConfig.entry.polyfills ??= [];
     cliConfig.entry.polyfills.push('zone.js');
   }
 


### PR DESCRIPTION
When cliConfig.entry.polyfills is undefined

Closes #32229

## What I did

Make sure `cliConfig.entry.polyfills` is defined before adding `zone.js` to it.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

No manual test is necessary. The fix is trivial.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a critical runtime error in Storybook's Angular framework integration. The issue occurred when `cliConfig.entry.polyfills` was undefined and the code attempted to call `.push('zone.js')` on it, resulting in a "Cannot read properties of undefined (reading 'push')" error.

The fix is elegantly simple: adding a single line `cliConfig.entry.polyfills ??= [];` before the push operation. This uses the nullish coalescing assignment operator to initialize an empty array only if the polyfills property is null or undefined, leaving existing arrays untouched.

The change is located in `code/frameworks/angular/src/server/angular-cli-webpack.js` within the zone.js injection logic. This code runs when Storybook processes Angular projects that aren't using the experimental zoneless mode. The bug was introduced in PR #30941, which added optional chaining for the condition check but didn't account for the undefined case in the subsequent array operation.

This fix integrates seamlessly with the existing codebase's error handling patterns and maintains backward compatibility. Angular's webpack configuration can legitimately have undefined polyfills arrays in certain project setups, so this defensive programming approach prevents crashes while preserving all existing functionality.

## Confidence score: 5/5

- This PR is extremely safe to merge with virtually no risk of introducing issues
- Score reflects the minimal, targeted nature of the fix that directly addresses a well-defined bug without side effects
- No files require special attention - the single-line change is straightforward and uses standard JavaScript patterns

<!-- /greptile_comment -->