### PR TITLE
Core: Fix `external-globals-plugin` handle `undefined` cache dir

### DIFF
--- a/code/builders/builder-vite/src/plugins/external-globals-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/external-globals-plugin.ts
@@ -52,7 +52,10 @@ export async function externalGlobalsPlugin(externals: Record<string, string>): 
       }
       const newAlias = mergeAlias([], config.resolve?.alias) as Alias[];
 
-      const cachePath = pkg.cache('sb-vite-plugin-externals', { create: true })!;
+      const cachePath =
+        pkg.cache('sb-vite-plugin-externals', { create: true }) ??
+        join(process.cwd(), 'node_modules', '.cache', 'sb-vite-plugin-externals');
+
       await Promise.all(
         (Object.keys(externals) as Array<keyof typeof externals>).map(async (externalKey) => {
           const externalCachePath = join(cachePath, `${externalKey}.js`);


### PR DESCRIPTION
## What I did

Updated the `storybook:external-globals-plugin` Vite plugin to handle the case where `pkg.cache('sb-vite-plugin-externals', { create: true })` returns `undefined`. This can apparently happen when the directory `empathic/package` finds is not writeable: 

```ts
/**
* Construct a path to a `node_modules/.cache/<name>` directory.
*
* This may return `undefined` if:
*   1. no "package.json" could be found
*   2. the nearest "node_modules" directory is not writable
*   3. the "node_modules" parent directory is not writable
*
* ...
*/
```

This causes a hard failure like this: 

<img width="974" height="51" alt="image" src="https://github.com/user-attachments/assets/c9848735-b405-4d07-bc75-5ad30c151de0" />

The change proposed in this PR is based on how this is handled in `code/core/src/common/utils/resolve-path-in-sb-cache.ts` ([here](https://github.com/storybookjs/storybook/blob/93afdbafc89b3a8e6e3cdd1f4617640dba2c1d6b/code/core/src/common/utils/resolve-path-in-sb-cache.ts#L16)).

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I tested this manually in our repository by patching `@storybook/builder-vite`. Not sure it's worth the effort to write an automated test, but happy to try if necessary.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development stability by adding a safe fallback for caching external dependencies, preventing rare crashes when a cache location isn’t available.
  * Ensures smoother startup and runtime during local serve scenarios with more resilient cache handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->