### PR TITLE
Core: Add default selection for tags in main config

### DIFF
--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -282,7 +282,6 @@ export const resolvedReact = async (existing: any) => {
 /** Set up `dev-only`, `docs-only`, `test-only` tags out of the box */
 export const tags = async (existing: any) => {
   return {
-    // If there should be any default selected tag, add them before ...existing so users can still override them
     ...existing,
     'dev-only': { excludeFromDocsStories: true },
     'docs-only': { excludeFromSidebar: true },

--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -282,6 +282,7 @@ export const resolvedReact = async (existing: any) => {
 /** Set up `dev-only`, `docs-only`, `test-only` tags out of the box */
 export const tags = async (existing: any) => {
   return {
+    // If there should be any default selected tag, add them before ...existing so users can still override them
     ...existing,
     'dev-only': { excludeFromDocsStories: true },
     'docs-only': { excludeFromSidebar: true },

--- a/code/core/src/manager/components/sidebar/Sidebar.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.tsx
@@ -7,7 +7,7 @@ import {
   TooltipNote,
   WithTooltip,
 } from 'storybook/internal/components';
-import type { API_LoadedRefData, StoryIndex } from 'storybook/internal/types';
+import type { API_LoadedRefData, StoryIndex, TagsOptions } from 'storybook/internal/types';
 import type { StatusesByStoryIdAndTypeId } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
@@ -152,6 +152,16 @@ export const Sidebar = React.memo(function Sidebar({
   const { isMobile } = useLayout();
   const api = useStorybookApi();
 
+  const tagPresets = useMemo(
+    () =>
+      Object.entries(global.TAGS_OPTIONS ?? {}).reduce((acc, entry) => {
+        const [tag, option] = entry;
+        acc[tag] = option;
+        return acc;
+      }, {} as TagsOptions),
+    []
+  );
+
   return (
     <Container className="container sidebar-container" aria-label="Global">
       <ScrollArea vertical offset={3} scrollbarSize={6}>
@@ -195,7 +205,12 @@ export const Sidebar = React.memo(function Sidebar({
             }
             searchFieldContent={
               indexJson && (
-                <TagsFilter api={api} indexJson={indexJson} isDevelopment={isDevelopment} />
+                <TagsFilter
+                  api={api}
+                  indexJson={indexJson}
+                  isDevelopment={isDevelopment}
+                  tagPresets={tagPresets}
+                />
               )
             }
             {...lastViewedProps}

--- a/code/core/src/manager/components/sidebar/TagsFilter.stories.tsx
+++ b/code/core/src/manager/components/sidebar/TagsFilter.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { findByRole, fn } from 'storybook/test';
+import { findByRole, fn, screen } from 'storybook/test';
 
 import { TagsFilter } from './TagsFilter';
 
@@ -21,6 +21,7 @@ const meta = {
       applyQueryParams: fn().mockName('api::applyQueryParams'),
     } as any,
     isDevelopment: true,
+    tagPresets: {},
   },
 } satisfies Meta<typeof TagsFilter>;
 
@@ -42,22 +43,34 @@ export const Closed: Story = {
 export const ClosedWithSelection: Story = {
   args: {
     ...Closed.args,
-    initialSelectedTags: ['A', 'B'],
+    tagPresets: {
+      A: { defaultSelected: true },
+      B: { defaultSelected: true },
+    },
   },
 };
 
-export const Open: Story = {
+export const Open = {
   ...Closed,
   play: async ({ canvasElement }) => {
     const button = await findByRole(canvasElement, 'button');
     await button.click();
   },
-};
+} satisfies Story;
 
-export const OpenWithSelection: Story = {
+export const OpenWithSelection = {
   ...ClosedWithSelection,
   play: Open.play,
-};
+} satisfies Story;
+
+export const OpenWithSelectionAndInverted = {
+  ...ClosedWithSelection,
+  play: async (context) => {
+    await Open.play(context);
+    const button = await screen.findByRole('button', { name: 'Invert' });
+    await button.click();
+  },
+} satisfies Story;
 
 export const OpenEmpty: Story = {
   args: {

--- a/code/core/src/manager/components/sidebar/TagsFilter.stories.tsx
+++ b/code/core/src/manager/components/sidebar/TagsFilter.stories.tsx
@@ -44,8 +44,8 @@ export const ClosedWithSelection: Story = {
   args: {
     ...Closed.args,
     tagPresets: {
-      A: { defaultSelected: true },
-      B: { defaultSelected: true },
+      A: { defaultSelection: 'include' },
+      B: { defaultSelection: 'include' },
     },
   },
 };
@@ -63,12 +63,14 @@ export const OpenWithSelection = {
   play: Open.play,
 } satisfies Story;
 
-export const OpenWithSelectionAndInverted = {
-  ...ClosedWithSelection,
-  play: async (context) => {
-    await Open.play(context);
-    const button = await screen.findByRole('button', { name: 'Invert' });
-    await button.click();
+export const OpenWithSelectionInverted = {
+  ...Open,
+  args: {
+    ...Open.args,
+    tagPresets: {
+      A: { defaultSelection: 'exclude' },
+      B: { defaultSelection: 'exclude' },
+    },
   },
 } satisfies Story;
 

--- a/code/core/src/manager/components/sidebar/TagsFilter.tsx
+++ b/code/core/src/manager/components/sidebar/TagsFilter.tsx
@@ -47,33 +47,26 @@ const TagSelected = styled(Badge)(({ theme }) => ({
 export interface TagsFilterProps {
   api: API;
   indexJson: StoryIndex;
-  initialSelectedTags?: Tag[];
   isDevelopment: boolean;
   tagPresets: TagsOptions;
 }
 
-export const TagsFilter = ({
-  api,
-  indexJson,
-  initialSelectedTags = [],
-  isDevelopment,
-  tagPresets,
-}: TagsFilterProps) => {
+export const TagsFilter = ({ api, indexJson, isDevelopment, tagPresets }: TagsFilterProps) => {
   const allExcluded = Object.values(tagPresets).every(
     (preset) => !('defaultSelection' in preset) || preset.defaultSelection === 'exclude'
   );
 
-  const [selectedTags, setSelectedTags] = useState(initialSelectedTags);
+  const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [expanded, setExpanded] = useState(false);
   const [inverted, setInverted] = useState(allExcluded);
   const tagsActive = selectedTags.length > 0;
 
   useEffect(() => {
     const tags = Object.keys(tagPresets);
-    const selectedTags = tags.filter(
+    const defaultSelectedTags = tags.filter(
       (tag) => tagPresets[tag].defaultSelection === (allExcluded ? 'exclude' : 'include')
     );
-    setSelectedTags(selectedTags);
+    setSelectedTags(defaultSelectedTags);
   }, [tagPresets, allExcluded]);
 
   useEffect(() => {

--- a/code/core/src/manager/components/sidebar/TagsFilter.tsx
+++ b/code/core/src/manager/components/sidebar/TagsFilter.tsx
@@ -59,16 +59,22 @@ export const TagsFilter = ({
   isDevelopment,
   tagPresets,
 }: TagsFilterProps) => {
+  const allExcluded = Object.values(tagPresets).every(
+    (preset) => !('defaultSelection' in preset) || preset.defaultSelection === 'exclude'
+  );
+
   const [selectedTags, setSelectedTags] = useState(initialSelectedTags);
   const [expanded, setExpanded] = useState(false);
-  const [inverted, setInverted] = useState(false);
+  const [inverted, setInverted] = useState(allExcluded);
   const tagsActive = selectedTags.length > 0;
 
   useEffect(() => {
     const tags = Object.keys(tagPresets);
-    const selectedTags = tags.filter((tag) => tagPresets[tag].defaultSelected);
+    const selectedTags = tags.filter(
+      (tag) => tagPresets[tag].defaultSelection === (allExcluded ? 'exclude' : 'include')
+    );
     setSelectedTags(selectedTags);
-  }, [tagPresets]);
+  }, [tagPresets, allExcluded]);
 
   useEffect(() => {
     api.experimental_setFilter(TAGS_FILTER, (item) => {

--- a/code/core/src/manager/components/sidebar/TagsFilter.tsx
+++ b/code/core/src/manager/components/sidebar/TagsFilter.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { Badge, IconButton, WithTooltip } from 'storybook/internal/components';
-import type { StoryIndex, Tag } from 'storybook/internal/types';
+import type { StoryIndex, Tag, TagsOptions } from 'storybook/internal/types';
 
 import { FilterIcon } from '@storybook/icons';
 
@@ -49,6 +49,7 @@ export interface TagsFilterProps {
   indexJson: StoryIndex;
   initialSelectedTags?: Tag[];
   isDevelopment: boolean;
+  tagPresets: TagsOptions;
 }
 
 export const TagsFilter = ({
@@ -56,11 +57,18 @@ export const TagsFilter = ({
   indexJson,
   initialSelectedTags = [],
   isDevelopment,
+  tagPresets,
 }: TagsFilterProps) => {
   const [selectedTags, setSelectedTags] = useState(initialSelectedTags);
   const [expanded, setExpanded] = useState(false);
   const [inverted, setInverted] = useState(false);
   const tagsActive = selectedTags.length > 0;
+
+  useEffect(() => {
+    const tags = Object.keys(tagPresets);
+    const selectedTags = tags.filter((tag) => tagPresets[tag].defaultSelected);
+    setSelectedTags(selectedTags);
+  }, [tagPresets]);
 
   useEffect(() => {
     api.experimental_setFilter(TAGS_FILTER, (item) => {

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -330,6 +330,7 @@ export interface TestBuildConfig {
 type Tag = string;
 
 export interface TagOptions {
+  defaultSelected?: boolean;
   excludeFromSidebar: boolean;
   excludeFromDocsStories: boolean;
 }

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -330,6 +330,7 @@ export interface TestBuildConfig {
 type Tag = string;
 
 export interface TagOptions {
+  /** Whether the tag should be selected by default in the tags filter in Storybook */
   defaultSelected?: boolean;
   excludeFromSidebar: boolean;
   excludeFromDocsStories: boolean;

--- a/code/core/src/types/modules/core-common.ts
+++ b/code/core/src/types/modules/core-common.ts
@@ -330,8 +330,8 @@ export interface TestBuildConfig {
 type Tag = string;
 
 export interface TagOptions {
-  /** Whether the tag should be selected by default in the tags filter in Storybook */
-  defaultSelected?: boolean;
+  /** Visually include or exclude stories with this tag in the sidebar by default */
+  defaultSelection?: 'include' | 'exclude';
   excludeFromSidebar: boolean;
   excludeFromDocsStories: boolean;
 }


### PR DESCRIPTION
Finalizes #32268

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- Enhanced Sidebar component to utilize tag presets for managing selected tags.
- Updated TagsFilter to initialize selected tags based on tag presets.
- Modified TagsFilter stories to reflect new tag preset functionality.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-02 13:45:35 UTC

This PR implements tag preset functionality to allow users to control which tags are selected by default in the Storybook sidebar through main.ts configuration. The changes introduce a new `defaultSelected` property to the `TagOptions` interface, enabling users to specify initial tag selection state in their configuration.

The implementation follows a clear data flow: users configure tag options with `defaultSelected: true` in their main.ts file, which gets processed by the common preset system and made available via `global.TAGS_OPTIONS`. The Sidebar component transforms this configuration into `tagPresets` and passes it to the TagsFilter component. The TagsFilter component then uses a new useEffect hook to automatically select tags based on the preset configuration when the component mounts or when tagPresets change.

The changes also update the TagsFilter stories to demonstrate the new functionality, including a new story that tests the inversion feature. A documentation comment was added to the common preset to clarify the intended ordering for default selected tags, ensuring users can still override preset configurations.

This feature addresses issue #32268 and provides a more structured approach to tag filtering UX, moving away from relying solely on hardcoded initial selected tags to a configurable preset system that integrates with Storybook's existing configuration architecture.

## Confidence score: 2/5

- This PR has a critical implementation issue that could break existing functionality and introduce bugs
- Score lowered due to the TagsFilter useEffect overwriting initialSelectedTags prop without consideration and potential null safety issues
- Pay close attention to `code/core/src/manager/components/sidebar/TagsFilter.tsx` which contains the problematic logic

<!-- /greptile_comment -->