### PR TITLE
bug: Replace disabled attr with aria-disabled in Button

### DIFF
--- a/code/addons/onboarding/src/features/IntentSurvey/IntentSurvey.stories.tsx
+++ b/code/addons/onboarding/src/features/IntentSurvey/IntentSurvey.stories.tsx
@@ -20,23 +20,23 @@ export const Default: Story = {};
 export const Submitting: Story = {
   play: async ({ args }) => {
     const button = await screen.findByRole('button', { name: 'Submit' });
-    await expect(button).toBeDisabled();
+    await expect(button).toHaveAttribute('aria-disabled', true);
 
     await userEvent.click(await screen.findByText('Design system'));
-    await expect(button).toBeDisabled();
+    await expect(button).toHaveAttribute('aria-disabled', true);
 
     await userEvent.click(await screen.findByText('Functional testing'));
     await userEvent.click(await screen.findByText('Accessibility testing'));
     await userEvent.click(await screen.findByText('Visual testing'));
-    await expect(button).toBeDisabled();
+    await expect(button).toHaveAttribute('aria-disabled', true);
 
     await userEvent.selectOptions(screen.getByRole('combobox'), ['We use it at work']);
-    await expect(button).not.toBeDisabled();
+    await expect(button).not.toHaveAttribute('aria-disabled', true);
 
     await userEvent.click(button);
 
     await waitFor(async () => {
-      await expect(button).toBeDisabled();
+      await expect(button).toHaveAttribute('aria-disabled', true);
       await expect(args.onComplete).toHaveBeenCalledWith({
         building: {
           'application-ui': false,

--- a/code/addons/onboarding/src/features/IntentSurvey/IntentSurvey.stories.tsx
+++ b/code/addons/onboarding/src/features/IntentSurvey/IntentSurvey.stories.tsx
@@ -20,23 +20,23 @@ export const Default: Story = {};
 export const Submitting: Story = {
   play: async ({ args }) => {
     const button = await screen.findByRole('button', { name: 'Submit' });
-    await expect(button).toHaveAttribute('aria-disabled', true);
+    await expect(button).toHaveAttribute('aria-disabled', 'true');
 
     await userEvent.click(await screen.findByText('Design system'));
-    await expect(button).toHaveAttribute('aria-disabled', true);
+    await expect(button).toHaveAttribute('aria-disabled', 'true');
 
     await userEvent.click(await screen.findByText('Functional testing'));
     await userEvent.click(await screen.findByText('Accessibility testing'));
     await userEvent.click(await screen.findByText('Visual testing'));
-    await expect(button).toHaveAttribute('aria-disabled', true);
+    await expect(button).toHaveAttribute('aria-disabled', 'true');
 
     await userEvent.selectOptions(screen.getByRole('combobox'), ['We use it at work']);
-    await expect(button).not.toHaveAttribute('aria-disabled', true);
+    await expect(button).toHaveAttribute('aria-disabled', 'false');
 
     await userEvent.click(button);
 
     await waitFor(async () => {
-      await expect(button).toHaveAttribute('aria-disabled', true);
+      await expect(button).toHaveAttribute('aria-disabled', 'true');
       await expect(args.onComplete).toHaveBeenCalledWith({
         building: {
           'application-ui': false,

--- a/code/core/src/components/components/Button/Button.stories.tsx
+++ b/code/core/src/components/components/Button/Button.stories.tsx
@@ -160,13 +160,6 @@ export const Disabled = meta.story({
     children: 'Disabled Button',
     onClick: () => {},
   } satisfies ButtonProps,
-  render: (args) => (
-    <Row>
-      <Button variant="solid" {...args}>
-        Disabled Button
-      </Button>
-    </Row>
-  ),
 });
 
 export const WithHref = meta.story({

--- a/code/core/src/components/components/Button/Button.stories.tsx
+++ b/code/core/src/components/components/Button/Button.stories.tsx
@@ -5,7 +5,7 @@ import { styled } from 'storybook/internal/theming';
 import { FaceHappyIcon } from '@storybook/icons';
 
 import preview from '../../../../../.storybook/preview';
-import { Button } from './Button';
+import { Button, type ButtonProps } from './Button';
 
 const meta = preview.meta({
   id: 'button-component',
@@ -158,7 +158,15 @@ export const Disabled = meta.story({
   args: {
     disabled: true,
     children: 'Disabled Button',
-  },
+    onClick: () => {},
+  } satisfies ButtonProps,
+  render: (args) => (
+    <Row>
+      <Button variant="solid" {...args}>
+        Disabled Button
+      </Button>
+    </Row>
+  ),
 });
 
 export const WithHref = meta.story({

--- a/code/core/src/components/components/Button/Button.tsx
+++ b/code/core/src/components/components/Button/Button.tsx
@@ -5,7 +5,7 @@ import { Slot } from '@radix-ui/react-slot';
 import { darken, lighten, rgba, transparentize } from 'polished';
 import { isPropValid, styled } from 'storybook/theming';
 
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'disabled'> {
   asChild?: boolean;
   size?: 'small' | 'medium';
   padding?: 'small' | 'medium' | 'none';
@@ -25,9 +25,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       variant = 'outline',
       padding = 'medium',
       disabled = false,
+      disabled = false,
       active = false,
       onClick,
-      ...props
+      ...restProps
     },
     ref
   ) => {
@@ -40,6 +41,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const [isAnimating, setIsAnimating] = useState(false);
 
     const handleClick = (event: SyntheticEvent) => {
+      if (disabled) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       if (onClick) {
         onClick(event);
       }
@@ -66,12 +72,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         variant={variant}
         size={size}
         padding={padding}
+        aria-disabled={disabled}
         disabled={disabled}
         active={active}
         animating={isAnimating}
         animation={animation}
         onClick={handleClick}
-        {...props}
+        {...restProps}
       />
     );
   }
@@ -86,8 +93,10 @@ const StyledButton = styled('button', {
     animating: boolean;
     animation: ButtonProps['animation'];
   }
+>(({ theme, variant, size, active, disabled, animating, animation = 'none', padding }) => ({
 >(({ theme, variant, size, disabled, active, animating, animation = 'none', padding }) => ({
   border: 0,
+  cursor: disabled ? 'not-allowed' : 'pointer',
   cursor: disabled ? 'not-allowed' : 'pointer',
   display: 'inline-flex',
   gap: '6px',
@@ -122,6 +131,7 @@ const StyledButton = styled('button', {
   verticalAlign: 'top',
   whiteSpace: 'nowrap',
   userSelect: 'none',
+  opacity: disabled ? 0.5 : 1,
   opacity: disabled ? 0.5 : 1,
   margin: 0,
   fontSize: `${theme.typography.size.s1}px`,

--- a/code/core/src/components/components/Button/Button.tsx
+++ b/code/core/src/components/components/Button/Button.tsx
@@ -25,7 +25,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       variant = 'outline',
       padding = 'medium',
       disabled = false,
-      disabled = false,
       active = false,
       onClick,
       ...restProps
@@ -72,8 +71,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         variant={variant}
         size={size}
         padding={padding}
-        aria-disabled={disabled}
-        disabled={disabled}
+        aria-disabled={disabled ? 'true' : 'false'}
         active={active}
         animating={isAnimating}
         animation={animation}
@@ -93,7 +91,6 @@ const StyledButton = styled('button', {
     animating: boolean;
     animation: ButtonProps['animation'];
   }
->(({ theme, variant, size, active, disabled, animating, animation = 'none', padding }) => ({
 >(({ theme, variant, size, disabled, active, animating, animation = 'none', padding }) => ({
   border: 0,
   cursor: disabled ? 'not-allowed' : 'pointer',

--- a/code/core/src/components/components/Button/Button.tsx
+++ b/code/core/src/components/components/Button/Button.tsx
@@ -97,7 +97,6 @@ const StyledButton = styled('button', {
 >(({ theme, variant, size, disabled, active, animating, animation = 'none', padding }) => ({
   border: 0,
   cursor: disabled ? 'not-allowed' : 'pointer',
-  cursor: disabled ? 'not-allowed' : 'pointer',
   display: 'inline-flex',
   gap: '6px',
   alignItems: 'center',

--- a/code/core/src/components/components/Button/Button.tsx
+++ b/code/core/src/components/components/Button/Button.tsx
@@ -132,7 +132,6 @@ const StyledButton = styled('button', {
   whiteSpace: 'nowrap',
   userSelect: 'none',
   opacity: disabled ? 0.5 : 1,
-  opacity: disabled ? 0.5 : 1,
   margin: 0,
   fontSize: `${theme.typography.size.s1}px`,
   fontWeight: theme.typography.weight.bold,

--- a/code/e2e-tests/addon-toolbars.spec.ts
+++ b/code/e2e-tests/addon-toolbars.spec.ts
@@ -32,6 +32,6 @@ test.describe('addon-toolbars', () => {
     await expect(sbPage.previewRoot()).toContainText('안녕하세요');
 
     const button = sbPage.page.getByTitle('Internationalization locale');
-    await expect(button).toBeDisabled();
+    await expect(button).toHaveAttribute('aria-disabled');
   });
 });

--- a/code/e2e-tests/addon-viewport.spec.ts
+++ b/code/e2e-tests/addon-viewport.spec.ts
@@ -54,6 +54,6 @@ test.describe('addon-viewport', () => {
 
     const toolbar = page.getByTitle('Change the size of the preview');
 
-    await expect(toolbar).toHaveAttribute('aria-disabled');
+    await expect(toolbar).toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/code/e2e-tests/addon-viewport.spec.ts
+++ b/code/e2e-tests/addon-viewport.spec.ts
@@ -30,16 +30,16 @@ test.describe('addon-viewport', () => {
 
     // Measure the original dimensions of previewRoot
     const originalDimensions = await sbPage.getCanvasBodyElement().boundingBox();
-    await expect(originalDimensions?.width).toBeDefined();
+    expect(originalDimensions?.width).toBeDefined();
 
     await sbPage.selectToolbar('[title="Change the size of the preview"]', '#list-item-mobile1');
 
     // Measure the adjusted dimensions of previewRoot after clicking the mobile item.
     const adjustedDimensions = await sbPage.getCanvasBodyElement().boundingBox();
-    await expect(adjustedDimensions?.width).toBeDefined();
+    expect(adjustedDimensions?.width).toBeDefined();
 
     // Compare the two widths
-    await expect(adjustedDimensions?.width).not.toBe(originalDimensions?.width);
+    expect(adjustedDimensions?.width).not.toBe(originalDimensions?.width);
   });
 
   test('viewport should be uneditable when a viewport is set via globals', async ({ page }) => {
@@ -50,10 +50,10 @@ test.describe('addon-viewport', () => {
 
     // Measure the original dimensions of previewRoot
     const originalDimensions = await sbPage.getCanvasBodyElement().boundingBox();
-    await expect(originalDimensions?.width).toBeDefined();
+    expect(originalDimensions?.width).toBeDefined();
 
     const toolbar = page.getByTitle('Change the size of the preview');
 
-    await expect(toolbar).toBeDisabled();
+    await expect(toolbar).toHaveAttribute('aria-disabled');
   });
 });

--- a/test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/component-testing.spec.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/component-testing.spec.ts
@@ -214,9 +214,8 @@ test.describe("component testing", () => {
 
     // Wait for both the watch mode button to be disabled and the testing text to appear
     await Promise.all([
-      expect(watchModeButton).toBeDisabled(),
+      expect(watchModeButton).toHaveAttribute("aria-disabled", true),
       expect(page.locator("#testing-module-description")).toHaveText(/Testing/),
-
     ]);
 
     // Wait for test results to appear


### PR DESCRIPTION
Closes #31678

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Replaced native disabled with aria-disabled for accessibility.
This keeps the button focusable and prevents conflicts with native behavior while preserving styling and click handling.

Changes made:

Replaced native disabled attribute with aria-disabled to preserve focusability and accessibility.

Updated handleClick to prevent clicks when disabled is true, instead of conditionally removing the onClick handler.

Styled button still uses disabled for cursor and opacity styling.

Reasoning:

Using native disabled removes the button from keyboard navigation and makes it invisible to screen readers.
By using aria-disabled, the button remains focusable and perceivable by assistive technologies, while still preventing interactions.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-10 14:51:07 UTC

This PR implements accessibility improvements by replacing the native HTML `disabled` attribute with `aria-disabled` in the Button component. The change addresses the issue where disabled buttons are removed from the accessibility tree and cannot be navigated via keyboard, making them invisible to screen readers.

The PR updates the Button component to use `aria-disabled="true"` while maintaining visual styling through CSS that still references the `disabled` prop. The implementation adds click prevention logic in the `handleClick` method to prevent interactions when `disabled` is true, rather than relying on the native HTML disabled behavior. This approach keeps buttons focusable and perceivable by assistive technologies while still preventing user interactions.

Corresponding test files have been updated across the codebase to check for `aria-disabled` attributes instead of using DOM testing library matchers like `toBeDisabled()`. The changes affect E2E tests for addon-toolbars, addon-viewport, component testing, and IntentSurvey stories. The Button stories have been enhanced with proper TypeScript types and a custom render function for the disabled state demonstration.

## Confidence score: 1/5

- This PR contains critical syntax errors that will cause immediate compilation failures in production
- Score reflects severe code quality issues including duplicate property declarations and malformed function signatures in the core Button component
- Multiple files still contain both `disabled` and `aria-disabled` attributes simultaneously, creating conflicting implementations

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Disabled controls now expose their state via aria-disabled and block clicks, improving assistive tech behavior.

* **Bug Fixes**
  * Prevented interactions with disabled buttons and toolbar items to avoid unintended actions.

* **Tests**
  * Test assertions updated to check aria-disabled instead of the native disabled state; minor expectation adjustments to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->