### PR TITLE
CSF: Refactor CsfFile to support tests and tags

### DIFF
--- a/code/core/src/csf-tools/CsfFile.test.ts
+++ b/code/core/src/csf-tools/CsfFile.test.ts
@@ -2457,7 +2457,7 @@ describe('CsfFile', () => {
         const story = data._stories['A'];
         expect(story.__stats.tests).toBe(true);
 
-        const storyTests = data._storyTests['A'];
+        const storyTests = data.getStoryTests('A');
         expect(storyTests).toHaveLength(4);
         expect(storyTests[0].name).toBe('simple test');
         expect(storyTests[1].name).toBe('with overrides');

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -76,6 +76,34 @@ function parseTags(prop: t.Node) {
   }) as Tag[];
 }
 
+function parseTestTags(optionsNode: t.Node | null | undefined, program: t.Program) {
+  if (!optionsNode) {
+    return [] as string[];
+  }
+
+  let node: t.Node = optionsNode;
+  if (t.isIdentifier(node)) {
+    node = findVarInitialization(node.name, program);
+  }
+
+  if (t.isObjectExpression(node)) {
+    const tagsProp = node.properties.find(
+      (property) =>
+        t.isObjectProperty(property) && t.isIdentifier(property.key) && property.key.name === 'tags'
+    ) as t.ObjectProperty | undefined;
+
+    if (tagsProp) {
+      let tagsNode: t.Node = tagsProp.value as t.Node;
+      if (t.isIdentifier(tagsNode)) {
+        tagsNode = findVarInitialization(tagsNode.name, program);
+      }
+      return parseTags(tagsNode);
+    }
+  }
+
+  return [] as string[];
+}
+
 const formatLocation = (node: t.Node, fileName?: string) => {
   let loc = '';
   if (node.loc) {
@@ -276,16 +304,15 @@ export class CsfFile {
 
   imports: string[];
 
-  _storyTests: Record<
-    string,
-    Array<{
-      node: t.Node;
-      function: t.Node;
-      name: string;
-      id: string;
-      options: any;
-    }>
-  > = {};
+  _tests: Array<{
+    node: t.Node;
+    function: t.Node;
+    name: string;
+    id: string;
+    options: any;
+    tags: string[];
+    parent: { node: t.Node };
+  }> = [];
 
   constructor(ast: t.File, options: CsfOptions, file: BabelFile) {
     this._ast = ast;
@@ -698,12 +725,9 @@ export class CsfFile {
             const testFunction =
               expression.arguments.length === 2 ? expression.arguments[1] : expression.arguments[2];
             const testOptions = expression.arguments.length === 2 ? null : expression.arguments[1];
+            const tags = parseTestTags(testOptions as t.Node | null, self._ast.program);
 
-            if (!self._storyTests[exportName]) {
-              self._storyTests[exportName] = [];
-            }
-
-            self._storyTests[exportName].push({
+            self._tests.push({
               function: testFunction,
               name: testName,
               options: testOptions,
@@ -711,6 +735,8 @@ export class CsfFile {
               // can't set id because meta title isn't available yet
               // so it's set later on
               id: 'FIXME',
+              tags,
+              parent: { node: self._storyStatements[exportName] },
             });
 
             // TODO: fix this when stories fail
@@ -827,12 +853,14 @@ export class CsfFile {
         stats.mount = hasMount(storyAnnotations.play ?? self._metaAnnotations.play);
         stats.moduleMock = !!self.imports.find((fname) => isModuleMock(fname));
 
-        if (self._storyTests[key]) {
+        const storyNode = self._storyStatements[key];
+        const storyTests = self._tests.filter((t) => t.parent.node === storyNode);
+        if (storyTests.length > 0) {
           // TODO: [test-syntax] if we want to add a tag for the story that contains tests, this is the place for it
           // acc[key].tags = [...(acc[key].tags || []), 'story-with-tests'];
 
           stats.tests = true;
-          self._storyTests[key].forEach((test) => {
+          storyTests.forEach((test) => {
             test.id = toTestId(id, test.name);
           });
         }
@@ -876,6 +904,14 @@ export class CsfFile {
     return Object.values(this._stories);
   }
 
+  public getStoryTests(story: string | t.Node) {
+    const storyNode = typeof story === 'string' ? this._storyStatements[story] : story;
+    if (!storyNode) {
+      return [];
+    }
+    return this._tests.filter((t) => t.parent.node === storyNode);
+  }
+
   public get indexInputs(): IndexInput[] {
     const { fileName } = this._options;
     if (!fileName) {
@@ -901,8 +937,8 @@ export class CsfFile {
         __stats: story.__stats,
       };
 
-      const tests = this._storyTests[exportName];
-      const hasTests = tests?.length;
+      const tests = this.getStoryTests(exportName);
+      const hasTests = tests.length > 0;
 
       index.push({
         ...storyInput,
@@ -921,7 +957,14 @@ export class CsfFile {
             subtype: 'test',
             parent: story.id,
             name: test.name,
-            tags: [...storyInput.tags, 'test-fn'],
+            tags: [
+              ...storyInput.tags,
+              // this tag comes before test tags so users can invert if they like
+              '!autodocs',
+              ...test.tags,
+              // this tag comes after test tags so users can't change it
+              'test-fn',
+            ],
             __id: test.id,
           });
         });

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -265,6 +265,15 @@ export interface StaticStory extends Pick<StoryAnnotations, 'name' | 'parameters
   __stats: IndexInputStats;
 }
 
+export interface StoryTest {
+  node: t.Node;
+  function: t.Node;
+  name: string;
+  id: string;
+  tags: string[];
+  parent: { node: t.Node };
+}
+
 export class CsfFile {
   _ast: t.File;
 
@@ -304,15 +313,7 @@ export class CsfFile {
 
   imports: string[];
 
-  _tests: Array<{
-    node: t.Node;
-    function: t.Node;
-    name: string;
-    id: string;
-    options: any;
-    tags: string[];
-    parent: { node: t.Node };
-  }> = [];
+  _tests: StoryTest[] = [];
 
   constructor(ast: t.File, options: CsfOptions, file: BabelFile) {
     this._ast = ast;
@@ -724,13 +725,13 @@ export class CsfFile {
             const testName = expression.arguments[0].value;
             const testFunction =
               expression.arguments.length === 2 ? expression.arguments[1] : expression.arguments[2];
-            const testOptions = expression.arguments.length === 2 ? null : expression.arguments[1];
-            const tags = parseTestTags(testOptions as t.Node | null, self._ast.program);
+            const testArguments =
+              expression.arguments.length === 2 ? null : expression.arguments[1];
+            const tags = parseTestTags(testArguments as t.Node | null, self._ast.program);
 
             self._tests.push({
               function: testFunction,
               name: testName,
-              options: testOptions,
               node: expression,
               // can't set id because meta title isn't available yet
               // so it's set later on

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -238,7 +238,7 @@ export async function vitestTransform({
   const getDescribeStatementForStory = (options: {
     localName: string;
     exportName: string;
-    tests: (typeof parsed._storyTests)[string];
+    tests: Array<{ name: string; node: t.Node }>;
     node: t.Node;
   }): t.ExpressionStatement => {
     const { localName, exportName, tests, node } = options;
@@ -291,7 +291,7 @@ export async function vitestTransform({
       const localName = parsed._stories[exportName].localName ?? exportName;
       // use the story's name as the test title for vitest, and fallback to exportName
       const testTitle = parsed._stories[exportName].name ?? exportName;
-      const tests = parsed._storyTests[exportName];
+      const tests = parsed.getStoryTests(exportName);
 
       if (tests?.length > 0) {
         return getDescribeStatementForStory({ localName, exportName, tests, node });
@@ -306,7 +306,7 @@ export async function vitestTransform({
   ast.program.body.push(testBlock);
 
   const hasTests = Object.keys(validStories).some(
-    (exportName) => parsed._storyTests[exportName]?.length > 0
+    (exportName) => parsed.getStoryTests(exportName).length > 0
   );
 
   const imports = [

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.ts
@@ -189,12 +189,20 @@ function preparePartialAnnotations<TRenderer extends Renderer>(
 
   const defaultTags = ['dev', 'test'];
   const extraTags = globalThis.DOCS_OPTIONS?.autodocs === true ? ['autodocs'] : [];
+  /**
+   * DISCLAIMER: This feels like a hack but seems like it's the only way to override the autodocs
+   * tag for test-fn stories. That's because the Story index does not include negated tags e.g.
+   * !autodocs so the negation does not get passed through, and therefore we need to do it here.
+   * Therefore, unfortunately we have to duplicate the logic here.
+   */
+  const overrideTags = storyAnnotations?.tags?.includes('test-fn') ? ['!autodocs'] : [];
 
   const tags = combineTags(
     ...defaultTags,
     ...extraTags,
     ...(projectAnnotations.tags ?? []),
     ...(componentAnnotations.tags ?? []),
+    ...(overrideTags ?? []),
     ...(storyAnnotations?.tags ?? [])
   );
 

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.ts
@@ -202,7 +202,7 @@ function preparePartialAnnotations<TRenderer extends Renderer>(
     ...extraTags,
     ...(projectAnnotations.tags ?? []),
     ...(componentAnnotations.tags ?? []),
-    ...(overrideTags ?? []),
+    ...overrideTags,
     ...(storyAnnotations?.tags ?? [])
   );
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR refactors the CSF file structure to have a flat list of tests, plus a utility to get story tests.
Additionally, it handles story test tags and fixes an issue where the tests were included in autodocs by default.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32385-sha-07e99aef`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32385-sha-07e99aef sandbox` or in an existing project with `npx storybook@0.0.0-pr-32385-sha-07e99aef upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32385-sha-07e99aef`](https://npmjs.com/package/storybook/v/0.0.0-pr-32385-sha-07e99aef) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/fix-test-tags-extraction`](https://github.com/storybookjs/storybook/tree/yann/fix-test-tags-extraction) |
| **Commit** | [`07e99aef`](https://github.com/storybookjs/storybook/commit/07e99aefe0522d5628b97928db30b31cd4752080) |
| **Datetime** | Wed Sep  3 12:39:56 UTC 2025 (`1756903196`) |
| **Workflow run** | [17433721863](https://github.com/storybookjs/storybook/actions/runs/17433721863) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32385`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-03 11:49:45 UTC

This PR refactors the CsfFile class to improve API design and support test functionality in Storybook's Component Story Format (CSF). The changes introduce a new `getStoryTests()` method to replace direct access to private `_storyTests` properties, improving encapsulation and providing a cleaner API surface. Additionally, the PR adds special handling for stories tagged with `test-fn` by automatically applying a `!autodocs` override tag to prevent test stories from appearing in documentation.

The refactoring touches three key areas: the CSF file test suite, the story preparation logic in preview-api, and the vitest plugin transformer. The `getStoryTests()` method now serves as the public interface for accessing story test data, hiding implementation details behind a proper getter method. This change supports Storybook's evolving test infrastructure where stories can function as both visual components and executable tests.

The test-fn tag handling ensures that stories intended for testing frameworks like Vitest are properly excluded from Storybook's documentation while remaining available for test execution. This separation allows developers to write test stories alongside regular stories without cluttering the documentation interface.

**PR Description Notes:**
- The PR description is incomplete with an empty "What I did" section and unchecked testing/documentation checklists
- No issue number is provided in the "Closes #" placeholder

## Confidence score: 4/5

- This PR appears safe to merge with some minor concerns about the hardcoded hack implementation
- Score reflects clean API improvements but includes a temporary workaround that acknowledges technical debt
- Pay close attention to the prepareStory.ts file where the hardcoded override logic may need future refinement

<!-- /greptile_comment -->