### PR TITLE
Svelte: Support `@sveltejs/vite-plugin-svelte` v6

### DIFF
--- a/code/frameworks/svelte-vite/package.json
+++ b/code/frameworks/svelte-vite/package.json
@@ -68,7 +68,7 @@
     "vite": "^7.0.4"
   },
   "peerDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+    "@sveltejs/vite-plugin-svelte": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "storybook": "workspace:^",
     "svelte": "^5.0.0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6896,7 +6896,7 @@ __metadata:
     typescript: "npm:^5.8.3"
     vite: "npm:^7.0.4"
   peerDependencies:
-    "@sveltejs/vite-plugin-svelte": ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+    "@sveltejs/vite-plugin-svelte": ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     storybook: "workspace:^"
     svelte: ^5.0.0
     vite: ^5.0.0 || ^6.0.0 || ^7.0.0


### PR DESCRIPTION
Closes #32082

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR extends the peer dependency range for `@sveltejs/vite-plugin-svelte` in the `@storybook/svelte-vite` package to include version 6.x by adding `|| ^6.0.0` to the existing range. The change addresses issue #32082 where users encountered dependency conflicts when attempting to upgrade to Vite 7, as newer versions of `@sveltejs/vite-plugin-svelte` (specifically v6) are required to support Vite 7.

The modification is minimal and surgical, expanding the peer dependency constraint from `^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0` to `^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0`. This maintains backward compatibility with existing projects while enabling forward compatibility with newer tooling versions. The change allows Storybook users working with Svelte to upgrade their Vite dependencies without encountering peer dependency resolution failures.

This fits into the broader ecosystem by ensuring Storybook's Svelte framework integration remains compatible with the latest versions of the underlying build tools, particularly as the Vite ecosystem continues to evolve rapidly.

PR Description Notes:
- The PR title claims "v7" support but the actual change adds "v6" support
- The "What I did" section is empty and should describe the dependency range expansion

## Confidence score: 3/5

- This PR is relatively safe but has a title/implementation mismatch that could cause confusion
- Score reflects the minimal nature of the change but concerns about the version discrepancy between title and implementation
- Pay close attention to the version mismatch between PR title (v7) and actual implementation (v6)

<!-- /greptile_comment -->