### PR TITLE
Build: Fix react native expo e2e tests

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -7,6 +7,7 @@ import {
   ensureDir,
   ensureSymlink,
   existsSync,
+  mkdir,
   pathExists,
   readFile,
   readFileSync,
@@ -155,6 +156,13 @@ export const init: Task['run'] = async (
     extra = { type: 'server' };
   } else if (template.expected.framework === '@storybook/react-native-web-vite') {
     extra = { type: 'react_native_web' };
+  }
+
+  switch (template.expected.framework) {
+    case '@storybook/react-native-web-vite':
+      await prepareReactNativeWebSandbox(cwd);
+      break;
+    default:
   }
 
   await executeCLIStep(steps.init, {
@@ -839,6 +847,14 @@ export async function setImportMap(cwd: string) {
   };
 
   await writeJson(join(cwd, 'package.json'), packageJson, { spaces: 2 });
+}
+
+async function prepareReactNativeWebSandbox(cwd: string) {
+  // Make it so that RN sandboxes have stories in src/stories similar to
+  // other react sandboxes, for consistency.
+  if (!(await pathExists(join(cwd, 'src')))) {
+    await mkdir(join(cwd, 'src'));
+  }
 }
 
 async function prepareAngularSandbox(cwd: string, templateName: string) {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes end-to-end test failures for the React Native Expo template by making two targeted changes. The first change improves the robustness of the `isReactSandbox` utility function by refactoring it to use explicit null checking and optional chaining, preventing runtime errors when template lookups fail. The second change modifies the React Native Expo sandbox template creation script to establish the expected directory structure by moving the default `app` directory into `src/app` after project creation.

These changes address infrastructure issues in the testing pipeline where the e2e tests expected a specific project structure that wasn't being created by the default `create-expo-app` command. The utility function improvement adds defensive programming practices that make the template lookup more resilient to edge cases. Both changes are focused on internal testing infrastructure and don't affect user-facing functionality.

PR Description Notes:
- The PR description is missing details about what was actually done - the "What I did" section is empty
- No manual testing steps are provided despite the checklist requirement
- No automated test coverage is indicated

## Confidence score: 4/5

- This PR is safe to merge with low risk of production issues
- Score reflects solid defensive programming improvements and targeted test infrastructure fixes
- Pay attention to the React Native Expo template configuration and utility function error handling

<!-- /greptile_comment -->