### PR TITLE
Release: Ensure newline at the end of `package.json`

### DIFF
--- a/scripts/release/version.ts
+++ b/scripts/release/version.ts
@@ -127,7 +127,7 @@ const bumpCodeVersion = async (nextVersion: string) => {
   const codePkgJson = await readJson(CODE_PACKAGE_JSON_PATH);
 
   codePkgJson.version = nextVersion;
-  await writeFile(CODE_PACKAGE_JSON_PATH, JSON.stringify(codePkgJson, null, 2));
+  await writeFile(CODE_PACKAGE_JSON_PATH, JSON.stringify(codePkgJson, null, 2) + '\n');
 
   console.log(`✅ Bumped version of ${picocolors.cyan('code')}'s package.json`);
 };
@@ -202,7 +202,7 @@ const bumpDeferred = async (nextVersion: string) => {
   }
 
   codePkgJson.deferredNextVersion = nextVersion;
-  await writeFile(CODE_PACKAGE_JSON_PATH, JSON.stringify(codePkgJson, null, 2));
+  await writeFile(CODE_PACKAGE_JSON_PATH, JSON.stringify(codePkgJson, null, 2) + '\n');
 
   console.log(`✅ Set a ${picocolors.cyan('deferred')} version bump. Not bumping any packages.`);
 };
@@ -224,7 +224,7 @@ const applyDeferredVersionBump = async () => {
   }
 
   delete codePkgJson.deferredNextVersion;
-  await writeFile(CODE_PACKAGE_JSON_PATH, JSON.stringify(codePkgJson, null, 2));
+  await writeFile(CODE_PACKAGE_JSON_PATH, JSON.stringify(codePkgJson, null, 2) + '\n');
 
   console.log(
     `✅ Extracted and removed deferred version ${picocolors.green(


### PR DESCRIPTION
## What I did

When we dropped `fs-extra` and used native `writeFile`, it stopped having a newline at the end of `package.json` This causes issues during the release PRs

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized package metadata file formatting by ensuring a trailing newline is added when version bump scripts update package.json, improving cross-tool compatibility and reducing noisy diffs.
* **Style**
  * Enforced POSIX-style newline at end of package.json files generated by release scripts for consistent formatting across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->