### PR TITLE
Canary: Auto trigger canary release based on branch name ending

### DIFF
--- a/.github/workflows/canary-release-pr.yml
+++ b/.github/workflows/canary-release-pr.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: "Pull request number to create a canary release for"
+        description: 'Pull request number to create a canary release for'
         required: true
         type: number
   pull_request:
@@ -27,7 +27,7 @@ jobs:
     name: Release canary version
     runs-on: ubuntu-latest
     environment: release
-    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'sb10/esm-only'
+    if: github.event_name == 'workflow_dispatch' || endsWith(github.head_ref, 'with-canary-release')
     steps:
       - name: Fail if triggering actor is not administrator
         uses: prince-chrismc/check-actor-permissions-action@v2.0.4
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: '.nvmrc'
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -97,7 +97,7 @@ jobs:
         with:
           githubToken: ${{ secrets.GH_TOKEN }}
           prNumber: ${{ github.event_name == 'workflow_dispatch' && inputs.pr || '' }}
-          find: "CANARY_RELEASE_SECTION"
+          find: 'CANARY_RELEASE_SECTION'
           isHtmlCommentTag: true
           replace: |
             This pull request has been released as version `${{ steps.version.outputs.next-version }}`. Try it out in a new sandbox by running `npx storybook@${{ steps.version.outputs.next-version }} sandbox` or in an existing project with `npx storybook@${{ steps.version.outputs.next-version }} upgrade`.


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR automates the canary release process by modifying the `.github/workflows/canary-release-pr.yml` workflow to automatically trigger canary releases based on branch naming conventions. The key changes include:

1. **Automatic triggering**: Added a `pull_request` trigger that responds to opened, synchronized, and reopened events, eliminating the need for manual workflow dispatch in many cases
2. **Branch name pattern matching**: Changed from checking a hardcoded branch name (`sb10/esm-only`) to checking if any branch name ends with `with-canary-release`, making the system more flexible and scalable
3. **Conditional logic update**: Modified the workflow condition to `github.event_name == 'workflow_dispatch' || endsWith(github.head_ref, 'with-canary-release')` to support both manual and automatic triggers
4. **Style improvements**: Updated quote styles from double to single quotes throughout the workflow file

This change transforms the canary release workflow from a manual, single-branch system to an automated, pattern-based system. Contributors and maintainers can now trigger canary releases by simply naming their branches with the `with-canary-release` suffix, reducing manual overhead and providing a self-service mechanism for getting canary builds. The workflow maintains backward compatibility with manual triggers while adding the new automatic capability.

PR Description Notes:
- The PR description is incomplete - the "What I did" section is empty and should describe the automation changes
- No issue number is provided in the "Closes #" section
- Testing and documentation checklists are not filled out

## Confidence score: 2/5

- This PR introduces significant security and resource concerns by allowing external contributors to trigger expensive canary releases automatically
- Score reflects the potential for abuse and unintended resource consumption, plus possible authentication issues with the admin permission check
- Pay close attention to the security implications of the new pull_request trigger and consider adding additional safeguards

<!-- /greptile_comment -->