### PR TITLE
Telemetry: Log userAgent in onboarding

### DIFF
--- a/code/addons/onboarding/src/Onboarding.tsx
+++ b/code/addons/onboarding/src/Onboarding.tsx
@@ -82,6 +82,8 @@ export default function Onboarding({ api }: { api: API }) {
     sourceFileName: string;
   } | null>();
 
+  const userAgent = window?.navigator?.userAgent;
+
   const selectStory = useCallback(
     (storyId: string) => {
       try {
@@ -111,15 +113,17 @@ export default function Onboarding({ api }: { api: API }) {
       api.emit(STORYBOOK_ADDON_ONBOARDING_CHANNEL, {
         step: '7:FinishedOnboarding' satisfies StepKey,
         type: 'telemetry',
+        userAgent,
       });
       api.emit(STORYBOOK_ADDON_ONBOARDING_CHANNEL, {
         answers,
         type: 'survey',
+        userAgent,
       });
       selectStory('configure-your-project--docs');
       disableOnboarding();
     },
-    [api, selectStory, disableOnboarding]
+    [api, selectStory, disableOnboarding, userAgent]
   );
 
   useEffect(() => {
@@ -177,8 +181,8 @@ export default function Onboarding({ api }: { api: API }) {
   }, [api]);
 
   useEffect(
-    () => api.emit(STORYBOOK_ADDON_ONBOARDING_CHANNEL, { step, type: 'telemetry' }),
-    [api, step]
+    () => api.emit(STORYBOOK_ADDON_ONBOARDING_CHANNEL, { step, type: 'telemetry', userAgent }),
+    [api, step, userAgent]
   );
 
   if (!enabled) {

--- a/code/addons/onboarding/src/Onboarding.tsx
+++ b/code/addons/onboarding/src/Onboarding.tsx
@@ -82,7 +82,8 @@ export default function Onboarding({ api }: { api: API }) {
     sourceFileName: string;
   } | null>();
 
-  const userAgent = window?.navigator?.userAgent;
+  // eslint-disable-next-line compat/compat
+  const userAgent = globalThis?.navigator?.userAgent;
 
   const selectStory = useCallback(
     (storyId: string) => {


### PR DESCRIPTION
Closes N/A

## What I did

Log userAgent in browser-generated onboarding events.

We can theoretically get this information from the channel, but I did not want to rewrite everything to be able to pull it out.

## Checklist for Contributors

### Testing

#### Manual testing

- [x] Ran a sandbox with `STORYBOOK_TELEMETRY_DEBUG=1` and navigate to `?path=/onboarding`. Verify userAgent is sent properly.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced telemetry to include browser information in analytics and survey events.
  * Ensured these onboarding events consistently carry the additional data.
  * No changes to user-facing behavior, UI, or performance are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->