### PR TITLE
Angular: Enable experimental zoneless detection on Angular v21

### DIFF
--- a/code/frameworks/angular/build-schema.json
+++ b/code/frameworks/angular/build-schema.json
@@ -67,18 +67,27 @@
     "compodocArgs": {
       "type": "array",
       "description": "Compodoc options : https://compodoc.app/guides/options.html. Options `-p` with tsconfig path and `-d` with workspace root is always given.",
-      "default": ["-e", "json"],
+      "default": [
+        "-e",
+        "json"
+      ],
       "items": {
         "type": "string"
       }
     },
     "webpackStatsJson": {
-      "type": ["boolean", "string"],
+      "type": [
+        "boolean",
+        "string"
+      ],
       "description": "Write Webpack Stats JSON to disk",
       "default": false
     },
     "statsJson": {
-      "type": ["boolean", "string"],
+      "type": [
+        "boolean",
+        "string"
+      ],
       "description": "Write stats JSON to disk",
       "default": false
     },
@@ -116,14 +125,16 @@
       }
     },
     "sourceMap": {
-      "type": ["boolean", "object"],
+      "type": [
+        "boolean",
+        "object"
+      ],
       "description": "Configure sourcemaps. See: https://angular.io/guide/workspace-config#source-map-configuration",
       "default": false
     },
     "experimentalZoneless": {
       "type": "boolean",
-      "description": "Experimental: Use zoneless change detection.",
-      "default": false
+      "description": "Experimental: Use zoneless change detection."
     }
   },
   "additionalProperties": false,
@@ -159,7 +170,11 @@
             }
           },
           "additionalProperties": false,
-          "required": ["glob", "input", "output"]
+          "required": [
+            "glob",
+            "input",
+            "output"
+          ]
         },
         {
           "type": "string"
@@ -187,7 +202,9 @@
             }
           },
           "additionalProperties": false,
-          "required": ["input"]
+          "required": [
+            "input"
+          ]
         },
         {
           "type": "string",

--- a/code/frameworks/angular/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.ts
@@ -32,6 +32,7 @@ import { catchError, map, mapTo, switchMap } from 'rxjs/operators';
 import { errorSummary, printErrorDetails } from '../utils/error-handler';
 import { runCompodoc } from '../utils/run-compodoc';
 import type { StandaloneOptions } from '../utils/standalone-options';
+import { VERSION } from '@angular/core';
 
 addToGlobalContext('cliVersion', versions.storybook);
 
@@ -113,7 +114,7 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (
         previewUrl,
         sourceMap = false,
         preserveSymlinks = false,
-        experimentalZoneless = false,
+        experimentalZoneless = !!(VERSION.major && Number(VERSION.major) >= 21),
       } = options;
 
       const packageJsonPath = pkg.up({ cwd: __dirname });

--- a/code/frameworks/angular/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.ts
@@ -31,6 +31,7 @@ import { map, mapTo, switchMap } from 'rxjs/operators';
 import { errorSummary, printErrorDetails } from '../utils/error-handler';
 import { runCompodoc } from '../utils/run-compodoc';
 import type { StandaloneOptions } from '../utils/standalone-options';
+import { VERSION } from '@angular/core';
 
 addToGlobalContext('cliVersion', versions.storybook);
 
@@ -130,7 +131,7 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (options, cont
         previewUrl,
         sourceMap = false,
         preserveSymlinks = false,
-        experimentalZoneless = false,
+        experimentalZoneless = !!(VERSION.major && Number(VERSION.major) >= 21),
       } = options;
 
       const packageJsonPath = pkg.up({ cwd: __dirname });

--- a/code/frameworks/angular/src/server/framework-preset-angular-cli.ts
+++ b/code/frameworks/angular/src/server/framework-preset-angular-cli.ts
@@ -150,6 +150,8 @@ export async function getBuilderOptions(options: PresetOptions, builderContext: 
     browserTargetOptions.tsConfig;
   logger.info(`=> Using angular project with "tsConfig:${builderOptions.tsConfig}"`);
 
+  builderOptions.experimentalZoneless = options.angularBuilderOptions?.experimentalZoneless;
+
   return builderOptions;
 }
 

--- a/code/frameworks/angular/start-schema.json
+++ b/code/frameworks/angular/start-schema.json
@@ -93,7 +93,10 @@
     "compodocArgs": {
       "type": "array",
       "description": "Compodoc options : https://compodoc.app/guides/options.html. Options `-p` with tsconfig path and `-d` with workspace root is always given.",
-      "default": ["-e", "json"],
+      "default": [
+        "-e",
+        "json"
+      ],
       "items": {
         "type": "string"
       }
@@ -132,12 +135,18 @@
       "description": "URL path to be appended when visiting Storybook for the first time"
     },
     "webpackStatsJson": {
-      "type": ["boolean", "string"],
+      "type": [
+        "boolean",
+        "string"
+      ],
       "description": "Write Webpack Stats JSON to disk",
       "default": false
     },
     "statsJson": {
-      "type": ["boolean", "string"],
+      "type": [
+        "boolean",
+        "string"
+      ],
       "description": "Write stats JSON to disk",
       "default": false
     },
@@ -151,14 +160,16 @@
       "pattern": "(silly|verbose|info|warn|silent)"
     },
     "sourceMap": {
-      "type": ["boolean", "object"],
+      "type": [
+        "boolean",
+        "object"
+      ],
       "description": "Configure sourcemaps. See: https://angular.io/guide/workspace-config#source-map-configuration",
       "default": false
     },
     "experimentalZoneless": {
       "type": "boolean",
-      "description": "Experimental: Use zoneless change detection.",
-      "default": false
+      "description": "Experimental: Use zoneless change detection."
     }
   },
   "additionalProperties": false,
@@ -194,7 +205,11 @@
             }
           },
           "additionalProperties": false,
-          "required": ["glob", "input", "output"]
+          "required": [
+            "glob",
+            "input",
+            "output"
+          ]
         },
         {
           "type": "string"
@@ -222,7 +237,9 @@
             }
           },
           "additionalProperties": false,
-          "required": ["input"]
+          "required": [
+            "input"
+          ]
         },
         {
           "type": "string",

--- a/docs/get-started/frameworks/angular.mdx
+++ b/docs/get-started/frameworks/angular.mdx
@@ -367,12 +367,13 @@ These are common options you may need for the Angular builder:
 | `"webpackStatsJson"`         | Write Webpack Stats JSON to disk. <br /> `"webpackStatsJson": true`                                                                                                                             |
 | `"previewUrl"`               | Disables the default storybook preview and lets you use your own. <br /> `"previewUrl": "iframe.html"`                                                                                          |
 | `"loglevel"`                 | Controls level of logging during build. Can be one of: [silly, verbose, info (default), warn, error, silent]. <br /> `"loglevel": "info"`                                                       |
-| `"sourceMap"`                | Configure [sourcemaps](https://angular.io/guide/workspace-config#source-map-configuration.). <br /> `"sourceMap": true`                                                                         |
+| `"sourceMap"`                | Configure [sourcemaps](https://angular.dev/reference/configs/workspace-config#source-map-configuration.). <br /> `"sourceMap": true`                                                                         |
+| `"experimentalZoneless"`     | Configure [zoneless change detection](https://angular.dev/guide/zoneless). <br /> `"experimentalZoneless": true`                                                                 |
 
 The full list of options can be found in the Angular builder schemas:
 
-* [Build Storybook](https://github.com/storybookjs/storybook/blob/main/code/frameworks/angular/src/builders/build-storybook/schema.json)
-* [Start Storybook](https://github.com/storybookjs/storybook/blob/main/code/frameworks/angular/src/builders/start-storybook/schema.json)
+* [Build Storybook](https://github.com/storybookjs/storybook/blob/main/code/frameworks/angular/build-schema.json)
+* [Start Storybook](https://github.com/storybookjs/storybook/blob/main/code/frameworks/angular/start-schema.json)
 
 ## API
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Starting in Angular 21, zone.js is not included anymore. Therefore, we set the `experimentalZoneless` option turned on by default.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically enables zoneless mode when running with Angular v21+; remains configurable via experimentalZoneless.
- Bug Fixes
  - Ensures the experimentalZoneless setting is correctly propagated to the final build/start options.
- Documentation
  - Updated Angular docs and links; added experimentalZoneless option entry and clarified sourceMap reference.
- Chores
  - Reformatted Angular schemas for readability; removed the schema default for experimentalZoneless (no other behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->