### PR TITLE
Mocking: Fix `sb.mock` usage in Storybook's deployed in subpaths

### DIFF
--- a/code/core/src/core-server/presets/vitePlugins/vite-inject-mocker/plugin.ts
+++ b/code/core/src/core-server/presets/vitePlugins/vite-inject-mocker/plugin.ts
@@ -33,7 +33,7 @@ export const viteInjectMockerRuntime = (options: {
             'server',
             'mocker-runtime.template.js'
           ),
-          fileName: entryPath.slice(1),
+          fileName: entryPath.slice(2),
         });
       }
     },

--- a/code/core/src/core-server/presets/vitePlugins/vite-inject-mocker/plugin.ts
+++ b/code/core/src/core-server/presets/vitePlugins/vite-inject-mocker/plugin.ts
@@ -8,7 +8,7 @@ import type { ResolvedConfig, ViteDevServer } from 'vite';
 
 import { resolvePackageDir } from '../../../../shared/utils/module';
 
-const entryPath = '/vite-inject-mocker-entry.js';
+const entryPath = './vite-inject-mocker-entry.js';
 
 const entryCode = dedent`
     <script type="module" src="${entryPath}"></script>

--- a/code/core/src/core-server/presets/vitePlugins/vite-inject-mocker/plugin.ts
+++ b/code/core/src/core-server/presets/vitePlugins/vite-inject-mocker/plugin.ts
@@ -8,10 +8,10 @@ import type { ResolvedConfig, ViteDevServer } from 'vite';
 
 import { resolvePackageDir } from '../../../../shared/utils/module';
 
-const entryPath = './vite-inject-mocker-entry.js';
+const entryPath = '/vite-inject-mocker-entry.js';
 
 const entryCode = dedent`
-    <script type="module" src="${entryPath}"></script>
+    <script type="module" src=".${entryPath}"></script>
   `;
 
 let server: ViteDevServer;
@@ -33,7 +33,7 @@ export const viteInjectMockerRuntime = (options: {
             'server',
             'mocker-runtime.template.js'
           ),
-          fileName: entryPath.slice(2),
+          fileName: entryPath.slice(1),
         });
       }
     },


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32631

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32678-sha-bda76dca`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32678-sha-bda76dca sandbox` or in an existing project with `npx storybook@0.0.0-pr-32678-sha-bda76dca upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32678-sha-bda76dca`](https://npmjs.com/package/storybook/v/0.0.0-pr-32678-sha-bda76dca) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-sb-mock-on-subpath-deployed-storybooks`](https://github.com/storybookjs/storybook/tree/valentin/fix-sb-mock-on-subpath-deployed-storybooks) |
| **Commit** | [`bda76dca`](https://github.com/storybookjs/storybook/commit/bda76dcaf9f376504e29bfaa19d7ef2b5f741fdd) |
| **Datetime** | Thu Oct  9 08:03:09 UTC 2025 (`1759996989`) |
| **Workflow run** | [18369640830](https://github.com/storybookjs/storybook/actions/runs/18369640830) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=32678`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The injected mocker script now loads via a relative URL (./...), fixing failures when the app is hosted in subdirectories, behind reverse proxies, or on custom/static bases.
  * No public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->