### PR TITLE
Reduce flakiness of cli test by running command only once

### DIFF
--- a/code/lib/cli-storybook/test/default/cli.test.cjs
+++ b/code/lib/cli-storybook/test/default/cli.test.cjs
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 const { run, cleanLog } = require('../helpers.cjs');
 
@@ -15,9 +15,18 @@ describe('Default behavior', () => {
 });
 
 describe('Help command', () => {
-  it('should prints out "init" command', () => {
-    const { status, stdout, stderr } = run(['help']);
+  let status;
+  let stdout;
+  let stderr;
 
+  beforeAll(() => {
+    const result = run(['help']);
+    status = result.status;
+    stdout = result.stdout;
+    stderr = result.stderr;
+  });
+
+  it('should prints out "init" command', () => {
     expect(stderr.toString()).toBe('');
     expect(stdout.toString()).toContain('init');
     expect(stdout.toString()).toContain('Initialize Storybook into your project');
@@ -25,8 +34,6 @@ describe('Help command', () => {
   });
 
   it('should prints out "add" command', () => {
-    const { status, stdout, stderr } = run(['help']);
-
     expect(stderr.toString()).toBe('');
     expect(stdout.toString()).toContain('add');
     expect(stdout.toString()).toContain('Add an addon to your Storybook');
@@ -34,8 +41,6 @@ describe('Help command', () => {
   });
 
   it('should prints out "remove" command', () => {
-    const { status, stdout, stderr } = run(['help']);
-
     expect(stderr.toString()).toBe('');
     expect(stdout.toString()).toContain('remove');
     expect(stdout.toString()).toContain('Remove an addon from your Storybook');
@@ -43,8 +48,6 @@ describe('Help command', () => {
   });
 
   it('should prints out "upgrade" command', () => {
-    const { status, stdout, stderr } = run(['help']);
-
     expect(stderr.toString()).toBe('');
     expect(stdout.toString()).toContain('upgrade');
     expect(stdout.toString()).toContain('Upgrade your Storybook packages to');
@@ -52,8 +55,6 @@ describe('Help command', () => {
   });
 
   it('should prints out "migrate" command', () => {
-    const { status, stdout, stderr } = run(['help']);
-
     expect(stderr.toString()).toBe('');
     expect(stdout.toString()).toContain('migrate');
     expect(stdout.toString()).toContain('Run a Storybook codemod migration on your source files');
@@ -61,8 +62,6 @@ describe('Help command', () => {
   });
 
   it('should prints out "sandbox" command', () => {
-    const { status, stdout, stderr } = run(['help']);
-
     expect(stderr.toString()).toBe('');
     expect(stdout.toString()).toContain('sandbox');
     expect(stdout.toString()).toContain('Create a sandbox from a set of possible templates');
@@ -70,8 +69,6 @@ describe('Help command', () => {
   });
 
   it('should prints out "link" command', () => {
-    const { status, stdout, stderr } = run(['help']);
-
     expect(stderr.toString()).toBe('');
     expect(stdout.toString()).toContain('link');
     expect(stdout.toString()).toContain(
@@ -81,8 +78,6 @@ describe('Help command', () => {
   });
 
   it('should prints out "automigrate" command', () => {
-    const { status, stdout, stderr } = run(['help']);
-
     expect(stderr.toString()).toBe('');
     expect(stdout.toString()).toContain('automigrate');
     expect(stdout.toString()).toContain(
@@ -92,8 +87,6 @@ describe('Help command', () => {
   });
 
   it('should prints out "doctor" command', () => {
-    const { status, stdout, stderr } = run(['help']);
-
     expect(stderr.toString()).toBe('');
     expect(stdout.toString()).toContain('doctor');
     expect(stdout.toString()).toContain(


### PR DESCRIPTION
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The `cli.test.cjs` file contains a test that tests for the description of commands after running the help command.

It does this by running the same help command in each test and checking the output.

When parallelised, this snarls up vitest so much that the tests timeout.

This change runs the help command only once, and then maintains the same assertions.

On my machine this takes the test time down from ~25s to ~5s.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Automation tests sufficient.

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-15 18:17:05 UTC

This PR optimizes a test suite in `code/lib/cli-storybook/test/default/cli.test.cjs` by eliminating redundant command executions. The original implementation ran the CLI help command 9 times (once per test case) to verify the output contained specific command descriptions like "migrate" and "link". This repetitive approach caused significant performance issues and test flakiness when running in parallel with Vitest.

The refactor introduces a `beforeAll()` hook that executes the `run(['help'])` command once and stores the results (`status`, `stdout`, `stderr`) in shared variables. All 9 individual test cases now reference these shared variables instead of executing the command locally. This maintains identical test assertions while dramatically improving performance (25s → 5s) and reducing parallelization conflicts.

This change fits well within Storybook's testing infrastructure as it follows standard Jest/Vitest patterns for optimizing expensive setup operations. The CLI testing utilities remain unchanged, and the test coverage is preserved exactly as before. This type of optimization is particularly valuable for CLI tests that involve process spawning and I/O operations, which are inherently more expensive than simple unit tests.

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only optimizes test execution without changing functionality
- Score reflects the straightforward nature of the refactor and preservation of all existing test logic
- No files require special attention as the change is isolated to a single test file with clear performance benefits

<!-- /greptile_comment -->