### PR TITLE
Build: Update addon-designs to sb10 canary

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -110,7 +110,7 @@
     "@nx/workspace": "20.8.2",
     "@playwright/test": "1.52.0",
     "@storybook/addon-a11y": "workspace:*",
-    "@storybook/addon-designs": "10.0.3--canary.20142ee.0",
+    "@storybook/addon-designs": "10.0.3--canary.67522d1.0",
     "@storybook/addon-docs": "workspace:*",
     "@storybook/addon-jest": "workspace:*",
     "@storybook/addon-links": "workspace:*",

--- a/code/package.json
+++ b/code/package.json
@@ -110,7 +110,7 @@
     "@nx/workspace": "20.8.2",
     "@playwright/test": "1.52.0",
     "@storybook/addon-a11y": "workspace:*",
-    "@storybook/addon-designs": "9.0.0-next.1",
+    "@storybook/addon-designs": "10.0.3--canary.20142ee.0",
     "@storybook/addon-docs": "workspace:*",
     "@storybook/addon-jest": "workspace:*",
     "@storybook/addon-links": "workspace:*",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6099,23 +6099,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-designs@npm:9.0.0-next.1":
-  version: 9.0.0-next.1
-  resolution: "@storybook/addon-designs@npm:9.0.0-next.1"
+"@storybook/addon-designs@npm:10.0.3--canary.20142ee.0":
+  version: 10.0.3--canary.20142ee.0
+  resolution: "@storybook/addon-designs@npm:10.0.3--canary.20142ee.0"
   dependencies:
     "@figspec/react": "npm:^1.0.0"
   peerDependencies:
+    "@storybook/addon-docs": ^10.0.0 || ^10.0.0-0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    storybook: ^0.0.0-0 || ^9.0.0 || ^9.0.0-0
+    storybook: ^10.0.0 || ^10.0.0-0
   peerDependenciesMeta:
-    "@storybook/blocks":
+    "@storybook/addon-docs":
       optional: true
     react:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/6989444d6caeb7abbb1a763e0a29d0749c529216d03d690618575378845e4259ddcf1935f7990fb05667a373940086dbacdcc6c97ff3f11eaa76f132bb11a1d5
+  checksum: 10c0/0ff49a2863fdce70a6633874c0f1313db2b364b2159859585663a134a905e28315c6b3cc5d04ceab4622c0aa311f0aa285981ea78ad64cc39e3910f52c9f2978
   languageName: node
   linkType: hard
 
@@ -6868,7 +6869,7 @@ __metadata:
     "@nx/workspace": "npm:20.8.2"
     "@playwright/test": "npm:1.52.0"
     "@storybook/addon-a11y": "workspace:*"
-    "@storybook/addon-designs": "npm:9.0.0-next.1"
+    "@storybook/addon-designs": "npm:10.0.3--canary.20142ee.0"
     "@storybook/addon-docs": "workspace:*"
     "@storybook/addon-jest": "workspace:*"
     "@storybook/addon-links": "workspace:*"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6099,9 +6099,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/addon-designs@npm:10.0.3--canary.20142ee.0":
-  version: 10.0.3--canary.20142ee.0
-  resolution: "@storybook/addon-designs@npm:10.0.3--canary.20142ee.0"
+"@storybook/addon-designs@npm:10.0.3--canary.67522d1.0":
+  version: 10.0.3--canary.67522d1.0
+  resolution: "@storybook/addon-designs@npm:10.0.3--canary.67522d1.0"
   dependencies:
     "@figspec/react": "npm:^1.0.0"
   peerDependencies:
@@ -6116,7 +6116,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/0ff49a2863fdce70a6633874c0f1313db2b364b2159859585663a134a905e28315c6b3cc5d04ceab4622c0aa311f0aa285981ea78ad64cc39e3910f52c9f2978
+  checksum: 10c0/050fa029304f998904944300c19a9fa85393e7177b0a84a2125fbccce55c21c4edd2be58a94ca27d1164d67bee07a5b4b09ca1e933c794987b2426857875e542
   languageName: node
   linkType: hard
 
@@ -6869,7 +6869,7 @@ __metadata:
     "@nx/workspace": "npm:20.8.2"
     "@playwright/test": "npm:1.52.0"
     "@storybook/addon-a11y": "workspace:*"
-    "@storybook/addon-designs": "npm:10.0.3--canary.20142ee.0"
+    "@storybook/addon-designs": "npm:10.0.3--canary.67522d1.0"
     "@storybook/addon-docs": "workspace:*"
     "@storybook/addon-jest": "workspace:*"
     "@storybook/addon-links": "workspace:*"


### PR DESCRIPTION
## What I did

I created a canary for testing addon-designs with sb10.
This canary is ESM-only, and tested here.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a design tooling dependency used in Storybook to a newer version to keep our internal tooling current.
  * This change does not affect app functionality, performance, or the user interface.
  * No user-facing features were added or modified, and there are no changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->