### PR TITLE
Next.js: Remove next/config usage in Next.js >=v16 projects

### DIFF
--- a/code/frameworks/nextjs-vite/build-config.ts
+++ b/code/frameworks/nextjs-vite/build-config.ts
@@ -12,6 +12,11 @@ const config: BuildEntries = {
         entryPoint: './src/preview.tsx',
       },
       {
+        exportEntries: ['./config/preview'],
+        entryPoint: './src/config/preview.ts',
+        dts: false,
+      },
+      {
         exportEntries: ['./cache.mock'],
         entryPoint: './src/export-mocks/cache/index.ts',
       },

--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -35,6 +35,7 @@
       "types": "./dist/export-mocks/cache/index.d.ts",
       "default": "./dist/export-mocks/cache/index.js"
     },
+    "./config/preview": "./dist/config/preview.js",
     "./headers.mock": {
       "types": "./dist/export-mocks/headers/index.d.ts",
       "default": "./dist/export-mocks/headers/index.js"

--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -89,6 +89,7 @@
     "@types/node": "^22.0.0",
     "next": "^15.2.3",
     "postcss-load-config": "^6.0.1",
+    "semver": "^7.3.5",
     "typescript": "^5.8.3"
   },
   "peerDependencies": {

--- a/code/frameworks/nextjs-vite/src/preset.ts
+++ b/code/frameworks/nextjs-vite/src/preset.ts
@@ -11,8 +11,10 @@ import type { StorybookConfigVite } from '@storybook/builder-vite';
 import { viteFinal as reactViteFinal } from '@storybook/react-vite/preset';
 
 import postCssLoadConfig from 'postcss-load-config';
+import semver from 'semver';
 
 import type { FrameworkOptions } from './types';
+import { getNextjsVersion } from './utils';
 
 const require = createRequire(import.meta.url);
 
@@ -35,8 +37,20 @@ export const core: PresetProperty<'core'> = async (config, options) => {
 };
 
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entry = []) => {
-  const result = [...entry, fileURLToPath(import.meta.resolve('@storybook/nextjs-vite/preview'))];
-  return result;
+  const annotations = [
+    ...entry,
+    fileURLToPath(import.meta.resolve('@storybook/nextjs-vite/preview')),
+  ];
+
+  const nextjsVersion = getNextjsVersion();
+  const isNext16orNewer = semver.gte(nextjsVersion, '16.0.0');
+
+  // TODO: Remove this once we only support Next.js v16 and above
+  if (!isNext16orNewer) {
+    annotations.push(fileURLToPath(import.meta.resolve('@storybook/nextjs-vite/config/preview')));
+  }
+
+  return annotations;
 };
 
 export const optimizeViteDeps = [

--- a/code/frameworks/nextjs-vite/src/preview.tsx
+++ b/code/frameworks/nextjs-vite/src/preview.tsx
@@ -2,7 +2,7 @@ import type * as React from 'react';
 
 import type { Addon_DecoratorFunction, LoaderFunction } from 'storybook/internal/types';
 
-import type { ReactRenderer, StoryFn } from '@storybook/react';
+import type { ReactRenderer } from '@storybook/react';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore we must ignore types here as during compilation they are not generated yet
@@ -13,7 +13,6 @@ import { createRouter } from '@storybook/nextjs-vite/router.mock';
 
 import { isNextRouterError } from 'next/dist/client/components/is-next-router-error';
 
-import './config/preview';
 import { HeadManagerDecorator } from './head-manager/decorator';
 import { ImageDecorator } from './images/decorator';
 import { RouterDecorator } from './routing/decorator';

--- a/code/frameworks/nextjs-vite/src/utils.ts
+++ b/code/frameworks/nextjs-vite/src/utils.ts
@@ -1,0 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { resolvePackageDir } from '../../../core/src/shared/utils/module';
+
+export const getNextjsVersion = (): string =>
+  JSON.parse(readFileSync(join(resolvePackageDir('next'), 'package.json'), 'utf8')).version;

--- a/code/frameworks/nextjs/build-config.ts
+++ b/code/frameworks/nextjs/build-config.ts
@@ -12,6 +12,11 @@ const config: BuildEntries = {
         entryPoint: './src/preview.tsx',
       },
       {
+        exportEntries: ['./config/preview'],
+        entryPoint: './src/config/preview.ts',
+        dts: false,
+      },
+      {
         exportEntries: ['./cache.mock'],
         entryPoint: './src/export-mocks/cache/index.ts',
       },

--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -35,6 +35,7 @@
       "default": "./dist/export-mocks/cache/index.js"
     },
     "./compatibility/draft-mode.compat": "./dist/compatibility/draft-mode.compat.js",
+    "./config/preview": "./dist/config/preview.js",
     "./export-mocks": "./dist/export-mocks/index.js",
     "./headers.mock": {
       "types": "./dist/export-mocks/headers/index.d.ts",

--- a/code/frameworks/nextjs/src/config/webpack.ts
+++ b/code/frameworks/nextjs/src/config/webpack.ts
@@ -1,9 +1,13 @@
 import { fileURLToPath } from 'node:url';
 
 import type { NextConfig } from 'next';
+import semver from 'semver';
 import type { Configuration as WebpackConfig } from 'webpack';
 
-import { addScopedAlias, resolveNextConfig } from '../utils';
+import { addScopedAlias, getNextjsVersion, resolveNextConfig } from '../utils';
+
+const nextjsVersion = getNextjsVersion();
+const isNext16orNewer = semver.gte(nextjsVersion, '16.0.0');
 
 const tryResolve = (path: string) => {
   try {
@@ -22,7 +26,10 @@ export const configureConfig = async ({
 }): Promise<NextConfig> => {
   const nextConfig = await resolveNextConfig({ nextConfigPath });
 
-  addScopedAlias(baseConfig, 'next/config');
+  // TODO: Remove this once we only support Next.js 16 and above
+  if (!isNext16orNewer) {
+    addScopedAlias(baseConfig, 'next/config');
+  }
 
   // @ts-expect-error We know that alias is an object
   if (baseConfig.resolve?.alias?.['react-dom']) {
@@ -58,14 +65,17 @@ const setupRuntimeConfig = async (
   baseConfig: WebpackConfig,
   nextConfig: NextConfig
 ): Promise<void> => {
-  const definePluginConfig: Record<string, any> = {
+  const definePluginConfig: Record<string, any> = {};
+
+  // TODO: Remove this once we only support Next.js 16 and above
+  if (!isNext16orNewer) {
     // this mimics what nextjs does client side
     // https://github.com/vercel/next.js/blob/57702cb2a9a9dba4b552e0007c16449cf36cfb44/packages/next/client/index.tsx#L101
-    'process.env.__NEXT_RUNTIME_CONFIG': JSON.stringify({
+    definePluginConfig['process.env.__NEXT_RUNTIME_CONFIG'] = JSON.stringify({
       serverRuntimeConfig: {},
       publicRuntimeConfig: nextConfig.publicRuntimeConfig,
-    }),
-  };
+    });
+  }
 
   const newNextLinkBehavior = (nextConfig.experimental as any)?.newNextLinkBehavior;
 

--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -15,6 +15,7 @@ import nextBabelPreset from './babel/preset';
 import { configureConfig } from './config/webpack';
 import TransformFontImports from './font/babel';
 import type { FrameworkOptions, StorybookConfig } from './types';
+import { getNextjsVersion } from './utils';
 
 export const addons: PresetProperty<'addons'> = [
   fileURLToPath(import.meta.resolve('@storybook/preset-react-webpack')),

--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -49,17 +49,14 @@ export const core: PresetProperty<'core'> = async (config, options) => {
 };
 
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entry = []) => {
-  const annotations = [
-    ...entry,
-    fileURLToPath(import.meta.resolve('@storybook/nextjs-vite/preview')),
-  ];
+  const annotations = [...entry, fileURLToPath(import.meta.resolve('@storybook/nextjs/preview'))];
 
   const nextjsVersion = getNextjsVersion();
   const isNext16orNewer = semver.gte(nextjsVersion, '16.0.0');
 
   // TODO: Remove this once we only support Next.js v16 and above
   if (!isNext16orNewer) {
-    annotations.push(fileURLToPath(import.meta.resolve('@storybook/nextjs-vite/config/preview')));
+    annotations.push(fileURLToPath(import.meta.resolve('@storybook/nextjs/config/preview')));
   }
 
   return annotations;

--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -48,8 +48,20 @@ export const core: PresetProperty<'core'> = async (config, options) => {
 };
 
 export const previewAnnotations: PresetProperty<'previewAnnotations'> = (entry = []) => {
-  const result = [...entry, fileURLToPath(import.meta.resolve('@storybook/nextjs/preview'))];
-  return result;
+  const annotations = [
+    ...entry,
+    fileURLToPath(import.meta.resolve('@storybook/nextjs-vite/preview')),
+  ];
+
+  const nextjsVersion = getNextjsVersion();
+  const isNext16orNewer = semver.gte(nextjsVersion, '16.0.0');
+
+  // TODO: Remove this once we only support Next.js v16 and above
+  if (!isNext16orNewer) {
+    annotations.push(fileURLToPath(import.meta.resolve('@storybook/nextjs-vite/config/preview')));
+  }
+
+  return annotations;
 };
 
 export const babel: PresetProperty<'babel'> = async (baseConfig: TransformOptions) => {

--- a/code/frameworks/nextjs/src/preview.tsx
+++ b/code/frameworks/nextjs/src/preview.tsx
@@ -14,7 +14,6 @@ import { createRouter } from '@storybook/nextjs/router.mock';
 
 import { isNextRouterError } from 'next/dist/client/components/is-next-router-error';
 
-import './config/preview';
 import { HeadManagerDecorator } from './head-manager/decorator';
 import { ImageDecorator } from './images/decorator';
 import { RouterDecorator } from './routing/decorator';

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6566,6 +6566,7 @@ __metadata:
     "@types/node": "npm:^22.0.0"
     next: "npm:^15.2.3"
     postcss-load-config: "npm:^6.0.1"
+    semver: "npm:^7.3.5"
     styled-jsx: "npm:5.1.6"
     typescript: "npm:^5.8.3"
     vite-plugin-storybook-nextjs: "npm:^2.0.7"


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have removed the usage of `next/config` (runtime config) in Next.js versions 16 and above.
Related: https://github.com/vercel/next.js/pull/83944/files

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a preview config for direct import in both Next.js and Next.js-Vite packages.
  * Version-aware preview setup: includes legacy preview only when running on Next.js < 16.

* **Refactor**
  * Removed automatic side-effect loading of the preview config to streamline initialization.

* **Chores**
  * Updated package exports/build outputs and added a dev dependency for version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->