### PR TITLE
UI: Add proper focus outline to Button

### DIFF
--- a/code/core/src/components/components/Button/Button.stories.tsx
+++ b/code/core/src/components/components/Button/Button.stories.tsx
@@ -100,6 +100,17 @@ export const PseudoStates = meta.story({
           Hover
         </Button>
       </Row>
+      <Row id="active">
+        <Button ariaLabel={false} variant="solid">
+          active
+        </Button>
+        <Button ariaLabel={false} variant="outline">
+          active
+        </Button>
+        <Button ariaLabel={false} variant="ghost">
+          active
+        </Button>
+      </Row>
       <Row id="focus">
         <Button ariaLabel={false} variant="solid">
           Focus
@@ -127,6 +138,7 @@ export const PseudoStates = meta.story({
   parameters: {
     pseudo: {
       hover: '#hover button',
+      active: '#active button',
       focus: '#focus button',
       focusVisible: '#focus-visible button',
     },

--- a/code/core/src/components/components/Button/Button.tsx
+++ b/code/core/src/components/components/Button/Button.tsx
@@ -278,9 +278,9 @@ const StyledButton = styled('button', {
     })(),
   },
 
-  '&:focus': {
-    boxShadow: `${rgba(theme.color.secondary, 1)} 0 0 0 1px inset`,
-    outline: 'none',
+  '&:focus-visible': {
+    outline: `2px solid ${rgba(theme.color.secondary, 1)}`,
+    outlineOffset: 2,
   },
 
   '> svg': {


### PR DESCRIPTION
## What I did

Added a thicker, WCAG compliant focus outline to Button which we seem to have missed :)

LMK what you think!

### Before
<img width="747" height="199" alt="image" src="https://github.com/user-attachments/assets/c14f5119-3a0e-4dab-bdc6-77cc84804f0e" />

### After
<img width="747" height="253" alt="image" src="https://github.com/user-attachments/assets/442b4cab-1a83-45af-9384-36ad29dc2e16" />


## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories

#### Manual testing


http://localhost:6006/?path=/story/button-component--pseudo-states&globals=sb_theme:side-by-side

### Documentation
N/A

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
