### PR TITLE
UI: Migrate Select from Popper.js tooltip to react-aria overlay

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -339,6 +339,7 @@
     "pretty-hrtime": "^1.0.3",
     "prompts": "^2.4.0",
     "react": "^18.2.0",
+    "react-aria-components": "^1.12.1",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^1.3.0",
     "react-inspector": "^6.0.0",

--- a/code/core/src/components/components/Select/Select.stories.tsx
+++ b/code/core/src/components/components/Select/Select.stories.tsx
@@ -217,7 +217,7 @@ export const DefaultOptionMulti = meta.story({
 
 const disabledPlayFn: StoryAnnotations['play'] = async ({ canvasElement, args }) => {
   const canvas = within(canvasElement);
-  const selectButton = canvas.getByRole('combobox');
+  const selectButton = canvas.getByRole(args.multiSelect ? 'combobox' : 'button');
   expect(selectButton).toHaveAttribute('aria-disabled', 'true');
 
   await userEvent.click(selectButton);
@@ -261,7 +261,7 @@ export const DefaultOpen = meta.story({
 export const MouseSelection = meta.story({
   name: 'Mouse Selection (single)',
   play: async ({ canvasElement, args }) => {
-    const selectButton = within(canvasElement).getByRole('combobox');
+    const selectButton = within(canvasElement).getByRole('button');
     await userEvent.click(selectButton);
 
     const listbox = await screen.findByRole('listbox');
@@ -309,16 +309,15 @@ export const MouseSelectionMulti = meta.story({
     expect(selectButton).toHaveTextContent('2');
     expect(screen.getByRole('listbox')).toBeInTheDocument();
 
-    // FIXME: cannot run until #32249 is fixed.
-    // await userEvent.click(canvas.getByText('Other content'));
-    // expect(screen.queryByRole('listbox')).not.toBeInTheDocument(); // Now closed.
+    await userEvent.click(canvas.getByText('Other content'));
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument(); // Now closed.
   },
 });
 
 const kbSelectionTest =
   (triggerKey: string, selectKey: string): StoryAnnotations['play'] =>
   async ({ canvasElement, args, step }) => {
-    const selectButton = within(canvasElement).getByRole('combobox');
+    const selectButton = within(canvasElement).getByRole(args.multiSelect ? 'combobox' : 'button');
     selectButton.focus();
 
     await step('Open listbox', async () => {
@@ -433,7 +432,7 @@ export const KeyboardSelectionMultiSS = meta.story({
 export const MouseOpenNoAutoselect = meta.story({
   name: 'AutoSelect - nothing selected on Mouse open (single)',
   play: async ({ canvasElement, args, step }) => {
-    const selectButton = within(canvasElement).getByRole('combobox');
+    const selectButton = within(canvasElement).getByRole('button');
 
     await step('Click on button', async () => {
       await userEvent.click(selectButton);
@@ -456,7 +455,7 @@ export const MouseOpenNoAutoselect = meta.story({
 export const KeyboardOpenAutoselect = meta.story({
   name: 'AutoSelect - first item select on Enter (single)',
   play: async ({ canvasElement, args, step }) => {
-    const selectButton = within(canvasElement).getByRole('combobox');
+    const selectButton = within(canvasElement).getByRole(args.multiSelect ? 'combobox' : 'button');
 
     await step('Open with Enter', async () => {
       selectButton.focus();
@@ -485,7 +484,7 @@ export const KeyboardOpenAutoselect = meta.story({
 export const ArrowDownAutoSelect = meta.story({
   name: 'AutoSelect - first item select on ArrowDown (single)',
   play: async ({ canvasElement, args }) => {
-    const selectButton = within(canvasElement).getByRole('combobox');
+    const selectButton = within(canvasElement).getByRole('button');
     selectButton.focus();
     await userEvent.keyboard('{ArrowDown}');
     expect(args.onSelect).toHaveBeenCalledWith('tadpole');
@@ -499,7 +498,7 @@ export const ArrowDownAutoSelect = meta.story({
 export const ArrowUpAutoSelect = meta.story({
   name: 'AutoSelect - last item select on ArrowUp (single)',
   play: async ({ canvasElement, args }) => {
-    const selectButton = within(canvasElement).getByRole('combobox');
+    const selectButton = within(canvasElement).getByRole('button');
     selectButton.focus();
     await userEvent.keyboard('{ArrowUp}');
     expect(args.onSelect).toHaveBeenCalledWith('frog');
@@ -519,7 +518,7 @@ export const MouseFastNavPage = meta.story({
     })),
   },
   play: async ({ canvasElement, step }) => {
-    const selectButton = within(canvasElement).getByRole('combobox');
+    const selectButton = within(canvasElement).getByRole('button');
 
     await step('Open select (no active option)', async () => {
       await userEvent.click(selectButton);
@@ -550,7 +549,7 @@ export const KeyboardFastNavPage = meta.story({
     })),
   },
   play: async ({ canvasElement, step }) => {
-    const selectButton = within(canvasElement).getByRole('combobox');
+    const selectButton = within(canvasElement).getByRole('button');
     selectButton.focus();
 
     await step('Open select (1st option is active)', async () => {
@@ -584,7 +583,7 @@ export const MouseFastNavHomeEnd = meta.story({
     })),
   },
   play: async ({ canvasElement, step }) => {
-    const selectButton = within(canvasElement).getByRole('combobox');
+    const selectButton = within(canvasElement).getByRole('button');
 
     await step('Open select (no active option)', async () => {
       await userEvent.click(selectButton);
@@ -622,7 +621,7 @@ export const KeyboardFastNavHomeEnd = meta.story({
     })),
   },
   play: async ({ canvasElement, step }) => {
-    const selectButton = within(canvasElement).getByRole('combobox');
+    const selectButton = within(canvasElement).getByRole('button');
     selectButton.focus();
 
     await step('Open select (1st option is active)', async () => {
@@ -730,7 +729,7 @@ export const OnSelectHandler = meta.story({
   },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
-    const selectButton = canvas.getByRole('combobox');
+    const selectButton = canvas.getByRole('button');
 
     await userEvent.click(selectButton);
 
@@ -798,7 +797,7 @@ export const WithResetSingle = meta.story({
   },
   play: async ({ canvasElement, args, step }) => {
     const canvas = within(canvasElement);
-    const selectButton = canvas.getByRole('combobox');
+    const selectButton = canvas.getByRole('button');
 
     await step('Check initial state', async () => {
       expect(selectButton).toHaveTextContent('Frog');
@@ -871,7 +870,7 @@ export const KeyboardResetSingle = meta.story({
   },
   play: async ({ canvasElement, args, step }) => {
     const canvas = within(canvasElement);
-    const selectButton = canvas.getByRole('combobox');
+    const selectButton = canvas.getByRole('button');
     selectButton.focus();
 
     await step('Open with Enter and navigate to reset option', async () => {
@@ -973,7 +972,7 @@ export const ResetButtonVisibilitySingle = meta.story({
   },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
-    const selectButton = canvas.getByRole('combobox');
+    const selectButton = canvas.getByRole('button');
 
     await step('Open without selection', async () => {
       await userEvent.click(selectButton);
@@ -1040,7 +1039,7 @@ export const CustomResetLabel = meta.story({
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const selectButton = canvas.getByRole('combobox');
+    const selectButton = canvas.getByRole('button');
 
     await userEvent.click(selectButton);
 
@@ -1056,7 +1055,7 @@ export const WithoutReset = meta.story({
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const selectButton = canvas.getByRole('combobox');
+    const selectButton = canvas.getByRole('button');
 
     await userEvent.click(selectButton);
 

--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -2,13 +2,17 @@ import type { KeyboardEvent } from 'react';
 import React, { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import type { ButtonProps } from 'storybook/internal/components';
-import { Button, ScrollArea, WithTooltipPure } from 'storybook/internal/components';
+import { Button, ScrollArea } from 'storybook/internal/components';
 
 import { RefreshIcon } from '@storybook/icons';
 
+import { useObjectRef } from '@react-aria/utils';
 import { transparentize } from 'polished';
+import { Overlay, useInteractOutside, useOverlay, useOverlayPosition } from 'react-aria';
+import { useOverlayTriggerState } from 'react-stately';
 import { styled } from 'storybook/theming';
 
+import { Tooltip } from '../tooltip/Tooltip';
 import { SelectOption } from './SelectOption';
 import type { Option, ResetOption } from './helpers';
 import { Listbox, PAGE_STEP_SIZE } from './helpers';
@@ -112,6 +116,57 @@ const StyledButton = styled(Button)<ButtonProps & { hasSelection?: boolean; isOp
   })
 );
 
+/*
+ * This popover does not do any keyboard handling or placement. It uses a portal to place
+ * its children under its sibling's position. When clicking outside the popover, it closes.
+ */
+function MinimalistPopover({
+  children,
+  handleClose,
+  triggerRef,
+}: {
+  children: React.ReactNode;
+  handleClose: () => void;
+  triggerRef: React.RefObject<HTMLElement>;
+}) {
+  const popoverRef = React.useRef(null);
+
+  useInteractOutside({
+    ref: popoverRef,
+    onInteractOutside: handleClose,
+  });
+
+  const { overlayProps: positionProps } = useOverlayPosition({
+    targetRef: triggerRef,
+    overlayRef: popoverRef,
+    placement: 'bottom start',
+    offset: 8,
+    isOpen: true,
+  });
+
+  const { overlayProps, underlayProps } = useOverlay(
+    {
+      isOpen: true,
+      onClose: handleClose,
+      isDismissable: true,
+      /* We do this ourselves. */
+      shouldCloseOnBlur: false,
+      /* We also do this ourselves. */
+      isKeyboardDismissDisabled: true,
+    },
+    popoverRef
+  );
+
+  return (
+    <Overlay disableFocusManagement {...overlayProps}>
+      <div {...underlayProps} className="underlay" />
+      <Tooltip hasChrome ref={popoverRef} {...positionProps}>
+        {children}
+      </Tooltip>
+    </Overlay>
+  );
+}
+
 export const Select = forwardRef<HTMLButtonElement, SelectProps>(
   (
     {
@@ -134,15 +189,21 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
     ref
   ) => {
     const [isOpen, setIsOpen] = useState(props.defaultOpen || false);
+    const triggerRef = useObjectRef(ref);
 
     const id = useId();
     const listboxId = `${id}-listbox`;
     const listboxRef = useRef<HTMLUListElement>(null);
 
+    const otState = useOverlayTriggerState({
+      isOpen: isOpen && !disabled,
+      onOpenChange: setIsOpen,
+    });
+
     const handleClose = useCallback(() => {
       setIsOpen(false);
-      document.getElementById(id)?.focus();
-    }, [id]);
+      triggerRef.current?.focus();
+    }, [triggerRef]);
 
     // The last selected option(s), which will be used by the app.
     const [selectedOptions, setSelectedOptions] = useState<Option[]>(
@@ -341,90 +402,14 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
     }, [isOpen, activeOption, id]);
 
     return (
-      <WithTooltipPure
-        closeOnOutsideClick={true}
-        visible={isOpen && !disabled}
-        tooltip={
-          <ScrollArea vertical>
-            <Listbox
-              role="listbox"
-              id={listboxId}
-              ref={listboxRef}
-              aria-multiselectable={multiSelect}
-              onKeyDown={(e) => {
-                // We don't prevent default on Tab, so that the Tab or Shift+Tab goes
-                // through after we've repositioned to the Button.
-                if (e.key !== 'Tab') {
-                  e.preventDefault();
-                }
-                if (e.key === 'Escape') {
-                  handleClose();
-                } else if (e.key === 'ArrowDown') {
-                  moveActiveOptionDown();
-                } else if (e.key === 'ArrowUp') {
-                  moveActiveOptionUp();
-                } else if (e.key === 'Home') {
-                  setActiveOption(options[0]);
-                } else if (e.key === 'End') {
-                  setActiveOption(options[options.length - 1]);
-                } else if (e.key === 'PageDown') {
-                  moveActiveOptionDown(PAGE_STEP_SIZE);
-                } else if (e.key === 'PageUp') {
-                  moveActiveOptionUp(PAGE_STEP_SIZE);
-                }
-              }}
-            >
-              {options.map((option) => (
-                <SelectOption
-                  key={option.value ?? 'sb-reset'}
-                  title={option.title}
-                  description={option.description}
-                  icon={option.icon}
-                  id={valueToId(id, option)}
-                  isActive={isOpen && activeOption?.value === option.value}
-                  isSelected={
-                    selectedOptions?.some((sel) => sel.value === option.value) ||
-                    (selectedOptions.length === 0 && option === resetOption)
-                  }
-                  onClick={() => {
-                    handleSelectOption(option);
-                    if (!multiSelect) {
-                      handleClose();
-                    }
-                  }}
-                  onFocus={() => setActiveOption(option)}
-                  shouldLookDisabled={
-                    option === resetOption && selectedOptions.length === 0 && multiSelect
-                  }
-                  onKeyDown={(e: KeyboardEvent) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      handleSelectOption(option);
-                      if (!multiSelect) {
-                        handleClose();
-                      }
-                    } else if (e.key === 'Tab') {
-                      if (!multiSelect) {
-                        handleSelectOption(option);
-                      }
-                      handleClose();
-                    }
-                  }}
-                >
-                  {option.children}
-                </SelectOption>
-              ))}
-            </Listbox>
-          </ScrollArea>
-        }
-      >
+      <>
         <StyledButton
           {...props}
           variant="ghost"
           ariaLabel={ariaLabel}
           tooltip={isOpen ? undefined : tooltip}
           id={id}
-          ref={ref}
+          ref={triggerRef}
           padding={padding}
           isOpen={isOpen}
           hasSelection={!!selectedOptions.length}
@@ -440,11 +425,11 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
           }}
           tabIndex={isOpen ? -1 : 0}
           onKeyDown={handleButtonKeyDown}
-          role="combobox"
+          role={multiSelect ? 'combobox' : 'button'}
           aria-autocomplete="none"
-          aria-haspopup="listbox"
-          aria-expanded={isOpen}
           aria-controls={listboxId}
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
         >
           {!multiSelect && selectedOptions.length === 0 && (
             <>
@@ -473,7 +458,85 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
             </>
           )}
         </StyledButton>
-      </WithTooltipPure>
+        {otState.isOpen && (
+          <MinimalistPopover handleClose={handleClose} triggerRef={triggerRef}>
+            <ScrollArea vertical>
+              <Listbox
+                role="listbox"
+                id={listboxId}
+                ref={listboxRef}
+                aria-multiselectable={multiSelect}
+                onKeyDown={(e) => {
+                  // We don't prevent default on Tab, so that the Tab or Shift+Tab goes
+                  // through after we've repositioned to the Button.
+                  if (e.key !== 'Tab') {
+                    e.preventDefault();
+                  } else {
+                    handleClose();
+                  }
+
+                  if (e.key === 'Escape') {
+                    handleClose();
+                  } else if (e.key === 'ArrowDown') {
+                    moveActiveOptionDown();
+                  } else if (e.key === 'ArrowUp') {
+                    moveActiveOptionUp();
+                  } else if (e.key === 'Home') {
+                    setActiveOption(options[0]);
+                  } else if (e.key === 'End') {
+                    setActiveOption(options[options.length - 1]);
+                  } else if (e.key === 'PageDown') {
+                    moveActiveOptionDown(PAGE_STEP_SIZE);
+                  } else if (e.key === 'PageUp') {
+                    moveActiveOptionUp(PAGE_STEP_SIZE);
+                  }
+                }}
+              >
+                {options.map((option) => (
+                  <SelectOption
+                    key={option.value ?? 'sb-reset'}
+                    title={option.title}
+                    description={option.description}
+                    icon={option.icon}
+                    id={valueToId(id, option)}
+                    isActive={isOpen && activeOption?.value === option.value}
+                    isSelected={
+                      selectedOptions?.some((sel) => sel.value === option.value) ||
+                      (selectedOptions.length === 0 && option === resetOption)
+                    }
+                    onClick={() => {
+                      handleSelectOption(option);
+                      if (!multiSelect) {
+                        handleClose();
+                      }
+                    }}
+                    onFocus={() => setActiveOption(option)}
+                    shouldLookDisabled={
+                      option === resetOption && selectedOptions.length === 0 && multiSelect
+                    }
+                    onKeyDown={(e: KeyboardEvent) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleSelectOption(option);
+                        if (!multiSelect) {
+                          handleClose();
+                        }
+                      } else if (e.key === 'Tab') {
+                        if (!multiSelect) {
+                          handleSelectOption(option);
+                        }
+                        handleClose();
+                      }
+                    }}
+                  >
+                    {option.children}
+                  </SelectOption>
+                ))}
+              </Listbox>
+            </ScrollArea>
+          </MinimalistPopover>
+        )}
+      </>
     );
   }
 );

--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent } from 'react';
+import type { FC, KeyboardEvent } from 'react';
 import React, { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import type { ButtonProps } from 'storybook/internal/components';
@@ -116,19 +116,24 @@ const StyledButton = styled(Button)<ButtonProps & { hasSelection?: boolean; isOp
   })
 );
 
+const Underlay = styled.div({
+  position: 'fixed',
+  inset: 0,
+  // This will do for now, our popovers use the max z-index of 2147483647. We'll want to
+  // inherit a base from a CSS variable and add preset values to it in the future (e.g.
+  // 100 for underlay, 200 for overlay) if we start using Select in dialogs.
+  zIndex: 1000,
+});
+
 /*
  * This popover does not do any keyboard handling or placement. It uses a portal to place
  * its children under its sibling's position. When clicking outside the popover, it closes.
  */
-function MinimalistPopover({
-  children,
-  handleClose,
-  triggerRef,
-}: {
+const MinimalistPopover: FC<{
   children: React.ReactNode;
   handleClose: () => void;
   triggerRef: React.RefObject<HTMLElement>;
-}) {
+}> = ({ children, handleClose, triggerRef }) => {
   const popoverRef = React.useRef(null);
 
   useInteractOutside({
@@ -159,13 +164,13 @@ function MinimalistPopover({
 
   return (
     <Overlay disableFocusManagement {...overlayProps}>
-      <div {...underlayProps} className="underlay" />
+      <Underlay {...underlayProps} />
       <Tooltip hasChrome ref={popoverRef} {...positionProps}>
         {children}
       </Tooltip>
     </Overlay>
   );
-}
+};
 
 export const Select = forwardRef<HTMLButtonElement, SelectProps>(
   (

--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -394,6 +394,35 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
       [options, resetOption, setActiveOption, selectedOptions]
     );
 
+    const handleListboxKeyDown = useCallback(
+      (e: KeyboardEvent<HTMLUListElement>) => {
+        // We don't prevent default on Tab, so that the Tab or Shift+Tab goes
+        // through after we've repositioned to the Button.
+        if (e.key !== 'Tab') {
+          e.preventDefault();
+        } else {
+          handleClose();
+        }
+
+        if (e.key === 'Escape') {
+          handleClose();
+        } else if (e.key === 'ArrowDown') {
+          moveActiveOptionDown();
+        } else if (e.key === 'ArrowUp') {
+          moveActiveOptionUp();
+        } else if (e.key === 'Home') {
+          setActiveOption(options[0]);
+        } else if (e.key === 'End') {
+          setActiveOption(options[options.length - 1]);
+        } else if (e.key === 'PageDown') {
+          moveActiveOptionDown(PAGE_STEP_SIZE);
+        } else if (e.key === 'PageUp') {
+          moveActiveOptionUp(PAGE_STEP_SIZE);
+        }
+      },
+      [handleClose, moveActiveOptionDown, moveActiveOptionUp, options, setActiveOption]
+    );
+
     // Transfer focus to the active option whenever we open the listbox.
     useEffect(() => {
       if (isOpen && activeOption) {
@@ -471,31 +500,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
                 id={listboxId}
                 ref={listboxRef}
                 aria-multiselectable={multiSelect}
-                onKeyDown={(e) => {
-                  // We don't prevent default on Tab, so that the Tab or Shift+Tab goes
-                  // through after we've repositioned to the Button.
-                  if (e.key !== 'Tab') {
-                    e.preventDefault();
-                  } else {
-                    handleClose();
-                  }
-
-                  if (e.key === 'Escape') {
-                    handleClose();
-                  } else if (e.key === 'ArrowDown') {
-                    moveActiveOptionDown();
-                  } else if (e.key === 'ArrowUp') {
-                    moveActiveOptionUp();
-                  } else if (e.key === 'Home') {
-                    setActiveOption(options[0]);
-                  } else if (e.key === 'End') {
-                    setActiveOption(options[options.length - 1]);
-                  } else if (e.key === 'PageDown') {
-                    moveActiveOptionDown(PAGE_STEP_SIZE);
-                  } else if (e.key === 'PageUp') {
-                    moveActiveOptionUp(PAGE_STEP_SIZE);
-                  }
-                }}
+                onKeyDown={handleListboxKeyDown}
               >
                 {options.map((option) => (
                   <SelectOption

--- a/code/core/src/components/components/Select/SelectOption.tsx
+++ b/code/core/src/components/components/Select/SelectOption.tsx
@@ -61,6 +61,7 @@ const Item = styled('li')(({ theme }) => ({
     background: theme.background.hoverable,
     outline: `2px solid ${theme.barSelectedColor}`,
     outlineOffset: 1,
+    borderRadius: 2,
   },
   display: 'flex',
   alignItems: 'flex-start',

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2609,6 +2609,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/ecma402-abstract@npm:2.3.4":
+  version: 2.3.4
+  resolution: "@formatjs/ecma402-abstract@npm:2.3.4"
+  dependencies:
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/intl-localematcher": "npm:0.6.1"
+    decimal.js: "npm:^10.4.3"
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/2644bc618a34dc610ef9691281eeb45ae6175e6982cf19f1bd140672fc95c748747ce3c85b934649ea7e4a304f7ae0060625fd53d5df76f92ca3acf743e1eb0a
+  languageName: node
+  linkType: hard
+
+"@formatjs/fast-memoize@npm:2.2.7":
+  version: 2.2.7
+  resolution: "@formatjs/fast-memoize@npm:2.2.7"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/f5eabb0e4ab7162297df8252b4cfde194b23248120d9df267592eae2be2d2f7c4f670b5a70523d91b4ecdc35d40e65823bb8eeba8dd79fbf8601a972bf3b8866
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-messageformat-parser@npm:2.11.2":
+  version: 2.11.2
+  resolution: "@formatjs/icu-messageformat-parser@npm:2.11.2"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.4"
+    "@formatjs/icu-skeleton-parser": "npm:1.8.14"
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/a121f2d2c6b36a1632ffd64c3545e2500c8ee0f7fee5db090318c035d635c430ab123faedb5d000f18d9423a7b55fbf670b84e2e2dd72cc307a38aed61d3b2e0
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-skeleton-parser@npm:1.8.14":
+  version: 1.8.14
+  resolution: "@formatjs/icu-skeleton-parser@npm:1.8.14"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.4"
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/a1807ed6e90b8a2e8d0e5b5125e6f9a2c057d3cff377fb031d2333af7cfaa6de4ed3a15c23da7294d4c3557f8b28b2163246434a19720f26b5db0497d97e9b58
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-localematcher@npm:0.6.1":
+  version: 0.6.1
+  resolution: "@formatjs/intl-localematcher@npm:0.6.1"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/bacbedd508519c1bb5ca2620e89dc38f12101be59439aa14aa472b222915b462cb7d679726640f6dcf52a05dd218b5aa27ccd60f2e5010bb96f1d4929848cde0
+  languageName: node
+  linkType: hard
+
 "@gilbarbara/deep-equal@npm:^0.1.1":
   version: 0.1.2
   resolution: "@gilbarbara/deep-equal@npm:0.1.2"
@@ -3340,6 +3391,43 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/92382c1b046559ddb16c53e1353a900a43266566a0d73902e5325433c640b6aaeaf3e34cc5b2a68fd089ff5d8add914d0b9875cdec64f7a09313f9c4420b021d
+  languageName: node
+  linkType: hard
+
+"@internationalized/date@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@internationalized/date@npm:3.9.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 10c0/8f2bf54c407aa95ab9922759c27f19bd9185bc6c4bde936fb5cc7a99bf764de8483102a61d53afa0598eefa11711617d3c05a65e8a5cb8bfac10c2c0800e488a
+  languageName: node
+  linkType: hard
+
+"@internationalized/message@npm:^3.1.8":
+  version: 3.1.8
+  resolution: "@internationalized/message@npm:3.1.8"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    intl-messageformat: "npm:^10.1.0"
+  checksum: 10c0/91019d66d62ab6733fa46ed495fac6878bcc98f082e51be9fd0e4b5836a4df0f488c8dcd218f2e566c713e59cc68ef3aa5fc45e5b9bca8cca458d0990765b77a
+  languageName: node
+  linkType: hard
+
+"@internationalized/number@npm:^3.6.5":
+  version: 3.6.5
+  resolution: "@internationalized/number@npm:3.6.5"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 10c0/f87d710863a8dbf057aac311193c82f3c42e862abdd99e5b71034f1022926036552620eab5dd00c23e975f28b9e41e830cb342ba0264436749d9cdc5ae031d44
+  languageName: node
+  linkType: hard
+
+"@internationalized/string@npm:^3.2.7":
+  version: 3.2.7
+  resolution: "@internationalized/string@npm:3.2.7"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 10c0/8f7bea379ce047026ef20d535aa1bd7612a5e5a5108d1e514965696a46bce34e38111411943b688d00dae2c81eae7779ae18343961310696d32ebb463a19b94a
   languageName: node
   linkType: hard
 
@@ -5570,6 +5658,1693 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-aria/autocomplete@npm:3.0.0-rc.1":
+  version: 3.0.0-rc.1
+  resolution: "@react-aria/autocomplete@npm:3.0.0-rc.1"
+  dependencies:
+    "@react-aria/combobox": "npm:^3.13.2"
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/listbox": "npm:^3.14.8"
+    "@react-aria/searchfield": "npm:^3.8.8"
+    "@react-aria/textfield": "npm:^3.18.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/autocomplete": "npm:3.0.0-beta.3"
+    "@react-stately/combobox": "npm:^3.11.1"
+    "@react-types/autocomplete": "npm:3.0.0-alpha.34"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/375538f556f833f800ab9c8ebb957dd61fbeda07f6adf062e6a1418affdfd3abe4ef6195de328e76d1afb123650ce1e2670639baf1e79f2fd84a08ac9e9f0397
+  languageName: node
+  linkType: hard
+
+"@react-aria/breadcrumbs@npm:^3.5.28":
+  version: 3.5.28
+  resolution: "@react-aria/breadcrumbs@npm:3.5.28"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/link": "npm:^3.8.5"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/breadcrumbs": "npm:^3.7.16"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/ce0948f36a4944b59788d10d34a1cda81ba8d48f9bef9959c4c0dd1e05a24c86f9d0c014b398b804fbe50909334e86801a20f4e559a7faa69a1252881653d506
+  languageName: node
+  linkType: hard
+
+"@react-aria/button@npm:^3.14.1":
+  version: 3.14.1
+  resolution: "@react-aria/button@npm:3.14.1"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/toolbar": "npm:3.0.0-beta.20"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/toggle": "npm:^3.9.1"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/fde6d70cbc95966094b513de5d2959143e7f027ee88d53bbcca638b0be7c355e79206be1cedce122a890dac74cc49695a9cadf4fba5cc91af37d2a6dfc97176f
+  languageName: node
+  linkType: hard
+
+"@react-aria/calendar@npm:^3.9.1":
+  version: 3.9.1
+  resolution: "@react-aria/calendar@npm:3.9.1"
+  dependencies:
+    "@internationalized/date": "npm:^3.9.0"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/calendar": "npm:^3.8.4"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/calendar": "npm:^3.7.4"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/0df71500322aad5cded31f1728947cdd4affc4b1199d6b443a0e4132b6c0c0ddc241dc85624e35d6fed658773088d6679e807e2bf3672d4b5891c50e0a0d73a0
+  languageName: node
+  linkType: hard
+
+"@react-aria/checkbox@npm:^3.16.1":
+  version: 3.16.1
+  resolution: "@react-aria/checkbox@npm:3.16.1"
+  dependencies:
+    "@react-aria/form": "npm:^3.1.1"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/label": "npm:^3.7.21"
+    "@react-aria/toggle": "npm:^3.12.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/checkbox": "npm:^3.7.1"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/toggle": "npm:^3.9.1"
+    "@react-types/checkbox": "npm:^3.10.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/ab7d10874bd0b0608b9fb8e47985ff5c6bcb810b1ea09ba187a0e8b0840c1d9a03b5d116308698efca84b9b2483517f50d2113d5920cd377c45bebd8e0902d9b
+  languageName: node
+  linkType: hard
+
+"@react-aria/collections@npm:3.0.0-rc.6":
+  version: 3.0.0-rc.6
+  resolution: "@react-aria/collections@npm:3.0.0-rc.6"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/4daa4c41edc300bfc5c78b5f4c0ed23bc92ac4219cecca7b0a6ac7352a7eac903696514e62ad34e12688bcb3f203c383cceed3a71cb6b871864eeb84a6a634d3
+  languageName: node
+  linkType: hard
+
+"@react-aria/color@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@react-aria/color@npm:3.1.1"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/numberfield": "npm:^3.12.1"
+    "@react-aria/slider": "npm:^3.8.1"
+    "@react-aria/spinbutton": "npm:^3.6.18"
+    "@react-aria/textfield": "npm:^3.18.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-aria/visually-hidden": "npm:^3.8.27"
+    "@react-stately/color": "npm:^3.9.1"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-types/color": "npm:^3.1.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/bf318d04de679ba169282fa8c57336b8faaed41632895e5d863d5fb8b426bd27ff8516152b0f30360ee6c88602ed840da83dac6d218586575edb18d2c8f14c93
+  languageName: node
+  linkType: hard
+
+"@react-aria/combobox@npm:^3.13.2":
+  version: 3.13.2
+  resolution: "@react-aria/combobox@npm:3.13.2"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/listbox": "npm:^3.14.8"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/menu": "npm:^3.19.2"
+    "@react-aria/overlays": "npm:^3.29.1"
+    "@react-aria/selection": "npm:^3.25.1"
+    "@react-aria/textfield": "npm:^3.18.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/combobox": "npm:^3.11.1"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/combobox": "npm:^3.13.8"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/b02ed213774d67454d1f5234f444803bd0c4b12ab74614aa5120e8ccc1c08fa109d23a160f1fbc12fc5eaf28cf1173e8b16dcfc457cb75a5238de49f7de210f4
+  languageName: node
+  linkType: hard
+
+"@react-aria/datepicker@npm:^3.15.1":
+  version: 3.15.1
+  resolution: "@react-aria/datepicker@npm:3.15.1"
+  dependencies:
+    "@internationalized/date": "npm:^3.9.0"
+    "@internationalized/number": "npm:^3.6.5"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/form": "npm:^3.1.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/label": "npm:^3.7.21"
+    "@react-aria/spinbutton": "npm:^3.6.18"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/datepicker": "npm:^3.15.1"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/calendar": "npm:^3.7.4"
+    "@react-types/datepicker": "npm:^3.13.1"
+    "@react-types/dialog": "npm:^3.5.21"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/36bed73eb30ac3a24ae5bb3866dc2b25f9362be45ae3dca0cc30f122dd8787ee8aa2e3279846abee26940b68e471466db9e3acd321a39f59c046f8abda7681b1
+  languageName: node
+  linkType: hard
+
+"@react-aria/dialog@npm:^3.5.30":
+  version: 3.5.30
+  resolution: "@react-aria/dialog@npm:3.5.30"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/overlays": "npm:^3.29.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/dialog": "npm:^3.5.21"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/d7b739731b543386a47ac4920cd9b66892604062626930c4befe1e430a849d13e14a3f2ca0b9db5bf257e7d581e57da2bc71e356525c32ce7df6e0a292e4870c
+  languageName: node
+  linkType: hard
+
+"@react-aria/disclosure@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@react-aria/disclosure@npm:3.0.8"
+  dependencies:
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/disclosure": "npm:^3.0.7"
+    "@react-types/button": "npm:^3.14.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/ec110787e77c3b95ce694251cf7278b651cd50c99effeff805691258aad7abbb4b899f6687327a3ee0a7bc95af96d592a5359baa584437dac1da6ed9315dacb9
+  languageName: node
+  linkType: hard
+
+"@react-aria/dnd@npm:^3.11.2":
+  version: 3.11.2
+  resolution: "@react-aria/dnd@npm:3.11.2"
+  dependencies:
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/overlays": "npm:^3.29.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/dnd": "npm:^3.7.0"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/a714b5acc58c3cecc5cb620c15f5f07a817e556459747c31512a8ee8d0a622563c0ca8a1e29354d5001b7ef34ac7b37845514ed24c9db240145e55652508979b
+  languageName: node
+  linkType: hard
+
+"@react-aria/focus@npm:^3.21.1":
+  version: 3.21.1
+  resolution: "@react-aria/focus@npm:3.21.1"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+    clsx: "npm:^2.0.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/9271132d9b215f916a19fa72a8a15eb68dc15a73ed8f9fc41096166c703a27336a1d908e3d55cd95de7eac234037abe3ff1fe2a33f15fc48934e9dd8cb97ff48
+  languageName: node
+  linkType: hard
+
+"@react-aria/form@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@react-aria/form@npm:3.1.1"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/34872e8b30e2e407311e94bc6104af360f8795eaf7c66600c0de2a7c842d5aacc65628493fde92be0b578206761d720088150b12c2b9243032795c5a0b50d3fe
+  languageName: node
+  linkType: hard
+
+"@react-aria/grid@npm:^3.14.4":
+  version: 3.14.4
+  resolution: "@react-aria/grid@npm:3.14.4"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/selection": "npm:^3.25.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/grid": "npm:^3.11.5"
+    "@react-stately/selection": "npm:^3.20.5"
+    "@react-types/checkbox": "npm:^3.10.1"
+    "@react-types/grid": "npm:^3.3.5"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/f7cf1586b2c1da0b3e1e3ea66bc1b94d54329815ffba38d069c129fb3c1e724d39d3a1b37f6f7fa3dc58e6203ad3692ac35524d7b9dad926111446fc00fa4985
+  languageName: node
+  linkType: hard
+
+"@react-aria/gridlist@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "@react-aria/gridlist@npm:3.14.0"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/grid": "npm:^3.14.4"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/selection": "npm:^3.25.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/list": "npm:^3.13.0"
+    "@react-stately/tree": "npm:^3.9.2"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/b5eec01376889c04b45738eb6e354b87d380367fbb7b65d9835d5807d799246c7f8b4443ce5aa577050c0685d72ed2651bc0310065ed09dfbe10dd3215f322e1
+  languageName: node
+  linkType: hard
+
+"@react-aria/i18n@npm:^3.12.12":
+  version: 3.12.12
+  resolution: "@react-aria/i18n@npm:3.12.12"
+  dependencies:
+    "@internationalized/date": "npm:^3.9.0"
+    "@internationalized/message": "npm:^3.1.8"
+    "@internationalized/number": "npm:^3.6.5"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/83e1c4d0f246951ca9da6adf2e2825d50668b31f2de62a23ac04a0d9dd3e874a17e4616c72321a3fca6a99e22460f79fb15dee86637b6c7bea5c00835a076f8a
+  languageName: node
+  linkType: hard
+
+"@react-aria/interactions@npm:^3.25.5":
+  version: 3.25.5
+  resolution: "@react-aria/interactions@npm:3.25.5"
+  dependencies:
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/flags": "npm:^3.1.2"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/056875ecc08b085134cc8298d5824ed55ff11433cd240320e14f8514e517d64f02f6a95e414a5304f46488c83090e3d1c138b0cf9cbe5d6fdab4e5a4bad5d727
+  languageName: node
+  linkType: hard
+
+"@react-aria/label@npm:^3.7.21":
+  version: 3.7.21
+  resolution: "@react-aria/label@npm:3.7.21"
+  dependencies:
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/34d55f423cd0ca6061453b2feee0dacc6ad70f7ddea7922615287a11283c8fc053e89e7425b2f2ca3d7e1a077b1bcedf5a2b4c6e95e8c7a203756b6703ffbd78
+  languageName: node
+  linkType: hard
+
+"@react-aria/landmark@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@react-aria/landmark@npm:3.0.6"
+  dependencies:
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/ab5413e32d2fc21090ae39fd4414d00b37d56afec715d8715ad285d59f41f454547bf94919f386aa4c447723c1f817a0b47f4cb39c03c64b5211f4c105270453
+  languageName: node
+  linkType: hard
+
+"@react-aria/link@npm:^3.8.5":
+  version: 3.8.5
+  resolution: "@react-aria/link@npm:3.8.5"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/link": "npm:^3.6.4"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/cda1ac2c75f950745510bcc536ce4aab5f9f95e0310ad040070ff21ae2c42409eaab262ea4f69ad419f0044d78fcfe91e7224c8b87e779afc106dab7457e5d9a
+  languageName: node
+  linkType: hard
+
+"@react-aria/listbox@npm:^3.14.8":
+  version: 3.14.8
+  resolution: "@react-aria/listbox@npm:3.14.8"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/label": "npm:^3.7.21"
+    "@react-aria/selection": "npm:^3.25.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/list": "npm:^3.13.0"
+    "@react-types/listbox": "npm:^3.7.3"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/48f64c99047a94bb272027891f8840587b7e889d5c17bf772baea28d945d21a5d8e63217fa61bf45cc21e4c70f7dbcb759d4d97761318b402ba025ff42208c60
+  languageName: node
+  linkType: hard
+
+"@react-aria/live-announcer@npm:^3.4.4":
+  version: 3.4.4
+  resolution: "@react-aria/live-announcer@npm:3.4.4"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 10c0/1598372e773ee8dbb2f1d2a946652384f5140ab54106416e2a182c72eaabc1b3739e624bac7aea3d95429ba16487074c782ff90db093be36dd1d4cf84f9f9a17
+  languageName: node
+  linkType: hard
+
+"@react-aria/menu@npm:^3.19.2":
+  version: 3.19.2
+  resolution: "@react-aria/menu@npm:3.19.2"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/overlays": "npm:^3.29.1"
+    "@react-aria/selection": "npm:^3.25.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/menu": "npm:^3.9.7"
+    "@react-stately/selection": "npm:^3.20.5"
+    "@react-stately/tree": "npm:^3.9.2"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/menu": "npm:^3.10.4"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/3592ff723178ec8f98f8cfde9bb8d4626daf553c5683b88b435e3275713b9b0ff0f26e9df00d8957423f0712e61799aa4a606f9f610950ae6e9ab72ab8772ed3
+  languageName: node
+  linkType: hard
+
+"@react-aria/meter@npm:^3.4.26":
+  version: 3.4.26
+  resolution: "@react-aria/meter@npm:3.4.26"
+  dependencies:
+    "@react-aria/progress": "npm:^3.4.26"
+    "@react-types/meter": "npm:^3.4.12"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/5e88247ef1e0a8a0141f6aae07da748dd03814eded8627cd392d8b7335616680486676f7212f05d6a797550b0b4bcfa306d2bbd94cb155a7340829a65bc4e9e5
+  languageName: node
+  linkType: hard
+
+"@react-aria/numberfield@npm:^3.12.1":
+  version: 3.12.1
+  resolution: "@react-aria/numberfield@npm:3.12.1"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/spinbutton": "npm:^3.6.18"
+    "@react-aria/textfield": "npm:^3.18.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/numberfield": "npm:^3.10.1"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/numberfield": "npm:^3.8.14"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/333f860a5c12692fb7904515950959e2b9bf175a1db5acddbbd206081ad1106ea41e46d94336704a9bf199b0fca0faf591fda79682ed59cb6fd340d0f3bb2fae
+  languageName: node
+  linkType: hard
+
+"@react-aria/overlays@npm:^3.29.1":
+  version: 3.29.1
+  resolution: "@react-aria/overlays@npm:3.29.1"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-aria/visually-hidden": "npm:^3.8.27"
+    "@react-stately/overlays": "npm:^3.6.19"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/overlays": "npm:^3.9.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/e69f2178cbbd30bd43373ca4dcb68edf275dae57926912c2845bd109b0ddf5820e28e8882df049ce188a42a1690ae7a31795d0be8895318b80478c61baf8af4c
+  languageName: node
+  linkType: hard
+
+"@react-aria/progress@npm:^3.4.26":
+  version: 3.4.26
+  resolution: "@react-aria/progress@npm:3.4.26"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/label": "npm:^3.7.21"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/progress": "npm:^3.5.15"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/1d41424898c39c8c20b3943d3572367f2d3c937a48c8d4167f4874b31e03c4e894a21314729f44cfcbf6283c95a260111152b07d5fc570d86b6bbde785f7f1bf
+  languageName: node
+  linkType: hard
+
+"@react-aria/radio@npm:^3.12.1":
+  version: 3.12.1
+  resolution: "@react-aria/radio@npm:3.12.1"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/form": "npm:^3.1.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/label": "npm:^3.7.21"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/radio": "npm:^3.11.1"
+    "@react-types/radio": "npm:^3.9.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/2c8625ce2214142c09af2f5a751a5d390dda6ef3148055973dc8ea71504e631ca0dc5e7d7202e557235c3175dad74b75a4c9440ce3de15d8f07a3b5a55571773
+  languageName: node
+  linkType: hard
+
+"@react-aria/searchfield@npm:^3.8.8":
+  version: 3.8.8
+  resolution: "@react-aria/searchfield@npm:3.8.8"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/textfield": "npm:^3.18.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/searchfield": "npm:^3.5.15"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/searchfield": "npm:^3.6.5"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/72a55f3695762aec4da83240d5c3dc1e501f3b2520b3db3aa74d94e7b5981b6909a542b6f589f299f2d76538732b5ad814c86ab704c378d22ee5b3251b5682ba
+  languageName: node
+  linkType: hard
+
+"@react-aria/select@npm:^3.16.2":
+  version: 3.16.2
+  resolution: "@react-aria/select@npm:3.16.2"
+  dependencies:
+    "@react-aria/form": "npm:^3.1.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/label": "npm:^3.7.21"
+    "@react-aria/listbox": "npm:^3.14.8"
+    "@react-aria/menu": "npm:^3.19.2"
+    "@react-aria/selection": "npm:^3.25.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-aria/visually-hidden": "npm:^3.8.27"
+    "@react-stately/select": "npm:^3.7.1"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/select": "npm:^3.10.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/c9ead86371cc583dcda11b1316df2f897c4cd618291302346d2980010196aa618f86a4ce5759ace539d144fc0f38fd8f380f6015af5160cc6fb5a27f7b2b6995
+  languageName: node
+  linkType: hard
+
+"@react-aria/selection@npm:^3.25.1":
+  version: 3.25.1
+  resolution: "@react-aria/selection@npm:3.25.1"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/selection": "npm:^3.20.5"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/7212dfc3280167c5f87256bbc580c3f05e1a8388d93ce5d66090778b67b7a3bcb49c522172a1a062c0c237204e1d85e6a9cb8ae6095725ed7f1e194ba277ed0e
+  languageName: node
+  linkType: hard
+
+"@react-aria/separator@npm:^3.4.12":
+  version: 3.4.12
+  resolution: "@react-aria/separator@npm:3.4.12"
+  dependencies:
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/fa808a76b35ef663a0ff6745562b1238655e9112c27c3243a4334ad1d298f3ba3bb19eb551b8e96e52b23a9500a660fb8fdc8dd292f067b34a9200cb92792a8b
+  languageName: node
+  linkType: hard
+
+"@react-aria/slider@npm:^3.8.1":
+  version: 3.8.1
+  resolution: "@react-aria/slider@npm:3.8.1"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/label": "npm:^3.7.21"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/slider": "npm:^3.7.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/slider": "npm:^3.8.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/1282cc395fcc531b35a94bb769d5cc462224f20fd876d96fabc432a40201eae9d01a87d6f8fdedc7382d3a1928eac9579aa9f6cc875461abd5bc8ae1c0bffd62
+  languageName: node
+  linkType: hard
+
+"@react-aria/spinbutton@npm:^3.6.18":
+  version: 3.6.18
+  resolution: "@react-aria/spinbutton@npm:3.6.18"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/c9fdd24fe563e450130bb1e3ae7f09f9fc2728120feea965be413d4b1cf10eb2790bf13783dbf8247fc241d9691d12bcb77ea88f656966092f520d22c9eb6da5
+  languageName: node
+  linkType: hard
+
+"@react-aria/ssr@npm:^3.9.10":
+  version: 3.9.10
+  resolution: "@react-aria/ssr@npm:3.9.10"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/44acb4c441d9c5d65aab94aa81fd8368413cf2958ab458582296dd78f6ba4783583f2311fa986120060e5c26b54b1f01e8910ffd17e4f41ccc5fc8c357d84089
+  languageName: node
+  linkType: hard
+
+"@react-aria/switch@npm:^3.7.7":
+  version: 3.7.7
+  resolution: "@react-aria/switch@npm:3.7.7"
+  dependencies:
+    "@react-aria/toggle": "npm:^3.12.1"
+    "@react-stately/toggle": "npm:^3.9.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/switch": "npm:^3.5.14"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/386dd60efad6544e8bb03393c13d712e47aa68e3169a3d865375831e5353c8e5e849903ea51af09ae40eb1ae206df5c9b8854ce8601e81a7d21fd952bc18c8a2
+  languageName: node
+  linkType: hard
+
+"@react-aria/table@npm:^3.17.7":
+  version: 3.17.7
+  resolution: "@react-aria/table@npm:3.17.7"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/grid": "npm:^3.14.4"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-aria/visually-hidden": "npm:^3.8.27"
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/flags": "npm:^3.1.2"
+    "@react-stately/table": "npm:^3.15.0"
+    "@react-types/checkbox": "npm:^3.10.1"
+    "@react-types/grid": "npm:^3.3.5"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/table": "npm:^3.13.3"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/ee09d8827929df9be0fdf313c22518f82a7e91669c2e6bb6754f6fbd4f656366d9fa86afc290c73e827ec8fb0574bcab19b35b385e7c16d28713569e20c91b6b
+  languageName: node
+  linkType: hard
+
+"@react-aria/tabs@npm:^3.10.7":
+  version: 3.10.7
+  resolution: "@react-aria/tabs@npm:3.10.7"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/selection": "npm:^3.25.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/tabs": "npm:^3.8.5"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/tabs": "npm:^3.3.18"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/ace9e245e0d8d9bf8a1e79a6e31a48dcc8c4604d8c3143c456a29a499eb39c484d4b2470b025f2c0adf86e531140f1c673df44ec012bd32704eb573fcd5a3ee1
+  languageName: node
+  linkType: hard
+
+"@react-aria/tag@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "@react-aria/tag@npm:3.7.1"
+  dependencies:
+    "@react-aria/gridlist": "npm:^3.14.0"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/label": "npm:^3.7.21"
+    "@react-aria/selection": "npm:^3.25.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/list": "npm:^3.13.0"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/d7066939ca4d083f0dd651ca0884851601a920a6609741ec2ce088b52658d5b3b82481fe3acaf3e2522e2d37f5f6cde27e744386b5a4c354318780a23efad567
+  languageName: node
+  linkType: hard
+
+"@react-aria/textfield@npm:^3.18.1":
+  version: 3.18.1
+  resolution: "@react-aria/textfield@npm:3.18.1"
+  dependencies:
+    "@react-aria/form": "npm:^3.1.1"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/label": "npm:^3.7.21"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/textfield": "npm:^3.12.5"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/c596e2414fd64d2354e7dc5f56c959ed033f465e4dce20b602efab9c35bbabe27bcc2e80ef213ab1aa2ff541adcb33c0c967b530f32dd3280a627c317331f5b8
+  languageName: node
+  linkType: hard
+
+"@react-aria/toast@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@react-aria/toast@npm:3.0.7"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/landmark": "npm:^3.0.6"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/toast": "npm:^3.1.2"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/83f2dc36c312150724bc4b669917374bf042156a8e4c9cd67a9c8a7e3250c43f97d7e75ddeaa4190474606323ee1239431b929019b919a8645273770c7c2d803
+  languageName: node
+  linkType: hard
+
+"@react-aria/toggle@npm:^3.12.1":
+  version: 3.12.1
+  resolution: "@react-aria/toggle@npm:3.12.1"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/toggle": "npm:^3.9.1"
+    "@react-types/checkbox": "npm:^3.10.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/3ace07768327c7d86f57d7bcf22a60d64c84f7d9adef66e80db2194d237f82016a635903417289eaa7408caca74fee094b8e9dc7ac7d923823b63eabcc094b38
+  languageName: node
+  linkType: hard
+
+"@react-aria/toolbar@npm:3.0.0-beta.20":
+  version: 3.0.0-beta.20
+  resolution: "@react-aria/toolbar@npm:3.0.0-beta.20"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/af186a16ba6d55b6fd80988ae95031e04bcfcd20bdedb02f12007f5f3c4ef1ace515a0d71d0191544c333bb181df8dfe33f89e52fde7ad83148172561d0c4049
+  languageName: node
+  linkType: hard
+
+"@react-aria/tooltip@npm:^3.8.7":
+  version: 3.8.7
+  resolution: "@react-aria/tooltip@npm:3.8.7"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/tooltip": "npm:^3.5.7"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/tooltip": "npm:^3.4.20"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/481ec2ee3d43ecae62c01f0c0a1122c735dfaddffbc8db5e4d38963201d4ecc2f66df50d27c97cc93b5480998d545480ec962282f3cf702f220e22ee3e443b73
+  languageName: node
+  linkType: hard
+
+"@react-aria/tree@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "@react-aria/tree@npm:3.1.3"
+  dependencies:
+    "@react-aria/gridlist": "npm:^3.14.0"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/selection": "npm:^3.25.1"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/tree": "npm:^3.9.2"
+    "@react-types/button": "npm:^3.14.0"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/01b63f94951bbc8797437c27478552b945c107f580c04f2da8aac0f43ea8730ebe750c7a3b1acaf1c79066f6ef24425adff8f977e5cfe2dfe856abc2872ac604
+  languageName: node
+  linkType: hard
+
+"@react-aria/utils@npm:^3.30.1":
+  version: 3.30.1
+  resolution: "@react-aria/utils@npm:3.30.1"
+  dependencies:
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-stately/flags": "npm:^3.1.2"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+    clsx: "npm:^2.0.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/3417a3ea7250c4ad23e6943117eb304a3708859fe8c738e0bee39edaefe7a7b82cedecc564f1a7f7fdf715ad13f57804a0b7c015a75fefdecbe3ecd7162f3e2f
+  languageName: node
+  linkType: hard
+
+"@react-aria/virtualizer@npm:^4.1.9":
+  version: 4.1.9
+  resolution: "@react-aria/virtualizer@npm:4.1.9"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-stately/virtualizer": "npm:^4.4.3"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/adfd45a5e328c5dfc9abc6167bfb2e06ff3d8a688a8c2901a5b5cb7fe2b7d688537d1c13e0dddf348dc9adc26c1c498329bc68afb831a590a96952aa7141f655
+  languageName: node
+  linkType: hard
+
+"@react-aria/visually-hidden@npm:^3.8.27":
+  version: 3.8.27
+  resolution: "@react-aria/visually-hidden@npm:3.8.27"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/b9c1e64c9560ec6ff5e186502cc4c89f366d17d8ccd0487c698b22358b0583385f404c567861497cb4c0b035b3906993f700fc219040519b0ce9be1f69d74b24
+  languageName: node
+  linkType: hard
+
+"@react-stately/autocomplete@npm:3.0.0-beta.3":
+  version: 3.0.0-beta.3
+  resolution: "@react-stately/autocomplete@npm:3.0.0-beta.3"
+  dependencies:
+    "@react-stately/utils": "npm:^3.10.8"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/e3c07424f298746783b50bba8b366ca5262431c28b257239f2a91285578182991f0d5472afb596e83f32369e29fd5f84062383e604b17a6f0145537ded202ed5
+  languageName: node
+  linkType: hard
+
+"@react-stately/calendar@npm:^3.8.4":
+  version: 3.8.4
+  resolution: "@react-stately/calendar@npm:3.8.4"
+  dependencies:
+    "@internationalized/date": "npm:^3.9.0"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/calendar": "npm:^3.7.4"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/ce7d212735b94d2ad8a0a2bd6c552f2aa6883b6d4ce34a2d9c8989536845d15bc90aabb66665ff4932eb32d2b43fe15602c5503c35edd05fa567348582b8ab16
+  languageName: node
+  linkType: hard
+
+"@react-stately/checkbox@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "@react-stately/checkbox@npm:3.7.1"
+  dependencies:
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/checkbox": "npm:^3.10.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/283d7e5aa63761c956fc48c42d12e5dee779c362013afabd36e086f530b4b8137966e6769421951c28cbffa4e793c0ce857de5aea85403a42688f0898f2503fa
+  languageName: node
+  linkType: hard
+
+"@react-stately/collections@npm:^3.12.7":
+  version: 3.12.7
+  resolution: "@react-stately/collections@npm:3.12.7"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/9f8e2f34a7e8a9630699ca91d8d5f215468b2a669df4e06bfd337d365d52df9b2e42b983d18f2023b746e30f0b06ee76e5838e1067299935ce78fab1c2c959c1
+  languageName: node
+  linkType: hard
+
+"@react-stately/color@npm:^3.9.1":
+  version: 3.9.1
+  resolution: "@react-stately/color@npm:3.9.1"
+  dependencies:
+    "@internationalized/number": "npm:^3.6.5"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/numberfield": "npm:^3.10.1"
+    "@react-stately/slider": "npm:^3.7.1"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/color": "npm:^3.1.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/1d1833e7c20758318b80f19b1d9fa97eebe47a81089d4dbc05fe41dc9d82e8fc0e32a5cab28005429b145401384a648393e1a673e04869e655979b9f48a0fdb0
+  languageName: node
+  linkType: hard
+
+"@react-stately/combobox@npm:^3.11.1":
+  version: 3.11.1
+  resolution: "@react-stately/combobox@npm:3.11.1"
+  dependencies:
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/list": "npm:^3.13.0"
+    "@react-stately/overlays": "npm:^3.6.19"
+    "@react-stately/select": "npm:^3.7.1"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/combobox": "npm:^3.13.8"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/d89f22d54f96e829a70e6700904a163d30766767567964ab29b78772b6bbe4f2abbe85ccd0a25b5d8a54a6c60e1d653215699b19d82d84b6620c9e5d73f9fe10
+  languageName: node
+  linkType: hard
+
+"@react-stately/data@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "@react-stately/data@npm:3.14.0"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/264de3396ba49e60b02c9fc204b2150c42cf72659e05ce27bf85d6c5a426b2447c6744d4fd824083a486e58c679428afdadebaffce76ab8001d2981683ef201a
+  languageName: node
+  linkType: hard
+
+"@react-stately/datepicker@npm:^3.15.1":
+  version: 3.15.1
+  resolution: "@react-stately/datepicker@npm:3.15.1"
+  dependencies:
+    "@internationalized/date": "npm:^3.9.0"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/overlays": "npm:^3.6.19"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/datepicker": "npm:^3.13.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/65167c563757d30a80656081ac51335a1c3f5b7b587dd4702bd28983b5a9a9cb7ce24b34e9e4a77ec7b6cc5dcd59748e4ec067ebba93e3b1a2709f9625e5f13b
+  languageName: node
+  linkType: hard
+
+"@react-stately/disclosure@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@react-stately/disclosure@npm:3.0.7"
+  dependencies:
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/2cba308fea9af713a1560c2f2b62323a08c325f6a0ce2ea35fea96f94f352aa17cd8b4666c2e91a46496d50974fc5580a6536a312eac23b0e14ad9dfc6303a42
+  languageName: node
+  linkType: hard
+
+"@react-stately/dnd@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "@react-stately/dnd@npm:3.7.0"
+  dependencies:
+    "@react-stately/selection": "npm:^3.20.5"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/179961eada46bcd884dc48bf29230350f8361c87d578582006e67233a56b47e112d6eb316d5297562b1bd39413782d32b364121a1d9d39710d88b78298fb140e
+  languageName: node
+  linkType: hard
+
+"@react-stately/flags@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@react-stately/flags@npm:3.1.2"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 10c0/d86890ce662f04c7d8984e9560527f46c9779b97757abded9e1bf7e230a6900a0ea7a3e7c22534de8d2ff278abae194e4e4ad962d710f3b04c52a4e1011c2e5b
+  languageName: node
+  linkType: hard
+
+"@react-stately/form@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@react-stately/form@npm:3.2.1"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/9aa4c38001ea7811fc65677f04ffdaecf03be75bd9da911754d2510ef30be1b83fc45ef023660727bfdaf2f24dcebaa5587ca1ca4f5e1bc7aeb2319b3768c2c2
+  languageName: node
+  linkType: hard
+
+"@react-stately/grid@npm:^3.11.5":
+  version: 3.11.5
+  resolution: "@react-stately/grid@npm:3.11.5"
+  dependencies:
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/selection": "npm:^3.20.5"
+    "@react-types/grid": "npm:^3.3.5"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/bacfde659d10815a435cf0c8333a15da9ff1629483fa32c2263ebb1975ee1b8de21e1768f136c0dc6db8e7e60fac6d7ae72f610915d1b147716d47022a1f35c9
+  languageName: node
+  linkType: hard
+
+"@react-stately/layout@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "@react-stately/layout@npm:4.5.0"
+  dependencies:
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/table": "npm:^3.15.0"
+    "@react-stately/virtualizer": "npm:^4.4.3"
+    "@react-types/grid": "npm:^3.3.5"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/table": "npm:^3.13.3"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/f03bd4fd4aed29b14172250aeecc4cd70f2c686106825c0c85d362583c1ba8b8b99b20f3d227b6e17b13b4446c315eaa95cf09c243e4cbf86a610080f5e667d6
+  languageName: node
+  linkType: hard
+
+"@react-stately/list@npm:^3.13.0":
+  version: 3.13.0
+  resolution: "@react-stately/list@npm:3.13.0"
+  dependencies:
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/selection": "npm:^3.20.5"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/d408513e6b984ce912bb744b4da04222c0fa1a57e11fe53976c42df6d7126d3945fc65caaf8d67587ccaf2dce147658de432ddaa80e5b2b0b49012f7b572f810
+  languageName: node
+  linkType: hard
+
+"@react-stately/menu@npm:^3.9.7":
+  version: 3.9.7
+  resolution: "@react-stately/menu@npm:3.9.7"
+  dependencies:
+    "@react-stately/overlays": "npm:^3.6.19"
+    "@react-types/menu": "npm:^3.10.4"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/4ad5b7da2f6c09efcb459f77bab624be65d37ba6b72cf76c704e28361f9ee6f598365728f351aa15dc27bdb2dca8e1c634e0cf131f036fc5aafd308a2d0c111f
+  languageName: node
+  linkType: hard
+
+"@react-stately/numberfield@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "@react-stately/numberfield@npm:3.10.1"
+  dependencies:
+    "@internationalized/number": "npm:^3.6.5"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/numberfield": "npm:^3.8.14"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/1e7eb49fa1e135368bbc4f2e795be70f9db38d049139ce7efd988cddf0b01290527780ab0123b5c953a21991ffdafc76f5cc2cf1c09d68a91b18bdaec810f1ba
+  languageName: node
+  linkType: hard
+
+"@react-stately/overlays@npm:^3.6.19":
+  version: 3.6.19
+  resolution: "@react-stately/overlays@npm:3.6.19"
+  dependencies:
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/overlays": "npm:^3.9.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/bc6749850313185a927f3d2f72e8e155d8452a4ec9f19ff3df7c167c6a60a29d91dd97e0b5d5f78ed8fa1a0b275cbfc4f5b135dbd37412246e0cc647499d4cde
+  languageName: node
+  linkType: hard
+
+"@react-stately/radio@npm:^3.11.1":
+  version: 3.11.1
+  resolution: "@react-stately/radio@npm:3.11.1"
+  dependencies:
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/radio": "npm:^3.9.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/f9e59f90f54507da594ef54df96d99cc2baa36e999674aed1950288dc29a5c5ef5235e2f90e3c92fe8a63a4963a7b0ccee9652b55e2552865b3029e34c11eaf8
+  languageName: node
+  linkType: hard
+
+"@react-stately/searchfield@npm:^3.5.15":
+  version: 3.5.15
+  resolution: "@react-stately/searchfield@npm:3.5.15"
+  dependencies:
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/searchfield": "npm:^3.6.5"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/e71cf9eee9b2112662abccf9d3a1af11693b9251db265a1312f2ba3a943a8dd9c824b9a0a797b37cc636838a6a0a6eca28d1d2ce17bf08b979cf1f98196db27c
+  languageName: node
+  linkType: hard
+
+"@react-stately/select@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "@react-stately/select@npm:3.7.1"
+  dependencies:
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/list": "npm:^3.13.0"
+    "@react-stately/overlays": "npm:^3.6.19"
+    "@react-types/select": "npm:^3.10.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/807b870e1bc26ed05b152f10aac3d2c34e66aeab70f01eed472b75edafe10808b03dca45d7ed2273e79b55f7af646a745d0c6a4c61f63067a3a11c5f1f8378c6
+  languageName: node
+  linkType: hard
+
+"@react-stately/selection@npm:^3.20.5":
+  version: 3.20.5
+  resolution: "@react-stately/selection@npm:3.20.5"
+  dependencies:
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/fa3e9440c10d836e48e019ce8811eab2bc38c15e807fec0d1f857ec30f180fa87005f882385259c48fa73d9793c292f3322c35b94df06535fe19eb7b0e715c76
+  languageName: node
+  linkType: hard
+
+"@react-stately/slider@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "@react-stately/slider@npm:3.7.1"
+  dependencies:
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/slider": "npm:^3.8.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/2efd3c3bb50cb5874975ae2019566fc3df443e5f838472b2e56428ecbf184c39710ddb774dc69c856767a95278699a857bcfd3fdd9926ca638d7e4ca80cccc05
+  languageName: node
+  linkType: hard
+
+"@react-stately/table@npm:^3.15.0":
+  version: 3.15.0
+  resolution: "@react-stately/table@npm:3.15.0"
+  dependencies:
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/flags": "npm:^3.1.2"
+    "@react-stately/grid": "npm:^3.11.5"
+    "@react-stately/selection": "npm:^3.20.5"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/grid": "npm:^3.3.5"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/table": "npm:^3.13.3"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/93813ef88a756755fdbb0a92f65d43b7cf83d2029290c34a2e0b337f1e2f25e9ebb7d54b122c4f280dc797ea82550bd0cc105072b7cdec836d5d48d175ea220e
+  languageName: node
+  linkType: hard
+
+"@react-stately/tabs@npm:^3.8.5":
+  version: 3.8.5
+  resolution: "@react-stately/tabs@npm:3.8.5"
+  dependencies:
+    "@react-stately/list": "npm:^3.13.0"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/tabs": "npm:^3.3.18"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/577f4640fbdedd2049c4b2b326ad32c8f9b89366c2e4bffbf5501713a8bc314623f72399ca3e0c112abdebc291d8733f381f34aabf304b87d30d5d29e09b63d9
+  languageName: node
+  linkType: hard
+
+"@react-stately/toast@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@react-stately/toast@npm:3.1.2"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/5de06a2ca5830824a236f809e44a5084ae58a4f463c86aa2e72ec84c8ca632dfe1f5054248a9a1f6ee2aa213e22bfc186e0f4d5ef9a552eb369ee906686f8fec
+  languageName: node
+  linkType: hard
+
+"@react-stately/toggle@npm:^3.9.1":
+  version: 3.9.1
+  resolution: "@react-stately/toggle@npm:3.9.1"
+  dependencies:
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/checkbox": "npm:^3.10.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/d7a87f9b00f324cfd2cab13733ceebaf66df9514024bfa85f7f8bef27ac0037b0568f763e96a4a9b46798fbd90048d8afffc0a6ad38803e121a3251d13bf7113
+  languageName: node
+  linkType: hard
+
+"@react-stately/tooltip@npm:^3.5.7":
+  version: 3.5.7
+  resolution: "@react-stately/tooltip@npm:3.5.7"
+  dependencies:
+    "@react-stately/overlays": "npm:^3.6.19"
+    "@react-types/tooltip": "npm:^3.4.20"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/fc180cd11b2ba557d64b30e495fc6ab60972b1fcc77924bf7d521d46a0973d8f0e3ff0dd846c031d604c66caac7a1654ad07505b0b577c6f2ac87b62f3e60a4d
+  languageName: node
+  linkType: hard
+
+"@react-stately/tree@npm:^3.9.2":
+  version: 3.9.2
+  resolution: "@react-stately/tree@npm:3.9.2"
+  dependencies:
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/selection": "npm:^3.20.5"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/e2c3eb2eec5c0fdfc18e7cf09c3a866f0ebc261bf3398df7b54fa41c8b233e68ba4366c043896a101ddb72d2786adc5bad00f85eb61d0ff60afec34665de096f
+  languageName: node
+  linkType: hard
+
+"@react-stately/utils@npm:^3.10.8":
+  version: 3.10.8
+  resolution: "@react-stately/utils@npm:3.10.8"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/a97cc292986e3eeb2ceb1626671ce60e8342a3ff35ab92bcfcb94bd6b28729836cc592e3fe4df2fba603e5fdd26291be77b7f60441920298c282bb93f424feba
+  languageName: node
+  linkType: hard
+
+"@react-stately/virtualizer@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "@react-stately/virtualizer@npm:4.4.3"
+  dependencies:
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-types/shared": "npm:^3.32.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/9e49131a18e968a3119b17bca6826a008ed23074751c2bc564cb6d812ae13825d1368830026b3afbe016a0747658d48997048e53332b500378c6c8a66bc94a30
+  languageName: node
+  linkType: hard
+
+"@react-types/autocomplete@npm:3.0.0-alpha.34":
+  version: 3.0.0-alpha.34
+  resolution: "@react-types/autocomplete@npm:3.0.0-alpha.34"
+  dependencies:
+    "@react-types/combobox": "npm:^3.13.8"
+    "@react-types/searchfield": "npm:^3.6.5"
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/05eca860ccfaa6df0e7a130cc2994cf4d35f1eee4285df94b77ede058687bf415cf98a2424ce1611b562bc7f814a28a27d8d080b3ae36377ebe20a1cf56e2d11
+  languageName: node
+  linkType: hard
+
+"@react-types/breadcrumbs@npm:^3.7.16":
+  version: 3.7.16
+  resolution: "@react-types/breadcrumbs@npm:3.7.16"
+  dependencies:
+    "@react-types/link": "npm:^3.6.4"
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/af033fc8f5f47b926f15154e1f6cceb24a666004a1df058c7c8accb3bc0b916fc28a56a400f10bdb697425119584df7c4f10a985a6400633caa6d05f315d2593
+  languageName: node
+  linkType: hard
+
+"@react-types/button@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "@react-types/button@npm:3.14.0"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/33891e850e0cccb5326cbd866c9bc7312611e7476ca82a83fee601a516a07a04da1eef1e9dbbf34f56a2f7cfcd546306ae91c088d99cdc548b49b80267e3f623
+  languageName: node
+  linkType: hard
+
+"@react-types/calendar@npm:^3.7.4":
+  version: 3.7.4
+  resolution: "@react-types/calendar@npm:3.7.4"
+  dependencies:
+    "@internationalized/date": "npm:^3.9.0"
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/0e05af84d55170792ae5f937bba3ae1534e25cafb9ff562b9b9485fc93631b887faf1400f2ef3b1fe764efbbdd999847494606cc770bc19c44d7d173601be2f0
+  languageName: node
+  linkType: hard
+
+"@react-types/checkbox@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "@react-types/checkbox@npm:3.10.1"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/cb2e3d0f4a47c2f664cce06a0956825d80e30d8c30e4d80fd6d657822dbbdee0d46f49d93c1f31d4919bbe2d69b09556d8185b1e0d4ebd4f658fe431e6a6aa65
+  languageName: node
+  linkType: hard
+
+"@react-types/color@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@react-types/color@npm:3.1.1"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/slider": "npm:^3.8.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/e2c4872a5c6534406356e05742f89f81d76a0114aebc754b381a416c029d08d1c79ad23ac79d3618adcfaace983779780b15009f30afabd48968e89699e3d187
+  languageName: node
+  linkType: hard
+
+"@react-types/combobox@npm:^3.13.8":
+  version: 3.13.8
+  resolution: "@react-types/combobox@npm:3.13.8"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/539abb36dc9b9de407c80d832933bcf073dc0bd6b11ce5da6a8b2aa279e839dcea713335601fdf45fa9693cdd39b18e1a4b5bc5a19cf5cf780a0449013807e0d
+  languageName: node
+  linkType: hard
+
+"@react-types/datepicker@npm:^3.13.1":
+  version: 3.13.1
+  resolution: "@react-types/datepicker@npm:3.13.1"
+  dependencies:
+    "@internationalized/date": "npm:^3.9.0"
+    "@react-types/calendar": "npm:^3.7.4"
+    "@react-types/overlays": "npm:^3.9.1"
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/e0d61abe97a3a40ce36a0814fb010509e47153416b3c3adb05cb55c6142703c8c837f2fa73fd8d52a19ce7812c3931e75a88818941908ff8a6eb24bf939a8053
+  languageName: node
+  linkType: hard
+
+"@react-types/dialog@npm:^3.5.21":
+  version: 3.5.21
+  resolution: "@react-types/dialog@npm:3.5.21"
+  dependencies:
+    "@react-types/overlays": "npm:^3.9.1"
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/129bbdca319ab5353361f861c973837b73f7ed21cc7a887acb1e528b781ccbf390292bf5c8ca48a425e8b5a14d59d45be708e40a5b5f3aca4404c816a14ad135
+  languageName: node
+  linkType: hard
+
+"@react-types/form@npm:^3.7.15":
+  version: 3.7.15
+  resolution: "@react-types/form@npm:3.7.15"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/135ce29135bc66277a99840a01916b495dca98d4ce5854f3fa756c7bf891e897b325fc5777047c3e91ab938e73986be482b17ab3d669e083b8b815835c59fa1d
+  languageName: node
+  linkType: hard
+
+"@react-types/grid@npm:^3.3.5":
+  version: 3.3.5
+  resolution: "@react-types/grid@npm:3.3.5"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/4b49af54683ce73ed2ee9be2b6f7a03870ee461bf41f1943f5d88fc4a4cedf62091e9a7937245db10acc0a1e4feedffe579be7e8746a7d71f6483553eed08e55
+  languageName: node
+  linkType: hard
+
+"@react-types/link@npm:^3.6.4":
+  version: 3.6.4
+  resolution: "@react-types/link@npm:3.6.4"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/69fa28299af26bd1473933dffd55a932b1a5cbd263898efc16c0fc5cbef02d21201f947e739a63ee26a9f0a311c3ee77a60689004176517558ada4622cfd5f7f
+  languageName: node
+  linkType: hard
+
+"@react-types/listbox@npm:^3.7.3":
+  version: 3.7.3
+  resolution: "@react-types/listbox@npm:3.7.3"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/94fce2d390bfb9beafcc5a241ffe32524512240c7980fafee3195c859973ba84e1df2afc8a55e679d797c74f5d33fa18162fbaeeda983187423f7ce9bfd6d74a
+  languageName: node
+  linkType: hard
+
+"@react-types/menu@npm:^3.10.4":
+  version: 3.10.4
+  resolution: "@react-types/menu@npm:3.10.4"
+  dependencies:
+    "@react-types/overlays": "npm:^3.9.1"
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/699da0cac2e31fdc362e8f5e227c2221187e4d883509ae242b1efd58ab28c55c2ee695c227ea04c3a4510354dc3348b409fa13a38b88a91544597cad63eb202b
+  languageName: node
+  linkType: hard
+
+"@react-types/meter@npm:^3.4.12":
+  version: 3.4.12
+  resolution: "@react-types/meter@npm:3.4.12"
+  dependencies:
+    "@react-types/progress": "npm:^3.5.15"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/64e1177f43d3df794c339ea6d172d4703ee2084b04df113a453b49f7741a3ba8f5dc04333cf0d0757056f664fd0d005a7a29bb006432671e663a1b92694afedf
+  languageName: node
+  linkType: hard
+
+"@react-types/numberfield@npm:^3.8.14":
+  version: 3.8.14
+  resolution: "@react-types/numberfield@npm:3.8.14"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/1c9c4212a32e87d34eb1fff7a34dd1a7a4f616653087e8cdbe40ddafe6c6424b9a8d0a70076f6fdf88a2736a394de3f2cd697c955a6ca01c8d8c9a9133bc1f8d
+  languageName: node
+  linkType: hard
+
+"@react-types/overlays@npm:^3.9.1":
+  version: 3.9.1
+  resolution: "@react-types/overlays@npm:3.9.1"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/bf0e1c11251e2c6c79e12762d30e886ba5587cd7d38761d4174c3f512ace205cf7b3d7da44ca7fe3797af27ad32b844a6c4ecb3cf0a5c6b9784557cfaf035346
+  languageName: node
+  linkType: hard
+
+"@react-types/progress@npm:^3.5.15":
+  version: 3.5.15
+  resolution: "@react-types/progress@npm:3.5.15"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/7a5f4b2690fdea608b8b6d8c0ea8c262fc303b0440102ec2873a80fec45558139aeac20c507e6fbbad77686fb7f6c50ee0c4ec26c18d7ea5c7595081bda9b426
+  languageName: node
+  linkType: hard
+
+"@react-types/radio@npm:^3.9.1":
+  version: 3.9.1
+  resolution: "@react-types/radio@npm:3.9.1"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/1af8c2612cde155082797f225e995bdaab2d7e127edd9b8ec82bee925699c053a106b506022ee12cb0dd52509b10d00dba4d168c89886d58c7b22884ece615d0
+  languageName: node
+  linkType: hard
+
+"@react-types/searchfield@npm:^3.6.5":
+  version: 3.6.5
+  resolution: "@react-types/searchfield@npm:3.6.5"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/textfield": "npm:^3.12.5"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/df9a7fc615e8c1098991550814bfbb67e22290ae89e10876144fdac9bde4156ab64a5c4b8c623184bf0e9f0b7a34855cb35be63d434a24de2ebe802ca5e271d2
+  languageName: node
+  linkType: hard
+
+"@react-types/select@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "@react-types/select@npm:3.10.1"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/b236419695ace9eb27e3f975d5b45bf6ff7c3c50a07ac7fbdc87ab1ec8bc977bf85187713656c14df1dd9da0b07b04a64b866bfc627e8d9f84bf709f1109f5aa
+  languageName: node
+  linkType: hard
+
+"@react-types/shared@npm:^3.32.0":
+  version: 3.32.0
+  resolution: "@react-types/shared@npm:3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/8484f310a8911ab01daa87f9bfdea0a9a76e152d13d8421c28560dc84d64a7df23cda956db59f7010d2e8eaea27d7644118bfbe60b603499903b5f7e6cdfe4fa
+  languageName: node
+  linkType: hard
+
+"@react-types/slider@npm:^3.8.1":
+  version: 3.8.1
+  resolution: "@react-types/slider@npm:3.8.1"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/c57cd9e7a7e561eaf367ca733c315db2c4132a754a43dd44a4100068bc9e695dadc9b482737f0a11e2991baed79d80ea29bf1cd18df6563b7c54767012ab1bde
+  languageName: node
+  linkType: hard
+
+"@react-types/switch@npm:^3.5.14":
+  version: 3.5.14
+  resolution: "@react-types/switch@npm:3.5.14"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/43318b370863fd9fbc2537c3773dba8e28fb1f4e0d2849f0c115f523f59d8d8e88f59c6ede436fa32f634211e96d7a75b2752ec4bcf87a1edc392b624fab7ddd
+  languageName: node
+  linkType: hard
+
+"@react-types/table@npm:^3.13.3":
+  version: 3.13.3
+  resolution: "@react-types/table@npm:3.13.3"
+  dependencies:
+    "@react-types/grid": "npm:^3.3.5"
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/f1d40064f28441ae0387467f29ff01c641a8eb134b0e2d0dcb3b97331bdf56ac8d619e000bbb5a6229a31ddc288884913fcefb1e255f0c2f1c37f30575170b72
+  languageName: node
+  linkType: hard
+
+"@react-types/tabs@npm:^3.3.18":
+  version: 3.3.18
+  resolution: "@react-types/tabs@npm:3.3.18"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/dd830c08a517e3932d8c694896d5585b639530a7bad2d103b85531b8b4d8bcfde2bba512410260837eb1a0f464cce85d67675d025d56c5c23b30815039e400a0
+  languageName: node
+  linkType: hard
+
+"@react-types/textfield@npm:^3.12.5":
+  version: 3.12.5
+  resolution: "@react-types/textfield@npm:3.12.5"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/4770454303a5b3d93afbc93e6d2e026eed62227a71474e791a598458880d2e06d681e9f3b1d586a8108cbb2e4f75ad64a77e5e71b9adb0e70d73bd8f0ee96bab
+  languageName: node
+  linkType: hard
+
+"@react-types/tooltip@npm:^3.4.20":
+  version: 3.4.20
+  resolution: "@react-types/tooltip@npm:3.4.20"
+  dependencies:
+    "@react-types/overlays": "npm:^3.9.1"
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/7fd8415658a140db98974225859fc355a81282563b61246897b98ed0afb398eaff1e770b1bafe246aaa2cc4a07485c501ebed9de9a0a3882a20c658ea29ffa6b
+  languageName: node
+  linkType: hard
+
 "@remix-run/router@npm:1.8.0":
   version: 1.8.0
   resolution: "@remix-run/router@npm:1.8.0"
@@ -7067,7 +8842,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:~0.5.0":
+"@swc/helpers@npm:^0.5.0, @swc/helpers@npm:~0.5.0":
   version: 0.5.17
   resolution: "@swc/helpers@npm:0.5.17"
   dependencies:
@@ -11179,7 +12954,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"client-only@npm:0.0.1":
+"client-only@npm:0.0.1, client-only@npm:^0.0.1":
   version: 0.0.1
   resolution: "client-only@npm:0.0.1"
   checksum: 10c0/9d6cfd0c19e1c96a434605added99dff48482152af791ec4172fb912a71cff9027ff174efd8cdb2160cc7f377543e0537ffc462d4f279bc4701de3f2a3c4b358
@@ -11258,7 +13033,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^2.1.1":
+"clsx@npm:^2.0.0, clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
@@ -12160,6 +13935,13 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 10c0/85c39fe8fbf0482d4a1e224ef0119db5c1897f8503bcef8b826adff7a1b11414972f6fef2d7dec2ee0b4be3863cf64ac1439137ae9e6af23a3d8dcbe26a5b4b2
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.4.3":
+  version: 10.6.0
+  resolution: "decimal.js@npm:10.6.0"
+  checksum: 10c0/07d69fbcc54167a340d2d97de95f546f9ff1f69d2b45a02fd7a5292412df3cd9eb7e23065e532a318f5474a2e1bccf8392fdf0443ef467f97f3bf8cb0477e5aa
   languageName: node
   linkType: hard
 
@@ -16620,6 +18402,18 @@ __metadata:
     hasown: "npm:^2.0.2"
     side-channel: "npm:^1.1.0"
   checksum: 10c0/03966f5e259b009a9bf1a78d60da920df198af4318ec004f57b8aef1dd3fe377fbc8cce63a96e8c810010302654de89f9e19de1cd8ad0061d15be28a695465c7
+  languageName: node
+  linkType: hard
+
+"intl-messageformat@npm:^10.1.0":
+  version: 10.7.16
+  resolution: "intl-messageformat@npm:10.7.16"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.4"
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/icu-messageformat-parser": "npm:2.11.2"
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/537735bf6439f0560f132895d117df6839957ac04cdd58d861f6da86803d40bfc19059e3d341ddb8de87214b73a6329b57f9acdb512bb0f745dcf08729507b9b
   languageName: node
   linkType: hard
 
@@ -22116,6 +23910,99 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-aria-components@npm:^1.12.1":
+  version: 1.12.1
+  resolution: "react-aria-components@npm:1.12.1"
+  dependencies:
+    "@internationalized/date": "npm:^3.9.0"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/autocomplete": "npm:3.0.0-rc.1"
+    "@react-aria/collections": "npm:3.0.0-rc.6"
+    "@react-aria/dnd": "npm:^3.11.2"
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/overlays": "npm:^3.29.1"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/textfield": "npm:^3.18.1"
+    "@react-aria/toolbar": "npm:3.0.0-beta.20"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-aria/virtualizer": "npm:^4.1.9"
+    "@react-stately/autocomplete": "npm:3.0.0-beta.3"
+    "@react-stately/layout": "npm:^4.5.0"
+    "@react-stately/selection": "npm:^3.20.5"
+    "@react-stately/table": "npm:^3.15.0"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-stately/virtualizer": "npm:^4.4.3"
+    "@react-types/form": "npm:^3.7.15"
+    "@react-types/grid": "npm:^3.3.5"
+    "@react-types/shared": "npm:^3.32.0"
+    "@react-types/table": "npm:^3.13.3"
+    "@swc/helpers": "npm:^0.5.0"
+    client-only: "npm:^0.0.1"
+    react-aria: "npm:^3.43.1"
+    react-stately: "npm:^3.41.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/9b48a3b22d0afb45f79a224fa6b786c8761c9f3108e8da298ef66facc86f2446b11d2a20ecf0a173f0d660059a3d50025cd3907e91751ed5d4af0188378d1c7d
+  languageName: node
+  linkType: hard
+
+"react-aria@npm:^3.43.1":
+  version: 3.43.1
+  resolution: "react-aria@npm:3.43.1"
+  dependencies:
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/breadcrumbs": "npm:^3.5.28"
+    "@react-aria/button": "npm:^3.14.1"
+    "@react-aria/calendar": "npm:^3.9.1"
+    "@react-aria/checkbox": "npm:^3.16.1"
+    "@react-aria/color": "npm:^3.1.1"
+    "@react-aria/combobox": "npm:^3.13.2"
+    "@react-aria/datepicker": "npm:^3.15.1"
+    "@react-aria/dialog": "npm:^3.5.30"
+    "@react-aria/disclosure": "npm:^3.0.8"
+    "@react-aria/dnd": "npm:^3.11.2"
+    "@react-aria/focus": "npm:^3.21.1"
+    "@react-aria/gridlist": "npm:^3.14.0"
+    "@react-aria/i18n": "npm:^3.12.12"
+    "@react-aria/interactions": "npm:^3.25.5"
+    "@react-aria/label": "npm:^3.7.21"
+    "@react-aria/landmark": "npm:^3.0.6"
+    "@react-aria/link": "npm:^3.8.5"
+    "@react-aria/listbox": "npm:^3.14.8"
+    "@react-aria/menu": "npm:^3.19.2"
+    "@react-aria/meter": "npm:^3.4.26"
+    "@react-aria/numberfield": "npm:^3.12.1"
+    "@react-aria/overlays": "npm:^3.29.1"
+    "@react-aria/progress": "npm:^3.4.26"
+    "@react-aria/radio": "npm:^3.12.1"
+    "@react-aria/searchfield": "npm:^3.8.8"
+    "@react-aria/select": "npm:^3.16.2"
+    "@react-aria/selection": "npm:^3.25.1"
+    "@react-aria/separator": "npm:^3.4.12"
+    "@react-aria/slider": "npm:^3.8.1"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/switch": "npm:^3.7.7"
+    "@react-aria/table": "npm:^3.17.7"
+    "@react-aria/tabs": "npm:^3.10.7"
+    "@react-aria/tag": "npm:^3.7.1"
+    "@react-aria/textfield": "npm:^3.18.1"
+    "@react-aria/toast": "npm:^3.0.7"
+    "@react-aria/tooltip": "npm:^3.8.7"
+    "@react-aria/tree": "npm:^3.1.3"
+    "@react-aria/utils": "npm:^3.30.1"
+    "@react-aria/visually-hidden": "npm:^3.8.27"
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/cf4e8cc615c687ecd16fdc1a80dba70d5e8e6fa98fde22467b949b4815a03e93600da1157e6aa7658d852000944d965806edc507fd02e7e40dfd1eb62443b3ba
+  languageName: node
+  linkType: hard
+
 "react-colorful@npm:^5.1.2":
   version: 5.6.1
   resolution: "react-colorful@npm:5.6.1"
@@ -22449,6 +24336,42 @@ __metadata:
   peerDependencies:
     react: ">=16.8"
   checksum: 10c0/19be638294926e2d6b1ca6de753d3b69ac9cd3e295158f933a2c5d9befe2d6dd84f2b15d45d904ac5009f813901183b0a92d50f9d4c2f496c974192b0b8fb2ec
+  languageName: node
+  linkType: hard
+
+"react-stately@npm:^3.41.0":
+  version: 3.41.0
+  resolution: "react-stately@npm:3.41.0"
+  dependencies:
+    "@react-stately/calendar": "npm:^3.8.4"
+    "@react-stately/checkbox": "npm:^3.7.1"
+    "@react-stately/collections": "npm:^3.12.7"
+    "@react-stately/color": "npm:^3.9.1"
+    "@react-stately/combobox": "npm:^3.11.1"
+    "@react-stately/data": "npm:^3.14.0"
+    "@react-stately/datepicker": "npm:^3.15.1"
+    "@react-stately/disclosure": "npm:^3.0.7"
+    "@react-stately/dnd": "npm:^3.7.0"
+    "@react-stately/form": "npm:^3.2.1"
+    "@react-stately/list": "npm:^3.13.0"
+    "@react-stately/menu": "npm:^3.9.7"
+    "@react-stately/numberfield": "npm:^3.10.1"
+    "@react-stately/overlays": "npm:^3.6.19"
+    "@react-stately/radio": "npm:^3.11.1"
+    "@react-stately/searchfield": "npm:^3.5.15"
+    "@react-stately/select": "npm:^3.7.1"
+    "@react-stately/selection": "npm:^3.20.5"
+    "@react-stately/slider": "npm:^3.7.1"
+    "@react-stately/table": "npm:^3.15.0"
+    "@react-stately/tabs": "npm:^3.8.5"
+    "@react-stately/toast": "npm:^3.1.2"
+    "@react-stately/toggle": "npm:^3.9.1"
+    "@react-stately/tooltip": "npm:^3.5.7"
+    "@react-stately/tree": "npm:^3.9.2"
+    "@react-types/shared": "npm:^3.32.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10c0/36acef7ad6f0d58bc66804d152c25f31bd2e977b34cc131c6d70af142a20478a9e7d3826d22084ce4abedb94b6c87aa627ee7467337cab7ad5ae0d45b571d6b2
   languageName: node
   linkType: hard
 
@@ -24517,6 +26440,7 @@ __metadata:
     pretty-hrtime: "npm:^1.0.3"
     prompts: "npm:^2.4.0"
     react: "npm:^18.2.0"
+    react-aria-components: "npm:^1.12.1"
     react-dom: "npm:^18.2.0"
     react-helmet-async: "npm:^1.3.0"
     react-inspector: "npm:^6.0.0"
@@ -26186,6 +28110,15 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/161599bf921cfaa41c85d2b01c871975ee99260f3e874c2d41c05890d41170297bdcf314bc5185e7a700de2034ac5b888e3efc8e9f35724f4918f53538d717c9
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.4.0":
+  version: 1.5.0
+  resolution: "use-sync-external-store@npm:1.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/1b8663515c0be34fa653feb724fdcce3984037c78dd4a18f68b2c8be55cc1a1084c578d5b75f158d41b5ddffc2bf5600766d1af3c19c8e329bb20af2ec6f52f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> [!CAUTION]
> Must base onto next once the IconButton branch is merged! ⚠️⚠️⚠️ 

## What I did

This PR is part of the work done on WithTooltip replacement. It specifically addresses Select's use of WithTooltip.

Select's menu is not a tooltip, it's an interactive popover with a listbox role. We already have KB nav and aria markup working, all we were missing was:
* A popover placement logic that doesn't depend on Popper.js
* A hook to close the popover when clicking outside of its content

The PR uses low-level react-aria hooks to achieve this.

The miminalist popover inside `Select.tsx` will likely not be reusable. We have higher-level primitives for most use cases, but here I needed something very low-level to keep the existing KB nav logic in place.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run local instance
2. Go to http://localhost:6006/?path=/story/select-component--mouse-selection-multi
3. Play around with the stories

### Documentation

N/A

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-03 17:34:52 UTC

This PR migrates the Select component from using `WithTooltipPure` (based on Popper.js) to react-aria overlay hooks for better semantic correctness and accessibility. The Select component's dropdown menu was previously implemented as a tooltip, but semantically it should be an interactive popover with a listbox role.

The main changes include:

1. **New dependency**: Adds `react-aria-components@^1.12.1` to the core package to access overlay positioning and interaction hooks

2. **Custom MinimalistPopover component**: Replaces `WithTooltipPure` with a new component that uses three react-aria hooks:
   - `useOverlayPosition` for popover placement without Popper.js
   - `useInteractOutside` for handling clicks outside the popover
   - `useOverlay` for focus management and dismissal behavior

3. **Improved ARIA semantics**: Updates role assignments so single-select uses `button` role and multi-select uses `combobox` role, following proper accessibility guidelines

4. **Enhanced keyboard navigation**: Maintains existing keyboard shortcuts while adding Tab key handling to close the popover

5. **Visual consistency**: Adds `borderRadius: 2` to focused select options for consistent styling

The migration preserves all existing functionality including complex multi-select logic, keyboard navigation, and ARIA markup while moving to a more semantically correct and accessible implementation. The new MinimalistPopover is intentionally low-level and non-reusable to maintain the existing keyboard navigation behavior.

## Confidence score: 4/5

- This PR introduces significant architectural changes but follows established patterns and maintains existing functionality
- Score reflects the complexity of the migration and potential edge cases with the new react-aria dependency
- Pay close attention to the Select component implementation and test the popover positioning thoroughly

<!-- /greptile_comment -->