### PR TITLE
React Native: Fix document reference error in open-in-editor

### DIFF
--- a/code/core/src/manager-api/modules/open-in-editor.tsx
+++ b/code/core/src/manager-api/modules/open-in-editor.tsx
@@ -55,7 +55,7 @@ export const init: ModuleFn = ({ provider, fullAPI }) => {
     api,
     state,
     init: async () => {
-      const { color } = await import('storybook/theming');
+      const { color } = await import('../../theming');
       provider.channel?.on(OPEN_IN_EDITOR_RESPONSE, (payload: OpenInEditorResponsePayload) => {
         if (payload.error !== null) {
           fullAPI.addNotification({

--- a/code/core/src/manager-api/modules/open-in-editor.tsx
+++ b/code/core/src/manager-api/modules/open-in-editor.tsx
@@ -9,8 +9,6 @@ import type { API_Notification } from 'storybook/internal/types';
 
 import { FailedIcon } from '@storybook/icons';
 
-import { color } from 'storybook/theming';
-
 import type { ModuleFn } from '../lib/types';
 
 export interface SubState {
@@ -57,6 +55,7 @@ export const init: ModuleFn = ({ provider, fullAPI }) => {
     api,
     state,
     init: async () => {
+      const { color } = await import('storybook/theming');
       provider.channel?.on(OPEN_IN_EDITOR_RESPONSE, (payload: OpenInEditorResponsePayload) => {
         if (payload.error !== null) {
           fullAPI.addNotification({


### PR DESCRIPTION
Closes #
related to this:
https://github.com/storybookjs/react-native/pull/795

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fixes an issue where react native storybook was crashing due to references to the document triggered by emotion web being loaded in storybook/theming

since this code isn't actually executed by RN then just moving it to be lazy loaded is enough to fix the crash. 

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32572-sha-c9578275`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32572-sha-c9578275 sandbox` or in an existing project with `npx storybook@0.0.0-pr-32572-sha-c9578275 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32572-sha-c9578275`](https://npmjs.com/package/storybook/v/0.0.0-pr-32572-sha-c9578275) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`dannyhw/feat/rn-fix-openeditor-document-reference-error`](https://github.com/storybookjs/storybook/tree/dannyhw/feat/rn-fix-openeditor-document-reference-error) |
| **Commit** | [`c9578275`](https://github.com/storybookjs/storybook/commit/c95782758af9b381c20f2452103d6c73039e3762) |
| **Datetime** | Fri Sep 26 18:25:01 UTC 2025 (`1758911101`) |
| **Workflow run** | [18046073542](https://github.com/storybookjs/storybook/actions/runs/18046073542) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32572`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Theme colors are now loaded during initialization rather than upfront, improving startup responsiveness.
  * Notification and error styling remain unchanged and continue to display correctly.
  * More robust theming when styling assets become available later.
  * No changes to public interfaces or user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->