### PR TITLE
UI: Repair aria-readonly, labels and fieldsets in controls

### DIFF
--- a/code/addons/docs/src/blocks/controls/Color.tsx
+++ b/code/addons/docs/src/blocks/controls/Color.tsx
@@ -13,22 +13,17 @@ import { styled } from 'storybook/theming';
 import { getControlId } from './helpers';
 import type { ColorConfig, ColorValue, ControlProps, PresetColor } from './types';
 
-const Wrapper = styled.div({
+const Wrapper = styled.div<{ readOnly: boolean }>(({ readOnly }) => ({
   position: 'relative',
   maxWidth: 250,
-  '&[aria-readonly="true"]': {
-    opacity: 0.5,
-  },
-});
+  opacity: readOnly ? 0.5 : 1,
+}));
 
 const PickerTooltip = styled(WithTooltip)({
   position: 'absolute',
   zIndex: 1,
   top: 4,
   left: 4,
-  '[aria-readonly=true] &': {
-    cursor: 'not-allowed',
-  },
 });
 
 const TooltipContent = styled.div({
@@ -82,6 +77,7 @@ const Input = styled(Form.Input)(({ theme, readOnly }) => ({
   paddingRight: 30,
   boxSizing: 'border-box',
   fontFamily: theme.typography.fonts.base,
+  cursor: readOnly ? 'not-allowed' : 'text',
 }));
 
 const ToggleIcon = styled(MarkupIcon)(({ theme }) => ({
@@ -378,13 +374,17 @@ export const ColorControl: FC<ColorControlProps> = ({
   const { presets, addPreset } = usePresets(presetColors ?? [], color, colorSpace);
   const Picker = ColorPicker[colorSpace];
 
-  const readonly = !!argType?.table?.readonly;
+  const readOnly = !!argType?.table?.readonly;
+  const controlId = getControlId(name);
 
   return (
-    <Wrapper aria-readonly={readonly}>
+    <Wrapper readOnly={readOnly}>
+      <label htmlFor={controlId} className="sb-sr-only">
+        {name}
+      </label>
       <PickerTooltip
         startOpen={startOpen}
-        trigger={readonly ? null : undefined}
+        trigger={readOnly ? null : undefined}
         closeOnOutsideClick
         onVisibleChange={() => color && addPreset(color)}
         tooltip={
@@ -423,11 +423,11 @@ export const ColorControl: FC<ColorControlProps> = ({
         <Swatch value={realValue} style={{ margin: 4 }} />
       </PickerTooltip>
       <Input
-        id={getControlId(name)}
+        id={controlId}
         value={value}
         onChange={(e: ChangeEvent<HTMLInputElement>) => updateValue(e.target.value)}
         onFocus={(e: FocusEvent<HTMLInputElement>) => e.target.select()}
-        readOnly={readonly}
+        readOnly={readOnly}
         placeholder="Choose color..."
       />
       {value ? <ToggleIcon onClick={cycleColorSpace} /> : null}

--- a/code/addons/docs/src/blocks/controls/Date.tsx
+++ b/code/addons/docs/src/blocks/controls/Date.tsx
@@ -42,9 +42,12 @@ const FormInput = styled(Form.Input)(({ readOnly }) => ({
   opacity: readOnly ? 0.5 : 1,
 }));
 
-const FlexSpaced = styled.div(({ theme }) => ({
+const FlexSpaced = styled.fieldset(({ theme }) => ({
   flex: 1,
   display: 'flex',
+  border: 0,
+  marginInline: 0,
+  padding: 0,
 
   input: {
     marginLeft: 10,
@@ -119,6 +122,10 @@ export const DateControl: FC<DateProps> = ({ name, value, onChange, onFocus, onB
 
   return (
     <FlexSpaced>
+      <legend className="sb-sr-only">{name}</legend>
+      <label htmlFor={`${controlId}-date`} className="sb-sr-only">
+        Date
+      </label>
       <FormInput
         type="date"
         max="9999-12-31" // I do this because of a rendering bug in chrome
@@ -129,6 +136,9 @@ export const DateControl: FC<DateProps> = ({ name, value, onChange, onFocus, onB
         onChange={onDateChange}
         {...{ onFocus, onBlur }}
       />
+      <label htmlFor={`${controlId}-time`} className="sb-sr-only">
+        Time
+      </label>
       <FormInput
         type="time"
         id={`${controlId}-time`}

--- a/code/addons/docs/src/blocks/controls/Files.tsx
+++ b/code/addons/docs/src/blocks/controls/Files.tsx
@@ -63,17 +63,24 @@ export const FilesControl: FC<FilesControlProps> = ({
     }
   }, [value, name]);
 
+  const controlId = getControlId(name);
+
   return (
-    <FileInput
-      ref={inputElement}
-      id={getControlId(name)}
-      type="file"
-      name={name}
-      multiple
-      disabled={readonly}
-      onChange={handleFileChange}
-      accept={accept}
-      size="flex"
-    />
+    <>
+      <label htmlFor={controlId} className="sb-sr-only">
+        {name}
+      </label>
+      <FileInput
+        ref={inputElement}
+        id={controlId}
+        type="file"
+        name={name}
+        multiple
+        disabled={readonly}
+        onChange={handleFileChange}
+        accept={accept}
+        size="flex"
+      />
+    </>
   );
 };

--- a/code/addons/docs/src/blocks/controls/Object.tsx
+++ b/code/addons/docs/src/blocks/controls/Object.tsx
@@ -16,14 +16,11 @@ const { window: globalWindow } = globalThis;
 
 type JsonTreeProps = ComponentProps<typeof JsonTree>;
 
-const Wrapper = styled.div(({ theme }) => ({
+const Wrapper = styled.div<{ readOnly: boolean }>(({ theme, readOnly }) => ({
   position: 'relative',
   display: 'flex',
   isolation: 'isolate',
-
-  '&[aria-readonly="true"]': {
-    opacity: 0.5,
-  },
+  opacity: readOnly ? 0.5 : 1,
 
   '.rejt-tree': {
     marginLeft: '1rem',
@@ -242,9 +239,10 @@ export const ObjectControl: FC<ObjectProps> = ({ name, value, onChange, argType 
     Array.isArray(value) || (typeof value === 'object' && value?.constructor === Object);
 
   return (
-    <Wrapper aria-readonly={readonly}>
+    <Wrapper readOnly={readonly}>
       {isObjectOrArray && (
         <RawButton
+          disabled={readonly}
           pressed={showRaw}
           ariaLabel={`Edit the ${name} properties in JSON format`}
           onClick={(e: SyntheticEvent) => {

--- a/code/addons/docs/src/blocks/controls/Range.tsx
+++ b/code/addons/docs/src/blocks/controls/Range.tsx
@@ -160,9 +160,6 @@ const RangeLabel = styled.span({
   whiteSpace: 'nowrap',
   fontFeatureSettings: 'tnum',
   fontVariantNumeric: 'tabular-nums',
-  '[aria-readonly=true] &': {
-    opacity: 0.5,
-  },
 });
 
 const RangeCurrentAndMaxLabel = styled(RangeLabel)<{
@@ -176,11 +173,12 @@ const RangeCurrentAndMaxLabel = styled(RangeLabel)<{
   flexShrink: 0,
 }));
 
-const RangeWrapper = styled.div({
+const RangeWrapper = styled.div<{ readOnly: boolean }>(({ readOnly }) => ({
   display: 'flex',
   alignItems: 'center',
   width: '100%',
-});
+  opacity: readOnly ? 0.5 : 1,
+}));
 
 function getNumberOfDecimalPlaces(number: number) {
   const match = number.toString().match(/(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/);
@@ -214,12 +212,16 @@ export const RangeControl: FC<RangeProps> = ({
   const numberOFDecimalsPlaces = useMemo(() => getNumberOfDecimalPlaces(step), [step]);
 
   const readonly = !!argType?.table?.readonly;
+  const controlId = getControlId(name);
 
   return (
-    <RangeWrapper aria-readonly={readonly}>
+    <RangeWrapper readOnly={readonly}>
+      <label htmlFor={controlId} className="sb-sr-only">
+        {name}
+      </label>
       <RangeLabel>{min}</RangeLabel>
       <RangeInput
-        id={getControlId(name)}
+        id={controlId}
         type="range"
         disabled={readonly}
         onChange={handleChange}

--- a/code/addons/docs/src/blocks/controls/options/Checkbox.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Checkbox.tsx
@@ -9,33 +9,30 @@ import { getControlId } from '../helpers';
 import type { ControlProps, NormalizedOptionsConfig, OptionsMultiSelection } from '../types';
 import { selectedKeys, selectedValues } from './helpers';
 
-const Wrapper = styled.div<{ isInline: boolean }>(
+const Wrapper = styled.fieldset<{ isInline: boolean }>(
+  {
+    border: 'none',
+    marginInline: 0,
+    padding: 0,
+    display: 'flex',
+    alignItems: 'flex-start',
+  },
   ({ isInline }) =>
     isInline
       ? {
-          display: 'flex',
           flexWrap: 'wrap',
-          alignItems: 'flex-start',
-
+          gap: 15,
           label: {
             display: 'inline-flex',
-            marginRight: 15,
           },
         }
       : {
+          flexDirection: 'column',
+          gap: 8,
           label: {
             display: 'flex',
           },
-        },
-  (props) => {
-    if (props['aria-readonly'] === 'true') {
-      return {
-        input: {
-          cursor: 'not-allowed',
-        },
-      };
-    }
-  }
+        }
 );
 
 const Text = styled.span({
@@ -47,13 +44,14 @@ const Text = styled.span({
 const Label = styled.label({
   lineHeight: '20px',
   alignItems: 'center',
-  marginBottom: 8,
-
-  '&:last-child': {
-    marginBottom: 0,
+  '[aria-readonly=true] &': {
+    cursor: 'not-allowed',
   },
 
   input: {
+    '[aria-readonly=true] &': {
+      cursor: 'not-allowed',
+    },
     margin: 0,
     marginRight: 6,
   },
@@ -98,7 +96,8 @@ export const CheckboxControl: FC<CheckboxProps> = ({
   const controlId = getControlId(name);
 
   return (
-    <Wrapper aria-readonly={readonly} isInline={isInline}>
+    <Wrapper aria-readonly={readonly || undefined} isInline={isInline}>
+      <legend className="sb-sr-only">{name}</legend>
       {Object.keys(options).map((key, index) => {
         const id = `${controlId}-${index}`;
         return (

--- a/code/addons/docs/src/blocks/controls/options/Radio.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Radio.tsx
@@ -9,33 +9,30 @@ import { getControlId } from '../helpers';
 import type { ControlProps, NormalizedOptionsConfig, OptionsSingleSelection } from '../types';
 import { selectedKey } from './helpers';
 
-const Wrapper = styled.div<{ isInline: boolean }>(
+const Wrapper = styled.fieldset<{ isInline: boolean }>(
+  {
+    border: 'none',
+    marginInline: 0,
+    padding: 0,
+    display: 'flex',
+    alignItems: 'flex-start',
+  },
   ({ isInline }) =>
     isInline
       ? {
-          display: 'flex',
           flexWrap: 'wrap',
-          alignItems: 'flex-start',
-
+          gap: 15,
           label: {
             display: 'inline-flex',
-            marginRight: 15,
           },
         }
       : {
+          flexDirection: 'column',
+          gap: 8,
           label: {
             display: 'flex',
           },
-        },
-  (props) => {
-    if (props['aria-readonly'] === 'true') {
-      return {
-        input: {
-          cursor: 'not-allowed',
-        },
-      };
-    }
-  }
+        }
 );
 
 const Text = styled.span({
@@ -47,13 +44,15 @@ const Text = styled.span({
 const Label = styled.label({
   lineHeight: '20px',
   alignItems: 'center',
-  marginBottom: 8,
 
-  '&:last-child': {
-    marginBottom: 0,
+  '[aria-readonly=true] &': {
+    cursor: 'not-allowed',
   },
 
   input: {
+    '[aria-readonly=true] &': {
+      cursor: 'not-allowed',
+    },
     margin: 0,
     marginRight: 6,
   },
@@ -79,7 +78,8 @@ export const RadioControl: FC<RadioProps> = ({
   const readonly = !!argType?.table?.readonly;
 
   return (
-    <Wrapper aria-readonly={readonly} isInline={isInline}>
+    <Wrapper aria-readonly={readonly || undefined} isInline={isInline}>
+      <legend className="sb-sr-only">{name}</legend>
       {Object.keys(options).map((key, index) => {
         const id = `${controlId}-${index}`;
         return (

--- a/code/addons/docs/src/blocks/controls/options/Select.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Select.tsx
@@ -107,6 +107,9 @@ const SingleSelect: FC<SelectProps> = ({ name, value, options, onChange, argType
   return (
     <SelectWrapper>
       <ChevronSmallDownIcon />
+      <label htmlFor={controlId} className="sb-sr-only">
+        {name}
+      </label>
       <OptionsSelect disabled={readonly} id={controlId} value={selection} onChange={handleChange}>
         <option key="no-selection" disabled>
           {NO_SELECTION}


### PR DESCRIPTION
Closes #32250


## What I did

* Added label elements where missing
* Grouped radio and checkbox in fieldset instead of div
* Removed aria-readonly attribute where not allowed, defined a `readOnly` prop for emotion wrappers instead

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing


1. Run local `yarn storybook:ui` (and another old instance to compare if you like)
2. Go to controls stories, open a11y tab
3. Notice absence of a11y violations


### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
