### PR TITLE
Docs: Add experimental test syntax to main config features page

### DIFF
--- a/docs/_snippets/main-config-features-experimental-test-syntax.md
+++ b/docs/_snippets/main-config-features-experimental-test-syntax.md
@@ -1,43 +1,4 @@
-```js filename=".storybook/main.js" renderer="react" language="js" tabTitle="CSF 3"
-export default {
-  // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
-  framework: '@storybook/your-framework',
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  features: {
-    experimentalTestSyntax: true,
-  },
-};
-```
-
-```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF 3"
-// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
-import type { StorybookConfig } from '@storybook/your-framework';
-
-const config: StorybookConfig = {
-  framework: '@storybook/your-framework',
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  features: {
-    experimentalTestSyntax: true,
-  },
-};
-
-export default config;
-```
-
-```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF Next 🧪"
-// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
-import { defineMain } from '@storybook/your-framework/node';
-
-export default defineMain({
-  framework: '@storybook/your-framework',
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  features: {
-    experimentalTestSyntax: true,
-  },
-});
-```
-
-```js filename=".storybook/main.js" renderer="react" language="js" tabTitle="CSF Next 🧪"
+```ts filename=".storybook/main.js|ts (CSF Next 🧪)" renderer="react" language="ts"
 // Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
 import { defineMain } from '@storybook/your-framework/node';
 

--- a/docs/_snippets/main-config-features-experimental-test-syntax.md
+++ b/docs/_snippets/main-config-features-experimental-test-syntax.md
@@ -1,0 +1,51 @@
+```js filename=".storybook/main.js" renderer="react" language="js" tabTitle="CSF 3"
+export default {
+  // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  features: {
+    experimentalTestSyntax: true,
+  },
+};
+```
+
+```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF 3"
+// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+import type { StorybookConfig } from '@storybook/your-framework';
+
+const config: StorybookConfig = {
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  features: {
+    experimentalTestSyntax: true,
+  },
+};
+
+export default config;
+```
+
+```ts filename=".storybook/main.ts" renderer="react" language="ts" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { defineMain } from '@storybook/your-framework/node';
+
+export default defineMain({
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  features: {
+    experimentalTestSyntax: true,
+  },
+});
+```
+
+```js filename=".storybook/main.js" renderer="react" language="js" tabTitle="CSF Next 🧪"
+// Replace your-framework with the framework you are using (e.g., react-vite, nextjs, nextjs-vite)
+import { defineMain } from '@storybook/your-framework/node';
+
+export default defineMain({
+  framework: '@storybook/your-framework',
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  features: {
+    experimentalTestSyntax: true,
+  },
+});
+```

--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -224,6 +224,27 @@ export const PrimaryDisabled = Primary.extend({
 });
 ```
 
+#### `<Story>.test`
+
+(⚠️ **Experimental**)
+
+A more ergonomic way to define [tests for your stories](../../writing-tests/index.mdx). While this API is still experimental, it is [documented in the RFC to gather feedback](https://github.com/storybookjs/storybook/discussions/30119) and must be enabled via the [`experimentalTestSyntax` feature flag](../main-config/main-config-features.mdx#experimentaltestsyntax).
+
+```ts title="Button.stories.js|ts"
+// ...from above
+export const PrimaryDisabled = Primary.extend({ args: { disabled: true } });
+
+// 👇 .test method: Attach tests to a story
+//    The test function can run the same code as the play function
+PrimaryDisabled.test('should be disabled', async ({ canvas, userEvent, args }) => {
+  const button = await canvas.findByRole('button');
+  await userEvent(button).click();
+
+  await expect(button).toBeDisabled();
+  await expect(args.onClick).not.toHaveBeenCalled();
+});
+```
+
 ## Upgrade to CSF Next
 
 You can upgrade your stories to CSF Next either automatically (from CSF 3) or manually (from CSF 1, 2, or 3). CSF Next is designed to be usable incrementally; you do not have to upgrade all of your story files at once. However, you cannot mix story formats within the same file.

--- a/docs/api/main-config/main-config-features.mdx
+++ b/docs/api/main-config/main-config-features.mdx
@@ -136,7 +136,7 @@ Set `NODE_ENV` to `'development'` in built Storybooks for better testing and deb
 
 Type: `boolean`
 
-Enable the experimental `.test` function with the [CSF Next](../csf/csf-next.mdx) format.
+Enable the [experimental `.test` method with the CSF Next format](../csf/csf-next#storytest).
 
 {/* prettier-ignore-start */}
 

--- a/docs/api/main-config/main-config-features.mdx
+++ b/docs/api/main-config/main-config-features.mdx
@@ -9,6 +9,29 @@ Parent: [main.js|ts configuration](./main-config.mdx)
 
 Type:
 
+<If renderer="react">
+
+```ts
+{
+  actions?: boolean;
+  argTypeTargetsV7?: boolean;
+  backgrounds?: boolean;
+  controls?: boolean;
+  developmentModeForBuild?: boolean;
+  experimentalTestSyntax?: boolean;
+  highlight?: boolean;
+  interactions?: boolean;
+  legacyDecoratorFileOrder?: boolean;
+  measure?: boolean;
+  outline?: boolean;
+  toolbars?: boolean;
+  viewport?: boolean;
+}
+```
+</If>
+
+<If renderer="angular">
+
 ```ts
 {
   actions?: boolean;
@@ -26,6 +49,28 @@ Type:
   viewport?: boolean;
 }
 ```
+</If>
+
+<If notRenderer={['react','angular']}>
+
+```ts
+{
+  actions?: boolean;
+  argTypeTargetsV7?: boolean;
+  backgrounds?: boolean;
+  controls?: boolean;
+  developmentModeForBuild?: boolean;
+  highlight?: boolean;
+  interactions?: boolean;
+  legacyDecoratorFileOrder?: boolean;
+  measure?: boolean;
+  outline?: boolean;
+  toolbars?: boolean;
+  viewport?: boolean;
+}
+```
+</If>
+
 
 Enables Storybook's additional features.
 
@@ -35,11 +80,15 @@ Type: `boolean`
 
 Enable the [Actions](../../essentials/actions.mdx) feature.
 
+<If renderer="angular">
+
 ## `angularFilterNonInputControls`
 
 Type: `boolean`
 
 Filter non-input controls in Angular.
+
+</If>
 
 ## `argTypeTargetsV7`
 
@@ -78,6 +127,24 @@ Set `NODE_ENV` to `'development'` in built Storybooks for better testing and deb
 <CodeSnippets path="main-config-features-development-mode-for-build.md" />
 
 {/* prettier-ignore-end */}
+
+<If renderer="react">
+
+## `experimentalTestSyntax`
+
+(⚠️ **Experimental**)
+
+Type: `boolean`
+
+Enable the experimental `.test` function with the [CSF Next](../csf/csf-next.mdx) format.
+
+{/* prettier-ignore-start */}
+
+<CodeSnippets path="main-config-features-experimental-test-syntax.md" />
+
+{/* prettier-ignore-end */}
+
+</If>
 
 ## `highlight`
 


### PR DESCRIPTION
Closes #32636

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

With this pull request, the features API page was updated to include the missing `experimentalTestSyntax` feature flag.

What was done:
- Adjusted the documentation to render the options based on the selected framework conditionally
- Included the missing feature flag
- Added snippets

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added documentation and snippets for an experimental story test syntax, including guidance for attaching tests to stories.
  - Expanded configuration docs with renderer-specific feature-flag sections (React, Angular, generic) and examples for enabling experimental test syntax.
  - Documented Angular-specific behavior for filtering non-input controls and clarified which flags apply per renderer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->