### PR TITLE
Build:  Fix critical bug in the pre-build hook

### DIFF
--- a/code/core/build-config.ts
+++ b/code/core/build-config.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { x as exec } from 'tinyexec';

--- a/code/core/scripts/generate-source-files.ts
+++ b/code/core/scripts/generate-source-files.ts
@@ -16,7 +16,8 @@ import { BROWSER_TARGETS, SUPPORTED_FEATURES } from '../src/shared/constants/env
 
 GlobalRegistrator.register({ url: 'http://localhost:3000', width: 1920, height: 1080 });
 
-const CORE_ROOT_DIR = join(import.meta.dirname, '..', '..', '..', '..', 'code', 'core');
+const CODE_DIR = join(import.meta.dirname, '..', '..', '..', 'code');
+const CORE_ROOT_DIR = join(CODE_DIR, 'core');
 const tempDir = () => realpath(os.tmpdir());
 const getPath = async (prefix = '') =>
   join(await tempDir(), prefix + (Math.random() + 1).toString(36).substring(7));
@@ -89,15 +90,7 @@ async function generateVersionsFile(prettierConfig: prettier.Options | null): Pr
 async function generateFrameworksFile(prettierConfig: prettier.Options | null): Promise<void> {
   const thirdPartyFrameworks = ['qwik', 'solid', 'nuxt', 'react-rsbuild', 'vue3-rsbuild'];
   const destination = join(CORE_ROOT_DIR, 'src', 'types', 'modules', 'frameworks.ts');
-  const frameworksDirectory = join(
-    import.meta.dirname,
-    '..',
-    '..',
-    '..',
-    '..',
-    'code',
-    'frameworks'
-  );
+  const frameworksDirectory = join(CODE_DIR, 'frameworks');
 
   const readFrameworks = (await readdir(frameworksDirectory)).filter((framework) =>
     existsSync(join(frameworksDirectory, framework, 'package.json'))
@@ -184,3 +177,5 @@ async function generateExportsFile(prettierConfig: prettier.Options | null): Pro
     )
   );
 }
+
+generateSourceFiles();


### PR DESCRIPTION
## What I did

Fix critical bug in pre-build script

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-16 09:03:53 UTC

This PR addresses a critical bug in Storybook's pre-build hook system by making key fixes and dependency updates. The core issue was that the `generate-source-files.ts` script wasn't self-executing when called by the pre-build hook in `build-config.ts`. The main changes include:

1. **Fixed the pre-build script execution**: Added a direct function call `generateSourceFiles()` at the end of `generate-source-files.ts` to make it self-executing when run via jiti. Without this, the pre-build hook would load the script but not actually generate the critical source files needed for the build.

2. **Code cleanup and organization**: Removed unused `fs` import from `build-config.ts` and refactored path construction in the generator script to use a shared `CODE_DIR` constant for better maintainability.

3. **Major dependency updates**: Updated `commander` (v12 → v14), `boxen` (v7 → v8), and `giget` (v1 → v2) across multiple packages (`@storybook/core`, `@storybook/cli`, and `@storybook/create-storybook`). These updates likely resolve compatibility issues that were contributing to the pre-build failures.

The pre-build hook is critical to Storybook's build process as it generates framework types, version mappings, and export configurations that other parts of the system depend on. The script uses esbuild to compile TypeScript files, generates framework metadata, and formats output with prettier. Without proper execution, this would cause silent failures leading to stale or missing generated files that could break the entire build pipeline.

## Confidence score: 4/5

- This PR addresses a critical build system issue with a focused fix that directly resolves the root cause
- Score reflects the straightforward nature of the core fix (adding function execution) combined with uncertainty about major dependency updates
- Pay close attention to the dependency updates in `package.json` files as they involve major version bumps that could introduce breaking changes

<!-- /greptile_comment -->