### PR TITLE
fix:re-export ThemeVars

### DIFF
--- a/code/core/src/theming/create.ts
+++ b/code/core/src/theming/create.ts
@@ -10,6 +10,8 @@ export const themes: { light: ThemeVars; dark: ThemeVars; normal: ThemeVars } = 
   normal: lightThemeVars,
 };
 
+export type { ThemeVars };
+
 interface Rest {
   [key: string]: any;
 }


### PR DESCRIPTION
## What I did

Re-export the `ThemeVars` type.

Currently, the return value of `create` uses a type that is not exported. This means this result cannot itself be rexported.

Given a file `.storybook/theme.ts`...

```ts
import { create } from "storybook/theming/create";

// TS4023: Exported variable themes has or is using name ThemeVars from external module
export const themes = {
  dark: create({...}),
  light: create({...})
}
```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

-

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR addresses a TypeScript compilation issue by re-exporting the `ThemeVars` type from the theming create module. The change adds a single line `export type { ThemeVars };` to `code/core/src/theming/create.ts`.

The problem occurs when developers try to create and re-export theme objects using Storybook's `create` function. While the `create` function returns a `ThemeVars` object, this type wasn't previously exported from the module, causing TypeScript error TS4023 when users attempt to export their theme configurations. This is a common pattern where developers create custom themes in `.storybook/theme.ts` and want to share them across projects.

The fix integrates seamlessly with the existing theming system. The `create.ts` file already imports `ThemeVars` from type definitions and uses it as the return type for the `create` function. By adding the type export, the module maintains its existing functionality while enabling the expected usage pattern of exporting theme objects created with the `create` function. This change doesn't affect any runtime behavior - it's purely a TypeScript interface improvement that makes the theming API more developer-friendly.

**PR Description Notes:**
- The PR title doesn't follow the required format 'Area: Summary' (should be something like 'Theming: Re-export ThemeVars type')
- Missing label assignment as mentioned in the checklist
- Testing section indicates no automated tests cover this change

## Confidence score: 5/5

- This PR is extremely safe to merge with no risk of breaking changes or runtime issues
- Score reflects a minimal, well-targeted fix that only adds a type export without changing any implementation logic
- No files require special attention as this is a single-line addition to improve TypeScript compatibility

### Context used:
**Context -** PR titles must be in the format of 'Area: Summary', with both Area and Summary starting with a capital letter. ([link](https://app.greptile.com/review/custom-context?memory=b5aedbe7-fa39-4616-a54b-c8147b7dce13))
**Context -** Ensure all pull requests are labeled appropriately before submission, including one of the specified labels for categorization. ([link](https://app.greptile.com/review/custom-context?memory=a3291e6c-d5d1-4828-9139-908602b16eb9))

<!-- /greptile_comment -->