### PR TITLE
CircleCI: Split workflows for unit and story tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -852,7 +852,27 @@ jobs:
       - run:
           command: |
             cd code
-            TEST_FILES=$(circleci tests glob "**/*.{test,spec,stories}.{ts,tsx,js,jsx,cjs}" | sed "/^e2e-tests\//d" | sed "/^node_modules\//d")
+            TEST_FILES=$(circleci tests glob "**/*.{test,spec}.{ts,tsx,js,jsx,cjs}" | sed "/^e2e-tests\//d" | sed "/^node_modules\//d")
+            echo "$TEST_FILES" | circleci tests run --command="xargs yarn test --reporter=junit --reporter=default --outputFile=../test-results/junit-${CIRCLE_NODE_INDEX}.xml" --verbose
+          name: Run tests
+      - store_test_results:
+          path: test-results
+      - report-workflow-on-failure
+      - cancel-workflow-on-failure
+  stories-tests:
+    executor:
+      class: xlarge
+      name: sb_playwright
+    parallelism: 2
+    steps:
+      - git-shallow-clone/checkout_advanced:
+          clone_options: --depth 1 --verbose
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            cd code
+            TEST_FILES=$(circleci tests glob "**/*.{stories}.{ts,tsx,js,jsx,cjs}" | sed "/^e2e-tests\//d" | sed "/^node_modules\//d")
             echo "$TEST_FILES" | circleci tests run --command="xargs yarn test --reporter=junit --reporter=default --outputFile=../test-results/junit-${CIRCLE_NODE_INDEX}.xml" --verbose
           name: Run tests
       - store_test_results:
@@ -934,6 +954,9 @@ workflows:
             - build
       - check
       - unit-tests:
+          requires:
+            - build
+      - stories-tests:
           requires:
             - build
       - script-checks:
@@ -1022,6 +1045,9 @@ workflows:
       - unit-tests:
           requires:
             - build
+      - stories-tests:
+          requires:
+            - build
       - script-checks:
           requires:
             - build
@@ -1090,6 +1116,9 @@ workflows:
             - build
       - check
       - unit-tests:
+          requires:
+            - build
+      - stories-tests:
           requires:
             - build
       - script-checks:


### PR DESCRIPTION
Related: https://github.com/storybookjs/storybook/issues/27018

## What I did

This pull request updates the CircleCI configuration to improve test organization and reporting. The main changes introduce a dedicated job for running Storybook stories tests separately from unit tests, enhance test result reporting, and ensure both types of tests are executed in the CI workflows.

**CircleCI configuration improvements:**

* Added a new `stories-tests` job to run tests for files matching the `*.stories.*` pattern, separating them from standard unit tests for better clarity and parallelization.
* Updated the unit test job to exclude story files and improved test result reporting by storing test results and adding workflow failure handlers.

**Workflow enhancements:**

* Integrated the new `stories-tests` job into all relevant workflows, ensuring it runs after the build step alongside unit tests. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R959-R961) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R1048-R1050) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R1121-R1123)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-12 09:57:07 UTC

This PR refactors the CircleCI configuration to separate story tests from unit tests into distinct jobs. The changes modify the existing `unit-tests` job to exclude story files by changing the test glob pattern from `**/*.{test,spec,stories}.{ts,tsx,js,jsx,cjs}` to `**/*.{test,spec}.{ts,tsx,js,jsx,cjs}`, removing the "stories" pattern. A new `stories-tests` job is introduced that specifically targets story files with the pattern `**/*.{stories}.{ts,tsx,js,jsx,cjs}` and runs with parallelism set to 2 for better performance.

The new `stories-tests` job uses the `sb_playwright` executor with xlarge resource class and includes the same infrastructure as unit tests: test result storage, workflow failure reporting, and cancellation on failure. This job is integrated into all three CircleCI workflows (normal, merged, and daily), positioned to run after the build step alongside the existing unit tests.

This architectural change aligns with the broader CI/CD strategy of the Storybook project, which already employs job separation for different test types (e2e-dev, e2e-production, e2e-ui). The separation enables better parallelization, clearer test result categorization, and more targeted debugging when specific test types fail. The change maintains the same test coverage while providing improved organization and potentially more reliable CI runs.

## Confidence score: 4/5

- This PR is safe to merge with low risk as it maintains existing test coverage while improving CI organization
- Score reflects well-structured changes that follow existing patterns in the codebase and address a documented issue
- Pay attention to the CircleCI configuration file to ensure the glob patterns correctly capture intended test files

<!-- /greptile_comment -->