### PR TITLE
Publish: Fix sentry in release yaml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: '.nvmrc'
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -191,7 +191,7 @@ jobs:
 
       - name: Create Sentry release
         if: steps.publish-needed.outputs.published == 'false'
-        uses: sentry/action-release@v2
+        uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -206,4 +206,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_URL }}
         uses: Ilshidur/action-discord@master
         with:
-          args: "The GitHub Action for publishing version ${{ steps.version.outputs.current-version }} (triggered by ${{ github.triggering_actor }}) failed! See run at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          args: 'The GitHub Action for publishing version ${{ steps.version.outputs.current-version }} (triggered by ${{ github.triggering_actor }}) failed! See run at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'


### PR DESCRIPTION
## What I did

Fix a small error in the action yaml

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-15 08:36:52 UTC

This PR fixes a critical issue in the Storybook publishing workflow by correcting the Sentry release action reference. The main change updates the deprecated `sentry/action-release@v2` to the correct `getsentry/action-release@v3` on line 194 of `.github/workflows/publish.yml`. This fix is essential because the Sentry action was referencing an incorrect organization - the official Sentry GitHub Action is published under the `getsentry` organization, not `sentry`.

The PR also includes minor cosmetic improvements by standardizing quote usage throughout the YAML file, changing from double quotes to single quotes for consistency. These changes affect the `node-version-file` property and Discord notification message, but don't impact functionality.

This change integrates with Storybook's release pipeline, which is responsible for publishing new versions and tracking releases in Sentry for error monitoring and deployment tracking. The workflow runs in the `release` environment and is triggered during the publishing process, making proper Sentry integration crucial for release visibility and debugging.

**PR Description Notes:**
- The manual testing section is empty and should be filled out or explicitly state that no manual testing is necessary
- No automated test coverage is indicated for these workflow changes
- No labels have been applied yet (maintainers should add appropriate labels per the checklist)

## Confidence score: 5/5

- This PR is extremely safe to merge with virtually no risk of issues
- Score reflects a simple, well-targeted fix of a clearly incorrect action reference with no complex logic changes
- No files require special attention as this is a straightforward workflow correction

<!-- /greptile_comment -->