### PR TITLE
Core: Update `StoryStore.extract` to handle tests

### DIFF
--- a/code/core/src/core-server/utils/StoryIndexGenerator.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.ts
@@ -453,7 +453,9 @@ export class StoryIndexGenerator {
           importPath,
           componentPath,
           tags,
-          ...(input.type === 'story' && input.parent ? { parent: input.parent } : {}),
+          ...(input.type === 'story' && input.subtype === 'test'
+            ? { parent: input.parent, parentName: input.parentName }
+            : {}),
         };
       }
     );

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -919,8 +919,9 @@ export class CsfFile {
             // title: `${storyInput.title}/${story.name}`,
             type: 'story',
             subtype: 'test',
-            parent: story.id,
             name: test.name,
+            parent: story.id,
+            parentName: story.name,
             tags: [...storyInput.tags, 'test-fn'],
             __id: test.id,
           });

--- a/code/core/src/preview-api/modules/store/StoryStore.test.ts
+++ b/code/core/src/preview-api/modules/store/StoryStore.test.ts
@@ -343,6 +343,7 @@ describe('StoryStore', () => {
             "renderToCanvas": undefined,
             "story": "A",
             "storyGlobals": {},
+            "storyId": "component-one--a",
             "subcomponents": undefined,
             "tags": [
               "dev",
@@ -535,6 +536,7 @@ describe('StoryStore', () => {
             "renderToCanvas": undefined,
             "story": "A",
             "storyGlobals": {},
+            "storyId": "component-one--a",
             "subcomponents": undefined,
             "tags": [
               "dev",
@@ -600,6 +602,7 @@ describe('StoryStore', () => {
             "renderToCanvas": undefined,
             "story": "B",
             "storyGlobals": {},
+            "storyId": "component-one--b",
             "subcomponents": undefined,
             "tags": [
               "dev",
@@ -665,6 +668,7 @@ describe('StoryStore', () => {
             "renderToCanvas": undefined,
             "story": "C",
             "storyGlobals": {},
+            "storyId": "component-two--c",
             "subcomponents": undefined,
             "tags": [
               "dev",

--- a/code/core/src/preview-api/modules/store/StoryStore.ts
+++ b/code/core/src/preview-api/modules/store/StoryStore.ts
@@ -292,12 +292,12 @@ export class StoryStore<TRenderer extends Renderer> {
     }
 
     const stories = Object.entries(this.storyIndex.entries).reduce(
-      (acc, [storyId, { type, importPath }]) => {
-        if (type === 'docs') {
+      (acc, [storyId, entry]) => {
+        if (entry.type === 'docs') {
           return acc;
         }
 
-        const csfFile = cachedCSFFiles[importPath];
+        const csfFile = cachedCSFFiles[entry.importPath];
         const story = this.storyFromCSFFile({ storyId, csfFile });
 
         if (!options.includeDocsOnly && story.parameters.docsOnly) {
@@ -306,6 +306,9 @@ export class StoryStore<TRenderer extends Renderer> {
 
         acc[storyId] = Object.entries(story).reduce(
           (storyAcc, [key, value]) => {
+            if (key === 'story' && entry.subtype === 'test') {
+              return { ...storyAcc, story: entry.parentName };
+            }
             if (key === 'moduleExport') {
               return storyAcc;
             }
@@ -318,13 +321,13 @@ export class StoryStore<TRenderer extends Renderer> {
             return Object.assign(storyAcc, { [key]: value });
           },
           {
-            //
             args: story.initialArgs,
             globals: {
               ...this.userGlobals.initialGlobals,
               ...this.userGlobals.globals,
               ...story.storyGlobals,
             },
+            storyId: entry.parent ? entry.parent : storyId,
           }
         );
         return acc;

--- a/code/core/src/types/modules/indexer.ts
+++ b/code/core/src/types/modules/indexer.ts
@@ -75,6 +75,7 @@ export type StoryIndexEntry = BaseIndexEntry & {
   type: 'story';
   subtype: 'story' | 'test';
   parent?: StoryId; // exists only on tests
+  parentName?: StoryName; // exists only on tests
 };
 
 export type DocsIndexEntry = BaseIndexEntry & {
@@ -135,6 +136,7 @@ export type StoryIndexInput = BaseIndexInput & {
   type: 'story';
   subtype: 'story' | 'test';
   parent?: StoryId; // exists only on tests
+  parentName?: StoryName; // exists only on tests
 };
 
 /** The input for indexing a docs entry. */


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Make it possible to distinguish tests from stories in `StoryStore.extract`, and track the parent story name for a test.

- Updated `story` property to always be the story name rather than the test name
- Added `storyId` property to point to the parent story from a test

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-03 14:47:43 UTC

This PR enhances Storybook's `StoryStore.extract` method to properly distinguish between tests and stories, which is part of a test function prototype feature. The changes introduce a new `parentName` property to the story indexing system that tracks the parent story name for test entries.

The implementation spans across four key files:

1. **Type definitions** (`indexer.ts`): Adds optional `parentName` property to both `StoryIndexEntry` and `StoryIndexInput` interfaces
2. **Story index generation** (`StoryIndexGenerator.ts`): Conditionally includes parent metadata (both `parent` ID and `parentName`) when processing test entries
3. **CSF file parsing** (`CsfFile.ts`): Adds `parentName` to test index entries during CSF parsing
4. **Story store extraction** (`StoryStore.ts`): Modifies the extract method so that test entries use their parent story name in the `story` property and includes a new `storyId` property for tracking parent-child relationships

The core behavioral change is that when extracting test entries, the `story` property now contains the parent story name rather than the test name itself, and a new `storyId` property points to the parent story ID. This allows consumers to understand that tests are conceptually part of their parent story while maintaining clear hierarchical relationships.

The changes maintain backward compatibility since the `parentName` property is optional and only applies to test entries. This fits into Storybook's architecture by extending the existing story indexing system to support test-story relationships without breaking existing functionality.

## Confidence score: 4/5

- This PR appears safe to merge with proper testing and review
- Score reflects well-structured changes with clear intent and consistent implementation patterns
- Pay close attention to the StoryStore.ts extract method logic and type definitions to ensure test-story relationships work correctly

<!-- /greptile_comment -->