### PR TITLE
CLI: Fix init not running `dev` when it should

### DIFF
--- a/code/lib/create-storybook/build-config.ts
+++ b/code/lib/create-storybook/build-config.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path';
-
 import type { BuildEntries } from '../../../scripts/build/utils/entry-utils';
 
 const config: BuildEntries = {

--- a/code/lib/create-storybook/src/bin/run.ts
+++ b/code/lib/create-storybook/src/bin/run.ts
@@ -3,9 +3,9 @@ import { addToGlobalContext } from 'storybook/internal/telemetry';
 
 import { program } from 'commander';
 
-import { initiate } from '..';
 import { version } from '../../package.json';
 import type { CommandOptions } from '../generators/types';
+import { initiate } from '../initiate';
 
 addToGlobalContext('cliVersion', version);
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32379

## What I did

The wrong function was being used to init, causing only a subset of the procedure to run.

That caused the final step to not be called, thus `dev` wouldn't be executed.

I modified the bin code so it imports the correct function

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-15 12:29:56 UTC

This PR fixes a critical bug in the Storybook CLI initialization process where the development server was not automatically launching after project setup when using `pnpm create storybook@next`. The root cause was an incorrect import path in the `create-storybook` package's bin entry point.

The key change is in `code/lib/create-storybook/src/bin/run.ts`, where the import statement was corrected from importing `initiate` from the package's top-level index (which exported `doInitiate as initiate`) to importing `initiate` directly from the `initiate.ts` file. Based on the codebase context, `doInitiate` is an internal function that only performs the setup steps, while `initiate` is the complete public API wrapper that includes additional logic to launch the development server when appropriate.

The change also includes cleanup in `build-config.ts` by removing unused imports (`join` from `node:path`). This fix ensures feature parity between the beta version (`@next`) and stable version (`@latest`) where the dev server was correctly starting after initialization, resolving the user experience issue where developers had to manually run `storybook dev` after the init process completed.

## Confidence score: 4/5

- This PR addresses a specific, well-documented bug with a targeted fix that maintains existing behavior
- The change involves correcting an import path to use the intended function, which is a low-risk modification
- Careful attention should be paid to the import changes to ensure the correct function is being called across different entry points

<!-- /greptile_comment -->