### PR TITLE
UI: Replace Popper.js Tooltip with react-aria Tooltip and Popover

### DIFF
--- a/code/core/src/components/components/Button/helpers/InteractiveTooltipWrapper.tsx
+++ b/code/core/src/components/components/Button/helpers/InteractiveTooltipWrapper.tsx
@@ -37,7 +37,12 @@ export const InteractiveTooltipWrapper: React.FC<{
   }, [shortcut, tooltip]);
 
   return tooltipLabel ? (
-    <WithTooltip trigger="hover" hasChrome={false} tooltip={<NoMarginNote note={tooltipLabel} />}>
+    <WithTooltip
+      trigger="hover"
+      hasChrome={false}
+      placement="top"
+      tooltip={<NoMarginNote note={tooltipLabel} />}
+    >
       {children}
     </WithTooltip>
   ) : (

--- a/code/core/src/components/components/Button/helpers/InteractiveTooltipWrapper.tsx
+++ b/code/core/src/components/components/Button/helpers/InteractiveTooltipWrapper.tsx
@@ -12,8 +12,8 @@ const NoMarginNote = styled(TooltipNote)(() => ({
   margin: 0,
 }));
 
-// TODO: Improve delay management; make the delay near-instantaneous if any instance of this component has been recently shown.
-// TODO: Find way to trigger the tooltip when the child component is focused too. Will need this for general a11y but particularly for Sidebar nav secondary actions.
+// TODO: Port to new react aria tooltip
+
 export const InteractiveTooltipWrapper: React.FC<{
   children: React.ReactNode;
   shortcut?: API_KeyCollection;

--- a/code/core/src/components/components/overlay/MenuItem.stories.tsx
+++ b/code/core/src/components/components/overlay/MenuItem.stories.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+
+import { Overlay } from 'storybook/internal/components';
+
+import { FaceHappyIcon, StorybookIcon } from '@storybook/icons';
+
+import { Menu } from 'react-aria-components';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import preview from '../../../../../.storybook/preview';
+import { MenuItem } from './MenuItem';
+
+const meta = preview.meta({
+  id: 'menuitem-component',
+  title: 'Overlay/MenuItem',
+  component: MenuItem,
+  args: {},
+  decorators: [
+    (Story) => (
+      <Overlay hasChrome padding="0 4px">
+        <Menu aria-label="Menu" style={{ width: 200 }}>
+          <Story />
+        </Menu>
+      </Overlay>
+    ),
+  ],
+});
+
+export const Base = meta.story({
+  args: {
+    title: 'Menu item',
+  },
+});
+
+export const WithIcon = meta.story({
+  args: {
+    title: 'Menu item',
+    icon: <FaceHappyIcon />,
+  },
+});
+
+export const WithDescription = meta.story({
+  args: {
+    title: 'Menu item',
+    description: 'Clicking this will make you happy, I swear!',
+  },
+});
+
+export const ExtraDefault = meta.story({
+  args: {
+    title: 'Menu item',
+    isDefault: true,
+  },
+});
+
+export const ExtraSelected = meta.story({
+  args: {
+    title: 'Menu item',
+    isSelected: true,
+  },
+});
+
+export const ExtraShortcut = meta.story({
+  args: {
+    title: 'Menu item',
+    shortcut: ['control', 'alt', 'K'],
+  },
+});
+
+export const ExtraHighlighted = meta.story({
+  args: {
+    title: 'Menu item',
+    isHighlighted: true,
+  },
+});
+
+export const ExtraExternal = meta.story({
+  args: {
+    title: 'Menu item',
+    showExternalIcon: true,
+  },
+});
+
+export const ExtraDisabled = meta.story({
+  args: {
+    title: 'Menu item',
+    isDisabled: true,
+  },
+});
+
+export const ExtraIndented = meta.story({
+  args: {
+    title: 'Menu item',
+    isIndented: true,
+  },
+});
+
+export const ExtraIndentedWithIcon = meta.story({
+  args: {
+    title: 'Menu item',
+    isIndented: true,
+    icon: <FaceHappyIcon />,
+  },
+});
+
+export const WithHref = meta.story({
+  args: {
+    title: 'External link',
+    icon: <StorybookIcon />,
+    href: 'https://storybook.js.org',
+    showExternalIcon: true,
+  },
+});
+
+export const DisabledWithIcon = meta.story({
+  args: {
+    title: 'Disabled item',
+    icon: <FaceHappyIcon />,
+    isDisabled: true,
+  },
+});
+
+export const DisabledWithDescription = meta.story({
+  args: {
+    title: 'Disabled item',
+    description: 'This item is disabled and cannot be clicked',
+    isDisabled: true,
+  },
+});
+
+export const SelectedWithDescription = meta.story({
+  args: {
+    title: 'Selected item',
+    description: 'This item is currently selected',
+    isSelected: true,
+  },
+});
+
+export const HighlightedWithIcon = meta.story({
+  args: {
+    title: 'Highlighted item',
+    icon: <FaceHappyIcon />,
+    isHighlighted: true,
+  },
+});
+
+export const DefaultWithIcon = meta.story({
+  args: {
+    title: 'Default item',
+    icon: <FaceHappyIcon />,
+    isDefault: true,
+  },
+});
+
+export const LongShortcut = meta.story({
+  args: {
+    title: 'Long shortcut',
+    shortcut: ['control', 'alt', 'shift', 'meta', 'K'],
+  },
+});
+
+export const LongTitle = meta.story({
+  args: {
+    title: 'This is a very long menu item title that might need to wrap or truncate',
+    icon: <FaceHappyIcon />,
+  },
+});
+
+export const LongDescription = meta.story({
+  args: {
+    title: 'Menu item',
+    description:
+      'This is a very long description that explains in great detail what this menu item does and why you might want to click on it. It goes on and on to test how the component handles long text content.',
+    icon: <FaceHappyIcon />,
+  },
+});
+
+export const Interactive = meta.story({
+  args: {
+    title: 'Interactive menu item',
+    description: 'Click me to see event handling',
+    icon: <FaceHappyIcon />,
+    onAction: fn(),
+  },
+});
+
+export const InteractiveDisabled = meta.story({
+  args: {
+    title: 'Disabled interactive item',
+    description: 'This should not trigger any events',
+    icon: <FaceHappyIcon />,
+    isDisabled: true,
+    onAction: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const item = canvas.getByText('Disabled interactive item');
+
+    await userEvent.click(item);
+    await expect(args.onAction).not.toHaveBeenCalled();
+  },
+});

--- a/code/core/src/components/components/overlay/MenuItem.tsx
+++ b/code/core/src/components/components/overlay/MenuItem.tsx
@@ -1,0 +1,185 @@
+import React, { type FC, type ReactElement, type ReactNode, forwardRef } from 'react';
+
+import { type API_KeyCollection, shortcutToHumanString } from 'storybook/internal/manager-api';
+
+import { CheckIcon, ShareAltIcon } from '@storybook/icons';
+
+import { MenuItem as MenuItemUpstream } from 'react-aria-components';
+import { type MenuItemProps as MenuItemPropsUpstream } from 'react-aria-components';
+import { styled } from 'storybook/theming';
+
+const Root = styled(MenuItemUpstream)<{ isSelected: boolean }>(({ isSelected, theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'stretch',
+
+  minHeight: 32,
+  margin: '0 4px',
+  padding: 8,
+  gap: 8,
+
+  color: isSelected
+    ? theme.color.secondary
+    : theme.base === 'light'
+      ? theme.color.darkest
+      : theme.color.lightest,
+  textDecoration: 'none',
+
+  transition: 'all 150ms ease-out',
+  // Same as overlay withChrome
+  borderRadius: theme.appBorderRadius + 2,
+
+  '&:hover:not([aria-disabled="true"])': {
+    background: theme.background.hoverable,
+    color: theme.color.secondary,
+    cursor: 'pointer',
+  },
+  '&:focus-visible:not([aria-disabled="true"])': {
+    outline: 'none',
+    background: theme.background.hoverable,
+    color: theme.color.secondary,
+    // boxShadow: `inset 0 0 0 2px ${theme.color.secondary}`,
+  },
+  '&[aria-disabled="true"]': {
+    opacity: 0.6,
+    cursor: 'not-allowed',
+  },
+}));
+
+const Row = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+});
+
+const Title = styled.div<{ isIndented: boolean; isSelected: boolean }>(
+  ({ isIndented, isSelected, theme }) => ({
+    flex: 1,
+    fontWeight: isSelected ? 700 : 400,
+    fontFamily: theme.typography.fonts.base,
+    fontSize: theme.typography.size.s1,
+    lineHeight: `${theme.typography.size.s3}px`,
+    // 14px icon + 8px gap.
+    marginInlineStart: isIndented ? 22 : undefined,
+  })
+);
+
+const ExtraLabelText = styled.div<{ isSelected: boolean }>(({ theme, isSelected }) => ({
+  color: isSelected ? theme.color.secondary : theme.textMutedColor,
+  fontFamily: theme.typography.fonts.mono,
+  fontSize: 11,
+  lineHeight: `${theme.typography.size.s3}px`,
+}));
+
+const Description = styled.div<{ isSelected: boolean }>(({ theme, isSelected }) => ({
+  color: isSelected ? theme.color.secondary : theme.textMutedColor,
+  fontSize: 11,
+  lineHeight: `${theme.typography.size.s3}px`,
+}));
+
+const HighlightPill = styled.div(({ theme }) => ({
+  display: 'inline-block',
+  width: 6,
+  height: 6,
+  borderRadius: 9999,
+  background: theme.color.positiveText,
+}));
+
+const ExtraLabel: FC<{
+  shortcut?: API_KeyCollection;
+  isDefault: boolean;
+  isHighlighted: boolean;
+  isSelected: boolean;
+  showExternalIcon: boolean;
+}> = ({ shortcut, isDefault, isHighlighted, isSelected, showExternalIcon }) => {
+  const outputs = [];
+
+  if (shortcut) {
+    outputs.push(
+      <ExtraLabelText isSelected={isSelected}>{shortcutToHumanString(shortcut)}</ExtraLabelText>
+    );
+  } else if (isDefault) {
+    outputs.push(<ExtraLabelText isSelected={isSelected}>default</ExtraLabelText>);
+  }
+
+  if (isSelected) {
+    outputs.push(<CheckIcon size={14} />);
+  } else if (isHighlighted) {
+    outputs.push(<HighlightPill />);
+  } else if (showExternalIcon) {
+    outputs.push(<ShareAltIcon size={14} />);
+  }
+
+  return <>{outputs}</>;
+};
+
+export interface MenuItemProps extends Omit<MenuItemPropsUpstream, 'children'> {
+  /* --- Anatomy and layout --- */
+  title: string;
+  description?: ReactNode;
+  icon?: ReactElement;
+  isIndented?: boolean;
+
+  /* --- Interactivity state --- */
+  isLoading?: boolean;
+  isDisabled?: boolean;
+
+  /* --- Additional content types --- */
+  isDefault?: boolean;
+  isSelected?: boolean;
+  isHighlighted?: boolean;
+  showExternalIcon?: boolean;
+
+  /* --- Actions --- */
+  href?: string;
+  shortcut?: API_KeyCollection;
+}
+
+export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
+  (
+    {
+      title,
+      description,
+      icon,
+      isIndented = false,
+      isDefault = false,
+      isDisabled = false,
+      showExternalIcon = false,
+      isHighlighted = false,
+      isSelected = false,
+      shortcut,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <Root
+        ref={ref}
+        isDisabled={isDisabled}
+        isSelected={isSelected}
+        {...props}
+        target={props.href ? '_blank' : undefined}
+      >
+        <Row>
+          {icon && React.cloneElement(icon, { size: 14 })}
+          <Title isIndented={isIndented && !icon} isSelected={isSelected}>
+            {title}
+          </Title>
+          <ExtraLabel
+            isDefault={isDefault}
+            isHighlighted={isHighlighted}
+            isSelected={isSelected}
+            showExternalIcon={showExternalIcon}
+            shortcut={shortcut}
+          />
+        </Row>
+        {description && (
+          <Row>
+            <Description isSelected={isSelected}>{description}</Description>
+          </Row>
+        )}
+      </Root>
+    );
+  }
+);
+MenuItem.displayName = 'MenuItem';

--- a/code/core/src/components/components/overlay/Overlay.stories.tsx
+++ b/code/core/src/components/components/overlay/Overlay.stories.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+
+import { Button } from 'storybook/internal/components';
+
+import { CloseAltIcon } from '@storybook/icons';
+
+import { fn } from 'storybook/test';
+
+import preview from '../../../../../.storybook/preview';
+import { Overlay } from './Overlay';
+
+const SampleTooltip = () => 'Lorem ipsum dolor sit amet';
+
+const SamplePopover = () => (
+  <div>
+    <h3>Lorem ipsum dolor sit amet</h3>
+    <p>Consectatur vestibulum concet durum politu coret weirom</p>
+    <button onClick={fn()}>Continue</button>
+  </div>
+);
+
+const meta = preview.meta({
+  id: 'overlay-component',
+  title: 'Overlay/Overlay',
+  component: Overlay,
+  args: {
+    children: <SamplePopover />,
+    color: undefined,
+    hasChrome: true,
+  },
+  argTypes: {
+    color: {
+      type: 'string',
+      control: 'select',
+      options: ['default', 'inverse', 'positive', 'negative', 'warning'],
+    },
+  },
+});
+
+export const AsTooltip = meta.story({
+  args: {
+    children: <SampleTooltip />,
+  },
+});
+
+export const AsPopover = meta.story({
+  args: {
+    children: <SamplePopover />,
+  },
+});
+
+export const WithChrome = meta.story({
+  args: {
+    hasChrome: true,
+  },
+});
+
+export const WithoutChrome = meta.story({
+  args: {
+    hasChrome: false,
+  },
+});
+
+export const WithHideButton = meta.story({
+  args: {
+    hasChrome: true,
+    onHide: fn(),
+  },
+});
+
+export const WithCustomHideLabel = meta.story({
+  args: {
+    hasChrome: true,
+    onHide: fn(),
+    hideLabel: 'Close Overlay',
+  },
+});
+
+export const WithHideButtonAndPadding = meta.story({
+  args: {
+    children: (
+      <div>
+        When the close button covers content, setting <code>padding</code> to{' '}
+        <code>8px 40px 8px 8px</code> solves simple use cases.
+      </div>
+    ),
+    hasChrome: true,
+    onHide: fn(),
+    padding: '8px 40px 8px 8px',
+  },
+});
+
+export const WithCustomHideButton = meta.story({
+  args: {
+    children: (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div>For more advanced use cases, pass your own close button to the overlay.</div>
+        <Button
+          ariaLabel="Close Overlay"
+          onClick={fn()}
+          size="small"
+          padding="small"
+          variant="ghost"
+        >
+          <CloseAltIcon />
+        </Button>
+      </div>
+    ),
+    hasChrome: true,
+  },
+});
+
+export const ColorDefault = meta.story({
+  args: {
+    color: 'default',
+  },
+});
+
+export const ColorInverse = meta.story({
+  args: {
+    color: 'inverse',
+  },
+});
+
+export const ColorPositive = meta.story({
+  args: {
+    color: 'positive',
+  },
+});
+
+export const ColorNegative = meta.story({
+  args: {
+    color: 'negative',
+  },
+});
+
+export const ColorWarning = meta.story({
+  args: {
+    color: 'warning',
+  },
+});

--- a/code/core/src/components/components/overlay/Overlay.tsx
+++ b/code/core/src/components/components/overlay/Overlay.tsx
@@ -1,0 +1,104 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import { Button } from 'storybook/internal/components';
+
+import { CloseIcon } from '@storybook/icons';
+
+import { lighten, styled } from 'storybook/theming';
+
+export interface OverlayProps {
+  /** Content of the overlay. */
+  children: React.ReactNode;
+
+  /** Preset overlay color taken from the theme, affecting both bathground and foreground. */
+  color?: 'default' | 'inverse' | 'positive' | 'negative' | 'warning';
+
+  /** Whether the overlay is rendered with a decorative window-like appearance. */
+  hasChrome: boolean;
+
+  /** Optional callback connected to a close button. Then button is shown only when passed. */
+  onHide?: () => void;
+
+  /** Optional custom label for the close button, if there is one. */
+  hideLabel?: string;
+
+  /** Padding between the content and overlay edge. */
+  padding?: number | string;
+}
+
+const Wrapper = styled.div<{
+  bgColor: NonNullable<OverlayProps['color']>;
+  hasChrome: boolean;
+  hasCloseButton: boolean;
+  padding: NonNullable<OverlayProps['padding']>;
+}>(
+  ({ hasCloseButton, padding }) => ({
+    display: 'inline-block',
+    position: 'relative',
+    minHeight: hasCloseButton ? 36 : undefined,
+    zIndex: 2147483647,
+    colorScheme: 'light dark',
+    padding,
+  }),
+  ({ theme, hasChrome }) =>
+    hasChrome
+      ? {
+          filter: `
+            drop-shadow(0px 5px 5px rgba(0,0,0,0.05))
+            drop-shadow(0 1px 3px rgba(0,0,0,0.1))
+          `,
+          borderRadius: theme.appBorderRadius + 2,
+          fontSize: theme.typography.size.s1,
+        }
+      : {},
+  ({ theme, bgColor }) =>
+    bgColor === 'default' && {
+      background: theme.base === 'light' ? lighten(theme.background.app) : theme.background.app,
+      color: theme.color.defaultText,
+    },
+  ({ theme, bgColor }) =>
+    bgColor === 'inverse' && {
+      background: theme.base === 'light' ? theme.color.darkest : theme.color.lightest,
+      color: theme.color.inverseText,
+    },
+  ({ theme, bgColor }) =>
+    (bgColor === 'positive' || bgColor === 'negative' || bgColor === 'warning') && {
+      background: theme.background[bgColor],
+      color: theme.color[`${bgColor}Text`],
+    }
+);
+
+const AbsoluteButton = styled(Button)({
+  position: 'absolute',
+  top: 4,
+  right: 4,
+});
+
+export const Overlay: FC<OverlayProps> = ({
+  children,
+  color = 'default',
+  hasChrome = true,
+  hideLabel = 'Close',
+  onHide,
+  padding = 8,
+}) => {
+  return (
+    <Wrapper bgColor={color} hasChrome={hasChrome} hasCloseButton={!!onHide} padding={padding}>
+      {children}
+      {onHide && (
+        <AbsoluteButton
+          ariaLabel={hideLabel}
+          onClick={onHide}
+          padding="small"
+          variant="ghost"
+          size="small"
+        >
+          <CloseIcon />
+        </AbsoluteButton>
+      )}
+    </Wrapper>
+  );
+};
+
+Overlay.displayName = 'Overlay';

--- a/code/core/src/components/components/overlay/WithMenu.stories.tsx
+++ b/code/core/src/components/components/overlay/WithMenu.stories.tsx
@@ -1,0 +1,349 @@
+import React from 'react';
+
+import {
+  CommandIcon,
+  InfoIcon,
+  PinIcon,
+  QuestionIcon,
+  StorybookIcon,
+  WandIcon,
+} from '@storybook/icons';
+
+import { expect, fn, screen, userEvent, within } from 'storybook/test';
+import { styled } from 'storybook/theming';
+
+import preview from '../../../../../.storybook/preview';
+import { WithMenu, type WithMenuProps } from './WithMenu';
+
+const ViewPort = styled.div({
+  height: 300,
+});
+
+const BackgroundBox = styled.div({
+  width: 500,
+  height: 500,
+  overflowY: 'scroll',
+  background: '#eee',
+  position: 'relative',
+});
+
+const Spacer = styled.div({
+  height: 100,
+});
+
+const Trigger = styled.button({
+  width: 120,
+  height: 50,
+  margin: 10,
+  '&:focus-visible': {
+    outline: '2px solid blue',
+    outlineOffset: '2px',
+  },
+});
+
+const SampleItems = [
+  {
+    id: 'first',
+    title: 'Lorem ipsum dolor sit amet',
+    onAction: fn(),
+  },
+  {
+    id: 'second',
+    title: 'Consectatur vestibulum concet durum politu coret weirom',
+    onAction: fn(),
+  },
+  { type: 'separator' },
+  {
+    id: 'third',
+    icon: <StorybookIcon />,
+    title: 'Storybook',
+    href: 'http://localhost:6006',
+    showExternalIcon: true,
+  },
+  { type: 'separator' },
+  {
+    id: 'fourth',
+    icon: <PinIcon />,
+    title: 'Local link',
+    href: '?path=/story/tooltip-withmenu--base',
+  },
+] satisfies WithMenuProps['items'];
+
+const ClassicMenu = [
+  {
+    id: 'about',
+    title: 'About your Storybook',
+    icon: <InfoIcon />,
+    onAction: fn().mockName('About'),
+  },
+  {
+    id: 'whats-new',
+    title: "What's new?",
+    icon: <WandIcon />,
+    isHighlighted: true,
+    onAction: fn().mockName("What's new?"),
+  },
+  {
+    id: 'documentation',
+    title: 'Documentation',
+    showExternalIcon: true,
+    onAction: fn().mockName('Documentation'),
+  },
+  {
+    id: 'shortcuts',
+    title: 'Shortcuts',
+    icon: <CommandIcon />,
+    onAction: fn().mockName('Shortcuts'),
+  },
+  { type: 'separator' },
+  {
+    id: 'sidebar',
+    title: 'Hide sidebar',
+    shortcut: ['alt', 's'],
+    onAction: fn().mockName('Hide sidebar'),
+  },
+  {
+    id: 'toolbar',
+    title: 'Hide toolbar',
+    shortcut: ['alt', 't'],
+    onAction: fn().mockName('Hide toolbar'),
+  },
+  {
+    id: 'addons',
+    title: 'Hide addons panel',
+    shortcut: ['alt', 'a'],
+    onAction: fn().mockName('Hide addons panel'),
+  },
+  {
+    id: 'addon-orientation',
+    title: 'Change addons orientation',
+    shortcut: ['alt', 'd'],
+    onAction: fn().mockName('Change addons orientation'),
+  },
+  {
+    id: 'fullscren',
+    title: 'Go fullscren',
+    shortcut: ['alt', 'f'],
+    onAction: fn().mockName('Go fullscren'),
+  },
+  {
+    id: 'search',
+    title: 'Search',
+    shortcut: ['control', 'k'],
+    onAction: fn().mockName('Search'),
+  },
+  { type: 'separator' },
+  {
+    id: 'help',
+    title: 'Get help',
+    icon: <QuestionIcon />,
+    showExternalIcon: true,
+    onAction: fn().mockName('Get help'),
+  },
+] satisfies WithMenuProps['items'];
+
+const meta = preview.meta({
+  id: 'tooltip-WithMenu',
+  title: 'Overlay/WithMenu',
+  component: WithMenu,
+  args: {
+    offset: 8,
+    placement: 'top',
+  },
+  decorators: [
+    (storyFn) => (
+      <ViewPort>
+        <BackgroundBox>
+          <Spacer />
+          {storyFn()}
+        </BackgroundBox>
+      </ViewPort>
+    ),
+  ],
+});
+
+export const Base = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    items: SampleItems,
+  },
+});
+
+export const Showcase = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    items: ClassicMenu,
+  },
+});
+
+export const Placements = meta.story({
+  args: {
+    children: <Trigger>ignored</Trigger>,
+    items: SampleItems,
+  },
+  render: (args) => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gap: '1rem',
+        padding: '2rem',
+      }}
+    >
+      <WithMenu {...args} placement="top">
+        <Trigger>Top</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="top-start">
+        <Trigger>Top Start</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="top-end">
+        <Trigger>Top End</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="bottom">
+        <Trigger>Bottom</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="bottom-start">
+        <Trigger>Bottom Start</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="bottom-end">
+        <Trigger>Bottom End</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="left">
+        <Trigger>Left</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="left-start">
+        <Trigger>Left Start</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="left-end">
+        <Trigger>Left End</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="right">
+        <Trigger>Right</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="right-start">
+        <Trigger>Right Start</Trigger>
+      </WithMenu>
+      <WithMenu {...args} placement="right-end">
+        <Trigger>Right End</Trigger>
+      </WithMenu>
+    </div>
+  ),
+});
+
+export const CustomOffset = meta.story({
+  args: {
+    offset: 20,
+    children: <Trigger>Click me!</Trigger>,
+    items: SampleItems,
+  },
+});
+
+export const AlwaysOpen = meta.story({
+  args: {
+    visible: true,
+    children: <Trigger>Always visible tooltip</Trigger>,
+    items: SampleItems,
+    placement: 'right-start',
+  },
+  play: async () => {
+    await expect(await screen.findByText('Lorem ipsum dolor sit')).toBeInTheDocument();
+  },
+});
+
+export const NeverOpen = meta.story({
+  args: {
+    visible: false,
+    children: <Trigger>Never visible tooltip</Trigger>,
+    items: SampleItems,
+    placement: 'right-start',
+  },
+  play: async () => {
+    await expect(screen.queryByText('Lorem ipsum dolor sit')).not.toBeInTheDocument();
+  },
+});
+
+export const WithVisibilityCallback = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    items: SampleItems,
+    onVisibleChange: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByText('Click me!');
+
+    await userEvent.click(trigger);
+    await expect(args.onVisibleChange).toHaveBeenCalledWith(true);
+
+    await userEvent.click(trigger);
+    await expect(args.onVisibleChange).toHaveBeenCalledWith(false);
+  },
+});
+
+export const InteractiveMenuKB = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    items: SampleItems,
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByText('Click me!');
+
+    await step('Open menu', async () => {
+      trigger.focus();
+      await userEvent.keyboard('{Enter}');
+      const firstItem = await screen.findByText('Lorem ipsum dolor sit amet');
+      await expect(firstItem).toBeInTheDocument();
+      await expect(firstItem).toHaveFocus();
+    });
+
+    const firstItem = await screen.findByText('Lorem ipsum dolor sit amet');
+    const secondItem = await screen.findByText('Lorem ipsum dolor sit amet');
+
+    await step('Pressing Tab does not move focus', async () => {
+      await userEvent.tab();
+      await expect(firstItem).toHaveFocus();
+    });
+
+    await step('Press ArrowDown and ArrowUp to navigate items', async () => {
+      await userEvent.keyboard('{ArrowDown}');
+      await expect(secondItem).toHaveFocus();
+
+      await userEvent.keyboard('{ArrowUp}');
+      await expect(firstItem).toHaveFocus();
+    });
+
+    await step('Press Esc to close items', async () => {
+      await userEvent.keyboard('{Escape}');
+      await expect(screen.queryByText('Lorem ipsum dolor sit amet')).not.toBeInTheDocument();
+    });
+  },
+});
+
+export const InteractiveMenuMouse = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    items: SampleItems,
+  },
+  render: (args) => (
+    <div>
+      <WithMenu {...args} />
+      <button>Sibling Button</button>
+    </div>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByText('Click me!');
+
+    await step('Open menu', async () => {
+      await userEvent.click(trigger);
+      await expect(screen.queryByText('Lorem ipsum dolor sit amet')).toBeInTheDocument();
+    });
+
+    await step('Click an item, closing the menu', async () => {
+      await userEvent.click(await screen.findByText('Lorem ipsum dolor sit amet'));
+      await expect(screen.queryByText('Lorem ipsum dolor sit amet')).not.toBeInTheDocument();
+      await expect(trigger).toHaveFocus();
+    });
+  },
+});

--- a/code/core/src/components/components/overlay/WithMenu.tsx
+++ b/code/core/src/components/components/overlay/WithMenu.tsx
@@ -1,0 +1,103 @@
+import type { DOMAttributes, ReactElement } from 'react';
+import React, { useMemo } from 'react';
+
+import { Overlay, convertToReactAriaPlacement } from 'storybook/internal/components';
+import type { MenuItemProps, PopperPlacement } from 'storybook/internal/components';
+
+import {
+  Menu,
+  MenuTrigger,
+  Popover,
+  Pressable,
+  Separator,
+  type SeparatorProps,
+} from 'react-aria-components';
+import { styled } from 'storybook/theming';
+
+import { MenuItem } from './MenuItem';
+
+type MenuItemChild = Omit<MenuItemProps, 'isIndented'> & { type?: 'item' };
+type SeparatorChild = SeparatorProps & { type: 'separator' };
+
+// Cancelling a default outline that occurs on the MenuTrigger container with react-aria.
+const StyledMenu = styled(Menu)({
+  '&:focus': {
+    outline: 'none',
+  },
+});
+
+const StyledSeparator = styled(Separator)(({ theme }) => ({
+  border: 'none',
+  borderTop: `1px solid ${theme.base === 'light' ? '#264A7326' : '#FFFFFF12'}`,
+  margin: '4px 0',
+}));
+
+export interface WithMenuProps {
+  /** Distance between the trigger and Menu. Customize only if you have a good reason to. */
+  offset?: number;
+
+  /**
+   * Placement of the Menu. Start and End variants involve additional JS dimension calculations and
+   * should be used sparingly. Left and Right get inverted in RTL.
+   */
+  placement?: PopperPlacement;
+
+  /** Items in the menu. */
+  items: (MenuItemChild | SeparatorChild)[];
+
+  /** Menu trigger, must be a single child with click/press events. Must forward refs. */
+  children: ReactElement<DOMAttributes<Element>, string>;
+
+  /** Uncontrolled state: whether the Menu is initially visible. */
+  defaultVisible?: boolean;
+
+  /** Controlled state: whether the Menu is visible. */
+  visible?: boolean;
+
+  /** Controlled state: fires when user interaction causes the Menu to change visibility. */
+  onVisibleChange?: (isVisible: boolean) => void;
+}
+
+function isSeparator(item: MenuItemChild | SeparatorChild): item is SeparatorChild {
+  return item.type === 'separator';
+}
+
+export const WithMenu = ({
+  placement: placementProp = 'bottom-start',
+  offset = 8,
+  items,
+  children,
+  defaultVisible,
+  visible,
+  onVisibleChange,
+  ...props
+}: WithMenuProps) => {
+  // Map Popper.js placement to react-aria placement best we can.
+  const placement = convertToReactAriaPlacement(placementProp);
+
+  const hasIcons = useMemo(() => items.some((item) => 'icon' in item), [items]);
+
+  return (
+    <MenuTrigger
+      defaultOpen={defaultVisible}
+      isOpen={visible}
+      onOpenChange={onVisibleChange}
+      {...props}
+    >
+      <Pressable>{children}</Pressable>
+      <Popover placement={placement} offset={offset} style={{ outlineColor: 'transparent' }}>
+        <Overlay hasChrome padding="4px 0">
+          <StyledMenu>
+            {items.map((item, index) => {
+              return isSeparator(item) ? (
+                <StyledSeparator key={index} />
+              ) : (
+                <MenuItem key={item.id} {...item} isIndented={hasIcons} />
+              );
+            })}
+          </StyledMenu>
+        </Overlay>
+      </Popover>
+    </MenuTrigger>
+  );
+};

--- a/code/core/src/components/components/overlay/WithPopover.stories.tsx
+++ b/code/core/src/components/components/overlay/WithPopover.stories.tsx
@@ -1,0 +1,294 @@
+import React from 'react';
+
+import { expect, fn, screen, userEvent, within } from 'storybook/test';
+import { styled } from 'storybook/theming';
+
+import preview from '../../../../../.storybook/preview';
+import { WithPopover } from './WithPopover';
+
+const ViewPort = styled.div({
+  height: 300,
+});
+
+const BackgroundBox = styled.div({
+  width: 500,
+  height: 500,
+  overflowY: 'scroll',
+  background: '#eee',
+  position: 'relative',
+});
+
+const Spacer = styled.div({
+  height: 100,
+});
+
+const Trigger = styled.button({
+  width: 120,
+  height: 50,
+  margin: 10,
+  '&:focus-visible': {
+    outline: '2px solid blue',
+    outlineOffset: '2px',
+  },
+});
+
+const StyledSamplePopover = styled.div({
+  padding: 10,
+  maxWidth: 200,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+});
+
+const SamplePopover = () => (
+  <StyledSamplePopover>
+    <h3>Lorem ipsum dolor sit amet</h3>
+    <p>Consectatur vestibulum concet durum politu coret weirom</p>
+    <button onClick={fn()}>Continue</button>
+  </StyledSamplePopover>
+);
+
+const meta = preview.meta({
+  id: 'tooltip-WithPopover',
+  title: 'Overlay/WithPopover',
+  component: WithPopover,
+  args: {
+    hasChrome: true,
+    offset: 8,
+    placement: 'top',
+  },
+  decorators: [
+    (storyFn) => (
+      <ViewPort>
+        <BackgroundBox>
+          <Spacer />
+          {storyFn()}
+        </BackgroundBox>
+      </ViewPort>
+    ),
+  ],
+});
+
+export const Base = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    popover: <SamplePopover />,
+  },
+});
+
+export const Placements = meta.story({
+  args: {
+    children: <Trigger>ignored</Trigger>,
+    popover: 'ignored',
+  },
+  render: (args) => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gap: '1rem',
+        padding: '2rem',
+      }}
+    >
+      <WithPopover {...args} placement="top" popover="Top placement">
+        <Trigger>Top</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="top-start" popover="Top start placement">
+        <Trigger>Top Start</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="top-end" popover="Top end placement">
+        <Trigger>Top End</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="bottom" popover="Bottom placement">
+        <Trigger>Bottom</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="bottom-start" popover="Bottom start placement">
+        <Trigger>Bottom Start</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="bottom-end" popover="Bottom end placement">
+        <Trigger>Bottom End</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="left" popover="Left placement">
+        <Trigger>Left</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="left-start" popover="Left start placement">
+        <Trigger>Left Start</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="left-end" popover="Left end placement">
+        <Trigger>Left End</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="right" popover="Right placement">
+        <Trigger>Right</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="right-start" popover="Right start placement">
+        <Trigger>Right Start</Trigger>
+      </WithPopover>
+      <WithPopover {...args} placement="right-end" popover="Right end placement">
+        <Trigger>Right End</Trigger>
+      </WithPopover>
+    </div>
+  ),
+});
+
+export const WithChrome = meta.story({
+  args: {
+    hasChrome: true,
+    children: <Trigger>Click me!</Trigger>,
+    popover: <SamplePopover />,
+  },
+});
+
+export const WithoutChrome = meta.story({
+  args: {
+    hasChrome: false,
+    children: <Trigger>Click me!</Trigger>,
+    popover: <SamplePopover />,
+  },
+});
+
+export const CustomOffset = meta.story({
+  args: {
+    offset: 20,
+    children: <Trigger>Click me!</Trigger>,
+    popover: <SamplePopover />,
+  },
+});
+
+export const CustomPadding = meta.story({
+  args: {
+    padding: 20,
+    children: <Trigger>Click me!</Trigger>,
+    popover: <SamplePopover />,
+  },
+});
+
+export const WithCloseButton = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    popover: <SamplePopover />,
+    hasCloseButton: true,
+  },
+});
+
+export const WithoutCloseButton = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    popover: <SamplePopover />,
+    hasCloseButton: false,
+  },
+});
+
+export const AlwaysOpen = meta.story({
+  args: {
+    visible: true,
+    children: <Trigger>Always visible tooltip</Trigger>,
+    popover: <SamplePopover />,
+    placement: 'right-start',
+  },
+  play: async () => {
+    await expect(await screen.findByText('Lorem ipsum dolor sit')).toBeInTheDocument();
+  },
+});
+
+export const NeverOpen = meta.story({
+  args: {
+    visible: false,
+    children: <Trigger>Never visible tooltip</Trigger>,
+    popover: <SamplePopover />,
+    placement: 'right-start',
+  },
+  play: async () => {
+    await expect(screen.queryByText('Lorem ipsum dolor sit')).not.toBeInTheDocument();
+  },
+});
+
+export const WithVisibilityCallback = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    popover: <SamplePopover />,
+    onVisibleChange: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByText('Click me!');
+
+    await userEvent.click(trigger);
+    await expect(args.onVisibleChange).toHaveBeenCalledWith(true);
+
+    await userEvent.click(trigger);
+    await expect(args.onVisibleChange).toHaveBeenCalledWith(false);
+  },
+});
+
+export const InteractivePopoverKB = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    popover: <SamplePopover />,
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByText('Click me!');
+
+    await step('Open popover', async () => {
+      trigger.focus();
+      await userEvent.keyboard('{Enter}');
+      await expect(screen.queryByText('Lorem ipsum dolor sit amet')).toBeInTheDocument();
+    });
+
+    await step('Press Tab to enter popover', async () => {
+      await userEvent.tab();
+      const continueButton = await screen.findByText('Continue');
+      await expect(continueButton).toHaveFocus();
+    });
+
+    await step('Press Esc to close popover', async () => {
+      await userEvent.keyboard('{Escape}');
+      await expect(screen.queryByText('Lorem ipsum dolor sit amet')).not.toBeInTheDocument();
+    });
+  },
+});
+
+export const InteractivePopoverMouse = meta.story({
+  args: {
+    children: <Trigger>Click me!</Trigger>,
+    popover: <SamplePopover />,
+  },
+  render: (args) => (
+    <div>
+      <WithPopover {...args} />
+      <button>Sibling Button</button>
+    </div>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Open popover', async () => {
+      const trigger = canvas.getByText('Click me!');
+      await userEvent.click(trigger);
+      await expect(screen.queryByText('Lorem ipsum dolor sit amet')).toBeInTheDocument();
+    });
+
+    await step('Click outside popover to close it', async () => {
+      const sibling = canvas.getByText('Sibling Button');
+      await userEvent.click(sibling);
+      await expect(screen.queryByText('Lorem ipsum dolor sit amet')).not.toBeInTheDocument();
+    });
+  },
+});
+
+export const LongContent = meta.story({
+  args: {
+    children: <Trigger>Long content</Trigger>,
+    popover: (
+      <div style={{ maxWidth: '300px', padding: '8px' }}>
+        <h3 style={{ margin: '0 0 8px 0' }}>Very Long Tooltip Content</h3>
+        <p style={{ margin: '0', fontSize: '12px', lineHeight: '1.4' }}>
+          This is a very long popover that demonstrates how the popover component handles extensive
+          content. It should wrap properly and maintain good readability even with multiple lines of
+          text. The popover positioning should also adapt to ensure it remains visible within the
+          viewport boundaries.
+        </p>
+      </div>
+    ),
+  },
+});

--- a/code/core/src/components/components/overlay/WithPopover.tsx
+++ b/code/core/src/components/components/overlay/WithPopover.tsx
@@ -1,0 +1,104 @@
+import type { DOMAttributes, ReactElement, ReactNode } from 'react';
+import React, { useCallback, useState } from 'react';
+
+import { Overlay, convertToReactAriaPlacement } from 'storybook/internal/components';
+import type { PopperPlacement } from 'storybook/internal/components';
+
+import { DialogTrigger, Popover as PopoverUpstream, Pressable } from 'react-aria-components';
+
+export interface WithPopoverProps {
+  /** Whether to display the Popover in a prestyled container. True by default. */
+  hasChrome?: boolean;
+
+  /**
+   * Whether to display a close button in the top right corner of the popover overlay. Can overlap
+   * with overlay content, make sure to test your use case. False by default.
+   */
+  hasCloseButton?: boolean;
+
+  /** Optional custom label for the close button, if there is one. */
+  closeLabel?: string;
+
+  /** Optional custom padding for the popover overlay. */
+  padding?: number | string;
+
+  /** Distance between the trigger and Popover. Customize only if you have a good reason to. */
+  offset?: number;
+
+  /**
+   * Placement of the Popover. Start and End variants involve additional JS dimension calculations
+   * and should be used sparingly. Left and Right get inverted in RTL.
+   */
+  placement?: PopperPlacement;
+
+  /**
+   * Popover content. Pass a function to receive a onHide callback to collect to your close button,
+   * or if you want to wait for the popover to be opened to call your content component.
+   */
+  popover: ReactNode | ((props: { onHide: () => void }) => ReactNode);
+
+  /** Popover trigger, must be a single child with click/press events. Must forward refs. */
+  children: ReactElement<DOMAttributes<Element>, string>;
+
+  /** Uncontrolled state: whether the Popover is initially visible. */
+  defaultVisible?: boolean;
+
+  /** Controlled state: whether the Popover is visible. */
+  visible?: boolean;
+
+  /** Controlled state: fires when user interaction causes the Popover to change visibility. */
+  onVisibleChange?: (isVisible: boolean) => void;
+}
+
+export const WithPopover = ({
+  placement: placementProp = 'bottom-start',
+  hasChrome = true,
+  hasCloseButton = false,
+  closeLabel,
+  offset = 8,
+  padding,
+  popover,
+  children,
+  defaultVisible,
+  visible,
+  onVisibleChange,
+  ...props
+}: WithPopoverProps) => {
+  // Map Popper.js placement to react-aria placement best we can.
+  const placement = convertToReactAriaPlacement(placementProp);
+
+  const [isOpen, setIsOpen] = useState(defaultVisible ?? false);
+  const onOpenChange = useCallback(
+    (isOpen: boolean) => {
+      setIsOpen(isOpen);
+      onVisibleChange?.(isOpen);
+    },
+    [onVisibleChange]
+  );
+  const onHide = useCallback(() => setIsOpen(false), []);
+
+  return (
+    <DialogTrigger
+      defaultOpen={defaultVisible}
+      isOpen={visible ?? isOpen}
+      onOpenChange={onOpenChange}
+      {...props}
+    >
+      <Pressable>{children}</Pressable>
+      <PopoverUpstream
+        placement={placement}
+        offset={offset}
+        style={{ outlineColor: 'transparent' }}
+      >
+        <Overlay
+          hasChrome={hasChrome}
+          hideLabel={closeLabel}
+          onHide={hasCloseButton ? onHide : undefined}
+          padding={padding}
+        >
+          {typeof popover === 'function' ? popover({ onHide }) : popover}
+        </Overlay>
+      </PopoverUpstream>
+    </DialogTrigger>
+  );
+};

--- a/code/core/src/components/components/overlay/helpers.ts
+++ b/code/core/src/components/components/overlay/helpers.ts
@@ -1,0 +1,38 @@
+import type { PositionProps } from '@react-types/overlays';
+import memoize from 'memoizerific';
+
+type BasicPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+type PlacementWithModifier =
+  | 'top-start'
+  | 'top-end'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left-start'
+  | 'left-end'
+  | 'right-start'
+  | 'right-end';
+
+export type PopperPlacement = BasicPlacement | PlacementWithModifier;
+
+export const convertToReactAriaPlacement = memoize(1000)((
+  p: PopperPlacement
+): NonNullable<PositionProps['placement']> => {
+  if (p === 'left-end') {
+    return 'left bottom';
+  }
+
+  if (p === 'right-end') {
+    return 'right bottom';
+  }
+
+  if (p === 'left-start') {
+    return 'left top';
+  }
+
+  if (p === 'right-start') {
+    return 'right top';
+  }
+
+  return p.replace('-', ' ') as NonNullable<PositionProps['placement']>;
+});

--- a/code/core/src/components/components/tooltip/Tooltip.tsx
+++ b/code/core/src/components/components/tooltip/Tooltip.tsx
@@ -1,6 +1,9 @@
+import type { ComponentProps } from 'react';
 import React from 'react';
 
 import memoize from 'memoizerific';
+import { Tooltip as TooltipUpstream } from 'react-aria-components';
+import type { TooltipProps as TooltipPropsUpstream } from 'react-aria-components';
 import { type Color, lighten, styled } from 'storybook/theming';
 
 const match = memoize(1000)((requests, actual, value, fallback = 0) =>
@@ -10,7 +13,7 @@ const match = memoize(1000)((requests, actual, value, fallback = 0) =>
 const ArrowSpacing = 8;
 
 export interface ArrowProps {
-  color: keyof Color;
+  color?: keyof Color;
   placement: string;
 }
 
@@ -54,7 +57,7 @@ const Arrow = styled.div<ArrowProps>(
     borderTopColor: match(
       'top',
       placement,
-      theme.color[color] || color || theme.base === 'light'
+      (color && theme.color[color]) || color || theme.base === 'light'
         ? lighten(theme.background.app)
         : theme.background.app,
       'transparent'
@@ -62,7 +65,7 @@ const Arrow = styled.div<ArrowProps>(
     borderBottomColor: match(
       'bottom',
       placement,
-      theme.color[color] || color || theme.base === 'light'
+      (color && theme.color[color]) || color || theme.base === 'light'
         ? lighten(theme.background.app)
         : theme.background.app,
       'transparent'
@@ -70,7 +73,7 @@ const Arrow = styled.div<ArrowProps>(
     borderLeftColor: match(
       'left',
       placement,
-      theme.color[color] || color || theme.base === 'light'
+      (color && theme.color[color]) || color || theme.base === 'light'
         ? lighten(theme.background.app)
         : theme.background.app,
       'transparent'
@@ -78,7 +81,7 @@ const Arrow = styled.div<ArrowProps>(
     borderRightColor: match(
       'right',
       placement,
-      theme.color[color] || color || theme.base === 'light'
+      (color && theme.color[color]) || color || theme.base === 'light'
         ? lighten(theme.background.app)
         : theme.background.app,
       'transparent'
@@ -149,3 +152,57 @@ export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
 );
 
 Tooltip.displayName = 'Tooltip';
+
+/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+
+type PlacementWithModifier =
+  | 'top-start'
+  | 'top-end'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left-start'
+  | 'left-end'
+  | 'right-start'
+  | 'right-end';
+
+type BasicPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export interface TooltipDbgProps extends Omit<TooltipPropsUpstream, 'children' | 'placement'> {
+  children: React.ReactNode;
+  hasChrome?: boolean;
+  placement?: BasicPlacement | PlacementWithModifier;
+}
+
+function convertToReactAriaPlacement(
+  p: BasicPlacement | PlacementWithModifier
+): NonNullable<ComponentProps<typeof TooltipUpstream>['placement']> {
+  return p.replace('-', ' ') as NonNullable<ComponentProps<typeof TooltipUpstream>['placement']>;
+}
+
+export const TooltipDbg = React.forwardRef<HTMLDivElement, TooltipDbgProps>(
+  (
+    { children, hasChrome = true, placement: placementProp = 'top', ...props }: TooltipDbgProps,
+    ref
+  ) => {
+    // Map Popper.js placement to react-aria placement best we can.
+    const placement = convertToReactAriaPlacement(placementProp);
+
+    return (
+      <TooltipUpstream data-testid="tooltip" ref={ref} placement={placement} {...props}>
+        <Wrapper hasChrome={hasChrome} color={undefined}>
+          {children}
+        </Wrapper>
+      </TooltipUpstream>
+    );
+  }
+);
+
+TooltipDbg.displayName = 'Tooltip';

--- a/code/core/src/components/components/tooltip/WithTooltip.tsx
+++ b/code/core/src/components/components/tooltip/WithTooltip.tsx
@@ -261,6 +261,8 @@ export interface WithPopoverProps {
 // BREAKING: The `followCursor` prop was removed because it was unused.
 // BREAKING: The `closeOnOutsideClick` prop was removed. It is now always enabled. Use a Dialog if you need a popover that does not close automatically.
 
+// BREAKING: popper to aria placement -> top-start becomes top start (hyphen to space), etc. left-start becomes "left top", left-end "left bottom", right-start "right top", right-end "right bottom"
+
 export interface WithTooltipProps {
   /** Tooltips trigger on hover and focus by default. To trigger on focus only, set this to `true`. */
   triggerOnFocusOnly?: boolean;

--- a/code/core/src/components/components/tooltip/WithTooltipDBG.stories.tsx
+++ b/code/core/src/components/components/tooltip/WithTooltipDBG.stories.tsx
@@ -1,0 +1,273 @@
+import React from 'react';
+
+import { expect, fn, screen } from 'storybook/test';
+import { styled } from 'storybook/theming';
+
+import preview from '../../../../../.storybook/preview';
+import { TooltipNote } from './TooltipNote';
+import { WithTooltipDBG as WithTooltip } from './WithTooltip';
+
+const ViewPort = styled.div({
+  height: 300,
+});
+
+const BackgroundBox = styled.div({
+  width: 500,
+  height: 500,
+  overflowY: 'scroll',
+  background: '#eee',
+  position: 'relative',
+});
+
+const Spacer = styled.div({
+  height: 100,
+});
+
+const Trigger = styled.button({
+  width: 120,
+  margin: 10,
+  '&:focus-visible': {
+    outline: '2px solid blue',
+    outlineOffset: '2px',
+  },
+});
+
+const SimpleTooltip = () => 'Lorem ipsum dolor sit';
+
+const meta = preview.meta({
+  id: 'tooltip-withtooltip',
+  title: 'WithTooltipDbg',
+  component: WithTooltip,
+  args: {
+    triggerOnFocusOnly: false,
+    placement: 'top',
+    hasChrome: true,
+    offset: 8,
+    delayShow: 400,
+    delayHide: 200,
+    tooltip: <SimpleTooltip />,
+    children: <Trigger>Hover me!</Trigger>,
+  },
+  decorators: [
+    (storyFn) => (
+      <ViewPort>
+        <BackgroundBox>
+          <Spacer />
+          {storyFn()}
+        </BackgroundBox>
+      </ViewPort>
+    ),
+  ],
+});
+
+export const Base = meta.story({
+  args: {
+    tooltip: <SimpleTooltip />,
+    children: <Trigger>Hover me!</Trigger>,
+  },
+});
+
+export const FocusOnly = meta.story({
+  args: {
+    triggerOnFocusOnly: true,
+    tooltip: <SimpleTooltip />,
+    children: <Trigger tabIndex={0}>Focus me!</Trigger>,
+  },
+});
+
+export const Placements = meta.story({
+  args: {
+    children: 'ignored',
+    tooltip: 'ignored',
+  },
+  render: (args) => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gap: '1rem',
+        padding: '2rem',
+      }}
+    >
+      <WithTooltip {...args} placement="top" tooltip="Top placement">
+        <Trigger>Top</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="top-start" tooltip="Top start placement">
+        <Trigger>Top Start</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="top-end" tooltip="Top end placement">
+        <Trigger>Top End</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="bottom" tooltip="Bottom placement">
+        <Trigger>Bottom</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="bottom-start" tooltip="Bottom start placement">
+        <Trigger>Bottom Start</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="bottom-end" tooltip="Bottom end placement">
+        <Trigger>Bottom End</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="left" tooltip="Left placement">
+        <Trigger>Left</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="left-start" tooltip="Left start placement">
+        <Trigger>Left Start</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="left-end" tooltip="Left end placement">
+        <Trigger>Left End</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="right" tooltip="Right placement">
+        <Trigger>Right</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="right-start" tooltip="Right start placement">
+        <Trigger>Right Start</Trigger>
+      </WithTooltip>
+      <WithTooltip {...args} placement="right-end" tooltip="Right end placement">
+        <Trigger>Right End</Trigger>
+      </WithTooltip>
+    </div>
+  ),
+});
+
+export const WithChrome = meta.story({
+  args: {
+    hasChrome: true,
+    tooltip: 'Simple tooltip with chrome styling',
+    children: <Trigger>Hover me!</Trigger>,
+  },
+});
+
+export const WithoutChrome = meta.story({
+  args: {
+    hasChrome: false,
+    tooltip: 'Simple tooltip without chrome styling',
+    children: <Trigger>Hover me!</Trigger>,
+  },
+});
+
+export const WithoutChromeTooltipNote = meta.story({
+  args: {
+    hasChrome: false,
+    tooltip: <TooltipNote note="Simple tooltip without chrome styling" />,
+    children: <Trigger>Hover me!</Trigger>,
+  },
+});
+
+export const CustomOffset = meta.story({
+  args: {
+    offset: 20,
+    tooltip: 'Tooltip with custom offset (20px)',
+    children: <Trigger>Hover me!</Trigger>,
+  },
+});
+
+export const CustomDelays = meta.story({
+  args: {
+    delayShow: 1000,
+    delayHide: 500,
+    tooltip: 'Tooltip with custom delays (1000ms show, 500ms hide)',
+    children: <Trigger>Hover me!</Trigger>,
+  },
+});
+
+export const Instantaneous = meta.story({
+  args: {
+    delayShow: 0,
+    delayHide: 0,
+    tooltip: 'Tooltip with no delays',
+    children: <Trigger>Hover me!</Trigger>,
+  },
+});
+
+// TODO: check behaviour
+export const AlwaysOpen = meta.story({
+  args: {
+    visible: true,
+    tooltip: <SimpleTooltip />,
+    children: <Trigger>Always visible tooltip</Trigger>,
+    placement: 'right-start',
+  },
+  play: async () => {
+    await expect(await screen.findByText('Lorem ipsum dolor sit')).toBeInTheDocument();
+  },
+});
+
+export const NeverOpen = meta.story({
+  args: {
+    visible: false,
+    tooltip: <SimpleTooltip />,
+    children: <Trigger>Never visible tooltip</Trigger>,
+    placement: 'right-start',
+  },
+  play: async () => {
+    await expect(await screen.findByText('Lorem ipsum dolor sit')).toBeInTheDocument();
+  },
+});
+
+export const WithVisibilityCallback = meta.story({
+  args: {
+    onVisibleChange: fn(),
+    tooltip: 'Tooltip with visibility callback',
+    children: <Trigger>Hover me!</Trigger>,
+  },
+});
+
+export const ComplexTooltipContent = meta.story({
+  args: {
+    tooltip: (
+      <div style={{ padding: '8px' }}>
+        <h3 style={{ margin: '0 0 8px 0', fontSize: '14px' }}>Complex Tooltip</h3>
+        <p style={{ margin: '0 0 8px 0', fontSize: '12px' }}>
+          This tooltip contains multiple elements including:
+        </p>
+        <ul style={{ margin: '0', paddingLeft: '16px', fontSize: '12px' }}>
+          <li>Headings</li>
+          <li>Paragraphs</li>
+          <li>Lists</li>
+          <li>And more!</li>
+        </ul>
+      </div>
+    ),
+    children: <Trigger>Complex content</Trigger>,
+  },
+});
+
+export const InteractiveTooltip = meta.story({
+  args: {
+    tooltip: (
+      <div style={{ padding: '8px' }}>
+        <p style={{ margin: '0 0 8px 0' }}>Interactive tooltip with button</p>
+        <button
+          onClick={() => fn().mockName('Inside tooltip clicked')}
+          style={{
+            padding: '4px 8px',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            background: 'white',
+            cursor: 'pointer',
+          }}
+        >
+          Click me
+        </button>
+      </div>
+    ),
+    children: <Trigger>Interactive tooltip</Trigger>,
+  },
+});
+
+export const LongContent = meta.story({
+  args: {
+    tooltip: (
+      <div style={{ maxWidth: '300px', padding: '8px' }}>
+        <h3 style={{ margin: '0 0 8px 0' }}>Very Long Tooltip Content</h3>
+        <p style={{ margin: '0', fontSize: '12px', lineHeight: '1.4' }}>
+          This is a very long tooltip that demonstrates how the tooltip component handles extensive
+          content. It should wrap properly and maintain good readability even with multiple lines of
+          text. The tooltip positioning should also adapt to ensure it remains visible within the
+          viewport boundaries.
+        </p>
+      </div>
+    ),
+    children: <Trigger>Long content</Trigger>,
+  },
+});

--- a/code/core/src/components/components/typography/link/link.tsx
+++ b/code/core/src/components/components/typography/link/link.tsx
@@ -1,5 +1,5 @@
 import type { AnchorHTMLAttributes, MouseEvent } from 'react';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { ChevronRightIcon } from '@storybook/icons';
 
@@ -185,24 +185,31 @@ export interface LinkProps extends LinkInnerProps, LinkStylesProps, AProps {
   href?: string;
 }
 
-export const Link = ({
-  cancel = true,
-  children,
-  onClick = undefined,
-  withArrow = false,
-  containsIcon = false,
-  className = undefined,
-  style = undefined,
-  ...rest
-}: LinkProps) => (
-  <A
-    {...rest}
-    onClick={onClick && cancel ? (e) => cancelled(e, onClick) : onClick}
-    className={className}
-  >
-    <LinkInner withArrow={withArrow} containsIcon={containsIcon}>
-      {children}
-      {withArrow && <ChevronRightIcon />}
-    </LinkInner>
-  </A>
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  (
+    {
+      cancel = true,
+      children,
+      onClick = undefined,
+      withArrow = false,
+      containsIcon = false,
+      className = undefined,
+      style = undefined,
+      ...rest
+    },
+    ref
+  ) => (
+    <A
+      {...rest}
+      ref={ref}
+      onClick={onClick && cancel ? (e) => cancelled(e, onClick) : onClick}
+      className={className}
+    >
+      <LinkInner withArrow={withArrow} containsIcon={containsIcon}>
+        {children}
+        {withArrow && <ChevronRightIcon />}
+      </LinkInner>
+    </A>
+  )
 );
+Link.displayName = 'Link';

--- a/code/core/src/components/index.ts
+++ b/code/core/src/components/index.ts
@@ -58,7 +58,15 @@ export { Select } from './components/Select/Select';
 // Forms
 export { Form } from './components/Form/Form';
 
-// Tooltips
+// Overlays
+export { MenuItem } from './components/overlay/MenuItem';
+export type { MenuItemProps } from './components/overlay/MenuItem';
+export { Overlay } from './components/overlay/Overlay';
+export type { OverlayProps } from './components/overlay/Overlay';
+export { WithMenu } from './components/overlay/WithMenu';
+export { WithPopover } from './components/overlay/WithPopover';
+export { convertToReactAriaPlacement } from './components/overlay/helpers';
+export type { PopperPlacement } from './components/overlay/helpers';
 export { WithTooltip, WithTooltipPure } from './components/tooltip/lazy-WithTooltip';
 export { TooltipMessage } from './components/tooltip/TooltipMessage';
 export { TooltipNote } from './components/tooltip/TooltipNote';

--- a/code/core/src/manager/components/layout/LayoutProvider.tsx
+++ b/code/core/src/manager/components/layout/LayoutProvider.tsx
@@ -26,11 +26,15 @@ const LayoutContext = createContext<LayoutContextType>({
   isMobile: false,
 });
 
-export const LayoutProvider: FC<PropsWithChildren> = ({ children }) => {
+export const LayoutProvider: FC<
+  PropsWithChildren & {
+    forceDesktop?: boolean;
+  }
+> = ({ children, forceDesktop }) => {
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [isMobileAboutOpen, setMobileAboutOpen] = useState(false);
   const [isMobilePanelOpen, setMobilePanelOpen] = useState(false);
-  const isDesktop = useMediaQuery(`(min-width: ${BREAKPOINT}px)`);
+  const isDesktop = forceDesktop ?? useMediaQuery(`(min-width: ${BREAKPOINT}px)`);
   const isMobile = !isDesktop;
 
   const contextValue = useMemo(

--- a/code/core/src/manager/components/sidebar/Explorer.tsx
+++ b/code/core/src/manager/components/sidebar/Explorer.tsx
@@ -8,6 +8,7 @@ import { useHighlighted } from './useHighlighted';
 
 export interface ExplorerProps {
   isLoading: boolean;
+  isMobile: boolean;
   isBrowsing: boolean;
   dataset: CombinedDataset;
   selected: Selection;
@@ -15,6 +16,7 @@ export interface ExplorerProps {
 
 export const Explorer: FC<ExplorerProps> = React.memo(function Explorer({
   isLoading,
+  isMobile,
   isBrowsing,
   dataset,
   selected,
@@ -42,6 +44,7 @@ export const Explorer: FC<ExplorerProps> = React.memo(function Explorer({
           {...ref}
           key={refId}
           isLoading={isLoading}
+          isMobile={isMobile}
           isBrowsing={isBrowsing}
           selectedStoryId={selected?.refId === ref.id ? selected.storyId : null}
           highlightedRef={highlightedRef}

--- a/code/core/src/manager/components/sidebar/Menu.tsx
+++ b/code/core/src/manager/components/sidebar/Menu.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps, FC } from 'react';
 import React, { useState } from 'react';
 
-import { Button, ToggleButton, TooltipLinkList, WithTooltip } from 'storybook/internal/components';
+import { Button, ToggleButton, TooltipLinkList, WithPopover } from 'storybook/internal/components';
 
 import { CloseIcon, CogIcon } from '@storybook/icons';
 
@@ -124,10 +124,10 @@ export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick
   }
 
   return (
-    <WithTooltip
-      placement="top"
-      closeOnOutsideClick
-      tooltip={({ onHide }) => <SidebarMenuList onClick={onHide} menu={menu} />}
+    <WithPopover
+      placement={isMobile ? 'bottom' : 'right-start'}
+      padding={0}
+      popover={({ onHide }) => <SidebarMenuList onClick={onHide} menu={menu} />}
       onVisibleChange={setIsTooltipVisible}
     >
       <SidebarToggleButton
@@ -141,6 +141,6 @@ export const SidebarMenu: FC<SidebarMenuProps> = ({ menu, isHighlighted, onClick
       >
         <CogIcon />
       </SidebarToggleButton>
-    </WithTooltip>
+    </WithPopover>
   );
 };

--- a/code/core/src/manager/components/sidebar/RefBlocks.tsx
+++ b/code/core/src/manager/components/sidebar/RefBlocks.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import React, { Fragment, useCallback, useState } from 'react';
 
 import { logger } from 'storybook/internal/client-logger';
-import { Button, ErrorFormatter, Link, Spaced, WithTooltip } from 'storybook/internal/components';
+import { Button, ErrorFormatter, Link, Spaced, WithPopover } from 'storybook/internal/components';
 
 import { global } from '@storybook/global';
 import { ChevronDownIcon, LockIcon, SyncIcon } from '@storybook/icons';
@@ -34,14 +34,22 @@ const Text = styled.div(({ theme }) => ({
   },
 }));
 
-const ErrorDisplay = styled.pre(
+const ErrorDisplay = styled.pre<{ isMobile: boolean }>(
   {
-    width: 420,
     boxSizing: 'border-box',
     borderRadius: 8,
     overflow: 'auto',
     whiteSpace: 'pre',
   },
+  ({ isMobile }) =>
+    isMobile
+      ? {
+          maxWidth: 'calc(100vw - 40px)',
+        }
+      : {
+          minWidth: 420,
+          maxWidth: 640,
+        },
   ({ theme }) => ({
     color: theme.color.dark,
   })
@@ -103,15 +111,18 @@ export const AuthBlock: FC<{ loginUrl: string; id: string }> = ({ loginUrl, id }
   );
 };
 
-export const ErrorBlock: FC<{ error: Error }> = ({ error }) => (
+export const ErrorBlock: FC<{ error: Error; isMobile: boolean }> = ({ error, isMobile }) => (
   <Contained>
     <Spaced>
       <TextStyle>
         Oh no! Something went wrong loading this Storybook.
         <br />
-        <WithTooltip
-          tooltip={
-            <ErrorDisplay>
+        <WithPopover
+          hasCloseButton
+          offset={isMobile ? 0 : 8}
+          placement={isMobile ? 'bottom' : 'bottom-start'}
+          popover={
+            <ErrorDisplay isMobile={isMobile}>
               <ErrorFormatter error={error} />
             </ErrorDisplay>
           }
@@ -119,7 +130,7 @@ export const ErrorBlock: FC<{ error: Error }> = ({ error }) => (
           <Link isButton>
             View error <ChevronDownIcon />
           </Link>
-        </WithTooltip>{' '}
+        </WithPopover>{' '}
         <Link withArrow href="https://storybook.js.org/docs?ref=ui" cancel={false} target="_blank">
           View docs
         </Link>

--- a/code/core/src/manager/components/sidebar/Refs.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Refs.stories.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
+import type { StoryAnnotations } from 'storybook/internal/csf';
+
 import { ManagerContext } from 'storybook/manager-api';
-import { fn } from 'storybook/test';
+import { fn, within } from 'storybook/test';
 
 import { standardData as standardHeaderData } from './Heading.stories';
 import { IconSymbols } from './IconSymbols';
@@ -171,6 +173,7 @@ export const Optimized = () => (
   <Ref
     {...refs.optimized}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}
@@ -181,6 +184,7 @@ export const IsEmpty = () => (
   <Ref
     {...refs.empty}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}
@@ -191,6 +195,7 @@ export const StartInjectedUnknown = () => (
   <Ref
     {...refs.startInjected_unknown}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}
@@ -201,6 +206,7 @@ export const StartInjectedLoading = () => (
   <Ref
     {...refs.startInjected_loading}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}
@@ -211,6 +217,7 @@ export const StartInjectedReady = () => (
   <Ref
     {...refs.startInjected_ready}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}
@@ -221,6 +228,7 @@ export const Versions = () => (
   <Ref
     {...refs.versions}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}
@@ -231,6 +239,7 @@ export const VersionsMissingCurrent = () => (
   <Ref
     {...refs.versionsMissingCurrent}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}
@@ -241,16 +250,64 @@ export const Errored = () => (
   <Ref
     {...refs.error}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}
     setHighlighted={() => {}}
   />
 );
+export const ErroredMobile = () => (
+  <Ref
+    {...refs.error}
+    isLoading={false}
+    isMobile={true}
+    isBrowsing
+    selectedStoryId=""
+    highlightedRef={{ current: null }}
+    setHighlighted={() => {}}
+  />
+);
+ErroredMobile.globals = { sb_theme: 'stacked', viewport: { value: 'mobile1' } };
+export const ErroredWithErrorOpen: StoryAnnotations = {
+  render: () => Errored(),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByText('View error');
+    button.click();
+  },
+};
+export const ErroredMobileWithErrorOpen: StoryAnnotations = {
+  render: () => ErroredMobile(),
+  globals: { sb_theme: 'stacked', viewport: { value: 'mobile1' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByText('View error');
+    button.click();
+  },
+};
+export const ErroredWithIndicatorOpen: StoryAnnotations = {
+  render: () => Errored(),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByText('Extra actions');
+    button.click();
+  },
+};
+export const ErroredMobileWithIndicatorOpen: StoryAnnotations = {
+  render: () => ErroredMobile(),
+  globals: { sb_theme: 'stacked', viewport: { value: 'mobile1' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByText('Extra actions');
+    button.click();
+  },
+};
 export const Auth = () => (
   <Ref
     {...refs.auth}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}
@@ -261,6 +318,7 @@ export const Long = () => (
   <Ref
     {...refs.long}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}
@@ -272,6 +330,7 @@ export const WithSourceCode = () => (
   <Ref
     {...refs.withSourceCode}
     isLoading={false}
+    isMobile={false}
     isBrowsing
     selectedStoryId=""
     highlightedRef={{ current: null }}

--- a/code/core/src/manager/components/sidebar/Refs.tsx
+++ b/code/core/src/manager/components/sidebar/Refs.tsx
@@ -15,6 +15,7 @@ import type { Highlight, RefType } from './types';
 
 export interface RefProps {
   isLoading: boolean;
+  isMobile: boolean;
   isBrowsing: boolean;
   selectedStoryId: string | null;
   highlightedRef: MutableRefObject<Highlight>;
@@ -81,6 +82,7 @@ export const Ref: FC<RefType & RefProps> = React.memo(function Ref(props) {
     id: refId,
     title = refId,
     isLoading: isLoadingMain,
+    isMobile,
     isBrowsing,
     selectedStoryId,
     highlightedRef,
@@ -137,7 +139,7 @@ export const Ref: FC<RefType & RefProps> = React.memo(function Ref(props) {
             <CollapseIcon isExpanded={isExpanded} />
             <RefTitle title={title}>{title}</RefTitle>
           </CollapseButton>
-          <RefIndicator {...props} state={state} ref={indicatorRef} />
+          <RefIndicator {...props} isMobile={isMobile} state={state} ref={indicatorRef} />
         </RefHead>
       )}
       {isExpanded && (
@@ -145,7 +147,7 @@ export const Ref: FC<RefType & RefProps> = React.memo(function Ref(props) {
           {/* @ts-expect-error (non strict) */}
           {state === 'auth' && <AuthBlock id={refId} loginUrl={loginUrl} />}
           {/* @ts-expect-error (non strict) */}
-          {state === 'error' && <ErrorBlock error={indexError} />}
+          {state === 'error' && <ErrorBlock error={indexError} isMobile={isMobile} />}
           {state === 'loading' && <LoaderBlock isMain={isMain} />}
           {state === 'empty' && <EmptyBlock isMain={isMain} />}
           {state === 'ready' && (

--- a/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import type { StatusesByStoryIdAndTypeId } from 'storybook/internal/types';
+import type { DecoratorFunction, StatusesByStoryIdAndTypeId } from 'storybook/internal/types';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -8,6 +8,7 @@ import type { IndexHash } from 'storybook/manager-api';
 import { ManagerContext } from 'storybook/manager-api';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
+import { useGlobals } from '../../../preview-api';
 import { internal_fullStatusStore } from '../../manager-stores.mock';
 import { LayoutProvider } from '../layout/LayoutProvider';
 import { standardData as standardHeaderData } from './Heading.stories';
@@ -89,9 +90,15 @@ const meta = {
     isDevelopment: true,
   },
   decorators: [
-    (storyFn) => (
+    (storyFn, { globals, title }) => (
       <ManagerContext.Provider value={managerContext}>
-        <LayoutProvider>
+        <LayoutProvider
+          forceDesktop={
+            globals.viewport?.value === 'desktop' ||
+            globals.viewport?.value === undefined ||
+            title.endsWith('scrolled')
+          }
+        >
           <IconSymbols />
           {storyFn()}
         </LayoutProvider>
@@ -107,6 +114,21 @@ const meta = {
 export default meta;
 
 type Story = StoryObj<typeof meta>;
+
+const mobileLayoutDecorator: DecoratorFunction = (storyFn, { globals, title }) => (
+  <ManagerContext.Provider value={managerContext}>
+    <LayoutProvider
+      forceDesktop={
+        globals.viewport?.value === 'desktop' ||
+        globals.viewport?.value === undefined ||
+        title.endsWith('scrolled')
+      }
+    >
+      <IconSymbols />
+      {storyFn()}
+    </LayoutProvider>
+  </ManagerContext.Provider>
+);
 
 const refs: Record<string, RefType> = {
   optimized: {
@@ -148,6 +170,11 @@ export const SimpleInProduction: Story = {
   },
 };
 
+export const Mobile: Story = {
+  decorators: [mobileLayoutDecorator],
+  globals: { sb_theme: 'light', viewport: { value: 'mobile1' } },
+};
+
 export const Loading: Story = {
   args: {
     previewInitialized: false,
@@ -155,10 +182,22 @@ export const Loading: Story = {
   },
 };
 
+export const LoadingMobile: Story = {
+  args: Loading.args,
+  decorators: [mobileLayoutDecorator],
+  globals: { sb_theme: 'light', viewport: { value: 'mobile1' } },
+};
+
 export const Empty: Story = {
   args: {
     index: {},
   },
+};
+
+export const EmptyMobile: Story = {
+  args: Empty.args,
+  decorators: [mobileLayoutDecorator],
+  globals: { sb_theme: 'light', viewport: { value: 'mobile1' } },
 };
 
 export const IndexError: Story = {
@@ -209,6 +248,12 @@ export const WithRefsNarrow: Story = {
   },
 };
 
+export const WithRefsMobile: Story = {
+  args: WithRefs.args,
+  decorators: [mobileLayoutDecorator],
+  globals: { sb_theme: 'light', viewport: { value: 'mobile1' } },
+};
+
 export const LoadingWithRefs: Story = {
   args: {
     ...Loading.args,
@@ -221,6 +266,12 @@ export const LoadingWithRefError: Story = {
     ...Loading.args,
     refs: refsError,
   },
+};
+
+export const LoadingWithRefErrorMobile: Story = {
+  args: LoadingWithRefError.args,
+  decorators: [mobileLayoutDecorator],
+  globals: { sb_theme: 'light', viewport: { value: 'mobile1' } },
 };
 
 export const WithRefEmpty: Story = {

--- a/code/core/src/manager/components/sidebar/Sidebar.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.tsx
@@ -199,6 +199,7 @@ export const Sidebar = React.memo(function Sidebar({
                   dataset={dataset}
                   selected={selected}
                   isLoading={isLoading}
+                  isMobile={isMobile}
                   isBrowsing={isBrowsing}
                 />
                 <SearchResults

--- a/code/core/src/manager/components/sidebar/TagsFilter.tsx
+++ b/code/core/src/manager/components/sidebar/TagsFilter.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
-import { Badge, Button, WithTooltip } from 'storybook/internal/components';
+import { Badge, Button, WithPopover } from 'storybook/internal/components';
 import type { StoryIndex, Tag } from 'storybook/internal/types';
 
 import { FilterIcon } from '@storybook/icons';
@@ -117,42 +117,35 @@ export const TagsFilter = ({
   }
 
   return (
-    <>
-      <WithTooltip
-        placement="bottom"
-        trigger="click"
-        onVisibleChange={setExpanded}
-        // render the tooltip in the mobile menu (so that the stacking context is correct) and fallback to document.body on desktop
-        portalContainer="#storybook-mobile-menu"
-        tooltip={() => (
-          <TagsFilterPanel
-            api={api}
-            allTags={allTags}
-            selectedTags={selectedTags}
-            toggleTag={toggleTag}
-            setAllTags={setAllTags}
-            inverted={inverted}
-            setInverted={setInverted}
-            isDevelopment={isDevelopment}
-          />
-        )}
-        closeOnOutsideClick
+    <WithPopover
+      placement="bottom"
+      onVisibleChange={setExpanded}
+      offset={8}
+      popover={() => (
+        <TagsFilterPanel
+          api={api}
+          allTags={allTags}
+          selectedTags={selectedTags}
+          toggleTag={toggleTag}
+          setAllTags={setAllTags}
+          inverted={inverted}
+          setInverted={setInverted}
+          isDevelopment={isDevelopment}
+        />
+      )}
+    >
+      <StyledIconButton
+        key="tags"
+        ariaLabel="Tag filters"
+        ariaDescription="Filter the items shown in a sidebar based on the tags applied to them."
+        variant="ghost"
+        padding="small"
+        active={tagsActive}
+        onClick={handleToggleExpand}
       >
-        <Wrapper>
-          <StyledIconButton
-            key="tags"
-            ariaLabel="Tag filters"
-            ariaDescription="Filter the items shown in a sidebar based on the tags applied to them."
-            variant="ghost"
-            padding="small"
-            active={tagsActive}
-            onClick={handleToggleExpand}
-          >
-            <FilterIcon />
-          </StyledIconButton>
-          {selectedTags.length > 0 && <TagSelected />}
-        </Wrapper>
-      </WithTooltip>
-    </>
+        <FilterIcon />
+        {selectedTags.length > 0 && <TagSelected />}
+      </StyledIconButton>
+    </WithPopover>
   );
 };

--- a/code/core/src/manager/globals/exports.ts
+++ b/code/core/src/manager/globals/exports.ts
@@ -530,6 +530,7 @@ export default {
     'TooltipMessage',
     'TooltipNote',
     'UL',
+    'WithPopover',
     'WithTooltip',
     'WithTooltipPure',
     'Zoom',


### PR DESCRIPTION
Closes #32249


## What I did

* Remove many unused WithTooltip props to simplify API migration
* Replace Popper.js with react-aria whilst keeping WithTooltip API as stable as possible
* Create a Popover/WithPopover (name TBC) variant to ensure tooltip is only used for actual tooltip use cases
* Migrate relevant users of WithTooltip to WithPopover

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
