### PR TITLE
Docs: Update ERRORS.md

### DIFF
--- a/code/core/src/ERRORS.md
+++ b/code/core/src/ERRORS.md
@@ -7,15 +7,15 @@ Storybook errors reside in this package and are categorized into:
 1. **[Preview errors](./preview-errors.ts)**
    - Errors which occur in the preview part of Storybook (where user code executes)
    - e.g. Rendering issues, etc.
-   - available in `@storybook/core-events/preview-errors`
+   - available in `storybook/internal/preview-errors`
 2. **[Manager errors](./manager-errors.ts)**
    - Errors which occur in the manager part of Storybook (manager UI)
    - e.g. Sidebar, addons, Storybook UI, Storybook router, etc.
-   - available in `@storybook/core-events/server-errors`
+   - available in `storybook/internal/server-errors`
 3. **[Server errors](./server-errors.ts)**
    - Errors which occur in node
    - e.g. Storybook init command, dev command, builder errors (Webpack, Vite), etc.
-   - available in `@storybook/core-events/server-errors`
+   - available in `storybook/internal/server-errors`
 
 ## How to create errors
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR updates the ERRORS.md documentation file to reflect a package reorganization within the Storybook codebase. The changes update import paths from the old `@storybook/core-events/...` format to the new `storybook/internal/...` format for error handling modules.

Specifically, the documentation now instructs developers to import:
- Preview errors from `storybook/internal/preview-errors`
- Manager errors from `storybook/internal/server-errors` (this appears to be incorrect)
- Server errors from `storybook/internal/server-errors`

This change is part of Storybook's broader effort to better distinguish between public and internal APIs. The new `storybook/internal/...` paths clearly mark these error classes as internal APIs that shouldn't be consumed by external users, which is a more appropriate categorization since these are low-level error handling utilities primarily used within Storybook's own architecture.

The update ensures that developers working on Storybook internals or writing advanced integrations have the correct import paths for accessing these error classes, which are essential for proper error handling across the preview, manager, and server components of Storybook.

## Confidence score: 2/5

- This PR contains a critical documentation error that will mislead developers
- Score reflects the presence of incorrect import path mapping that could cause confusion
- Pay close attention to line 14 where manager errors are incorrectly mapped to server-errors path

<!-- /greptile_comment -->