### PR TITLE
fixed 32263

### DIFF
--- a/code/core/src/instrumenter/instrumenter.ts
+++ b/code/core/src/instrumenter/instrumenter.ts
@@ -228,7 +228,7 @@ export class Instrumenter {
         return resetState({ storyId, renderPhase: newPhase, isDebugging });
       }
 
-      if (newPhase === 'played') {
+      if (newPhase === 'played' || newPhase === 'testing' || newPhase === 'tested') {
         this.setState(storyId, {
           renderPhase: newPhase,
           isLocked: false,
@@ -599,7 +599,10 @@ export class Instrumenter {
     };
 
     try {
-      if (renderPhase === 'played' && !call.retain) {
+      if (
+        (renderPhase === 'played' || renderPhase === 'testing' || renderPhase === 'tested') &&
+        !call.retain
+      ) {
         throw alreadyCompletedException;
       }
 

--- a/code/core/src/preview-api/modules/preview-web/render/StoryRender.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/StoryRender.test.ts
@@ -247,6 +247,7 @@ describe('StoryRender', () => {
         expect(render.phase).toBe('loading');
         await mount();
         expect(render.phase).toBe('playing');
+        await tick();
         expect(render.phase).toBe('played');
       },
     });

--- a/code/core/src/preview-api/modules/preview-web/render/StoryRender.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/StoryRender.test.ts
@@ -83,6 +83,7 @@ describe('StoryRender', () => {
 
     await render.renderToElement({} as any);
     expect(story.playFunction).toHaveBeenCalled();
+    expect(render.phase).toBe('played');
   });
 
   it('does not run play function if passed autoplay=false', async () => {
@@ -143,6 +144,7 @@ describe('StoryRender', () => {
       expect(story.applyLoaders).toHaveBeenCalledTimes(2);
       expect(renderToScreen).toHaveBeenCalledTimes(2);
       expect(story.playFunction).toHaveBeenCalledOnce();
+      expect(render.phase).toBe('played');
     });
   });
 
@@ -245,6 +247,7 @@ describe('StoryRender', () => {
         expect(render.phase).toBe('loading');
         await mount();
         expect(render.phase).toBe('playing');
+        expect(render.phase).toBe('played');
       },
     });
     const render = new StoryRender(
@@ -262,6 +265,7 @@ describe('StoryRender', () => {
 
     await render.renderToElement({} as any);
     expect(actualMount).toHaveBeenCalled();
+    expect(render.phase).toBe('played');
   });
 
   it('should handle the "finished" phase correctly when the story finishes successfully', async () => {
@@ -469,6 +473,7 @@ describe('StoryRender', () => {
 
       // Assert - window is reloaded
       await vi.waitFor(() => {
+        expect(render.phase).toBe('played');
         expect(window.location.reload).toHaveBeenCalledOnce();
         expect(store.cleanupStory).toHaveBeenCalledOnce();
       });

--- a/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
@@ -40,6 +40,8 @@ export type RenderPhase =
   | 'rendering'
   | 'playing'
   | 'played'
+  | 'testing'
+  | 'tested'
   | 'completing'
   | 'completed'
   | 'afterEach'
@@ -349,7 +351,20 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
           if (!ignoreUnhandledErrors && unhandledErrors.size > 0) {
             await this.runPhase(abortSignal, 'errored');
           } else {
-            await this.runPhase(abortSignal, 'played');
+            try {
+              // Played phase
+              await this.runPhase(abortSignal, 'played');
+
+              // Testing phase
+              await this.runPhase(abortSignal, 'testing');
+
+              // Tested phase
+              await this.runPhase(abortSignal, 'tested');
+            } catch (error) {
+              // Handle errors gracefully and propagate to Instrumenter
+              console.error('Error during render phases:', error);
+              throw error;
+            }
           }
         } catch (error) {
           // Remove the loading screen, even if there was an error before rendering


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds two new render phases, 'testing' and 'tested', to Storybook's story render lifecycle. The changes extend the existing story execution flow to include these phases after the 'played' phase, creating a sequential execution pattern: played → testing → tested.

The implementation touches three core files:

**StoryRender.ts**: Adds 'testing' and 'tested' to the `RenderPhase` type union and implements the execution flow. After the 'played' phase completes, the code now runs `runPhase(abortSignal, 'testing')` followed by `runPhase(abortSignal, 'tested')` within a try-catch block that logs and re-throws any errors.

**instrumenter.ts**: Updates the instrumenter logic to handle the new phases consistently with the existing 'played' phase. When transitioning to 'testing' or 'tested' phases, the instrumenter sets `isLocked: false`, `isPlaying: false`, and `isDebugging: false`. It also prevents function calls during these completion phases unless explicitly retained via the `retain` flag.

**StoryRender.test.ts**: Adds test assertions to verify that the render phase correctly transitions to 'played' after play functions complete, providing test coverage for the phase tracking mechanism.

These changes appear to support a testing framework integration that allows automated tests to run on stories after their play functions complete. The instrumenter updates ensure that debugging and interaction features work consistently across all completion phases, maintaining the same behavior expectations users have with the 'played' phase.

PR Description Notes:
- The PR body is incomplete - it references "Closes #" without specifying an issue number, and the "What I did" section is empty
- None of the testing or documentation checkboxes are marked, despite the PR making functional changes that should have corresponding tests

## Confidence score: 2/5

- This PR has significant issues that prevent it from being safely merged
- Score lowered due to problematic test logic with duplicate phase assertions and potential race conditions in async testing
- Pay close attention to StoryRender.test.ts where test assertions may not properly wait for async phase transitions

<!-- /greptile_comment -->