### PR TITLE
Telemetry: Add query-parameter to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@
 </p>
 
 <p align="center">
-Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. Find out more at https://storybook.js.org/?utm_source=readme!
+Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. Find out more at <a href="https://storybook.js.org/?utm_source=readme">storybook.js.org</a>!
 </p>
 
 <center>
-  <img src="https://raw.githubusercontent.com/storybookjs/storybook/main/media/storybook-intro.gif" width="100%" />
+  <img src="https://raw.githubusercontent.com/storybookjs/storybook/refs/heads/release-6-5/media/storybook-intro.gif" width="100%" />
 </center>
 
 <p align="center">
@@ -108,7 +108,7 @@ For additional help, share your issue in [the repo's GitHub Discussions](https:/
 | [Svelte](code/renderers/svelte)                                | [![Storybook demo](https://img.shields.io/npm/v/@storybook/svelte/latest?style=flat-square&color=blue&label)](https://next--630873996e4e3557791c069c.chromatic.com/)         | [![Svelte](https://img.shields.io/npm/dm/@storybook/svelte?style=flat-square&color=eee)](code/renderers/svelte)                                       |
 | [Preact](code/renderers/preact)                                | [![Storybook demo](https://img.shields.io/npm/v/@storybook/preact/latest?style=flat-square&color=blue&label)](https://next--63b588a512565bfaace15e7c.chromatic.com/)         | [![Preact](https://img.shields.io/npm/dm/@storybook/preact?style=flat-square&color=eee)](code/renderers/preact)                                       |
 | [Qwik](https://github.com/literalpie/storybook-framework-qwik) | [![](https://img.shields.io/npm/v/storybook-framework-qwik/latest?style=flat-square&color=blue&label)](/)                                                                    | [![Qwik](https://img.shields.io/npm/dm/storybook-framework-qwik?style=flat-square&color=eee)](https://github.com/literalpie/storybook-framework-qwik) |
-| [SolidJS](https://github.com/solidjs-community/storybook)              | [![](https://img.shields.io/npm/v/storybook-solidjs-vite/latest?style=flat-square&color=blue&label)](/)                                                                           | [![SolidJS](https://img.shields.io/npm/dm/storybook-solidjs-vite?style=flat-square&color=eee)](https://github.com/solidjs-community/storybook)                     |
+| [SolidJS](https://github.com/solidjs-community/storybook)      | [![](https://img.shields.io/npm/v/storybook-solidjs-vite/latest?style=flat-square&color=blue&label)](/)                                                                      | [![SolidJS](https://img.shields.io/npm/dm/storybook-solidjs-vite?style=flat-square&color=eee)](https://github.com/solidjs-community/storybook)        |
 | [Android, iOS, Flutter](https://github.com/storybookjs/native) | [![](https://img.shields.io/npm/v/@storybook/native/latest?style=flat-square&color=blue&label)](/)                                                                           | [![Native](https://img.shields.io/npm/dm/@storybook/native?style=flat-square&color=eee)](https://github.com/storybookjs/native)                       |
 
 ### Addons

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://storybook.js.org/?utm_source=readme">
+  <a href="https://storybook.js.org/?ref=readme">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/263385/199832481-bbbf5961-6a26-481d-8224-51258cce9b33.png">
       <img src="https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png" alt="Storybook" width="400" />
@@ -27,7 +27,7 @@
   <a href="https://discord.gg/storybook">
     <img src="https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat" />
   </a>
-  <a href="https://storybook.js.org/community/?utm_source=readme">
+  <a href="https://storybook.js.org/community/?ref=readme">
     <img src="https://img.shields.io/badge/community-join-4BC424.svg" alt="Storybook Community" />
   </a>
   <a href="#backers">
@@ -45,7 +45,7 @@
 </p>
 
 <p align="center">
-Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. Find out more at <a href="https://storybook.js.org/?utm_source=readme">storybook.js.org</a>!
+Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. Find out more at <a href="https://storybook.js.org/?ref=readme">storybook.js.org</a>!
 </p>
 
 <center>
@@ -74,19 +74,19 @@ Storybook is a frontend workshop for building UI components and pages in isolati
 
 ## Getting Started
 
-Visit [Storybook's website](https://storybook.js.org/?utm_source=readme) to learn more about Storybook and to get started.
+Visit [Storybook's website](https://storybook.js.org/?ref=readme) to learn more about Storybook and to get started.
 
 ### Documentation
 
-Documentation can be found on [Storybook's docs site](https://storybook.js.org/docs?utm_source=readme).
+Documentation can be found on [Storybook's docs site](https://storybook.js.org/docs?ref=readme).
 
 ### Examples
 
-View [Component Encyclopedia](https://storybook.js.org/showcase?utm_source=readme) to see how leading teams use Storybook.
+View [Component Encyclopedia](https://storybook.js.org/showcase?ref=readme) to see how leading teams use Storybook.
 
 Use [storybook.new](https://storybook.new) to quickly create an example project in Stackblitz.
 
-Storybook comes with a lot of [addons](https://storybook.js.org/docs/configure/user-interface/storybook-addons?utm_source=readme) for component design, documentation, testing, interactivity, and so on. Storybook's API makes it possible to configure and extend in various ways. It has even been extended to support React Native, Android, iOS, and Flutter development for mobile.
+Storybook comes with a lot of [addons](https://storybook.js.org/docs/configure/user-interface/storybook-addons?ref=readme) for component design, documentation, testing, interactivity, and so on. Storybook's API makes it possible to configure and extend in various ways. It has even been extended to support React Native, Android, iOS, and Flutter development for mobile.
 
 ### Community
 
@@ -131,7 +131,7 @@ For additional help, share your issue in [the repo's GitHub Discussions](https:/
 | [query params](https://github.com/storybookjs/addon-queryparams)          | Mock query params                                                          |
 | [viewport](code/core/src/viewport/)                                       | Change display sizes and layouts for responsive components using Storybook |
 
-See [Addon / Framework Support Table](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?utm_source=readme)
+See [Addon / Framework Support Table](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?ref=readme)
 
 To continue improving your experience, we have to eventually deprecate or remove certain addons in favor of new and better tools.
 
@@ -139,7 +139,7 @@ If you're using info/notes, we highly recommend you migrate to [docs](code/addon
 
 If you're using contexts, we highly recommend you migrate to [toolbars](https://github.com/storybookjs/storybook/tree/next/code/addons/toolbars) and [here is a guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-addon-contexts) to help you.
 
-If you're using addon-storyshots, we highly recommend you migrate to the Storybook [test-runner](https://github.com/storybookjs/test-runner) and [here is a guide](https://storybook.js.org/docs/writing-tests/storyshots-migration-guide?utm_source=readme) to help you.
+If you're using addon-storyshots, we highly recommend you migrate to the Storybook [test-runner](https://github.com/storybookjs/test-runner) and [here is a guide](https://storybook.js.org/docs/writing-tests/storyshots-migration-guide?ref=readme) to help you.
 
 ## Badges & Presentation materials
 
@@ -156,7 +156,7 @@ If you're looking for material to use in your Storybook presentation, such as lo
 ## Community
 
 - Tweeting via [@storybookjs](https://x.com/storybookjs)
-- Blogging at [storybook.js.org](https://storybook.js.org/blog/?utm_source=readme) and [Medium](https://medium.com/storybookjs)
+- Blogging at [storybook.js.org](https://storybook.js.org/blog/?ref=readme) and [Medium](https://medium.com/storybookjs)
 - Chatting on [Discord](https://discord.gg/storybook)
 - Videos and streams at [YouTube](https://www.youtube.com/channel/UCr7Quur3eIyA_oe8FNYexfg)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://storybook.js.org/">
+  <a href="https://storybook.js.org/?utm_source=readme">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/263385/199832481-bbbf5961-6a26-481d-8224-51258cce9b33.png">
       <img src="https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png" alt="Storybook" width="400" />
@@ -27,7 +27,7 @@
   <a href="https://discord.gg/storybook">
     <img src="https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat" />
   </a>
-  <a href="https://storybook.js.org/community/">
+  <a href="https://storybook.js.org/community/?utm_source=readme">
     <img src="https://img.shields.io/badge/community-join-4BC424.svg" alt="Storybook Community" />
   </a>
   <a href="#backers">
@@ -45,7 +45,7 @@
 </p>
 
 <p align="center">
-Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. Find out more at https://storybook.js.org!
+Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. Find out more at https://storybook.js.org/?utm_source=readme!
 </p>
 
 <center>
@@ -74,19 +74,19 @@ Storybook is a frontend workshop for building UI components and pages in isolati
 
 ## Getting Started
 
-Visit [Storybook's website](https://storybook.js.org) to learn more about Storybook and to get started.
+Visit [Storybook's website](https://storybook.js.org/?utm_source=readme) to learn more about Storybook and to get started.
 
 ### Documentation
 
-Documentation can be found on [Storybook's docs site](https://storybook.js.org/docs).
+Documentation can be found on [Storybook's docs site](https://storybook.js.org/docs?utm_source=readme).
 
 ### Examples
 
-View [Component Encyclopedia](https://storybook.js.org/showcase) to see how leading teams use Storybook.
+View [Component Encyclopedia](https://storybook.js.org/showcase?utm_source=readme) to see how leading teams use Storybook.
 
 Use [storybook.new](https://storybook.new) to quickly create an example project in Stackblitz.
 
-Storybook comes with a lot of [addons](https://storybook.js.org/docs/configure/user-interface/storybook-addons) for component design, documentation, testing, interactivity, and so on. Storybook's API makes it possible to configure and extend in various ways. It has even been extended to support React Native, Android, iOS, and Flutter development for mobile.
+Storybook comes with a lot of [addons](https://storybook.js.org/docs/configure/user-interface/storybook-addons?utm_source=readme) for component design, documentation, testing, interactivity, and so on. Storybook's API makes it possible to configure and extend in various ways. It has even been extended to support React Native, Android, iOS, and Flutter development for mobile.
 
 ### Community
 
@@ -131,7 +131,7 @@ For additional help, share your issue in [the repo's GitHub Discussions](https:/
 | [query params](https://github.com/storybookjs/addon-queryparams)          | Mock query params                                                          |
 | [viewport](code/core/src/viewport/)                                       | Change display sizes and layouts for responsive components using Storybook |
 
-See [Addon / Framework Support Table](https://storybook.js.org/docs/configure/integration/frameworks-feature-support)
+See [Addon / Framework Support Table](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?utm_source=readme)
 
 To continue improving your experience, we have to eventually deprecate or remove certain addons in favor of new and better tools.
 
@@ -139,7 +139,7 @@ If you're using info/notes, we highly recommend you migrate to [docs](code/addon
 
 If you're using contexts, we highly recommend you migrate to [toolbars](https://github.com/storybookjs/storybook/tree/next/code/addons/toolbars) and [here is a guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-addon-contexts) to help you.
 
-If you're using addon-storyshots, we highly recommend you migrate to the Storybook [test-runner](https://github.com/storybookjs/test-runner) and [here is a guide](https://storybook.js.org/docs/writing-tests/storyshots-migration-guide) to help you.
+If you're using addon-storyshots, we highly recommend you migrate to the Storybook [test-runner](https://github.com/storybookjs/test-runner) and [here is a guide](https://storybook.js.org/docs/writing-tests/storyshots-migration-guide?utm_source=readme) to help you.
 
 ## Badges & Presentation materials
 
@@ -156,7 +156,7 @@ If you're looking for material to use in your Storybook presentation, such as lo
 ## Community
 
 - Tweeting via [@storybookjs](https://x.com/storybookjs)
-- Blogging at [storybook.js.org](https://storybook.js.org/blog/) and [Medium](https://medium.com/storybookjs)
+- Blogging at [storybook.js.org](https://storybook.js.org/blog/?utm_source=readme) and [Medium](https://medium.com/storybookjs)
 - Chatting on [Discord](https://discord.gg/storybook)
 - Videos and streams at [YouTube](https://www.youtube.com/channel/UCr7Quur3eIyA_oe8FNYexfg)
 

--- a/code/addons/a11y/README.md
+++ b/code/addons/a11y/README.md
@@ -10,6 +10,6 @@ The @storybook/addon-a11y package provides accessibility testing for Storybook s
 npx storybook add @storybook/addon-a11y
 ```
 
-[More on getting started with the accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing#accessibility-checks-with-a11y-addon?utm_source=readme)
+[More on getting started with the accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing#accessibility-checks-with-a11y-addon?ref=readme)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/addons/a11y/README.md
+++ b/code/addons/a11y/README.md
@@ -10,4 +10,6 @@ The @storybook/addon-a11y package provides accessibility testing for Storybook s
 npx storybook add @storybook/addon-a11y
 ```
 
-[More on getting started with the accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing#accessibility-checks-with-a11y-addon)
+[More on getting started with the accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing#accessibility-checks-with-a11y-addon?utm_source=readme)
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/addons/a11y/README.md
+++ b/code/addons/a11y/README.md
@@ -12,4 +12,4 @@ npx storybook add @storybook/addon-a11y
 
 [More on getting started with the accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing#accessibility-checks-with-a11y-addon?utm_source=readme)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/addons/docs/README.md
+++ b/code/addons/docs/README.md
@@ -76,7 +76,7 @@ For more information on `MDX`, see the [`MDX` reference](https://github.com/stor
 
 Storybook Docs supports all view layers that Storybook supports except for React Native (currently). There are some framework-specific features as well, such as props tables and inline story rendering. The following page captures the current state of support:
 
-[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support)
+[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?utm_source=readme)
 
 **Note:** `#` = WIP support
 
@@ -139,11 +139,11 @@ export default {
 
 `csfPluginOptions` is an object for configuring `@storybook/csf-plugin`. When set to `null` it tells docs not to run the `csf-plugin` at all, which can be used as an optimization, or if you're already using `csf-plugin` in your `main.js`.
 
-> With the release of version 7.0, it is no longer possible to import `.md` files directly into Storybook using the `transcludeMarkdown` [option](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#importing-plain-markdown-files-with-transcludemarkdown-has-changed). Instead, we recommend using the [`Markdown`](https://storybook.js.org/docs/api/doc-blocks/doc-block-markdown) Doc Block for importing Markdown files into your Storybook documentation.
+> With the release of version 7.0, it is no longer possible to import `.md` files directly into Storybook using the `transcludeMarkdown` [option](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#importing-plain-markdown-files-with-transcludemarkdown-has-changed). Instead, we recommend using the [`Markdown`](https://storybook.js.org/docs/api/doc-blocks/doc-block-markdown?utm_source=readme) Doc Block for importing Markdown files into your Storybook documentation.
 
 ## TypeScript configuration
 
-As of SB6 [TypeScript is zero-config](https://storybook.js.org/docs/configure/integration/typescript) and should work with SB Docs out of the box. For advanced configuration options, refer to the [Props documentation](https://github.com/storybookjs/storybook/tree/next/code/addons/docs/docs/props-tables.md).
+As of SB6 [TypeScript is zero-config](https://storybook.js.org/docs/configure/integration/typescript?utm_source=readme) and should work with SB Docs out of the box. For advanced configuration options, refer to the [Props documentation](https://github.com/storybookjs/storybook/tree/next/code/addons/docs/docs/props-tables.md).
 
 ## More resources
 
@@ -152,3 +152,5 @@ Want to learn more? Here are some more articles on Storybook Docs:
 - References: [DocsPage](https://github.com/storybookjs/storybook/tree/next/code/addons/docs/docs/docspage.md) / [MDX](https://github.com/storybookjs/storybook/tree/next/code/addons/docs/docs/mdx.md) / [FAQ](https://github.com/storybookjs/storybook/tree/next/code/addons/docs/docs/faq.md) / [Recipes](https://github.com/storybookjs/storybook/tree/next/code/addons/docs/docs/recipes.md) / [Theming](https://github.com/storybookjs/storybook/tree/next/code/addons/docs/docs/theming.md) / [Props](https://github.com/storybookjs/storybook/tree/next/code/addons/docs/docs/props-tables.md)
 - Announcements: [Vision](https://medium.com/storybookjs/storybook-docs-sneak-peak-5be78445094a) / [DocsPage](https://medium.com/storybookjs/storybook-docspage-e185bc3622bf) / [MDX](https://medium.com/storybookjs/rich-docs-with-storybook-mdx-61bc145ae7bc) / [Framework support](https://medium.com/storybookjs/storybook-docs-for-new-frameworks-b1f6090ee0ea)
 - Example: [Storybook Design System](https://github.com/storybookjs/design-system)
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/addons/docs/README.md
+++ b/code/addons/docs/README.md
@@ -76,7 +76,7 @@ For more information on `MDX`, see the [`MDX` reference](https://github.com/stor
 
 Storybook Docs supports all view layers that Storybook supports except for React Native (currently). There are some framework-specific features as well, such as props tables and inline story rendering. The following page captures the current state of support:
 
-[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?utm_source=readme)
+[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?ref=readme)
 
 **Note:** `#` = WIP support
 
@@ -139,11 +139,11 @@ export default {
 
 `csfPluginOptions` is an object for configuring `@storybook/csf-plugin`. When set to `null` it tells docs not to run the `csf-plugin` at all, which can be used as an optimization, or if you're already using `csf-plugin` in your `main.js`.
 
-> With the release of version 7.0, it is no longer possible to import `.md` files directly into Storybook using the `transcludeMarkdown` [option](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#importing-plain-markdown-files-with-transcludemarkdown-has-changed). Instead, we recommend using the [`Markdown`](https://storybook.js.org/docs/api/doc-blocks/doc-block-markdown?utm_source=readme) Doc Block for importing Markdown files into your Storybook documentation.
+> With the release of version 7.0, it is no longer possible to import `.md` files directly into Storybook using the `transcludeMarkdown` [option](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#importing-plain-markdown-files-with-transcludemarkdown-has-changed). Instead, we recommend using the [`Markdown`](https://storybook.js.org/docs/api/doc-blocks/doc-block-markdown?ref=readme) Doc Block for importing Markdown files into your Storybook documentation.
 
 ## TypeScript configuration
 
-As of SB6 [TypeScript is zero-config](https://storybook.js.org/docs/configure/integration/typescript?utm_source=readme) and should work with SB Docs out of the box. For advanced configuration options, refer to the [Props documentation](https://github.com/storybookjs/storybook/tree/next/code/addons/docs/docs/props-tables.md).
+As of SB6 [TypeScript is zero-config](https://storybook.js.org/docs/configure/integration/typescript?ref=readme) and should work with SB Docs out of the box. For advanced configuration options, refer to the [Props documentation](https://github.com/storybookjs/storybook/tree/next/code/addons/docs/docs/props-tables.md).
 
 ## More resources
 
@@ -153,4 +153,4 @@ Want to learn more? Here are some more articles on Storybook Docs:
 - Announcements: [Vision](https://medium.com/storybookjs/storybook-docs-sneak-peak-5be78445094a) / [DocsPage](https://medium.com/storybookjs/storybook-docspage-e185bc3622bf) / [MDX](https://medium.com/storybookjs/rich-docs-with-storybook-mdx-61bc145ae7bc) / [Framework support](https://medium.com/storybookjs/storybook-docs-for-new-frameworks-b1f6090ee0ea)
 - Example: [Storybook Design System](https://github.com/storybookjs/design-system)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/addons/docs/README.md
+++ b/code/addons/docs/README.md
@@ -153,4 +153,4 @@ Want to learn more? Here are some more articles on Storybook Docs:
 - Announcements: [Vision](https://medium.com/storybookjs/storybook-docs-sneak-peak-5be78445094a) / [DocsPage](https://medium.com/storybookjs/storybook-docspage-e185bc3622bf) / [MDX](https://medium.com/storybookjs/rich-docs-with-storybook-mdx-61bc145ae7bc) / [Framework support](https://medium.com/storybookjs/storybook-docs-for-new-frameworks-b1f6090ee0ea)
 - Example: [Storybook Design System](https://github.com/storybookjs/design-system)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/addons/jest/README.md
+++ b/code/addons/jest/README.md
@@ -258,4 +258,4 @@ All ideas and contributions are welcome.
 
 MIT © 2017-present Renaud Tertrais
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/addons/jest/README.md
+++ b/code/addons/jest/README.md
@@ -2,7 +2,7 @@
 
 Storybook addon for inspecting Jest unit test results.
 
-[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?utm_source=readme)
+[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?ref=readme)
 
 [![Storybook Jest Addon Demo](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/jest/docs/storybook-addon-jest.gif)](http://storybooks-official.netlify.com/?selectedKind=Addons%7Cjest&selectedStory=withTests&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Ftests%2Fpanel)
 
@@ -20,7 +20,7 @@ Or if you're using yarn as a package manager:
 
 ## Configuration
 
-Register the addon in your [`.storybook/main.js`](https://storybook.js.org/docs/configure#configure-your-storybook-project?utm_source=readme):
+Register the addon in your [`.storybook/main.js`](https://storybook.js.org/docs/configure#configure-your-storybook-project?ref=readme):
 
 ```js
 export default {
@@ -84,7 +84,7 @@ Assuming that you have already created a test file for your component (e.g., `My
 
 ### Story-level
 
-In your story file, add a [decorator](https://storybook.js.org/docs/writing-stories/decorators?utm_source=readme) to your story's default export to display the results:
+In your story file, add a [decorator](https://storybook.js.org/docs/writing-stories/decorators?ref=readme) to your story's default export to display the results:
 
 ```js
 // MyComponent.stories.js|jsx
@@ -99,7 +99,7 @@ export default {
 };
 ```
 
-You can also add multiple tests results within your story by including the `jest` [parameter](https://storybook.js.org/docs/writing-stories/parameters?utm_source=readme), for example:
+You can also add multiple tests results within your story by including the `jest` [parameter](https://storybook.js.org/docs/writing-stories/parameters?ref=readme), for example:
 
 ```js
 // MyComponent.stories.js|jsx
@@ -130,7 +130,7 @@ Default.parameters = {
 ### Global level
 
 To avoid importing the results of the tests in each story, you can update
-your [`.storybook/preview.js`](https://storybook.js.org/docs/configure#configure-story-rendering?utm_source=readme) and include a decorator allowing you to display the results only for the stories that have the `jest` parameter defined:
+your [`.storybook/preview.js`](https://storybook.js.org/docs/configure#configure-story-rendering?ref=readme) and include a decorator allowing you to display the results only for the stories that have the `jest` parameter defined:
 
 ```js
 // .storybook/preview.js
@@ -258,4 +258,4 @@ All ideas and contributions are welcome.
 
 MIT © 2017-present Renaud Tertrais
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/addons/jest/README.md
+++ b/code/addons/jest/README.md
@@ -2,7 +2,7 @@
 
 Storybook addon for inspecting Jest unit test results.
 
-[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support)
+[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?utm_source=readme)
 
 [![Storybook Jest Addon Demo](https://raw.githubusercontent.com/storybookjs/storybook/next/code/addons/jest/docs/storybook-addon-jest.gif)](http://storybooks-official.netlify.com/?selectedKind=Addons%7Cjest&selectedStory=withTests&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Ftests%2Fpanel)
 
@@ -20,7 +20,7 @@ Or if you're using yarn as a package manager:
 
 ## Configuration
 
-Register the addon in your [`.storybook/main.js`](https://storybook.js.org/docs/configure#configure-your-storybook-project):
+Register the addon in your [`.storybook/main.js`](https://storybook.js.org/docs/configure#configure-your-storybook-project?utm_source=readme):
 
 ```js
 export default {
@@ -84,7 +84,7 @@ Assuming that you have already created a test file for your component (e.g., `My
 
 ### Story-level
 
-In your story file, add a [decorator](https://storybook.js.org/docs/writing-stories/decorators) to your story's default export to display the results:
+In your story file, add a [decorator](https://storybook.js.org/docs/writing-stories/decorators?utm_source=readme) to your story's default export to display the results:
 
 ```js
 // MyComponent.stories.js|jsx
@@ -99,7 +99,7 @@ export default {
 };
 ```
 
-You can also add multiple tests results within your story by including the `jest` [parameter](https://storybook.js.org/docs/writing-stories/parameters), for example:
+You can also add multiple tests results within your story by including the `jest` [parameter](https://storybook.js.org/docs/writing-stories/parameters?utm_source=readme), for example:
 
 ```js
 // MyComponent.stories.js|jsx
@@ -130,7 +130,7 @@ Default.parameters = {
 ### Global level
 
 To avoid importing the results of the tests in each story, you can update
-your [`.storybook/preview.js`](https://storybook.js.org/docs/configure#configure-story-rendering) and include a decorator allowing you to display the results only for the stories that have the `jest` parameter defined:
+your [`.storybook/preview.js`](https://storybook.js.org/docs/configure#configure-story-rendering?utm_source=readme) and include a decorator allowing you to display the results only for the stories that have the `jest` parameter defined:
 
 ```js
 // .storybook/preview.js
@@ -257,3 +257,5 @@ All ideas and contributions are welcome.
 ## Licence
 
 MIT © 2017-present Renaud Tertrais
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/addons/links/README.md
+++ b/code/addons/links/README.md
@@ -146,4 +146,4 @@ It accepts all the props the `a` element does, plus `story` and `kind`. It the `
 
 To implement such a component for another framework, you need to add special handling for `click` event on native `a` element. See [`RoutedLink` sources](https://github.com/storybookjs/storybook/blob/next/code/addons/links/src/react/components/RoutedLink.tsx) for reference.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/addons/links/README.md
+++ b/code/addons/links/README.md
@@ -1,8 +1,8 @@
 # Story Links Addon
 
-The Storybook Links addon can be used to create links that navigate between stories in [Storybook](https://storybook.js.org).
+The Storybook Links addon can be used to create links that navigate between stories in [Storybook](https://storybook.js.org?utm_source=readme).
 
-[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support)
+[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?utm_source=readme)
 
 ## Getting Started
 
@@ -145,3 +145,5 @@ It accepts all the props the `a` element does, plus `story` and `kind`. It the `
 ```
 
 To implement such a component for another framework, you need to add special handling for `click` event on native `a` element. See [`RoutedLink` sources](https://github.com/storybookjs/storybook/blob/next/code/addons/links/src/react/components/RoutedLink.tsx) for reference.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/addons/links/README.md
+++ b/code/addons/links/README.md
@@ -1,8 +1,8 @@
 # Story Links Addon
 
-The Storybook Links addon can be used to create links that navigate between stories in [Storybook](https://storybook.js.org?utm_source=readme).
+The Storybook Links addon can be used to create links that navigate between stories in [Storybook](https://storybook.js.org?ref=readme).
 
-[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?utm_source=readme)
+[Framework Support](https://storybook.js.org/docs/configure/integration/frameworks-feature-support?ref=readme)
 
 ## Getting Started
 
@@ -146,4 +146,4 @@ It accepts all the props the `a` element does, plus `story` and `kind`. It the `
 
 To implement such a component for another framework, you need to add special handling for `click` event on native `a` element. See [`RoutedLink` sources](https://github.com/storybookjs/storybook/blob/next/code/addons/links/src/react/components/RoutedLink.tsx) for reference.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/addons/onboarding/README.md
+++ b/code/addons/onboarding/README.md
@@ -47,3 +47,5 @@ const config = {
 };
 export default config;
 ```
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/addons/onboarding/README.md
+++ b/code/addons/onboarding/README.md
@@ -48,4 +48,4 @@ const config = {
 export default config;
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/addons/onboarding/README.md
+++ b/code/addons/onboarding/README.md
@@ -48,4 +48,4 @@ const config = {
 export default config;
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/addons/pseudo-states/README.md
+++ b/code/addons/pseudo-states/README.md
@@ -82,4 +82,4 @@ DialogButton.parameters = {
 };
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/addons/pseudo-states/README.md
+++ b/code/addons/pseudo-states/README.md
@@ -81,3 +81,5 @@ DialogButton.parameters = {
   pseudo: { hover: true, rootSelector: 'body' },
 };
 ```
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/addons/pseudo-states/README.md
+++ b/code/addons/pseudo-states/README.md
@@ -82,4 +82,4 @@ DialogButton.parameters = {
 };
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/addons/themes/README.md
+++ b/code/addons/themes/README.md
@@ -1,6 +1,6 @@
 # @storybook/addon-themes
 
-Storybook Addon Themes can be used which between multiple themes for components inside the preview in [Storybook](https://storybook.js.org?utm_source=readme).
+Storybook Addon Themes can be used to switch between multiple themes for components inside the preview in [Storybook](https://storybook.js.org?utm_source=readme).
 
 ![React Storybook Screenshot](https://user-images.githubusercontent.com/18172605/274302488-77a39112-cdbe-4d16-9966-0d8e9e7e3399.gif)
 

--- a/code/addons/themes/README.md
+++ b/code/addons/themes/README.md
@@ -1,6 +1,6 @@
 # @storybook/addon-themes
 
-Storybook Addon Themes can be used which between multiple themes for components inside the preview in [Storybook](https://storybook.js.org).
+Storybook Addon Themes can be used which between multiple themes for components inside the preview in [Storybook](https://storybook.js.org?utm_source=readme).
 
 ![React Storybook Screenshot](https://user-images.githubusercontent.com/18172605/274302488-77a39112-cdbe-4d16-9966-0d8e9e7e3399.gif)
 
@@ -12,7 +12,7 @@ Requires Storybook 7.0 or later. If you need to add it to your Storybook, you ca
 npm i -D @storybook/addon-themes
 ```
 
-Then, add following content to [`.storybook/main.js`](https://storybook.js.org/docs/configure#configure-your-storybook-project):
+Then, add following content to [`.storybook/main.js`](https://storybook.js.org/docs/configure#configure-your-storybook-project?utm_source=readme):
 
 ```js
 export default {
@@ -65,3 +65,5 @@ export const PrimaryDark = {
   globals: { theme: 'dark' },
 };
 ```
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/addons/themes/README.md
+++ b/code/addons/themes/README.md
@@ -1,6 +1,6 @@
 # @storybook/addon-themes
 
-Storybook Addon Themes can be used to switch between multiple themes for components inside the preview in [Storybook](https://storybook.js.org?utm_source=readme).
+Storybook Addon Themes can be used to switch between multiple themes for components inside the preview in [Storybook](https://storybook.js.org?ref=readme).
 
 ![React Storybook Screenshot](https://user-images.githubusercontent.com/18172605/274302488-77a39112-cdbe-4d16-9966-0d8e9e7e3399.gif)
 
@@ -12,7 +12,7 @@ Requires Storybook 7.0 or later. If you need to add it to your Storybook, you ca
 npm i -D @storybook/addon-themes
 ```
 
-Then, add following content to [`.storybook/main.js`](https://storybook.js.org/docs/configure#configure-your-storybook-project?utm_source=readme):
+Then, add following content to [`.storybook/main.js`](https://storybook.js.org/docs/configure#configure-your-storybook-project?ref=readme):
 
 ```js
 export default {
@@ -66,4 +66,4 @@ export const PrimaryDark = {
 };
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/addons/themes/README.md
+++ b/code/addons/themes/README.md
@@ -66,4 +66,4 @@ export const PrimaryDark = {
 };
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/addons/vitest/README.md
+++ b/code/addons/vitest/README.md
@@ -2,4 +2,4 @@
 
 Addon to integrate Vitest test results with Storybook.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/addons/vitest/README.md
+++ b/code/addons/vitest/README.md
@@ -2,4 +2,4 @@
 
 Addon to integrate Vitest test results with Storybook.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/addons/vitest/README.md
+++ b/code/addons/vitest/README.md
@@ -1,3 +1,5 @@
 # Storybook Addon Test
 
 Addon to integrate Vitest test results with Storybook.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/builders/builder-vite/README.md
+++ b/code/builders/builder-vite/README.md
@@ -135,7 +135,7 @@ See [Customize Vite config](#customize-vite-config) for details about using `vit
 
 ### React Docgen
 
-Docgen is used in Storybook to populate the props table in docs view, the controls panel, and for several other addons. Docgen is supported in Svelte, Vue 3, and React. React docgen is configurable via the [`typescript.reactDocgen`](https://storybook.js.org/docs/api/main-config-typescript#reactdocgen) setting in `.storybook/main.js`.
+Docgen is used in Storybook to populate the props table in docs view, the controls panel, and for several other addons. Docgen is supported in Svelte, Vue 3, and React. React docgen is configurable via the [`typescript.reactDocgen`](https://storybook.js.org/docs/api/main-config-typescript#reactdocgen?utm_source=readme) setting in `.storybook/main.js`.
 
 ```javascript
 export default {
@@ -151,7 +151,7 @@ If you're using TypeScript, we encourage you to experiment and see which option 
 
 The builder will by default enable Vite's [server.fs.strict](https://vitejs.dev/config/#server-fs-strict)
 option, for increased security. The default project `root` is set to the parent directory of the
-Storybook configuration directory. This can be overridden in [viteFinal](https://storybook.js.org/docs/api/main-config-vite-final).
+Storybook configuration directory. This can be overridden in [viteFinal](https://storybook.js.org/docs/api/main-config-vite-final?utm_source=readme).
 
 ## Known issues
 
@@ -167,3 +167,5 @@ Have a look at the GitHub issues with the `vite` label for known bugs. If you fi
 feel free to create an issue or send a pull request!
 
 Please read the [How to contribute](/CONTRIBUTING.md) guide.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/builders/builder-vite/README.md
+++ b/code/builders/builder-vite/README.md
@@ -168,4 +168,4 @@ feel free to create an issue or send a pull request!
 
 Please read the [How to contribute](/CONTRIBUTING.md) guide.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/builders/builder-vite/README.md
+++ b/code/builders/builder-vite/README.md
@@ -135,7 +135,7 @@ See [Customize Vite config](#customize-vite-config) for details about using `vit
 
 ### React Docgen
 
-Docgen is used in Storybook to populate the props table in docs view, the controls panel, and for several other addons. Docgen is supported in Svelte, Vue 3, and React. React docgen is configurable via the [`typescript.reactDocgen`](https://storybook.js.org/docs/api/main-config-typescript#reactdocgen?utm_source=readme) setting in `.storybook/main.js`.
+Docgen is used in Storybook to populate the props table in docs view, the controls panel, and for several other addons. Docgen is supported in Svelte, Vue 3, and React. React docgen is configurable via the [`typescript.reactDocgen`](https://storybook.js.org/docs/api/main-config-typescript#reactdocgen?ref=readme) setting in `.storybook/main.js`.
 
 ```javascript
 export default {
@@ -151,7 +151,7 @@ If you're using TypeScript, we encourage you to experiment and see which option 
 
 The builder will by default enable Vite's [server.fs.strict](https://vitejs.dev/config/#server-fs-strict)
 option, for increased security. The default project `root` is set to the parent directory of the
-Storybook configuration directory. This can be overridden in [viteFinal](https://storybook.js.org/docs/api/main-config-vite-final?utm_source=readme).
+Storybook configuration directory. This can be overridden in [viteFinal](https://storybook.js.org/docs/api/main-config-vite-final?ref=readme).
 
 ## Known issues
 
@@ -168,4 +168,4 @@ feel free to create an issue or send a pull request!
 
 Please read the [How to contribute](/CONTRIBUTING.md) guide.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/builders/builder-webpack5/README.md
+++ b/code/builders/builder-webpack5/README.md
@@ -10,4 +10,4 @@ export default {
 };
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/builders/builder-webpack5/README.md
+++ b/code/builders/builder-webpack5/README.md
@@ -10,4 +10,4 @@ export default {
 };
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/builders/builder-webpack5/README.md
+++ b/code/builders/builder-webpack5/README.md
@@ -9,3 +9,5 @@ export default {
   },
 };
 ```
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/core/README.md
+++ b/code/core/README.md
@@ -49,3 +49,5 @@ The heuristic is simple:
 The sole exception is the `storybook` package itself.
 
 Obviously, the `storybook` package cannot depend on itself, so it must import from `@storybook/core`.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/core/README.md
+++ b/code/core/README.md
@@ -1,53 +1,38 @@
-# Storybook Core
+<p align="center">
+  <a href="https://storybook.js.org/?utm_source=readme">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/263385/199832481-bbbf5961-6a26-481d-8224-51258cce9b33.png">
+      <img src="https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png" alt="Storybook" width="400" />
+    </picture>
+    
+  </a>
+  
+</p>
 
-The `@storybook/core` package is the core of Storybook. It is responsible for the following:
+<p align="center">Build bulletproof UI components faster</p>
 
-- the main UI of storybook
-- the UI used by addons
-- the API used by addons
-- the API used by the CLI
-- the API used by the server
-- prebundled code used by the browser
-- static assets used by the browser
-- utilities for CSF, MDX & Docs
+<br/>
 
-## Private package
+<p align="center">
+Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. Find out more at <a href="https://storybook.js.org/?utm_source=readme">storybook.js.org</a>!
+</p>
 
-This package is not intended to be used by anyone but storybook internally.
+<center>
+  <img src="https://raw.githubusercontent.com/storybookjs/storybook/refs/heads/release-6-5/media/storybook-intro.gif" width="100%" />
+</center>
 
-Even though this is where all of the code is located, it is NOT to be the entry point when using functionality within!
+---
 
-Consumers of the code should import like so:
+# Storybook
 
-```ts
-import { addons } from 'storybook/manager-api';
-```
+The `storybook` package contains Storybook's core. It includes:
 
-Importing from `@storybook/core` is explicitly NOT supported; it WILL break in a future version of storybook, very likely in a non-major version bump.
+- Storybook's CLI and development server
+- Storybook's main UI (aka "the manager")
+- Core functionality including component controls, toolbar controls, action logging, viewport control, and interaction debugger
+- User-facing utility libraries such as `storybook/test`, `theming`, and `viewport`
+- Libraries used by Storybook's ecosystem of frameworks, addons, and builders
 
-# For maintainers
-
-## When to use `@storybook/core`
-
-In the following packages you should import from `@storybook/core` (and ONLY from `@storybook/core`):
-
-- `@storybook/core`
-- `@storybook/codemod`
-
-To prevent cyclical dependencies, these packages cannot depend on the `storybook` package.
-
-## When to use `storybook/internal`
-
-In every other package you should import from `storybook/internal` (and ONLY from `storybook/internal`).
-
-The heuristic is simple:
-
-> If you see a peerDependency on `storybook` in the `package.json` of the package you are working on, you should import from `storybook/internal`.
-
-## The 1 exception: the `storybook` package itself
-
-The sole exception is the `storybook` package itself.
-
-Obviously, the `storybook` package cannot depend on itself, so it must import from `@storybook/core`.
+It also contains a variety of other libraries and utilities under the `stroybook/internal` namespace, such as utilities for CSF, MDX & Docs.
 
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/core/README.md
+++ b/code/core/README.md
@@ -50,4 +50,4 @@ The sole exception is the `storybook` package itself.
 
 Obviously, the `storybook` package cannot depend on itself, so it must import from `@storybook/core`.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/core/README.md
+++ b/code/core/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://storybook.js.org/?utm_source=readme">
+  <a href="https://storybook.js.org/?ref=readme">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/263385/199832481-bbbf5961-6a26-481d-8224-51258cce9b33.png">
       <img src="https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png" alt="Storybook" width="400" />
@@ -14,7 +14,7 @@
 <br/>
 
 <p align="center">
-Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. Find out more at <a href="https://storybook.js.org/?utm_source=readme">storybook.js.org</a>!
+Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. Find out more at <a href="https://storybook.js.org/?ref=readme">storybook.js.org</a>!
 </p>
 
 <center>
@@ -35,4 +35,4 @@ The `storybook` package contains Storybook's core. It includes:
 
 It also contains a variety of other libraries and utilities under the `stroybook/internal` namespace, such as utilities for CSF, MDX & Docs.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/angular/README.md
+++ b/code/frameworks/angular/README.md
@@ -1,3 +1,5 @@
 # Storybook for Angular
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/angular?renderer=angular) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/angular?renderer=angular&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/angular/README.md
+++ b/code/frameworks/angular/README.md
@@ -2,4 +2,4 @@
 
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/angular?renderer=angular&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/angular/README.md
+++ b/code/frameworks/angular/README.md
@@ -1,5 +1,5 @@
 # Storybook for Angular
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/angular?renderer=angular&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/angular?renderer=angular&ref=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/ember/README.md
+++ b/code/frameworks/ember/README.md
@@ -52,4 +52,4 @@ export default {
 };
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/ember/README.md
+++ b/code/frameworks/ember/README.md
@@ -15,18 +15,18 @@ cd my-ember-app
 npx storybook@latest init
 ```
 
-For more information visit: [storybook.js.org](https://storybook.js.org)
+For more information visit: [storybook.js.org](https://storybook.js.org?utm_source=readme)
 
 ---
 
-Storybook also comes with a lot of [addons](https://storybook.js.org/addons) and a great API to customize as you wish.
-You can also build a [static version](https://storybook.js.org/docs/sharing/publish-storybook?renderer=ember) of your Storybook and deploy it anywhere you want.
+Storybook also comes with a lot of [addons](https://storybook.js.org/addons?utm_source=readme) and a great API to customize as you wish.
+You can also build a [static version](https://storybook.js.org/docs/sharing/publish-storybook?renderer=ember&utm_source=readme) of your Storybook and deploy it anywhere you want.
 
 ## Docs
 
-- [Basics](https://storybook.js.org/docs/get-started/install?renderer=ember)
-- [Configurations](https://storybook.js.org/docs/configure?renderer=ember)
-- [Addons](https://storybook.js.org/docs/configure/user-interface/storybook-addons?renderer=ember)
+- [Basics](https://storybook.js.org/docs/get-started/install?renderer=ember&utm_source=readme)
+- [Configurations](https://storybook.js.org/docs/configure?renderer=ember&utm_source=readme)
+- [Addons](https://storybook.js.org/docs/configure/user-interface/storybook-addons?renderer=ember&utm_source=readme)
 
 ## Working with polyfills
 
@@ -51,3 +51,5 @@ export default {
   [...]
 };
 ```
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/ember/README.md
+++ b/code/frameworks/ember/README.md
@@ -15,18 +15,18 @@ cd my-ember-app
 npx storybook@latest init
 ```
 
-For more information visit: [storybook.js.org](https://storybook.js.org?utm_source=readme)
+For more information visit: [storybook.js.org](https://storybook.js.org?ref=readme)
 
 ---
 
-Storybook also comes with a lot of [addons](https://storybook.js.org/addons?utm_source=readme) and a great API to customize as you wish.
-You can also build a [static version](https://storybook.js.org/docs/sharing/publish-storybook?renderer=ember&utm_source=readme) of your Storybook and deploy it anywhere you want.
+Storybook also comes with a lot of [addons](https://storybook.js.org/addons?ref=readme) and a great API to customize as you wish.
+You can also build a [static version](https://storybook.js.org/docs/sharing/publish-storybook?renderer=ember&ref=readme) of your Storybook and deploy it anywhere you want.
 
 ## Docs
 
-- [Basics](https://storybook.js.org/docs/get-started/install?renderer=ember&utm_source=readme)
-- [Configurations](https://storybook.js.org/docs/configure?renderer=ember&utm_source=readme)
-- [Addons](https://storybook.js.org/docs/configure/user-interface/storybook-addons?renderer=ember&utm_source=readme)
+- [Basics](https://storybook.js.org/docs/get-started/install?renderer=ember&ref=readme)
+- [Configurations](https://storybook.js.org/docs/configure?renderer=ember&ref=readme)
+- [Addons](https://storybook.js.org/docs/configure/user-interface/storybook-addons?renderer=ember&ref=readme)
 
 ## Working with polyfills
 
@@ -52,4 +52,4 @@ export default {
 };
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/html-vite/README.md
+++ b/code/frameworks/html-vite/README.md
@@ -2,4 +2,4 @@
 
 See [documentation](https://storybook.js.org/docs?utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/html-vite/README.md
+++ b/code/frameworks/html-vite/README.md
@@ -1,5 +1,5 @@
 # Storybook for HTML
 
-See [documentation](https://storybook.js.org/docs?utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs?ref=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/html-vite/README.md
+++ b/code/frameworks/html-vite/README.md
@@ -1,3 +1,5 @@
 # Storybook for HTML
 
-See [documentation](https://storybook.js.org/docs) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs?utm_source=readme) for installation instructions, usage examples, APIs, and more.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/nextjs-vite/README.md
+++ b/code/frameworks/nextjs-vite/README.md
@@ -1,6 +1,6 @@
 # Storybook for Next.js with Vite Builder
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/nextjs?renderer=react) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/nextjs?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
 ## Acknowledgements
 
@@ -8,3 +8,5 @@ This framework borrows heavily from these Storybook addons:
 
 - [storybook-addon-next](https://github.com/RyanClementsHax/storybook-addon-next) by [RyanClementsHax](https://github.com/RyanClementsHax/)
 - [storybook-addon-next-router](https://github.com/lifeiscontent/storybook-addon-next-router) by [lifeiscontent](https://github.com/lifeiscontent)
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/nextjs-vite/README.md
+++ b/code/frameworks/nextjs-vite/README.md
@@ -1,6 +1,6 @@
 # Storybook for Next.js with Vite Builder
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/nextjs?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/nextjs?renderer=react&ref=readme) for installation instructions, usage examples, APIs, and more.
 
 ## Acknowledgements
 
@@ -9,4 +9,4 @@ This framework borrows heavily from these Storybook addons:
 - [storybook-addon-next](https://github.com/RyanClementsHax/storybook-addon-next) by [RyanClementsHax](https://github.com/RyanClementsHax/)
 - [storybook-addon-next-router](https://github.com/lifeiscontent/storybook-addon-next-router) by [lifeiscontent](https://github.com/lifeiscontent)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/nextjs-vite/README.md
+++ b/code/frameworks/nextjs-vite/README.md
@@ -9,4 +9,4 @@ This framework borrows heavily from these Storybook addons:
 - [storybook-addon-next](https://github.com/RyanClementsHax/storybook-addon-next) by [RyanClementsHax](https://github.com/RyanClementsHax/)
 - [storybook-addon-next-router](https://github.com/lifeiscontent/storybook-addon-next-router) by [lifeiscontent](https://github.com/lifeiscontent)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/nextjs/README.md
+++ b/code/frameworks/nextjs/README.md
@@ -1,6 +1,6 @@
 # Storybook for Next.js
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/nextjs?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/nextjs?renderer=react&ref=readme) for installation instructions, usage examples, APIs, and more.
 
 ## Acknowledgements
 
@@ -9,4 +9,4 @@ This framework borrows heavily from these Storybook addons:
 - [storybook-addon-next](https://github.com/RyanClementsHax/storybook-addon-next) by [RyanClementsHax](https://github.com/RyanClementsHax/)
 - [storybook-addon-next-router](https://github.com/lifeiscontent/storybook-addon-next-router) by [lifeiscontent](https://github.com/lifeiscontent)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/nextjs/README.md
+++ b/code/frameworks/nextjs/README.md
@@ -1,6 +1,6 @@
 # Storybook for Next.js
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/nextjs?renderer=react) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/nextjs?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
 ## Acknowledgements
 
@@ -8,3 +8,5 @@ This framework borrows heavily from these Storybook addons:
 
 - [storybook-addon-next](https://github.com/RyanClementsHax/storybook-addon-next) by [RyanClementsHax](https://github.com/RyanClementsHax/)
 - [storybook-addon-next-router](https://github.com/lifeiscontent/storybook-addon-next-router) by [lifeiscontent](https://github.com/lifeiscontent)
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/nextjs/README.md
+++ b/code/frameworks/nextjs/README.md
@@ -9,4 +9,4 @@ This framework borrows heavily from these Storybook addons:
 - [storybook-addon-next](https://github.com/RyanClementsHax/storybook-addon-next) by [RyanClementsHax](https://github.com/RyanClementsHax/)
 - [storybook-addon-next-router](https://github.com/lifeiscontent/storybook-addon-next-router) by [lifeiscontent](https://github.com/lifeiscontent)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/preact-vite/README.md
+++ b/code/frameworks/preact-vite/README.md
@@ -1,6 +1,6 @@
 # Storybook for Preact & Vite
 
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/preact-vite?renderer=preact&utm_source=readme) for installation instructions, usage examples, APIs, and more.
-`;
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/preact-vite?renderer=preact&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/preact-vite/README.md
+++ b/code/frameworks/preact-vite/README.md
@@ -3,4 +3,4 @@
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/preact-vite?renderer=preact&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 `;
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/preact-vite/README.md
+++ b/code/frameworks/preact-vite/README.md
@@ -1,4 +1,6 @@
 # Storybook for Preact & Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/preact-vite?renderer=preact) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/preact-vite?renderer=preact&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 `;
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/preact-vite/README.md
+++ b/code/frameworks/preact-vite/README.md
@@ -2,6 +2,6 @@
 
 Develop, document, and test UI components in isolation.
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/preact-vite?renderer=preact&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/preact-vite?renderer=preact&ref=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/preact-vite/README.md
+++ b/code/frameworks/preact-vite/README.md
@@ -1,6 +1,7 @@
 # Storybook for Preact & Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/preact-vite?renderer=preact&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+Develop, document, and test UI components in isolation.
+
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/preact-vite?renderer=preact&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/react-native-web-vite/README.md
+++ b/code/frameworks/react-native-web-vite/README.md
@@ -1,5 +1,5 @@
 # Storybook for React Native Web & Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-native-web-vite?renderer=react-native-web&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-native-web-vite?renderer=react-native-web&ref=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/react-native-web-vite/README.md
+++ b/code/frameworks/react-native-web-vite/README.md
@@ -1,3 +1,5 @@
 # Storybook for React Native Web & Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-native-web-vite?renderer=react-native-web) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-native-web-vite?renderer=react-native-web&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/react-native-web-vite/README.md
+++ b/code/frameworks/react-native-web-vite/README.md
@@ -2,4 +2,4 @@
 
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-native-web-vite?renderer=react-native-web&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/react-vite/README.md
+++ b/code/frameworks/react-vite/README.md
@@ -2,4 +2,4 @@
 
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-vite?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/react-vite/README.md
+++ b/code/frameworks/react-vite/README.md
@@ -1,3 +1,5 @@
 # Storybook for React & Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-vite?renderer=react) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-vite?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/react-vite/README.md
+++ b/code/frameworks/react-vite/README.md
@@ -1,5 +1,7 @@
 # Storybook for React & Vite
 
+Develop, document, and test UI components in isolation.
+
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-vite?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/react-vite/README.md
+++ b/code/frameworks/react-vite/README.md
@@ -2,6 +2,6 @@
 
 Develop, document, and test UI components in isolation.
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-vite?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-vite?renderer=react&ref=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/react-webpack5/README.md
+++ b/code/frameworks/react-webpack5/README.md
@@ -2,4 +2,4 @@
 
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-webpack5?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/react-webpack5/README.md
+++ b/code/frameworks/react-webpack5/README.md
@@ -1,3 +1,5 @@
 # Storybook for React & Webpack
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-webpack5?renderer=react) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-webpack5?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/react-webpack5/README.md
+++ b/code/frameworks/react-webpack5/README.md
@@ -1,5 +1,7 @@
 # Storybook for React & Webpack
 
+Develop, document, and test UI components in isolation.
+
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-webpack5?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/react-webpack5/README.md
+++ b/code/frameworks/react-webpack5/README.md
@@ -2,6 +2,6 @@
 
 Develop, document, and test UI components in isolation.
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-webpack5?renderer=react&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/react-webpack5?renderer=react&ref=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/server-webpack5/README.md
+++ b/code/frameworks/server-webpack5/README.md
@@ -29,7 +29,7 @@ export const parameters = {
 
 The URL you connect to should have the ability to render a story, see [server rendering](#server-rendering) below.
 
-For more information visit: [storybook.js.org](https://storybook.js.org)
+For more information visit: [storybook.js.org](https://storybook.js.org?utm_source=readme)
 
 ## Writing Stories
 
@@ -230,7 +230,7 @@ Just like CSF stories we can define `argTypes` to specify the controls used in t
 
 ## Addon compatibility
 
-Storybook also comes with a lot of [addons](https://storybook.js.org/addons) and a great API to customize as you wish. As some addons assume the story is rendered in JS, they may not work with `@storybook/server` (yet!).
+Storybook also comes with a lot of [addons](https://storybook.js.org/addons?utm_source=readme) and a great API to customize as you wish. As some addons assume the story is rendered in JS, they may not work with `@storybook/server` (yet!).
 
 Many addons that act on the manager side (such as `backgrounds` and `viewport`) will work out of the box with `@storybook/server` -- you can configure them with parameters written on the server as usual.
 
@@ -315,3 +315,5 @@ type FetchStoryHtmlType = (
 - id: Id of the story being rendered given by `parameters.server.id`
 - params: Merged story params `parameters.server.params`and story args
 - context: The context of the story
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/server-webpack5/README.md
+++ b/code/frameworks/server-webpack5/README.md
@@ -316,4 +316,4 @@ type FetchStoryHtmlType = (
 - params: Merged story params `parameters.server.params`and story args
 - context: The context of the story
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/server-webpack5/README.md
+++ b/code/frameworks/server-webpack5/README.md
@@ -29,7 +29,7 @@ export const parameters = {
 
 The URL you connect to should have the ability to render a story, see [server rendering](#server-rendering) below.
 
-For more information visit: [storybook.js.org](https://storybook.js.org?utm_source=readme)
+For more information visit: [storybook.js.org](https://storybook.js.org?ref=readme)
 
 ## Writing Stories
 
@@ -230,7 +230,7 @@ Just like CSF stories we can define `argTypes` to specify the controls used in t
 
 ## Addon compatibility
 
-Storybook also comes with a lot of [addons](https://storybook.js.org/addons?utm_source=readme) and a great API to customize as you wish. As some addons assume the story is rendered in JS, they may not work with `@storybook/server` (yet!).
+Storybook also comes with a lot of [addons](https://storybook.js.org/addons?ref=readme) and a great API to customize as you wish. As some addons assume the story is rendered in JS, they may not work with `@storybook/server` (yet!).
 
 Many addons that act on the manager side (such as `backgrounds` and `viewport`) will work out of the box with `@storybook/server` -- you can configure them with parameters written on the server as usual.
 
@@ -316,4 +316,4 @@ type FetchStoryHtmlType = (
 - params: Merged story params `parameters.server.params`and story args
 - context: The context of the story
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/svelte-vite/README.md
+++ b/code/frameworks/svelte-vite/README.md
@@ -1,5 +1,5 @@
 # Storybook for Svelte & Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/svelte-vite?renderer=svelte&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/svelte-vite?renderer=svelte&ref=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/svelte-vite/README.md
+++ b/code/frameworks/svelte-vite/README.md
@@ -2,4 +2,4 @@
 
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/svelte-vite?renderer=svelte&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/svelte-vite/README.md
+++ b/code/frameworks/svelte-vite/README.md
@@ -1,3 +1,5 @@
 # Storybook for Svelte & Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/svelte-vite?renderer=svelte) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/svelte-vite?renderer=svelte&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/sveltekit/README.md
+++ b/code/frameworks/sveltekit/README.md
@@ -1,10 +1,10 @@
 # Storybook for SvelteKit
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/sveltekit?renderer=svelte&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/sveltekit?renderer=svelte&ref=readme) for installation instructions, usage examples, APIs, and more.
 
 ## Acknowledgements
 
 Integrating with SvelteKit would not have been possible if it weren't for the fantastic efforts by the Svelte core team - especially [Ben McCann](https://twitter.com/benjaminmccann) - to make integrations with the wider ecosystem possible.
 A big thank you also goes out to [Paolo Ricciuti](https://twitter.com/PaoloRicciuti) for improving the mocking capabilities.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/sveltekit/README.md
+++ b/code/frameworks/sveltekit/README.md
@@ -1,8 +1,10 @@
 # Storybook for SvelteKit
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/sveltekit?renderer=svelte) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/sveltekit?renderer=svelte&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
 ## Acknowledgements
 
 Integrating with SvelteKit would not have been possible if it weren't for the fantastic efforts by the Svelte core team - especially [Ben McCann](https://twitter.com/benjaminmccann) - to make integrations with the wider ecosystem possible.
 A big thank you also goes out to [Paolo Ricciuti](https://twitter.com/PaoloRicciuti) for improving the mocking capabilities.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/sveltekit/README.md
+++ b/code/frameworks/sveltekit/README.md
@@ -7,4 +7,4 @@ See [documentation](https://storybook.js.org/docs/get-started/frameworks/sveltek
 Integrating with SvelteKit would not have been possible if it weren't for the fantastic efforts by the Svelte core team - especially [Ben McCann](https://twitter.com/benjaminmccann) - to make integrations with the wider ecosystem possible.
 A big thank you also goes out to [Paolo Ricciuti](https://twitter.com/PaoloRicciuti) for improving the mocking capabilities.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/vue3-vite/README.md
+++ b/code/frameworks/vue3-vite/README.md
@@ -1,5 +1,5 @@
 # Storybook for Vue and Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/vue3-vite?renderer=vue&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/vue3-vite?renderer=vue&ref=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/frameworks/vue3-vite/README.md
+++ b/code/frameworks/vue3-vite/README.md
@@ -2,4 +2,4 @@
 
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/vue3-vite?renderer=vue&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/vue3-vite/README.md
+++ b/code/frameworks/vue3-vite/README.md
@@ -1,3 +1,5 @@
 # Storybook for Vue and Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/vue3-vite?renderer=vue) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/vue3-vite?renderer=vue&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/web-components-vite/README.md
+++ b/code/frameworks/web-components-vite/README.md
@@ -1,3 +1,5 @@
 # Storybook for Web components & Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/web-components-vite?renderer=web-components) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/web-components-vite?renderer=web-components&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/frameworks/web-components-vite/README.md
+++ b/code/frameworks/web-components-vite/README.md
@@ -2,4 +2,4 @@
 
 See [documentation](https://storybook.js.org/docs/get-started/frameworks/web-components-vite?renderer=web-components&utm_source=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/frameworks/web-components-vite/README.md
+++ b/code/frameworks/web-components-vite/README.md
@@ -1,5 +1,5 @@
 # Storybook for Web components & Vite
 
-See [documentation](https://storybook.js.org/docs/get-started/frameworks/web-components-vite?renderer=web-components&utm_source=readme) for installation instructions, usage examples, APIs, and more.
+See [documentation](https://storybook.js.org/docs/get-started/frameworks/web-components-vite?renderer=web-components&ref=readme) for installation instructions, usage examples, APIs, and more.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/lib/cli-sb/README.md
+++ b/code/lib/cli-sb/README.md
@@ -2,4 +2,4 @@
 
 This is a wrapper for <https://www.npmjs.com/package/@storybook/cli>
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/lib/cli-sb/README.md
+++ b/code/lib/cli-sb/README.md
@@ -1,3 +1,5 @@
 # Storybook CLI
 
 This is a wrapper for <https://www.npmjs.com/package/@storybook/cli>
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/lib/cli-sb/README.md
+++ b/code/lib/cli-sb/README.md
@@ -2,4 +2,4 @@
 
 This is a wrapper for <https://www.npmjs.com/package/@storybook/cli>
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/lib/cli-storybook/README.md
+++ b/code/lib/cli-storybook/README.md
@@ -48,4 +48,4 @@ This export contains the API that is available in the manager iframe.
 
 This export exposes a lot of TypeScript interfaces used throughout storybook, including for storybook configuration, addons etc.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/lib/cli-storybook/README.md
+++ b/code/lib/cli-storybook/README.md
@@ -47,3 +47,5 @@ This export contains the API that is available in the manager iframe.
 ### `storybook/types`
 
 This export exposes a lot of TypeScript interfaces used throughout storybook, including for storybook configuration, addons etc.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/lib/cli-storybook/README.md
+++ b/code/lib/cli-storybook/README.md
@@ -48,4 +48,4 @@ This export contains the API that is available in the manager iframe.
 
 This export exposes a lot of TypeScript interfaces used throughout storybook, including for storybook configuration, addons etc.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/lib/codemod/README.md
+++ b/code/lib/codemod/README.md
@@ -107,3 +107,5 @@ Basic.decorators = [ ... ];
 ```
 
 The new syntax is slightly more compact, is more ergonomic, and resembles React's `displayName`/`propTypes`/`defaultProps` annotations.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/lib/codemod/README.md
+++ b/code/lib/codemod/README.md
@@ -108,4 +108,4 @@ Basic.decorators = [ ... ];
 
 The new syntax is slightly more compact, is more ergonomic, and resembles React's `displayName`/`propTypes`/`defaultProps` annotations.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/lib/codemod/README.md
+++ b/code/lib/codemod/README.md
@@ -108,4 +108,4 @@ Basic.decorators = [ ... ];
 
 The new syntax is slightly more compact, is more ergonomic, and resembles React's `displayName`/`propTypes`/`defaultProps` annotations.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/lib/core-webpack/README.md
+++ b/code/lib/core-webpack/README.md
@@ -8,4 +8,4 @@ Supporting multiple version of webpack and this duplicating a large portion of c
 
 At some point we'll refactor this, it's likely a lot of this code is dead or barely used.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/lib/core-webpack/README.md
+++ b/code/lib/core-webpack/README.md
@@ -7,3 +7,5 @@ This is a lot of code extracted for convenience, not because it made sense.
 Supporting multiple version of webpack and this duplicating a large portion of code that was never meant to be generic caused this.
 
 At some point we'll refactor this, it's likely a lot of this code is dead or barely used.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/lib/core-webpack/README.md
+++ b/code/lib/core-webpack/README.md
@@ -8,4 +8,4 @@ Supporting multiple version of webpack and this duplicating a large portion of c
 
 At some point we'll refactor this, it's likely a lot of this code is dead or barely used.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/lib/create-storybook/README.md
+++ b/code/lib/create-storybook/README.md
@@ -1,3 +1,7 @@
-## Initialize Storybook into your project
+## Install Storybook in your project
+
+```sh
+npm create storybook@latest
+```
 
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/lib/create-storybook/README.md
+++ b/code/lib/create-storybook/README.md
@@ -1,1 +1,3 @@
 ## Initialize Storybook into your project
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/lib/create-storybook/README.md
+++ b/code/lib/create-storybook/README.md
@@ -1,3 +1,3 @@
 ## Initialize Storybook into your project
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/lib/create-storybook/README.md
+++ b/code/lib/create-storybook/README.md
@@ -4,4 +4,4 @@
 npm create storybook@latest
 ```
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/lib/csf-plugin/README.md
+++ b/code/lib/csf-plugin/README.md
@@ -24,3 +24,5 @@ Basic.parameters = {
 ```
 
 This allows `@storybook/addon-docs` to display the static source snippet.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/lib/csf-plugin/README.md
+++ b/code/lib/csf-plugin/README.md
@@ -25,4 +25,4 @@ Basic.parameters = {
 
 This allows `@storybook/addon-docs` to display the static source snippet.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/lib/csf-plugin/README.md
+++ b/code/lib/csf-plugin/README.md
@@ -25,4 +25,4 @@ Basic.parameters = {
 
 This allows `@storybook/addon-docs` to display the static source snippet.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/lib/eslint-plugin/README.md
+++ b/code/lib/eslint-plugin/README.md
@@ -145,7 +145,7 @@ import tseslint from 'typescript-eslint';
 export default tseslint.config(
   somePlugin,
   storybook.configs["flat/recommended"] // notice that it is not destructured
-);"
+);
 ```
 
 #### Overriding/disabling rules

--- a/code/lib/eslint-plugin/README.md
+++ b/code/lib/eslint-plugin/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://storybook.js.org/?utm_source=readme">
+  <a href="https://storybook.js.org/?ref=readme">
     <img src="https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png" alt="Storybook" width="400" />
   </a>
 </p>
@@ -12,7 +12,7 @@
   <a href="https://discord.gg/storybook">
     <img src="https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat" />
   </a>
-  <a href="https://storybook.js.org/community/?utm_source=readme">
+  <a href="https://storybook.js.org/community/?ref=readme">
     <img src="https://img.shields.io/badge/community-join-4BC424.svg" alt="Storybook Community" />
   </a>
   <a href="#backers">
@@ -138,13 +138,13 @@ export default [
 In case you are using utility functions from tools like `tseslint`, you might need to set the plugin a little differently:
 
 ```ts
-import storybook from "eslint-plugin-storybook";
-
+import storybook from 'eslint-plugin-storybook';
 import somePlugin from 'some-plugin';
 import tseslint from 'typescript-eslint';
+
 export default tseslint.config(
   somePlugin,
-  storybook.configs["flat/recommended"] // notice that it is not destructured
+  storybook.configs['flat/recommended'] // notice that it is not destructured
 );
 ```
 
@@ -210,4 +210,4 @@ This plugin does not support MDX files.
 Looking into improving this plugin? That would be awesome!
 Please refer to [the contributing guidelines](./CONTRIBUTING.md) for steps to contributing.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/lib/eslint-plugin/README.md
+++ b/code/lib/eslint-plugin/README.md
@@ -1,0 +1,213 @@
+<p align="center">
+  <a href="https://storybook.js.org/?utm_source=readme">
+    <img src="https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png" alt="Storybook" width="400" />
+  </a>
+</p>
+
+<p align="center">Build bulletproof UI components faster</p>
+
+<br/>
+
+<p align="center">
+  <a href="https://discord.gg/storybook">
+    <img src="https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat" />
+  </a>
+  <a href="https://storybook.js.org/community/?utm_source=readme">
+    <img src="https://img.shields.io/badge/community-join-4BC424.svg" alt="Storybook Community" />
+  </a>
+  <a href="#backers">
+    <img src="https://opencollective.com/storybook/backers/badge.svg" alt="Backers on Open Collective" />
+  </a>
+  <a href="#sponsors">
+    <img src="https://opencollective.com/storybook/sponsors/badge.svg" alt="Sponsors on Open Collective" />
+  </a>
+  <a href="https://twitter.com/intent/follow?screen_name=storybookjs">
+    <img src="https://badgen.net/twitter/follow/storybookjs?icon=twitter&label=%40storybookjs" alt="Official Twitter Handle" />
+  </a>
+</p>
+
+# eslint-plugin-storybook
+
+Best practice rules for Storybook
+
+## Installation
+
+You'll first need to install [ESLint](https://eslint.org/):
+
+```sh
+npm install eslint --save-dev
+# or
+yarn add eslint --dev
+```
+
+Next, install `eslint-plugin-storybook`:
+
+```sh
+npm install eslint-plugin-storybook --save-dev
+# or
+yarn add eslint-plugin-storybook --dev
+```
+
+And finally, add this to your `.eslintignore` file:
+
+```
+// Inside your .eslintignore file
+!.storybook
+```
+
+This allows for this plugin to also lint your configuration files inside the .storybook folder, so that you always have a correct configuration and don't face any issues regarding mistyped addon names, for instance.
+
+> For more info on why this line is required in the .eslintignore file, check this [ESLint documentation](https://eslint.org/docs/latest/use/configure/ignore-deprecated#:~:text=In%20addition%20to,contents%20are%20ignored).
+
+If you are using [flat config style](https://eslint.org/docs/latest/use/configure/configuration-files-new), add this to your configuration file:
+
+```js
+export default [
+  // ...
+  {
+    // Inside your .eslintignore file
+    ignores: ['!.storybook'],
+  },
+];
+```
+
+## ESLint compatibility
+
+Use the following table to use the correct version of this package, based on the version of ESLint you're using:
+
+| ESLint version | Storybook plugin version |
+| -------------- | ------------------------ |
+| ^9.0.0         | ^0.10.0                  |
+| ^8.57.0        | ^0.10.0                  |
+| ^7.0.0         | ~0.9.0                   |
+
+## Usage
+
+### Configuration (`.eslintrc`)
+
+Use `.eslintrc.*` file to configure rules in ESLint < v9. See also: https://eslint.org/docs/latest/use/configure/.
+
+Add `plugin:storybook/recommended` to the extends section of your `.eslintrc` configuration file. Note that we can omit the `eslint-plugin-` prefix:
+
+```js
+{
+  // extend plugin:storybook/<configuration>, such as:
+  "extends": ["plugin:storybook/recommended"]
+}
+```
+
+This plugin will only be applied to files following the `*.stories.*` (we recommend this) or `*.story.*` pattern. This is an automatic configuration, so you don't have to do anything.
+
+#### Overriding/disabling rules
+
+Optionally, you can override, add or disable rules settings. You likely don't want these settings to be applied in every file, so make sure that you add a `overrides` section in your `.eslintrc.*` file that applies the overrides only to your stories files.
+
+```js
+{
+  "overrides": [
+    {
+      // or whatever matches stories specified in .storybook/main.js
+      "files": ['**/*.stories.@(ts|tsx|js|jsx|mjs|cjs)'],
+      "rules": {
+        // example of overriding a rule
+        'storybook/hierarchy-separator': 'error',
+        // example of disabling a rule
+        'storybook/default-exports': 'off',
+      }
+    }
+  ]
+}
+```
+
+### Configuration (`eslint.config.[c|m]?js`)
+
+Use `eslint.config.[c|m]?js` file to configure rules using the [flat config style](https://eslint.org/docs/latest/use/configure/configuration-files-new). This is the default in ESLint v9, but can be used starting from ESLint v8.57.0. See also: https://eslint.org/docs/latest/use/configure/configuration-files-new.
+
+```js
+import storybook from 'eslint-plugin-storybook';
+
+export default [
+  // add more generic rulesets here, such as:
+  // js.configs.recommended,
+  ...storybook.configs['flat/recommended'],
+
+  // something ...
+];
+```
+
+In case you are using utility functions from tools like `tseslint`, you might need to set the plugin a little differently:
+
+```ts
+import storybook from "eslint-plugin-storybook";
+
+import somePlugin from 'some-plugin';
+import tseslint from 'typescript-eslint';
+export default tseslint.config(
+  somePlugin,
+  storybook.configs["flat/recommended"] // notice that it is not destructured
+);"
+```
+
+#### Overriding/disabling rules
+
+Optionally, you can override, add or disable rules settings. You likely don't want these settings to be applied in every file, so make sure that you add a flat config section in your `eslint.config.[m|c]?js` file that applies the overrides only to your stories files.
+
+```js
+import storybook from 'eslint-plugin-storybook';
+
+export default [
+  // ...
+
+  ...storybook.configs['flat/recommended'],
+  {
+    files: ['**/*.stories.@(ts|tsx|js|jsx|mjs|cjs)'],
+    rules: {
+      // example of overriding a rule
+      'storybook/hierarchy-separator': 'error',
+      // example of disabling a rule
+      'storybook/default-exports': 'off',
+    },
+  },
+
+  // something ...
+];
+```
+
+### MDX Support
+
+This plugin does not support MDX files.
+
+## Supported Rules and configurations
+
+<!-- RULES-LIST:START -->
+
+**Key**: 🔧 = fixable
+
+**Configurations**: csf, csf-strict, addon-interactions, recommended
+
+| Name                                                                                       | Description                                                                                                                   | 🔧  | Included in configurations                                                                                                     |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | --- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [`storybook/await-interactions`](./docs/rules/await-interactions.md)                       | Interactions should be awaited                                                                                                | 🔧  | <ul><li>addon-interactions</li><li>flat/addon-interactions</li><li>recommended</li><li>flat/recommended</li></ul>              |
+| [`storybook/context-in-play-function`](./docs/rules/context-in-play-function.md)           | Pass a context when invoking play function of another story                                                                   |     | <ul><li>recommended</li><li>flat/recommended</li><li>addon-interactions</li><li>flat/addon-interactions</li></ul>              |
+| [`storybook/csf-component`](./docs/rules/csf-component.md)                                 | The component property should be set                                                                                          |     | <ul><li>csf</li><li>flat/csf</li><li>csf-strict</li><li>flat/csf-strict</li></ul>                                              |
+| [`storybook/default-exports`](./docs/rules/default-exports.md)                             | Story files should have a default export                                                                                      | 🔧  | <ul><li>csf</li><li>flat/csf</li><li>recommended</li><li>flat/recommended</li><li>csf-strict</li><li>flat/csf-strict</li></ul> |
+| [`storybook/hierarchy-separator`](./docs/rules/hierarchy-separator.md)                     | Deprecated hierarchy separator in title property                                                                              | 🔧  | <ul><li>csf</li><li>flat/csf</li><li>recommended</li><li>flat/recommended</li><li>csf-strict</li><li>flat/csf-strict</li></ul> |
+| [`storybook/meta-inline-properties`](./docs/rules/meta-inline-properties.md)               | Meta should only have inline properties                                                                                       |     | N/A                                                                                                                            |
+| [`storybook/meta-satisfies-type`](./docs/rules/meta-satisfies-type.md)                     | Meta should use `satisfies Meta`                                                                                              | 🔧  | N/A                                                                                                                            |
+| [`storybook/no-redundant-story-name`](./docs/rules/no-redundant-story-name.md)             | A story should not have a redundant name property                                                                             | 🔧  | <ul><li>csf</li><li>flat/csf</li><li>recommended</li><li>flat/recommended</li><li>csf-strict</li><li>flat/csf-strict</li></ul> |
+| [`storybook/no-stories-of`](./docs/rules/no-stories-of.md)                                 | storiesOf is deprecated and should not be used                                                                                |     | <ul><li>csf-strict</li><li>flat/csf-strict</li></ul>                                                                           |
+| [`storybook/no-title-property-in-meta`](./docs/rules/no-title-property-in-meta.md)         | Do not define a title in meta                                                                                                 | 🔧  | <ul><li>csf-strict</li><li>flat/csf-strict</li></ul>                                                                           |
+| [`storybook/no-uninstalled-addons`](./docs/rules/no-uninstalled-addons.md)                 | This rule identifies storybook addons that are invalid because they are either not installed or contain a typo in their name. |     | <ul><li>recommended</li><li>flat/recommended</li></ul>                                                                         |
+| [`storybook/prefer-pascal-case`](./docs/rules/prefer-pascal-case.md)                       | Stories should use PascalCase                                                                                                 | 🔧  | <ul><li>recommended</li><li>flat/recommended</li></ul>                                                                         |
+| [`storybook/story-exports`](./docs/rules/story-exports.md)                                 | A story file must contain at least one story export                                                                           |     | <ul><li>recommended</li><li>flat/recommended</li><li>csf</li><li>flat/csf</li><li>csf-strict</li><li>flat/csf-strict</li></ul> |
+| [`storybook/use-storybook-expect`](./docs/rules/use-storybook-expect.md)                   | Use expect from `@storybook/test`, `storybook/test` or `@storybook/jest`                                                      | 🔧  | <ul><li>addon-interactions</li><li>flat/addon-interactions</li><li>recommended</li><li>flat/recommended</li></ul>              |
+| [`storybook/use-storybook-testing-library`](./docs/rules/use-storybook-testing-library.md) | Do not use testing-library directly on stories                                                                                | 🔧  | <ul><li>addon-interactions</li><li>flat/addon-interactions</li><li>recommended</li><li>flat/recommended</li></ul>              |
+
+<!-- RULES-LIST:END -->
+
+## Contributors
+
+Looking into improving this plugin? That would be awesome!
+Please refer to [the contributing guidelines](./CONTRIBUTING.md) for steps to contributing.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/lib/eslint-plugin/README.md
+++ b/code/lib/eslint-plugin/README.md
@@ -210,4 +210,4 @@ This plugin does not support MDX files.
 Looking into improving this plugin? That would be awesome!
 Please refer to [the contributing guidelines](./CONTRIBUTING.md) for steps to contributing.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/lib/react-dom-shim/README.md
+++ b/code/lib/react-dom-shim/README.md
@@ -2,4 +2,4 @@
 
 A shim for `react-dom` that provides a single API that will work whether the user is on `react-dom@17` or `react-dom@18`, as well as webpack/vite config necessary to make that work.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/lib/react-dom-shim/README.md
+++ b/code/lib/react-dom-shim/README.md
@@ -1,3 +1,5 @@
 # React Dom Shim
 
 A shim for `react-dom` that provides a single API that will work whether the user is on `react-dom@17` or `react-dom@18`, as well as webpack/vite config necessary to make that work.
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/lib/react-dom-shim/README.md
+++ b/code/lib/react-dom-shim/README.md
@@ -2,4 +2,4 @@
 
 A shim for `react-dom` that provides a single API that will work whether the user is on `react-dom@17` or `react-dom@18`, as well as webpack/vite config necessary to make that work.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/presets/create-react-app/README.md
+++ b/code/presets/create-react-app/README.md
@@ -117,7 +117,7 @@ config directory. If you have changed the conditions to utilize an `exclude`, th
 be true (which isn't likely going to work as expected).
 
 The steps to remedy this would be to follow the steps for customizing the webpack config within the storybook
-side of things. [Details for storybook custom webpack config](https://storybook.js.org/docs/configurations/custom-webpack-config/)
+side of things. [Details for storybook custom webpack config](https://storybook.js.org/docs/configurations/custom-webpack-config/?utm_source=readme)
 You'll have access to all of the rules in `config.module.rules`. You'll need to find the offending rule,
 and customize it how you need it to be to be compatible with your fork.
 
@@ -128,3 +128,5 @@ concerning the conditions.
 
 - [Walkthrough to set up Storybook Docs with CRA & typescript](https://gist.github.com/shilman/bc9cbedb2a7efb5ec6710337cbd20c0c)
 - [Example projects (used for testing this preset)](https://github.com/storybookjs/presets/tree/master/examples)
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/presets/create-react-app/README.md
+++ b/code/presets/create-react-app/README.md
@@ -129,4 +129,4 @@ concerning the conditions.
 - [Walkthrough to set up Storybook Docs with CRA & typescript](https://gist.github.com/shilman/bc9cbedb2a7efb5ec6710337cbd20c0c)
 - [Example projects (used for testing this preset)](https://github.com/storybookjs/presets/tree/master/examples)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/presets/create-react-app/README.md
+++ b/code/presets/create-react-app/README.md
@@ -117,7 +117,7 @@ config directory. If you have changed the conditions to utilize an `exclude`, th
 be true (which isn't likely going to work as expected).
 
 The steps to remedy this would be to follow the steps for customizing the webpack config within the storybook
-side of things. [Details for storybook custom webpack config](https://storybook.js.org/docs/configurations/custom-webpack-config/?utm_source=readme)
+side of things. [Details for storybook custom webpack config](https://storybook.js.org/docs/configurations/custom-webpack-config/?ref=readme)
 You'll have access to all of the rules in `config.module.rules`. You'll need to find the offending rule,
 and customize it how you need it to be to be compatible with your fork.
 
@@ -129,4 +129,4 @@ concerning the conditions.
 - [Walkthrough to set up Storybook Docs with CRA & typescript](https://gist.github.com/shilman/bc9cbedb2a7efb5ec6710337cbd20c0c)
 - [Example projects (used for testing this preset)](https://github.com/storybookjs/presets/tree/master/examples)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/presets/react-webpack/README.md
+++ b/code/presets/react-webpack/README.md
@@ -1,8 +1,8 @@
 # Storybook Webpack preset for React
 
-This package is a [preset](https://storybook.js.org/docs/addons/writing-presets?renderer=react&utm_source=readme) that configures Storybook's webpack settings for handling React.
+This package is a [preset](https://storybook.js.org/docs/addons/writing-presets?renderer=react&ref=readme) that configures Storybook's webpack settings for handling React.
 It's an internal package that's not intended to be used directly by users.
 
-- More info on [Storybook for React](https://storybook.js.org/docs/get-started/install?renderer=react&utm_source=readme)
+- More info on [Storybook for React](https://storybook.js.org/docs/get-started/install?renderer=react&ref=readme)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/presets/react-webpack/README.md
+++ b/code/presets/react-webpack/README.md
@@ -5,4 +5,4 @@ It's an internal package that's not intended to be used directly by users.
 
 - More info on [Storybook for React](https://storybook.js.org/docs/get-started/install?renderer=react&utm_source=readme)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/presets/react-webpack/README.md
+++ b/code/presets/react-webpack/README.md
@@ -1,6 +1,8 @@
 # Storybook Webpack preset for React
 
-This package is a [preset](https://storybook.js.org/docs/addons/writing-presets?renderer=react) that configures Storybook's webpack settings for handling React.
+This package is a [preset](https://storybook.js.org/docs/addons/writing-presets?renderer=react&utm_source=readme) that configures Storybook's webpack settings for handling React.
 It's an internal package that's not intended to be used directly by users.
 
-- More info on [Storybook for React](https://storybook.js.org/docs/get-started/install?renderer=react)
+- More info on [Storybook for React](https://storybook.js.org/docs/get-started/install?renderer=react&utm_source=readme)
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/presets/server-webpack/README.md
+++ b/code/presets/server-webpack/README.md
@@ -1,8 +1,8 @@
 # Storybook Webpack preset for Server
 
-This package is a [preset](https://storybook.js.org/docs/addons/writing-presets?utm_source=readme) that configures Storybook's webpack settings for handling React.
+This package is a [preset](https://storybook.js.org/docs/addons/writing-presets?ref=readme) that configures Storybook's webpack settings for handling React.
 It's an internal package that's not intended to be used directly by users.
 
 - More info on [Storybook for Server](https://github.com/storybookjs/storybook/tree/next/code/frameworks/server-webpack5)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/presets/server-webpack/README.md
+++ b/code/presets/server-webpack/README.md
@@ -1,6 +1,8 @@
 # Storybook Webpack preset for Server
 
-This package is a [preset](https://storybook.js.org/docs/addons/writing-presets) that configures Storybook's webpack settings for handling React.
+This package is a [preset](https://storybook.js.org/docs/addons/writing-presets?utm_source=readme) that configures Storybook's webpack settings for handling React.
 It's an internal package that's not intended to be used directly by users.
 
 - More info on [Storybook for Server](https://github.com/storybookjs/storybook/tree/next/code/frameworks/server-webpack5)
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/presets/server-webpack/README.md
+++ b/code/presets/server-webpack/README.md
@@ -5,4 +5,4 @@ It's an internal package that's not intended to be used directly by users.
 
 - More info on [Storybook for Server](https://github.com/storybookjs/storybook/tree/next/code/frameworks/server-webpack5)
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/html/README.md
+++ b/code/renderers/html/README.md
@@ -1,3 +1,3 @@
 # Storybook HTML Renderer
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/html/README.md
+++ b/code/renderers/html/README.md
@@ -1,3 +1,5 @@
 # Storybook HTML Renderer
 
+Develop, document, and test UI components in isolation.
+
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/html/README.md
+++ b/code/renderers/html/README.md
@@ -2,4 +2,4 @@
 
 Develop, document, and test UI components in isolation.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/renderers/html/README.md
+++ b/code/renderers/html/README.md
@@ -1,1 +1,3 @@
 # Storybook HTML Renderer
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/renderers/preact/README.md
+++ b/code/renderers/preact/README.md
@@ -1,1 +1,3 @@
 # Storybook Preact renderer
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/renderers/preact/README.md
+++ b/code/renderers/preact/README.md
@@ -2,4 +2,4 @@
 
 Develop, document, and test UI components in isolation.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/renderers/preact/README.md
+++ b/code/renderers/preact/README.md
@@ -1,3 +1,3 @@
 # Storybook Preact renderer
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/preact/README.md
+++ b/code/renderers/preact/README.md
@@ -1,3 +1,5 @@
 # Storybook Preact renderer
 
+Develop, document, and test UI components in isolation.
+
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/react/README.md
+++ b/code/renderers/react/README.md
@@ -1,3 +1,3 @@
 # Storybook React renderer
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/react/README.md
+++ b/code/renderers/react/README.md
@@ -1,3 +1,3 @@
 # Storybook React renderer
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/renderers/react/README.md
+++ b/code/renderers/react/README.md
@@ -1,1 +1,3 @@
 # Storybook React renderer
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/renderers/server/README.md
+++ b/code/renderers/server/README.md
@@ -2,4 +2,4 @@
 
 Develop, document, and test UI components in isolation.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/renderers/server/README.md
+++ b/code/renderers/server/README.md
@@ -1,3 +1,3 @@
 # Storybook Server renderer
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/server/README.md
+++ b/code/renderers/server/README.md
@@ -1,3 +1,5 @@
 # Storybook Server renderer
 
+Develop, document, and test UI components in isolation.
+
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/server/README.md
+++ b/code/renderers/server/README.md
@@ -1,1 +1,3 @@
 # Storybook Server renderer
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/renderers/svelte/README.md
+++ b/code/renderers/svelte/README.md
@@ -2,4 +2,4 @@
 
 Develop, document, and test UI components in isolation.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/renderers/svelte/README.md
+++ b/code/renderers/svelte/README.md
@@ -1,3 +1,5 @@
 # Storybook Svelte renderer
 
+Develop, document, and test UI components in isolation.
+
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/svelte/README.md
+++ b/code/renderers/svelte/README.md
@@ -1,3 +1,3 @@
 # Storybook Svelte renderer
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/svelte/README.md
+++ b/code/renderers/svelte/README.md
@@ -1,1 +1,3 @@
 # Storybook Svelte renderer
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/renderers/vue3/README.md
+++ b/code/renderers/vue3/README.md
@@ -1,1 +1,3 @@
 # Storybook Vue3 renderer
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/renderers/vue3/README.md
+++ b/code/renderers/vue3/README.md
@@ -2,4 +2,4 @@
 
 Develop, document, and test UI components in isolation.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/renderers/vue3/README.md
+++ b/code/renderers/vue3/README.md
@@ -1,3 +1,5 @@
 # Storybook Vue3 renderer
 
+Develop, document, and test UI components in isolation.
+
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/vue3/README.md
+++ b/code/renderers/vue3/README.md
@@ -1,3 +1,3 @@
 # Storybook Vue3 renderer
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/web-components/README.md
+++ b/code/renderers/web-components/README.md
@@ -1,1 +1,3 @@
 # Storybook web-components renderer
+
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)

--- a/code/renderers/web-components/README.md
+++ b/code/renderers/web-components/README.md
@@ -2,4 +2,4 @@
 
 Develop, document, and test UI components in isolation.
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/code/renderers/web-components/README.md
+++ b/code/renderers/web-components/README.md
@@ -1,3 +1,5 @@
 # Storybook web-components renderer
 
+Develop, document, and test UI components in isolation.
+
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).

--- a/code/renderers/web-components/README.md
+++ b/code/renderers/web-components/README.md
@@ -1,3 +1,3 @@
 # Storybook web-components renderer
 
-Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme)
+Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?utm_source=readme).


### PR DESCRIPTION
Closes N/A

## What I did

- [x] Update README files to with tracking parameters (`ref=readme`) to Storybook links. 
- [x] Add a "Learn more about Storybook" paragraph with a direct link to the Storybook homepage.
- [x] Restore ESLint Plugin README that was lost when the Plugin was moved to the monorepo

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
