### PR TITLE
CLI: Avoid mixed CSF in files with unconventional stories

### DIFF
--- a/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.test.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.test.ts
@@ -10,6 +10,7 @@ import { storyToCsfFactory } from './story-to-csf-factory';
 
 vi.mock('storybook/internal/node-logger', () => ({
   logger: {
+    log: vi.fn(),
     warn: vi.fn(),
   },
 }));
@@ -34,11 +35,13 @@ describe('stories codemod', () => {
         transform(dedent`
             const meta = { title: 'Component' };
             export default meta;
+            export const A = {};
           `)
       ).resolves.toMatchInlineSnapshot(`
         import preview from '#.storybook/preview';
 
         const meta = preview.meta({ title: 'Component' });
+        export const A = meta.story();
       `);
     });
 
@@ -46,6 +49,7 @@ describe('stories codemod', () => {
       await expect(
         transform(dedent`
             export default { title: 'Component' };
+            export const A = {};
           `)
       ).resolves.toMatchInlineSnapshot(`
         import preview from '#.storybook/preview';
@@ -53,6 +57,8 @@ describe('stories codemod', () => {
         const meta = preview.meta({
           title: 'Component',
         });
+
+        export const A = meta.story();
       `);
     });
 
@@ -61,11 +67,13 @@ describe('stories codemod', () => {
         transform(dedent`
             const componentMeta = { title: 'Component' };
             export default componentMeta;
+            export const A = {};
           `)
       ).resolves.toMatchInlineSnapshot(`
         import preview from '#.storybook/preview';
 
         const componentMeta = preview.meta({ title: 'Component' });
+        export const A = componentMeta.story();
       `);
     });
 
@@ -349,6 +357,7 @@ describe('stories codemod', () => {
                 source: dedent`
                   import preview, { extra } from '../../../.storybook/preview';
                   export default {};
+                  export const A = {};
                 `,
                 path: 'Component.stories.tsx',
               },
@@ -359,6 +368,7 @@ describe('stories codemod', () => {
           import preview, { extra } from '#.storybook/preview';
 
           const meta = preview.meta({});
+          export const A = meta.story();
         `);
 
         await expect(
@@ -369,6 +379,7 @@ describe('stories codemod', () => {
                 source: dedent`
                   import preview, { extra } from '#.storybook/preview';
                   export default {};
+                  export const A = {};
                 `,
                 path: 'Component.stories.tsx',
               },
@@ -379,6 +390,7 @@ describe('stories codemod', () => {
           import preview, { extra } from '../../preview';
 
           const meta = preview.meta({});
+          export const A = meta.story();
         `);
       } finally {
         relativeMock.mockRestore();
@@ -666,6 +678,24 @@ describe('stories codemod', () => {
       // expect(transformed).toContain('C = meta.story');
     });
 
+    it('should bail transformation when no stories can be transformed', async () => {
+      const source = dedent`
+        export default {
+          title: 'Component',
+        };
+      `;
+      const transformed = await transform(source);
+      const formattedSource = await formatFileContent('Component.stories.tsx', source);
+      expect(transformed).toEqual(formattedSource);
+
+      expect(transformed).not.toContain('preview.meta');
+      expect(transformed).not.toContain('meta.story');
+
+      expect(vi.mocked(logger.warn).mock.calls[0][0]).toMatchInlineSnapshot(
+        `Skipping codemod for Component.stories.tsx: no stories were transformed. Either there are no stories, file has been already transformed or some stories are written in an unsupported format.`
+      );
+    });
+
     it('should bail transformation and warn if some stories are not transformed to avoid mixed CSF formats', async () => {
       const source = dedent`
         export default {
@@ -700,7 +730,7 @@ describe('stories codemod', () => {
       const formattedSource = await formatFileContent('Component.stories.tsx', source);
       expect(transformed).toEqual(formattedSource);
 
-      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.log).not.toHaveBeenCalled();
     });
   });
 });

--- a/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
@@ -239,12 +239,16 @@ export async function storyToCsfFactory(
     },
   });
 
+  // If no stories were transformed, bail early to avoid having a mixed CSF syntax and therefore a broken indexer.
+  if (transformedStoryExports.size === 0) {
+    logger.warn(
+      `Skipping codemod for ${info.path}: no stories were transformed. Either there are no stories, file has been already transformed or some stories are written in an unsupported format.`
+    );
+    return info.source;
+  }
+
   // If some stories were detected but not all could be transformed, we skip the codemod to avoid mixed csf syntax and therefore a broken indexer.
-  if (
-    detectedStoryNames.length > 0 &&
-    transformedStoryExports.size > 0 &&
-    transformedStoryExports.size !== detectedStoryNames.length
-  ) {
+  if (detectedStoryNames.length > 0 && transformedStoryExports.size !== detectedStoryNames.length) {
     logger.warn(
       `Skipping codemod for ${info.path}:\nSome of the detected stories [${detectedStoryNames
         .map((name) => `"${name}"`)


### PR DESCRIPTION
Closes #32680

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds an early exit condition in `storyToCsfFactory` to skip transformation when no stories are detected, preventing mixed CSF syntax.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent mixed CSF output by bailing out when no stories can be transformed, returning the original source instead.
  * Improved and clarified warning messages for unsupported or pre-transformed files.
  * Aligned logging behavior for scenarios where no logging should occur.

* **Refactor**
  * Streamlined consistency checks to reduce false positives and improve reliability.

* **Tests**
  * Added tests for the no-transform bail-out scenario.
  * Updated expectations and snapshots to reflect new logging and transformation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->