### PR TITLE
PreactVite: Add `node` entry point

### DIFF
--- a/code/frameworks/preact-vite/package.json
+++ b/code/frameworks/preact-vite/package.json
@@ -79,6 +79,7 @@
   },
   "bundler": {
     "entries": [
+      "./src/node/index.ts",
       "./src/index.ts",
       "./src/preset.ts"
     ],


### PR DESCRIPTION
Closes: https://github.com/storybookjs/storybook/issues/32434

### What

I need to add this entrypoint in order to solve [this issue ](https://github.com/storybookjs/storybook/issues/32434).
However I cannot add that code to `next` because the bundler config has changed there.

@JReinhold do you have advice for how to best bring this to `main` and do a release (patch)

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
