### PR TITLE
UI: Review FileSearchList tooltip behavior and align style with sidebar

### DIFF
--- a/code/core/src/manager/components/sidebar/FileList.tsx
+++ b/code/core/src/manager/components/sidebar/FileList.tsx
@@ -42,11 +42,11 @@ export const FileListLi = styled('li')(({ theme }) => ({
   },
 }));
 
-export const FileListItem = styled('div')(({ theme }) => ({
+export const FileListItem = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   position: 'relative',
-}));
+});
 
 export const FileListItemContentWrapper = styled.div<{
   selected: boolean;
@@ -141,8 +141,7 @@ export const FileListExport = styled('ul')(({ theme }) => ({
 }));
 
 export const FileListItemExport = styled('li')<{ error: boolean }>(({ theme, error }) => ({
-  padding: '8px 16px 8px 16px',
-  marginLeft: '30px',
+  padding: '8px 16px 8px 58px',
   display: 'flex',
   gap: '8px',
   alignItems: 'center',
@@ -188,9 +187,13 @@ export const FileListItemExportNameContent = styled('span')(({ theme }) => ({
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',
   overflow: 'hidden',
-  maxWidth: 'calc(100% - 160px)',
   display: 'inline-block',
+  color: theme.base === 'dark' ? theme.color.lightest : theme.color.darkest,
 }));
+
+export const FileListItemExportNameContentWithExport = styled(FileListItemExportNameContent)({
+  maxWidth: 'calc(100% - 120px)',
+});
 
 export const DefaultExport = styled('span')(({ theme }) => ({
   display: 'inline-block',

--- a/code/core/src/manager/components/sidebar/FileSearchList.tsx
+++ b/code/core/src/manager/components/sidebar/FileSearchList.tsx
@@ -6,7 +6,12 @@ import type {
   FileComponentSearchResponsePayload,
 } from 'storybook/internal/core-events';
 
-import { ChevronDownIcon, ChevronRightIcon, ComponentIcon } from '@storybook/icons';
+import {
+  BookmarkHollowIcon,
+  ChevronSmallDownIcon,
+  ChevronSmallRightIcon,
+  ComponentIcon,
+} from '@storybook/icons';
 
 import type { VirtualItem } from '@tanstack/react-virtual';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -24,6 +29,7 @@ import {
   FileListItemExport,
   FileListItemExportName,
   FileListItemExportNameContent,
+  FileListItemExportNameContentWithExport,
   FileListItemLabel,
   FileListItemPath,
   FileListLi,
@@ -40,16 +46,14 @@ export interface NewStoryPayload extends CreateNewStoryRequestPayload {
   selectedItemId: string | number;
 }
 
-const ChevronRightIconStyled = styled(ChevronRightIcon)(({ theme }) => ({
-  display: 'none',
-  alignSelf: 'center',
+const TreeExpandIconStyled = styled(ChevronSmallRightIcon)(({ theme }) => ({
   color: theme.color.mediumdark,
+  marginTop: 2,
 }));
 
-const ChevronDownIconStyled = styled(ChevronDownIcon)(({ theme }) => ({
-  display: 'none',
-  alignSelf: 'center',
+const TreeCollapseIconStyled = styled(ChevronSmallDownIcon)(({ theme }) => ({
   color: theme.color.mediumdark,
+  marginTop: 2,
 }));
 
 interface FileSearchListProps {
@@ -189,6 +193,11 @@ export const FileSearchList = memo(function FileSearchList({
               searchResult.exportedComponents?.length === 0
             }
           >
+            {itemSelected ? (
+              <TreeCollapseIconStyled size={14} />
+            ) : (
+              <TreeExpandIconStyled size={14} />
+            )}
             <FileListIconWrapper error={itemError}>
               <ComponentIcon />
             </FileListIconWrapper>
@@ -198,7 +207,6 @@ export const FileSearchList = memo(function FileSearchList({
               </FileListItemLabel>
               <FileListItemPath>{searchResult.filepath}</FileListItemPath>
             </FileListItemContent>
-            {itemSelected ? <ChevronDownIconStyled /> : <ChevronRightIconStyled />}
           </FileListItemContentWrapper>
           {/* @ts-expect-error (non strict) */}
           {searchResult?.exportedComponents?.length > 1 && itemSelected && (
@@ -249,19 +257,20 @@ export const FileSearchList = memo(function FileSearchList({
                     }}
                   >
                     <FileListItemExportName>
-                      <ComponentIcon />
+                      <BookmarkHollowIcon />
                       {component.default ? (
                         <>
-                          <FileListItemExportNameContent>
+                          <FileListItemExportNameContentWithExport>
                             {searchResult.filepath.split('/').at(-1)?.split('.')?.at(0)}
-                          </FileListItemExportNameContent>
+                          </FileListItemExportNameContentWithExport>
                           <DefaultExport>Default export</DefaultExport>
                         </>
                       ) : (
-                        component.name
+                        <FileListItemExportNameContent>
+                          {component.name}
+                        </FileListItemExportNameContent>
                       )}
                     </FileListItemExportName>
-                    <ChevronRightIconStyled />
                   </FileListItemExport>
                 );
               })}
@@ -340,15 +349,15 @@ export const FileSearchList = memo(function FileSearchList({
                     <WithTooltip
                       {...itemProps}
                       style={{ width: '100%' }}
+                      trigger="hover"
                       hasChrome={false}
-                      closeOnOutsideClick={true}
+                      delayHide={100}
+                      delayShow={200}
+                      placement="top-start"
                       tooltip={
                         <TooltipNote
-                          // @ts-expect-error (non strict)
                           note={
-                            noExports
-                              ? "We can't evaluate exports for this file. You can't create a story for it automatically"
-                              : null
+                            "We can't evaluate exports for this file. Automatic story creation is disabled."
                           }
                         />
                       }


### PR DESCRIPTION
> [!CAUTION]
> Must base onto next once the IconButton branch is merged! ⚠️⚠️⚠️ 

## What I did

### Tooltip

Tidied up FileSearchList's UI a little bit. There's an error tooltip appearing in some entries that can't be selected/expanded, that only appears when clicking the seemingly disabled entry.

<img width="499" height="439" alt="image" src="https://github.com/user-attachments/assets/613a373d-71ef-4dc8-a43f-07049383f7d9" />

By making the tooltip appear on hover (like we do for disabled buttons elsewhere), we can provide more immediate feedback. Complete change list:
* **Changed trigger to hover so I know this is an actual Tooltip when splitting WithTooltip uses between Popover and Tooltip later** (actual reason to touch this)
* Added show/hide delays for more immediate feedback
* Shortened copy to match style used in disabled buttons elsewhere
* Aligned positioning to start of trigger
* Removed unnecessary code

### UI

What I did:
* Switched chevrons to small variants and aligned sizes to 14px
* Positioned chevrons to left and reworked margins/paddings to match sidebar tree
* Fixed up color of export texts (not quite visible in dark mode but it looked disabled in light mode)
* Switched export icon to match the story icon, not the component one
* Removed chevrons from stories as they are not expandable
* Fixed small CLS on hover on the default export tag (which was due to the chevron insert)

#### Before
<img width="504" height="491" alt="image" src="https://github.com/user-attachments/assets/b323f59a-9bdd-4d2f-ab53-eace2ca02144" />

<img width="502" height="462" alt="image" src="https://github.com/user-attachments/assets/bb30c31e-e4ad-4b0f-83ad-2a18c91e415f" />


#### After

<img width="549" height="556" alt="image" src="https://github.com/user-attachments/assets/13515181-8b4c-4db9-93b8-c06e1fb5f6fe" />

<img width="489" height="457" alt="image" src="https://github.com/user-attachments/assets/757fb90e-225d-4cdf-a770-22225ce4dc43" />


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Go to http://localhost:6006/?path=/story/manager-sidebar-filesearchmodal--loading-with-previous-results
2. Play a bit with the UI, compare to sidebar

### Documentation

N/A

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-03 19:25:08 UTC

This PR introduces UI improvements and architectural changes to Storybook's file search and component selection systems. The changes fall into two main categories:

### Tooltip and UI Cleanup
The PR modernizes the FileSearchList component by switching error tooltips from click-triggered to hover-triggered behavior, providing more immediate feedback when users encounter disabled entries. The tooltip improvements include adding show/hide delays, shortening tooltip text, and aligning positioning. Visual enhancements include switching chevron icons to smaller variants, repositioning them to the left to match sidebar tree patterns, fixing text color contrast in dark mode, and replacing component icons with bookmark icons for exports.

### Select Component Refactoring
A significant architectural change replaces the `WithTooltipPure` implementation in the Select component with a custom `MinimalistPopover` using React Aria libraries. This introduces new dependencies (`react-aria-components`, `@react-aria/utils`, `react-aria`, `react-stately`) and fundamentally changes how dropdown overlays are rendered - moving from a portal-based tooltip system to a controlled popover implementation with improved keyboard handling and accessibility patterns.

The changes align the file search interface with existing Storybook UI patterns and represent part of a broader effort to distinguish between true tooltips (informational hover overlays) and interactive popovers throughout the codebase.

## Confidence score: 3/5

- This PR introduces significant architectural changes in the Select component that could impact dropdown behavior across Storybook
- Score reflects the substantial shift from `react-popper-tooltip` to React Aria libraries and the complete restructuring of how dropdowns render
- Pay close attention to `code/core/src/components/components/Select/Select.tsx` for potential keyboard navigation or accessibility regressions

<!-- /greptile_comment -->